### PR TITLE
Bound direct Dokploy rollback break-glass

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -36,6 +36,18 @@ on:
         required: false
         default: false
         type: boolean
+      break_glass_confirm:
+        description: Type ROLL BACK LAUNCHPLANE THROUGH DIRECT DOKPLOY to run the manual emergency rollback job.
+        required: false
+        type: string
+      break_glass_image_reference:
+        description: Exact previous Launchplane image reference for manual direct Dokploy rollback.
+        required: false
+        type: string
+      break_glass_reason:
+        description: Operator reason for manual direct Dokploy rollback.
+        required: false
+        type: string
 
 permissions:
   actions: read
@@ -54,7 +66,7 @@ jobs:
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_branch == 'main') ||
-      github.event_name == 'workflow_dispatch'
+      (github.event_name == 'workflow_dispatch' && inputs.break_glass_confirm == '')
     runs-on:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
@@ -532,92 +544,14 @@ jobs:
             "${{ steps.service.outputs.service_url }}/v1/drivers/launchplane/self-deploy" || true)"
           if [ "$rollback_status" != "200" ] && [ "$rollback_status" != "202" ]; then
             cat "$rollback_response_file" >&2
-            echo "Launchplane rollback request failed with HTTP ${rollback_status}; trying direct Dokploy fallback." >&2
-
-            if [ -z "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:-}" ] || [ -z "${LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN:-}" ]; then
-              echo "Direct Dokploy rollback fallback requires LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST and LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN secrets." >&2
-              exit 1
-            fi
-
-          LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE="$previous_image_reference" uv run python - <<'PY'
-          import json
-          import os
-
-          from control_plane import dokploy as control_plane_dokploy
-
-
-          def _required_env(key: str) -> str:
-              value = os.environ.get(key, "").strip()
-              if not value:
-                  raise SystemExit(f"Missing required environment variable: {key}")
-              return value
-
-
-          host = _required_env("LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST")
-          token = _required_env("LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN")
-          target_type = _required_env("LAUNCHPLANE_DOKPLOY_TARGET_TYPE")
-          target_id = _required_env("LAUNCHPLANE_DOKPLOY_TARGET_ID")
-          image_reference = _required_env("LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE")
-          deploy_timeout_seconds = int(
-              os.environ.get("LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS") or "600"
-          )
-
-          target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-              host=host,
-              token=token,
-              target_type=target_type,
-              target_id=target_id,
-          )
-          raw_env_text = str(target_payload.get("env") or "")
-          updated_env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
-              raw_env_text,
-              updates={"DOCKER_IMAGE_REFERENCE": image_reference},
-          )
-          if updated_env_text != raw_env_text:
-              control_plane_dokploy.update_dokploy_target_env(
-                  host=host,
-                  token=token,
-                  target_type=target_type,
-                  target_id=target_id,
-                  target_payload=target_payload,
-                  env_text=updated_env_text,
-              )
-          latest_before = control_plane_dokploy.latest_deployment_for_target(
-              host=host,
-              token=token,
-              target_type=target_type,
-              target_id=target_id,
-          )
-          control_plane_dokploy.trigger_deployment(
-              host=host,
-              token=token,
-              target_type=target_type,
-              target_id=target_id,
-              no_cache=True,
-          )
-          deployment_result = control_plane_dokploy.wait_for_target_deployment(
-              host=host,
-              token=token,
-              target_type=target_type,
-              target_id=target_id,
-              before_key=control_plane_dokploy.deployment_key(latest_before),
-              timeout_seconds=deploy_timeout_seconds,
-          )
-          print(
-              json.dumps(
-                  {
-                      "status": "accepted",
-                      "target_type": target_type,
-                      "target_id": target_id,
-                      "image_reference": image_reference,
-                      "image_reference_changed": updated_env_text != raw_env_text,
-                      "deployment_result": deployment_result,
-                  },
-                  indent=2,
-                  sort_keys=True,
-              )
-          )
-          PY
+            {
+              echo "## Launchplane rollback failed"
+              echo
+              echo "- Service rollback HTTP status: $rollback_status"
+              echo "- Rollback image: $previous_image_reference"
+              echo "- Direct Dokploy mutation is manual break-glass only. Run Deploy Launchplane with the exact break-glass confirmation inputs if service rollback is unavailable."
+            } >>"$GITHUB_STEP_SUMMARY"
+            exit 1
           else
             cat "$rollback_response_file"
           fi
