### PR TITLE
Add typed ingress identity access CLI flags

### DIFF
--- a/control_plane/cli_ingress.py
+++ b/control_plane/cli_ingress.py
@@ -101,6 +101,19 @@ def ingress() -> None:
     default="none",
     show_default=True,
 )
+@click.option(
+    "--identity-access-provider",
+    type=click.Choice(["none", "anubis", "tinyauth", "authelia", "authentik"]),
+    default="none",
+    show_default=True,
+    help="Provider-neutral identity/access binding provider.",
+)
+@click.option(
+    "--identity-access-send-basic-auth",
+    is_flag=True,
+    default=False,
+    help="Use the Authentik basic-auth forwarding mode for the identity/access binding.",
+)
 @click.option("--advanced-config", default="")
 @click.option("--allow-create/--no-allow-create", default=True, show_default=True)
 @click.option("--allow-update/--no-allow-update", default=True, show_default=True)
@@ -128,6 +141,8 @@ def ingress_route_apply(
     http3_support: bool,
     npmplus_noindex: bool,
     auth_request: str,
+    identity_access_provider: str,
+    identity_access_send_basic_auth: bool,
     advanced_config: str,
     allow_create: bool,
     allow_update: bool,
@@ -162,6 +177,8 @@ def ingress_route_apply(
         http3_support=http3_support,
         npmplus_noindex=npmplus_noindex,
         auth_request=auth_request,
+        identity_access_provider=identity_access_provider,
+        identity_access_send_basic_auth=identity_access_send_basic_auth,
         advanced_config=advanced_config,
         allow_create=allow_create,
         allow_update=allow_update,
@@ -197,6 +214,8 @@ def _route_apply_payload(
     http3_support: bool,
     npmplus_noindex: bool,
     auth_request: str,
+    identity_access_provider: str,
+    identity_access_send_basic_auth: bool,
     advanced_config: str,
     allow_create: bool,
     allow_update: bool,
@@ -212,6 +231,18 @@ def _route_apply_payload(
             resolved_certificate_id = int(certificate_id)
         except ValueError as error:
             raise click.ClickException("--certificate-id must be an integer or 'new'.") from error
+    identity_access = _identity_access_binding(
+        provider=identity_access_provider,
+        send_basic_auth=identity_access_send_basic_auth,
+    )
+    if identity_access and auth_request not in {
+        "none",
+        _identity_access_auth_request(identity_access),
+    }:
+        raise click.ClickException(
+            "--identity-access-provider conflicts with --auth-request. "
+            "Use one provider mode or matching values."
+        )
     route: dict[str, object] = {
         "domain_names": list(domains),
         "forward_scheme": forward_scheme,
@@ -226,6 +257,8 @@ def _route_apply_payload(
         "advanced_config": advanced_config,
         "enabled": enabled,
     }
+    if identity_access:
+        route["identity_access"] = identity_access
     if forward_port is not None:
         route["forward_port"] = forward_port
     ingress_request: dict[str, object] = {
@@ -245,3 +278,31 @@ def _route_apply_payload(
         "context": context,
         "ingress": ingress_request,
     }
+
+
+def _identity_access_binding(*, provider: str, send_basic_auth: bool) -> dict[str, object] | None:
+    if provider == "none":
+        if send_basic_auth:
+            raise click.ClickException(
+                "--identity-access-send-basic-auth requires --identity-access-provider authentik."
+            )
+        return None
+    if send_basic_auth and provider != "authentik":
+        raise click.ClickException(
+            "--identity-access-send-basic-auth is only valid with --identity-access-provider authentik."
+        )
+    return {
+        "schema_version": 1,
+        "mode": "forward-auth",
+        "provider": provider,
+        "send_basic_auth": send_basic_auth,
+    }
+
+
+def _identity_access_auth_request(identity_access: dict[str, object]) -> str:
+    provider = identity_access["provider"]
+    if provider == "authentik" and identity_access["send_basic_auth"] is True:
+        return "authentik-send-basic-auth"
+    if isinstance(provider, str):
+        return provider
+    raise click.ClickException("Invalid identity/access provider.")

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -180,6 +180,7 @@ uv run launchplane ingress route-apply \
   --forward-host 192.0.2.10 \
   --forward-port 8080 \
   --certificate-id 1 \
+  --identity-access-provider authentik \
   --reason "Plan ingress route"
 ```
 
@@ -198,6 +199,11 @@ auth material through the Authentik integration for routes that intentionally
 need that mode. Keep Authentik instance placement, provider ids, app slugs, and
 private route evidence in private infra docs. Launchplane should consume only
 sanitized desired state and managed-secret references.
+
+Prefer the CLI's `--identity-access-provider` flag for new typed desired state.
+Use `--identity-access-send-basic-auth` only with `--identity-access-provider authentik`.
+The legacy `--auth-request` flag remains available for provider compatibility,
+but mixing it with a conflicting identity/access provider fails closed.
 
 Operators can also use the `Ingress Route Dry Run` GitHub workflow for a
 service-mediated canary plan through GitHub OIDC. The workflow accepts the

--- a/tests/test_ingress_cli.py
+++ b/tests/test_ingress_cli.py
@@ -131,6 +131,120 @@ class IngressCliTests(unittest.TestCase):
         self.assertFalse(route["enabled"])
         self.assertFalse(route["npmplus_http3_support"])
 
+    def test_route_apply_accepts_identity_access_binding(self) -> None:
+        captured_request: dict[str, object] = {}
+
+        def fake_post(**kwargs: object) -> dict[str, object]:
+            captured_request.update(kwargs)
+            return {
+                "status": "accepted",
+                "result": {"status": "planned", "dry_run": True},
+            }
+
+        with (
+            patch.dict(os.environ, {"LAUNCHPLANE_SERVICE_TOKEN": "service-token"}),
+            patch("control_plane.cli._post_launchplane_service_json", side_effect=fake_post),
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "ingress",
+                    "route-apply",
+                    "--service-url",
+                    "https://launchplane.example",
+                    "--product",
+                    "launchplane",
+                    "--context",
+                    "reon-prod",
+                    "--domain",
+                    "ingress-canary.example.test",
+                    "--forward-host",
+                    "192.0.2.10",
+                    "--certificate-id",
+                    "47",
+                    "--identity-access-provider",
+                    "authentik",
+                    "--identity-access-send-basic-auth",
+                    "--reason",
+                    "test route identity access",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = captured_request["payload"]
+        assert isinstance(payload, dict)
+        ingress = payload["ingress"]
+        assert isinstance(ingress, dict)
+        route = ingress["route"]
+        assert isinstance(route, dict)
+        self.assertEqual(route["npmplus_auth_request"], "none")
+        self.assertEqual(
+            route["identity_access"],
+            {
+                "schema_version": 1,
+                "mode": "forward-auth",
+                "provider": "authentik",
+                "send_basic_auth": True,
+            },
+        )
+
+    def test_route_apply_rejects_conflicting_identity_access_binding(self) -> None:
+        with patch.dict(os.environ, {"LAUNCHPLANE_SERVICE_TOKEN": "service-token"}):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "ingress",
+                    "route-apply",
+                    "--service-url",
+                    "https://launchplane.example",
+                    "--product",
+                    "launchplane",
+                    "--context",
+                    "reon-prod",
+                    "--domain",
+                    "ingress-canary.example.test",
+                    "--forward-host",
+                    "192.0.2.10",
+                    "--auth-request",
+                    "authelia",
+                    "--identity-access-provider",
+                    "authentik",
+                    "--reason",
+                    "test route identity access",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("conflicts with --auth-request", result.output)
+
+    def test_route_apply_rejects_identity_access_basic_auth_without_authentik(self) -> None:
+        with patch.dict(os.environ, {"LAUNCHPLANE_SERVICE_TOKEN": "service-token"}):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "ingress",
+                    "route-apply",
+                    "--service-url",
+                    "https://launchplane.example",
+                    "--product",
+                    "launchplane",
+                    "--context",
+                    "reon-prod",
+                    "--domain",
+                    "ingress-canary.example.test",
+                    "--forward-host",
+                    "192.0.2.10",
+                    "--identity-access-provider",
+                    "authelia",
+                    "--identity-access-send-basic-auth",
+                    "--reason",
+                    "test route identity access",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("only valid with --identity-access-provider authentik", result.output)
+
     def test_route_apply_requires_idempotency_key_in_apply_mode(self) -> None:
         with patch.dict(os.environ, {"LAUNCHPLANE_SERVICE_TOKEN": "service-token"}):
             result = CliRunner().invoke(


### PR DESCRIPTION
## Summary
- add provider-neutral identity/access flags to launchplane ingress route-apply
- fail closed when typed identity/access flags conflict with legacy --auth-request
- document the typed CLI path and keep provider deployment details out of Launchplane docs

## Tests
- uv run python -m unittest tests.test_ingress_cli tests.test_npmplus_ingress_workflow
- uv run --extra dev ruff check control_plane/cli_ingress.py tests/test_ingress_cli.py
- uv run --extra dev ruff format --check control_plane/cli_ingress.py tests/test_ingress_cli.py
- uv run --extra dev mypy control_plane tests
- git diff --check

Agent review: 2 read-only agents reviewed; one schema_version clarity finding was patched.