### PR TITLE
Configure Launchplane workflow service identity

### DIFF
--- a/.github/workflows/ingress-route-audit-read.yml
+++ b/.github/workflows/ingress-route-audit-read.yml
@@ -54,9 +54,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       PRODUCT: ${{ inputs.product }}
       CONTEXT: ${{ inputs.context }}
       RECORD_ID: ${{ inputs.record_id }}

--- a/.github/workflows/ingress-route-canary-apply.yml
+++ b/.github/workflows/ingress-route-canary-apply.yml
@@ -31,9 +31,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       CANARY_PRODUCT: launchplane
       CANARY_CONTEXT: reon-prod
       CANARY_DOMAIN: ${{ vars.LAUNCHPLANE_INGRESS_CANARY_DOMAIN }}

--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -84,9 +84,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     steps:
       - name: Build ingress route dry run payload
         id: payload

--- a/.github/workflows/live-target-runtime.yml
+++ b/.github/workflows/live-target-runtime.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Request live target runtime sync
         env:
-          SERVICE_URL: https://launchplane.shinycomputers.com
+          SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           PRODUCT: ${{ inputs.product }}
           CONTEXT: ${{ inputs.context }}
           INSTANCE: ${{ inputs.instance }}

--- a/.github/workflows/merge-train-policy-import.yml
+++ b/.github/workflows/merge-train-policy-import.yml
@@ -70,9 +70,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       APPLY_POLICY: ${{ inputs.apply && 'true' || 'false' }}
       POLICY_REPOSITORY: ${{ inputs.repository }}
       POLICY_BASE_BRANCH: ${{ inputs.base_branch }}

--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -102,9 +102,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       MERGE_TRAIN_REPOSITORY: >-
         ${{ inputs.repository || vars.LAUNCHPLANE_MERGE_TRAIN_REPOSITORY }}
       MERGE_TRAIN_BASE_BRANCH: ${{ inputs.base_branch || 'main' }}

--- a/.github/workflows/odoo-config-parameter-override.yml
+++ b/.github/workflows/odoo-config-parameter-override.yml
@@ -56,7 +56,7 @@ jobs:
       KEY_NAME: ${{ inputs.key }}
       VALUE: ${{ inputs.value }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-      LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
+      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
     steps:
       - name: Validate runtime inputs
         shell: bash
@@ -75,10 +75,24 @@ jobs:
             echo 'Only web.base.url is currently service-writable.' >&2
             exit 1
           fi
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
-            echo 'Missing Launchplane service URL or OIDC audience repository variable.' >&2
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
+            echo 'Missing Launchplane service URL repository variable.' >&2
             exit 1
           fi
+          if [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            LAUNCHPLANE_SERVICE_AUDIENCE="$({
+              python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_SERVICE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_SERVICE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+            })"
+          fi
+          echo "LAUNCHPLANE_SERVICE_AUDIENCE=${LAUNCHPLANE_SERVICE_AUDIENCE}" >>"$GITHUB_ENV"
 
       - name: Write config parameter override
         shell: bash

--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -73,7 +73,7 @@ jobs:
       TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
       HEALTH_TIMEOUT_SECONDS: ${{ inputs.health_timeout_seconds }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-      LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
+      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
       POLL_INTERVAL_SECONDS: "15"
       POLL_TIMEOUT_SECONDS: "3600"
     steps:
@@ -91,10 +91,24 @@ jobs:
               exit 1
             fi
           done
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
-            echo 'Missing Launchplane service URL or OIDC audience repository variable.' >&2
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
+            echo 'Missing Launchplane service URL repository variable.' >&2
             exit 1
           fi
+          if [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            LAUNCHPLANE_SERVICE_AUDIENCE="$({
+              python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_SERVICE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_SERVICE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+            })"
+          fi
+          echo "LAUNCHPLANE_SERVICE_AUDIENCE=${LAUNCHPLANE_SERVICE_AUDIENCE}" >>"$GITHUB_ENV"
 
       - name: Create and poll bootstrap operation
         shell: bash

