### PR TITLE
Project provider target read model

### DIFF
--- a/control_plane/contracts/lane_summary.py
+++ b/control_plane/contracts/lane_summary.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ConfigDict, model_validator
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.data_provenance import DataProvenance
-from control_plane.contracts.deploy_target import DeployedTargetReference
+from control_plane.contracts.deploy_target import DeployedTargetReference, ProviderTargetRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
@@ -27,6 +27,7 @@ class LaunchplaneLaneSummary(BaseModel):
     latest_promotion: PromotionRecord | None = None
     latest_backup_gate: BackupGateRecord | None = None
     deployed_target: DeployedTargetReference | None = None
+    provider_target: ProviderTargetRecord | None = None
     dokploy_target_id: DokployTargetIdRecord | None = None
     dokploy_target: DokployTargetRecord | None = None
     runtime_environment_records: tuple[RuntimeEnvironmentRecord, ...] = ()
@@ -40,6 +41,12 @@ class LaunchplaneLaneSummary(BaseModel):
 
     @model_validator(mode="after")
     def _populate_provider_neutral_target(self) -> "LaunchplaneLaneSummary":
+        if self.provider_target is None:
+            if self.dokploy_target is not None and self.dokploy_target_id is not None:
+                self.provider_target = ProviderTargetRecord.from_dokploy_records(
+                    target_record=self.dokploy_target,
+                    target_id_record=self.dokploy_target_id,
+                )
         if self.deployed_target is None and self.latest_deployment is not None:
             self.deployed_target = self.latest_deployment.deployed_target
         return self

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -222,6 +222,8 @@ class ProductTargetSummary(BaseModel):
     provider: str = "dokploy"
     target_type: str = ""
     target_name: str = ""
+    target_id: str = ""
+    provider_target_type: str = ""
     target_id_recorded: bool = False
     artifact_manifest: ArtifactIdentityManifest | None = None
     expected_runtime_identity: RuntimeIdentity | None = None
@@ -1693,6 +1695,27 @@ def _target_summary(lane_summary: LaunchplaneLaneSummary | None) -> ProductTarge
     elif lane_summary.latest_deployment is not None:
         expected_identity = lane_summary.latest_deployment.runtime_identity
         destination_health = lane_summary.latest_deployment.destination_health
+    if lane_summary.provider_target is not None:
+        return ProductTargetSummary(
+            provider=lane_summary.provider_target.provider_id,
+            target_type=lane_summary.provider_target.target_category,
+            target_name=lane_summary.provider_target.display_name,
+            target_id=lane_summary.provider_target.target_id,
+            provider_target_type=lane_summary.provider_target.provider_target_type,
+            target_id_recorded=True,
+            artifact_manifest=lane_summary.artifact_manifest,
+            expected_runtime_identity=expected_identity,
+            observed_runtime_identity=destination_health.observed_runtime_identity
+            if destination_health is not None
+            else None,
+            runtime_identity_status=destination_health.runtime_identity_status
+            if destination_health is not None
+            else "unchecked",
+            runtime_identity_detail=destination_health.runtime_identity_detail
+            if destination_health is not None
+            else "",
+            trust_state="recorded",
+        )
     if lane_summary.dokploy_target is None:
         return ProductTargetSummary(
             artifact_manifest=lane_summary.artifact_manifest,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -27,6 +27,7 @@ from control_plane.contracts.agent_write_intent import AgentWriteIntentRecord
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
@@ -3120,6 +3121,44 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplaneDokployTargetRow.instance.asc(),
             ),
         )
