### PR TITLE
Expose ingress identity access drift categories

### DIFF
--- a/control_plane/contracts/ingress_route_audit_record.py
+++ b/control_plane/contracts/ingress_route_audit_record.py
@@ -17,6 +17,16 @@ class IngressRouteAuditOperation(BaseModel):
     host_id: int | None = Field(default=None, ge=1)
     domain_names: tuple[str, ...]
     requires_apply: bool
+    change_categories: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_operation(self) -> "IngressRouteAuditOperation":
+        self.change_categories = tuple(
+            dict.fromkeys(
+                category.strip().lower() for category in self.change_categories if category.strip()
+            )
+        )
+        return self
 
 
 class IngressRouteAuditRecord(BaseModel):

--- a/control_plane/workflows/npmplus_ingress.py
+++ b/control_plane/workflows/npmplus_ingress.py
@@ -14,9 +14,62 @@ from control_plane.npmplus import (
 
 type NpmplusIngressMode = Literal["dry-run", "apply"]
 type NpmplusIngressOperationAction = Literal["create", "update", "enable", "disable", "no-op"]
+type NpmplusIngressChangeCategory = Literal[
+    "route",
+    "upstream",
+    "certificate",
+    "tls",
+    "access_list",
+    "identity_access",
+    "provider_options",
+    "enabled",
+]
 type NpmplusIngressStatus = Literal["planned", "applied", "unchanged"]
 type IngressIdentityAccessMode = Literal["none", "forward-auth"]
 type IngressIdentityAccessProvider = Literal["none", "anubis", "tinyauth", "authelia", "authentik"]
+
+
+_CHANGE_CATEGORY_ORDER: tuple[NpmplusIngressChangeCategory, ...] = (
+    "route",
+    "upstream",
+    "certificate",
+    "tls",
+    "access_list",
+    "identity_access",
+    "provider_options",
+    "enabled",
+)
+_CHANGE_CATEGORY_FIELDS: dict[NpmplusIngressChangeCategory, frozenset[str]] = {
+    "route": frozenset({"domain_names"}),
+    "upstream": frozenset({"forward_scheme", "forward_host", "forward_port"}),
+    "certificate": frozenset({"certificate_id"}),
+    "tls": frozenset(
+        {
+            "ssl_forced",
+            "hsts_enabled",
+            "hsts_subdomains",
+            "trust_forwarded_proto",
+            "http2_support",
+            "npmplus_http3_support",
+        }
+    ),
+    "access_list": frozenset({"access_list_id"}),
+    "identity_access": frozenset({"npmplus_auth_request"}),
+    "provider_options": frozenset(
+        {
+            "advanced_config",
+            "locations",
+            "npmplus_noindex",
+            "npmplus_crowdsec_appsec",
+            "npmplus_proxy_request_buffering",
+            "npmplus_proxy_response_buffering",
+            "npmplus_upstream_compression",
+            "npmplus_fancyindex",
+            "npmplus_x_frame_options",
+        }
+    ),
+    "enabled": frozenset({"enabled"}),
+}
 
 
 class NpmplusIngressClient(Protocol):
@@ -156,6 +209,7 @@ class NpmplusIngressOperation(BaseModel):
     host_id: int | None = None
     domain_names: tuple[str, ...]
     requires_apply: bool
+    change_categories: tuple[NpmplusIngressChangeCategory, ...] = ()
 
 
 class NpmplusIngressApplyResult(BaseModel):
@@ -299,11 +353,13 @@ def _plan_operations(
                 action="create",
                 domain_names=operation_domains,
                 requires_apply=True,
+                change_categories=_create_change_categories(desired_payload),
             ),
         )
 
     operations: list[NpmplusIngressOperation] = []
-    if not _payload_matches(existing_host, desired_payload):
+    change_categories = _update_change_categories(existing_host, desired_payload)
+    if change_categories:
         if not request.allow_update:
             raise click.ClickException("NPMplus ingress update is not allowed for this request.")
         operations.append(
@@ -312,6 +368,7 @@ def _plan_operations(
                 host_id=existing_host.id,
                 domain_names=operation_domains,
                 requires_apply=True,
+                change_categories=change_categories,
             )
         )
 
@@ -326,6 +383,7 @@ def _plan_operations(
                 host_id=existing_host.id,
                 domain_names=operation_domains,
                 requires_apply=True,
+                change_categories=("enabled",),
             )
         )
 
@@ -346,6 +404,47 @@ def _payload_matches(
     desired_payload: NpmplusProxyHostPayload,
 ) -> bool:
     return _comparable_payload(existing_host) == _comparable_payload(desired_payload)
