### PR TITLE
Add identity access inputs to ingress dry run

### DIFF
--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -53,6 +53,22 @@ name: Ingress Route Dry Run
         required: true
         default: "{}"
         type: string
+      identity_access_provider:
+        description: Provider-neutral identity/access provider for forward auth.
+        required: true
+        default: none
+        type: choice
+        options:
+          - none
+          - anubis
+          - tinyauth
+          - authelia
+          - authentik
+      identity_access_send_basic_auth:
+        description: Use Authentik basic-auth forwarding for the identity/access binding.
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -86,6 +102,8 @@ jobs:
           FORWARD_PORT: ${{ inputs.forward_port }}
           CERTIFICATE_ID: ${{ inputs.certificate_id }}
           ROUTE_OPTIONS_JSON: ${{ inputs.route_options_json }}
+          IDENTITY_ACCESS_PROVIDER: ${{ inputs.identity_access_provider }}
+          IDENTITY_ACCESS_SEND_BASIC_AUTH: ${{ inputs.identity_access_send_basic_auth }}
         run: |
           set -euo pipefail
           payload_file="$RUNNER_TEMP/ingress-route-dry-run-request.json"
@@ -97,12 +115,24 @@ jobs:
             --arg forward_scheme "$FORWARD_SCHEME" \
             --arg forward_host "$FORWARD_HOST" \
             --arg route_options_json "$ROUTE_OPTIONS_JSON" \
+            --arg identity_access_provider "$IDENTITY_ACCESS_PROVIDER" \
             --argjson expected_host_id "$EXPECTED_HOST_ID" \
             --argjson forward_port "$FORWARD_PORT" \
             --argjson certificate_id "$CERTIFICATE_ID" \
+            --argjson identity_access_send_basic_auth "$IDENTITY_ACCESS_SEND_BASIC_AUTH" \
             '($route_options_json | fromjson) as $options |
+            (if $identity_access_provider == "none" then "none"
+             elif $identity_access_provider == "authentik" and $identity_access_send_basic_auth then "authentik-send-basic-auth"
+             else $identity_access_provider
+             end) as $mapped_auth_request |
             if ($options | type) != "object" then
               error("route_options_json must be a JSON object")
+            elif $identity_access_provider == "none" and $identity_access_send_basic_auth then
+              error("identity_access_send_basic_auth requires identity_access_provider=authentik")
+            elif $identity_access_provider != "authentik" and $identity_access_send_basic_auth then
+              error("identity_access_send_basic_auth is only valid with identity_access_provider=authentik")
+            elif $identity_access_provider != "none" and (($options.npmplus_auth_request // "none") != "none") and ($options.npmplus_auth_request != $mapped_auth_request) then
+              error("identity_access_provider conflicts with route_options_json.npmplus_auth_request")
             elif ([
               $options
               | keys[]
@@ -129,6 +159,29 @@ jobs:
             ] | length) > 0 then
               error("route_options_json contains unsupported route option key(s)")
             else
+            ({
+              domain_names: [$domain],
+              forward_scheme: $forward_scheme,
+              forward_host: $forward_host,
+              forward_port: $forward_port,
+              certificate_id: $certificate_id,
+              enabled: true,
+              ssl_forced: true,
+              http2_support: true,
+              npmplus_http3_support: true,
+              npmplus_noindex: false,
+              access_list_id: 0
+            } + $options +
+            (if $identity_access_provider == "none" then {}
+             else {
+               identity_access: {
+                 schema_version: 1,
+                 mode: "forward-auth",
+                 provider: $identity_access_provider,
+                 send_basic_auth: $identity_access_send_basic_auth
+               }
+             }
+             end)) as $route |
             {
               schema_version: 1,
               product: $product,
@@ -138,19 +191,7 @@ jobs:
                 mode: "dry-run",
                 expected_host_id: $expected_host_id,
                 reason: $reason,
-                route: {
-                  domain_names: [$domain],
-                  forward_scheme: $forward_scheme,
-                  forward_host: $forward_host,
-                  forward_port: $forward_port,
-                  certificate_id: $certificate_id,
-                  enabled: true,
-                  ssl_forced: true,
-                  http2_support: true,
-                  npmplus_http3_support: true,
-                  npmplus_noindex: false,
-                  access_list_id: 0
-                } + $options
+                route: $route
               }
             }
             end' >"$payload_file"

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -208,9 +208,12 @@ but mixing it with a conflicting identity/access provider fails closed.
 Operators can also use the `Ingress Route Dry Run` GitHub workflow for a
 service-mediated canary plan through GitHub OIDC. The workflow accepts the
 product, context, domain, upstream target, existing certificate id, expected
-provider host id, and route toggles as manual inputs, then calls the same route with
-`mode: dry-run`. Its authz grant is plan-only; an apply still requires the
-separate `ingress_route.apply` permission and an explicit mutation path.
+provider host id, typed identity/access provider, and route toggles as manual
+inputs, then calls the same route with `mode: dry-run`. Its authz grant is
+plan-only; an apply still requires the separate `ingress_route.apply` permission
+and an explicit mutation path. The typed identity/access inputs build the same
+`identity_access` route binding as the CLI and fail closed if they conflict with
+legacy `npmplus_auth_request` values in route options.
 
 The `Ingress Route Canary Apply` workflow is the matching apply proof path. It
 uses the same canary-scoped product/context grant, reads the expected provider

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -261,6 +261,25 @@ class ProductOnboardingTests(unittest.TestCase):
             'error("route_options_json contains unsupported route option key(s)")',
             workflow_text,
         )
+        self.assertIn("identity_access_provider:", workflow_text)
+        self.assertIn("identity_access_send_basic_auth:", workflow_text)
+        self.assertIn(
+            "IDENTITY_ACCESS_PROVIDER: ${{ inputs.identity_access_provider }}", workflow_text
+        )
+        self.assertIn(
+            "IDENTITY_ACCESS_SEND_BASIC_AUTH: ${{ inputs.identity_access_send_basic_auth }}",
+            workflow_text,
+        )
+        self.assertIn("identity_access_provider=authentik", workflow_text)
+        self.assertIn(
+            'error("identity_access_provider conflicts with route_options_json.npmplus_auth_request")',
+            workflow_text,
+        )
+        self.assertIn("identity_access: {", workflow_text)
+        self.assertIn("schema_version: 1", workflow_text)
+        self.assertIn('mode: "forward-auth"', workflow_text)
+        self.assertIn("provider: $identity_access_provider", workflow_text)
+        self.assertIn("send_basic_auth: $identity_access_send_basic_auth", workflow_text)
         self.assertIn(
             "npmplus_noindex: false",
             workflow_text,


### PR DESCRIPTION
## Summary
- add provider-neutral identity/access inputs to the Ingress Route Dry Run workflow
- build the typed identity_access route binding in the dry-run payload
- fail closed on invalid Authentik basic-auth combinations and conflicts with legacy npmplus_auth_request options

## Tests
- uv run python -m unittest tests.test_product_onboarding
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev ruff format --check tests/test_product_onboarding.py
- uv run --extra dev mypy tests/test_product_onboarding.py
- git diff --check
- manual jq smoke tests for identity_access happy path and conflict rejection

Agent review: 2 read-only agents reported no blocking findings.