### PR TITLE
Dual-write provider-target rows

### DIFF
--- a/control_plane/cli_dokploy_targets.py
+++ b/control_plane/cli_dokploy_targets.py
@@ -6,12 +6,16 @@ from typing import Literal
 import click
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.dokploy_target_adoption import (
     adopt_dokploy_target,
     create_dokploy_application_target,
+)
+from control_plane.workflows.provider_target_dual_write import (
+    prepare_provider_target_from_dokploy_records,
 )
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -388,7 +392,20 @@ def dokploy_targets_put_shopify_protected_store_key(
                 source_label=source_label,
             )
         )
+        target_id_record = _find_dokploy_target_id_record(
+            target_id_records=target_id_records,
+            context_name=record.context,
+            instance_name=record.instance,
+        )
+        prepare_provider_target_from_dokploy_records(
+            record_store=postgres_store,
+            target_record=record,
+            target_id_record=target_id_record,
+        )
         postgres_store.write_dokploy_target_record(record)
+        postgres_store.write_provider_target_record(
+            record=record_to_provider_target(record=record, target_id_record=target_id_record)
+        )
     finally:
         postgres_store.close()
     target_ids_by_route = target_id_map(target_id_records)
@@ -447,7 +464,20 @@ def dokploy_targets_unset_shopify_protected_store_key(
                 source_label=source_label,
             )
         )
+        target_id_record = _find_dokploy_target_id_record(
+            target_id_records=target_id_records,
+            context_name=record.context,
+            instance_name=record.instance,
+        )
+        prepare_provider_target_from_dokploy_records(
+            record_store=postgres_store,
+            target_record=record,
+            target_id_record=target_id_record,
+        )
         postgres_store.write_dokploy_target_record(record)
+        postgres_store.write_provider_target_record(
+            record=record_to_provider_target(record=record, target_id_record=target_id_record)
+        )
     finally:
         postgres_store.close()
     target_ids_by_route = target_id_map(target_id_records)
@@ -492,7 +522,20 @@ def dokploy_targets_relabel(
             instance_name=instance_name,
             source_label=source_label,
         )
+        target_id_record = _find_dokploy_target_id_record(
+            target_id_records=target_id_records,
+            context_name=record.context,
+            instance_name=record.instance,
+        )
+        prepare_provider_target_from_dokploy_records(
+            record_store=postgres_store,
+            target_record=record,
+            target_id_record=target_id_record,
+        )
         postgres_store.write_dokploy_target_record(record)
+        postgres_store.write_provider_target_record(
+            record=record_to_provider_target(record=record, target_id_record=target_id_record)
+        )
     finally:
         postgres_store.close()
     target_ids_by_route = target_id_map(target_id_records)
