### PR TITLE
Add provider targets onboarding alias

### DIFF
--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -165,6 +165,24 @@ class ProductOnboardingManifest(BaseModel):
     updated_at: str = ""
     source_label: str = "product-onboarding"
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_provider_targets(cls, data: object) -> object:
+        if not isinstance(data, dict) or "provider_targets" not in data:
+            return data
+        updated = dict(data)
+        raw_provider_targets = updated.pop("provider_targets")
+        raw_dokploy_targets = updated.get("dokploy_targets", ())
+        if raw_dokploy_targets is None or raw_dokploy_targets == () or raw_dokploy_targets == []:
+            updated["dokploy_targets"] = raw_provider_targets or ()
+            return updated
+
+        provider_targets = _normalized_onboarding_targets(raw_provider_targets)
+        dokploy_targets = _normalized_onboarding_targets(raw_dokploy_targets)
+        if provider_targets != dokploy_targets:
+            raise ValueError("provider_targets must match dokploy_targets when both are set")
+        return updated
+
     @model_validator(mode="after")
     def _validate_manifest(self) -> "ProductOnboardingManifest":
         if not self.product.strip():
@@ -275,3 +293,14 @@ class ProductOnboardingManifest(BaseModel):
         return ProductExpectedConfigProfile.model_validate(
             self.expected_config.model_dump(mode="json")
         )
+
+
+def _normalized_onboarding_targets(data: object) -> tuple[dict[str, object], ...]:
+    if data is None:
+        return ()
+    if not isinstance(data, (list, tuple)):
+        raise ValueError("product onboarding provider_targets must be a list")
+    return tuple(
+        ProductOnboardingTargetManifest.model_validate(target).model_dump(mode="json")
+        for target in data
+    )

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -60,13 +60,15 @@ The manifest is applied idempotently and writes Launchplane-owned records for:
 - product profile with product key, owning repo, driver id, image repository,
   runtime port, health path, and preview policy
 - lane profiles for stable instances such as `testing` and `prod`
-- Dokploy or provider target records and target-id records
+- provider target records and target-id records
 - runtime-environment records for non-secret settings
 - disabled managed secret binding placeholders for required secret keys
 
-Each onboarding `dokploy_targets` entry must include the live provider
-`target_id`. Launchplane fails closed instead of seeding a target record that a
-later deploy cannot resolve.
+Each onboarding target entry must include the live provider `target_id`.
+Manifests may use the neutral `provider_targets` input name; Launchplane
+normalizes it to the existing `dokploy_targets` compatibility field until the
+target-record write path is migrated. Launchplane fails closed instead of
+seeding a target record that a later deploy cannot resolve.
 
 When the Dokploy application or compose target already exists, adopt it into
 Launchplane before or after onboarding instead of hand-editing target ids into

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1377,6 +1377,46 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(secret_bindings[0].binding_key, "SMTP_PASSWORD")
         self.assertEqual(secret_bindings[0].status, "disabled")
 
+    def test_product_onboarding_manifest_accepts_provider_targets_alias(self) -> None:
+        payload = _manifest_payload()
+        payload["provider_targets"] = payload.pop("dokploy_targets")
+
+        manifest = ProductOnboardingManifest.model_validate(payload)
+
+        self.assertEqual(len(manifest.dokploy_targets), 2)
+        self.assertEqual(
+            [
+                (target.context, target.instance, target.target_type, target.target_id)
+                for target in manifest.dokploy_targets
+            ],
+            [
+                ("example-site-testing", "testing", "application", "app-testing-123"),
+                ("example-site-prod", "prod", "application", "app-prod-123"),
+            ],
+        )
+        self.assertNotIn("provider_targets", manifest.model_dump())
+
+    def test_product_onboarding_manifest_accepts_matching_provider_targets_alias(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+        payload["provider_targets"] = json.loads(json.dumps(payload["dokploy_targets"]))
+
+        manifest = ProductOnboardingManifest.model_validate(payload)
+
+        self.assertEqual(len(manifest.dokploy_targets), 2)
+
+    def test_product_onboarding_manifest_rejects_conflicting_provider_targets_alias(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+        provider_targets = json.loads(json.dumps(payload["dokploy_targets"]))
+        provider_targets[0]["target_id"] = "app-other-123"
+        payload["provider_targets"] = provider_targets
+
+        with self.assertRaisesRegex(ValueError, "provider_targets must match dokploy_targets"):
+            ProductOnboardingManifest.model_validate(payload)
+
     def test_product_onboarding_manifest_rejects_unowned_target_route(self) -> None:
         payload = _manifest_payload()
         payload["dokploy_targets"] = [


### PR DESCRIPTION
## Summary

- accept neutral `provider_targets` input on product onboarding manifests
- normalize the alias into the existing `dokploy_targets` compatibility field for the current write path
- reject manifests that provide both names with conflicting target adoption data
- document the neutral input name and current compatibility boundary

Refs #1088

## Validation

- `uv run python -m unittest tests.test_product_onboarding`
- `uv run python -m unittest tests.test_product_onboarding_service`
- `uv run --extra dev ruff check control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py --diff`
- `uv run --extra dev ruff check control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py`
- `uv run --extra dev mypy control_plane tests`
- `npx --no-install markdownlint-cli2 docs/new-product-repo.md`
- `git diff --check`