+
+    def read_provider_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> ProviderTargetRecord:
+        target_record = self.read_dokploy_target_record(
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+        target_id_record = self.read_dokploy_target_id_record(
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+        return ProviderTargetRecord.from_dokploy_records(
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
+
+    def list_provider_target_records(
+        self, *, provider_id: str = ""
+    ) -> tuple[ProviderTargetRecord, ...]:
+        normalized_provider_id = provider_id.strip().lower()
+        target_id_records = {
+            (record.context, record.instance): record
+            for record in self.list_dokploy_target_id_records()
+        }
+        provider_records: list[ProviderTargetRecord] = []
+        for target_record in self.list_dokploy_target_records():
+            target_id_record = target_id_records.get((target_record.context, target_record.instance))
+            if target_id_record is None:
+                continue
+            provider_record = ProviderTargetRecord.from_dokploy_records(
+                target_record=target_record,
+                target_id_record=target_id_record,
+            )
+            if normalized_provider_id and provider_record.provider_id != normalized_provider_id:
+                continue
+            provider_records.append(provider_record)
+        return tuple(provider_records)
 
     def delete_dokploy_target_record(
         self,

--- a/docs/records.md
+++ b/docs/records.md
@@ -131,9 +131,10 @@ an ORM column/table or remains only in the evidence payload.
 - Provider target records define the neutral target inventory contract:
   `context`, `instance`, `provider_id`, `target_category`, `target_id`,
   `display_name`, `provider_target_type`, `updated_at`, and payload-only
-  provider evidence. Existing Dokploy target and target-id records remain the
-  active storage/write path until a later migration adds provider-neutral
-  storage and read-model coverage.
+  provider evidence. Launchplane read models can project these neutral records
+  from paired Dokploy target and target-id records. Existing Dokploy target and
+  target-id records remain the active storage/write path until a later migration
+  adds provider-neutral storage.
 - Shared ship and promotion request/evidence contracts accept a neutral
   `target_reference` compatibility input for target name, provider id,
   category, and provider target type. Persisted records still write the flat
@@ -572,6 +573,10 @@ state/
   domains, health policy, and typed product policies.
 - Live `target_id` values remain a sibling DB-backed record so operators can
   update route metadata and route identity independently when needed.
+- Paired Dokploy target and target-id records project to the neutral
+  `ProviderTargetRecord` read model. Missing halves remain missing; Launchplane
+  does not fabricate provider-neutral target identity from only route metadata or
+  only a live id.
 - Shopify guard values such as protected store keys now belong in
   `policies.shopify.protected_store_keys` on this record instead of a route map
   hardcoded in Python.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -863,6 +863,10 @@ Generic web deploys use `POST /v1/drivers/generic-web/deploy`. The request names
 the product, target instance, immutable artifact/image reference, and source ref;
 Launchplane resolves the context from the DB-backed product profile lane and the
 runtime target from DB-backed Dokploy target records.
+Product environment reads expose a neutral provider-target projection when a
+lane has paired DB-backed Dokploy target and target-id records, but generic-web
+deploy and live runtime apply still resolve and mutate through those Dokploy
+records until the provider-neutral write path exists.
 
 Generic web prod promotion can be exercised directly with
 `POST /v1/drivers/generic-web/prod-promotion`; browser sessions may only use this

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -212,6 +212,32 @@ def _deployment_record(*, record_id: str, started_at: str, finished_at: str) -> 
     )
 
 
+def _deployment_record_with_target_id(
+    *, record_id: str, target_id: str, started_at: str, finished_at: str
+) -> DeploymentRecord:
+    return DeploymentRecord(
+        record_id=record_id,
+        artifact_identity=ArtifactIdentityReference(artifact_id="artifact-20260420-a1b2c3d4"),
+        context="opw",
+        instance="testing",
+        source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+        resolved_target=ResolvedTargetEvidence(
+            target_type="compose",
+            target_id=target_id,
+            target_name="opw-testing",
+        ),
+        deploy=DeploymentEvidence(
+            target_name="opw-testing",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            deployment_id="dokploy-1",
+            status="pass",
+            started_at=started_at,
+            finished_at=finished_at,
+        ),
+    )
+
+
 def _generic_web_rollback_plan_record(
     *, plan_id: str, created_at: str
 ) -> GenericWebRollbackPlanRecord:
@@ -346,10 +372,13 @@ def _dokploy_target_id_record(
     )
 
 
-def _dokploy_target_record(*, context: str = "opw", instance: str = "prod") -> DokployTargetRecord:
+def _dokploy_target_record(
+    *, context: str = "opw", instance: str = "prod", project_name: str = ""
+) -> DokployTargetRecord:
     return DokployTargetRecord(
         context=context,
         instance=instance,
+        project_name=project_name,
         target_type="compose",
         target_name=f"{context}-{instance}",
         source_git_ref="origin/main",
@@ -1080,6 +1109,92 @@ class PostgresRecordStoreTests(unittest.TestCase):
             self.assertEqual(loaded.compose_path, "./docker-compose.yml")
             self.assertEqual(len(listed), 1)
             self.assertEqual(listed[0].context, "opw")
+
+    def test_provider_target_records_project_from_dokploy_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            store.write_dokploy_target_record(
+                _dokploy_target_record(
+                    context="syo",
+                    instance="prod",
+                    project_name="syo-prod-project",
+                )
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(
+                    context="syo",
+                    instance="prod",
+                    target_id="app-syo-prod",
+                )
+            )
+
+            loaded = store.read_provider_target_record(context_name="syo", instance_name="prod")
+            listed = store.list_provider_target_records()
+            filtered = store.list_provider_target_records(provider_id=" DOKPLOY ")
+            store.close()
+
+        self.assertEqual(loaded.provider_id, "dokploy")
+        self.assertEqual(loaded.context, "syo")
+        self.assertEqual(loaded.instance, "prod")
+        self.assertEqual(loaded.target_category, "compose")
+        self.assertEqual(loaded.target_id, "app-syo-prod")
+        self.assertEqual(loaded.provider_target_type, "compose")
+        self.assertEqual(loaded.provider_evidence["project_name"], "syo-prod-project")
+        self.assertEqual(len(listed), 1)
+        self.assertEqual(listed[0], loaded)
+        self.assertEqual(filtered, (loaded,))
+
+    def test_provider_target_list_skips_incomplete_dokploy_pairs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            store.write_dokploy_target_record(
+                _dokploy_target_record(context="syo", instance="prod")
+            )
+
+            self.assertEqual(store.list_provider_target_records(), ())
+            with self.assertRaises(FileNotFoundError):
+                store.read_provider_target_record(context_name="syo", instance_name="prod")
+            store.close()
+
+    def test_read_lane_summary_keeps_deployment_target_evidence_separate(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+            store.write_deployment_record(
+                _deployment_record_with_target_id(
+                    record_id="deployment-20260420T153000Z-opw-testing",
+                    target_id="old-compose-id",
+                    started_at="2026-04-20T15:30:00Z",
+                    finished_at="2026-04-20T15:32:00Z",
+                )
+            )
+            store.write_dokploy_target_record(
+                _dokploy_target_record(context="opw", instance="testing")
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(
+                    context="opw",
+                    instance="testing",
+                    target_id="current-compose-id",
+                )
+            )
+
+            summary = store.read_lane_summary(context_name="opw", instance_name="testing")
+            store.close()
+
+        provider_target = summary.provider_target
+        assert provider_target is not None
+        self.assertEqual(provider_target.target_id, "current-compose-id")
+        deployed_target = summary.deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.target_id, "old-compose-id")
 
     def test_idempotency_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2535,6 +2650,11 @@ env_var = "GH_TOKEN"
         dokploy_target = summary.dokploy_target
         assert dokploy_target is not None
         self.assertEqual(dokploy_target.target_name, "opw-testing")
+        provider_target = summary.provider_target
+        assert provider_target is not None
+        self.assertEqual(provider_target.provider_id, "dokploy")
+        self.assertEqual(provider_target.target_category, "compose")
+        self.assertEqual(provider_target.target_id, "compose-123")
         deployed_target = summary.deployed_target
         assert deployed_target is not None
         self.assertEqual(deployed_target.provider_id, "dokploy")

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -14,6 +14,8 @@ from control_plane.contracts.artifact_identity import (
     ArtifactImageReference,
 )
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_environment_read_model import (
     ACTION_AUTHZ_BY_ROUTE,
@@ -1165,6 +1167,53 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             "odoo-devkit",
         )
         self.assertIn("odoo-devkit", detail.model_dump_json())
+
+    def test_product_environment_detail_exposes_provider_target_projection(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            database_url = f"sqlite+pysqlite:///{database_path}"
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            profile = LaunchplaneProductProfileRecord.model_validate(
+                _site_profile_payload(preview_enabled=False, preview_context="")
+            )
+            store.write_product_profile_record(profile)
+            store.write_dokploy_target_record(
+                DokployTargetRecord(
+                    context="example-site-prod",
+                    instance="prod",
+                    project_name="example-site-prod-project",
+                    target_type="application",
+                    target_name="example-site-prod",
+                    updated_at="2026-05-02T22:30:00Z",
+                    source_label="test",
+                )
+            )
+            store.write_dokploy_target_id_record(
+                DokployTargetIdRecord(
+                    context="example-site-prod",
+                    instance="prod",
+                    target_id="app-example-prod",
+                    updated_at="2026-05-02T22:31:00Z",
+                    source_label="test",
+                )
+            )
+
+            detail = build_product_environment_detail(
+                record_store=store,
+                product=profile.product,
+                environment="prod",
+                action_allowed=lambda *_: False,
+            )
+            store.close()
+
+        self.assertEqual(detail.target.provider, "dokploy")
+        self.assertEqual(detail.target.target_type, "application")
+        self.assertEqual(detail.target.target_name, "example-site-prod")
+        self.assertEqual(detail.target.target_id, "app-example-prod")
+        self.assertEqual(detail.target.provider_target_type, "application")
+        self.assertTrue(detail.target.target_id_recorded)
+        self.assertEqual(detail.target.trust_state, "recorded")
 
     def test_product_environment_config_status_reports_expected_key_states(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- Adds neutral `provider_target` projection to `LaunchplaneLaneSummary` from paired Dokploy target + target-id records.
- Adds Postgres read-through helpers for `read_provider_target_record` and `list_provider_target_records` without adding a new table or write path.
- Exposes neutral target identity fields in product environment target summaries while keeping Dokploy compatibility fields.
- Documents that paired Dokploy records can project to `ProviderTargetRecord`, but existing Dokploy records remain the active storage/write authority.

## Live-prod safety

- VeriReel and SYO are live/prod, so this PR intentionally avoids schema migrations, backfills, deploy execution changes, live runtime mutation changes, and target write-path changes.
- Agent review found a semantic risk where projected target inventory could have overwritten `lane_summary.deployed_target`; that was fixed before PR by keeping `provider_target` separate from deployment evidence and adding a mismatch regression test.

## Validation

- `uv run python -m unittest tests.test_deploy_target tests.test_postgres_store tests.test_product_environment_read_model` (89 tests)
- `uv run python -m unittest tests.test_product_onboarding tests.test_product_onboarding_service tests.test_product_config_service tests.test_product_read_service tests.test_runtime_environments tests.test_dokploy` (155 tests)
- `uv run --extra dev ruff check control_plane/contracts/lane_summary.py control_plane/contracts/product_environment_read_model.py control_plane/storage/postgres.py tests/test_postgres_store.py tests/test_product_environment_read_model.py --diff`
- `uv run --extra dev ruff check control_plane/contracts/lane_summary.py control_plane/contracts/product_environment_read_model.py control_plane/storage/postgres.py tests/test_postgres_store.py tests/test_product_environment_read_model.py`
- `uv run --extra dev mypy control_plane tests`
- `npx --no-install markdownlint-cli2 docs/records.md docs/service-boundary.md`
- `git diff --check`

## Review

- Planning agents recommended the low-blast-radius read-through projection before any physical provider-target table.
- Read-only review agents reviewed the branch before PR; findings were addressed by preserving deployment evidence semantics and adding explicit mismatch coverage.

Refs #1065
Refs #1088
