### PR TITLE
Add neutral target reference contract input

### DIFF
--- a/control_plane/contracts/deploy_target.py
+++ b/control_plane/contracts/deploy_target.py
@@ -13,6 +13,98 @@ DeployTargetCategory = Literal[
     "unknown",
 ]
 
+DeployTargetCompatibilityType = Literal["application", "compose"]
+
+
+class DeployTargetContractReference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_name: str
+    provider_id: str = "dokploy"
+    target_category: DeployTargetCategory = "unknown"
+    provider_target_type: str = ""
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "DeployTargetContractReference":
+        self.target_name = self.target_name.strip()
+        self.provider_id = self.provider_id.strip().lower()
+        self.provider_target_type = self.provider_target_type.strip().lower()
+        if not self.target_name:
+            raise ValueError("deploy target contract reference requires target_name")
+        if not self.provider_id:
+            raise ValueError("deploy target contract reference requires provider_id")
+        return self
+
+    def legacy_target_type(self) -> DeployTargetCompatibilityType | None:
+        if self.target_category == "application":
+            return "application"
+        if self.target_category == "compose":
+            return "compose"
+        if self.provider_target_type == "application":
+            return "application"
+        if self.provider_target_type == "compose":
+            return "compose"
+        return None
+
+
+def apply_target_reference_defaults(data: object) -> object:
+    if not isinstance(data, dict):
+        return data
+    raw_reference = data.get("target_reference")
+    if raw_reference is None:
+        return data
+    reference = DeployTargetContractReference.model_validate(raw_reference)
+    updated = dict(data)
+    if not str(updated.get("target_name", "")).strip():
+        updated["target_name"] = reference.target_name
+    if not str(updated.get("provider_id", "")).strip():
+        updated["provider_id"] = reference.provider_id
+    if updated.get("target_category") in {None, ""}:
+        updated["target_category"] = reference.target_category
+    if not str(updated.get("provider_target_type", "")).strip():
+        updated["provider_target_type"] = reference.provider_target_type
+    if not str(updated.get("target_type", "")).strip():
+        legacy_target_type = reference.legacy_target_type()
+        if legacy_target_type is not None:
+            updated["target_type"] = legacy_target_type
+    return updated
+
+
+def ensure_target_reference_matches(
+    reference: DeployTargetContractReference | None,
+    *,
+    target_name: str,
+    target_type: DeployTargetCompatibilityType,
+    provider_id: str,
+    target_category: DeployTargetCategory,
+    provider_target_type: str,
+) -> DeployTargetContractReference:
+    if target_category == "application" and target_type != "application":
+        raise ValueError("target_category does not match target_type")
+    if target_category == "compose" and target_type != "compose":
+        raise ValueError("target_category does not match target_type")
+    if provider_id == "dokploy" and provider_target_type != target_type:
+        raise ValueError("provider_target_type does not match target_type")
+    canonical_reference = DeployTargetContractReference(
+        target_name=target_name,
+        provider_id=provider_id,
+        target_category=target_category,
+        provider_target_type=provider_target_type,
+    )
+    if reference is None:
+        return canonical_reference
+    if reference.target_name != canonical_reference.target_name:
+        raise ValueError("target_reference target_name does not match target_name")
+    if reference.provider_id != canonical_reference.provider_id:
+        raise ValueError("target_reference provider_id does not match provider_id")
+    if reference.target_category != canonical_reference.target_category:
+        raise ValueError("target_reference target_category does not match target_category")
+    if reference.provider_target_type != canonical_reference.provider_target_type:
+        raise ValueError(
+            "target_reference provider_target_type does not match provider_target_type"
+        )
+    return canonical_reference
+
 
 class DeployedTargetReference(BaseModel):
     model_config = ConfigDict(extra="forbid")

--- a/control_plane/contracts/promotion_record.py
+++ b/control_plane/contracts/promotion_record.py
@@ -2,7 +2,12 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from control_plane.contracts.deploy_target import DeployTargetCategory
+from control_plane.contracts.deploy_target import (
+    DeployTargetCategory,
+    DeployTargetContractReference,
+    apply_target_reference_defaults,
+    ensure_target_reference_matches,
+)
 from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
 
 ReleaseStatus = Literal["pending", "pass", "fail", "skipped"]