--- a/.github/workflows/odoo-target-replacement-apply.yml
+++ b/.github/workflows/odoo-target-replacement-apply.yml
@@ -119,7 +119,7 @@ jobs:
       TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
       HEALTH_TIMEOUT_SECONDS: ${{ inputs.health_timeout_seconds }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-      LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
+      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
       POLL_INTERVAL_SECONDS: "15"
       POLL_TIMEOUT_SECONDS: "3600"
     steps:
@@ -145,13 +145,26 @@ jobs:
               exit 1
             fi
           done
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || \
-             [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
             echo \
-              'Missing Launchplane service URL or OIDC audience variable.' \
+              'Missing Launchplane service URL variable.' \
               >&2
             exit 1
           fi
+          if [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            LAUNCHPLANE_SERVICE_AUDIENCE="$({
+              python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_SERVICE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_SERVICE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+            })"
+          fi
+          echo "LAUNCHPLANE_SERVICE_AUDIENCE=${LAUNCHPLANE_SERVICE_AUDIENCE}" >>"$GITHUB_ENV"
 
       - name: Create and poll replacement operation
         shell: bash

--- a/.github/workflows/odoo-target-replacement-plan.yml
+++ b/.github/workflows/odoo-target-replacement-plan.yml
@@ -67,7 +67,7 @@ jobs:
       DATA_SOURCE_MODE: ${{ inputs.data_source_mode }}
       CONFIRMATION: ${{ inputs.confirmation }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-      LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
+      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
     steps:
       - name: Validate runtime inputs
         shell: bash
@@ -76,13 +76,26 @@ jobs:
           : "${PRODUCT:?Missing product input}"
           : "${INSTANCE:?Missing instance input}"
           : "${STRATEGY:?Missing strategy input}"
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || \
-             [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
             echo \
-              'Missing Launchplane service URL or OIDC audience variable.' \
+              'Missing Launchplane service URL variable.' \
               >&2
             exit 1
           fi
+          if [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            LAUNCHPLANE_SERVICE_AUDIENCE="$({
+              python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_SERVICE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_SERVICE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+            })"
+          fi
+          echo "LAUNCHPLANE_SERVICE_AUDIENCE=${LAUNCHPLANE_SERVICE_AUDIENCE}" >>"$GITHUB_ENV"
 
       - name: Build replacement plan
         shell: bash

--- a/.github/workflows/odoo-website-bootstrap-override.yml
+++ b/.github/workflows/odoo-website-bootstrap-override.yml
@@ -49,7 +49,7 @@ jobs:
       INSTANCE: ${{ inputs.instance }}
       WEBSITE_BOOTSTRAP_PAYLOAD: ${{ inputs.website_bootstrap_payload }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-      LAUNCHPLANE_SERVICE_AUDIENCE: launchplane.shinycomputers.com
+      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
     steps:
       - name: Validate runtime inputs
         shell: bash
@@ -68,10 +68,24 @@ jobs:
           if [ "$PRODUCT" = "odoo-tenant-opw" ] && [ "$INSTANCE" = "prod" ]; then
             echo 'OPW prod bootstrap override allowed for canonical URL correction.' >&2
           fi
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ] || [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
-            echo 'Missing Launchplane service URL or OIDC audience repository variable.' >&2
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
+            echo 'Missing Launchplane service URL repository variable.' >&2
             exit 1
           fi
+          if [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
+            LAUNCHPLANE_SERVICE_AUDIENCE="$({
+              python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_SERVICE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_SERVICE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+            })"
+          fi
+          echo "LAUNCHPLANE_SERVICE_AUDIENCE=${LAUNCHPLANE_SERVICE_AUDIENCE}" >>"$GITHUB_ENV"
           jq -e 'type == "object"' <<< "$WEBSITE_BOOTSTRAP_PAYLOAD" >/dev/null
 
       - name: Write website bootstrap override

--- a/.github/workflows/product-context-cutover-audit.yml
+++ b/.github/workflows/product-context-cutover-audit.yml
@@ -39,9 +39,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       PRODUCT: ${{ inputs.product }}
       SOURCE_CONTEXT: ${{ inputs.source_context }}
       TARGET_CONTEXT: ${{ inputs.target_context }}

--- a/.github/workflows/product-context-cutover.yml
+++ b/.github/workflows/product-context-cutover.yml
@@ -44,9 +44,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       PRODUCT: ${{ inputs.product }}
       SOURCE_CONTEXT: ${{ inputs.source_context }}
       TARGET_CONTEXT: ${{ inputs.target_context }}

--- a/.github/workflows/product-legacy-context-cleanup.yml
+++ b/.github/workflows/product-legacy-context-cleanup.yml
@@ -41,9 +41,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       PRODUCT: ${{ inputs.product }}
       SOURCE_CONTEXT: ${{ inputs.source_context }}
       TARGET_CONTEXT: ${{ inputs.target_context }}

--- a/.github/workflows/public-ingress-monitor.yml
+++ b/.github/workflows/public-ingress-monitor.yml
@@ -31,9 +31,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       TIMEOUT_SECONDS: ${{ inputs.timeout_seconds || '10' }}
       NOTIFY: >-
         ${{ github.event_name == 'schedule' && 'true' ||

--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -23,6 +23,18 @@ name: Reusable Odoo Artifact Publish
         required: false
         default: "600000"
         type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
     secrets:
       ODOO_GHCR_PUBLISH_TOKEN:
         description: Token allowed to publish the tenant image to GHCR.
@@ -128,8 +140,8 @@ jobs:
         id: publish_inputs
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: https://launchplane.shinycomputers.com
-          audience: launchplane.shinycomputers.com
+          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/artifact-publish-inputs
           payload: >-
             {"schema_version":1,"inputs":{"schema_version":1}}
@@ -208,8 +220,8 @@ jobs:
         id: launchplane
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: https://launchplane.shinycomputers.com
-          audience: launchplane.shinycomputers.com
+          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/artifact-publish
           payload: >-
             {"schema_version":1,"publish":{"schema_version":1}}

--- a/.github/workflows/reusable-odoo-post-deploy.yml
+++ b/.github/workflows/reusable-odoo-post-deploy.yml
@@ -21,6 +21,18 @@ name: Reusable Odoo Post Deploy
         required: false
         default: "600000"
         type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -36,8 +48,8 @@ jobs:
         id: lp
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: https://launchplane.shinycomputers.com
-          audience: launchplane.shinycomputers.com
+          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/post-deploy
           payload: >-
             {"schema_version":1,"product":"odoo","post_deploy":{"schema_version":1}}

--- a/.github/workflows/reusable-odoo-prod-promotion.yml
+++ b/.github/workflows/reusable-odoo-prod-promotion.yml
@@ -13,6 +13,18 @@ name: Reusable Odoo Prod Promotion
         required: false
         default: "2700000"
         type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -28,8 +40,8 @@ jobs:
         id: lp
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: https://launchplane.shinycomputers.com
-          audience: launchplane.shinycomputers.com
+          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/prod-promotion-run
           payload: >-
             {"schema_version":1,"product":"odoo","run":{"schema_version":1}}

--- a/.github/workflows/reusable-odoo-prod-rollback.yml
+++ b/.github/workflows/reusable-odoo-prod-rollback.yml
@@ -26,6 +26,18 @@ name: Reusable Odoo Prod Rollback
         required: false
         default: "1800000"
         type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -41,8 +53,8 @@ jobs:
         id: lp
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: https://launchplane.shinycomputers.com
-          audience: launchplane.shinycomputers.com
+          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/prod-rollback
           payload: >-
             {"schema_version":1,"product":"odoo","rollback":{"schema_version":1,"instance":"prod","source_channel":"testing"}}

--- a/.github/workflows/reusable-odoo-testing-deploy.yml
+++ b/.github/workflows/reusable-odoo-testing-deploy.yml
@@ -27,6 +27,18 @@ name: Reusable Odoo Testing Deploy
         required: false
         default: "2700000"
         type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
     outputs:
       operation_id:
         description: Launchplane target replacement operation ID.
@@ -93,8 +105,8 @@ jobs:
         id: lp
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: https://launchplane.shinycomputers.com
-          audience: launchplane.shinycomputers.com
+          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/target-replacement-apply
           payload: >-
             {"schema_version":1,"replacement":{"schema_version":1,"instance":"testing","strategy":"recreate-in-place","allow_empty_data":true,"data_source_mode":"existing","verify_health":true,"verify_canonical":true,"verify_logo":true,"no_cache":false}}
@@ -115,12 +127,27 @@ jobs:
       - name: Poll target replacement operation
         id: poll
         env:
-          LAUNCHPLANE_URL: https://launchplane.shinycomputers.com
-          AUDIENCE: launchplane.shinycomputers.com
+          LAUNCHPLANE_URL: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          AUDIENCE: ${{ inputs.launchplane_audience }}
           OPERATION_ID: ${{ steps.lp.outputs.operation_id }}
           POLL_URL: ${{ steps.lp.outputs.poll_url }}
         run: |
           set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing Launchplane service URL. Set LAUNCHPLANE_PUBLIC_URL or pass launchplane_url.}"
+          if [ -z "${AUDIENCE:-}" ]; then
+            AUDIENCE="$({
+              python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
+          print(parsed.hostname)
+          PY
+            })"
+          fi
+          echo "AUDIENCE=${AUDIENCE}" >>"$GITHUB_ENV"
           if [ -z "$OPERATION_ID" ] || [ -z "$POLL_URL" ]; then
             echo 'Target replacement response missing operation metadata.' >&2
             exit 1

--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -60,9 +60,7 @@ jobs:
       - launchplane
       - chris-testing-ops-gate
     env:
-      LAUNCHPLANE_SERVICE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       RUNNER_HOST_NAME: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_HOST }}
       RUNNER_EXECUTION_LANE: >-
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE }}

