### PR TITLE
Add provider target record contract

### DIFF
--- a/control_plane/contracts/deploy_target.py
+++ b/control_plane/contracts/deploy_target.py
@@ -4,6 +4,9 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+
 DeployTargetCategory = Literal[
     "application",
     "compose",
@@ -136,3 +139,87 @@ class DeployedTargetReference(BaseModel):
             normalized_evidence[key] = raw_value.strip()
         self.provider_evidence = normalized_evidence
         return self
+
+
+class ProviderTargetRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str
+    provider_id: str
+    target_category: DeployTargetCategory = "unknown"
+    target_id: str
+    display_name: str
+    provider_target_type: str = ""
+    provider_evidence: dict[str, str] = Field(default_factory=dict)
+    updated_at: str
+    source_label: str = ""
+
+    @model_validator(mode="after")
+    def _validate_target(self) -> "ProviderTargetRecord":
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        self.provider_id = self.provider_id.strip().lower()
+        self.target_id = self.target_id.strip()
+        self.display_name = self.display_name.strip()
+        self.provider_target_type = self.provider_target_type.strip().lower()
+        self.updated_at = self.updated_at.strip()
+        self.source_label = self.source_label.strip()
+        if not self.context:
+            raise ValueError("provider target record requires context")
+        if not self.instance:
+            raise ValueError("provider target record requires instance")
+        if not self.provider_id:
+            raise ValueError("provider target record requires provider_id")
+        if not self.target_id:
+            raise ValueError("provider target record requires target_id")
+        if not self.display_name:
+            raise ValueError("provider target record requires display_name")
+        if not self.updated_at:
+            raise ValueError("provider target record requires updated_at")
+        normalized_evidence: dict[str, str] = {}
+        for raw_key, raw_value in self.provider_evidence.items():
+            key = raw_key.strip()
+            if not key:
+                raise ValueError("provider target evidence keys must be non-empty")
+            normalized_evidence[key] = raw_value.strip()
+        self.provider_evidence = normalized_evidence
+        return self
+
+    @classmethod
+    def from_dokploy_records(
+        cls,
+        *,
+        target_record: DokployTargetRecord,
+        target_id_record: DokployTargetIdRecord,
+    ) -> "ProviderTargetRecord":
+        if target_record.context != target_id_record.context:
+            raise ValueError("Dokploy target context must match target-id context")
+        if target_record.instance != target_id_record.instance:
+            raise ValueError("Dokploy target instance must match target-id instance")
+        return cls(
+            context=target_record.context,
+            instance=target_record.instance,
+            provider_id="dokploy",
+            target_category=target_record.target_type,
+            target_id=target_id_record.target_id,
+            display_name=target_record.target_name or target_record.instance,
+            provider_target_type=target_record.target_type,
+            provider_evidence={"project_name": target_record.project_name}
+            if target_record.project_name
+            else {},
+            updated_at=max(target_record.updated_at, target_id_record.updated_at),
+            source_label=target_record.source_label.strip()
+            or target_id_record.source_label.strip(),
+        )
+
+    def to_deployed_target_reference(self) -> DeployedTargetReference:
+        return DeployedTargetReference(
+            provider_id=self.provider_id,
+            target_category=self.target_category,
+            target_id=self.target_id,
+            display_name=self.display_name,
+            provider_target_type=self.provider_target_type,
+            provider_evidence=self.provider_evidence,
+        )

--- a/docs/records.md
+++ b/docs/records.md
@@ -128,6 +128,12 @@ an ORM column/table or remains only in the evidence payload.
   Existing Dokploy-shaped `resolved_target` and deploy-mode fields remain
   readable compatibility evidence and are translated into the neutral target
   reference when no explicit provider-neutral target is present.
+- Provider target records define the neutral target inventory contract:
+  `context`, `instance`, `provider_id`, `target_category`, `target_id`,
+  `display_name`, `provider_target_type`, `updated_at`, and payload-only
+  provider evidence. Existing Dokploy target and target-id records remain the
+  active storage/write path until a later migration adds provider-neutral
+  storage and read-model coverage.
 - Shared ship and promotion request/evidence contracts accept a neutral
   `target_reference` compatibility input for target name, provider id,
   category, and provider target type. Persisted records still write the flat

--- a/tests/test_deploy_target.py
+++ b/tests/test_deploy_target.py
@@ -1,0 +1,181 @@
+import unittest
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+
+
+class DeployTargetContractTests(unittest.TestCase):
+    def test_provider_target_record_normalizes_identity_and_evidence(self) -> None:
+        record = ProviderTargetRecord(
+            context=" syo ",
+            instance=" prod ",
+            provider_id=" Fake-Cloud ",
+            target_category="service",
+            target_id=" svc-123 ",
+            display_name=" SYO Prod ",
+            provider_target_type=" Managed-Service ",
+            provider_evidence={" region ": " us-east-1 "},
+            updated_at=" 2026-06-01T20:00:00Z ",
+            source_label=" import-material:syo ",
+        )
+
+        self.assertEqual(record.context, "syo")
+        self.assertEqual(record.instance, "prod")
+        self.assertEqual(record.provider_id, "fake-cloud")
+        self.assertEqual(record.target_id, "svc-123")
+        self.assertEqual(record.display_name, "SYO Prod")
+        self.assertEqual(record.provider_target_type, "managed-service")
+        self.assertEqual(record.provider_evidence, {"region": "us-east-1"})
+
+    def test_provider_target_record_rejects_empty_identity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires target_id"):
+            ProviderTargetRecord(
+                context="syo",
+                instance="prod",
+                provider_id="fake-cloud",
+                target_category="service",
+                target_id="",
+                display_name="SYO Prod",
+                provider_target_type="managed-service",
+                updated_at="2026-06-01T20:00:00Z",
+            )
+
+    def test_provider_target_record_rejects_empty_evidence_key(self) -> None:
+        with self.assertRaisesRegex(ValueError, "evidence keys"):
+            ProviderTargetRecord(
+                context="syo",
+                instance="prod",
+                provider_id="fake-cloud",
+                target_category="service",
+                target_id="svc-123",
+                display_name="SYO Prod",
+                provider_target_type="managed-service",
+                provider_evidence={" ": "us-east-1"},
+                updated_at="2026-06-01T20:00:00Z",
+            )
+
+    def test_provider_target_record_from_dokploy_records(self) -> None:
+        target_record = DokployTargetRecord(
+            context="syo",
+            instance="prod",
+            project_name="SYO",
+            target_type="application",
+            target_name="syo-prod",
+            updated_at="2026-06-01T20:00:00Z",
+            source_label="import-material:syo",
+        )
+        target_id_record = DokployTargetIdRecord(
+            context="syo",
+            instance="prod",
+            target_id="app-syo-prod",
+            updated_at="2026-06-01T20:00:01Z",
+            source_label="target-id:syo",
+        )
+
+        provider_record = ProviderTargetRecord.from_dokploy_records(
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
+
+        self.assertEqual(provider_record.provider_id, "dokploy")
+        self.assertEqual(provider_record.target_category, "application")
+        self.assertEqual(provider_record.target_id, "app-syo-prod")
+        self.assertEqual(provider_record.display_name, "syo-prod")
+        self.assertEqual(provider_record.provider_target_type, "application")
+        self.assertEqual(provider_record.provider_evidence, {"project_name": "SYO"})
+        self.assertEqual(provider_record.updated_at, "2026-06-01T20:00:01Z")
+        self.assertEqual(provider_record.source_label, "import-material:syo")
+
+    def test_provider_target_record_from_dokploy_records_uses_fallbacks(self) -> None:
+        target_record = DokployTargetRecord(
+            context="syo",
+            instance="prod",
+            target_type="application",
+            target_name="",
+            updated_at="2026-06-01T20:00:00Z",
+            source_label=" ",
+        )
+        target_id_record = DokployTargetIdRecord(
+            context="syo",
+            instance="prod",
+            target_id="app-syo-prod",
+            updated_at="2026-06-01T20:00:01Z",
+            source_label="target-id:syo",
+        )
+
+        provider_record = ProviderTargetRecord.from_dokploy_records(
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
+
+        self.assertEqual(provider_record.display_name, "prod")
+        self.assertEqual(provider_record.provider_evidence, {})
+        self.assertEqual(provider_record.source_label, "target-id:syo")
+
+    def test_provider_target_record_rejects_mismatched_dokploy_context(self) -> None:
+        target_record = DokployTargetRecord(
+            context="syo-testing",
+            instance="prod",
+            target_type="application",
+            target_name="syo-prod",
+            updated_at="2026-06-01T20:00:00Z",
+        )
+        target_id_record = DokployTargetIdRecord(
+            context="syo",
+            instance="prod",
+            target_id="app-syo-prod",
+            updated_at="2026-06-01T20:00:01Z",
+        )
+
+        with self.assertRaisesRegex(ValueError, "context must match"):
+            ProviderTargetRecord.from_dokploy_records(
+                target_record=target_record,
+                target_id_record=target_id_record,
+            )
+
+    def test_provider_target_record_rejects_mismatched_dokploy_instance(self) -> None:
+        target_record = DokployTargetRecord(
+            context="syo",
+            instance="testing",
+            target_type="application",
+            target_name="syo-testing",
+            updated_at="2026-06-01T20:00:00Z",
+        )
+        target_id_record = DokployTargetIdRecord(
+            context="syo",
+            instance="prod",
+            target_id="app-syo-prod",
+            updated_at="2026-06-01T20:00:01Z",
+        )
+
+        with self.assertRaisesRegex(ValueError, "instance must match"):
+            ProviderTargetRecord.from_dokploy_records(
+                target_record=target_record,
+                target_id_record=target_id_record,
+            )
+
+    def test_provider_target_record_exports_deployed_target_reference(self) -> None:
+        provider_record = ProviderTargetRecord(
+            context="verireel",
+            instance="prod",
+            provider_id="dokploy",
+            target_category="application",
+            target_id="app-ver-prod",
+            display_name="verireel-prod",
+            provider_target_type="application",
+            provider_evidence={"project_name": "VeriReel"},
+            updated_at="2026-06-01T20:00:00Z",
+        )
+
+        deployed_target = provider_record.to_deployed_target_reference()
+
+        self.assertEqual(deployed_target.provider_id, "dokploy")
+        self.assertEqual(deployed_target.target_category, "application")
+        self.assertEqual(deployed_target.target_id, "app-ver-prod")
+        self.assertEqual(deployed_target.display_name, "verireel-prod")
+        self.assertEqual(deployed_target.provider_evidence, {"project_name": "VeriReel"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add neutral `ProviderTargetRecord` contract for future provider-target inventory
- add conversion from existing Dokploy target + target-id records into the neutral contract
- add conversion from provider target records into deployed-target evidence references
- document that Dokploy target records remain the active storage/write path until a later storage/read-model migration

Refs #1065
Refs #1088

## Validation

- `uv run python -m unittest tests.test_deploy_target`
- `uv run python -m unittest tests.test_product_onboarding tests.test_product_onboarding_service tests.test_filesystem_store tests.test_postgres_store`
- `uv run --extra dev ruff check control_plane/contracts/deploy_target.py tests/test_deploy_target.py --diff`
- `uv run --extra dev ruff check control_plane/contracts/deploy_target.py tests/test_deploy_target.py`
- `uv run --extra dev mypy control_plane tests`
- `npx --no-install markdownlint-cli2 docs/records.md`
- `git diff --check`

## Review

- Read-only agent review completed before merge planning.
- Review findings applied: explicit `provider_id`, preserved source-label fallback after trimming, used newest source timestamp from paired Dokploy records, and added context/fallback branch coverage.

## Live-prod safety

- Contract/docs/tests only.
- No storage migration.
- No service, workflow, deploy, promotion, or runtime mutation path changes.
- VeriReel and SYO live/prod paths remain on existing compatibility behavior.
