### PR TITLE
Add provider-target backfill

### DIFF
--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -7,6 +7,7 @@ from control_plane.contracts.secret_record import SecretScope
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.provider_target_audit import audit_provider_targets
+from control_plane.workflows.provider_target_backfill import backfill_provider_targets
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
@@ -81,6 +82,41 @@ def storage_provider_target_audit(
         postgres_store.ensure_schema()
         result = audit_provider_targets(
             postgres_store,
+            provider_id=provider_id,
+            context_name=context_name,
+            instance_name=instance_name,
+        )
+        click.echo(json.dumps(result.to_report_payload(), indent=2, sort_keys=True))
+    finally:
+        postgres_store.close()
+    if not result.ok:
+        raise click.exceptions.Exit(1)
+
+
+@storage.command("provider-target-backfill")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane provider-target records.",
+)
+@click.option("--apply", "apply_changes", is_flag=True, help="Write missing rows.")
+@click.option("--provider-id", default="", help="Optional provider id filter.")
+@click.option("--context", "context_name", default="", help="Optional context filter.")
+@click.option("--instance", "instance_name", default="", help="Optional instance filter.")
+def storage_provider_target_backfill(
+    database_url: str,
+    apply_changes: bool,
+    provider_id: str,
+    context_name: str,
+    instance_name: str,
+) -> None:
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    try:
+        postgres_store.ensure_schema()
+        result = backfill_provider_targets(
+            postgres_store,
+            apply=apply_changes,
             provider_id=provider_id,
             context_name=context_name,
             instance_name=instance_name,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -102,6 +102,7 @@ PayloadDict = dict[str, Any]
 PayloadJsonType = JSON().with_variant(JSONB(), "postgresql")
 RuntimeEnvironmentDeleteStatus = Literal["deleted", "missing", "changed"]
 CurrentAuthorityDeleteStatus = Literal["deleted", "missing", "changed"]
+ProviderTargetCreateStatus = Literal["created", "exists"]
 
 
 class _PayloadRow(Protocol):
@@ -3235,6 +3236,29 @@ class PostgresRecordStore(HumanSessionStore):
                 payload=self._payload_dict(record),
             )
         )