+
+
+def _create_change_categories(
+    desired_payload: NpmplusProxyHostPayload,
+) -> tuple[NpmplusIngressChangeCategory, ...]:
+    categories: set[NpmplusIngressChangeCategory] = {
+        "route",
+        "upstream",
+        "certificate",
+        "tls",
+        "provider_options",
+    }
+    if desired_payload.access_list_id != 0:
+        categories.add("access_list")
+    if desired_payload.npmplus_auth_request != "none":
+        categories.add("identity_access")
+    if not desired_payload.enabled:
+        categories.add("enabled")
+    return _ordered_change_categories(categories)
+
+
+def _update_change_categories(
+    existing_host: NpmplusProxyHost,
+    desired_payload: NpmplusProxyHostPayload,
+) -> tuple[NpmplusIngressChangeCategory, ...]:
+    existing_comparison = _comparable_payload(existing_host)
+    desired_comparison = _comparable_payload(desired_payload)
+    categories = {
+        category
+        for category, fields in _CHANGE_CATEGORY_FIELDS.items()
+        if any(existing_comparison.get(field) != desired_comparison.get(field) for field in fields)
+    }
+    if existing_comparison != desired_comparison and not categories:
+        categories.add("provider_options")
+    return _ordered_change_categories(categories)
+
+
+def _ordered_change_categories(
+    categories: set[NpmplusIngressChangeCategory],
+) -> tuple[NpmplusIngressChangeCategory, ...]:
+    return tuple(category for category in _CHANGE_CATEGORY_ORDER if category in categories)
 
 
 def _comparable_payload(

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -212,7 +212,11 @@ asks the service to reject the request unless the expected provider host's domai
 set exactly matches the requested canary domain set. Dry-run and apply responses
 write Launchplane-owned ingress route audit records that preserve the trace id,
 mode, status, requested domains, expected/provider host ids, operations, reason,
-and idempotency key. Keep this workflow canary-scoped until broader route
+and idempotency key. Each plan operation includes high-level change categories
+such as `route`, `upstream`, `certificate`, `tls`, `access_list`,
+`identity_access`, `provider_options`, and `enabled`; those categories make
+identity/access drift visible without storing provider topology or secret values
+in the public contract. Keep this workflow canary-scoped until broader route
 ownership and approval UX are explicit.
 
 Operators with `ingress_route.plan` for the target product/context can inspect

--- a/docs/records.md
+++ b/docs/records.md
@@ -152,11 +152,11 @@ an ORM column/table or remains only in the evidence payload.
 - Ingress route audit: modeled fields are `record_id`, `product`, `context`,
   `mode`, `status`, `provider_host_id`, and `recorded_at`. The payload carries
   the typed requested domains, expected provider host id, dry-run/apply mode,
-  plan operations, trace id, idempotency key, and operator reason. Provider
-  payload details and comparison evidence stay payload-only until route
-  ownership gets a broader operator UI. Apply requests first write a `pending`
-  audit intent before provider mutation and then replace it with the final
-  `applied` or `unchanged` outcome.
+  plan operations, high-level change categories, trace id, idempotency key, and
+  operator reason. Provider payload details and comparison evidence stay
+  payload-only until route ownership gets a broader operator UI. Apply requests
+  first write a `pending` audit intent before provider mutation and then replace
+  it with the final `applied` or `unchanged` outcome.
 
 Promote a payload field into ORM structure when Launchplane needs to filter,
 order, join, authorize, constrain, display it regularly, or drive an action from

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -650,6 +650,20 @@ class FilesystemRecordStoreTests(unittest.TestCase):
         self.assertEqual([record.record_id for record in limited_records], [newer_record.record_id])
         self.assertEqual(loaded_record.record_id, newer_record.record_id)
 
+    def test_ingress_route_audit_operation_accepts_legacy_missing_categories(
+        self,
+    ) -> None:
+        operation = IngressRouteAuditOperation.model_validate(
+            {
+                "action": "update",
+                "host_id": 78,
+                "domain_names": ["ingress-canary.example.test"],
+                "requires_apply": True,
+            }
+        )
+
+        self.assertEqual(operation.change_categories, ())
+
     def test_postgres_store_round_trips_ingress_route_audit_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"

--- a/tests/test_npmplus_ingress_workflow.py
+++ b/tests/test_npmplus_ingress_workflow.py
@@ -108,6 +108,10 @@ class NpmplusIngressWorkflowTests(unittest.TestCase):
         self.assertEqual(result.status, "planned")
         self.assertTrue(result.dry_run)
         self.assertEqual(result.operations[0].action, "create")
+        self.assertEqual(
+            result.operations[0].change_categories,
+            ("route", "upstream", "certificate", "tls", "provider_options"),
+        )
         self.assertEqual(client.calls, ["list"])
         self.assertEqual(client.proxy_hosts, [])
 
@@ -132,6 +136,7 @@ class NpmplusIngressWorkflowTests(unittest.TestCase):
         )
 
         self.assertEqual(tuple(operation.action for operation in result.operations), ("update",))
+        self.assertEqual(result.operations[0].change_categories, ("upstream",))
         self.assertEqual(client.calls, ["list", "update:78"])
         self.assertEqual(result.proxy_host.forward_port if result.proxy_host else None, 8123)
 