@@ -542,10 +585,34 @@ def _find_dokploy_target_record(
     return None
 
 
+def _find_dokploy_target_id_record(
+    *,
+    target_id_records: tuple[DokployTargetIdRecord, ...],
+    context_name: str,
+    instance_name: str,
+) -> DokployTargetIdRecord:
+    normalized_route = (context_name.strip().lower(), instance_name.strip().lower())
+    for record in target_id_records:
+        if dokploy_target_route(record) == normalized_route:
+            return record
+    raise click.ClickException(
+        "Missing DB-backed tracked Dokploy target-id record for the requested route."
+    )
+
+
 def target_id_map(
     target_id_records: tuple[DokployTargetIdRecord, ...],
 ) -> dict[tuple[str, str], str]:
     return {dokploy_target_route(record): record.target_id for record in target_id_records}
+
+
+def record_to_provider_target(
+    *, record: DokployTargetRecord, target_id_record: DokployTargetIdRecord
+) -> ProviderTargetRecord:
+    return ProviderTargetRecord.from_dokploy_records(
+        target_record=record,
+        target_id_record=target_id_record,
+    )
 
 
 def summarize_dokploy_target_record(

--- a/control_plane/product_context_cutover.py
+++ b/control_plane/product_context_cutover.py
@@ -6,6 +6,7 @@ from typing import Literal, Protocol
 
 from pydantic import BaseModel, ConfigDict, model_validator
 
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
@@ -20,6 +21,9 @@ from control_plane.contracts.secret_record import (
     SecretBinding,
     SecretRecord,
     SecretVersion,
+)
+from control_plane.workflows.provider_target_dual_write import (
+    prepare_provider_target_from_dokploy_records,
 )
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -97,6 +101,10 @@ class ProductContextCutoverStore(ProductContextCutoverReadStore, Protocol):
     ) -> CurrentAuthorityDeleteStatus: ...
 
     def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None: ...
+
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]: ...
+
+    def write_provider_target_record(self, record: ProviderTargetRecord) -> None: ...
 
     def delete_dokploy_target_id_record(
         self, *, expected_record: DokployTargetIdRecord
@@ -581,6 +589,69 @@ def apply_product_context_cutover(
         return plan
 
     now = utc_now_timestamp()
+    source_target_records = tuple(
+        item
+        for item in record_store.list_dokploy_target_records()
+        if item.context == request.source_context
+    )
+    source_target_id_records = tuple(
+        item
+        for item in record_store.list_dokploy_target_id_records()
+        if item.context == request.source_context
+    )
+    target_target_records = {
+        target.instance: target
+        for target in record_store.list_dokploy_target_records()
+        if target.context == request.target_context
+    }
+    target_id_records = {
+        target.instance: target
+        for target in record_store.list_dokploy_target_id_records()
+        if target.context == request.target_context
+    }
+    planned_target_records = {
+        record.instance: record.model_copy(
+            update={
+                "context": request.target_context,
+                "updated_at": now,
+                "source_label": request.source_label,
+            }
+        )
+        for record in source_target_records
+        if record.instance not in target_target_records
+    }
+    planned_target_id_records = {
+        record.instance: DokployTargetIdRecord(
+            context=request.target_context,
+            instance=record.instance,
+            target_id=record.target_id,
+            updated_at=now,
+            source_label=request.source_label,
+        )
+        for record in source_target_id_records
+        if record.instance not in target_id_records
+    }
+    final_target_records = {**target_target_records, **planned_target_records}
+    final_target_id_records = {**target_id_records, **planned_target_id_records}
+    affected_target_instances = sorted(
+        set(planned_target_records) | set(planned_target_id_records)
+    )
+    planned_provider_target_records: dict[str, ProviderTargetRecord] = {}
+    for instance in affected_target_instances:
+        target_record = final_target_records.get(instance)
+        target_id_record = final_target_id_records.get(instance)
+        if target_record is None or target_id_record is None:
+            missing_record_type = "target" if target_record is None else "target-id"
+            raise ValueError(
+                "Provider target dual-write requires complete Dokploy target and target-id "
+                f"records for {request.target_context}/{instance}; missing {missing_record_type}."
+            )
+        planned_provider_target_records[instance] = prepare_provider_target_from_dokploy_records(
+            record_store=record_store,
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
+
     for runtime_record in record_store.list_runtime_environment_records(
         context_name=request.source_context
     ):
@@ -601,47 +672,14 @@ def apply_product_context_cutover(
                 )
             )
 
-    for dokploy_target_record in tuple(
-        item
-        for item in record_store.list_dokploy_target_records()
-        if item.context == request.source_context
-    ):
-        exists = any(
-            target.context == request.target_context
-            and target.instance == dokploy_target_record.instance
-            for target in record_store.list_dokploy_target_records()
-        )
-        if not exists:
-            record_store.write_dokploy_target_record(
-                dokploy_target_record.model_copy(
-                    update={
-                        "context": request.target_context,
-                        "updated_at": now,
-                        "source_label": request.source_label,
-                    }
-                )
-            )
+    for copied_target_record in planned_target_records.values():
+        record_store.write_dokploy_target_record(copied_target_record)
 
-    for target_id_record in tuple(
-        item
-        for item in record_store.list_dokploy_target_id_records()
-        if item.context == request.source_context
-    ):
-        exists = any(
-            target.context == request.target_context
-            and target.instance == target_id_record.instance
-            for target in record_store.list_dokploy_target_id_records()
-        )
-        if not exists:
-            record_store.write_dokploy_target_id_record(
-                DokployTargetIdRecord(
-                    context=request.target_context,
-                    instance=target_id_record.instance,
-                    target_id=target_id_record.target_id,
-                    updated_at=now,
-                    source_label=request.source_label,
-                )
-            )
+    for copied_target_id_record in planned_target_id_records.values():
+        record_store.write_dokploy_target_id_record(copied_target_id_record)
+
+    for provider_target_record in planned_provider_target_records.values():
+        record_store.write_provider_target_record(provider_target_record)
 
     for secret_record in record_store.list_secret_records(
         context_name=request.source_context,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -12574,10 +12574,24 @@ def create_launchplane_service_app(
                 )
                 if idempotent_response is not None:
                     return idempotent_response
-                onboarding_result = apply_product_onboarding_manifest(
-                    record_store=record_store,
-                    manifest=onboarding_request.manifest,
-                )
+                try:
+                    onboarding_result = apply_product_onboarding_manifest(
+                        record_store=record_store,
+                        manifest=onboarding_request.manifest,
+                    )
+                except ValueError as error:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "invalid_product_onboarding_manifest",
+                                "message": str(error),
+                            },
+                        },
+                    )
                 result, driver_result = (
                     control_plane_product_onboarding_service.build_product_onboarding_service_result(
                         onboarding_result

--- a/control_plane/workflows/dokploy_target_adoption.py
+++ b/control_plane/workflows/dokploy_target_adoption.py
@@ -3,9 +3,13 @@ from typing import Protocol
 
 from pydantic import BaseModel, ConfigDict
 
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord, DokployTargetType
 from control_plane.dokploy import JsonObject
+from control_plane.workflows.provider_target_dual_write import (
+    prepare_provider_target_from_dokploy_records,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -14,6 +18,10 @@ class DokployTargetAdoptionRecordStore(Protocol):
 
     def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None: ...
 
+    def write_provider_target_record(self, record: ProviderTargetRecord) -> None: ...
+
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]: ...
+
 
 class DokployTargetAdoptionResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -21,6 +29,7 @@ class DokployTargetAdoptionResult(BaseModel):
     applied: bool
     target_record: DokployTargetRecord
     target_id_record: DokployTargetIdRecord
+    provider_target_record: ProviderTargetRecord
     provider_fields: dict[str, str | tuple[str, ...] | bool | int | None] = {}
     warnings: tuple[str, ...] = ()
 
@@ -46,6 +55,7 @@ class DokployTargetCreateResult(BaseModel):
     environment_id: str = ""
     target_record: DokployTargetRecord
     target_id_record: DokployTargetIdRecord
+    provider_target_record: ProviderTargetRecord
     provider_fields: dict[str, str | tuple[str, ...] | bool | int | None] = {}
     provider_requests: tuple[dict[str, object], ...] = ()
     warnings: tuple[str, ...] = ()
@@ -132,15 +142,26 @@ def adopt_dokploy_target(
         updated_at=recorded_at,
         source_label=source_label.strip() or "cli:dokploy-targets:adopt",
     )
+    provider_target_record = ProviderTargetRecord.from_dokploy_records(
+        target_record=target_record,
+        target_id_record=target_id_record,
+    )
 
     if apply:
+        provider_target_record = prepare_provider_target_from_dokploy_records(
+            record_store=record_store,
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
         record_store.write_dokploy_target_record(target_record)
         record_store.write_dokploy_target_id_record(target_id_record)
+        record_store.write_provider_target_record(provider_target_record)
 
     return DokployTargetAdoptionResult(
         applied=apply,
         target_record=target_record,
         target_id_record=target_id_record,
+        provider_target_record=provider_target_record,
         provider_fields=provider_fields,
         warnings=warnings,
     )
@@ -243,14 +264,25 @@ def create_dokploy_application_target(
             updated_at=target_record.updated_at,
             source_label=target_record.source_label,
         )
+        provider_target_record = ProviderTargetRecord.from_dokploy_records(
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
         return DokployTargetCreateResult(
             applied=False,
             plan=plan,
             target_record=target_record,
             target_id_record=target_id_record,
+            provider_target_record=provider_target_record,
             provider_requests=provider_requests,
             warnings=("dry run only; provider was not mutated and records were not written",),
         )
+
+    _ensure_create_route_has_no_provider_target(
+        record_store=record_store,
+        context=normalized_context,
+        instance=normalized_instance,
+    )
 
     created_project_id = normalized_project_id
     if not created_project_id and not normalized_environment_id:
@@ -316,6 +348,7 @@ def create_dokploy_application_target(
         environment_id=created_environment_id,
         target_record=adoption.target_record,
         target_id_record=adoption.target_id_record,
+        provider_target_record=adoption.provider_target_record,
         provider_fields=adoption.provider_fields,
         provider_requests=provider_requests,
         warnings=adoption.warnings,
@@ -327,6 +360,17 @@ def _require_non_empty(value: str, field_name: str) -> str:
     if not normalized_value:
         raise ValueError(f"Dokploy target adoption requires {field_name}")
     return normalized_value
+
+
+def _ensure_create_route_has_no_provider_target(
+    *, record_store: DokployTargetAdoptionRecordStore, context: str, instance: str
+) -> None:
+    for record in record_store.list_physical_provider_target_records():
+        if record.context == context and record.instance == instance:
+            raise ValueError(
+                "Provider target dual-write conflict for "
+                f"{context}/{instance}; create would replace an explicit provider target."
+            )
 
 
 def _normalize_route_part(value: str, field_name: str) -> str:

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -4,6 +4,7 @@ from typing import Protocol
 
 from pydantic import BaseModel, ConfigDict
 
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.product_onboarding_manifest import (
@@ -18,6 +19,10 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretBinding
+from control_plane.workflows.provider_target_dual_write import (
+    prepare_provider_target_from_dokploy_records,
+    write_provider_target_from_dokploy_records,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -27,6 +32,10 @@ class ProductOnboardingRecordStore(Protocol):
     def write_dokploy_target_record(self, record: DokployTargetRecord) -> None: ...
 
     def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None: ...
+
+    def write_provider_target_record(self, record: ProviderTargetRecord) -> None: ...
+
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]: ...
 
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None: ...
 
@@ -132,6 +141,25 @@ def build_provider_target_id_records(
     )
 
 
+def build_physical_provider_target_records(
+    *,
+    provider_targets: tuple[DokployTargetRecord, ...],
+    provider_target_ids: tuple[DokployTargetIdRecord, ...],
+) -> tuple[ProviderTargetRecord, ...]:
+    target_ids_by_route = {
+        (record.context, record.instance): record for record in provider_target_ids
+    }
+    return tuple(
+        ProviderTargetRecord.from_dokploy_records(
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
+        for target_record in provider_targets
+        if (target_id_record := target_ids_by_route.get((target_record.context, target_record.instance)))
+        is not None
+    )
+
+
 def build_runtime_environment_records(
     *, manifest: ProductOnboardingManifest, updated_at: str
 ) -> tuple[RuntimeEnvironmentRecord, ...]:
@@ -179,16 +207,42 @@ def apply_product_onboarding_manifest(
     provider_target_ids = build_provider_target_id_records(
         manifest=manifest, updated_at=recorded_at
     )
+    physical_provider_targets = build_physical_provider_target_records(
+        provider_targets=provider_targets,
+        provider_target_ids=provider_target_ids,
+    )
     runtime_environments = build_runtime_environment_records(
         manifest=manifest, updated_at=recorded_at
     )
     secret_bindings = build_secret_bindings(manifest=manifest, updated_at=recorded_at)
+    target_records_by_route = {
+        (record.context, record.instance): record for record in provider_targets
+    }
+    target_id_records_by_route = {
+        (record.context, record.instance): record for record in provider_target_ids
+    }
+    provider_target_pairs = tuple(
+        (target_records_by_route[(record.context, record.instance)], target_id_records_by_route[(record.context, record.instance)])
+        for record in physical_provider_targets
+    )
+    for target_record, target_id_record in provider_target_pairs:
+        prepare_provider_target_from_dokploy_records(
+            record_store=record_store,
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
 
     record_store.write_product_profile_record(product_profile)
     for target_record in provider_targets:
         record_store.write_dokploy_target_record(target_record)
     for target_id_record in provider_target_ids:
         record_store.write_dokploy_target_id_record(target_id_record)
+    for target_record, target_id_record in provider_target_pairs:
+        write_provider_target_from_dokploy_records(
+            record_store=record_store,
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
     for runtime_record in runtime_environments:
         record_store.write_runtime_environment_record(runtime_record)
     for binding in secret_bindings:

--- a/control_plane/workflows/provider_target_dual_write.py
+++ b/control_plane/workflows/provider_target_dual_write.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+
+
+class ProviderTargetDualWriteStore(Protocol):
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]: ...
+
+    def write_provider_target_record(self, record: ProviderTargetRecord) -> None: ...
+
+
+def prepare_provider_target_from_dokploy_records(
+    *,
+    record_store: ProviderTargetDualWriteStore,
+    target_record: DokployTargetRecord,
+    target_id_record: DokployTargetIdRecord,
+) -> ProviderTargetRecord:
+    provider_target_record = ProviderTargetRecord.from_dokploy_records(
+        target_record=target_record,
+        target_id_record=target_id_record,
+    )
+    current_record = _find_current_provider_target_record(
+        record_store=record_store,
+        context=provider_target_record.context,
+        instance=provider_target_record.instance,
+    )
+    if current_record is not None and _authority_payload(current_record) != _authority_payload(
+        provider_target_record
+    ):
+        raise ValueError(
+            "Provider target dual-write conflict for "
+            f"{provider_target_record.context}/{provider_target_record.instance}."
+        )
+    return provider_target_record
+
+
+def write_provider_target_from_dokploy_records(
+    *,
+    record_store: ProviderTargetDualWriteStore,
+    target_record: DokployTargetRecord,
+    target_id_record: DokployTargetIdRecord,
+) -> ProviderTargetRecord:
+    provider_target_record = prepare_provider_target_from_dokploy_records(
+        record_store=record_store,
+        target_record=target_record,
+        target_id_record=target_id_record,
+    )
+    record_store.write_provider_target_record(provider_target_record)
+    return provider_target_record
+
+
+def _find_current_provider_target_record(
+    *, record_store: ProviderTargetDualWriteStore, context: str, instance: str
+) -> ProviderTargetRecord | None:
+    return next(
+        (
+            record
+            for record in record_store.list_physical_provider_target_records()
+            if record.context == context and record.instance == instance
+        ),
+        None,
+    )
+
+
+def _authority_payload(record: ProviderTargetRecord) -> dict[str, object]:
+    return {
+        "provider_id": record.provider_id,
+        "target_category": record.target_category,
+        "target_id": record.target_id,
+        "display_name": record.display_name,
+        "provider_target_type": record.provider_target_type,
+        "provider_evidence": dict(record.provider_evidence),
+    }

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -60,6 +60,13 @@ missing, partial Dokploy pairs exist, or explicit rows disagree with the
 Dokploy-derived projection. Backfill and authority cutover should not proceed
 until the audit has no unresolved blockers for the affected lanes.
 
+Provider-target dual-write is active for Launchplane-owned target identity
+mutations: product onboarding, Dokploy target adoption/creation, product context
+cutover, and tracked Dokploy target metadata commands. These paths validate an
+existing explicit provider-target row before mutating the Dokploy pair, write the
+Dokploy target/id records, then write the matching provider-target row. A stale
+explicit provider-target row blocks the mutation instead of being overwritten.
+
 ## Target Launchplane Ingress
 
 The target communication model is:

--- a/docs/records.md
+++ b/docs/records.md
@@ -137,6 +137,12 @@ an ORM column/table or remains only in the evidence payload.
   explicit provider-target row exists. Existing Dokploy target and target-id
   records remain the active live write/execution path until a later dual-write
   or cutover migration.
+- Product onboarding, Dokploy target adoption/creation, product context cutover,
+  and tracked Dokploy target metadata commands now dual-write explicit
+  provider-target rows when a complete Dokploy target and target-id pair exists.
+  The dual-write is identity-only: Dokploy route/runtime execution metadata such
+  as domains, health policy, source metadata, env keys, and product policies
+  remains in the Dokploy target record.
 - `uv run launchplane storage provider-target-audit` is the read-only Phase Two
   preflight for this record family. It compares explicit provider-target rows
   with the neutral projection from paired Dokploy target and target-id records,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -491,6 +491,9 @@ target_type = "compose"
             stored_record = store.read_dokploy_target_record(
                 context_name="opw", instance_name="testing"
             )
+            provider_target = store.read_provider_target_record(
+                context_name="opw", instance_name="testing"
+            )
             store.close()
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
@@ -504,6 +507,9 @@ target_type = "compose"
             stored_record.policies.shopify.protected_store_keys, ("yps-your-part-supplier",)
         )
         self.assertEqual(stored_record.source_label, "policy:test")
+        self.assertEqual(provider_target.target_id, "compose-123")
+        self.assertEqual(provider_target.provider_target_type, "compose")
+        self.assertEqual(provider_target.source_label, "policy:test")
 
     def test_dokploy_targets_unset_shopify_protected_store_key_reports_missing_keys(self) -> None:
         runner = CliRunner()
@@ -549,6 +555,9 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
             stored_record = store.read_dokploy_target_record(
                 context_name="opw", instance_name="testing"
             )
+            provider_target = store.read_provider_target_record(
+                context_name="opw", instance_name="testing"
+            )
             store.close()
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
@@ -557,6 +566,7 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
         self.assertEqual(payload["missing_keys"], ["missing-store"])
         self.assertEqual(payload["record"]["shopify_protected_store_keys"], ["spare-store"])
         self.assertEqual(stored_record.policies.shopify.protected_store_keys, ("spare-store",))
+        self.assertEqual(provider_target.target_id, "compose-123")
 
     def test_dokploy_targets_put_shopify_protected_store_key_requires_existing_record(self) -> None:
         runner = CliRunner()

--- a/tests/test_dokploy_target_adoption.py
+++ b/tests/test_dokploy_target_adoption.py
@@ -10,6 +10,7 @@ from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.dokploy import JsonObject
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.dokploy_target_adoption import (
@@ -117,6 +118,9 @@ class DokployTargetAdoptionTests(unittest.TestCase):
             target_id_record = store.read_dokploy_target_id_record(
                 context_name="odoo-tenant-cm", instance_name="testing"
             )
+            provider_target_record = store.read_provider_target_record(
+                context_name="odoo-tenant-cm", instance_name="testing"
+            )
             store.close()
 
         self.assertTrue(result.applied)
@@ -129,6 +133,50 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertIsNone(target_record.healthcheck_timeout_seconds)
         self.assertEqual(target_record.healthcheck_path, "/web/health")
         self.assertEqual(target_id_record.target_id, "compose-123")
+        self.assertEqual(provider_target_record.target_id, "compose-123")
+        self.assertEqual(provider_target_record.provider_target_type, "compose")
+
+    def test_adopt_target_blocks_conflicting_provider_target_before_writes(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_provider_target_record(
+                ProviderTargetRecord(
+                    context="discord-blue",
+                    instance="prod",
+                    provider_id="dokploy",
+                    target_category="application",
+                    target_id="stale-app-123",
+                    display_name="discord-blue-lxc",
+                    provider_target_type="application",
+                    provider_evidence={"project_name": "Discord Blue"},
+                    updated_at="2026-05-04T22:00:00Z",
+                    source_label="test:stale-provider-target",
+                )
+            )
+
+            with self.assertRaisesRegex(ValueError, "dual-write conflict"):
+                adopt_dokploy_target(
+                    record_store=store,
+                    host="https://dokploy.example.invalid",
+                    token="token",
+                    context="discord-blue",
+                    instance="prod",
+                    target_type="application",
+                    target_id="app-123",
+                    project_name="Discord Blue",
+                    target_name="discord-blue-lxc",
+                    healthcheck_path="/health",
+                    updated_at="2026-05-04T22:35:00Z",
+                    apply=True,
+                    fetch_target_payload=lambda *_args: {"name": "discord-blue-lxc"},
+                )
+
+            self.assertEqual(store.list_dokploy_target_records(), ())
+            self.assertEqual(store.list_dokploy_target_id_records(), ())
+            store.close()
 
     def test_adopt_target_preserves_live_healthcheck_settings(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -691,6 +739,58 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertEqual([path for path, _payload in requests], ["/api/application.create"])
         self.assertEqual(requests[0][1]["environmentId"], "env-existing")
         self.assertEqual(target_id_record.target_id, "app-456")
+
+    def test_create_application_target_blocks_existing_provider_target_before_provider_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_provider_target_record(
+                ProviderTargetRecord(
+                    context="verireel",
+                    instance="testing",
+                    provider_id="dokploy",
+                    target_category="application",
+                    target_id="existing-app-123",
+                    display_name="verireel-testing",
+                    provider_target_type="application",
+                    provider_evidence={"project_name": "VeriReel"},
+                    updated_at="2026-05-04T23:00:00Z",
+                    source_label="test:existing-provider-target",
+                )
+            )
+            requests: list[tuple[str, JsonObject]] = []
+
+            def mutate_provider(
+                _host: str, _token: str, path: str, payload: JsonObject
+            ) -> JsonObject:
+                requests.append((path, payload))
+                return {"applicationId": "app-456"}
+
+            with self.assertRaisesRegex(ValueError, "dual-write conflict"):
+                create_dokploy_application_target(
+                    record_store=store,
+                    host="https://dokploy.example.invalid",
+                    token="token",
+                    context="verireel",
+                    instance="testing",
+                    target_name="verireel-testing",
+                    project_name="VeriReel",
+                    environment_id="env-existing",
+                    apply=True,
+                    mutate_provider=mutate_provider,
+                    fetch_target_payload=lambda *_args: {"name": "verireel-testing"},
+                )
+            target_records = store.list_dokploy_target_records()
+            target_id_records = store.list_dokploy_target_id_records()
+            store.close()
+
+        self.assertEqual(requests, [])
+        self.assertEqual(target_records, ())
+        self.assertEqual(target_id_records, ())
 
     def test_create_application_target_rejects_healthcheck_path_before_provider_mutation(
         self,

--- a/tests/test_product_context_cutover.py
+++ b/tests/test_product_context_cutover.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
@@ -400,6 +401,10 @@ class ProductContextCutoverTests(unittest.TestCase):
                     context_name="sellyouroutboard",
                     instance_name="prod",
                 )
+                provider_target = store.read_provider_target_record(
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
                 secret = store.find_secret_record(
                     scope="context_instance",
                     integration="runtime_environment",
@@ -437,6 +442,8 @@ class ProductContextCutoverTests(unittest.TestCase):
         self.assertEqual(len(target_runtime_records), 2)
         self.assertEqual(target.target_name, "syo-prod-app")
         self.assertEqual(target_id.target_id, "target-prod-123")
+        self.assertEqual(provider_target.target_id, "target-prod-123")
+        self.assertEqual(provider_target.display_name, "syo-prod-app")
         self.assertEqual(secret.context, "sellyouroutboard")
         self.assertEqual(version.ciphertext, "encrypted-value")
         self.assertEqual([binding.binding_key for binding in bindings], ["SMTP_PASSWORD"])
@@ -449,6 +456,209 @@ class ProductContextCutoverTests(unittest.TestCase):
             {"created": 0, "skipped": 1},
         )
         self.assertEqual(_payload_section(repeated_payload, "profile")["action"], "unchanged")
+
+    def test_apply_context_cutover_blocks_conflicting_provider_target_before_writes(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+                store.write_provider_target_record(
+                    ProviderTargetRecord(
+                        context="sellyouroutboard",
+                        instance="prod",
+                        provider_id="dokploy",
+                        target_category="application",
+                        target_id="stale-target-prod-123",
+                        display_name="syo-prod-app",
+                        provider_target_type="application",
+                        provider_evidence={"project_name": "sellyouroutboard"},
+                        updated_at="2026-05-01T04:00:00Z",
+                        source_label="test:stale-provider-target",
+                    )
+                )
+
+                with self.assertRaisesRegex(ValueError, "dual-write conflict"):
+                    apply_product_context_cutover(
+                        record_store=store,
+                        request=ProductContextCutoverRequest(
+                            product="sellyouroutboard",
+                            source_context="sellyouroutboard-testing",
+                            target_context="sellyouroutboard",
+                            mode="apply",
+                            display_name="SellYourOutboard",
+                            source_label="test:cutover",
+                        ),
+                    )
+
+                target_runtime_records = store.list_runtime_environment_records(
+                    context_name="sellyouroutboard"
+                )
+                target_records = tuple(
+                    record
+                    for record in store.list_dokploy_target_records()
+                    if record.context == "sellyouroutboard"
+                )
+                target_id_records = tuple(
+                    record
+                    for record in store.list_dokploy_target_id_records()
+                    if record.context == "sellyouroutboard"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(target_runtime_records, ())
+        self.assertEqual(target_records, ())
+        self.assertEqual(target_id_records, ())
+
+    def test_apply_context_cutover_writes_provider_target_when_target_id_completes_existing_target(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+                store.write_dokploy_target_record(
+                    DokployTargetRecord(
+                        context="sellyouroutboard",
+                        instance="prod",
+                        target_type="application",
+                        project_name="sellyouroutboard",
+                        target_name="syo-prod-app",
+                        domains=(
+                            "https://www.sellyouroutboard.com",
+                            "https://sellyouroutboard.com",
+                        ),
+                        healthcheck_path="/api/health",
+                        updated_at="2026-05-01T04:29:07Z",
+                        source_label="test:existing-target",
+                    )
+                )
+
+                apply_product_context_cutover(
+                    record_store=store,
+                    request=ProductContextCutoverRequest(
+                        product="sellyouroutboard",
+                        source_context="sellyouroutboard-testing",
+                        target_context="sellyouroutboard",
+                        mode="apply",
+                        display_name="SellYourOutboard",
+                        source_label="test:cutover",
+                    ),
+                )
+
+                provider_target = store.read_provider_target_record(
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+                target_id = store.read_dokploy_target_id_record(
+                    context_name="sellyouroutboard",
+                    instance_name="prod",
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(target_id.target_id, "target-prod-123")
+        self.assertEqual(provider_target.target_id, "target-prod-123")
+        self.assertEqual(provider_target.display_name, "syo-prod-app")
+        self.assertEqual(provider_target.provider_evidence["project_name"], "sellyouroutboard")
+
+    def test_apply_context_cutover_blocks_target_id_only_source_before_writes(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+                deleted = store.delete_dokploy_target_record(
+                    expected_record=store.read_dokploy_target_record(
+                        context_name="sellyouroutboard-testing",
+                        instance_name="prod",
+                    )
+                )
+                self.assertEqual(deleted, "deleted")
+
+                with self.assertRaisesRegex(ValueError, "missing target"):
+                    apply_product_context_cutover(
+                        record_store=store,
+                        request=ProductContextCutoverRequest(
+                            product="sellyouroutboard",
+                            source_context="sellyouroutboard-testing",
+                            target_context="sellyouroutboard",
+                            mode="apply",
+                            display_name="SellYourOutboard",
+                            source_label="test:cutover",
+                        ),
+                    )
+
+                target_id_records = tuple(
+                    record
+                    for record in store.list_dokploy_target_id_records()
+                    if record.context == "sellyouroutboard"
+                )
+                target_runtime_records = store.list_runtime_environment_records(
+                    context_name="sellyouroutboard"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(target_id_records, ())
+        self.assertEqual(target_runtime_records, ())
+
+    def test_apply_context_cutover_blocks_target_only_source_before_writes(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "test.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                _seed_syo_source_records(store)
+                deleted = store.delete_dokploy_target_id_record(
+                    expected_record=store.read_dokploy_target_id_record(
+                        context_name="sellyouroutboard-testing",
+                        instance_name="prod",
+                    )
+                )
+                self.assertEqual(deleted, "deleted")
+
+                with self.assertRaisesRegex(ValueError, "missing target-id"):
+                    apply_product_context_cutover(
+                        record_store=store,
+                        request=ProductContextCutoverRequest(
+                            product="sellyouroutboard",
+                            source_context="sellyouroutboard-testing",
+                            target_context="sellyouroutboard",
+                            mode="apply",
+                            display_name="SellYourOutboard",
+                            source_label="test:cutover",
+                        ),
+                    )
+
+                target_records = tuple(
+                    record
+                    for record in store.list_dokploy_target_records()
+                    if record.context == "sellyouroutboard"
+                )
+                target_runtime_records = store.list_runtime_environment_records(
+                    context_name="sellyouroutboard"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(target_records, ())
+        self.assertEqual(target_runtime_records, ())
 
     def test_apply_preserves_distinct_preview_context_in_history(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -10,6 +10,7 @@ from click import Command
 from click.testing import CliRunner
 
 from control_plane.cli import main
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
@@ -1400,6 +1401,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             profile = store.read_product_profile_record("example-site")
             targets = store.list_dokploy_target_records()
             target_ids = store.list_dokploy_target_id_records()
+            provider_targets = store.list_physical_provider_target_records()
             runtime_records = store.list_runtime_environment_records()
             secret_bindings = store.list_secret_bindings()
             store.close()
@@ -1446,10 +1448,49 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         )
         self.assertEqual(len(targets), 2)
         self.assertEqual(len(target_ids), 2)
+        self.assertEqual(len(provider_targets), 2)
+        self.assertEqual(
+            [(record.context, record.instance, record.target_id) for record in provider_targets],
+            [
+                ("example-site-prod", "prod", "app-prod-123"),
+                ("example-site-testing", "testing", "app-testing-123"),
+            ],
+        )
         self.assertEqual(len(runtime_records), 1)
         self.assertEqual(len(secret_bindings), 1)
         self.assertEqual(secret_bindings[0].binding_key, "SMTP_PASSWORD")
         self.assertEqual(secret_bindings[0].status, "disabled")
+
+    def test_apply_product_onboarding_manifest_blocks_conflicting_provider_target(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_provider_target_record(
+                ProviderTargetRecord(
+                    context="example-site-prod",
+                    instance="prod",
+                    provider_id="dokploy",
+                    target_category="application",
+                    target_id="stale-app-prod-123",
+                    display_name="example-site-prod",
+                    provider_target_type="application",
+                    provider_evidence={"project_name": "example-site"},
+                    updated_at="2026-05-03T00:00:00Z",
+                    source_label="test:stale-provider-target",
+                )
+            )
+            manifest = ProductOnboardingManifest.model_validate(_manifest_payload())
+
+            with self.assertRaisesRegex(ValueError, "dual-write conflict"):
+                apply_product_onboarding_manifest(record_store=store, manifest=manifest)
+
+            self.assertEqual(store.list_dokploy_target_records(), ())
+            self.assertEqual(store.list_dokploy_target_id_records(), ())
+            store.close()
 
     def test_product_onboarding_manifest_prefers_provider_targets(self) -> None:
         payload = _manifest_payload()

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -2,32 +2,45 @@ from __future__ import annotations
 
 import unittest
 
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.product_onboarding_service import build_product_onboarding_service_result
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 
 
 class _ProductOnboardingStore:
     def __init__(self) -> None:
-        self.product_profiles: list[object] = []
-        self.dokploy_targets: list[object] = []
-        self.dokploy_target_ids: list[object] = []
-        self.runtime_environments: list[object] = []
-        self.secret_bindings: list[object] = []
+        self.product_profiles: list[LaunchplaneProductProfileRecord] = []
+        self.dokploy_targets: list[DokployTargetRecord] = []
+        self.dokploy_target_ids: list[DokployTargetIdRecord] = []
+        self.provider_targets: list[ProviderTargetRecord] = []
+        self.runtime_environments: list[RuntimeEnvironmentRecord] = []
+        self.secret_bindings: list[SecretBinding] = []
 
-    def write_product_profile_record(self, record: object) -> None:
+    def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> None:
         self.product_profiles.append(record)
 
-    def write_dokploy_target_record(self, record: object) -> None:
+    def write_dokploy_target_record(self, record: DokployTargetRecord) -> None:
         self.dokploy_targets.append(record)
 
-    def write_dokploy_target_id_record(self, record: object) -> None:
+    def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None:
         self.dokploy_target_ids.append(record)
 
-    def write_runtime_environment_record(self, record: object) -> None:
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]:
+        return tuple(self.provider_targets)
+
+    def write_provider_target_record(self, record: ProviderTargetRecord) -> None:
+        self.provider_targets.append(record)
+
+    def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None:
         self.runtime_environments.append(record)
 
-    def write_secret_binding(self, binding: object) -> None:
+    def write_secret_binding(self, binding: SecretBinding) -> None:
         self.secret_bindings.append(binding)
 
 
@@ -72,9 +85,8 @@ class ProductOnboardingServiceTests(unittest.TestCase):
                 "source_label": "test:discord-blue-onboarding",
             }
         )
-        onboarding_result = apply_product_onboarding_manifest(
-            record_store=_ProductOnboardingStore(), manifest=manifest
-        )
+        store = _ProductOnboardingStore()
+        onboarding_result = apply_product_onboarding_manifest(record_store=store, manifest=manifest)
 
         result, driver_result = build_product_onboarding_service_result(onboarding_result)
 
@@ -85,6 +97,7 @@ class ProductOnboardingServiceTests(unittest.TestCase):
         self.assertEqual(result["dokploy_target_id_count"], 1)
         self.assertEqual(result["runtime_environment_record_count"], 1)
         self.assertEqual(result["secret_binding_count"], 1)
+        self.assertEqual(len(store.provider_targets), 1)
         self.assertEqual(driver_result["product"], "discord-blue")
         self.assertEqual(driver_result["provider_targets"], driver_result["dokploy_targets"])
         self.assertEqual(driver_result["provider_target_ids"], driver_result["dokploy_target_ids"])

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31,6 +31,7 @@ from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
@@ -12040,6 +12041,101 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(secret_bindings[0].binding_key, "DISCORD_TOKEN")
         self.assertNotIn("secret_id", json.dumps(payload, sort_keys=True))
+
+    def test_product_onboarding_endpoint_rejects_provider_target_conflict(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+                store.write_provider_target_record(
+                    ProviderTargetRecord(
+                        context="discord-blue",
+                        instance="prod",
+                        provider_id="dokploy",
+                        target_category="application",
+                        target_id="stale-app-discord-blue",
+                        display_name="discord-blue",
+                        provider_target_type="application",
+                        provider_evidence={"project_name": "Discord Blue"},
+                        updated_at="2026-05-04T17:59:00Z",
+                        source_label="test:stale-provider-target",
+                    )
+                )
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/launchplane-seed-import.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_onboarding.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/launchplane-seed-import.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-onboarding/apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "manifest": {
+                        "product": "discord-blue",
+                        "display_name": "Discord Blue",
+                        "repository": "cbusillo/discord-blue",
+                        "driver_id": "generic-web",
+                        "image_repository": "ghcr.io/cbusillo/discord-blue",
+                        "runtime_port": 8787,
+                        "health_path": "/health",
+                        "lanes": [
+                            {"instance": "prod", "context": "discord-blue"},
+                        ],
+                        "provider_targets": [
+                            {
+                                "context": "discord-blue",
+                                "instance": "prod",
+                                "target_id": "app-discord-blue",
+                                "target_type": "application",
+                                "target_name": "discord-blue",
+                                "healthcheck_enabled": False,
+                            }
+                        ],
+                        "updated_at": "2026-05-04T18:00:00Z",
+                        "source_label": "test:discord-blue-onboarding",
+                    },
+                },
+                headers={"Idempotency-Key": "product-onboarding-discord-blue-conflict"},
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_product_onboarding_manifest")
+        self.assertIn("dual-write conflict", payload["error"]["message"])
 
     def test_product_onboarding_endpoint_rejects_self_deploy_authority(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add a shared provider-target dual-write helper that derives explicit identity rows from complete Dokploy target/id pairs and blocks stale physical-row conflicts
- dual-write provider-target rows from product onboarding, Dokploy target adoption/create, product context cutover, and tracked Dokploy metadata commands
- fail closed for incomplete cutover target pairs and preflight create-application routes before live Dokploy mutation when a physical provider-target row already occupies the route
- return a structured 400 from the onboarding service route when dual-write validation rejects a manifest
- update records/operations docs for the Phase Two dual-write window

Odoo target replacement was inspected for #1102. It deploys against existing tracked target identity and does not mutate the stored target id/type, so this slice leaves it unchanged.

Refs #1100
Refs #1102

## Validation
- `uv run python -m unittest tests.test_product_context_cutover tests.test_dokploy_target_adoption tests.test_product_onboarding tests.test_product_onboarding_service tests.test_dokploy tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_rejects_provider_target_conflict tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle`
- `uv run --extra dev ruff check control_plane/workflows/provider_target_dual_write.py control_plane/workflows/product_onboarding.py control_plane/workflows/dokploy_target_adoption.py control_plane/product_context_cutover.py control_plane/cli_dokploy_targets.py control_plane/service.py tests/test_product_onboarding.py tests/test_product_onboarding_service.py tests/test_dokploy_target_adoption.py tests/test_product_context_cutover.py tests/test_dokploy.py tests/test_service.py docs/records.md docs/operations.md --diff`
- `uv run --extra dev ruff check control_plane/workflows/provider_target_dual_write.py control_plane/workflows/product_onboarding.py control_plane/workflows/dokploy_target_adoption.py control_plane/product_context_cutover.py control_plane/cli_dokploy_targets.py control_plane/service.py tests/test_product_onboarding.py tests/test_product_onboarding_service.py tests/test_dokploy_target_adoption.py tests/test_product_context_cutover.py tests/test_dokploy.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests/test_product_onboarding.py tests/test_product_onboarding_service.py tests/test_dokploy_target_adoption.py tests/test_product_context_cutover.py tests/test_dokploy.py tests/test_service.py`
- `uv run python -m unittest`
