### PR TITLE
Add provider target operations workflow

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -87,6 +87,7 @@
     "Product Context Cutover Audit",
     "Product Context Cutover",
     "Product Legacy Context Cleanup",
+    "Provider Target Operations",
     "Work Graph Snapshot Validate",
     "Dependency Graph"
   ],

--- a/.github/workflows/provider-target-operations.yml
+++ b/.github/workflows/provider-target-operations.yml
@@ -1,0 +1,251 @@
+---
+name: Provider Target Operations
+
+"on":
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Provider target operation mode.
+        required: true
+        default: audit
+        type: choice
+        options:
+          - audit
+          - backfill-dry-run
+          - backfill-apply
+      target_set:
+        description: Route set to operate on.
+        required: true
+        default: single
+        type: choice
+        options:
+          - single
+          - phase-two-initial
+      context:
+        description: Route context when target_set=single.
+        required: false
+        default: verireel
+        type: string
+      instance:
+        description: Route instance when target_set=single.
+        required: false
+        default: testing
+        type: string
+      provider_id:
+        description: Provider id to inspect/backfill.
+        required: false
+        default: dokploy
+        type: string
+      confirmation:
+        description: Exact apply confirmation text.
+        required: false
+        default: ""
+        type: string
+      reason:
+        description: Operator reason. Required when mode=backfill-apply.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: launchplane-provider-target-operations
+  cancel-in-progress: false
+
+jobs:
+  operate:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      MODE: ${{ inputs.mode }}
+      TARGET_SET: ${{ inputs.target_set }}
+      CONTEXT: ${{ inputs.context }}
+      INSTANCE: ${{ inputs.instance }}
+      PROVIDER_ID: ${{ inputs.provider_id }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve service endpoint
+        id: service
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+
+          python3 - <<'PY'
+          import os
+          from urllib.parse import urlsplit
+
+          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
+          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
+              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
+          output_path = os.environ["GITHUB_OUTPUT"]
+          with open(output_path, "a", encoding="utf-8") as handle:
+              handle.write(f"origin={parsed.scheme}://{parsed.netloc}\n")
+              handle.write(f"audience={parsed.hostname}\n")
+          PY
+
+      - name: Validate apply guard
+        if: env.MODE == 'backfill-apply'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRMATION" != "APPLY PROVIDER TARGET BACKFILL" ]; then
+            echo "Exact apply confirmation text is required." >&2
+            exit 1
+          fi
+          if [ -z "$(printf '%s' "$REASON" | xargs)" ]; then
+            echo "reason is required when mode=backfill-apply." >&2
+            exit 1
+          fi
+
+      - name: Resolve target routes
+        shell: bash
+        run: |
+          set -euo pipefail
+          routes_file="provider-target-routes.json"
+          case "$TARGET_SET" in
+            single)
+              if [ -z "$(printf '%s' "$CONTEXT" | xargs)" ]; then
+                echo "context is required when target_set=single." >&2
+                exit 1
+              fi
+              if [ -z "$(printf '%s' "$INSTANCE" | xargs)" ]; then
+                echo "instance is required when target_set=single." >&2
+                exit 1
+              fi
+              jq -n --arg context "$CONTEXT" --arg instance "$INSTANCE" \
+                '[{"context":$context,"instance":$instance}]' > "$routes_file"
+              ;;
+            phase-two-initial)
+              cat > "$routes_file" <<'JSON'
+          [
+            {"context":"discord-blue","instance":"prod"},
+            {"context":"verireel","instance":"testing"},
+            {"context":"verireel","instance":"prod"},
+            {"context":"cm","instance":"testing"},
+            {"context":"cm","instance":"prod"},
+            {"context":"opw","instance":"testing"},
+            {"context":"opw","instance":"prod"}
+          ]
+          JSON
+              ;;
+            *)
+              echo "Unsupported target_set: $TARGET_SET" >&2
+              exit 1
+              ;;
+          esac
+          jq . "$routes_file"
+
+      - name: Run provider-target operation
+        env:
+          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
+          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
+            echo "GitHub OIDC token response did not include a token value." >&2
+            exit 1
+          fi
+
+          mkdir -p provider-target-operation-results
+          jq -c '.[]' provider-target-routes.json | while read -r route; do
+            context="$(jq -r '.context' <<< "$route")"
+            instance="$(jq -r '.instance' <<< "$route")"
+            response_file="provider-target-operation-results/${context}-${instance}.json"
+            idempotency_key="provider-target:${MODE}:${PROVIDER_ID}:"
+            idempotency_key+="${context}:${instance}"
+            body="$({
+              jq -n \
+                --arg mode "$MODE" \
+                --arg provider_id "$PROVIDER_ID" \
+                --arg context "$context" \
+                --arg instance "$instance" \
+                --arg reason "$REASON" \
+                '{schema_version:1,
+                  mode:$mode,
+                  product:"launchplane",
+                  provider_id:$provider_id,
+                  context:$context,
+                  instance:$instance,
+                  reason:$reason}'
+            })"
+            status_code="$(curl -sS \
+              -o "$response_file" \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Accept: application/json' \
+              -H 'Content-Type: application/json' \
+              -H "Idempotency-Key: ${idempotency_key}" \
+              --data "$body" \
+              "${SERVICE_ORIGIN%/}/v1/provider-targets/operations")"
+            jq . "$response_file"
+            if [ "$status_code" != "202" ]; then
+              printf 'Provider-target operation failed for %s/%s.\n' \
+                "$context" "$instance" >&2
+              echo "HTTP status: ${status_code}." >&2
+              exit 1
+            fi
+            operation_status="$({
+              jq -r '.result.operation_status // empty' "$response_file"
+            })"
+            if [ "$operation_status" != "ok" ]; then
+              printf 'Provider-target operation was not ok for %s/%s.\n' \
+                "$context" "$instance" >&2
+              echo "Status: ${operation_status}" >&2
+              exit 1
+            fi
+          done
+
+      - name: Upload operation evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: >-
+            provider-target-ops-${{ inputs.mode }}-${{ inputs.target_set }}
+          path: |
+            provider-target-routes.json
+            provider-target-operation-results/*.json
+          if-no-files-found: error
+
+      - name: Summarize operation
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Provider target operation"
+            echo
+            echo "- Mode: $MODE"
+            echo "- Target set: $TARGET_SET"
+            echo "- Provider: $PROVIDER_ID"
+            echo "- Results: provider-target-ops-${MODE}-${TARGET_SET}"
+            echo
+            if compgen -G 'provider-target-operation-results/*.json' \
+              > /dev/null; then
+              jq -s '[.[] | {
+                context:.result.context,
+                instance:.result.instance,
+                status:.result.operation_status,
+                blocked:.result.blocked_count,
+                warnings:.result.warning_count,
+                counts:.result.report.counts
+              }]' \
+                provider-target-operation-results/*.json
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/provider_target_operations_http.py
+++ b/control_plane/provider_target_operations_http.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.service_auth import (
+    LaunchplaneAuthzPolicy,
+    LaunchplaneIdentity,
+    LocalAdminIdentity,
+    LocalOperatorIdentity,
+)
+from control_plane.workflows.provider_target_audit import (
+    ProviderTargetAuditRecordStore,
+    audit_provider_targets,
+)
+from control_plane.workflows.provider_target_backfill import (
+    ProviderTargetBackfillStore,
+    backfill_provider_targets,
+)
+
+
+LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+PROVIDER_TARGET_OPERATIONS_ROUTE = "/v1/provider-targets/operations"
+
+ProviderTargetOperationMode = Literal["audit", "backfill-dry-run", "backfill-apply"]
+
+
+class ProviderTargetOperationStore(
+    ProviderTargetAuditRecordStore,
+    ProviderTargetBackfillStore,
+    Protocol,
+):
+    pass
+
+
+class ProviderTargetOperationEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: ProviderTargetOperationMode
+    product: str = "launchplane"
+    provider_id: str = "dokploy"
+    context: str
+    instance: str
+    reason: str = ""
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "ProviderTargetOperationEnvelope":
+        self.product = self.product.strip()
+        self.provider_id = self.provider_id.strip().lower()
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        self.reason = self.reason.strip()
+        if self.product != "launchplane":
+            raise ValueError("provider-target operations require product 'launchplane'")
+        if not self.provider_id:
+            raise ValueError("provider-target operations require provider_id")
+        if not self.context:
+            raise ValueError("provider-target operations require context")
+        if not self.instance:
+            raise ValueError("provider-target operations require instance")
+        if self.mode == "backfill-apply" and not self.reason:
+            raise ValueError("provider-target backfill apply requires reason")
+        return self
+
+
+@dataclass(frozen=True)
+class ProviderTargetOperationRouteResult:
+    result: dict[str, object]
+    driver_result: dict[str, object]
+
+
+def provider_target_operation_authorized(
+    *,
+    authz_policy: LaunchplaneAuthzPolicy,
+    identity: LaunchplaneIdentity,
+    request: ProviderTargetOperationEnvelope,
+) -> bool:
+    action = (
+        "provider_target.backfill"
+        if request.mode == "backfill-apply"
+        else "provider_target.audit"
+    )
+    return authz_policy.allows(
+        identity=identity,
+        action=action,
+        product=request.product,
+        context=LAUNCHPLANE_SERVICE_CONTEXT,
+    )
+
+
+def provider_target_operation_requires_reason(
+    *, identity: LaunchplaneIdentity, request: ProviderTargetOperationEnvelope
+) -> bool:
+    return (
+        isinstance(identity, (LocalOperatorIdentity, LocalAdminIdentity))
+        and request.mode == "backfill-apply"
+        and not request.reason
+    )
+
+
+def execute_provider_target_operation_route(
+    *,
+    record_store: ProviderTargetOperationStore,
+    request: ProviderTargetOperationEnvelope,
+) -> ProviderTargetOperationRouteResult:
+    if request.mode == "audit":
+        audit_result = audit_provider_targets(
+            record_store,
+            provider_id=request.provider_id,
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+        report = audit_result.to_report_payload()
+    else:
+        backfill_result = backfill_provider_targets(
+            record_store,
+            apply=request.mode == "backfill-apply",
+            provider_id=request.provider_id,
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+        report = backfill_result.to_report_payload()
+    result = {
+        "mode": request.mode,
+        "provider_id": request.provider_id,
+        "context": request.context,
+        "instance": request.instance,
+        "operation_status": str(report.get("status", "")),
+        "blocked_count": _report_int(report.get("blocked_count")),
+        "warning_count": _report_int(report.get("warning_count")),
+        "inspected_route_count": _report_int(report.get("inspected_route_count")),
+    }
+    return ProviderTargetOperationRouteResult(
+        result=result,
+        driver_result={
+            **result,
+            "reason": request.reason,
+            "report": report,
+        },
+    )
+
+
+def _report_int(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        return int(value.strip())
+    return 0

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -241,6 +241,14 @@ from control_plane.product_config_http import (
     product_config_database_required_response,
     validate_product_config_apply_request,
 )
+from control_plane.provider_target_operations_http import (
+    PROVIDER_TARGET_OPERATIONS_ROUTE,
+    ProviderTargetOperationEnvelope,
+    ProviderTargetOperationRouteResult,
+    execute_provider_target_operation_route,
+    provider_target_operation_authorized,
+    provider_target_operation_requires_reason,
+)
 from control_plane.work_graph_github_projects import (
     build_github_project_planning_facts,
     load_github_project_planning_facts_config_from_env,
@@ -3104,6 +3112,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/runtime-key-safety/policies/apply",
         "/v1/live-target-runtime/apply",
         "/v1/product-onboarding/apply",
+        PROVIDER_TARGET_OPERATIONS_ROUTE,
         "/v1/product-config/apply",
         "/v1/product-profiles/context-cutover/apply",
         "/v1/product-profiles/legacy-context-cleanup/apply",
@@ -5862,6 +5871,12 @@ def _should_store_idempotency_record(
         path == "/v1/merge-train/policies/import"
         and isinstance(driver_result, dict)
         and driver_result.get("mode") == "dry_run"
+    ):
+        return False
+    if (
+        path == PROVIDER_TARGET_OPERATIONS_ROUTE
+        and isinstance(driver_result, dict)
+        and driver_result.get("mode") != "backfill-apply"
     ):
         return False
     if driver_result is None:
@@ -12597,6 +12612,86 @@ def create_launchplane_service_app(
                         onboarding_result
                     )
                 )
+            elif path == PROVIDER_TARGET_OPERATIONS_ROUTE:
+                provider_target_request = ProviderTargetOperationEnvelope.model_validate(
+                    payload
+                )
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": (
+                                    "Provider-target operations require Launchplane"
+                                    " database storage."
+                                ),
+                            },
+                        },
+                    )
+                if provider_target_operation_requires_reason(
+                    identity=identity,
+                    request=provider_target_request,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "reason_required",
+                                "message": (
+                                    "Local operator provider-target backfill apply"
+                                    " requires a reason."
+                                ),
+                            },
+                        },
+                    )
+                if not provider_target_operation_authorized(
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    request=provider_target_request,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot run Launchplane provider-target"
+                                    " operations."
+                                ),
+                            },
+                        },
+                    )
+                if provider_target_request.mode == "backfill-apply":
+                    idempotent_response = _check_idempotent_request(
+                        record_store=record_store,
+                        scope=request_scope,
+                        route_path=path,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                    )
+                    if idempotent_response is not None:
+                        return idempotent_response
+                provider_target_result = execute_provider_target_operation_route(
+                    record_store=record_store,
+                    request=provider_target_request,
+                )
+                assert isinstance(
+                    provider_target_result, ProviderTargetOperationRouteResult
+                )
+                result = provider_target_result.result
+                driver_result = provider_target_result.driver_result
             elif path == "/v1/drivers/launchplane/self-deploy":
                 self_deploy_request = LaunchplaneSelfDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -49,7 +49,19 @@ is a long-running service with authenticated HTTP ingress. The CLI should remain
 a client of Launchplane's stable API contract or an explicit DB-backed operator
 tool, not a separate live-state authority.
 
-Provider-target Phase Two data changes must start with a read-only audit:
+Provider-target Phase Two data changes for shared or production lanes must use
+the deployed Launchplane service. The manual `Provider Target Operations`
+workflow calls `POST /v1/provider-targets/operations` with GitHub OIDC and is
+authorized through DB-backed `provider_target.audit` and
+`provider_target.backfill` grants for product/context `launchplane`. Run it
+first in `audit` or `backfill-dry-run` mode, review the artifact, then run
+`backfill-apply` only with the exact confirmation phrase and an operator reason.
+The initial Phase Two target set is ordered from the lower-risk proof lane into
+live production lanes: `discord-blue/prod`, `verireel/testing`,
+`verireel/prod`, `cm/testing`, `cm/prod`, `opw/testing`, and `opw/prod`.
+
+The local CLI remains a DB-backed inspection and rehearsal helper. Local
+provider-target data changes must start with a read-only audit:
 
 ```bash
 uv run launchplane storage provider-target-audit \
@@ -149,6 +161,7 @@ Current implementation scope:
 - `POST /v1/authz-policies/terminal-agents/grants`
 - `POST /v1/authz-policies/local-operators/grants`
 - `POST /v1/authz-policies/local-admins/grants`
+- `POST /v1/provider-targets/operations`
 - `POST /v1/product-profiles/context-cutover/apply`
 - `POST /v1/products/public-ingress-monitor/run-once`
 - `POST /v1/public-ingress/notification-policies/apply`
@@ -215,6 +228,12 @@ and merge-train policy import workflows through the service-backed removals
 route. Do not reintroduce those broad rules; keep those workflows paired with
 the narrow `product_onboarding.apply`, `runtime_key_safety.write`, and
 `merge_train.policy_import` grants.
+
+The deploy workflow also reconciles the manual `Provider Target Operations`
+workflow grants. `provider_target.audit` covers audit and dry-run requests;
+`provider_target.backfill` covers apply requests. The route is intentionally
+Launchplane-scoped and single-route per request, so production rows are seeded
+through explicit audited workflow runs rather than local live-target commands.
 
 Routine local-operator product-config grants are scoped, not wildcard, and the
 deploy reconciliation skips them unless explicit product/context scopes are

--- a/docs/records.md
+++ b/docs/records.md
@@ -154,6 +154,12 @@ an ORM column/table or remains only in the evidence payload.
   physical row. Existing matching physical rows are skipped without churn,
   incomplete pairs are reported but not guessed, and conflicts or unsupported
   provider rows are never overwritten automatically.
+- Shared and production Phase Two backfill uses the deployed service route
+  `POST /v1/provider-targets/operations`, normally through the manual
+  `Provider Target Operations` workflow. The workflow records per-route audit,
+  dry-run, or apply evidence as artifacts and uses DB-backed
+  `provider_target.audit` or `provider_target.backfill` authz grants instead of
+  local checkout writes.
 - Shared ship and promotion request/evidence contracts accept a neutral
   `target_reference` compatibility input for target name, provider id,
   category, and provider target type. Persisted records still write the flat

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -52,6 +52,8 @@ VeriReel product paths:
   - `POST /v1/product-config/apply`
 - product onboarding route:
   - `POST /v1/product-onboarding/apply`
+- provider-target operation route:
+  - `POST /v1/provider-targets/operations`
 - product context cutover route:
   - `POST /v1/product-profiles/context-cutover/apply`
 - product legacy context cleanup route:
@@ -841,6 +843,17 @@ sanitized summaries, and exists so the Launchplane seed import workflow can seed
 product records without product repos storing live lifecycle truth. Responses
 include neutral `provider_target*` summary keys while retaining `dokploy_*`
 compatibility keys until the target-record write path is migrated.
+
+Provider-target Phase Two operations use `POST /v1/provider-targets/operations`.
+The route accepts one Launchplane-owned route at a time with mode `audit`,
+`backfill-dry-run`, or `backfill-apply`, `provider_id`, `context`, `instance`,
+and an apply-only `reason`. It requires DB-backed storage and authorizes through
+`provider_target.audit` for audit/dry-run or `provider_target.backfill` for
+apply, always scoped to product/context `launchplane`. Apply requests are
+idempotency-keyed and write only complete non-conflicting Dokploy target/id
+projections; existing rows and conflicts are reported rather than overwritten.
+The manual `Provider Target Operations` workflow is the supported shared and
+production caller for Phase Two backfill evidence.
 
 Live target runtime sync uses `POST /v1/live-target-runtime/apply`. The route
 accepts `mode: "dry-run"` or `mode: "apply"`, product/context/instance, and

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -649,6 +649,22 @@ post_grant \
   runtime_key_safety.write \
   deploy:launchplane-seed-import-runtime-key-safety-grant \
   launchplane-seed-import-runtime-key-safety
+post_grant \
+  "$GITHUB_REPOSITORY" \
+  provider-target-operations.yml \
+  launchplane \
+  launchplane \
+  provider_target.audit \
+  deploy:provider-target-operations-audit-grant \
+  provider-target-operations-audit
+post_grant \
+  "$GITHUB_REPOSITORY" \
+  provider-target-operations.yml \
+  launchplane \
+  launchplane \
+  provider_target.backfill \
+  deploy:provider-target-operations-backfill-grant \
+  provider-target-operations-backfill
 post_syo_grant \
   promote-prod.yml \
   launchplane \

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12204,6 +12204,197 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_provider_target_operation_endpoint_backfills_route(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="verireel",
+                instance="testing",
+                target_id="app-verireel-testing",
+                target_type="application",
+                target_name="ver-testing-app",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/provider-target-operations.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": [
+                                "provider_target.audit",
+                                "provider_target.backfill",
+                            ],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/provider-target-operations.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            dry_run_status, dry_run_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/provider-targets/operations",
+                payload={
+                    "schema_version": 1,
+                    "mode": "backfill-dry-run",
+                    "product": "launchplane",
+                    "provider_id": "dokploy",
+                    "context": "verireel",
+                    "instance": "testing",
+                },
+                headers={"Idempotency-Key": "provider-target-verireel-testing-dry"},
+            )
+            dry_run_rerun_status, dry_run_rerun_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/provider-targets/operations",
+                payload={
+                    "schema_version": 1,
+                    "mode": "backfill-dry-run",
+                    "product": "launchplane",
+                    "provider_id": "dokploy",
+                    "context": "verireel",
+                    "instance": "testing",
+                },
+                headers={"Idempotency-Key": "provider-target-verireel-testing-dry"},
+            )
+            apply_status, apply_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/provider-targets/operations",
+                payload={
+                    "schema_version": 1,
+                    "mode": "backfill-apply",
+                    "product": "launchplane",
+                    "provider_id": "dokploy",
+                    "context": "verireel",
+                    "instance": "testing",
+                    "reason": "Seed provider-target row for Phase Two cutover.",
+                },
+                headers={"Idempotency-Key": "provider-target-verireel-testing"},
+            )
+            audit_status, audit_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/provider-targets/operations",
+                payload={
+                    "schema_version": 1,
+                    "mode": "audit",
+                    "product": "launchplane",
+                    "provider_id": "dokploy",
+                    "context": "verireel",
+                    "instance": "testing",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                provider_target = store.read_provider_target_record(
+                    context_name="verireel", instance_name="testing"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(dry_run_status, 202)
+        self.assertEqual(dry_run_payload["result"]["report"]["counts"], {"would-create": 1})
+        self.assertEqual(dry_run_rerun_status, 202)
+        self.assertNotIn("replayed", dry_run_rerun_payload)
+        self.assertEqual(
+            dry_run_rerun_payload["result"]["report"]["counts"], {"would-create": 1}
+        )
+        self.assertEqual(apply_status, 202)
+        self.assertEqual(apply_payload["result"]["report"]["counts"], {"created": 1})
+        self.assertEqual(audit_status, 202)
+        self.assertEqual(audit_payload["result"]["report"]["counts"], {"complete": 1})
+        self.assertIsNotNone(provider_target)
+        assert provider_target is not None
+        self.assertEqual(provider_target.target_id, "app-verireel-testing")
+
+    def test_provider_target_operation_endpoint_rejects_apply_without_authz(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="verireel",
+                instance="testing",
+                target_id="app-verireel-testing",
+                target_type="application",
+                target_name="ver-testing-app",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/provider-target-operations.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["provider_target.audit"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/provider-target-operations.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/provider-targets/operations",
+                payload={
+                    "schema_version": 1,
+                    "mode": "backfill-apply",
+                    "product": "launchplane",
+                    "provider_id": "dokploy",
+                    "context": "verireel",
+                    "instance": "testing",
+                    "reason": "Seed provider-target row for Phase Two cutover.",
+                },
+                headers={"Idempotency-Key": "provider-target-denied"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_product_overview_endpoint_is_generic_web_profile_driven(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add `POST /v1/provider-targets/operations` for Launchplane-scoped provider-target audit, dry-run, and apply operations
- add the manual Provider Target Operations workflow for Phase Two audit/backfill evidence, with ordered initial targets and apply confirmation guard
- reconcile workflow authz grants during Launchplane deploy and document the service-backed shared/prod boundary

## Verification
- `uv run python -m unittest tests.test_provider_target_audit tests.test_provider_target_backfill tests.test_product_onboarding_service tests.test_service.LaunchplaneServiceTests.test_provider_target_operation_endpoint_backfills_route tests.test_service.LaunchplaneServiceTests.test_provider_target_operation_endpoint_rejects_apply_without_authz`
- `uv run python -m unittest`
- `uv run --extra dev ruff check --diff control_plane/provider_target_operations_http.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/provider_target_operations_http.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane/provider_target_operations_http.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `shellcheck scripts/deploy/ensure-authz-grants.sh`
- `yamllint .github/workflows/provider-target-operations.yml`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/provider-target-operations.yml`
- `markdownlint-cli2 docs/operations.md docs/records.md docs/service-boundary.md`
- `prettier --check docs/operations.md docs/records.md docs/service-boundary.md .github/workflows/provider-target-operations.yml .github/github.json`
