### PR TITLE
Move ingress provider env wiring behind adapter

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -29,7 +29,6 @@ from control_plane import product_context_cutover as control_plane_product_conte
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import live_target_runtime as control_plane_live_target_runtime
-from control_plane.npmplus import NpmplusClient, NpmplusCredentials
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
 from control_plane.agent_context_service import (
@@ -271,7 +270,14 @@ from control_plane.workflows.npmplus_ingress import (
     NpmplusIngressClient,
     NpmplusIngressApplyResult,
 )
-from control_plane.workflows.ingress_provider import IngressProvider, NpmplusIngressProvider
+from control_plane.workflows.ingress_provider import (
+    IngressProvider,
+    NPMPLUS_BASE_URL_ENV_KEY,
+    NPMPLUS_IDENTITY_ENV_KEY,
+    NPMPLUS_SECRET_ENV_KEY,
+    NpmplusIngressProvider,
+    default_ingress_provider,
+)
 from control_plane.merge_train import MergeTrainDryRunResult
 from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train import build_merge_train_dry_run_result
@@ -793,9 +799,9 @@ class _ResolvedProductDriverContext:
 
 
 _LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY = "DOCKER_IMAGE_REFERENCE"
-_NPMPLUS_BASE_URL_ENV_KEY = "LAUNCHPLANE_NPMPLUS_BASE_URL"
-_NPMPLUS_IDENTITY_ENV_KEY = "LAUNCHPLANE_NPMPLUS_IDENTITY"
-_NPMPLUS_SECRET_ENV_KEY = "LAUNCHPLANE_NPMPLUS_SECRET"
+_NPMPLUS_BASE_URL_ENV_KEY = NPMPLUS_BASE_URL_ENV_KEY
+_NPMPLUS_IDENTITY_ENV_KEY = NPMPLUS_IDENTITY_ENV_KEY
+_NPMPLUS_SECRET_ENV_KEY = NPMPLUS_SECRET_ENV_KEY
 _LOGGER = logging.getLogger(__name__)
 _LAUNCHPLANE_SELF_DEPLOY_OAUTH_ENV_KEYS = frozenset(
     {
@@ -6167,31 +6173,6 @@ def _local_operator_identity_from_bearer(
     return LocalOperatorIdentity(subject=subject, token_label=token_label)
 
 
-def _build_npmplus_ingress_client_from_env() -> NpmplusIngressClient:
-    required_env = (
-        _NPMPLUS_BASE_URL_ENV_KEY,
-        _NPMPLUS_IDENTITY_ENV_KEY,
-        _NPMPLUS_SECRET_ENV_KEY,
-    )
-    missing_env = tuple(key for key in required_env if not os.environ.get(key, "").strip())
-    if missing_env:
-        missing_list = ", ".join(missing_env)
-        raise click.ClickException(
-            f"NPMplus ingress client is not configured; missing {missing_list}."
-        )
-    return NpmplusClient(
-        credentials=NpmplusCredentials(
-            base_url=os.environ.get(_NPMPLUS_BASE_URL_ENV_KEY, ""),
-            identity=os.environ.get(_NPMPLUS_IDENTITY_ENV_KEY, ""),
-            secret=os.environ.get(_NPMPLUS_SECRET_ENV_KEY, ""),
-        )
-    )
-
-
-def _build_ingress_provider_from_env() -> IngressProvider:
-    return NpmplusIngressProvider(client=_build_npmplus_ingress_client_from_env())
-
-
 def _local_admin_identity_from_bearer(
     environ: dict[str, object],
 ) -> LocalAdminIdentity | None:
@@ -8300,7 +8281,7 @@ def create_launchplane_service_app(
 
             resolved_ingress_provider_factory = npmplus_ingress_provider_from_client_factory
         else:
-            resolved_ingress_provider_factory = _build_ingress_provider_from_env
+            resolved_ingress_provider_factory = default_ingress_provider
 
     def app(
         environ: dict[str, object],

--- a/control_plane/workflows/ingress_provider.py
+++ b/control_plane/workflows/ingress_provider.py
@@ -1,13 +1,22 @@
 from __future__ import annotations
 
+import os
 from typing import Protocol
 
+import click
+
+from control_plane.npmplus import NpmplusClient, NpmplusCredentials
 from control_plane.workflows.npmplus_ingress import (
     NpmplusIngressApplyRequest,
     NpmplusIngressApplyResult,
     NpmplusIngressClient,
     apply_npmplus_ingress_route,
 )
+
+
+NPMPLUS_BASE_URL_ENV_KEY = "LAUNCHPLANE_NPMPLUS_BASE_URL"
+NPMPLUS_IDENTITY_ENV_KEY = "LAUNCHPLANE_NPMPLUS_IDENTITY"
+NPMPLUS_SECRET_ENV_KEY = "LAUNCHPLANE_NPMPLUS_SECRET"
 
 
 class IngressProvider(Protocol):
@@ -34,3 +43,28 @@ class NpmplusIngressProvider:
         request: NpmplusIngressApplyRequest,
     ) -> NpmplusIngressApplyResult:
         return apply_npmplus_ingress_route(client=self._client, request=request)
+
+
+def build_npmplus_ingress_client_from_env() -> NpmplusIngressClient:
+    required_env = (
+        NPMPLUS_BASE_URL_ENV_KEY,
+        NPMPLUS_IDENTITY_ENV_KEY,
+        NPMPLUS_SECRET_ENV_KEY,
+    )
+    missing_env = tuple(key for key in required_env if not os.environ.get(key, "").strip())
+    if missing_env:
+        missing_list = ", ".join(missing_env)
+        raise click.ClickException(
+            f"NPMplus ingress client is not configured; missing {missing_list}."
+        )
+    return NpmplusClient(
+        credentials=NpmplusCredentials(
+            base_url=os.environ.get(NPMPLUS_BASE_URL_ENV_KEY, ""),
+            identity=os.environ.get(NPMPLUS_IDENTITY_ENV_KEY, ""),
+            secret=os.environ.get(NPMPLUS_SECRET_ENV_KEY, ""),
+        )
+    )
+
+
+def default_ingress_provider() -> IngressProvider:
+    return NpmplusIngressProvider(client=build_npmplus_ingress_client_from_env())

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -163,9 +163,10 @@ Callers send a product/context envelope plus a typed route request. `mode` is
 `ingress_route.plan` for dry-run authorization and `ingress_route.apply` for
 provider mutation authorization. The service resolves an ingress provider
 adapter for route execution; the default provider is NPMplus. The default
-provider constructs its client from environment keys named `LAUNCHPLANE_NPMPLUS_BASE_URL`,
-`LAUNCHPLANE_NPMPLUS_IDENTITY`, and `LAUNCHPLANE_NPMPLUS_SECRET`; do not commit
-real values or local operator overrides.
+provider adapter constructs its client from environment keys named
+`LAUNCHPLANE_NPMPLUS_BASE_URL`, `LAUNCHPLANE_NPMPLUS_IDENTITY`, and
+`LAUNCHPLANE_NPMPLUS_SECRET`; do not commit real values or local operator
+overrides.
 Ingress audit records must persist the adapter's provider identity explicitly;
 do not rely on a provider-specific model default for operator evidence.
 

--- a/tests/test_ingress_provider.py
+++ b/tests/test_ingress_provider.py
@@ -1,0 +1,61 @@
+import os
+import unittest
+from unittest.mock import patch
+
+import click
+
+from control_plane.npmplus import NpmplusClient
+from control_plane.workflows.ingress_provider import (
+    NPMPLUS_BASE_URL_ENV_KEY,
+    NPMPLUS_IDENTITY_ENV_KEY,
+    NPMPLUS_SECRET_ENV_KEY,
+    NpmplusIngressProvider,
+    build_npmplus_ingress_client_from_env,
+    default_ingress_provider,
+)
+
+
+class IngressProviderTests(unittest.TestCase):
+    def test_build_npmplus_ingress_client_from_env_fails_closed_when_missing_env(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(click.ClickException) as raised:
+                build_npmplus_ingress_client_from_env()
+
+        message = str(raised.exception)
+        self.assertIn(NPMPLUS_BASE_URL_ENV_KEY, message)
+        self.assertIn(NPMPLUS_IDENTITY_ENV_KEY, message)
+        self.assertIn(NPMPLUS_SECRET_ENV_KEY, message)
+
+    def test_build_npmplus_ingress_client_from_env_builds_client(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                NPMPLUS_BASE_URL_ENV_KEY: "https://npmplus.example.test",
+                NPMPLUS_IDENTITY_ENV_KEY: "launchplane@example.test",
+                NPMPLUS_SECRET_ENV_KEY: "secret",
+            },
+            clear=True,
+        ):
+            client = build_npmplus_ingress_client_from_env()
+
+        self.assertIsInstance(client, NpmplusClient)
+
+    def test_default_ingress_provider_wraps_npmplus_provider(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                NPMPLUS_BASE_URL_ENV_KEY: "https://npmplus.example.test",
+                NPMPLUS_IDENTITY_ENV_KEY: "launchplane@example.test",
+                NPMPLUS_SECRET_ENV_KEY: "secret",
+            },
+            clear=True,
+        ):
+            provider = default_ingress_provider()
+
+        self.assertIsInstance(provider, NpmplusIngressProvider)
+        self.assertEqual(provider.provider_id, "npmplus")
+        self.assertEqual(provider.delegated_executor, "control-plane.npmplus")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- move default NPMplus ingress env/client construction behind the ingress provider adapter
- keep service-level test injection compatibility for fake NPMplus clients
- add provider module tests for fail-closed missing env and default provider identity
- update driver development docs to name the adapter as the credential construction boundary

Refs #1065
Refs #1041

## Validation

- `git diff --check`
- `uv run --extra dev ruff check control_plane/workflows/ingress_provider.py control_plane/service.py tests/test_ingress_provider.py`
- `uv run python -m unittest tests.test_ingress_provider tests.test_npmplus_ingress_workflow tests.test_ingress_cli tests.test_service.LaunchplaneServiceTests.test_npmplus_ingress_route_apply_dry_run_returns_plan_without_mutation tests.test_service.LaunchplaneServiceTests.test_npmplus_ingress_route_apply_mutates_when_authorized tests.test_service.LaunchplaneServiceTests.test_ingress_route_apply_uses_provider_adapter tests.test_service.LaunchplaneServiceTests.test_npmplus_ingress_route_apply_fails_before_mutation_when_audit_unavailable tests.test_service.LaunchplaneServiceTests.test_npmplus_ingress_route_apply_requires_idempotency_key tests.test_service.LaunchplaneServiceTests.test_npmplus_ingress_route_apply_rejects_unauthorized_context`
- `uv run python -m unittest tests.test_ingress_provider tests.test_generic_web_deploy`
