### PR TITLE
Add provider target physical storage

### DIFF
--- a/control_plane/storage/migrations/versions/b2d4f6a8c0e1_add_provider_targets.py
+++ b/control_plane/storage/migrations/versions/b2d4f6a8c0e1_add_provider_targets.py
@@ -1,0 +1,78 @@
+"""add provider targets
+
+Revision ID: b2d4f6a8c0e1
+Revises: a9c1e3f5b7d9
+Create Date: 2026-06-01 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "b2d4f6a8c0e1"
+down_revision: str | None = "a9c1e3f5b7d9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_provider_targets"
+_PROVIDER_INDEX = "launchplane_provider_targets_provider_idx"
+_UPDATED_INDEX = "launchplane_provider_targets_updated_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("context", sa.String(), nullable=False),
+            sa.Column("instance", sa.String(), nullable=False),
+            sa.Column("provider_id", sa.String(), nullable=False),
+            sa.Column("target_category", sa.String(), nullable=False),
+            sa.Column("target_id", sa.String(), nullable=False),
+            sa.Column("display_name", sa.String(), nullable=False),
+            sa.Column("provider_target_type", sa.String(), nullable=False),
+            sa.Column("updated_at", sa.String(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("context", "instance"),
+        )
+    if not _index_exists(_TABLE, _PROVIDER_INDEX):
+        op.create_index(
+            _PROVIDER_INDEX,
+            _TABLE,
+            ["provider_id", sa.text("updated_at DESC")],
+        )
+    if not _index_exists(_TABLE, _UPDATED_INDEX):
+        op.create_index(
+            _UPDATED_INDEX,
+            _TABLE,
+            [sa.text("updated_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists(_TABLE):
+        return
+    if _index_exists(_TABLE, _UPDATED_INDEX):
+        op.drop_index(_UPDATED_INDEX, table_name=_TABLE)
+    if _index_exists(_TABLE, _PROVIDER_INDEX):
+        op.drop_index(_PROVIDER_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -623,6 +623,24 @@ class LaunchplaneDokployTargetRow(Base):
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
+class LaunchplaneProviderTargetRow(Base):
+    __tablename__ = "launchplane_provider_targets"
+    __table_args__ = (
+        Index("launchplane_provider_targets_provider_idx", "provider_id", desc("updated_at")),
+        Index("launchplane_provider_targets_updated_idx", desc("updated_at")),
+    )
+
+    context: Mapped[str] = mapped_column(String, primary_key=True)
+    instance: Mapped[str] = mapped_column(String, primary_key=True)
+    provider_id: Mapped[str] = mapped_column(String, nullable=False)
+    target_category: Mapped[str] = mapped_column(String, nullable=False)
+    target_id: Mapped[str] = mapped_column(String, nullable=False)
+    display_name: Mapped[str] = mapped_column(String, nullable=False)
+    provider_target_type: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
 class LaunchplaneRuntimeEnvironmentRow(Base):
     __tablename__ = "launchplane_runtime_environments"
     __table_args__ = (Index("launchplane_runtime_environments_updated_idx", desc("updated_at")),)
@@ -3125,6 +3143,16 @@ class PostgresRecordStore(HumanSessionStore):
     def read_provider_target_record(
         self, *, context_name: str, instance_name: str
     ) -> ProviderTargetRecord:
+        record = self._read_optional_model(
+            model_type=ProviderTargetRecord,
+            orm_model=LaunchplaneProviderTargetRow,
+            filters=(
+                LaunchplaneProviderTargetRow.context == context_name,
+                LaunchplaneProviderTargetRow.instance == instance_name,
+            ),
+        )
+        if record is not None:
+            return record
         target_record = self.read_dokploy_target_record(
             context_name=context_name,
             instance_name=instance_name,
@@ -3142,13 +3170,35 @@ class PostgresRecordStore(HumanSessionStore):
         self, *, provider_id: str = ""
     ) -> tuple[ProviderTargetRecord, ...]:
         normalized_provider_id = provider_id.strip().lower()
+        all_physical_records = list(
+            self._list_models(
+                model_type=ProviderTargetRecord,
+                orm_model=LaunchplaneProviderTargetRow,
+                order_by=(
+                    LaunchplaneProviderTargetRow.context.asc(),
+                    LaunchplaneProviderTargetRow.instance.asc(),
+                ),
+            )
+        )
+        physical_record_keys = {
+            (record.context, record.instance) for record in all_physical_records
+        }
+        physical_records = list(
+            record
+            for record in all_physical_records
+            if not normalized_provider_id or record.provider_id == normalized_provider_id
+        )
         target_id_records = {
             (record.context, record.instance): record
             for record in self.list_dokploy_target_id_records()
         }
-        provider_records: list[ProviderTargetRecord] = []
+        provider_records: list[ProviderTargetRecord] = [*physical_records]
         for target_record in self.list_dokploy_target_records():
-            target_id_record = target_id_records.get((target_record.context, target_record.instance))
+            if (target_record.context, target_record.instance) in physical_record_keys:
+                continue
+            target_id_record = target_id_records.get(
+                (target_record.context, target_record.instance)
+            )
             if target_id_record is None:
                 continue
             provider_record = ProviderTargetRecord.from_dokploy_records(
@@ -3158,7 +3208,51 @@ class PostgresRecordStore(HumanSessionStore):
             if normalized_provider_id and provider_record.provider_id != normalized_provider_id:
                 continue
             provider_records.append(provider_record)
+        provider_records.sort(key=lambda record: (record.context, record.instance))
         return tuple(provider_records)
+
+    def write_provider_target_record(self, record: ProviderTargetRecord) -> None:
+        self._write_row(
+            LaunchplaneProviderTargetRow(
+                context=record.context,
+                instance=record.instance,
+                provider_id=record.provider_id,
+                target_category=record.target_category,
+                target_id=record.target_id,
+                display_name=record.display_name,
+                provider_target_type=record.provider_target_type,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def delete_provider_target_record(
+        self,
+        *,
+        expected_record: ProviderTargetRecord,
+    ) -> CurrentAuthorityDeleteStatus:
+        statement = (
+            select(LaunchplaneProviderTargetRow)
+            .where(
+                LaunchplaneProviderTargetRow.context == expected_record.context,
+                LaunchplaneProviderTargetRow.instance == expected_record.instance,
+            )
+            .limit(1)
+            .with_for_update()
+        )
+        with self._session_factory() as session:
+            row = session.scalar(statement)
+            if row is None:
+                return "missing"
+            current_record = self._read_payload(
+                model_type=ProviderTargetRecord,
+                payload=row.payload,
+            )
+            if self._payload_dict(current_record) != self._payload_dict(expected_record):
+                return "changed"
+            session.delete(row)
+            session.commit()
+            return "deleted"
 
     def delete_dokploy_target_record(
         self,
@@ -3397,6 +3491,10 @@ class PostgresRecordStore(HumanSessionStore):
                 ),
                 None,
             ),
+            provider_target=self._read_optional_physical_provider_target_record(
+                context_name=context_name,
+                instance_name=instance_name,
+            ),
             dokploy_target_id=self._read_optional_model(
                 model_type=DokployTargetIdRecord,
                 orm_model=LaunchplaneDokployTargetIdRow,
@@ -3425,6 +3523,18 @@ class PostgresRecordStore(HumanSessionStore):
             secret_bindings=self.list_secret_bindings(
                 context_name=context_name,
                 instance_name=instance_name,
+            ),
+        )
+
+    def _read_optional_physical_provider_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> ProviderTargetRecord | None:
+        return self._read_optional_model(
+            model_type=ProviderTargetRecord,
+            orm_model=LaunchplaneProviderTargetRow,
+            filters=(
+                LaunchplaneProviderTargetRow.context == context_name,
+                LaunchplaneProviderTargetRow.instance == instance_name,
             ),
         )
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -131,10 +131,12 @@ an ORM column/table or remains only in the evidence payload.
 - Provider target records define the neutral target inventory contract:
   `context`, `instance`, `provider_id`, `target_category`, `target_id`,
   `display_name`, `provider_target_type`, `updated_at`, and payload-only
-  provider evidence. Launchplane read models can project these neutral records
-  from paired Dokploy target and target-id records. Existing Dokploy target and
-  target-id records remain the active storage/write path until a later migration
-  adds provider-neutral storage.
+  provider evidence. DB-backed storage uses `launchplane_provider_targets` for
+  explicit provider-neutral target rows, and read models can still project these
+  neutral records from paired Dokploy target and target-id records when no
+  explicit provider-target row exists. Existing Dokploy target and target-id
+  records remain the active live write/execution path until a later dual-write
+  or cutover migration.
 - Shared ship and promotion request/evidence contracts accept a neutral
   `target_reference` compatibility input for target name, provider id,
   category, and provider target type. Persisted records still write the flat
@@ -576,7 +578,9 @@ state/
 - Paired Dokploy target and target-id records project to the neutral
   `ProviderTargetRecord` read model. Missing halves remain missing; Launchplane
   does not fabricate provider-neutral target identity from only route metadata or
-  only a live id.
+  only a live id. Explicit `launchplane_provider_targets` rows take precedence in
+  provider-target read models, but Dokploy records remain the live execution
+  authority until the write path is migrated.
 - Shopify guard values such as protected store keys now belong in
   `policies.shopify.protected_store_keys` on this record instead of a route map
   hardcoded in Python.

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -25,7 +25,7 @@ from control_plane.contracts.agent_write_intent import (
 )
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
-from control_plane.contracts.deploy_target import DeployedTargetReference
+from control_plane.contracts.deploy_target import DeployedTargetReference, ProviderTargetRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
@@ -389,6 +389,28 @@ def _dokploy_target_record(
         domains=(f"https://{instance}.example.com",),
         updated_at="2026-04-21T18:30:00Z",
         source_label="import:test",
+    )
+
+
+def _provider_target_record(
+    *,
+    context: str = "syo",
+    instance: str = "prod",
+    provider_id: str = "dokploy",
+    target_id: str = "app-syo-prod",
+    updated_at: str = "2026-04-21T18:35:00Z",
+) -> ProviderTargetRecord:
+    return ProviderTargetRecord(
+        context=context,
+        instance=instance,
+        provider_id=provider_id,
+        target_category="application",
+        target_id=target_id,
+        display_name=f"{context}-{instance}",
+        provider_target_type="application",
+        provider_evidence={"project_name": f"{context}-project"},
+        updated_at=updated_at,
+        source_label="test:provider-target",
     )
 
 
@@ -894,14 +916,48 @@ class PostgresRecordStoreTests(unittest.TestCase):
             )
             store.write_artifact_manifest(manifest)
             store.write_ingress_route_audit_record(ingress_route_audit)
+            provider_target = _provider_target_record(context="reon", instance="prod")
+            store.write_provider_target_record(provider_target)
+            inspect_engine = create_engine(database_url)
+            inspector = inspect(inspect_engine)
+            table_names = set(inspector.get_table_names())
+            provider_target_columns = {
+                column["name"] for column in inspector.get_columns("launchplane_provider_targets")
+            }
+            provider_target_indexes = {
+                index["name"] for index in inspector.get_indexes("launchplane_provider_targets")
+            }
             loaded = store.read_artifact_manifest(manifest.artifact_id)
+            loaded_provider_target = store.read_provider_target_record(
+                context_name="reon",
+                instance_name="prod",
+            )
             audit_records = store.list_ingress_route_audit_records(
                 product="launchplane", context_name="reon-prod"
             )
             store.close()
+            inspect_engine.dispose()
 
         self.assertEqual(loaded.artifact_id, manifest.artifact_id)
         self.assertEqual(loaded.image.digest, "sha256:image123")
+        self.assertEqual(loaded_provider_target.target_id, provider_target.target_id)
+        self.assertIn("launchplane_provider_targets", table_names)
+        self.assertGreaterEqual(
+            provider_target_columns,
+            {
+                "context",
+                "instance",
+                "provider_id",
+                "target_category",
+                "target_id",
+                "display_name",
+                "provider_target_type",
+                "updated_at",
+                "payload",
+            },
+        )
+        self.assertIn("launchplane_provider_targets_provider_idx", provider_target_indexes)
+        self.assertIn("launchplane_provider_targets_updated_idx", provider_target_indexes)
         self.assertEqual(
             [record.record_id for record in audit_records], [ingress_route_audit.record_id]
         )
@@ -1146,6 +1202,164 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(len(listed), 1)
         self.assertEqual(listed[0], loaded)
         self.assertEqual(filtered, (loaded,))
+
+    def test_provider_target_records_round_trip_from_physical_storage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            record = _provider_target_record(
+                context="verireel",
+                instance="prod",
+                provider_id=" Dokploy ",
+                target_id="app-verireel-prod",
+            )
+            store.write_provider_target_record(record)
+
+            loaded = store.read_provider_target_record(
+                context_name="verireel",
+                instance_name="prod",
+            )
+            listed = store.list_provider_target_records()
+            filtered = store.list_provider_target_records(provider_id=" DOKPLOY ")
+            store.close()
+
+        self.assertEqual(loaded, record)
+        self.assertEqual(listed, (record,))
+        self.assertEqual(filtered, (record,))
+
+    def test_delete_provider_target_record_uses_current_authority_match(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            record = _provider_target_record(context="verireel", instance="prod")
+            changed_record = _provider_target_record(
+                context="verireel",
+                instance="prod",
+                target_id="app-verireel-prod-new",
+            )
+            store.write_provider_target_record(record)
+
+            changed_status = store.delete_provider_target_record(expected_record=changed_record)
+            loaded_after_changed = store.read_provider_target_record(
+                context_name="verireel",
+                instance_name="prod",
+            )
+            deleted_status = store.delete_provider_target_record(expected_record=record)
+            missing_status = store.delete_provider_target_record(expected_record=record)
+            store.close()
+
+        self.assertEqual(changed_status, "changed")
+        self.assertEqual(loaded_after_changed, record)
+        self.assertEqual(deleted_status, "deleted")
+        self.assertEqual(missing_status, "missing")
+
+    def test_provider_target_physical_storage_precedes_dokploy_projection(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            physical_record = _provider_target_record(
+                context="syo",
+                instance="prod",
+                target_id="physical-app-syo-prod",
+            )
+            store.write_provider_target_record(physical_record)
+            store.write_dokploy_target_record(
+                _dokploy_target_record(context="syo", instance="prod")
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(
+                    context="syo",
+                    instance="prod",
+                    target_id="projected-app-syo-prod",
+                )
+            )
+
+            loaded = store.read_provider_target_record(context_name="syo", instance_name="prod")
+            listed = store.list_provider_target_records()
+            summary = store.read_lane_summary(context_name="syo", instance_name="prod")
+            store.close()
+
+        self.assertEqual(loaded, physical_record)
+        self.assertEqual(listed, (physical_record,))
+        self.assertEqual(summary.provider_target, physical_record)
+
+    def test_provider_target_filter_suppresses_shadowed_dokploy_projection(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            physical_record = _provider_target_record(
+                context="syo",
+                instance="prod",
+                provider_id="future-provider",
+                target_id="physical-syo-prod",
+            )
+            store.write_provider_target_record(physical_record)
+            store.write_dokploy_target_record(
+                _dokploy_target_record(context="syo", instance="prod")
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(
+                    context="syo",
+                    instance="prod",
+                    target_id="legacy-dokploy-syo-prod",
+                )
+            )
+
+            dokploy_records = store.list_provider_target_records(provider_id="dokploy")
+            future_provider_records = store.list_provider_target_records(
+                provider_id="future-provider"
+            )
+            store.close()
+
+        self.assertEqual(dokploy_records, ())
+        self.assertEqual(future_provider_records, (physical_record,))
+
+    def test_provider_target_list_combines_physical_and_projected_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            physical_record = _provider_target_record(
+                context="verireel",
+                instance="prod",
+                target_id="app-verireel-prod",
+            )
+            store.write_provider_target_record(physical_record)
+            store.write_dokploy_target_record(
+                _dokploy_target_record(context="syo", instance="prod")
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(
+                    context="syo",
+                    instance="prod",
+                    target_id="app-syo-prod",
+                )
+            )
+            store.write_dokploy_target_record(
+                _dokploy_target_record(context="incomplete", instance="prod")
+            )
+
+            listed = store.list_provider_target_records()
+            filtered = store.list_provider_target_records(provider_id="dokploy")
+            store.close()
+
+        self.assertEqual(
+            [(record.context, record.instance, record.target_id) for record in listed],
+            [
+                ("syo", "prod", "app-syo-prod"),
+                ("verireel", "prod", "app-verireel-prod"),
+            ],
+        )
+        self.assertEqual(filtered, listed)
 
     def test_provider_target_list_skips_incomplete_dokploy_pairs(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add the `launchplane_provider_targets` table, ORM row, and Postgres read/write/delete helpers for neutral provider-target records
- prefer explicit physical provider-target rows in read models while preserving paired Dokploy target/id projection as the compatibility fallback
- document that Dokploy target records remain the live write/execution authority until a later dual-write or cutover slice

## Prod safety
- storage-only slice; no onboarding, adoption, deploy, promotion, or live workflow writers are changed
- VeriReel and SYO can continue using existing Dokploy-backed projection paths when no explicit provider-target row exists
- review agents found and I fixed provider-filter fallback suppression plus redundant lane-summary fallback reads before opening this PR

## Validation
- `uv run --extra dev ruff check control_plane/storage/postgres.py control_plane/storage/migrations/versions/b2d4f6a8c0e1_add_provider_targets.py tests/test_postgres_store.py --diff`
- `uv run --extra dev ruff check control_plane/storage/postgres.py control_plane/storage/migrations/versions/b2d4f6a8c0e1_add_provider_targets.py tests/test_postgres_store.py`
- `uv run --extra dev ruff format --check control_plane/storage/postgres.py control_plane/storage/migrations/versions/b2d4f6a8c0e1_add_provider_targets.py tests/test_postgres_store.py`
- `npx --no-install markdownlint-cli2 docs/records.md`
- `git diff --check`
- `uv run python -m unittest tests.test_deploy_target tests.test_postgres_store`
- `uv run python -m unittest tests.test_product_environment_read_model tests.test_product_onboarding tests.test_product_onboarding_service tests.test_product_config_service tests.test_product_read_service tests.test_runtime_environments tests.test_dokploy`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`

Refs #1065
Refs #1088
