### PR TITLE
Prefer provider targets in onboarding manifests

### DIFF
--- a/control_plane/cli_product_config.py
+++ b/control_plane/cli_product_config.py
@@ -23,7 +23,9 @@ _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 def register_product_config_commands(
     main: click.Group,
     *,
-    summarize_product_profile_record: Callable[[LaunchplaneProductProfileRecord], dict[str, object]],
+    summarize_product_profile_record: Callable[
+        [LaunchplaneProductProfileRecord], dict[str, object]
+    ],
     summarize_dokploy_target_record: Callable[..., dict[str, object]],
     dokploy_target_route: Callable[[DokployTargetRecord | DokployTargetIdRecord], tuple[str, str]],
     target_id_map: Callable[[tuple[DokployTargetIdRecord, ...]], dict[tuple[str, str], str]],
@@ -136,7 +138,14 @@ def product_onboarding_apply(database_url: str, manifest_file: Path, updated_at:
     finally:
         store.close()
 
-    target_id_map = callbacks.target_id_map(result.dokploy_target_ids)
+    target_id_map = callbacks.target_id_map(result.provider_target_ids)
+    provider_targets = [
+        callbacks.summarize_dokploy_target_record(
+            record,
+            target_id=target_id_map.get(callbacks.dokploy_target_route(record), ""),
+        )
+        for record in result.provider_targets
+    ]
     click.echo(
         json.dumps(
             {
@@ -145,14 +154,10 @@ def product_onboarding_apply(database_url: str, manifest_file: Path, updated_at:
                 "product_profile": callbacks.summarize_product_profile_record(
                     result.product_profile
                 ),
-                "dokploy_target_count": len(result.dokploy_targets),
-                "dokploy_targets": [
-                    callbacks.summarize_dokploy_target_record(
-                        record,
-                        target_id=target_id_map.get(callbacks.dokploy_target_route(record), ""),
-                    )
-                    for record in result.dokploy_targets
-                ],
+                "provider_target_count": len(result.provider_targets),
+                "provider_targets": provider_targets,
+                "dokploy_target_count": len(result.provider_targets),
+                "dokploy_targets": provider_targets,
                 "runtime_environment_record_count": len(result.runtime_environments),
                 "runtime_environment_records": [
                     callbacks.summarize_runtime_environment_record(record)
@@ -174,11 +179,17 @@ class _ProductOnboardingApplyCallbacks:
     def __init__(
         self,
         *,
-        summarize_product_profile_record: Callable[[LaunchplaneProductProfileRecord], dict[str, object]],
+        summarize_product_profile_record: Callable[
+            [LaunchplaneProductProfileRecord], dict[str, object]
+        ],
         summarize_dokploy_target_record: Callable[..., dict[str, object]],
-        dokploy_target_route: Callable[[DokployTargetRecord | DokployTargetIdRecord], tuple[str, str]],
+        dokploy_target_route: Callable[
+            [DokployTargetRecord | DokployTargetIdRecord], tuple[str, str]
+        ],
         target_id_map: Callable[[tuple[DokployTargetIdRecord, ...]], dict[tuple[str, str], str]],
-        summarize_runtime_environment_record: Callable[[RuntimeEnvironmentRecord], dict[str, object]],
+        summarize_runtime_environment_record: Callable[
+            [RuntimeEnvironmentRecord], dict[str, object]
+        ],
         summarize_secret_binding_record: Callable[[SecretBinding], dict[str, object]],
     ) -> None:
         self.summarize_product_profile_record = summarize_product_profile_record

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -156,7 +156,7 @@ class ProductOnboardingManifest(BaseModel):
     promotion_workflow: ProductPromotionWorkflowProfile = Field(
         default_factory=ProductPromotionWorkflowProfile
     )
-    dokploy_targets: tuple[ProductOnboardingTargetManifest, ...] = ()
+    provider_targets: tuple[ProductOnboardingTargetManifest, ...] = ()
     runtime_environments: tuple[ProductOnboardingRuntimeEnvironmentManifest, ...] = ()
     secret_bindings: tuple[ProductOnboardingSecretBindingManifest, ...] = ()
     expected_config: ProductOnboardingExpectedConfigManifest = Field(
@@ -165,21 +165,25 @@ class ProductOnboardingManifest(BaseModel):
     updated_at: str = ""
     source_label: str = "product-onboarding"
 
+    @property
+    def dokploy_targets(self) -> tuple[ProductOnboardingTargetManifest, ...]:
+        return self.provider_targets
+
     @model_validator(mode="before")
     @classmethod
     def _normalize_provider_targets(cls, data: object) -> object:
-        if not isinstance(data, dict) or "provider_targets" not in data:
+        if not isinstance(data, dict):
             return data
         updated = dict(data)
-        raw_provider_targets = updated.pop("provider_targets")
-        raw_dokploy_targets = updated.get("dokploy_targets", ())
-        if raw_dokploy_targets is None or raw_dokploy_targets == () or raw_dokploy_targets == []:
-            updated["dokploy_targets"] = raw_provider_targets or ()
+        raw_provider_targets = updated.get("provider_targets", ())
+        raw_dokploy_targets = updated.pop("dokploy_targets", ())
+        if raw_provider_targets is None or raw_provider_targets == () or raw_provider_targets == []:
+            updated["provider_targets"] = raw_dokploy_targets or ()
             return updated
 
         provider_targets = _normalized_onboarding_targets(raw_provider_targets)
         dokploy_targets = _normalized_onboarding_targets(raw_dokploy_targets)
-        if provider_targets != dokploy_targets:
+        if dokploy_targets and provider_targets != dokploy_targets:
             raise ValueError("provider_targets must match dokploy_targets when both are set")
         return updated
 
@@ -208,7 +212,7 @@ class ProductOnboardingManifest(BaseModel):
             raise ValueError("product onboarding lanes must be unique by instance")
         ProductPreviewProfile.model_validate(self.preview.model_dump(mode="json"))
 
-        for target in self.dokploy_targets:
+        for target in self.provider_targets:
             route = (target.context.strip(), target.instance.strip())
             if route not in lane_routes:
                 raise ValueError(

--- a/control_plane/product_onboarding_service.py
+++ b/control_plane/product_onboarding_service.py
@@ -8,15 +8,15 @@ def build_product_onboarding_service_result(
 ) -> tuple[dict[str, object], dict[str, object]]:
     result: dict[str, object] = {
         "product_profile": onboarding_result.product_profile.product,
-        "provider_target_count": len(onboarding_result.dokploy_targets),
-        "provider_target_id_count": len(onboarding_result.dokploy_target_ids),
-        "dokploy_target_count": len(onboarding_result.dokploy_targets),
-        "dokploy_target_id_count": len(onboarding_result.dokploy_target_ids),
+        "provider_target_count": len(onboarding_result.provider_targets),
+        "provider_target_id_count": len(onboarding_result.provider_target_ids),
+        "dokploy_target_count": len(onboarding_result.provider_targets),
+        "dokploy_target_id_count": len(onboarding_result.provider_target_ids),
         "runtime_environment_record_count": len(onboarding_result.runtime_environments),
         "secret_binding_count": len(onboarding_result.secret_bindings),
     }
     provider_targets = [
-        record.model_dump(mode="json") for record in onboarding_result.dokploy_targets
+        record.model_dump(mode="json") for record in onboarding_result.provider_targets
     ]
     provider_target_ids = [
         {
@@ -26,7 +26,7 @@ def build_product_onboarding_service_result(
             "updated_at": record.updated_at,
             "source_label": record.source_label,
         }
-        for record in onboarding_result.dokploy_target_ids
+        for record in onboarding_result.provider_target_ids
     ]
     driver_result: dict[str, object] = {
         "product": onboarding_result.product,

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -38,10 +38,18 @@ class ProductOnboardingApplyResult(BaseModel):
 
     product: str
     product_profile: LaunchplaneProductProfileRecord
-    dokploy_targets: tuple[DokployTargetRecord, ...] = ()
-    dokploy_target_ids: tuple[DokployTargetIdRecord, ...] = ()
+    provider_targets: tuple[DokployTargetRecord, ...] = ()
+    provider_target_ids: tuple[DokployTargetIdRecord, ...] = ()
     runtime_environments: tuple[RuntimeEnvironmentRecord, ...] = ()
     secret_bindings: tuple[SecretBinding, ...] = ()
+
+    @property
+    def dokploy_targets(self) -> tuple[DokployTargetRecord, ...]:
+        return self.provider_targets
+
+    @property
+    def dokploy_target_ids(self) -> tuple[DokployTargetIdRecord, ...]:
+        return self.provider_target_ids
 
 
 def build_product_profile_record(
@@ -76,7 +84,7 @@ def build_product_profile_record(
     )
 
 
-def build_dokploy_target_records(
+def build_provider_target_records(
     *, manifest: ProductOnboardingManifest, updated_at: str
 ) -> tuple[DokployTargetRecord, ...]:
     return tuple(
@@ -104,11 +112,11 @@ def build_dokploy_target_records(
             updated_at=updated_at,
             source_label=manifest.source_label,
         )
-        for target in manifest.dokploy_targets
+        for target in manifest.provider_targets
     )
 
 
-def build_dokploy_target_id_records(
+def build_provider_target_id_records(
     *, manifest: ProductOnboardingManifest, updated_at: str
 ) -> tuple[DokployTargetIdRecord, ...]:
     return tuple(
@@ -119,7 +127,7 @@ def build_dokploy_target_id_records(
             updated_at=updated_at,
             source_label=manifest.source_label,
         )
-        for target in manifest.dokploy_targets
+        for target in manifest.provider_targets
         if target.target_id.strip()
     )
 
@@ -167,17 +175,19 @@ def apply_product_onboarding_manifest(
 ) -> ProductOnboardingApplyResult:
     recorded_at = updated_at.strip() or manifest.updated_at.strip() or utc_now_timestamp()
     product_profile = build_product_profile_record(manifest=manifest, updated_at=recorded_at)
-    dokploy_targets = build_dokploy_target_records(manifest=manifest, updated_at=recorded_at)
-    dokploy_target_ids = build_dokploy_target_id_records(manifest=manifest, updated_at=recorded_at)
+    provider_targets = build_provider_target_records(manifest=manifest, updated_at=recorded_at)
+    provider_target_ids = build_provider_target_id_records(
+        manifest=manifest, updated_at=recorded_at
+    )
     runtime_environments = build_runtime_environment_records(
         manifest=manifest, updated_at=recorded_at
     )
     secret_bindings = build_secret_bindings(manifest=manifest, updated_at=recorded_at)
 
     record_store.write_product_profile_record(product_profile)
-    for target_record in dokploy_targets:
+    for target_record in provider_targets:
         record_store.write_dokploy_target_record(target_record)
-    for target_id_record in dokploy_target_ids:
+    for target_id_record in provider_target_ids:
         record_store.write_dokploy_target_id_record(target_id_record)
     for runtime_record in runtime_environments:
         record_store.write_runtime_environment_record(runtime_record)
@@ -187,8 +197,8 @@ def apply_product_onboarding_manifest(
     return ProductOnboardingApplyResult(
         product=manifest.product,
         product_profile=product_profile,
-        dokploy_targets=dokploy_targets,
-        dokploy_target_ids=dokploy_target_ids,
+        provider_targets=provider_targets,
+        provider_target_ids=provider_target_ids,
         runtime_environments=runtime_environments,
         secret_bindings=secret_bindings,
     )

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -65,10 +65,11 @@ The manifest is applied idempotently and writes Launchplane-owned records for:
 - disabled managed secret binding placeholders for required secret keys
 
 Each onboarding target entry must include the live provider `target_id`.
-Manifests may use the neutral `provider_targets` input name; Launchplane
-normalizes it to the existing `dokploy_targets` compatibility field until the
-target-record write path is migrated. Launchplane fails closed instead of
-seeding a target record that a later deploy cannot resolve.
+Manifests should use the neutral `provider_targets` input name. Launchplane
+still accepts the existing `dokploy_targets` compatibility input for import
+material and older operator payloads while the target-record write path remains
+Dokploy-backed. Launchplane fails closed instead of seeding a target record that
+a later deploy cannot resolve.
 
 When the Dokploy application or compose target already exists, adopt it into
 Launchplane before or after onboarding instead of hand-editing target ids into

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -831,10 +831,12 @@ not include secret plaintext.
 
 Product onboarding uses `POST /v1/product-onboarding/apply`. The route accepts
 the same operator-approved manifest as `launchplane product-onboarding apply`
-and writes the full Launchplane-owned bundle: product profile, Dokploy target
-records, target-id records, runtime-environment records, and managed secret
-binding placeholders. It is restricted to `product_onboarding.apply` authority
-for product/context `launchplane`, requires DB-backed storage, returns only
+and writes the full Launchplane-owned bundle: product profile, existing
+Dokploy-backed target records, target-id records, runtime-environment records,
+and managed secret binding placeholders. Manifests should use neutral
+`provider_targets`; legacy `dokploy_targets` remains accepted as compatibility
+input. The route is restricted to `product_onboarding.apply` authority for
+product/context `launchplane`, requires DB-backed storage, returns only
 sanitized summaries, and exists so the Launchplane seed import workflow can seed
 product records without product repos storing live lifecycle truth. Responses
 include neutral `provider_target*` summary keys while retaining `dokploy_*`

--- a/scripts/deploy/apply-launchplane-seed-imports.py
+++ b/scripts/deploy/apply-launchplane-seed-imports.py
@@ -65,23 +65,36 @@ def _patch_target_ids(entry: dict[str, Any], manifest_payload: dict[str, Any]) -
     raw_mappings = entry.get("target_id_env", [])
     if not isinstance(raw_mappings, list):
         raise SystemExit(f"{entry['import_id']} target_id_env must be an array.")
-    raw_targets = manifest_payload.get("dokploy_targets", [])
-    if not isinstance(raw_targets, list):
-        raise SystemExit(f"{entry['import_id']} manifest dokploy_targets must be an array.")
+    raw_target_lists = [
+        targets
+        for targets in (
+            manifest_payload.get("provider_targets"),
+            manifest_payload.get("dokploy_targets"),
+        )
+        if targets is not None
+    ]
+    if not raw_target_lists:
+        raw_target_lists = [[]]
+    if not all(isinstance(targets, list) for targets in raw_target_lists):
+        raise SystemExit(
+            f"{entry['import_id']} manifest provider_targets/dokploy_targets must be an array."
+        )
 
-    targets_by_route = {
-        (str(target.get("context", "")), str(target.get("instance", ""))): target
-        for target in raw_targets
-        if isinstance(target, dict)
-    }
+    targets_by_route: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for raw_targets in raw_target_lists:
+        for target in raw_targets:
+            if not isinstance(target, dict):
+                continue
+            route = (str(target.get("context", "")), str(target.get("instance", "")))
+            targets_by_route.setdefault(route, []).append(target)
     for raw_mapping in raw_mappings:
         if not isinstance(raw_mapping, dict):
             raise SystemExit(f"{entry['import_id']} target_id_env entries must be objects.")
         context = _required_string(raw_mapping, "context")
         instance = _required_string(raw_mapping, "instance")
         env_key = _required_string(raw_mapping, "env")
-        target = targets_by_route.get((context, instance))
-        if target is None:
+        targets = targets_by_route.get((context, instance), [])
+        if not targets:
             raise SystemExit(
                 f"{entry['import_id']} target_id_env references missing target "
                 f"{context}/{instance}."
@@ -89,7 +102,8 @@ def _patch_target_ids(entry: dict[str, Any], manifest_payload: dict[str, Any]) -
         target_id = os.environ.get(env_key, "").strip()
         if not target_id:
             raise SystemExit(f"{env_key} is required for seed import {entry['import_id']}.")
-        target["target_id"] = target_id
+        for target in targets:
+            target["target_id"] = target_id
 
 
 def _product_onboarding_payload(entry: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -142,27 +142,27 @@ def _seed_import_manifest(
     import_id: str, target_ids_by_env: dict[str, str] | None = None
 ) -> dict[str, object]:
     catalog = json.loads(
-        Path("import-material/launchplane/seed-imports/catalog.json").read_text(
-            encoding="utf-8"
-        )
+        Path("import-material/launchplane/seed-imports/catalog.json").read_text(encoding="utf-8")
     )
-    entry = next(
-        item for item in catalog["imports"] if item["import_id"] == import_id
-    )
+    entry = next(item for item in catalog["imports"] if item["import_id"] == import_id)
     manifest_payload = json.loads(json.dumps(entry["manifest"]))
     target_ids = target_ids_by_env or {}
     for mapping in entry.get("target_id_env", []):
-        for target in manifest_payload.get("dokploy_targets", []):
-            if target["context"] == mapping["context"] and target["instance"] == mapping["instance"]:
+        targets = manifest_payload.get("provider_targets")
+        if targets is None:
+            targets = manifest_payload.get("dokploy_targets", [])
+        for target in targets:
+            if (
+                target["context"] == mapping["context"]
+                and target["instance"] == mapping["instance"]
+            ):
                 target["target_id"] = target_ids.get(mapping["env"], "")
     return cast(dict[str, object], manifest_payload)
 
 
 class ProductOnboardingTests(unittest.TestCase):
     def test_launchplane_seed_import_workflow_owns_seed_writes(self) -> None:
-        deploy_script = Path("scripts/deploy/ensure-authz-grants.sh").read_text(
-            encoding="utf-8"
-        )
+        deploy_script = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
         workflow_text = Path(".github/workflows/launchplane-seed-import.yml").read_text(
             encoding="utf-8"
         )
@@ -209,7 +209,10 @@ class ProductOnboardingTests(unittest.TestCase):
             if entry["kind"] == "product_onboarding":
                 manifest_payload = json.loads(json.dumps(entry["manifest"]))
                 for mapping in entry.get("target_id_env", []):
-                    for target in manifest_payload.get("dokploy_targets", []):
+                    targets = manifest_payload.get("provider_targets")
+                    if targets is None:
+                        targets = manifest_payload.get("dokploy_targets", [])
+                    for target in targets:
                         if (
                             target["context"] == mapping["context"]
                             and target["instance"] == mapping["instance"]
@@ -258,6 +261,77 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("ODOO_CM_TESTING_DOKPLOY_TARGET_ID is required", result.stderr)
+
+    def test_launchplane_seed_import_script_patches_provider_targets(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            output_dir = temporary_directory / "seed-import"
+            catalog_path = temporary_directory / "catalog.json"
+            manifest_payload = _manifest_payload()
+            manifest_payload["provider_targets"] = manifest_payload.pop("dokploy_targets")
+            manifest_payload["dokploy_targets"] = json.loads(
+                json.dumps(manifest_payload["provider_targets"])
+            )
+            for target in cast(list[dict[str, object]], manifest_payload["provider_targets"]):
+                if target["instance"] == "prod":
+                    target["target_id"] = ""
+            for target in cast(list[dict[str, object]], manifest_payload["dokploy_targets"]):
+                if target["instance"] == "prod":
+                    target["target_id"] = ""
+            catalog_path.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "imports": [
+                            {
+                                "import_id": "example-provider-targets",
+                                "kind": "product_onboarding",
+                                "manifest": manifest_payload,
+                                "target_id_env": [
+                                    {
+                                        "context": "example-site-prod",
+                                        "instance": "prod",
+                                        "env": "EXAMPLE_PROD_TARGET_ID",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "scripts/deploy/apply-launchplane-seed-imports.py",
+                    "--catalog",
+                    str(catalog_path),
+                    "--output-dir",
+                    str(output_dir),
+                    "--import-id",
+                    "example-provider-targets",
+                    "--reason",
+                    "test dry run",
+                ],
+                check=False,
+                capture_output=True,
+                env={**os.environ, "EXAMPLE_PROD_TARGET_ID": "app-prod-patched"},
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            output_payload = json.loads(
+                (output_dir / "example-provider-targets-payload.json").read_text(encoding="utf-8")
+            )
+
+        manifest = output_payload["manifest"]
+        self.assertIn("provider_targets", manifest)
+        self.assertNotIn("dokploy_targets", manifest)
+        provider_targets = manifest["provider_targets"]
+        self.assertEqual(provider_targets[1]["target_id"], "app-prod-patched")
 
     def test_deploy_authz_grants_include_scheduled_merge_train_runner(
         self,
@@ -393,7 +467,9 @@ class ProductOnboardingTests(unittest.TestCase):
             with self.subTest(workflow=workflow_path.name):
                 self.assertIn("launchplane_url:", workflow_text)
                 self.assertIn("launchplane_audience:", workflow_text)
-                self.assertIn("inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL", workflow_text)
+                self.assertIn(
+                    "inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL", workflow_text
+                )
                 self.assertIn("audience: ${{ inputs.launchplane_audience }}", workflow_text)
 
     def test_ingress_route_dry_run_workflow_rejects_non_object_options(self) -> None:
@@ -1148,9 +1224,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             self.assertNotEqual(grant["products"], ["*"])
             self.assertNotEqual(grant["contexts"], ["*"])
             self.assertTrue(
-                grant["source_label"].startswith(
-                    "deploy:local-operator-product-config-"
-                )
+                grant["source_label"].startswith("deploy:local-operator-product-config-")
             )
 
     def test_seed_import_verireel_onboarding_manifest_enrolls_preview_lifecycle(self) -> None:
@@ -1377,26 +1451,40 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(secret_bindings[0].binding_key, "SMTP_PASSWORD")
         self.assertEqual(secret_bindings[0].status, "disabled")
 
-    def test_product_onboarding_manifest_accepts_provider_targets_alias(self) -> None:
+    def test_product_onboarding_manifest_prefers_provider_targets(self) -> None:
         payload = _manifest_payload()
         payload["provider_targets"] = payload.pop("dokploy_targets")
 
         manifest = ProductOnboardingManifest.model_validate(payload)
 
+        self.assertEqual(len(manifest.provider_targets), 2)
         self.assertEqual(len(manifest.dokploy_targets), 2)
         self.assertEqual(
             [
                 (target.context, target.instance, target.target_type, target.target_id)
-                for target in manifest.dokploy_targets
+                for target in manifest.provider_targets
             ],
             [
                 ("example-site-testing", "testing", "application", "app-testing-123"),
                 ("example-site-prod", "prod", "application", "app-prod-123"),
             ],
         )
-        self.assertNotIn("provider_targets", manifest.model_dump())
+        self.assertIn("provider_targets", manifest.model_dump())
+        self.assertNotIn("dokploy_targets", manifest.model_dump())
 
-    def test_product_onboarding_manifest_accepts_matching_provider_targets_alias(
+    def test_product_onboarding_manifest_accepts_dokploy_targets_compat_input(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+
+        manifest = ProductOnboardingManifest.model_validate(payload)
+
+        self.assertEqual(len(manifest.provider_targets), 2)
+        self.assertEqual(manifest.dokploy_targets, manifest.provider_targets)
+        self.assertIn("provider_targets", manifest.model_dump())
+        self.assertNotIn("dokploy_targets", manifest.model_dump())
+
+    def test_product_onboarding_manifest_accepts_matching_provider_targets_input(
         self,
     ) -> None:
         payload = _manifest_payload()
@@ -1404,9 +1492,10 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
 
         manifest = ProductOnboardingManifest.model_validate(payload)
 
+        self.assertEqual(len(manifest.provider_targets), 2)
         self.assertEqual(len(manifest.dokploy_targets), 2)
 
-    def test_product_onboarding_manifest_rejects_conflicting_provider_targets_alias(
+    def test_product_onboarding_manifest_rejects_conflicting_provider_targets_input(
         self,
     ) -> None:
         payload = _manifest_payload()

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -87,9 +87,7 @@ class ProductOnboardingServiceTests(unittest.TestCase):
         self.assertEqual(result["secret_binding_count"], 1)
         self.assertEqual(driver_result["product"], "discord-blue")
         self.assertEqual(driver_result["provider_targets"], driver_result["dokploy_targets"])
-        self.assertEqual(
-            driver_result["provider_target_ids"], driver_result["dokploy_target_ids"]
-        )
+        self.assertEqual(driver_result["provider_target_ids"], driver_result["dokploy_target_ids"])
         self.assertNotIn("secret_id", str(driver_result))
 
 


### PR DESCRIPTION
## Summary
- make `provider_targets` the canonical product onboarding manifest field while keeping `dokploy_targets` as compatibility input/property
- rename onboarding apply-result internals and summaries to prefer provider target terminology while preserving Dokploy-backed writes and legacy response keys
- update seed-import target-id patching so neutral and compatibility target lists stay aligned

## Safety
- no storage schema changes
- no provider-target dual-write/backfill/cutover
- store writes remain `write_dokploy_target_record` / `write_dokploy_target_id_record`
- legacy `dokploy_targets` payloads and output aliases remain supported

## Verification
- `uv run python -m unittest tests.test_product_onboarding tests.test_product_onboarding_service`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle`
- `uv run python -m unittest tests.test_product_onboarding tests.test_product_onboarding_service tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle`
- `uv run python -m unittest tests.test_product_onboarding tests.test_product_onboarding_service tests.test_service tests.test_postgres_store tests.test_filesystem_store`
- `uv run python -m unittest`
- `uv run mypy control_plane/cli_product_config.py control_plane/contracts/product_onboarding_manifest.py control_plane/product_onboarding_service.py control_plane/workflows/product_onboarding.py scripts/deploy/apply-launchplane-seed-imports.py tests/test_product_onboarding.py tests/test_product_onboarding_service.py`
- `uv run ruff check --diff control_plane/cli_product_config.py control_plane/contracts/product_onboarding_manifest.py control_plane/product_onboarding_service.py control_plane/workflows/product_onboarding.py scripts/deploy/apply-launchplane-seed-imports.py tests/test_product_onboarding.py tests/test_product_onboarding_service.py`
- `uv run ruff check control_plane/cli_product_config.py control_plane/contracts/product_onboarding_manifest.py control_plane/product_onboarding_service.py control_plane/workflows/product_onboarding.py scripts/deploy/apply-launchplane-seed-imports.py tests/test_product_onboarding.py tests/test_product_onboarding_service.py`
- `uv run ruff format --check control_plane/cli_product_config.py control_plane/contracts/product_onboarding_manifest.py control_plane/product_onboarding_service.py control_plane/workflows/product_onboarding.py scripts/deploy/apply-launchplane-seed-imports.py tests/test_product_onboarding.py tests/test_product_onboarding_service.py`

Closes #1088.
