### PR TITLE
Harden direct Dokploy rollback break-glass

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -645,8 +645,16 @@ jobs:
           : "${LAUNCHPLANE_DOKPLOY_TARGET_ID:?Missing LAUNCHPLANE_DOKPLOY_TARGET_ID variable}"
           : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST secret}"
           : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN secret}"
-          : "${{ inputs.break_glass_image_reference }}"
-          : "${{ inputs.break_glass_reason }}"
+          break_glass_image_reference="${{ inputs.break_glass_image_reference }}"
+          break_glass_reason="${{ inputs.break_glass_reason }}"
+          if [ -z "$break_glass_image_reference" ]; then
+            echo "break_glass_image_reference is required for direct Dokploy rollback." >&2
+            exit 1
+          fi
+          if [ -z "$break_glass_reason" ]; then
+            echo "break_glass_reason is required for direct Dokploy rollback." >&2
+            exit 1
+          fi
 
       - name: Run manual direct Dokploy rollback
         shell: bash
@@ -655,6 +663,7 @@ jobs:
           evidence_file="$RUNNER_TEMP/launchplane-break-glass-rollback.json"
           LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true \
             LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE="${{ inputs.break_glass_image_reference }}" \
+            LAUNCHPLANE_ROLLBACK_REASON="${{ inputs.break_glass_reason }}" \
             LAUNCHPLANE_ROLLBACK_REQUEST_STATUS="manual-break-glass" \
             uv run python scripts/deploy/emergency-dokploy-rollback.py | tee "$evidence_file"
 

--- a/scripts/deploy/emergency-dokploy-rollback.py
+++ b/scripts/deploy/emergency-dokploy-rollback.py
@@ -47,6 +47,7 @@ def run_break_glass_rollback() -> dict[str, Any]:
     target_type = _required_env("LAUNCHPLANE_DOKPLOY_TARGET_TYPE")
     target_id = _required_env("LAUNCHPLANE_DOKPLOY_TARGET_ID")
     image_reference = _required_env("LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE")
+    rollback_reason = _required_env("LAUNCHPLANE_ROLLBACK_REASON")
     rollback_request_status = _required_env("LAUNCHPLANE_ROLLBACK_REQUEST_STATUS")
     deploy_timeout_seconds = _deploy_timeout_seconds()
 
@@ -98,7 +99,7 @@ def run_break_glass_rollback() -> dict[str, Any]:
         "schema_version": 1,
         "event": "launchplane_break_glass_rollback",
         "fallback_kind": "direct_dokploy",
-        "reason": "Launchplane self-deploy rollback service request failed.",
+        "reason": rollback_reason,
         "service_rollback_http_status": rollback_request_status,
         "target_type": target_type,
         "target_id": target_id,

--- a/tests/test_emergency_dokploy_rollback.py
+++ b/tests/test_emergency_dokploy_rollback.py
@@ -34,6 +34,7 @@ class EmergencyDokployRollbackTests(unittest.TestCase):
             "LAUNCHPLANE_DOKPLOY_TARGET_TYPE": "compose",
             "LAUNCHPLANE_DOKPLOY_TARGET_ID": "target-1",
             "LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE": "ghcr.io/example/launchplane@sha256:old",
+            "LAUNCHPLANE_ROLLBACK_REASON": "Restore the last known-good Launchplane image.",
             "LAUNCHPLANE_ROLLBACK_REQUEST_STATUS": "503",
             "LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS": "12",
         }
@@ -70,6 +71,7 @@ class EmergencyDokployRollbackTests(unittest.TestCase):
         self.assertEqual(evidence["schema_version"], 1)
         self.assertEqual(evidence["event"], "launchplane_break_glass_rollback")
         self.assertEqual(evidence["fallback_kind"], "direct_dokploy")
+        self.assertEqual(evidence["reason"], "Restore the last known-good Launchplane image.")
         self.assertEqual(evidence["service_rollback_http_status"], "503")
         self.assertEqual(evidence["target_type"], "compose")
         self.assertEqual(evidence["target_id"], "target-1")

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -559,7 +559,10 @@ class ProductOnboardingTests(unittest.TestCase):
         workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
 
         self.assertIn("LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true", workflow_text)
+        self.assertIn("break_glass_image_reference is required", workflow_text)
+        self.assertIn("break_glass_reason is required", workflow_text)
         self.assertIn("scripts/deploy/emergency-dokploy-rollback.py", workflow_text)
+        self.assertIn("LAUNCHPLANE_ROLLBACK_REASON", workflow_text)
         self.assertNotIn(
             "from control_plane import dokploy as control_plane_dokploy", workflow_text
         )


### PR DESCRIPTION
## Summary
- fail closed when manual direct Dokploy rollback is dispatched without a rollback image or reason
- pass the operator reason into the emergency rollback script
- include the operator reason in reviewable break-glass evidence

## Tests
- git diff --check
- uv run --extra dev ruff check scripts/deploy/emergency-dokploy-rollback.py tests/test_emergency_dokploy_rollback.py tests/test_product_onboarding.py --diff
- uv run --extra dev ruff check scripts/deploy/emergency-dokploy-rollback.py tests/test_emergency_dokploy_rollback.py tests/test_product_onboarding.py
- uv run python -m unittest tests.test_emergency_dokploy_rollback tests.test_product_onboarding
- docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.7 -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml

Refs #1049