@@ -144,6 +149,7 @@ class NpmplusIngressWorkflowTests(unittest.TestCase):
         )
 
         self.assertEqual(tuple(operation.action for operation in result.operations), ("disable",))
+        self.assertEqual(result.operations[0].change_categories, ("enabled",))
         self.assertFalse(result.proxy_host.enabled if result.proxy_host else True)
         self.assertEqual(client.calls, ["list", "disable:78"])
 
@@ -169,6 +175,7 @@ class NpmplusIngressWorkflowTests(unittest.TestCase):
 
         self.assertEqual(result.status, "unchanged")
         self.assertEqual(tuple(operation.action for operation in result.operations), ("no-op",))
+        self.assertEqual(result.operations[0].change_categories, ())
         self.assertEqual(client.calls, ["list"])
 
     def test_noop_ignores_api_assigned_location_ids(self) -> None:
@@ -184,6 +191,35 @@ class NpmplusIngressWorkflowTests(unittest.TestCase):
         self.assertEqual(result.status, "unchanged")
         self.assertEqual(tuple(operation.action for operation in result.operations), ("no-op",))
         self.assertEqual(client.calls, ["list"])
+
+    def test_update_identifies_identity_access_change(self) -> None:
+        client = _FakeNpmplusClient((_proxy_host(npmplus_auth_request="none"),))
+
+        result = apply_npmplus_ingress_route(
+            client=client,
+            request=_request(
+                route=_desired_route(
+                    identity_access={
+                        "mode": "forward-auth",
+                        "provider": "authentik",
+                    }
+                )
+            ),
+        )
+
+        self.assertEqual(tuple(operation.action for operation in result.operations), ("update",))
+        self.assertEqual(result.operations[0].change_categories, ("identity_access",))
+
+    def test_update_identifies_location_change_as_provider_options(self) -> None:
+        client = _FakeNpmplusClient((_proxy_host(locations=[_location(forward_port=9001)]),))
+
+        result = apply_npmplus_ingress_route(
+            client=client,
+            request=_request(route=_desired_route(locations=[_location()])),
+        )
+
+        self.assertEqual(tuple(operation.action for operation in result.operations), ("update",))
+        self.assertEqual(result.operations[0].change_categories, ("provider_options",))
 
     def test_identity_access_binding_maps_authentik_forward_auth(self) -> None:
         route = _desired_route(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2054,11 +2054,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["status"], "planned")
         self.assertTrue(payload["result"]["dry_run"])
         self.assertEqual(payload["result"]["operations"][0]["action"], "create")
+        self.assertEqual(
+            payload["result"]["operations"][0]["change_categories"],
+            ["route", "upstream", "certificate", "tls", "provider_options"],
+        )
         self.assertIn("ingress_route_audit_record_id", payload["records"])
         self.assertEqual(client.calls, ["list"])
         self.assertEqual(len(records), 1)
         self.assertEqual(records[0].mode, "dry-run")
         self.assertEqual(records[0].status, "planned")
+        self.assertEqual(
+            records[0].operations[0].change_categories,
+            ("route", "upstream", "certificate", "tls", "provider_options"),
+        )
         self.assertEqual(records[0].trace_id, payload["trace_id"])
 
     def test_ingress_route_audit_record_api_lists_and_reads_records(self) -> None:
@@ -20164,9 +20172,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "target_type": "compose",
                         "target_id": "compose-123",
                         "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
-                        "oauth_env": {
-                            "LAUNCHPLANE_NPMPLUS_BASE_URL": "https://npmplus.example"
-                        },
+                        "oauth_env": {"LAUNCHPLANE_NPMPLUS_BASE_URL": "https://npmplus.example"},
                         "oauth_env_removals": ["LAUNCHPLANE_NPMPLUS_BASE_URL"],
                     },
                 },


### PR DESCRIPTION
## Summary
- add high-level ingress operation change categories, including identity_access
- persist categories in ingress route audit records while keeping provider details payload-only
- document category semantics and add regression coverage for old audit operations without categories

## Tests
- uv run python -m unittest tests.test_npmplus_ingress_workflow tests.test_service.LaunchplaneServiceTests.test_npmplus_ingress_route_apply_dry_run_returns_plan_without_mutation
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_ingress_route_audit_record_api_lists_and_reads_records tests.test_filesystem_store tests.test_postgres_store
- uv run --extra dev ruff check control_plane/workflows/npmplus_ingress.py control_plane/contracts/ingress_route_audit_record.py tests/test_npmplus_ingress_workflow.py tests/test_service.py tests/test_filesystem_store.py
- uv run --extra dev ruff format --check control_plane/workflows/npmplus_ingress.py control_plane/contracts/ingress_route_audit_record.py tests/test_npmplus_ingress_workflow.py tests/test_service.py tests/test_filesystem_store.py
- uv run --extra dev mypy control_plane tests
- git diff --check

Agent review: 2 read-only agents reported no blocking findings.