### PR TITLE
Add neutral onboarding target result summaries

### DIFF
--- a/control_plane/product_onboarding_service.py
+++ b/control_plane/product_onboarding_service.py
@@ -8,27 +8,33 @@ def build_product_onboarding_service_result(
 ) -> tuple[dict[str, object], dict[str, object]]:
     result: dict[str, object] = {
         "product_profile": onboarding_result.product_profile.product,
+        "provider_target_count": len(onboarding_result.dokploy_targets),
+        "provider_target_id_count": len(onboarding_result.dokploy_target_ids),
         "dokploy_target_count": len(onboarding_result.dokploy_targets),
         "dokploy_target_id_count": len(onboarding_result.dokploy_target_ids),
         "runtime_environment_record_count": len(onboarding_result.runtime_environments),
         "secret_binding_count": len(onboarding_result.secret_bindings),
     }
+    provider_targets = [
+        record.model_dump(mode="json") for record in onboarding_result.dokploy_targets
+    ]
+    provider_target_ids = [
+        {
+            "context": record.context,
+            "instance": record.instance,
+            "target_id_recorded": bool(record.target_id.strip()),
+            "updated_at": record.updated_at,
+            "source_label": record.source_label,
+        }
+        for record in onboarding_result.dokploy_target_ids
+    ]
     driver_result: dict[str, object] = {
         "product": onboarding_result.product,
         "product_profile": onboarding_result.product_profile.model_dump(mode="json"),
-        "dokploy_targets": [
-            record.model_dump(mode="json") for record in onboarding_result.dokploy_targets
-        ],
-        "dokploy_target_ids": [
-            {
-                "context": record.context,
-                "instance": record.instance,
-                "target_id_recorded": bool(record.target_id.strip()),
-                "updated_at": record.updated_at,
-                "source_label": record.source_label,
-            }
-            for record in onboarding_result.dokploy_target_ids
-        ],
+        "provider_targets": provider_targets,
+        "provider_target_ids": provider_target_ids,
+        "dokploy_targets": provider_targets,
+        "dokploy_target_ids": provider_target_ids,
         "runtime_environment_records": [
             {
                 "scope": record.scope,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -836,7 +836,9 @@ records, target-id records, runtime-environment records, and managed secret
 binding placeholders. It is restricted to `product_onboarding.apply` authority
 for product/context `launchplane`, requires DB-backed storage, returns only
 sanitized summaries, and exists so the Launchplane seed import workflow can seed
-product records without product repos storing live lifecycle truth.
+product records without product repos storing live lifecycle truth. Responses
+include neutral `provider_target*` summary keys while retaining `dokploy_*`
+compatibility keys until the target-record write path is migrated.
 
 Live target runtime sync uses `POST /v1/live-target-runtime/apply`. The route
 accepts `mode: "dry-run"` or `mode: "apply"`, product/context/instance, and

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -79,11 +79,17 @@ class ProductOnboardingServiceTests(unittest.TestCase):
         result, driver_result = build_product_onboarding_service_result(onboarding_result)
 
         self.assertEqual(result["product_profile"], "discord-blue")
+        self.assertEqual(result["provider_target_count"], 1)
+        self.assertEqual(result["provider_target_id_count"], 1)
         self.assertEqual(result["dokploy_target_count"], 1)
         self.assertEqual(result["dokploy_target_id_count"], 1)
         self.assertEqual(result["runtime_environment_record_count"], 1)
         self.assertEqual(result["secret_binding_count"], 1)
         self.assertEqual(driver_result["product"], "discord-blue")
+        self.assertEqual(driver_result["provider_targets"], driver_result["dokploy_targets"])
+        self.assertEqual(
+            driver_result["provider_target_ids"], driver_result["dokploy_target_ids"]
+        )
         self.assertNotIn("secret_id", str(driver_result))
 
 


### PR DESCRIPTION
## Summary

- add neutral `provider_target*` count keys to product-onboarding apply summaries
- expose `provider_targets` and `provider_target_ids` in the driver result while preserving existing `dokploy_*` compatibility keys
- document the response-shape compatibility boundary in `docs/service-boundary.md`

Refs #1088

## Validation

- `uv run python -m unittest tests.test_product_onboarding_service tests.test_product_onboarding`
- `uv run --extra dev ruff check control_plane/product_onboarding_service.py tests/test_product_onboarding_service.py --diff`
- `uv run --extra dev ruff check control_plane/product_onboarding_service.py tests/test_product_onboarding_service.py`
- `uv run --extra dev mypy control_plane tests`
- `npx --no-install markdownlint-cli2 docs/service-boundary.md`
- `git diff --check`
