### PR TITLE
Fix provider target compatibility defaults

### DIFF
--- a/control_plane/contracts/deploy_target.py
+++ b/control_plane/contracts/deploy_target.py
@@ -64,10 +64,17 @@ def apply_target_reference_defaults(data: object) -> object:
         updated["provider_id"] = reference.provider_id
     if updated.get("target_category") in {None, ""}:
         updated["target_category"] = reference.target_category
+    legacy_target_type = reference.legacy_target_type()
+    reference_provider_target_type = reference.provider_target_type.strip()
     if not str(updated.get("provider_target_type", "")).strip():
-        updated["provider_target_type"] = reference.provider_target_type
+        if reference_provider_target_type:
+            updated["provider_target_type"] = reference_provider_target_type
+        elif legacy_target_type is not None:
+            updated["provider_target_type"] = legacy_target_type
+            updated["target_reference"] = reference.model_copy(
+                update={"provider_target_type": legacy_target_type}
+            )
     if not str(updated.get("target_type", "")).strip():
-        legacy_target_type = reference.legacy_target_type()
         if legacy_target_type is not None:
             updated["target_type"] = legacy_target_type
     return updated

--- a/control_plane/contracts/deployment_record.py
+++ b/control_plane/contracts/deployment_record.py
@@ -77,9 +77,18 @@ class DeploymentRecord(BaseModel):
             raise ValueError("deployment record requires delegated_executor")
         if self.deployed_target is None and self.resolved_target is not None:
             provider_id = self.deploy.provider_id.strip().lower() or "dokploy"
+            target_category = self.deploy.target_category or self.resolved_target.target_type
+            provider_target_type = (
+                self.deploy.provider_target_type.strip().lower() or self.resolved_target.target_type
+            )
             self.deployed_target = self.resolved_target.to_deployed_target_reference(
                 provider_id=provider_id
             )
-            if self.deploy.provider_target_type:
+            self.deployed_target.target_category = target_category
+            self.deployed_target.provider_target_type = provider_target_type
+        elif self.deployed_target is not None:
+            if self.deployed_target.target_category == "unknown" and self.deploy.target_category:
+                self.deployed_target.target_category = self.deploy.target_category
+            if not self.deployed_target.provider_target_type and self.deploy.provider_target_type:
                 self.deployed_target.provider_target_type = self.deploy.provider_target_type
         return self

--- a/control_plane/workflows/launchplane_self_deploy.py
+++ b/control_plane/workflows/launchplane_self_deploy.py
@@ -61,6 +61,17 @@ class LaunchplaneSelfDeployRequest(BaseModel):
     oauth_env_removals: tuple[str, ...] = ()
     no_cache: bool = False
 
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_input(cls, data: object) -> object:
+        if not isinstance(data, dict):
+            return data
+        updated = dict(data)
+        raw_target_type = updated.get("target_type")
+        if isinstance(raw_target_type, str):
+            updated["target_type"] = raw_target_type.strip().lower()
+        return updated
+
     @model_validator(mode="after")
     def _validate_values(self) -> "LaunchplaneSelfDeployRequest":
         if not self.target_id.strip():

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -1361,8 +1361,44 @@ class FilesystemRecordStoreTests(unittest.TestCase):
         deployed_target = record.deployed_target
         assert deployed_target is not None
         self.assertEqual(deployed_target.provider_id, "fake-cloud")
+        self.assertEqual(deployed_target.target_category, "service")
         self.assertEqual(deployed_target.provider_target_type, "managed-service")
         self.assertEqual(deployed_target.target_id, "svc-123")