@@ -53,6 +58,9 @@ class DeploymentEvidence(BaseModel):
     target_name: str
     target_type: Literal["compose", "application"]
     deploy_mode: str
+    target_reference: DeployTargetContractReference | None = Field(
+        default=None, exclude=True
+    )
     provider_id: str = "dokploy"
     target_category: DeployTargetCategory | None = None
     provider_target_type: str = ""
@@ -61,6 +69,11 @@ class DeploymentEvidence(BaseModel):
     status: ReleaseStatus = "pending"
     started_at: str = ""
     finished_at: str = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_target_reference_defaults(cls, data: object) -> object:
+        return apply_target_reference_defaults(data)
 
     @model_validator(mode="after")
     def _validate_provider_evidence(self) -> "DeploymentEvidence":
@@ -75,6 +88,14 @@ class DeploymentEvidence(BaseModel):
             self.provider_target_type = self.target_type
         if not self.provider_deploy_mode:
             self.provider_deploy_mode = self.deploy_mode
+        self.target_reference = ensure_target_reference_matches(
+            self.target_reference,
+            target_name=self.target_name,
+            target_type=self.target_type,
+            provider_id=self.provider_id,
+            target_category=self.target_category,
+            provider_target_type=self.provider_target_type,
+        )
         return self
 
 
@@ -188,6 +209,9 @@ class PromotionRequest(BaseModel):
     to_instance: str
     target_name: str
     target_type: Literal["compose", "application"]
+    target_reference: DeployTargetContractReference | None = Field(
+        default=None, exclude=True
+    )
     provider_id: str = "dokploy"
     target_category: DeployTargetCategory | None = None
     provider_target_type: str = ""
@@ -203,6 +227,11 @@ class PromotionRequest(BaseModel):
     source_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
     backup_gate: BackupGateEvidence = Field(default_factory=BackupGateEvidence)
     destination_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_target_reference_defaults(cls, data: object) -> object:
+        return apply_target_reference_defaults(data)
 
     @model_validator(mode="after")
     def _validate_request(self) -> "PromotionRequest":
@@ -227,6 +256,14 @@ class PromotionRequest(BaseModel):
             self.provider_target_type = self.target_type
         if not self.provider_deploy_mode:
             self.provider_deploy_mode = self.deploy_mode
+        self.target_reference = ensure_target_reference_matches(
+            self.target_reference,
+            target_name=self.target_name,
+            target_type=self.target_type,
+            provider_id=self.provider_id,
+            target_category=self.target_category,
+            provider_target_type=self.provider_target_type,
+        )
         if self.from_instance == self.to_instance:
             raise ValueError("promotion source and destination instances must differ")
         return self

--- a/control_plane/contracts/ship_request.py
+++ b/control_plane/contracts/ship_request.py
@@ -1,6 +1,11 @@
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from control_plane.contracts.deploy_target import DeployTargetCategory
+from control_plane.contracts.deploy_target import (
+    DeployTargetCategory,
+    DeployTargetContractReference,
+    apply_target_reference_defaults,
+    ensure_target_reference_matches,
+)
 from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 
@@ -15,6 +20,9 @@ class ShipRequest(BaseModel):
     source_git_ref: str
     target_name: str
     target_type: DokployTargetType
+    target_reference: DeployTargetContractReference | None = Field(
+        default=None, exclude=True
+    )
     provider_id: str = "dokploy"
     target_category: DeployTargetCategory | None = None
     provider_target_type: str = ""
@@ -28,6 +36,11 @@ class ShipRequest(BaseModel):
     no_cache: bool = False
     allow_dirty: bool = False
     destination_health: HealthcheckEvidence = Field(default_factory=HealthcheckEvidence)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_target_reference_defaults(cls, data: object) -> object:
+        return apply_target_reference_defaults(data)
 
     @model_validator(mode="after")
     def _validate_request(self) -> "ShipRequest":
@@ -50,4 +63,12 @@ class ShipRequest(BaseModel):
             self.provider_target_type = self.target_type
         if not self.provider_deploy_mode:
             self.provider_deploy_mode = self.deploy_mode
+        self.target_reference = ensure_target_reference_matches(
+            self.target_reference,
+            target_name=self.target_name,
+            target_type=self.target_type,
+            provider_id=self.provider_id,
+            target_category=self.target_category,
+            provider_target_type=self.provider_target_type,
+        )
         return self

