### PR TITLE
Add provider-target parity audit

### DIFF
--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -6,6 +6,7 @@ from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.secret_record import SecretScope
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.provider_target_audit import audit_provider_targets
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
@@ -57,6 +58,38 @@ def storage_import_core_records(state_dir: Path, database_url: str) -> None:
     postgres_store.ensure_schema()
     counts = postgres_store.import_core_records_from_filesystem(filesystem_store)
     click.echo(json.dumps({"status": "ok", "counts": counts}, indent=2, sort_keys=True))
+
+
+@storage.command("provider-target-audit")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane provider-target records.",
+)
+@click.option("--provider-id", default="", help="Optional provider id filter.")
+@click.option("--context", "context_name", default="", help="Optional context filter.")
+@click.option("--instance", "instance_name", default="", help="Optional instance filter.")
+def storage_provider_target_audit(
+    database_url: str,
+    provider_id: str,
+    context_name: str,
+    instance_name: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        postgres_store.ensure_schema()
+        result = audit_provider_targets(
+            postgres_store,
+            provider_id=provider_id,
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+        click.echo(json.dumps(result.to_report_payload(), indent=2, sort_keys=True))
+    finally:
+        postgres_store.close()
+    if not result.ok:
+        raise click.exceptions.Exit(1)
 
 
 @secrets.command("put")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -3211,6 +3211,16 @@ class PostgresRecordStore(HumanSessionStore):
         provider_records.sort(key=lambda record: (record.context, record.instance))
         return tuple(provider_records)
 
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]:
+        return self._list_models(
+            model_type=ProviderTargetRecord,
+            orm_model=LaunchplaneProviderTargetRow,
+            order_by=(
+                LaunchplaneProviderTargetRow.context.asc(),
+                LaunchplaneProviderTargetRow.instance.asc(),
+            ),
+        )
+
     def write_provider_target_record(self, record: ProviderTargetRecord) -> None:
         self._write_row(
             LaunchplaneProviderTargetRow(

--- a/control_plane/workflows/provider_target_audit.py
+++ b/control_plane/workflows/provider_target_audit.py
@@ -1,0 +1,423 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+
+
+ProviderTargetAuditStatus = Literal[
+    "complete",
+    "missing_provider_target",
+    "missing_dokploy_pair",
+    "missing_dokploy_target",
+    "missing_target_id",
+    "no_matching_routes",
+    "identity_mismatch",
+    "category_mismatch",
+    "display_name_mismatch",
+    "provider_target_type_mismatch",
+    "provider_evidence_mismatch",
+    "future_provider",
+]
+ProviderTargetAuditSeverity = Literal["ok", "warning", "blocked"]
+
+
+class ProviderTargetAuditRecordStore(Protocol):
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]: ...
+
+    def list_dokploy_target_records(self) -> tuple[DokployTargetRecord, ...]: ...
+
+    def list_dokploy_target_id_records(self) -> tuple[DokployTargetIdRecord, ...]: ...
+
+
+class ProviderTargetAuditFinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    context: str
+    instance: str
+    status: ProviderTargetAuditStatus
+    severity: ProviderTargetAuditSeverity
+    detail: str
+    physical_record: ProviderTargetRecord | None = None
+    projected_record: ProviderTargetRecord | None = None
+
+    @model_validator(mode="after")
+    def _validate_finding(self) -> "ProviderTargetAuditFinding":
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        self.detail = self.detail.strip()
+        if not self.context:
+            raise ValueError("provider target audit finding requires context")
+        if not self.instance:
+            raise ValueError("provider target audit finding requires instance")
+        if not self.detail:
+            raise ValueError("provider target audit finding requires detail")
+        return self
+
+
+class ProviderTargetAuditResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    findings: tuple[ProviderTargetAuditFinding, ...] = ()
+    counts: dict[str, int] = Field(default_factory=dict)
+    inspected_route_count: int = 0
+    blocked_count: int = 0
+    warning_count: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return self.blocked_count == 0
+
+    def to_report_payload(self) -> dict[str, object]:
+        return {
+            "status": "ok" if self.ok else "blocked",
+            "inspected_route_count": self.inspected_route_count,
+            "blocked_count": self.blocked_count,
+            "warning_count": self.warning_count,
+            "counts": self.counts,
+            "findings": [
+                finding.model_dump(mode="json", exclude_none=True)
+                for finding in self.findings
+            ],
+        }
+
+
+def audit_provider_targets(
+    record_store: ProviderTargetAuditRecordStore,
+    *,
+    provider_id: str = "",
+    context_name: str = "",
+    instance_name: str = "",
+) -> ProviderTargetAuditResult:
+    normalized_provider_id = provider_id.strip().lower()
+    normalized_context = context_name.strip()
+    normalized_instance = instance_name.strip()
+    physical_records = {
+        _route_key(record.context, record.instance): record
+        for record in record_store.list_physical_provider_target_records()
+    }
+    dokploy_target_records = {
+        _route_key(record.context, record.instance): record
+        for record in record_store.list_dokploy_target_records()
+    }
+    dokploy_target_id_records = {
+        _route_key(record.context, record.instance): record
+        for record in record_store.list_dokploy_target_id_records()
+    }
+    route_keys = sorted(
+        physical_records.keys()
+        | dokploy_target_records.keys()
+        | dokploy_target_id_records.keys()
+    )
+    findings: list[ProviderTargetAuditFinding] = []
+    inspected_route_count = 0
+    for context, instance in route_keys:
+        if normalized_context and context != normalized_context:
+            continue
+        if normalized_instance and instance != normalized_instance:
+            continue
+        physical_record = physical_records.get((context, instance))
+        target_record = dokploy_target_records.get((context, instance))
+        target_id_record = dokploy_target_id_records.get((context, instance))
+        if not _matches_provider_filter(
+            normalized_provider_id=normalized_provider_id,
+            physical_record=physical_record,
+            target_record=target_record,
+            target_id_record=target_id_record,
+        ):
+            continue
+        inspected_route_count += 1
+        findings.extend(
+            _audit_route(
+                context=context,
+                instance=instance,
+                physical_record=physical_record,
+                target_record=target_record,
+                target_id_record=target_id_record,
+            )
+        )
+    if inspected_route_count == 0 and (
+        normalized_provider_id or normalized_context or normalized_instance
+    ):
+        findings.append(
+            _finding(
+                context=normalized_context or "*",
+                instance=normalized_instance or "*",
+                status="no_matching_routes",
+                severity="blocked",
+                detail="provider-target audit filters did not match any stored route",
+            )
+        )
+    counts = Counter(finding.status for finding in findings)
+    return ProviderTargetAuditResult(
+        findings=tuple(findings),
+        counts=dict(sorted(counts.items())),
+        inspected_route_count=inspected_route_count,
+        blocked_count=sum(1 for finding in findings if finding.severity == "blocked"),
+        warning_count=sum(1 for finding in findings if finding.severity == "warning"),
+    )
+
+
+def _audit_route(
+    *,
+    context: str,
+    instance: str,
+    physical_record: ProviderTargetRecord | None,
+    target_record: DokployTargetRecord | None,
+    target_id_record: DokployTargetIdRecord | None,
+) -> tuple[ProviderTargetAuditFinding, ...]:
+    findings: list[ProviderTargetAuditFinding] = []
+    if physical_record is not None and physical_record.provider_id != "dokploy":
+        return (
+            _finding(
+                context=context,
+                instance=instance,
+                status="future_provider",
+                severity="warning",
+                detail="explicit provider-target row is not managed by the Dokploy projection audit",
+                physical_record=physical_record,
+            ),
+        )
+    if target_record is None and target_id_record is None:
+        if physical_record is None or physical_record.provider_id != "dokploy":
+            return tuple(findings)
+        findings.append(
+            _finding(
+                context=context,
+                instance=instance,
+                status="missing_dokploy_pair",
+                severity="blocked",
+                detail="explicit Dokploy provider-target row has no Dokploy target or target-id records",
+                physical_record=physical_record,
+            )
+        )
+        return tuple(findings)
+    if target_record is None:
+        findings.append(
+            _finding(
+                context=context,
+                instance=instance,
+                status="missing_dokploy_target",
+                severity="blocked",
+                detail="Dokploy target metadata record is missing",
+                physical_record=physical_record,
+            )
+        )
+        return tuple(findings)
+    if target_id_record is None:
+        findings.append(
+            _finding(
+                context=context,
+                instance=instance,
+                status="missing_target_id",
+                severity="blocked",
+                detail="Dokploy target-id record is missing",
+                physical_record=physical_record,
+            )
+        )
+        return tuple(findings)
+    projected_record = ProviderTargetRecord.from_dokploy_records(
+        target_record=target_record,
+        target_id_record=target_id_record,
+    )
+    if physical_record is None:
+        findings.append(
+            _finding(
+                context=context,
+                instance=instance,
+                status="missing_provider_target",
+                severity="blocked",
+                detail="Dokploy target/id pair has no explicit provider-target row",
+                projected_record=projected_record,
+            )
+        )
+        return tuple(findings)
+    findings.extend(
+        _compare_records(
+            context=context,
+            instance=instance,
+            physical_record=physical_record,
+            projected_record=projected_record,
+        )
+    )
+    if len(findings) == 0 or all(
+        finding.status == "future_provider" for finding in findings
+    ):
+        findings.append(
+            _finding(
+                context=context,
+                instance=instance,
+                status="complete",
+                severity="ok",
+                detail="explicit provider-target row matches the Dokploy projection",
+                physical_record=physical_record,
+                projected_record=projected_record,
+            )
+        )
+    return tuple(findings)
+
+
+def _compare_records(
+    *,
+    context: str,
+    instance: str,
+    physical_record: ProviderTargetRecord,
+    projected_record: ProviderTargetRecord,
+) -> tuple[ProviderTargetAuditFinding, ...]:
+    findings: list[ProviderTargetAuditFinding] = []
+    identity_differences = _identity_differences(
+        physical_record=physical_record,
+        projected_record=projected_record,
+    )
+    if identity_differences:
+        findings.append(
+            _finding(
+                context=context,
+                instance=instance,
+                status="identity_mismatch",
+                severity="blocked",
+                detail="provider-target identity mismatch: "
+                + ", ".join(identity_differences),
+                physical_record=physical_record,
+                projected_record=projected_record,
+            )
+        )
+    if physical_record.target_category != projected_record.target_category:
+        findings.append(
+            _field_mismatch_finding(
+                context=context,
+                instance=instance,
+                status="category_mismatch",
+                field_name="target_category",
+                physical_value=physical_record.target_category,
+                projected_value=projected_record.target_category,
+                physical_record=physical_record,
+                projected_record=projected_record,
+            )
+        )
+    if physical_record.display_name != projected_record.display_name:
+        findings.append(
+            _field_mismatch_finding(
+                context=context,
+                instance=instance,
+                status="display_name_mismatch",
+                field_name="display_name",
+                physical_value=physical_record.display_name,
+                projected_value=projected_record.display_name,
+                physical_record=physical_record,
+                projected_record=projected_record,
+            )
+        )
+    if physical_record.provider_target_type != projected_record.provider_target_type:
+        findings.append(
+            _field_mismatch_finding(
+                context=context,
+                instance=instance,
+                status="provider_target_type_mismatch",
+                field_name="provider_target_type",
+                physical_value=physical_record.provider_target_type,
+                projected_value=projected_record.provider_target_type,
+                physical_record=physical_record,
+                projected_record=projected_record,
+            )
+        )
+    if physical_record.provider_evidence != projected_record.provider_evidence:
+        findings.append(
+            _finding(
+                context=context,
+                instance=instance,
+                status="provider_evidence_mismatch",
+                severity="blocked",
+                detail="provider_evidence differs between explicit row and Dokploy projection",
+                physical_record=physical_record,
+                projected_record=projected_record,
+            )
+        )
+    return tuple(findings)
+
+
+def _identity_differences(
+    *,
+    physical_record: ProviderTargetRecord,
+    projected_record: ProviderTargetRecord,
+) -> tuple[str, ...]:
+    differences: list[str] = []
+    if physical_record.provider_id != projected_record.provider_id:
+        differences.append(
+            f"provider_id physical={physical_record.provider_id!r} projected={projected_record.provider_id!r}"
+        )
+    if physical_record.target_id != projected_record.target_id:
+        differences.append(
+            f"target_id physical={physical_record.target_id!r} projected={projected_record.target_id!r}"
+        )
+    return tuple(differences)
+
+
+def _field_mismatch_finding(
+    *,
+    context: str,
+    instance: str,
+    status: ProviderTargetAuditStatus,
+    field_name: str,
+    physical_value: str,
+    projected_value: str,
+    physical_record: ProviderTargetRecord,
+    projected_record: ProviderTargetRecord,
+) -> ProviderTargetAuditFinding:
+    return _finding(
+        context=context,
+        instance=instance,
+        status=status,
+        severity="blocked",
+        detail=f"{field_name} physical={physical_value!r} projected={projected_value!r}",
+        physical_record=physical_record,
+        projected_record=projected_record,
+    )
+
+
+def _finding(
+    *,
+    context: str,
+    instance: str,
+    status: ProviderTargetAuditStatus,
+    severity: ProviderTargetAuditSeverity,
+    detail: str,
+    physical_record: ProviderTargetRecord | None = None,
+    projected_record: ProviderTargetRecord | None = None,
+) -> ProviderTargetAuditFinding:
+    return ProviderTargetAuditFinding(
+        context=context,
+        instance=instance,
+        status=status,
+        severity=severity,
+        detail=detail,
+        physical_record=physical_record,
+        projected_record=projected_record,
+    )
+
+
+def _matches_provider_filter(
+    *,
+    normalized_provider_id: str,
+    physical_record: ProviderTargetRecord | None,
+    target_record: DokployTargetRecord | None,
+    target_id_record: DokployTargetIdRecord | None,
+) -> bool:
+    if not normalized_provider_id:
+        return True
+    if physical_record is not None and physical_record.provider_id == normalized_provider_id:
+        return True
+    if normalized_provider_id == "dokploy" and (
+        target_record is not None or target_id_record is not None
+    ):
+        return True
+    return False
+
+
+def _route_key(context: str, instance: str) -> tuple[str, str]:
+    return (context.strip(), instance.strip())

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -33,6 +33,8 @@ API path instead of running the local command from an arbitrary checkout.
   TOML catalog from minted state.
 - `service`: run the first local Launchplane HTTP ingress slice.
 - `ship`: plan, resolve, and execute artifact-backed deploy requests.
+- `storage provider-target-audit`: run the read-only provider-target parity
+  preflight before Phase Two backfill or provider-target authority cutover.
 
 `deployments write`, `promotions write`, `inventory write-from-deployment`,
 `inventory write-from-promotion`, and `release-tuples write-from-promotion`
@@ -44,6 +46,19 @@ Those commands are current implementation scaffolding. The Launchplane boundary
 is a long-running service with authenticated HTTP ingress. The CLI should remain
 a client of Launchplane's stable API contract or an explicit DB-backed operator
 tool, not a separate live-state authority.
+
+Provider-target Phase Two data changes must start with a read-only audit:
+
+```bash
+uv run launchplane storage provider-target-audit \
+  --database-url "$LAUNCHPLANE_DATABASE_URL"
+```
+
+Use `--provider-id`, `--context`, or `--instance` for narrower inspection. The
+command emits JSON and exits nonzero when explicit provider-target rows are
+missing, partial Dokploy pairs exist, or explicit rows disagree with the
+Dokploy-derived projection. Backfill and authority cutover should not proceed
+until the audit has no unresolved blockers for the affected lanes.
 
 ## Target Launchplane Ingress
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -137,6 +137,11 @@ an ORM column/table or remains only in the evidence payload.
   explicit provider-target row exists. Existing Dokploy target and target-id
   records remain the active live write/execution path until a later dual-write
   or cutover migration.
+- `uv run launchplane storage provider-target-audit` is the read-only Phase Two
+  preflight for this record family. It compares explicit provider-target rows
+  with the neutral projection from paired Dokploy target and target-id records,
+  reports missing halves and mismatches, and exits nonzero when unresolved
+  blockers would make backfill or authority cutover unsafe.
 - Shared ship and promotion request/evidence contracts accept a neutral
   `target_reference` compatibility input for target name, provider id,
   category, and provider target type. Persisted records still write the flat

--- a/tests/test_provider_target_audit.py
+++ b/tests/test_provider_target_audit.py
@@ -1,0 +1,297 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.deploy_target import DeployTargetCategory
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord, DokployTargetType
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.provider_target_audit import audit_provider_targets
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite:///{database_path}"
+
+
+def _dokploy_target_record(
+    *,
+    context: str = "syo",
+    instance: str = "prod",
+    target_type: str = "application",
+    target_name: str = "",
+    project_name: str = "syo-project",
+) -> DokployTargetRecord:
+    return DokployTargetRecord(
+        context=context,
+        instance=instance,
+        project_name=project_name,
+        target_type=cast(DokployTargetType, target_type),
+        target_name=target_name or f"{context}-{instance}",
+        source_git_ref="origin/main",
+        source_type="git",
+        custom_git_url="git@github.com:example/product.git",
+        custom_git_branch=instance,
+        compose_path="./docker-compose.yml",
+        domains=(f"https://{instance}.example.com",),
+        updated_at="2026-04-21T18:30:00Z",
+        source_label="test:dokploy-target",
+    )
+
+
+def _dokploy_target_id_record(
+    *,
+    context: str = "syo",
+    instance: str = "prod",
+    target_id: str = "app-syo-prod",
+) -> DokployTargetIdRecord:
+    return DokployTargetIdRecord(
+        context=context,
+        instance=instance,
+        target_id=target_id,
+        updated_at="2026-04-21T18:31:00Z",
+        source_label="test:dokploy-target-id",
+    )
+
+
+def _provider_target_record(
+    *,
+    context: str = "syo",
+    instance: str = "prod",
+    provider_id: str = "dokploy",
+    target_category: str = "application",
+    target_id: str = "app-syo-prod",
+    display_name: str = "",
+    provider_target_type: str = "application",
+    provider_evidence: dict[str, str] | None = None,
+) -> ProviderTargetRecord:
+    return ProviderTargetRecord(
+        context=context,
+        instance=instance,
+        provider_id=provider_id,
+        target_category=cast(DeployTargetCategory, target_category),
+        target_id=target_id,
+        display_name=display_name or f"{context}-{instance}",
+        provider_target_type=provider_target_type,
+        provider_evidence=provider_evidence
+        if provider_evidence is not None
+        else {"project_name": "syo-project"},
+        updated_at="2026-04-21T18:32:00Z",
+        source_label="test:provider-target",
+    )
+
+
+class ProviderTargetAuditTests(unittest.TestCase):
+    def test_audit_reports_complete_matching_physical_row(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+            store.write_provider_target_record(_provider_target_record())
+
+            result = audit_provider_targets(store)
+            store.close()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.counts, {"complete": 1})
+        self.assertEqual(result.findings[0].status, "complete")
+
+    def test_audit_reports_missing_provider_target(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+
+            result = audit_provider_targets(store)
+            store.close()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.counts, {"missing_provider_target": 1})
+        self.assertEqual(result.blocked_count, 1)
+
+    def test_audit_reports_missing_halves(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(
+                _dokploy_target_record(context="target-only", instance="prod")
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(context="id-only", instance="prod")
+            )
+
+            result = audit_provider_targets(store)
+            store.close()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(
+            result.counts,
+            {"missing_dokploy_target": 1, "missing_target_id": 1},
+        )
+
+    def test_audit_reports_identity_and_field_mismatches(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+            store.write_provider_target_record(
+                _provider_target_record(
+                    target_category="compose",
+                    target_id="stale-app-syo-prod",
+                    display_name="stale-display-name",
+                    provider_target_type="compose",
+                    provider_evidence={"project_name": "stale-project"},
+                )
+            )
+
+            result = audit_provider_targets(store)
+            statuses = {finding.status for finding in result.findings}
+            store.close()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(
+            statuses,
+            {
+                "identity_mismatch",
+                "category_mismatch",
+                "display_name_mismatch",
+                "provider_target_type_mismatch",
+                "provider_evidence_mismatch",
+            },
+        )
+
+    def test_audit_warns_for_future_provider_row(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_provider_target_record(
+                _provider_target_record(provider_id="future-provider")
+            )
+
+            result = audit_provider_targets(store)
+            filtered = audit_provider_targets(store, provider_id="dokploy")
+            store.close()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.warning_count, 1)
+        self.assertEqual(result.counts, {"future_provider": 1})
+        self.assertFalse(filtered.ok)
+        self.assertEqual(filtered.counts, {"no_matching_routes": 1})
+
+    def test_audit_warns_for_future_provider_row_with_dokploy_pair(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_provider_target_record(
+                _provider_target_record(provider_id="future-provider")
+            )
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+
+            result = audit_provider_targets(store)
+            store.close()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.warning_count, 1)
+        self.assertEqual(result.counts, {"future_provider": 1})
+
+    def test_audit_blocks_zero_match_filters(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+
+            result = audit_provider_targets(store, context_name="missing-context")
+            store.close()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.inspected_route_count, 0)
+        self.assertEqual(result.counts, {"no_matching_routes": 1})
+
+    def test_cli_emits_json_and_fails_on_blockers(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            database_url = _sqlite_database_url(database_path)
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+            store.close()
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "storage",
+                    "provider-target-audit",
+                    "--database-url",
+                    database_url,
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["inspected_route_count"], 1)
+        self.assertEqual(payload["counts"], {"missing_provider_target": 1})
+
+    def test_cli_initializes_fresh_database_schema(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "storage",
+                    "provider-target-audit",
+                    "--database-url",
+                    database_url,
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["inspected_route_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a read-only provider-target parity audit workflow that compares explicit physical provider-target rows with Dokploy target/id projections.
- Exposes `launchplane storage provider-target-audit` with JSON output, filter support, schema initialization, and nonzero exit for blockers.
- Documents the audit as the Phase Two preflight before backfill or provider-target authority cutover.

## Safety

- Blocks missing provider-target rows, partial Dokploy pairs, conflicting explicit rows, and zero-match filtered audits.
- Treats non-Dokploy physical provider-target rows as future-provider warnings instead of comparing them to Dokploy projections.
- Does not mutate runtime records or change live deploy/promotion authority.

Refs #1100
Refs #1101

## Validation

- `uv run python -m unittest tests.test_provider_target_audit`
- `uv run python -m unittest tests.test_provider_target_audit tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_records_project_from_dokploy_records tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_physical_storage_precedes_dokploy_projection tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_filter_suppresses_shadowed_dokploy_projection tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_list_combines_physical_and_projected_records tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_list_skips_incomplete_dokploy_pairs`
- `uv run --extra dev ruff check control_plane/workflows/provider_target_audit.py control_plane/storage/postgres.py control_plane/cli_storage_secrets.py tests/test_provider_target_audit.py docs/records.md docs/operations.md --diff`
- `uv run --extra dev ruff check control_plane/workflows/provider_target_audit.py control_plane/storage/postgres.py control_plane/cli_storage_secrets.py tests/test_provider_target_audit.py`
- `uv run --extra dev mypy control_plane tests/test_provider_target_audit.py`
- `uv run python -m unittest` (1934 tests)