--- a/.github/workflows/work-graph-snapshot-validate.yml
+++ b/.github/workflows/work-graph-snapshot-validate.yml
@@ -18,9 +18,7 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
-      LAUNCHPLANE_URL: >-
-        ${{ vars.LAUNCHPLANE_PUBLIC_URL ||
-        'https://launchplane.shinycomputers.com' }}
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     steps:
       - name: Request work graph snapshot
         shell: bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -277,6 +277,9 @@ testing environment of its own.
 Required GitHub configuration for that workflow:
 
 - repository variables:
+  - `LAUNCHPLANE_PUBLIC_URL`
+  - optional `LAUNCHPLANE_SERVICE_AUDIENCE`; when unset, trusted workflows
+    derive the GitHub OIDC audience from `LAUNCHPLANE_PUBLIC_URL`'s host
   - `LAUNCHPLANE_DOKPLOY_TARGET_TYPE`
   - `LAUNCHPLANE_DOKPLOY_TARGET_ID`
   - `LAUNCHPLANE_DEPLOY_HEALTH_URLS`

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -187,7 +187,10 @@ workflow should not duplicate `/v1/drivers/odoo/artifact-publish-inputs` or
 `/v1/drivers/odoo/artifact-publish` wiring once it uses that workflow. The
 reusable workflow defaults the Launchplane product key to
 `odoo-tenant-${context}` so publish metadata resolves through the tenant product
