### PR TITLE
Show ingress change categories in workflow summaries

### DIFF
--- a/.github/workflows/ingress-route-canary-apply.yml
+++ b/.github/workflows/ingress-route-canary-apply.yml
@@ -141,7 +141,8 @@ jobs:
             echo '### Operations'
             jq -r '
               .result.operations[]?
-              | "- \(.action) host=\(.host_id // "new") requires_apply=\(.requires_apply)"
+              | (.change_categories // [] | if length == 0 then "none" else join(",") end) as $categories
+              | "- \(.action) host=\(.host_id // "new") requires_apply=\(.requires_apply) categories=\($categories)"
             ' "$result_file"
           } >>"$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -227,7 +227,8 @@ jobs:
             echo '### Operations'
             jq -r '
               .result.operations[]?
-              | "- \(.action) host=\(.host_id // "new") requires_apply=\(.requires_apply)"
+              | (.change_categories // [] | if length == 0 then "none" else join(",") end) as $categories
+              | "- \(.action) host=\(.host_id // "new") requires_apply=\(.requires_apply) categories=\($categories)"
             ' "$result_file"
           } >>"$GITHUB_STEP_SUMMARY"
 

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -280,6 +280,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn('mode: "forward-auth"', workflow_text)
         self.assertIn("provider: $identity_access_provider", workflow_text)
         self.assertIn("send_basic_auth: $identity_access_send_basic_auth", workflow_text)
+        self.assertIn("categories=\\($categories)", workflow_text)
         self.assertIn(
             "npmplus_noindex: false",
             workflow_text,
@@ -350,6 +351,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertNotIn("      expected_host_id:", inputs_section)
         self.assertIn('forward_scheme: "http"', workflow_text)
         self.assertIn("npmplus_noindex: true", workflow_text)
+        self.assertIn("categories=\\($categories)", workflow_text)
         self.assertNotIn("route_options_json", workflow_text)
         self.assertIn("ingress-route-canary-apply.yml", script_text)
         self.assertIn("deploy:ingress-route-canary-apply-grant", script_text)
@@ -425,7 +427,9 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn("LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true", workflow_text)
         self.assertIn("scripts/deploy/emergency-dokploy-rollback.py", workflow_text)
-        self.assertNotIn("from control_plane import dokploy as control_plane_dokploy", workflow_text)
+        self.assertNotIn(
+            "from control_plane import dokploy as control_plane_dokploy", workflow_text
+        )
         self.assertIn("inputs.break_glass_confirm == ''", workflow_text)
         self.assertIn(
             "inputs.break_glass_confirm == 'ROLL BACK LAUNCHPLANE THROUGH DIRECT DOKPLOY'",


### PR DESCRIPTION
## Summary
- show ingress operation change_categories in dry-run and canary apply workflow summaries
- default missing or empty categories to none for old/no-op responses
- pin the display behavior in workflow contract tests

## Tests
- uv run python -m unittest tests.test_product_onboarding
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev ruff format --check tests/test_product_onboarding.py
- uv run --extra dev mypy tests/test_product_onboarding.py
- git diff --check
- manual jq summary smoke with categorized and uncategorized operations

Agent review: 2 read-only agents reported no blocking findings.