### PR TITLE
Make promotion target contracts provider-neutral

### DIFF
--- a/control_plane/contracts/deploy_target.py
+++ b/control_plane/contracts/deploy_target.py
@@ -93,7 +93,7 @@ def ensure_target_reference_matches(
         raise ValueError("target_category does not match target_type")
     if target_category == "compose" and target_type != "compose":
         raise ValueError("target_category does not match target_type")
-    if provider_id == "dokploy" and provider_target_type != target_type:
+    if provider_target_type in {"application", "compose"} and provider_target_type != target_type:
         raise ValueError("provider_target_type does not match target_type")
     canonical_reference = DeployTargetContractReference(
         target_name=target_name,

--- a/control_plane/contracts/promotion_record.py
+++ b/control_plane/contracts/promotion_record.py
@@ -1,9 +1,10 @@
-from typing import Literal
+from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.deploy_target import (
     DeployTargetCategory,
+    DeployTargetCompatibilityType,
     DeployTargetContractReference,
     apply_target_reference_defaults,
     ensure_target_reference_matches,
@@ -55,12 +56,12 @@ class BackupGateEvidence(BaseModel):
 class DeploymentEvidence(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    target_name: str
-    target_type: Literal["compose", "application"]
-    deploy_mode: str
-    target_reference: DeployTargetContractReference | None = Field(
-        default=None, exclude=True
+    target_name: str = ""
+    target_type: DeployTargetCompatibilityType = Field(
+        default=cast(DeployTargetCompatibilityType, "")
     )
+    deploy_mode: str
+    target_reference: DeployTargetContractReference | None = Field(default=None, exclude=True)
     provider_id: str = "dokploy"
     target_category: DeployTargetCategory | None = None
     provider_target_type: str = ""
@@ -78,10 +79,15 @@ class DeploymentEvidence(BaseModel):
     @model_validator(mode="after")
     def _validate_provider_evidence(self) -> "DeploymentEvidence":
         self.provider_id = self.provider_id.strip().lower()
+        self.target_name = self.target_name.strip()
         self.provider_target_type = self.provider_target_type.strip().lower()
         self.provider_deploy_mode = self.provider_deploy_mode.strip()
         if not self.provider_id:
             raise ValueError("deployment evidence requires provider_id")
+        if not self.target_name:
+            raise ValueError("deployment evidence requires target_name")
+        if not self.target_type:
+            raise ValueError("deployment evidence requires target_type")
         if self.target_category is None:
             self.target_category = self.target_type
         if not self.provider_target_type:
@@ -207,11 +213,11 @@ class PromotionRequest(BaseModel):
     context: str
     from_instance: str
     to_instance: str
-    target_name: str
-    target_type: Literal["compose", "application"]
-    target_reference: DeployTargetContractReference | None = Field(
-        default=None, exclude=True
+    target_name: str = ""
+    target_type: DeployTargetCompatibilityType = Field(
+        default=cast(DeployTargetCompatibilityType, "")
     )
+    target_reference: DeployTargetContractReference | None = Field(default=None, exclude=True)
     provider_id: str = "dokploy"
     target_category: DeployTargetCategory | None = None
     provider_target_type: str = ""
@@ -241,8 +247,11 @@ class PromotionRequest(BaseModel):
             raise ValueError("promotion request requires source_git_ref")
         if not self.context.strip():
             raise ValueError("promotion request requires context")
+        self.target_name = self.target_name.strip()
         if not self.target_name.strip():
             raise ValueError("promotion request requires target_name")
+        if not self.target_type:
+            raise ValueError("promotion request requires target_type")
         if not self.deploy_mode.strip():
             raise ValueError("promotion request requires deploy_mode")
         self.provider_id = self.provider_id.strip().lower()

--- a/control_plane/contracts/ship_request.py
+++ b/control_plane/contracts/ship_request.py
@@ -1,12 +1,14 @@
+from typing import cast
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.deploy_target import (
     DeployTargetCategory,
+    DeployTargetCompatibilityType,
     DeployTargetContractReference,
     apply_target_reference_defaults,
     ensure_target_reference_matches,
 )
-from control_plane.contracts.dokploy_target_record import DokployTargetType
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 
 
@@ -18,11 +20,11 @@ class ShipRequest(BaseModel):
     context: str
     instance: str
     source_git_ref: str
-    target_name: str
-    target_type: DokployTargetType
-    target_reference: DeployTargetContractReference | None = Field(
-        default=None, exclude=True
+    target_name: str = ""
+    target_type: DeployTargetCompatibilityType = Field(
+        default=cast(DeployTargetCompatibilityType, "")
     )
+    target_reference: DeployTargetContractReference | None = Field(default=None, exclude=True)
     provider_id: str = "dokploy"
     target_category: DeployTargetCategory | None = None
     provider_target_type: str = ""
@@ -52,6 +54,11 @@ class ShipRequest(BaseModel):
             raise ValueError("ship request requires instance")
         if not self.source_git_ref.strip():
             raise ValueError("ship request requires source_git_ref")
+        self.target_name = self.target_name.strip()
+        if not self.target_name:
+            raise ValueError("ship request requires target_name")
+        if not self.target_type:
+            raise ValueError("ship request requires target_type")
         self.provider_id = self.provider_id.strip().lower()
         self.provider_target_type = self.provider_target_type.strip().lower()
         self.provider_deploy_mode = self.provider_deploy_mode.strip()

--- a/control_plane/workflows/promotion_ship_resolution.py
+++ b/control_plane/workflows/promotion_ship_resolution.py
@@ -158,6 +158,26 @@ def resolve_ship_request_for_promotion(
             "Promotion request deploy_mode does not match resolved Dokploy ship mode. "
             f"Request={request.deploy_mode} configured={ship_request.deploy_mode}."
         )
+    if request.provider_id != ship_request.provider_id:
+        raise click.ClickException(
+            "Promotion request provider_id does not match resolved ship provider_id. "
+            f"Request={request.provider_id} configured={ship_request.provider_id}."
+        )
+    if request.target_category != ship_request.target_category:
+        raise click.ClickException(
+            "Promotion request target_category does not match resolved ship target_category. "
+            f"Request={request.target_category} configured={ship_request.target_category}."
+        )
+    if request.provider_target_type != ship_request.provider_target_type:
+        raise click.ClickException(
+            "Promotion request provider_target_type does not match resolved ship provider_target_type. "
+            f"Request={request.provider_target_type} configured={ship_request.provider_target_type}."
+        )
+    if request.provider_deploy_mode != ship_request.provider_deploy_mode:
+        raise click.ClickException(
+            "Promotion request provider_deploy_mode does not match resolved ship provider_deploy_mode. "
+            f"Request={request.provider_deploy_mode} configured={ship_request.provider_deploy_mode}."
+        )
     return ship_request
 
 

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -148,6 +148,16 @@ class VeriReelProdPromotionTargetResultFields(BaseModel):
     target_type: str
 
 
+class VeriReelProdPromotionDeployEvidenceFields(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    deploy_mode: str
+    provider_id: str
+    target_category: DeployTargetCategory
+    provider_target_type: str
+    provider_deploy_mode: str
+
+
 def _default_target_name() -> str:
     return "ver-prod-app"
 
@@ -182,6 +192,49 @@ def _target_result_fields_from_deployment(
         provider_id=deployment_result.provider_id,
         provider_target_type=deployment_result.provider_target_type,
         target_type=deployment_result.target_type,
+    )
+
+
+def _target_result_fields_from_promotion_record(
+    promotion_record: PromotionRecord,
+    *,
+    fallback: VeriReelProdPromotionTargetResultFields,
+) -> VeriReelProdPromotionTargetResultFields:
+    return VeriReelProdPromotionTargetResultFields(
+        target_name=promotion_record.deploy.target_name,
+        target_id=promotion_record.deploy.deployment_id,
+        target_category=promotion_record.deploy.target_category or fallback.target_category,
+        provider_id=promotion_record.deploy.provider_id or fallback.provider_id,
+        provider_target_type=(
+            promotion_record.deploy.provider_target_type or fallback.provider_target_type
+        ),
+        target_type=promotion_record.deploy.target_type,
+    )
+
+
+def _provider_deploy_fields_from_deployment_record(
+    *,
+    deployment_record: DeploymentRecord | None,
+    fallback: VeriReelProdPromotionTargetResultFields,
+    target_type: DokployTargetType,
+) -> VeriReelProdPromotionDeployEvidenceFields:
+    deploy_mode = _default_deploy_mode()
+    provider_id = fallback.provider_id
+    target_category = fallback.target_category
+    provider_target_type = fallback.provider_target_type
+    provider_deploy_mode = deploy_mode
+    if deployment_record is not None:
+        deploy_mode = deployment_record.deploy.deploy_mode
+        provider_id = deployment_record.deploy.provider_id
+        target_category = deployment_record.deploy.target_category or target_type
+        provider_target_type = deployment_record.deploy.provider_target_type
+        provider_deploy_mode = deployment_record.deploy.provider_deploy_mode
+    return VeriReelProdPromotionDeployEvidenceFields(
+        deploy_mode=deploy_mode,
+        provider_id=provider_id,
+        target_category=target_category,
+        provider_target_type=provider_target_type,
+        provider_deploy_mode=provider_deploy_mode,
     )
 
 
@@ -296,9 +349,18 @@ def _build_promotion_record(
     migration_detail: str,
     health_result: VeriReelRolloutVerificationResult | None,
 ) -> PromotionRecord:
-    deploy_mode = _default_deploy_mode()
-    if deployment_record is not None:
-        deploy_mode = deployment_record.deploy.deploy_mode
+    provider_deploy_fields = _provider_deploy_fields_from_deployment_record(
+        deployment_record=deployment_record,
+        fallback=VeriReelProdPromotionTargetResultFields(
+            target_name=target_name,
+            target_id=target_id,
+            target_category=target_type,
+            provider_id="dokploy",
+            provider_target_type=target_type,
+            target_type=target_type,
+        ),
+        target_type=target_type,
+    )
     destination_health = _build_destination_health(
         request=request,
         health_result=health_result,
@@ -325,7 +387,11 @@ def _build_promotion_record(
         deploy=DeploymentEvidence(
             target_name=target_name,
             target_type=target_type,
-            deploy_mode=deploy_mode,
+            deploy_mode=provider_deploy_fields.deploy_mode,
+            provider_id=provider_deploy_fields.provider_id,
+            target_category=provider_deploy_fields.target_category,
+            provider_target_type=provider_deploy_fields.provider_target_type,
+            provider_deploy_mode=provider_deploy_fields.provider_deploy_mode,
             deployment_id=target_id,
             status="pass" if deploy_status == "pass" else "fail",
             started_at=deploy_started_at,
@@ -391,12 +457,27 @@ def _write_failed_promotion_record(
     target_name: str | None = None,
     target_type: DokployTargetType | None = None,
     target_id: str = "",
+    target_fields: VeriReelProdPromotionTargetResultFields | None = None,
+    deployment_record: DeploymentRecord | None = None,
     migration_status: ReleaseStatus = "skipped",
     migration_detail: str = "",
     health_result: VeriReelRolloutVerificationResult | None = None,
 ) -> None:
     resolved_target_name = target_name or _default_target_name()
     resolved_target_type = target_type or _default_target_type()
+    provider_deploy_fields = _provider_deploy_fields_from_deployment_record(
+        deployment_record=deployment_record,
+        fallback=target_fields
+        or VeriReelProdPromotionTargetResultFields(
+            target_name=resolved_target_name,
+            target_id=target_id,
+            target_category=resolved_target_type,
+            provider_id="dokploy",
+            provider_target_type=resolved_target_type,
+            target_type=resolved_target_type,
+        ),
+        target_type=resolved_target_type,
+    )
     destination_health = _build_destination_health(
         request=request,
         health_result=health_result,
@@ -423,7 +504,11 @@ def _write_failed_promotion_record(
             deploy=DeploymentEvidence(
                 target_name=resolved_target_name,
                 target_type=resolved_target_type,
-                deploy_mode=_default_deploy_mode(),
+                deploy_mode=provider_deploy_fields.deploy_mode,
+                provider_id=provider_deploy_fields.provider_id,
+                target_category=provider_deploy_fields.target_category,
+                provider_target_type=provider_deploy_fields.provider_target_type,
+                provider_deploy_mode=provider_deploy_fields.provider_deploy_mode,
                 deployment_id=target_id,
                 status=deploy_status,
                 started_at=deploy_started_at,
@@ -730,7 +815,10 @@ def execute_verireel_prod_promotion(
             health_status="skipped",
             deploy_started_at=deployment_result.deploy_started_at,
             deploy_finished_at=deployment_result.deploy_finished_at,
-            target_fields=target_fields,
+            target_fields=_target_result_fields_from_promotion_record(
+                promotion_record,
+                fallback=target_fields,
+            ),
             error_message=deployment_result.error_message,
         )
 
@@ -755,6 +843,8 @@ def execute_verireel_prod_promotion(
             target_name=deployment_result.target_name,
             target_type=legacy_target_type,
             target_id=deployment_result.target_id,
+            target_fields=target_fields,
+            deployment_record=deployment_record,
             health_result=failed_rollout_result,
         )
         return _build_result(
@@ -799,6 +889,8 @@ def execute_verireel_prod_promotion(
             target_name=deployment_result.target_name,
             target_type=legacy_target_type,
             target_id=deployment_result.target_id,
+            target_fields=target_fields,
+            deployment_record=deployment_record,
             migration_status="fail",
             migration_detail=error_message,
             health_result=None,
@@ -849,6 +941,8 @@ def execute_verireel_prod_promotion(
             target_name=deployment_result.target_name,
             target_type=legacy_target_type,
             target_id=deployment_result.target_id,
+            target_fields=target_fields,
+            deployment_record=deployment_record,
             migration_status="pass",
             migration_detail="",
             health_result=failed_health_result,
@@ -893,6 +987,9 @@ def execute_verireel_prod_promotion(
         health_status=health_result.status,
         deploy_started_at=deployment_result.deploy_started_at,
         deploy_finished_at=deployment_result.deploy_finished_at,
-        target_fields=target_fields,
+        target_fields=_target_result_fields_from_promotion_record(
+            promotion_record,
+            fallback=target_fields,
+        ),
         error_message=deployment_result.error_message,
     )

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -47,6 +47,9 @@ from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.ship import build_deployment_record
 from control_plane.workflows.promote import build_promotion_record
 from control_plane.workflows.promote import build_executed_promotion_record
+from control_plane.workflows.promotion_ship_resolution import (
+    resolve_ship_request_for_promotion,
+)
 
 
 def _write_artifact_manifest(
@@ -437,6 +440,25 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(request.target_type, "compose")
         self.assertEqual(request.provider_target_type, "compose")
 
+    def test_ship_request_schema_prefers_target_reference_over_legacy_fields(self) -> None:
+        required_fields = set(ShipRequest.model_json_schema()["required"])
+
+        self.assertIn("target_reference", ShipRequest.model_fields)
+        self.assertNotIn("target_name", required_fields)
+        self.assertNotIn("target_type", required_fields)
+
+    def test_ship_request_requires_resolved_target_identity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ship request requires target_name"):
+            ShipRequest.model_validate(
+                {
+                    "artifact_id": "artifact-sha256-image456",
+                    "context": "opw",
+                    "instance": "prod",
+                    "source_git_ref": "abc123",
+                    "deploy_mode": "dokploy-compose-api",
+                }
+            )
+
     def test_ship_request_rejects_conflicting_target_reference(self) -> None:
         with self.assertRaisesRegex(ValueError, "target_reference provider_id"):
             ShipRequest.model_validate(
@@ -456,6 +478,23 @@ class PromoteWorkflowTests(unittest.TestCase):
                     },
                     "deploy_mode": "dokploy-compose-api",
                 },
+            )
+
+    def test_ship_request_rejects_compat_type_mismatch_for_non_dokploy_provider(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(ValueError, "provider_target_type does not match target_type"):
+            ShipRequest(
+                artifact_id="artifact-sha256-image456",
+                context="syo",
+                instance="prod",
+                source_git_ref="abc123",
+                target_name="syo-prod-service",
+                target_type="compose",
+                provider_id="fake-cloud",
+                target_category="compose",
+                provider_target_type="application",
+                deploy_mode="fake-cloud-compose-api",
             )
 
     def test_promotion_request_accepts_provider_target_type(self) -> None:
@@ -530,6 +569,116 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(request.target_name, "opw-prod")
         self.assertEqual(request.target_type, "application")
         self.assertEqual(request.provider_target_type, "application")
+
+    def test_promotion_request_schema_prefers_target_reference_over_legacy_fields(
+        self,
+    ) -> None:
+        required_fields = set(PromotionRequest.model_json_schema()["required"])
+
+        self.assertIn("target_reference", PromotionRequest.model_fields)
+        self.assertNotIn("target_name", required_fields)
+        self.assertNotIn("target_type", required_fields)
+
+    def test_promotion_request_requires_resolved_target_identity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "promotion request requires target_name"):
+            PromotionRequest.model_validate(
+                {
+                    "artifact_id": "artifact-sha256-image456",
+                    "backup_record_id": "backup-opw-prod-20260410T182231Z",
+                    "source_git_ref": "abc123",
+                    "context": "opw",
+                    "from_instance": "testing",
+                    "to_instance": "prod",
+                    "deploy_mode": "dokploy-application-api",
+                }
+            )
+
+    def test_promotion_ship_resolution_accepts_matching_provider_target_facts(
+        self,
+    ) -> None:
+        request = PromotionRequest(
+            artifact_id="artifact-sha256-image456",
+            backup_record_id="backup-opw-prod-20260410T182231Z",
+            source_git_ref="abc123",
+            context="syo",
+            from_instance="testing",
+            to_instance="prod",
+            target_name="syo-prod-service",
+            target_type="application",
+            provider_id="fake-cloud",
+            target_category="service",
+            provider_target_type="managed-service",
+            deploy_mode="fake-cloud-service-api",
+            provider_deploy_mode="service-api",
+        )
+        ship_request = ShipRequest(
+            artifact_id="artifact-sha256-image456",
+            context="syo",
+            instance="prod",
+            source_git_ref="abc123",
+            target_name="syo-prod-service",
+            target_type="application",
+            provider_id="fake-cloud",
+            target_category="service",
+            provider_target_type="managed-service",
+            deploy_mode="fake-cloud-service-api",
+            provider_deploy_mode="service-api",
+        )
+
+        with patch(
+            "control_plane.workflows.promotion_ship_resolution.resolve_native_ship_request",
+            return_value=ship_request,
+        ):
+            resolved = resolve_ship_request_for_promotion(
+                control_plane_root=Path("."),
+                request=request,
+            )
+
+        self.assertEqual(resolved, ship_request)
+
+    def test_promotion_ship_resolution_rejects_provider_target_fact_drift(
+        self,
+    ) -> None:
+        request = PromotionRequest(
+            artifact_id="artifact-sha256-image456",
+            backup_record_id="backup-opw-prod-20260410T182231Z",
+            source_git_ref="abc123",
+            context="syo",
+            from_instance="testing",
+            to_instance="prod",
+            target_name="syo-prod-service",
+            target_type="application",
+            provider_id="fake-cloud",
+            target_category="service",
+            provider_target_type="managed-service",
+            deploy_mode="fake-cloud-service-api",
+            provider_deploy_mode="service-api",
+        )
+        ship_request = ShipRequest(
+            artifact_id="artifact-sha256-image456",
+            context="syo",
+            instance="prod",
+            source_git_ref="abc123",
+            target_name="syo-prod-service",
+            target_type="application",
+            provider_id="fake-cloud",
+            target_category="service",
+            provider_target_type="container-service",
+            deploy_mode="fake-cloud-service-api",
+            provider_deploy_mode="service-api",
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.promotion_ship_resolution.resolve_native_ship_request",
+                return_value=ship_request,
+            ),
+            self.assertRaisesRegex(click.ClickException, "provider_target_type"),
+        ):
+            resolve_ship_request_for_promotion(
+                control_plane_root=Path("."),
+                request=request,
+            )
 
     def test_promotion_request_rejects_provider_reference_without_type(self) -> None:
         with self.assertRaisesRegex(ValueError, "target_reference provider_target_type"):
@@ -631,6 +780,25 @@ class PromoteWorkflowTests(unittest.TestCase):
         self.assertEqual(evidence.target_name, "opw-prod")
         self.assertEqual(evidence.target_type, "compose")
         self.assertEqual(evidence.provider_target_type, "compose")
+
+    def test_deployment_evidence_schema_prefers_target_reference_over_legacy_fields(
+        self,
+    ) -> None:
+        required_fields = set(DeploymentEvidence.model_json_schema()["required"])
+
+        self.assertIn("target_reference", DeploymentEvidence.model_fields)
+        self.assertNotIn("target_name", required_fields)
+        self.assertNotIn("target_type", required_fields)
+
+    def test_deployment_evidence_requires_resolved_target_identity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "deployment evidence requires target_name"):
+            DeploymentEvidence.model_validate(
+                {
+                    "deploy_mode": "dokploy-compose-api",
+                    "deployment_id": "deploy-123",
+                    "status": "pass",
+                }
+            )
 
     def test_deployment_evidence_rejects_provider_reference_without_type(self) -> None:
         with self.assertRaisesRegex(ValueError, "target_reference provider_target_type"):

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -55,6 +55,10 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                         target_name="ver-prod-app",
                         target_type="application",
                         deploy_mode="dokploy-application-api",
+                        provider_id="runtime-provider",
+                        target_category="service",
+                        provider_target_type="managed-service",
+                        provider_deploy_mode="service-api",
                         deployment_id="control-plane-dokploy",
                         status="pass",
                         started_at="2026-04-21T18:20:00Z",
@@ -127,9 +131,9 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             self.assertEqual(result.rollout_status, "pass")
             self.assertEqual(result.migration_status, "pass")
             self.assertEqual(result.health_status, "pass")
-            self.assertEqual(result.target_category, "application")
-            self.assertEqual(result.provider_id, "dokploy")
-            self.assertEqual(result.provider_target_type, "application")
+            self.assertEqual(result.target_category, "service")
+            self.assertEqual(result.provider_id, "runtime-provider")
+            self.assertEqual(result.provider_target_type, "managed-service")
             self.assertEqual(result.target_type, "application")
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
@@ -139,6 +143,10 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             )
             self.assertEqual(promotion.source_health.status, "pass")
             self.assertEqual(promotion.deploy.status, "pass")
+            self.assertEqual(promotion.deploy.provider_id, "runtime-provider")
+            self.assertEqual(promotion.deploy.target_category, "service")
+            self.assertEqual(promotion.deploy.provider_target_type, "managed-service")
+            self.assertEqual(promotion.deploy.provider_deploy_mode, "service-api")
             self.assertEqual(promotion.deploy.deployment_id, "prod-app-123")
             self.assertEqual(promotion.deploy.started_at, "2026-04-21T18:20:00Z")
             self.assertEqual(promotion.deploy.finished_at, "2026-04-21T18:21:15Z")
@@ -163,6 +171,35 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                     source="verireel-prod-gate",
                     status="pass",
                     evidence={"snapshot_name": "ver-predeploy-20260421T180500Z"},
+                )
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890"
+                    ),
+                    context="verireel",
+                    instance="prod",
+                    source_git_ref="abcdef1234567890",
+                    resolved_target=ResolvedTargetEvidence(
+                        target_type="application",
+                        target_id="prod-app-123",
+                        target_name="ver-prod-app",
+                    ),
+                    deploy=DeploymentEvidence(
+                        target_name="ver-prod-app",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        provider_id="runtime-provider",
+                        target_category="service",
+                        provider_target_type="managed-service",
+                        provider_deploy_mode="service-api",
+                        deployment_id="control-plane-dokploy",
+                        status="pass",
+                        started_at="2026-04-21T18:20:00Z",
+                        finished_at="2026-04-21T18:21:15Z",
+                    ),
                 )
             )
             request = VeriReelProdPromotionRequest(
@@ -229,6 +266,10 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             )
             self.assertEqual(promotion.backup_gate.status, "pass")
             self.assertEqual(promotion.deploy.status, "pass")
+            self.assertEqual(promotion.deploy.provider_id, "runtime-provider")
+            self.assertEqual(promotion.deploy.target_category, "service")
+            self.assertEqual(promotion.deploy.provider_target_type, "managed-service")
+            self.assertEqual(promotion.deploy.provider_deploy_mode, "service-api")
             self.assertEqual(promotion.post_deploy_update.status, "fail")
             self.assertEqual(promotion.destination_health.status, "skipped")
 


### PR DESCRIPTION
## Summary
- loosen ship/promotion/evidence target schemas so `target_reference` can supply resolved provider-neutral facts while legacy flat fields remain required after validation
- make compatibility-type mismatch checks provider-neutral and fail closed when promotion request provider facts drift from the resolved ship request
- preserve provider facts from VeriReel deployment records across prod promotion success and failure evidence/results

## Verification
- `uv run python -m unittest tests.test_promote tests.test_generic_web_deploy tests.test_generic_web_promotion tests.test_verireel_prod_promotion tests.test_filesystem_store tests.test_deploy_target`
- `uv run python -m unittest`
- `uv run mypy control_plane/contracts/deploy_target.py control_plane/contracts/ship_request.py control_plane/contracts/promotion_record.py control_plane/workflows/promotion_ship_resolution.py control_plane/workflows/verireel_prod_promotion.py tests/test_promote.py tests/test_verireel_prod_promotion.py`
- `uv run ruff check --diff control_plane/contracts/deploy_target.py control_plane/contracts/ship_request.py control_plane/contracts/promotion_record.py control_plane/workflows/promotion_ship_resolution.py control_plane/workflows/verireel_prod_promotion.py tests/test_promote.py tests/test_verireel_prod_promotion.py`
- `uv run ruff format --diff control_plane/contracts/deploy_target.py control_plane/contracts/ship_request.py control_plane/contracts/promotion_record.py control_plane/workflows/promotion_ship_resolution.py control_plane/workflows/verireel_prod_promotion.py tests/test_promote.py tests/test_verireel_prod_promotion.py`
- `uv run ruff check control_plane/contracts/deploy_target.py control_plane/contracts/ship_request.py control_plane/contracts/promotion_record.py control_plane/workflows/promotion_ship_resolution.py control_plane/workflows/verireel_prod_promotion.py tests/test_promote.py tests/test_verireel_prod_promotion.py`
- `uv run ruff format --check control_plane/contracts/deploy_target.py control_plane/contracts/ship_request.py control_plane/contracts/promotion_record.py control_plane/workflows/promotion_ship_resolution.py control_plane/workflows/verireel_prod_promotion.py tests/test_promote.py tests/test_verireel_prod_promotion.py`

Closes #1087.
