### PR TITLE
Fix provider metadata review regressions

### DIFF
--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -175,16 +175,25 @@ class ProductOnboardingManifest(BaseModel):
         if not isinstance(data, dict):
             return data
         updated = dict(data)
+        provider_targets_provided = "provider_targets" in updated
         raw_provider_targets = updated.get("provider_targets", ())
         raw_dokploy_targets = updated.pop("dokploy_targets", ())
-        if raw_provider_targets is None or raw_provider_targets == () or raw_provider_targets == []:
+        if not provider_targets_provided:
             updated["provider_targets"] = raw_dokploy_targets or ()
             return updated
 
+        if raw_provider_targets is None:
+            updated["provider_targets"] = raw_dokploy_targets or ()
+            return updated
         provider_targets = _normalized_onboarding_targets(raw_provider_targets)
+        if not provider_targets:
+            updated["provider_targets"] = provider_targets
+            return updated
+
         dokploy_targets = _normalized_onboarding_targets(raw_dokploy_targets)
         if dokploy_targets and provider_targets != dokploy_targets:
             raise ValueError("provider_targets must match dokploy_targets when both are set")
+        updated["provider_targets"] = provider_targets
         return updated
 
     @model_validator(mode="after")

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -225,9 +225,28 @@ def _provider_deploy_fields_from_deployment_record(
     provider_deploy_mode = deploy_mode
     if deployment_record is not None:
         deploy_mode = deployment_record.deploy.deploy_mode
-        provider_id = deployment_record.deploy.provider_id
-        target_category = deployment_record.deploy.target_category or target_type
-        provider_target_type = deployment_record.deploy.provider_target_type
+        legacy_category: DeployTargetCategory = target_type
+        record_target_category = deployment_record.deploy.target_category or legacy_category
+        if record_target_category == "unknown":
+            record_target_category = legacy_category
+        provider_id = _prefer_fresh_provider_metadata(
+            record_value=deployment_record.deploy.provider_id,
+            fallback_value=fallback.provider_id,
+            legacy_value="dokploy",
+        )
+        target_category = cast(
+            DeployTargetCategory,
+            _prefer_fresh_provider_metadata(
+                record_value=record_target_category,
+                fallback_value=fallback.target_category,
+                legacy_value=legacy_category,
+            ),
+        )
+        provider_target_type = _prefer_fresh_provider_metadata(
+            record_value=deployment_record.deploy.provider_target_type,
+            fallback_value=fallback.provider_target_type,
+            legacy_value=target_type,
+        )
         provider_deploy_mode = deployment_record.deploy.provider_deploy_mode
     return VeriReelProdPromotionDeployEvidenceFields(
         deploy_mode=deploy_mode,
@@ -236,6 +255,19 @@ def _provider_deploy_fields_from_deployment_record(
         provider_target_type=provider_target_type,
         provider_deploy_mode=provider_deploy_mode,
     )
+
+
+def _prefer_fresh_provider_metadata(
+    *,
+    record_value: str,
+    fallback_value: str,
+    legacy_value: str,
+) -> str:
+    if not record_value:
+        return fallback_value
+    if fallback_value and fallback_value != legacy_value and record_value == legacy_value:
+        return fallback_value
+    return record_value
 
 
 def _legacy_dokploy_target_type(
@@ -348,10 +380,12 @@ def _build_promotion_record(
     migration_status: ReleaseStatus,
     migration_detail: str,
     health_result: VeriReelRolloutVerificationResult | None,
+    target_fields: VeriReelProdPromotionTargetResultFields | None = None,
 ) -> PromotionRecord:
     provider_deploy_fields = _provider_deploy_fields_from_deployment_record(
         deployment_record=deployment_record,
-        fallback=VeriReelProdPromotionTargetResultFields(
+        fallback=target_fields
+        or VeriReelProdPromotionTargetResultFields(
             target_name=target_name,
             target_id=target_id,
             target_category=target_type,
@@ -803,6 +837,7 @@ def execute_verireel_prod_promotion(
             migration_status="skipped",
             migration_detail="",
             health_result=None,
+            target_fields=target_fields,
         )
         record_store.write_promotion_record(promotion_record)
         return _build_result(
@@ -975,6 +1010,7 @@ def execute_verireel_prod_promotion(
         migration_status="pass",
         migration_detail="",
         health_result=health_result,
+        target_fields=target_fields,
     )
     record_store.write_promotion_record(promotion_record)
     return _build_result(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1525,6 +1525,17 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("provider_targets", manifest.model_dump())
         self.assertNotIn("dokploy_targets", manifest.model_dump())
 
+    def test_product_onboarding_manifest_accepts_null_provider_targets_compat_input(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+        payload["provider_targets"] = None
+
+        manifest = ProductOnboardingManifest.model_validate(payload)
+
+        self.assertEqual(len(manifest.provider_targets), 2)
+        self.assertEqual(manifest.dokploy_targets, manifest.provider_targets)
+
     def test_product_onboarding_manifest_accepts_matching_provider_targets_input(
         self,
     ) -> None:
@@ -1535,6 +1546,17 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
 
         self.assertEqual(len(manifest.provider_targets), 2)
         self.assertEqual(len(manifest.dokploy_targets), 2)
+
+    def test_product_onboarding_manifest_keeps_empty_provider_targets_intentional(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+        payload["provider_targets"] = []
+
+        manifest = ProductOnboardingManifest.model_validate(payload)
+
+        self.assertEqual(manifest.provider_targets, ())
+        self.assertEqual(manifest.dokploy_targets, ())
 
     def test_product_onboarding_manifest_rejects_conflicting_provider_targets_input(
         self,

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -157,6 +157,114 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                 ("https://ver-prod.shinycomputers.com/api/health",),
             )
 
+    def test_execute_preserves_fresh_provider_metadata_from_deploy_result(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_backup_gate_record(
+                BackupGateRecord(
+                    record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    context="verireel",
+                    instance="prod",
+                    created_at="2026-04-21T18:05:00Z",
+                    source="verireel-prod-gate",
+                    status="pass",
+                    evidence={"snapshot_name": "ver-predeploy-20260421T180500Z"},
+                )
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-verireel-prod-run-12345-attempt-1",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890"
+                    ),
+                    context="verireel",
+                    instance="prod",
+                    source_git_ref="abcdef1234567890",
+                    resolved_target=ResolvedTargetEvidence(
+                        target_type="application",
+                        target_id="prod-app-123",
+                        target_name="ver-prod-app",
+                    ),
+                    deploy=DeploymentEvidence(
+                        target_name="ver-prod-app",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        provider_id="dokploy",
+                        target_category="application",
+                        provider_target_type="application",
+                        provider_deploy_mode="dokploy-application-api",
+                        deployment_id="prod-app-123",
+                        status="pass",
+                        started_at="2026-04-21T18:20:00Z",
+                        finished_at="2026-04-21T18:21:15Z",
+                    ),
+                )
+            )
+            request = VeriReelProdPromotionRequest(
+                artifact_id="ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                source_git_ref="abcdef1234567890",
+                backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                promotion_record_id="promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                source_health_status="pass",
+                expected_build_revision="abcdef1234567890",
+                expected_build_tag="sha-abcdef1234567890",
+            )
+
+            with (
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion.execute_verireel_stable_deploy",
+                    return_value=VeriReelStableDeployResult(
+                        deployment_record_id="deployment-verireel-prod-run-12345-attempt-1",
+                        deploy_status="pass",
+                        deploy_started_at="2026-04-21T18:20:00Z",
+                        deploy_finished_at="2026-04-21T18:21:15Z",
+                        target_name="ver-prod-app",
+                        target_id="prod-app-123",
+                        target_category="service",
+                        provider_id="runtime-provider",
+                        provider_target_type="managed-service",
+                        target_type="application",
+                        rollout_status="pass",
+                        rollout_base_url="https://ver-prod.shinycomputers.com",
+                        rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                        rollout_started_at="2026-04-21T18:21:16Z",
+                        rollout_finished_at="2026-04-21T18:21:45Z",
+                    ),
+                ),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._run_prisma_migrations",
+                    return_value=None,
+                ),
+                patch(
+                    "control_plane.workflows.verireel_prod_promotion._verify_rollout",
+                    return_value=VeriReelRolloutVerificationResult(
+                        status="pass",
+                        base_url="https://ver-prod.shinycomputers.com",
+                        health_urls=("https://ver-prod.shinycomputers.com/api/health",),
+                    ),
+                ),
+            ):
+                result = execute_verireel_prod_promotion(
+                    control_plane_root=root,
+                    record_store=store,
+                    request=request,
+                )
+
+            self.assertEqual(result.provider_id, "runtime-provider")
+            self.assertEqual(result.target_category, "service")
+            self.assertEqual(result.provider_target_type, "managed-service")
+            promotion = store.read_promotion_record(
+                "promotion-verireel-testing-to-prod-run-12345-attempt-1"
+            )
+            self.assertEqual(promotion.deploy.provider_id, "runtime-provider")
+            self.assertEqual(promotion.deploy.target_category, "service")
+            self.assertEqual(promotion.deploy.provider_target_type, "managed-service")
+            self.assertEqual(promotion.deploy.provider_deploy_mode, "dokploy-application-api")
+
     def test_execute_writes_failed_promotion_record_when_prisma_migration_fails(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- Treat explicit empty provider_targets as intentional without reviving legacy dokploy_targets, while preserving provider_targets=null compatibility fallback.
- Preserve fresh VeriReel deploy-result provider metadata when a deployment_record only carries legacy/default provider fields.
- Add regressions for explicit empty/null onboarding targets and stale deployment-record provider metadata.

## Tests
- uv run python -m unittest tests.test_product_onboarding tests.test_verireel_prod_promotion
- uv run --extra dev ruff check --diff control_plane/contracts/product_onboarding_manifest.py control_plane/workflows/verireel_prod_promotion.py tests/test_product_onboarding.py tests/test_verireel_prod_promotion.py
- uv run --extra dev ruff check control_plane/contracts/product_onboarding_manifest.py control_plane/workflows/verireel_prod_promotion.py tests/test_product_onboarding.py tests/test_verireel_prod_promotion.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest
