### PR TITLE
Derive deployed target provider from deploy evidence

### DIFF
--- a/control_plane/contracts/deployment_record.py
+++ b/control_plane/contracts/deployment_record.py
@@ -30,9 +30,11 @@ class ResolvedTargetEvidence(BaseModel):
             raise ValueError("resolved target evidence requires target_name")
         return self
 
-    def to_deployed_target_reference(self) -> DeployedTargetReference:
+    def to_deployed_target_reference(
+        self, *, provider_id: str = "dokploy"
+    ) -> DeployedTargetReference:
         return DeployedTargetReference(
-            provider_id="dokploy",
+            provider_id=provider_id,
             target_category=self.target_type,
             target_id=self.target_id,
             display_name=self.target_name,
@@ -74,5 +76,8 @@ class DeploymentRecord(BaseModel):
         if not self.delegated_executor:
             raise ValueError("deployment record requires delegated_executor")
         if self.deployed_target is None and self.resolved_target is not None:
-            self.deployed_target = self.resolved_target.to_deployed_target_reference()
+            provider_id = self.deploy.provider_id.strip().lower() or "dokploy"
+            self.deployed_target = self.resolved_target.to_deployed_target_reference(
+                provider_id=provider_id
+            )
         return self

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -1327,6 +1327,40 @@ class FilesystemRecordStoreTests(unittest.TestCase):
         self.assertEqual(loaded_record.deploy.provider_id, "fake-cloud")
         self.assertEqual(loaded_record.deploy.target_category, "service")
 
+    def test_deployment_record_derives_deployed_target_provider_from_deploy_evidence(
+        self,
+    ) -> None:
+        record = DeploymentRecord(
+            record_id="deployment-20260410T182231Z-syo-prod",
+            artifact_identity=_artifact_identity("artifact-20260410-f45db648"),
+            context="syo",
+            instance="prod",
+            source_git_ref="abc123",
+            resolved_target=ResolvedTargetEvidence(
+                target_type="application",
+                target_id="svc-123",
+                target_name="syo-prod-service",
+            ),
+            deploy=DeploymentEvidence(
+                target_name="syo-prod-service",
+                target_type="application",
+                deploy_mode="fake-cloud-application-api",
+                provider_id="fake-cloud",
+                target_category="service",
+                provider_deploy_mode="application-api",
+                deployment_id="deploy-123",
+                status="pass",
+                started_at="2026-04-10T18:22:31Z",
+                finished_at="2026-04-10T18:24:00Z",
+            ),
+        )
+
+        deployed_target = record.deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.provider_id, "fake-cloud")
+        self.assertEqual(deployed_target.provider_target_type, "application")
+        self.assertEqual(deployed_target.target_id, "svc-123")
+
     def test_list_deployment_records_filters_and_sorts_latest_first(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1367,6 +1367,49 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(loaded_record.deploy.provider_id, "fake-cloud")
         self.assertEqual(loaded_record.deploy.target_category, "service")
 
+    def test_write_and_read_resolved_target_uses_deploy_provider_id(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            record = DeploymentRecord(
+                record_id="deployment-20260420T153000Z-syo-prod",
+                artifact_identity=ArtifactIdentityReference(
+                    artifact_id="artifact-20260420-a1b2c3d4"
+                ),
+                context="syo",
+                instance="prod",
+                source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                resolved_target=ResolvedTargetEvidence(
+                    target_type="application",
+                    target_id="svc-123",
+                    target_name="syo-prod-service",
+                ),
+                deploy=DeploymentEvidence(
+                    target_name="syo-prod-service",
+                    target_type="application",
+                    deploy_mode="fake-cloud-service-api",
+                    provider_id="fake-cloud",
+                    target_category="service",
+                    deployment_id="deploy-123",
+                    status="pass",
+                    started_at="2026-04-20T15:30:00Z",
+                    finished_at="2026-04-20T15:32:00Z",
+                ),
+            )
+
+            store.write_deployment_record(record)
+            loaded_record = store.read_deployment_record(record.record_id)
+            store.close()
+
+        deployed_target = loaded_record.deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.provider_id, "fake-cloud")
+        self.assertEqual(deployed_target.target_id, "svc-123")
+
     def test_write_and_list_generic_web_rollback_plan_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(


### PR DESCRIPTION
## Summary

- Makes `ResolvedTargetEvidence.to_deployed_target_reference()` provider-aware instead of always producing a Dokploy target reference.
- Uses `DeploymentRecord.deploy.provider_id` when backfilling `deployed_target` from legacy `resolved_target` evidence.
- Adds filesystem and postgres regression coverage for non-Dokploy deploy records that only carry resolved target evidence.

Refs #1065
Refs #1041

## Validation

- `git diff --check`
- `uv run --extra dev ruff check control_plane/contracts/deployment_record.py tests/test_filesystem_store.py tests/test_postgres_store.py --diff`
- `uv run --extra dev ruff check control_plane/contracts/deployment_record.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run python -m unittest tests.test_filesystem_store tests.test_postgres_store`
