### PR TITLE
Scope local operator product config grants

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -148,6 +148,13 @@ DB-backed GitHub-human grants for `product_config.plan` and
 Leave those variables unset to skip reconciliation; do not hard-code human
 logins or product-specific operator grants in source.
 
+Routine local-operator product-config grants are scoped, not wildcard. By
+default the deploy reconciliation derives product/context scopes from the typed
+Launchplane seed import catalog. Set
+`LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON` only for an explicit
+operator-reviewed override; use local-admin grants for rare broader repair
+authority instead of widening routine local-operator access.
+
 The deploy workflow maintains DB-backed grants for SellYourOutboard operational
 workflows, including product profile cutover reads/writes, production promotion,
 and generic-web preview refresh/destroy requests. The grant request returns only

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -197,6 +197,55 @@ post_local_owner_grant() {
   return 1
 }
 
+local_operator_product_config_scopes_json() {
+  if [ -n "${LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON:-}" ]; then
+    jq -c \
+      'if type != "array" then error("LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON must be a JSON array") else . end
+       | map({product: (.product // ""), context: (.context // "")})
+       | map(select((.product | length) > 0 and (.context | length) > 0))
+       | unique_by(.product, .context)' \
+      <<<"${LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON}"
+    return 0
+  fi
+
+  jq -c \
+    '[.imports[]
+      | .manifest as $manifest
+      | select(($manifest.product // "") != "")
+      | ($manifest.lanes // [])[]?
+      | select((.context // "") != "")
+      | {product: $manifest.product, context: .context}]
+     | unique_by(.product, .context)' \
+    import-material/launchplane/seed-imports/catalog.json
+}
+
+post_local_operator_product_config_grants() {
+  local action_name="$1"
+  local source_label_prefix="$2"
+  local idempotency_prefix="$3"
+  local scopes_json scope_count product_name context_name scope_suffix
+
+  scopes_json="$(local_operator_product_config_scopes_json)"
+  scope_count="$(jq 'length' <<<"$scopes_json")"
+  if [ "$scope_count" = "0" ]; then
+    echo "No local-operator product-config scopes configured; skipping ${action_name} grant."
+    return 0
+  fi
+
+  jq -c '.[]' <<<"$scopes_json" | while IFS= read -r scope_json; do
+    product_name="$(jq -r '.product' <<<"$scope_json")"
+    context_name="$(jq -r '.context' <<<"$scope_json")"
+    scope_suffix="$(printf '%s-%s' "$product_name" "$context_name" | tr -c '[:alnum:]_.-' '-')"
+    post_local_owner_grant \
+      local-operator \
+      "$product_name" \
+      "$context_name" \
+      "$action_name" \
+      "${source_label_prefix}-${scope_suffix}" \
+      "${idempotency_prefix}-${scope_suffix}"
+  done
+}
+
 post_product_config_human_grant() {
   local action_name="$1"
   local source_label="$2"
@@ -711,17 +760,11 @@ post_grant \
   ingress_route.apply \
   deploy:ingress-route-canary-apply-grant \
   ingress-route-canary-apply
-post_local_owner_grant \
-  local-operator \
-  "*" \
-  "*" \
+post_local_operator_product_config_grants \
   product_config.plan \
   deploy:local-operator-product-config-plan-grant \
   local-operator-product-config-plan
-post_local_owner_grant \
-  local-operator \
-  "*" \
-  "*" \
+post_local_operator_product_config_grants \
   product_config.apply \
   deploy:local-operator-product-config-apply-grant \
   local-operator-product-config-apply

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -827,6 +827,114 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             script_text,
         )
 
+    def test_deploy_authz_grants_scope_local_operator_product_config(
+        self,
+    ) -> None:
+        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
+        extractor = """
+set -euo pipefail
+PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
+"""
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            captured_bin_directory = temporary_directory / "bin"
+            captured_bin_directory.mkdir()
+            (captured_bin_directory / "curl").write_text(
+                "#!/usr/bin/env bash\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
+                "  *)\n"
+                "    output_file=''\n"
+                "    request_payload=''\n"
+                '    while [ "$#" -gt 0 ]; do\n'
+                '      case "$1" in\n'
+                '        -o) shift; output_file="$1" ;;\n'
+                '        --data) shift; request_payload="$1" ;;\n'
+                "      esac\n"
+                "      shift || true\n"
+                "    done\n"
+                "    if printf '%s' \"$request_payload\" | grep -q '\"grant\"'; then\n"
+                "      printf '%s\\n%s\\n' \"$request_payload\" '---END-GRANT---' >> \"$CAPTURED_GRANTS\"\n"
+                "    fi\n"
+                '    if [ -n "$output_file" ]; then\n'
+                '      printf \'{"status":"ok"}\' > "$output_file"\n'
+                "    fi\n"
+                "    printf '200'\n"
+                "    ;;\n"
+                "esac\n"
+            )
+            (captured_bin_directory / "mktemp").write_text(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+            )
+            (captured_bin_directory / "curl").chmod(0o755)
+            (captured_bin_directory / "mktemp").chmod(0o755)
+            captured_grants = temporary_directory / "grants.jsonl"
+            captured_grants.touch()
+            captured_response_file = temporary_directory / "response.json"
+            env = {
+                **os.environ,
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "GITHUB_SHA": "test-sha",
+                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
+                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+                "CAPTURED_GRANTS": str(captured_grants),
+                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
+                "CAPTURED_BIN_DIR": str(captured_bin_directory),
+            }
+
+            result = subprocess.run(
+                ["bash", "-c", extractor],
+                check=False,
+                cwd=script_path.parent.parent.parent,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            grants = [
+                json.loads(grant_text)["grant"]
+                for grant_text in captured_grants.read_text().split("---END-GRANT---")
+                if grant_text.strip()
+            ]
+
+        product_config_grants = [
+            grant
+            for grant in grants
+            if grant["actions"][0].startswith("product_config.")
+            and "subjects" in grant
+            and "token_labels" in grant
+        ]
+        scoped_grants = {
+            (grant["products"][0], grant["contexts"][0], grant["actions"][0])
+            for grant in product_config_grants
+        }
+        expected_scopes = {
+            ("discord-blue", "discord-blue"),
+            ("verireel", "verireel"),
+            ("odoo-tenant-cm", "cm"),
+            ("odoo-tenant-opw", "opw"),
+        }
+
+        self.assertEqual(
+            scoped_grants,
+            {
+                (product, context, action)
+                for product, context in expected_scopes
+                for action in ("product_config.plan", "product_config.apply")
+            },
+        )
+        for grant in product_config_grants:
+            self.assertNotEqual(grant["products"], ["*"])
+            self.assertNotEqual(grant["contexts"], ["*"])
+            self.assertTrue(
+                grant["source_label"].startswith(
+                    "deploy:local-operator-product-config-"
+                )
+            )
+
     def test_seed_import_verireel_onboarding_manifest_enrolls_preview_lifecycle(self) -> None:
         manifest_payload = _seed_import_manifest("verireel-product-onboarding")
         manifest = ProductOnboardingManifest.model_validate(manifest_payload)


### PR DESCRIPTION
## Summary

- replace default wildcard local-operator product-config grants with catalog-derived product/context scopes
- allow explicit scope override through `LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON`
- add a capture-style regression test that runs the deploy grant script and verifies product-config grants are not `*/*`
- document routine local-operator product-config scope behavior

Refs #1067
Refs #1049
Refs #1041

## Validation

- `git diff --check`
- `shellcheck scripts/deploy/ensure-authz-grants.sh`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run python -m unittest tests.test_product_onboarding`