@@ -686,3 +620,59 @@ jobs:
           LAUNCHPLANE_SERVICE_AUDIENCE: ${{ steps.service.outputs.service_audience }}
           LAUNCHPLANE_SERVICE_URL: ${{ steps.service.outputs.service_url }}
         run: bash scripts/deploy/ensure-authz-grants.sh
+
+  emergency-dokploy-rollback:
+    if: github.event_name == 'workflow_dispatch' && inputs.break_glass_confirm == 'ROLL BACK LAUNCHPLANE THROUGH DIRECT DOKPLOY'
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_DOKPLOY_TARGET_ID: ${{ vars.LAUNCHPLANE_DOKPLOY_TARGET_ID }}
+      LAUNCHPLANE_DOKPLOY_TARGET_TYPE: ${{ vars.LAUNCHPLANE_DOKPLOY_TARGET_TYPE }}
+      LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS: ${{ vars.LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS }}
+      LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
+      LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+
+      - name: Validate manual break-glass request
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_DOKPLOY_TARGET_TYPE:?Missing LAUNCHPLANE_DOKPLOY_TARGET_TYPE variable}"
+          : "${LAUNCHPLANE_DOKPLOY_TARGET_ID:?Missing LAUNCHPLANE_DOKPLOY_TARGET_ID variable}"
+          : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST secret}"
+          : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN secret}"
+          : "${{ inputs.break_glass_image_reference }}"
+          : "${{ inputs.break_glass_reason }}"
+
+      - name: Run manual direct Dokploy rollback
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence_file="$RUNNER_TEMP/launchplane-break-glass-rollback.json"
+          LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true \
+            LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE="${{ inputs.break_glass_image_reference }}" \
+            LAUNCHPLANE_ROLLBACK_REQUEST_STATUS="manual-break-glass" \
+            uv run python scripts/deploy/emergency-dokploy-rollback.py | tee "$evidence_file"
+
+          {
+            echo "## Launchplane break-glass rollback"
+            echo
+            echo "- Fallback: direct Dokploy"
+            echo "- Reason: ${{ inputs.break_glass_reason }}"
+            echo "- Target type: $LAUNCHPLANE_DOKPLOY_TARGET_TYPE"
+            echo "- Target id: $LAUNCHPLANE_DOKPLOY_TARGET_ID"
+            echo "- Rollback image: ${{ inputs.break_glass_image_reference }}"
+            echo "- Evidence artifact: launchplane-break-glass-rollback"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload break-glass rollback evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: launchplane-break-glass-rollback
+          path: ${{ runner.temp }}/launchplane-break-glass-rollback.json
+          if-no-files-found: ignore

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -287,11 +287,17 @@ The workflow should use GitHub OIDC to call Launchplane's own service API and
 update the image digest plus known OAuth env only. DB-backed authz policy records
 own live product/workflow grants; keep Dokploy host/token authority in
 Launchplane-managed secrets instead of duplicating those credentials in GitHub
-repository secrets for normal deploy execution. The deploy workflow also needs
-break-glass `LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST` and
-`LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN` repository secrets for rollback fallback:
-they are used only when a failed rollout makes the Launchplane service route
-unable to accept its own rollback request.
+repository secrets for normal deploy execution. Automatic rollback also uses the
+Launchplane service route. If a failed rollout makes that route unable to accept
+its own rollback request, direct Dokploy rollback is available only through the
+manual break-glass inputs on the Deploy Launchplane workflow: provide the exact
+confirmation text, previous image reference, and operator reason.
+Keep the workflow configured with break-glass
+`LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST` and
+`LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN` repository secrets for that manual
+emergency path. When direct Dokploy break-glass rollback runs, the workflow
+writes a redacted `launchplane-break-glass-rollback` artifact and summary so the
+provider mutation remains reviewable after the emergency.
 Before rollback, the workflow uses those same break-glass credentials to capture
 redacted Dokploy target, container, and recent log diagnostics for the failed
 rollout. Diagnostics failures are non-blocking so rollback remains the priority.

--- a/scripts/deploy/emergency-dokploy-rollback.py
+++ b/scripts/deploy/emergency-dokploy-rollback.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from control_plane import dokploy as control_plane_dokploy
+
+
+def _env(name: str) -> str:
+    return os.environ.get(name, "").strip()
+
+
+def _required_env(name: str) -> str:
+    value = _env(name)
+    if not value:
+        raise SystemExit(f"Missing required environment variable: {name}")
+    return value
+
+
+def _require_break_glass_allowed() -> None:
+    if _env("LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK").lower() != "true":
+        raise SystemExit(
+            "Direct Dokploy rollback fallback requires "
+            "LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true."
+        )
+
+
+def _deploy_timeout_seconds() -> int:
+    raw_timeout = _env("LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS") or "600"
+    try:
+        timeout_seconds = int(raw_timeout)
+    except ValueError as error:
+        raise SystemExit(
+            "LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS must be an integer."
+        ) from error
+    if timeout_seconds <= 0:
+        raise SystemExit("LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS must be positive.")
+    return timeout_seconds
+
+
+def run_break_glass_rollback() -> dict[str, Any]:
+    _require_break_glass_allowed()
+
+    host = _required_env("LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST")
+    token = _required_env("LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN")
+    target_type = _required_env("LAUNCHPLANE_DOKPLOY_TARGET_TYPE")
+    target_id = _required_env("LAUNCHPLANE_DOKPLOY_TARGET_ID")
+    image_reference = _required_env("LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE")
+    rollback_request_status = _required_env("LAUNCHPLANE_ROLLBACK_REQUEST_STATUS")
+    deploy_timeout_seconds = _deploy_timeout_seconds()
+
+    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    raw_env_text = str(target_payload.get("env") or "")
+    updated_env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
+        raw_env_text,
+        updates={"DOCKER_IMAGE_REFERENCE": image_reference},
+    )
+    image_reference_changed = updated_env_text != raw_env_text
+    if image_reference_changed:
+        control_plane_dokploy.update_dokploy_target_env(
+            host=host,
+            token=token,
+            target_type=target_type,
+            target_id=target_id,
+            target_payload=target_payload,
+            env_text=updated_env_text,
+        )
+
+    latest_before = control_plane_dokploy.latest_deployment_for_target(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    control_plane_dokploy.trigger_deployment(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+        no_cache=True,
+    )
+    deployment_result = control_plane_dokploy.wait_for_target_deployment(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+        before_key=control_plane_dokploy.deployment_key(latest_before),
+        timeout_seconds=deploy_timeout_seconds,
+    )
+
+    return {
+        "schema_version": 1,
+        "event": "launchplane_break_glass_rollback",
+        "fallback_kind": "direct_dokploy",
+        "reason": "Launchplane self-deploy rollback service request failed.",
+        "service_rollback_http_status": rollback_request_status,
+        "target_type": target_type,
+        "target_id": target_id,
+        "image_reference": image_reference,
+        "image_reference_changed": image_reference_changed,
+        "deployment_result": deployment_result,
+    }
+
+
+def main() -> int:
+    print(json.dumps(run_break_glass_rollback(), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_emergency_dokploy_rollback.py
+++ b/tests/test_emergency_dokploy_rollback.py
@@ -1,6 +1,8 @@
 import os
 from pathlib import Path
 import runpy
+from types import SimpleNamespace
+from typing import Any, cast
 import unittest
 from unittest.mock import patch
 
@@ -8,9 +10,9 @@ from unittest.mock import patch
 _SCRIPT_PATH = Path("scripts/deploy/emergency-dokploy-rollback.py")
 
 
-def _load_script() -> type:
+def _load_script() -> SimpleNamespace:
     module_globals = runpy.run_path(str(_SCRIPT_PATH), run_name="emergency_dokploy_rollback")
-    return type("EmergencyRollbackScript", (), module_globals)
+    return SimpleNamespace(**module_globals)
 
 
 class EmergencyDokployRollbackTests(unittest.TestCase):
@@ -18,7 +20,7 @@ class EmergencyDokployRollbackTests(unittest.TestCase):
         script_module = _load_script()
 
         with patch.dict(os.environ, {}, clear=True), self.assertRaises(SystemExit) as context:
-            script_module.run_break_glass_rollback()
+            cast(Any, script_module.run_break_glass_rollback)()
 
         self.assertIn("LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true", str(context.exception))
 
@@ -63,7 +65,7 @@ class EmergencyDokployRollbackTests(unittest.TestCase):
             "wait_for_target_deployment",
             return_value={"status": "done", "deploymentId": "deploy-after"},
         ) as wait_for_deployment:
-            evidence = script_module.run_break_glass_rollback()
+            evidence = cast(Any, script_module.run_break_glass_rollback)()
 
         self.assertEqual(evidence["schema_version"], 1)
         self.assertEqual(evidence["event"], "launchplane_break_glass_rollback")

--- a/tests/test_emergency_dokploy_rollback.py
+++ b/tests/test_emergency_dokploy_rollback.py
@@ -1,0 +1,104 @@
+import os
+from pathlib import Path
+import runpy
+import unittest
+from unittest.mock import patch
+
+
+_SCRIPT_PATH = Path("scripts/deploy/emergency-dokploy-rollback.py")
+
+
+def _load_script() -> type:
+    module_globals = runpy.run_path(str(_SCRIPT_PATH), run_name="emergency_dokploy_rollback")
+    return type("EmergencyRollbackScript", (), module_globals)
+
+
+class EmergencyDokployRollbackTests(unittest.TestCase):
+    def test_fails_closed_without_allow_env(self) -> None:
+        script_module = _load_script()
+
+        with patch.dict(os.environ, {}, clear=True), self.assertRaises(SystemExit) as context:
+            script_module.run_break_glass_rollback()
+
+        self.assertIn("LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true", str(context.exception))
+
+    def test_writes_reviewable_evidence(self) -> None:
+        script_module = _load_script()
+        env = {
+            **os.environ,
+            "LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK": "true",
+            "LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST": "https://dokploy.example.test",
+            "LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN": "token-1",
+            "LAUNCHPLANE_DOKPLOY_TARGET_TYPE": "compose",
+            "LAUNCHPLANE_DOKPLOY_TARGET_ID": "target-1",
+            "LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE": "ghcr.io/example/launchplane@sha256:old",
+            "LAUNCHPLANE_ROLLBACK_REQUEST_STATUS": "503",
+            "LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS": "12",
+        }
+
+        with patch.dict(os.environ, env, clear=True), patch.object(
+            script_module.control_plane_dokploy,
+            "fetch_dokploy_target_payload",
+            return_value={"env": "DOCKER_IMAGE_REFERENCE=ghcr.io/example/launchplane@sha256:new\n"},
+        ) as fetch_target, patch.object(
+            script_module.control_plane_dokploy,
+            "render_dokploy_env_text_with_overrides",
+            return_value="DOCKER_IMAGE_REFERENCE=ghcr.io/example/launchplane@sha256:old\n",
+        ) as render_env, patch.object(
+            script_module.control_plane_dokploy,
+            "update_dokploy_target_env",
+        ) as update_env, patch.object(
+            script_module.control_plane_dokploy,
+            "latest_deployment_for_target",
+            return_value={"deploymentId": "deploy-before"},
+        ), patch.object(
+            script_module.control_plane_dokploy,
+            "deployment_key",
+            return_value="deploy-before",
+        ), patch.object(
+            script_module.control_plane_dokploy,
+            "trigger_deployment",
+        ) as trigger_deployment, patch.object(
+            script_module.control_plane_dokploy,
+            "wait_for_target_deployment",
+            return_value={"status": "done", "deploymentId": "deploy-after"},
+        ) as wait_for_deployment:
+            evidence = script_module.run_break_glass_rollback()
+
+        self.assertEqual(evidence["schema_version"], 1)
+        self.assertEqual(evidence["event"], "launchplane_break_glass_rollback")
+        self.assertEqual(evidence["fallback_kind"], "direct_dokploy")
+        self.assertEqual(evidence["service_rollback_http_status"], "503")
+        self.assertEqual(evidence["target_type"], "compose")
+        self.assertEqual(evidence["target_id"], "target-1")
+        self.assertTrue(evidence["image_reference_changed"])
+        fetch_target.assert_called_once_with(
+            host="https://dokploy.example.test",
+            token="token-1",
+            target_type="compose",
+            target_id="target-1",
+        )
+        render_env.assert_called_once_with(
+            "DOCKER_IMAGE_REFERENCE=ghcr.io/example/launchplane@sha256:new\n",
+            updates={"DOCKER_IMAGE_REFERENCE": "ghcr.io/example/launchplane@sha256:old"},
+        )
+        update_env.assert_called_once()
+        trigger_deployment.assert_called_once_with(
+            host="https://dokploy.example.test",
+            token="token-1",
+            target_type="compose",
+            target_id="target-1",
+            no_cache=True,
+        )
+        wait_for_deployment.assert_called_once_with(
+            host="https://dokploy.example.test",
+            token="token-1",
+            target_type="compose",
+            target_id="target-1",
+            before_key="deploy-before",
+            timeout_seconds=12,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -401,6 +401,23 @@ class ProductOnboardingTests(unittest.TestCase):
             workflow_text,
         )
 
+    def test_deploy_launchplane_break_glass_rollback_uploads_evidence(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+
+        self.assertIn("LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true", workflow_text)
+        self.assertIn("scripts/deploy/emergency-dokploy-rollback.py", workflow_text)
+        self.assertNotIn("from control_plane import dokploy as control_plane_dokploy", workflow_text)
+        self.assertIn("inputs.break_glass_confirm == ''", workflow_text)
+        self.assertIn(
+            "inputs.break_glass_confirm == 'ROLL BACK LAUNCHPLANE THROUGH DIRECT DOKPLOY'",
+            workflow_text,
+        )
+        self.assertIn("launchplane-break-glass-rollback.json", workflow_text)
+        self.assertIn("name: launchplane-break-glass-rollback", workflow_text)
+        self.assertIn("uses: actions/upload-artifact@v7", workflow_text)
+        self.assertIn("Evidence artifact: launchplane-break-glass-rollback", workflow_text)
+        self.assertIn("manual break-glass only", workflow_text)
+
     def test_deploy_authz_grants_seed_local_admin_self_deploy_authority(self) -> None:
         script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- remove automatic direct Dokploy mutation from failed Launchplane self-deploy rollback
- add an explicit manual break-glass rollback job guarded by exact confirmation inputs
- move direct Dokploy rollback logic into a fail-closed script with reviewable evidence output
- document the new emergency path and add workflow/script tests

Part of #1049.

## Validation
- actionlint .github/workflows/deploy-launchplane.yml
- uv run --extra dev ruff check --diff scripts/deploy/emergency-dokploy-rollback.py tests/test_emergency_dokploy_rollback.py tests/test_product_onboarding.py
- uv run --extra dev ruff check scripts/deploy/emergency-dokploy-rollback.py tests/test_emergency_dokploy_rollback.py tests/test_product_onboarding.py
- uv run python -m unittest tests.test_emergency_dokploy_rollback tests.test_product_onboarding.ProductOnboardingTests.test_deploy_launchplane_break_glass_rollback_uploads_evidence
- uv run python -m unittest tests.test_product_onboarding tests.test_emergency_dokploy_rollback tests.test_service