-profile that owns the image repository and stable lanes.
+profile that owns the image repository and stable lanes. Reusable Odoo workflows
+read the Launchplane service URL from `LAUNCHPLANE_PUBLIC_URL` by default and
+derive the GitHub OIDC audience from that URL host unless the caller passes an
+explicit `launchplane_audience` input.
 
 Odoo testing deploys follow the same ownership shape. Tenant repos own the
 manual dispatch confirmation and pass an explicit stored `artifact_id` plus

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -357,6 +357,36 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("          - prod", workflow_text)
         self.assertNotIn("writes only cm/testing", workflow_text)
 
+    def test_launchplane_workflows_do_not_hardcode_public_service_defaults(self) -> None:
+        workflow_dir = Path(".github/workflows")
+        forbidden_literals = (
+            "https://launchplane.shinycomputers.com",
+            "launchplane.shinycomputers.com",
+        )
+
+        for workflow_path in workflow_dir.glob("*.yml"):
+            workflow_text = workflow_path.read_text(encoding="utf-8")
+            for literal in forbidden_literals:
+                with self.subTest(workflow=workflow_path.name, literal=literal):
+                    self.assertNotIn(literal, workflow_text)
+
+    def test_reusable_odoo_workflows_accept_configured_service_identity(self) -> None:
+        workflow_paths = (
+            Path(".github/workflows/reusable-odoo-artifact-publish.yml"),
+            Path(".github/workflows/reusable-odoo-testing-deploy.yml"),
+            Path(".github/workflows/reusable-odoo-post-deploy.yml"),
+            Path(".github/workflows/reusable-odoo-prod-promotion.yml"),
+            Path(".github/workflows/reusable-odoo-prod-rollback.yml"),
+        )
+
+        for workflow_path in workflow_paths:
+            workflow_text = workflow_path.read_text(encoding="utf-8")
+            with self.subTest(workflow=workflow_path.name):
+                self.assertIn("launchplane_url:", workflow_text)
+                self.assertIn("launchplane_audience:", workflow_text)
+                self.assertIn("inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL", workflow_text)
+                self.assertIn("audience: ${{ inputs.launchplane_audience }}", workflow_text)
+
     def test_ingress_route_dry_run_workflow_rejects_non_object_options(self) -> None:
         workflow_text = Path(".github/workflows/ingress-route-dry-run.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

- Replaces hard-coded Launchplane hosted URL/audience literals in workflow runtime config with `vars.LAUNCHPLANE_PUBLIC_URL` and optional `vars.LAUNCHPLANE_SERVICE_AUDIENCE`.
- Adds optional `launchplane_url` / `launchplane_audience` inputs to reusable Odoo workflows while preserving default caller compatibility via repository variables.
- Documents the configured service identity contract and adds static regression coverage so workflows do not reintroduce production URL/audience literals.

Refs #1069
Refs #1049

## Validation

- `git diff --check`
- `uv run --extra dev ruff check tests/test_product_onboarding.py --diff`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run python -m unittest tests.test_product_onboarding`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml`