--- a/docs/records.md
+++ b/docs/records.md
@@ -128,6 +128,12 @@ an ORM column/table or remains only in the evidence payload.
   Existing Dokploy-shaped `resolved_target` and deploy-mode fields remain
   readable compatibility evidence and are translated into the neutral target
   reference when no explicit provider-neutral target is present.
+- Shared ship and promotion request/evidence contracts accept a neutral
+  `target_reference` compatibility input for target name, provider id,
+  category, and provider target type. Persisted records still write the flat
+  compatibility fields until the record schema migration has explicit
+  retirement criteria; mixed neutral and legacy target facts fail closed when
+  they disagree.
 - Runtime environment: modeled fields are `scope`, `context`, `instance`, and
   `updated_at`. Individual key/value settings stay payload-only until GUI
   filtering or editing requires a setting table.

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -388,6 +388,55 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(request.target_category, "compose")
         self.assertEqual(request.provider_target_type, "compose")
         self.assertEqual(request.provider_deploy_mode, "dokploy-compose-api")
+        self.assertIsNotNone(request.target_reference)
+        assert request.target_reference is not None
+        self.assertEqual(request.target_reference.target_name, "opw-prod")
+        self.assertEqual(request.target_reference.provider_id, "dokploy")
+
+    def test_ship_request_accepts_target_reference_input(self) -> None:
+        request = ShipRequest.model_validate(
+            {
+                "artifact_id": "artifact-sha256-image456",
+                "context": "opw",
+                "instance": "prod",
+                "source_git_ref": "abc123",
+                "target_reference": {
+                    "target_name": "opw-prod",
+                    "provider_id": "dokploy",
+                    "target_category": "compose",
+                    "provider_target_type": "compose",
+                },
+                "deploy_mode": "dokploy-compose-api",
+            }
+        )
+
+        self.assertEqual(request.target_name, "opw-prod")
+        self.assertEqual(request.target_type, "compose")
+        self.assertEqual(request.provider_id, "dokploy")
+        self.assertEqual(request.target_category, "compose")
+        self.assertEqual(request.provider_target_type, "compose")
+        self.assertNotIn("target_reference", request.model_dump())
+
+    def test_ship_request_rejects_conflicting_target_reference(self) -> None:
+        with self.assertRaisesRegex(ValueError, "target_reference provider_id"):
+            ShipRequest.model_validate(
+                {
+                    "artifact_id": "artifact-sha256-image456",
+                    "context": "opw",
+                    "instance": "prod",
+                    "source_git_ref": "abc123",
+                    "target_name": "opw-prod",
+                    "target_type": "compose",
+                    "provider_id": "dokploy",
+                    "target_reference": {
+                        "target_name": "opw-prod",
+                        "provider_id": "fake-cloud",
+                        "target_category": "compose",
+                        "provider_target_type": "compose",
+                    },
+                    "deploy_mode": "dokploy-compose-api",
+                },
+            )
 
     def test_promotion_request_accepts_provider_target_type(self) -> None:
         request = PromotionRequest(
@@ -410,6 +459,57 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(request.target_category, "service")
         self.assertEqual(request.provider_target_type, "managed-service")
         self.assertEqual(request.provider_deploy_mode, "service-api")
+        self.assertIsNotNone(request.target_reference)
+        assert request.target_reference is not None
+        self.assertEqual(request.target_reference.provider_id, "fake-cloud")
+
+    def test_promotion_request_accepts_target_reference_input(self) -> None:
+        request = PromotionRequest.model_validate(
+            {
+                "artifact_id": "artifact-sha256-image456",
+                "backup_record_id": "backup-opw-prod-20260410T182231Z",
+                "source_git_ref": "abc123",
+                "context": "opw",
+                "from_instance": "testing",
+                "to_instance": "prod",
+                "target_reference": {
+                    "target_name": "opw-prod",
+                    "provider_id": "dokploy",
+                    "target_category": "application",
+                    "provider_target_type": "application",
+                },
+                "deploy_mode": "dokploy-application-api",
+            }
+        )
+
+        self.assertEqual(request.target_name, "opw-prod")
+        self.assertEqual(request.target_type, "application")
+        self.assertEqual(request.provider_id, "dokploy")
+        self.assertEqual(request.target_category, "application")
+        self.assertEqual(request.provider_target_type, "application")
+        self.assertNotIn("target_reference", request.model_dump())
+
+    def test_promotion_request_rejects_conflicting_target_reference(self) -> None:
+        with self.assertRaisesRegex(ValueError, "target_category does not match target_type"):
+            PromotionRequest.model_validate(
+                {
+                    "artifact_id": "artifact-sha256-image456",
+                    "backup_record_id": "backup-opw-prod-20260410T182231Z",
+                    "source_git_ref": "abc123",
+                    "context": "opw",
+                    "from_instance": "testing",
+                    "to_instance": "prod",
+                    "target_name": "opw-prod",
+                    "target_type": "compose",
+                    "target_reference": {
+                        "target_name": "opw-prod",
+                        "provider_id": "dokploy",
+                        "target_category": "application",
+                        "provider_target_type": "compose",
+                    },
+                    "deploy_mode": "dokploy-compose-api",
+                },
+            )
 
     def test_deployment_evidence_accepts_provider_target_type(self) -> None:
         evidence = DeploymentEvidence(
@@ -426,6 +526,47 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(evidence.target_category, "service")
         self.assertEqual(evidence.provider_target_type, "managed-service")
         self.assertEqual(evidence.provider_deploy_mode, "service-api")
+        self.assertIsNotNone(evidence.target_reference)
+        assert evidence.target_reference is not None
+        self.assertEqual(evidence.target_reference.target_name, "syo-prod-service")
+
+    def test_deployment_evidence_accepts_target_reference_input(self) -> None:
+        evidence = DeploymentEvidence.model_validate(
+            {
+                "target_reference": {
+                    "target_name": "opw-prod",
+                    "provider_id": "dokploy",
+                    "target_category": "compose",
+                    "provider_target_type": "compose",
+                },
+                "deploy_mode": "dokploy-compose-api",
+                "deployment_id": "deploy-123",
+                "status": "pass",
+            }
+        )
+
+        self.assertEqual(evidence.target_name, "opw-prod")
+        self.assertEqual(evidence.target_type, "compose")
+        self.assertEqual(evidence.provider_id, "dokploy")
+        self.assertEqual(evidence.target_category, "compose")
+        self.assertEqual(evidence.provider_target_type, "compose")
+        self.assertNotIn("target_reference", evidence.model_dump())
+
+    def test_deployment_evidence_rejects_conflicting_target_reference(self) -> None:
+        with self.assertRaisesRegex(ValueError, "provider_target_type does not match target_type"):
+            DeploymentEvidence.model_validate(
+                {
+                    "target_name": "opw-prod",
+                    "target_type": "compose",
+                    "target_reference": {
+                        "target_name": "opw-prod",
+                        "provider_id": "dokploy",
+                        "target_category": "compose",
+                        "provider_target_type": "application",
+                    },
+                    "deploy_mode": "dokploy-compose-api",
+                },
+            )
 
     def test_build_executed_promotion_record_preserves_provider_target_type(self) -> None:
         request = PromotionRequest(


### PR DESCRIPTION
## Summary

- add a shared `DeployTargetContractReference` compatibility input model
- let `ShipRequest`, `PromotionRequest`, and `DeploymentEvidence` accept `target_reference` and normalize it back to existing flat compatibility fields
- fail closed when mixed neutral and legacy target facts disagree, without changing persisted record serialization
- document the compatibility boundary in `docs/records.md`

Refs #1087

## Validation

- `uv run python -m unittest tests.test_promote`
- `uv run python -m unittest tests.test_generic_web_deploy tests.test_generic_web_promotion tests.test_filesystem_store tests.test_evidence_ingestion`
- `uv run python -m unittest tests.test_promote tests.test_generic_web_deploy tests.test_generic_web_promotion tests.test_filesystem_store tests.test_evidence_ingestion`
- `uv run --extra dev ruff check control_plane/contracts/deploy_target.py control_plane/contracts/ship_request.py control_plane/contracts/promotion_record.py tests/test_promote.py --diff`
- `uv run --extra dev ruff check control_plane/contracts/deploy_target.py control_plane/contracts/ship_request.py control_plane/contracts/promotion_record.py tests/test_promote.py`
- `uv run --extra dev mypy control_plane tests`
- `npx --no-install markdownlint-cli2 docs/records.md`
- `git diff --check`