+
+    def test_deployment_record_backfills_legacy_deployed_target_provider_fields(
+        self,
+    ) -> None:
+        record = DeploymentRecord(
+            record_id="deployment-20260410T182231Z-syo-prod",
+            artifact_identity=_artifact_identity("artifact-20260410-f45db648"),
+            context="syo",
+            instance="prod",
+            source_git_ref="abc123",
+            deployed_target=DeployedTargetReference(
+                provider_id="fake-cloud",
+                target_category="unknown",
+                target_id="svc-123",
+                display_name="syo-prod-service",
+            ),
+            deploy=DeploymentEvidence(
+                target_name="syo-prod-service",
+                target_type="application",
+                deploy_mode="fake-cloud-application-api",
+                provider_id="fake-cloud",
+                target_category="service",
+                provider_target_type="managed-service",
+                provider_deploy_mode="application-api",
+                deployment_id="deploy-123",
+                status="pass",
+                started_at="2026-04-10T18:22:31Z",
+                finished_at="2026-04-10T18:24:00Z",
+            ),
+        )
+
+        deployed_target = record.deployed_target
+        assert deployed_target is not None
+        self.assertEqual(deployed_target.target_category, "service")
+        self.assertEqual(deployed_target.provider_target_type, "managed-service")
 
     def test_list_deployment_records_filters_and_sorts_latest_first(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_launchplane_self_deploy.py
+++ b/tests/test_launchplane_self_deploy.py
@@ -10,13 +10,15 @@ from control_plane.workflows.launchplane_self_deploy import (
 
 class LaunchplaneSelfDeployWorkflowTests(unittest.TestCase):
     def test_execute_updates_target_env_and_triggers_deployment(self) -> None:
-        request = LaunchplaneSelfDeployRequest(
-            target_type="compose",
-            target_id="compose-123",
-            image_reference="ghcr.io/cbusillo/launchplane@sha256:new",
-            oauth_env={"LAUNCHPLANE_PUBLIC_URL": "https://launchplane.example"},
-            oauth_env_removals=("LAUNCHPLANE_NPMPLUS_SECRET",),
-            no_cache=True,
+        request = LaunchplaneSelfDeployRequest.model_validate(
+            {
+                "target_type": " Compose ",
+                "target_id": "compose-123",
+                "image_reference": "ghcr.io/cbusillo/launchplane@sha256:new",
+                "oauth_env": {"LAUNCHPLANE_PUBLIC_URL": "https://launchplane.example"},
+                "oauth_env_removals": ("LAUNCHPLANE_NPMPLUS_SECRET",),
+                "no_cache": True,
+            }
         )
 
         with (
@@ -27,8 +29,7 @@ class LaunchplaneSelfDeployWorkflowTests(unittest.TestCase):
             patch(
                 "control_plane.workflows.launchplane_self_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
                 return_value={
-                    "env": "DOCKER_IMAGE_REFERENCE=old\n"
-                    "LAUNCHPLANE_NPMPLUS_SECRET=npmplus-secret\n"
+                    "env": "DOCKER_IMAGE_REFERENCE=old\nLAUNCHPLANE_NPMPLUS_SECRET=npmplus-secret\n"
                 },
             ),
             patch(

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -417,6 +417,26 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(request.provider_target_type, "compose")
         self.assertNotIn("target_reference", request.model_dump())
 
+    def test_ship_request_accepts_minimal_legacy_target_reference_input(self) -> None:
+        request = ShipRequest.model_validate(
+            {
+                "artifact_id": "artifact-sha256-image456",
+                "context": "opw",
+                "instance": "prod",
+                "source_git_ref": "abc123",
+                "target_reference": {
+                    "target_name": "opw-prod",
+                    "provider_id": "dokploy",
+                    "target_category": "compose",
+                },
+                "deploy_mode": "dokploy-compose-api",
+            }
+        )
+
+        self.assertEqual(request.target_name, "opw-prod")
+        self.assertEqual(request.target_type, "compose")
+        self.assertEqual(request.provider_target_type, "compose")
+
     def test_ship_request_rejects_conflicting_target_reference(self) -> None:
         with self.assertRaisesRegex(ValueError, "target_reference provider_id"):
             ShipRequest.model_validate(
@@ -489,6 +509,48 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(request.provider_target_type, "application")
         self.assertNotIn("target_reference", request.model_dump())
 
+    def test_promotion_request_accepts_minimal_legacy_target_reference_input(self) -> None:
+        request = PromotionRequest.model_validate(
+            {
+                "artifact_id": "artifact-sha256-image456",
+                "backup_record_id": "backup-opw-prod-20260410T182231Z",
+                "source_git_ref": "abc123",
+                "context": "opw",
+                "from_instance": "testing",
+                "to_instance": "prod",
+                "target_reference": {
+                    "target_name": "opw-prod",
+                    "provider_id": "dokploy",
+                    "target_category": "application",
+                },
+                "deploy_mode": "dokploy-application-api",
+            }
+        )
+
+        self.assertEqual(request.target_name, "opw-prod")
+        self.assertEqual(request.target_type, "application")
+        self.assertEqual(request.provider_target_type, "application")
+
+    def test_promotion_request_rejects_provider_reference_without_type(self) -> None:
+        with self.assertRaisesRegex(ValueError, "target_reference provider_target_type"):
+            PromotionRequest.model_validate(
+                {
+                    "artifact_id": "artifact-sha256-image456",
+                    "backup_record_id": "backup-opw-prod-20260410T182231Z",
+                    "source_git_ref": "abc123",
+                    "context": "opw",
+                    "from_instance": "testing",
+                    "to_instance": "prod",
+                    "target_reference": {
+                        "target_name": "opw-prod-service",
+                        "provider_id": "fake-cloud",
+                        "target_category": "service",
+                    },
+                    "target_type": "application",
+                    "deploy_mode": "fake-cloud-service-api",
+                }
+            )
+
     def test_promotion_request_rejects_conflicting_target_reference(self) -> None:
         with self.assertRaisesRegex(ValueError, "target_category does not match target_type"):
             PromotionRequest.model_validate(
@@ -551,6 +613,40 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(evidence.target_category, "compose")
         self.assertEqual(evidence.provider_target_type, "compose")
         self.assertNotIn("target_reference", evidence.model_dump())
+
+    def test_deployment_evidence_accepts_minimal_legacy_target_reference_input(self) -> None:
+        evidence = DeploymentEvidence.model_validate(
+            {
+                "target_reference": {
+                    "target_name": "opw-prod",
+                    "provider_id": "dokploy",
+                    "target_category": "compose",
+                },
+                "deploy_mode": "dokploy-compose-api",
+                "deployment_id": "deploy-123",
+                "status": "pass",
+            }
+        )
+
+        self.assertEqual(evidence.target_name, "opw-prod")
+        self.assertEqual(evidence.target_type, "compose")
+        self.assertEqual(evidence.provider_target_type, "compose")
+
+    def test_deployment_evidence_rejects_provider_reference_without_type(self) -> None:
+        with self.assertRaisesRegex(ValueError, "target_reference provider_target_type"):
+            DeploymentEvidence.model_validate(
+                {
+                    "target_reference": {
+                        "target_name": "opw-prod-service",
+                        "provider_id": "fake-cloud",
+                        "target_category": "service",
+                    },
+                    "target_type": "application",
+                    "deploy_mode": "fake-cloud-service-api",
+                    "deployment_id": "deploy-123",
+                    "status": "pass",
+                }
+            )
 
     def test_deployment_evidence_rejects_conflicting_target_reference(self) -> None:
         with self.assertRaisesRegex(ValueError, "provider_target_type does not match target_type"):
@@ -742,7 +838,7 @@ class ArtifactImageOverrideTests(unittest.TestCase):
                                 target_name="opw-prod",
                                 domains=("opw-prod.shinycomputers.com",),
                             ),
-                        )
+                        ),
                     ),
                 ),
                 patch(
@@ -886,7 +982,7 @@ class ArtifactImageOverrideTests(unittest.TestCase):
                                 target_name="cm-testing",
                                 domains=("cm-testing.shinycomputers.com",),
                             ),
-                        )
+                        ),
                     ),
                 ),
                 patch(


### PR DESCRIPTION
## Summary
- infer `provider_target_type` for minimal legacy target references (`application` / `compose`) while keeping non-legacy provider references fail-closed unless explicit
- preserve provider-neutral target category/type when deriving or backfilling `deployed_target` on deployment records
- normalize Launchplane self-deploy `target_type` before literal validation so whitespace/case-padded raw payloads remain accepted

## Context
This is a follow-up to the post-merge auto-review signal after #1096. I did not merge the stale auto-review worktree; it was based on an older snapshot. Instead I validated the findings against current `main` with agents and applied the minimal current-branch fixes.

## Prod safety
- contract normalization/backfill only; no live deploy/promotion execution path changes
- keeps non-legacy provider references without provider-specific type rejected rather than silently defaulted
- compatibility-focused for stored deployment records and raw self-deploy request payloads

## Validation
- `uv run python -m unittest tests.test_promote tests.test_filesystem_store tests.test_launchplane_self_deploy tests.test_deploy_target`
- `uv run --extra dev ruff check control_plane/contracts/deploy_target.py control_plane/contracts/deployment_record.py control_plane/workflows/launchplane_self_deploy.py tests/test_promote.py tests/test_filesystem_store.py tests/test_launchplane_self_deploy.py --diff`
- `uv run --extra dev ruff check control_plane/contracts/deploy_target.py control_plane/contracts/deployment_record.py control_plane/workflows/launchplane_self_deploy.py tests/test_promote.py tests/test_filesystem_store.py tests/test_launchplane_self_deploy.py`
- `uv run --extra dev ruff format --check control_plane/contracts/deploy_target.py control_plane/contracts/deployment_record.py control_plane/workflows/launchplane_self_deploy.py tests/test_promote.py tests/test_filesystem_store.py tests/test_launchplane_self_deploy.py`
- `git diff --check`
- `uv run --extra dev mypy control_plane/contracts/deploy_target.py control_plane/contracts/deployment_record.py control_plane/workflows/launchplane_self_deploy.py tests/test_promote.py tests/test_filesystem_store.py tests/test_launchplane_self_deploy.py`

Refs #1065
Refs #1088