+
+    def create_provider_target_record_if_absent(
+        self, record: ProviderTargetRecord
+    ) -> ProviderTargetCreateStatus:
+        row = LaunchplaneProviderTargetRow(
+            context=record.context,
+            instance=record.instance,
+            provider_id=record.provider_id,
+            target_category=record.target_category,
+            target_id=record.target_id,
+            display_name=record.display_name,
+            provider_target_type=record.provider_target_type,
+            updated_at=record.updated_at,
+            payload=self._payload_dict(record),
+        )
+        with self._session_factory() as session:
+            session.add(row)
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                return "exists"
+        return "created"
 
     def delete_provider_target_record(
         self,

--- a/control_plane/workflows/provider_target_backfill.py
+++ b/control_plane/workflows/provider_target_backfill.py
@@ -1,0 +1,375 @@
+from __future__ import annotations
+
+from collections import Counter
+from collections.abc import Callable
+from typing import Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+
+
+ProviderTargetBackfillStatus = Literal[
+    "would-create",
+    "created",
+    "skipped-exists",
+    "skipped-incomplete",
+    "skipped-conflict",
+    "unsupported-provider",
+    "no_matching_routes",
+]
+ProviderTargetBackfillSeverity = Literal["ok", "warning", "blocked"]
+
+
+class ProviderTargetBackfillStore(Protocol):
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]: ...
+
+    def list_dokploy_target_records(self) -> tuple[DokployTargetRecord, ...]: ...
+
+    def list_dokploy_target_id_records(self) -> tuple[DokployTargetIdRecord, ...]: ...
+
+    def write_provider_target_record(self, record: ProviderTargetRecord) -> None: ...
+
+
+ProviderTargetConditionalCreate = Callable[[ProviderTargetRecord], Literal["created", "exists"]]
+
+
+class ProviderTargetBackfillItem(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    context: str
+    instance: str
+    status: ProviderTargetBackfillStatus
+    severity: ProviderTargetBackfillSeverity
+    detail: str
+    provider_id: str = "dokploy"
+    physical_record: ProviderTargetRecord | None = None
+    projected_record: ProviderTargetRecord | None = None
+
+    @model_validator(mode="after")
+    def _validate_item(self) -> "ProviderTargetBackfillItem":
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        self.detail = self.detail.strip()
+        self.provider_id = self.provider_id.strip().lower()
+        if not self.context:
+            raise ValueError("provider-target backfill item requires context")
+        if not self.instance:
+            raise ValueError("provider-target backfill item requires instance")
+        if not self.detail:
+            raise ValueError("provider-target backfill item requires detail")
+        if not self.provider_id:
+            raise ValueError("provider-target backfill item requires provider_id")
+        return self
+
+
+class ProviderTargetBackfillResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    applied: bool = False
+    items: tuple[ProviderTargetBackfillItem, ...] = ()
+    counts: dict[str, int] = Field(default_factory=dict)
+    inspected_route_count: int = 0
+    blocked_count: int = 0
+    warning_count: int = 0
+
+    @property
+    def ok(self) -> bool:
+        return self.blocked_count == 0
+
+    def to_report_payload(self) -> dict[str, object]:
+        return {
+            "status": "ok" if self.ok else "blocked",
+            "applied": self.applied,
+            "inspected_route_count": self.inspected_route_count,
+            "blocked_count": self.blocked_count,
+            "warning_count": self.warning_count,
+            "counts": self.counts,
+            "items": [
+                item.model_dump(mode="json", exclude_none=True) for item in self.items
+            ],
+        }
+
+
+def backfill_provider_targets(
+    record_store: ProviderTargetBackfillStore,
+    *,
+    apply: bool = False,
+    provider_id: str = "",
+    context_name: str = "",
+    instance_name: str = "",
+) -> ProviderTargetBackfillResult:
+    normalized_provider_id = provider_id.strip().lower()
+    normalized_context = context_name.strip()
+    normalized_instance = instance_name.strip()
+    physical_records = {
+        _route_key(record.context, record.instance): record
+        for record in record_store.list_physical_provider_target_records()
+    }
+    dokploy_target_records = {
+        _route_key(record.context, record.instance): record
+        for record in record_store.list_dokploy_target_records()
+    }
+    dokploy_target_id_records = {
+        _route_key(record.context, record.instance): record
+        for record in record_store.list_dokploy_target_id_records()
+    }
+    route_keys = sorted(
+        physical_records.keys()
+        | dokploy_target_records.keys()
+        | dokploy_target_id_records.keys()
+    )
+    items: list[ProviderTargetBackfillItem] = []
+    inspected_route_count = 0
+    for context, instance in route_keys:
+        if normalized_context and context != normalized_context:
+            continue
+        if normalized_instance and instance != normalized_instance:
+            continue
+        physical_record = physical_records.get((context, instance))
+        target_record = dokploy_target_records.get((context, instance))
+        target_id_record = dokploy_target_id_records.get((context, instance))
+        if not _matches_provider_filter(
+            normalized_provider_id=normalized_provider_id,
+            physical_record=physical_record,
+            target_record=target_record,
+            target_id_record=target_id_record,
+        ):
+            continue
+        inspected_route_count += 1
+        item, write_candidate = _plan_backfill_route(
+            context=context,
+            instance=instance,
+            physical_record=physical_record,
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
+        items.append(item)
+    if inspected_route_count == 0 and (
+        normalized_provider_id or normalized_context or normalized_instance
+    ):
+        items.append(
+            _item(
+                context=normalized_context or "*",
+                instance=normalized_instance or "*",
+                status="no_matching_routes",
+                severity="blocked",
+                detail="provider-target backfill filters did not match any stored route",
+                provider_id=normalized_provider_id or "dokploy",
+            )
+        )
+    if apply and not any(item.severity == "blocked" for item in items):
+        conditional_create = getattr(
+            record_store, "create_provider_target_record_if_absent", None
+        )
+        applied_items: list[ProviderTargetBackfillItem] = []
+        for item in items:
+            if item.status != "would-create":
+                applied_items.append(item)
+                continue
+            record = item.projected_record
+            if record is None:
+                applied_items.append(item)
+                continue
+            create_status = _create_provider_target_record(
+                record_store=record_store,
+                conditional_create=conditional_create,
+                record=record,
+            )
+            if create_status == "exists":
+                applied_items.append(
+                    _item(
+                        context=record.context,
+                        instance=record.instance,
+                        status="skipped-conflict",
+                        severity="blocked",
+                        detail="provider-target row changed before backfill could create it",
+                        projected_record=record,
+                    )
+                )
+                continue
+            applied_items.append(
+                _item(
+                    context=record.context,
+                    instance=record.instance,
+                    status="created",
+                    severity="ok",
+                    detail="created explicit provider-target row",
+                    projected_record=record,
+                )
+            )
+        items = applied_items
+    counts = Counter(item.status for item in items)
+    blocked_count = sum(1 for item in items if item.severity == "blocked")
+    return ProviderTargetBackfillResult(
+        applied=apply,
+        items=tuple(items),
+        counts=dict(sorted(counts.items())),
+        inspected_route_count=inspected_route_count,
+        blocked_count=blocked_count,
+        warning_count=sum(1 for item in items if item.severity == "warning"),
+    )
+
+
+def _create_provider_target_record(
+    *,
+    record_store: ProviderTargetBackfillStore,
+    conditional_create: object,
+    record: ProviderTargetRecord,
+) -> Literal["created", "exists"]:
+    if conditional_create is not None:
+        return cast(ProviderTargetConditionalCreate, conditional_create)(record)
+    current_record = next(
+        (
+            item
+            for item in record_store.list_physical_provider_target_records()
+            if item.context == record.context and item.instance == record.instance
+        ),
+        None,
+    )
+    if current_record is not None:
+        return "exists"
+    record_store.write_provider_target_record(record)
+    return "created"
+
+
+def _plan_backfill_route(
+    *,
+    context: str,
+    instance: str,
+    physical_record: ProviderTargetRecord | None,
+    target_record: DokployTargetRecord | None,
+    target_id_record: DokployTargetIdRecord | None,
+) -> tuple[ProviderTargetBackfillItem, ProviderTargetRecord | None]:
+    if physical_record is not None and physical_record.provider_id != "dokploy":
+        return (
+            _item(
+                context=context,
+                instance=instance,
+                status="unsupported-provider",
+                severity="warning",
+                detail="explicit provider-target row is not managed by Dokploy backfill",
+                provider_id=physical_record.provider_id,
+                physical_record=physical_record,
+            ),
+            None,
+        )
+    if target_record is None or target_id_record is None:
+        missing_parts = []
+        if target_record is None:
+            missing_parts.append("target")
+        if target_id_record is None:
+            missing_parts.append("target-id")
+        severity: ProviderTargetBackfillSeverity = (
+            "blocked" if physical_record is not None else "warning"
+        )
+        return (
+            _item(
+                context=context,
+                instance=instance,
+                status="skipped-incomplete",
+                severity=severity,
+                detail="Dokploy route is incomplete; missing " + ", ".join(missing_parts),
+                physical_record=physical_record,
+            ),
+            None,
+        )
+    projected_record = ProviderTargetRecord.from_dokploy_records(
+        target_record=target_record,
+        target_id_record=target_id_record,
+    )
+    if physical_record is None:
+        return (
+            _item(
+                context=context,
+                instance=instance,
+                status="would-create",
+                severity="ok",
+                detail="would create explicit provider-target row",
+                projected_record=projected_record,
+            ),
+            projected_record,
+        )
+    if _authority_payload(physical_record) == _authority_payload(projected_record):
+        return (
+            _item(
+                context=context,
+                instance=instance,
+                status="skipped-exists",
+                severity="ok",
+                detail="explicit provider-target row already matches the Dokploy projection",
+                physical_record=physical_record,
+                projected_record=projected_record,
+            ),
+            None,
+        )
+    return (
+        _item(
+            context=context,
+            instance=instance,
+            status="skipped-conflict",
+            severity="blocked",
+            detail="existing provider-target row differs from the Dokploy projection",
+            physical_record=physical_record,
+            projected_record=projected_record,
+        ),
+        None,
+    )
+
+
+def _item(
+    *,
+    context: str,
+    instance: str,
+    status: ProviderTargetBackfillStatus,
+    severity: ProviderTargetBackfillSeverity,
+    detail: str,
+    provider_id: str = "dokploy",
+    physical_record: ProviderTargetRecord | None = None,
+    projected_record: ProviderTargetRecord | None = None,
+) -> ProviderTargetBackfillItem:
+    return ProviderTargetBackfillItem(
+        context=context,
+        instance=instance,
+        status=status,
+        severity=severity,
+        detail=detail,
+        provider_id=provider_id,
+        physical_record=physical_record,
+        projected_record=projected_record,
+    )
+
+
+def _matches_provider_filter(
+    *,
+    normalized_provider_id: str,
+    physical_record: ProviderTargetRecord | None,
+    target_record: DokployTargetRecord | None,
+    target_id_record: DokployTargetIdRecord | None,
+) -> bool:
+    if not normalized_provider_id:
+        return True
+    if physical_record is not None and physical_record.provider_id == normalized_provider_id:
+        return True
+    if normalized_provider_id == "dokploy" and (
+        target_record is not None or target_id_record is not None
+    ):
+        return True
+    return False
+
+
+def _authority_payload(record: ProviderTargetRecord) -> dict[str, object]:
+    return {
+        "provider_id": record.provider_id,
+        "target_category": record.target_category,
+        "target_id": record.target_id,
+        "display_name": record.display_name,
+        "provider_target_type": record.provider_target_type,
+        "provider_evidence": dict(record.provider_evidence),
+    }
+
+
+def _route_key(context: str, instance: str) -> tuple[str, str]:
+    return (context.strip(), instance.strip())

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -35,6 +35,8 @@ API path instead of running the local command from an arbitrary checkout.
 - `ship`: plan, resolve, and execute artifact-backed deploy requests.
 - `storage provider-target-audit`: run the read-only provider-target parity
   preflight before Phase Two backfill or provider-target authority cutover.
+- `storage provider-target-backfill`: dry-run or apply explicit provider-target
+  rows from complete Dokploy target/id pairs during Phase Two migration.
 
 `deployments write`, `promotions write`, `inventory write-from-deployment`,
 `inventory write-from-promotion`, and `release-tuples write-from-promotion`
@@ -59,6 +61,30 @@ command emits JSON and exits nonzero when explicit provider-target rows are
 missing, partial Dokploy pairs exist, or explicit rows disagree with the
 Dokploy-derived projection. Backfill and authority cutover should not proceed
 until the audit has no unresolved blockers for the affected lanes.
+
+Use the backfill command to seed missing physical rows after reviewing the audit
+output and after dual-write is deployed:
+
+```bash
+uv run launchplane storage provider-target-backfill \
+  --database-url "$LAUNCHPLANE_DATABASE_URL"
+```
+
+Dry-run is the default. It reports `would-create`, `skipped-exists`,
+`skipped-incomplete`, `skipped-conflict`, and `unsupported-provider` rows without
+writing anything. Review incomplete pairs and conflicts before applying; conflicts
+are never overwritten automatically. Apply only after the dry-run output is
+acceptable:
+
+```bash
+uv run launchplane storage provider-target-backfill \
+  --database-url "$LAUNCHPLANE_DATABASE_URL" \
+  --apply
+```
+
+Backfill writes only complete, non-conflicting Dokploy-derived rows and is
+idempotent. Re-run `storage provider-target-audit` after apply and require clean
+evidence before provider-target authority cutover.
 
 Provider-target dual-write is active for Launchplane-owned target identity
 mutations: product onboarding, Dokploy target adoption/creation, product context

--- a/docs/records.md
+++ b/docs/records.md
@@ -148,6 +148,12 @@ an ORM column/table or remains only in the evidence payload.
   with the neutral projection from paired Dokploy target and target-id records,
   reports missing halves and mismatches, and exits nonzero when unresolved
   blockers would make backfill or authority cutover unsafe.
+- `uv run launchplane storage provider-target-backfill` is the Phase Two seeding
+  path for explicit provider-target rows. Dry-run is the default; `--apply`
+  writes only complete Dokploy target/id projections that have no conflicting
+  physical row. Existing matching physical rows are skipped without churn,
+  incomplete pairs are reported but not guessed, and conflicts or unsupported
+  provider rows are never overwritten automatically.
 - Shared ship and promotion request/evidence contracts accept a neutral
   `target_reference` compatibility input for target name, provider id,
   category, and provider target type. Persisted records still write the flat

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1229,6 +1229,29 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(listed, (record,))
         self.assertEqual(filtered, (record,))
 
+    def test_create_provider_target_record_if_absent_refuses_existing_route(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+
+            record = _provider_target_record(context="verireel", instance="prod")
+            changed_record = _provider_target_record(
+                context="verireel",
+                instance="prod",
+                target_id="app-verireel-prod-new",
+            )
+            first_status = store.create_provider_target_record_if_absent(record)
+            second_status = store.create_provider_target_record_if_absent(changed_record)
+            loaded = store.read_provider_target_record(
+                context_name="verireel", instance_name="prod"
+            )
+            store.close()
+
+        self.assertEqual(first_status, "created")
+        self.assertEqual(second_status, "exists")
+        self.assertEqual(loaded, record)
+
     def test_delete_provider_target_record_uses_current_authority_match(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"

--- a/tests/test_provider_target_backfill.py
+++ b/tests/test_provider_target_backfill.py
@@ -1,0 +1,442 @@
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.deploy_target import DeployTargetCategory, ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord, DokployTargetType
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.provider_target_backfill import backfill_provider_targets
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite:///{database_path}"
+
+
+def _dokploy_target_record(
+    *,
+    context: str = "syo",
+    instance: str = "prod",
+    target_type: str = "application",
+    target_name: str = "",
+    project_name: str = "syo-project",
+) -> DokployTargetRecord:
+    return DokployTargetRecord(
+        context=context,
+        instance=instance,
+        project_name=project_name,
+        target_type=cast(DokployTargetType, target_type),
+        target_name=target_name or f"{context}-{instance}",
+        source_git_ref="origin/main",
+        domains=(f"https://{instance}.example.com",),
+        updated_at="2026-04-21T18:30:00Z",
+        source_label="test:dokploy-target",
+    )
+
+
+def _dokploy_target_id_record(
+    *,
+    context: str = "syo",
+    instance: str = "prod",
+    target_id: str = "app-syo-prod",
+) -> DokployTargetIdRecord:
+    return DokployTargetIdRecord(
+        context=context,
+        instance=instance,
+        target_id=target_id,
+        updated_at="2026-04-21T18:31:00Z",
+        source_label="test:dokploy-target-id",
+    )
+
+
+def _provider_target_record(
+    *,
+    context: str = "syo",
+    instance: str = "prod",
+    provider_id: str = "dokploy",
+    target_category: str = "application",
+    target_id: str = "app-syo-prod",
+    display_name: str = "",
+    provider_target_type: str = "application",
+    provider_evidence: dict[str, str] | None = None,
+    updated_at: str = "2026-04-21T18:32:00Z",
+    source_label: str = "test:provider-target",
+) -> ProviderTargetRecord:
+    return ProviderTargetRecord(
+        context=context,
+        instance=instance,
+        provider_id=provider_id,
+        target_category=cast(DeployTargetCategory, target_category),
+        target_id=target_id,
+        display_name=display_name or f"{context}-{instance}",
+        provider_target_type=provider_target_type,
+        provider_evidence=provider_evidence
+        if provider_evidence is not None
+        else {"project_name": "syo-project"},
+        updated_at=updated_at,
+        source_label=source_label,
+    )
+
+
+class ProviderTargetBackfillTests(unittest.TestCase):
+    def test_dry_run_reports_would_create_without_writing(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+
+            result = backfill_provider_targets(store)
+            physical_records = store.list_physical_provider_target_records()
+            store.close()
+
+        self.assertTrue(result.ok)
+        self.assertFalse(result.applied)
+        self.assertEqual(result.counts, {"would-create": 1})
+        self.assertIsNotNone(result.items[0].projected_record)
+        assert result.items[0].projected_record is not None
+        self.assertEqual(result.items[0].projected_record.target_id, "app-syo-prod")
+        self.assertEqual(physical_records, ())
+
+    def test_apply_creates_missing_rows_and_second_apply_skips_existing(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+
+            first_result = backfill_provider_targets(store, apply=True)
+            first_physical = store.read_provider_target_record(
+                context_name="syo", instance_name="prod"
+            )
+            second_result = backfill_provider_targets(store, apply=True)
+            second_physical = store.read_provider_target_record(
+                context_name="syo", instance_name="prod"
+            )
+            store.close()
+
+        self.assertTrue(first_result.ok)
+        self.assertEqual(first_result.counts, {"created": 1})
+        self.assertEqual(first_physical.target_id, "app-syo-prod")
+        self.assertTrue(second_result.ok)
+        self.assertEqual(second_result.counts, {"skipped-exists": 1})
+        self.assertEqual(second_physical, first_physical)
+
+    def test_apply_does_not_churn_matching_physical_row(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+            existing_record = _provider_target_record(
+                updated_at="2026-04-01T00:00:00Z",
+                source_label="test:existing-row",
+            )
+            store.write_provider_target_record(existing_record)
+
+            result = backfill_provider_targets(store, apply=True)
+            physical_record = store.read_provider_target_record(
+                context_name="syo", instance_name="prod"
+            )
+            store.close()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.counts, {"skipped-exists": 1})
+        self.assertEqual(physical_record.updated_at, "2026-04-01T00:00:00Z")
+        self.assertEqual(physical_record.source_label, "test:existing-row")
+
+    def test_reports_incomplete_pairs_without_writing(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(
+                _dokploy_target_record(context="target-only", instance="prod")
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(context="id-only", instance="prod")
+            )
+
+            result = backfill_provider_targets(store, apply=True)
+            physical_records = store.list_physical_provider_target_records()
+            store.close()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.warning_count, 2)
+        self.assertEqual(result.counts, {"skipped-incomplete": 2})
+        self.assertEqual(physical_records, ())
+
+    def test_reports_conflict_and_never_overwrites(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+            stale_record = _provider_target_record(target_id="stale-app-syo-prod")
+            store.write_provider_target_record(stale_record)
+
+            result = backfill_provider_targets(store, apply=True)
+            physical_record = store.read_provider_target_record(
+                context_name="syo", instance_name="prod"
+            )
+            store.close()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.counts, {"skipped-conflict": 1})
+        self.assertEqual(physical_record.target_id, "stale-app-syo-prod")
+
+    def test_apply_refuses_all_writes_when_any_route_is_blocked(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record(context="create-me"))
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(context="create-me", target_id="app-create-me-prod")
+            )
+            store.write_dokploy_target_record(_dokploy_target_record(context="conflict"))
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(context="conflict", target_id="app-conflict-prod")
+            )
+            store.write_provider_target_record(
+                _provider_target_record(context="conflict", target_id="stale-conflict-prod")
+            )
+
+            result = backfill_provider_targets(store, apply=True)
+            physical_records = store.list_physical_provider_target_records()
+            store.close()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.counts, {"skipped-conflict": 1, "would-create": 1})
+        self.assertEqual(
+            [(record.context, record.target_id) for record in physical_records],
+            [("conflict", "stale-conflict-prod")],
+        )
+
+    def test_existing_dokploy_physical_row_with_missing_source_record_blocks(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_provider_target_record(_provider_target_record())
+
+            result = backfill_provider_targets(store, apply=True)
+            store.close()
+
+        self.assertFalse(result.ok)
+        self.assertEqual(result.blocked_count, 1)
+        self.assertEqual(result.counts, {"skipped-incomplete": 1})
+
+    def test_reports_unsupported_provider_row(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_provider_target_record(
+                _provider_target_record(provider_id="future-provider")
+            )
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+
+            result = backfill_provider_targets(store, apply=True)
+            physical_records = store.list_physical_provider_target_records()
+            store.close()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.counts, {"unsupported-provider": 1})
+        self.assertEqual(physical_records[0].provider_id, "future-provider")
+
+    def test_filters_scope_backfill_and_block_zero_matches(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record(context="syo"))
+            store.write_dokploy_target_id_record(_dokploy_target_id_record(context="syo"))
+            store.write_dokploy_target_record(_dokploy_target_record(context="verireel"))
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(context="verireel", target_id="app-verireel-prod")
+            )
+
+            scoped_result = backfill_provider_targets(
+                store, apply=True, context_name="syo", provider_id="dokploy"
+            )
+            zero_match_result = backfill_provider_targets(
+                store, apply=True, context_name="missing-context"
+            )
+            physical_records = store.list_physical_provider_target_records()
+            store.close()
+
+        self.assertTrue(scoped_result.ok)
+        self.assertEqual(scoped_result.counts, {"created": 1})
+        self.assertFalse(zero_match_result.ok)
+        self.assertEqual(zero_match_result.counts, {"no_matching_routes": 1})
+        self.assertEqual(
+            [(record.context, record.target_id) for record in physical_records],
+            [("syo", "app-syo-prod")],
+        )
+
+    def test_instance_filter_scopes_backfill(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record(instance="prod"))
+            store.write_dokploy_target_id_record(_dokploy_target_id_record(instance="prod"))
+            store.write_dokploy_target_record(
+                _dokploy_target_record(instance="testing", target_name="syo-testing")
+            )
+            store.write_dokploy_target_id_record(
+                _dokploy_target_id_record(instance="testing", target_id="app-syo-testing")
+            )
+
+            result = backfill_provider_targets(store, apply=True, instance_name="testing")
+            physical_records = store.list_physical_provider_target_records()
+            store.close()
+
+        self.assertTrue(result.ok)
+        self.assertEqual(result.counts, {"created": 1})
+        self.assertEqual(
+            [(record.instance, record.target_id) for record in physical_records],
+            [("testing", "app-syo-testing")],
+        )
+
+    def test_cli_dry_run_and_apply_emit_json(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            database_url = _sqlite_database_url(database_path)
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+            store.close()
+
+            dry_run = CliRunner().invoke(
+                main,
+                [
+                    "storage",
+                    "provider-target-backfill",
+                    "--database-url",
+                    database_url,
+                ],
+            )
+            apply_result = CliRunner().invoke(
+                main,
+                [
+                    "storage",
+                    "provider-target-backfill",
+                    "--database-url",
+                    database_url,
+                    "--apply",
+                ],
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            physical_record = store.read_provider_target_record(
+                context_name="syo", instance_name="prod"
+            )
+            store.close()
+
+        self.assertEqual(dry_run.exit_code, 0, dry_run.output)
+        dry_run_payload = json.loads(dry_run.output)
+        self.assertFalse(dry_run_payload["applied"])
+        self.assertEqual(dry_run_payload["counts"], {"would-create": 1})
+        self.assertEqual(apply_result.exit_code, 0, apply_result.output)
+        apply_payload = json.loads(apply_result.output)
+        self.assertTrue(apply_payload["applied"])
+        self.assertEqual(apply_payload["counts"], {"created": 1})
+        self.assertEqual(physical_record.target_id, "app-syo-prod")
+
+    def test_cli_exits_nonzero_on_conflicts(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            database_url = _sqlite_database_url(database_path)
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+            store.write_provider_target_record(
+                _provider_target_record(target_id="stale-app-syo-prod")
+            )
+            store.close()
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "storage",
+                    "provider-target-backfill",
+                    "--database-url",
+                    database_url,
+                    "--apply",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "blocked")
+        self.assertEqual(payload["counts"], {"skipped-conflict": 1})
+
+    def test_cli_initializes_fresh_database_schema(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "storage",
+                    "provider-target-backfill",
+                    "--database-url",
+                    database_url,
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["inspected_route_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `storage provider-target-backfill` as a dry-run-by-default operator command with `--apply` to seed explicit provider-target rows from complete Dokploy target/id pairs
- classify rows as `would-create`, `created`, `skipped-exists`, `skipped-incomplete`, `skipped-conflict`, `unsupported-provider`, or `no_matching_routes`
- make apply all-or-nothing for preflight blockers and use a conditional provider-target insert so backfill does not upsert over a concurrently created physical row
- document the dry-run, review, apply, and post-apply audit flow for Phase Two

Refs #1100
Refs #1103

## Validation
- `uv run python -m unittest tests.test_provider_target_backfill tests.test_provider_target_audit tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_records_project_from_dokploy_records tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_records_round_trip_from_physical_storage tests.test_postgres_store.PostgresRecordStoreTests.test_create_provider_target_record_if_absent_refuses_existing_route tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_physical_storage_precedes_dokploy_projection tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_filter_suppresses_shadowed_dokploy_projection tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_list_combines_physical_and_projected_records tests.test_postgres_store.PostgresRecordStoreTests.test_provider_target_list_skips_incomplete_dokploy_pairs`
- `uv run --extra dev ruff check control_plane/workflows/provider_target_backfill.py control_plane/cli_storage_secrets.py control_plane/storage/postgres.py tests/test_provider_target_backfill.py tests/test_postgres_store.py docs/operations.md docs/records.md --diff`
- `uv run --extra dev ruff check control_plane/workflows/provider_target_backfill.py control_plane/cli_storage_secrets.py control_plane/storage/postgres.py tests/test_provider_target_backfill.py tests/test_postgres_store.py`
- `uv run --extra dev mypy control_plane tests/test_provider_target_backfill.py tests/test_postgres_store.py`
- `uv run python -m unittest`
