### PR TITLE
Retire managed secret placeholders on config apply

### DIFF
--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -167,11 +167,32 @@ def apply_product_config_bundle(
                 actor=actor,
                 source_label=source_label,
             )
+            secret_id = str(result["secret_id"])
+            binding_key = str(secret["binding_key"])
+            now = utc_now_timestamp()
+            _retire_disabled_runtime_secret_placeholders(
+                record_store=record_store,
+                configured_binding=SecretBinding(
+                    binding_id=control_plane_secrets.expected_secret_binding_id(
+                        secret_id=secret_id,
+                        binding_key=binding_key,
+                    ),
+                    secret_id=secret_id,
+                    integration=str(secret["integration"]),
+                    binding_key=binding_key,
+                    context=str(secret["context"]),
+                    instance=str(secret["instance"]),
+                    status="configured",
+                    created_at=now,
+                    updated_at=now,
+                ),
+                updated_at=now,
+            )
             secret_summaries.append(
                 _summarize_product_config_secret_input(
                     action=str(result["action"]),
                     secret=secret,
-                    secret_id=str(result["secret_id"]),
+                    secret_id=secret_id,
                 )
             )
             continue
@@ -509,13 +530,11 @@ def _planned_runtime_secret_bindings(
     record_store: ProductConfigStore,
     secrets: tuple[dict[str, object], ...],
 ) -> tuple[SecretBinding, ...]:
-    existing_bindings = {
-        binding.binding_id: binding
-        for binding in record_store.list_secret_bindings(
-            integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
-            limit=None,
-        )
-    }
+    existing_runtime_bindings = record_store.list_secret_bindings(
+        integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+        limit=None,
+    )
+    existing_bindings = {binding.binding_id: binding for binding in existing_runtime_bindings}
     planned_bindings: list[SecretBinding] = []
     for secret in secrets:
         existing_record = record_store.find_secret_record(
@@ -554,7 +573,53 @@ def _planned_runtime_secret_bindings(
                 updated_at=now,
             )
         )
-    return tuple(planned_bindings)
+    planned_binding_ids = {binding.binding_id for binding in planned_bindings}
+    planned_routes = {
+        (binding.integration, binding.binding_key, binding.context, binding.instance)
+        for binding in planned_bindings
+    }
+    configured_existing_bindings = tuple(
+        binding
+        for binding in existing_runtime_bindings
+        if binding.status == "configured"
+        and binding.binding_id not in planned_binding_ids
+        and (binding.integration, binding.binding_key, binding.context, binding.instance)
+        in planned_routes
+    )
+    return (*planned_bindings, *configured_existing_bindings)
+
+
+def _retire_disabled_runtime_secret_placeholders(
+    *,
+    record_store: ProductConfigStore,
+    configured_binding: SecretBinding,
+    updated_at: str,
+) -> None:
+    if (
+        configured_binding.integration
+        != control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION
+    ):
+        return
+    for binding in record_store.list_secret_bindings(
+        integration=configured_binding.integration,
+        context_name=configured_binding.context,
+        instance_name=configured_binding.instance,
+        limit=None,
+    ):
+        if binding.binding_id == configured_binding.binding_id:
+            continue
+        if binding.binding_key != configured_binding.binding_key:
+            continue
+        if binding.status != "disabled":
+            continue
+        record_store.write_secret_binding(
+            binding.model_copy(
+                update={
+                    "integration": f"retired:{binding.integration}",
+                    "updated_at": updated_at,
+                }
+            )
+        )
 
 
 def _product_config_runtime_environment_class(

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -39,6 +39,15 @@ class ProductOnboardingRecordStore(Protocol):
 
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None: ...
 
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]: ...
+
     def write_secret_binding(self, binding: SecretBinding) -> None: ...
 
 
@@ -155,7 +164,11 @@ def build_physical_provider_target_records(
             target_id_record=target_id_record,
         )
         for target_record in provider_targets
-        if (target_id_record := target_ids_by_route.get((target_record.context, target_record.instance)))
+        if (
+            target_id_record := target_ids_by_route.get(
+                (target_record.context, target_record.instance)
+            )
+        )
         is not None
     )
 
@@ -177,22 +190,41 @@ def build_runtime_environment_records(
 
 
 def build_secret_bindings(
-    *, manifest: ProductOnboardingManifest, updated_at: str
+    *,
+    manifest: ProductOnboardingManifest,
+    updated_at: str,
+    existing_bindings: tuple[SecretBinding, ...] = (),
 ) -> tuple[SecretBinding, ...]:
-    return tuple(
-        SecretBinding(
-            binding_id=_secret_binding_id(product=manifest.product, binding=binding),
-            secret_id=_secret_id(product=manifest.product, binding=binding),
-            integration=binding.integration,
-            binding_key=binding.binding_key,
-            context=binding.context,
-            instance=binding.instance,
-            status=binding.status,
-            created_at=updated_at,
-            updated_at=updated_at,
+    existing_bindings_by_id = {binding.binding_id: binding for binding in existing_bindings}
+    configured_routes = {
+        (binding.integration, binding.binding_key, binding.context, binding.instance)
+        for binding in existing_bindings
+        if binding.status == "configured"
+    }
+    secret_bindings: list[SecretBinding] = []
+    for binding in manifest.secret_bindings:
+        if (
+            binding.status != "configured"
+            and (binding.integration, binding.binding_key, binding.context, binding.instance)
+            in configured_routes
+        ):
+            continue
+        binding_id = _secret_binding_id(product=manifest.product, binding=binding)
+        existing_binding = existing_bindings_by_id.get(binding_id)
+        secret_bindings.append(
+            SecretBinding(
+                binding_id=binding_id,
+                secret_id=_secret_id(product=manifest.product, binding=binding),
+                integration=binding.integration,
+                binding_key=binding.binding_key,
+                context=binding.context,
+                instance=binding.instance,
+                status=binding.status,
+                created_at=existing_binding.created_at if existing_binding else updated_at,
+                updated_at=updated_at,
+            )
         )
-        for binding in manifest.secret_bindings
-    )
+    return tuple(secret_bindings)
 
 
 def apply_product_onboarding_manifest(
@@ -214,7 +246,11 @@ def apply_product_onboarding_manifest(
     runtime_environments = build_runtime_environment_records(
         manifest=manifest, updated_at=recorded_at
     )
-    secret_bindings = build_secret_bindings(manifest=manifest, updated_at=recorded_at)
+    secret_bindings = build_secret_bindings(
+        manifest=manifest,
+        updated_at=recorded_at,
+        existing_bindings=record_store.list_secret_bindings(limit=None),
+    )
     target_records_by_route = {
         (record.context, record.instance): record for record in provider_targets
     }
@@ -222,7 +258,10 @@ def apply_product_onboarding_manifest(
         (record.context, record.instance): record for record in provider_target_ids
     }
     provider_target_pairs = tuple(
-        (target_records_by_route[(record.context, record.instance)], target_id_records_by_route[(record.context, record.instance)])
+        (
+            target_records_by_route[(record.context, record.instance)],
+            target_id_records_by_route[(record.context, record.instance)],
+        )
         for record in physical_provider_targets
     )
     for target_record, target_id_record in provider_target_pairs:

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -176,6 +176,12 @@ title: Secrets
   previously recorded matching dry-run. They must still send plaintext secret
   values only in the request body over the Launchplane service API. Do not copy
   those request bodies into logs, GitHub issues, PR bodies, or docs.
+- Product onboarding may create disabled managed-secret binding placeholders for
+  expected runtime secrets. Once product-config writes the configured managed
+  secret for the same integration, binding key, context, and instance, Launchplane
+  retires the disabled placeholder from active runtime-secret lookups. Later
+  onboarding imports preserve the configured binding instead of recreating the
+  disabled placeholder.
 - `uv run launchplane environments unset --scope <scope> --key KEY` removes
   stale keys from DB-backed runtime-environment records without reading or
   printing plaintext values.

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -12,6 +12,7 @@ from click.testing import CliRunner
 from control_plane.cli import main
 from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
+from control_plane.contracts.secret_record import SecretBinding
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 
@@ -1497,6 +1498,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             second_result = apply_product_onboarding_manifest(
                 record_store=store,
                 manifest=manifest,
+                updated_at="2026-05-03T02:30:00Z",
             )
 
             profile = store.read_product_profile_record("example-site")
@@ -1508,7 +1510,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             store.close()
 
         self.assertEqual(first_result.product, "example-site")
-        self.assertEqual(second_result.product_profile.updated_at, "2026-05-03T01:30:00Z")
+        self.assertEqual(second_result.product_profile.updated_at, "2026-05-03T02:30:00Z")
         self.assertEqual(profile.driver_id, "generic-web")
         self.assertEqual(profile.lanes[0].health_url, "https://testing.example.invalid/api/health")
         self.assertTrue(profile.lanes[0].odoo_stable_bootstrap.enabled)
@@ -1561,6 +1563,48 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(len(secret_bindings), 1)
         self.assertEqual(secret_bindings[0].binding_key, "SMTP_PASSWORD")
         self.assertEqual(secret_bindings[0].status, "disabled")
+        self.assertEqual(secret_bindings[0].created_at, first_result.secret_bindings[0].created_at)
+        self.assertEqual(secret_bindings[0].updated_at, second_result.secret_bindings[0].updated_at)
+
+    def test_apply_product_onboarding_manifest_preserves_configured_secret_binding(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            manifest = ProductOnboardingManifest.model_validate(_manifest_payload())
+            store.write_secret_binding(
+                SecretBinding(
+                    binding_id="secret-runtime-environment-smtp-password-example-site-prod-prod-binding-smtp-password",
+                    secret_id="secret-runtime-environment-smtp-password-example-site-prod-prod",
+                    integration="runtime_environment",
+                    binding_key="SMTP_PASSWORD",
+                    context="example-site-prod",
+                    instance="prod",
+                    status="configured",
+                    created_at="2026-05-03T00:30:00Z",
+                    updated_at="2026-05-03T00:30:00Z",
+                )
+            )
+
+            result = apply_product_onboarding_manifest(
+                record_store=store,
+                manifest=manifest,
+            )
+
+            secret_bindings = store.list_secret_bindings(
+                integration="runtime_environment",
+                context_name="example-site-prod",
+                instance_name="prod",
+            )
+            store.close()
+
+        self.assertEqual(result.secret_bindings, ())
+        self.assertEqual(len(secret_bindings), 1)
+        self.assertEqual(secret_bindings[0].binding_key, "SMTP_PASSWORD")
+        self.assertEqual(secret_bindings[0].status, "configured")
 
     def test_apply_product_onboarding_manifest_blocks_conflicting_provider_target(
         self,

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -40,6 +40,23 @@ class _ProductOnboardingStore:
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None:
         self.runtime_environments.append(record)
 
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        bindings = tuple(
+            binding
+            for binding in self.secret_bindings
+            if (not integration or binding.integration == integration)
+            and (not context_name or binding.context == context_name)
+            and (not instance_name or binding.instance == instance_name)
+        )
+        return bindings[:limit] if limit is not None else bindings
+
     def write_secret_binding(self, binding: SecretBinding) -> None:
         self.secret_bindings.append(binding)
 

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -354,6 +354,141 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertEqual(secret_binding.binding_key, "SMTP_PASSWORD")
         self.assertEqual(store.secret_audit_events[0].actor, "operator@example.com")
 
+    def test_product_config_apply_retires_disabled_runtime_secret_placeholder(self) -> None:
+        store = _FakeProductConfigStore()
+        store.runtime_key_safety_policy_records = (
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-discord-token",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T20:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="DISCORD_TOKEN",
+                        secret_class="prod_only",
+                        allowed_contexts=("discord-blue",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            ),
+        )
+        store.write_secret_binding(
+            SecretBinding(
+                binding_id="binding-discord-blue-placeholder",
+                secret_id="secret-discord-blue-placeholder",
+                integration="runtime_environment",
+                binding_key="DISCORD_TOKEN",
+                context="discord-blue",
+                instance="prod",
+                status="disabled",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+            )
+        )
+
+        with patch.dict(
+            os.environ,
+            {"LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key"},
+            clear=True,
+        ):
+            payload = control_plane_product_config.apply_product_config_bundle(
+                record_store=store,
+                payload={
+                    "schema_version": 1,
+                    "product": "discord-blue",
+                    "context": "discord-blue",
+                    "instance": "prod",
+                    "secrets": [
+                        {
+                            "name": "DISCORD_TOKEN",
+                            "binding_key": "DISCORD_TOKEN",
+                            "value": "discord-token-value",
+                        }
+                    ],
+                },
+                mode="apply",
+                actor="operator@example.com",
+                source_label="discord-blue-secret-config",
+            )
+
+        self.assertEqual(payload["status"], "ok")
+        active_bindings = store.list_secret_bindings(
+            integration="runtime_environment",
+            context_name="discord-blue",
+            instance_name="prod",
+        )
+        self.assertEqual(len(active_bindings), 1)
+        self.assertEqual(active_bindings[0].binding_key, "DISCORD_TOKEN")
+        self.assertEqual(active_bindings[0].status, "configured")
+        retired_placeholder = store.secret_bindings["binding-discord-blue-placeholder"]
+        self.assertEqual(retired_placeholder.integration, "retired:runtime_environment")
+        self.assertEqual(retired_placeholder.binding_key, "DISCORD_TOKEN")
+        self.assertEqual(retired_placeholder.status, "disabled")
+
+    def test_product_config_rejects_existing_configured_runtime_secret_duplicate(
+        self,
+    ) -> None:
+        store = _FakeProductConfigStore()
+        store.runtime_key_safety_policy_records = (
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-discord-token",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T20:00:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="DISCORD_TOKEN",
+                        secret_class="prod_only",
+                        allowed_contexts=("discord-blue",),
+                        allowed_instances=("prod",),
+                    ),
+                ),
+            ),
+        )
+        store.write_secret_binding(
+            SecretBinding(
+                binding_id="secret-legacy-discord-token-binding-discord-token",
+                secret_id="secret-legacy-discord-token",
+                integration="runtime_environment",
+                binding_key="DISCORD_TOKEN",
+                context="discord-blue",
+                instance="prod",
+                status="configured",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+            )
+        )
+
+        with patch.dict(
+            os.environ,
+            {"LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key"},
+            clear=True,
+        ):
+            with self.assertRaises(control_plane_product_config.ProductConfigError) as caught:
+                control_plane_product_config.apply_product_config_bundle(
+                    record_store=store,
+                    payload={
+                        "schema_version": 1,
+                        "product": "discord-blue",
+                        "context": "discord-blue",
+                        "instance": "prod",
+                        "secrets": [
+                            {
+                                "name": "DISCORD_TOKEN",
+                                "binding_key": "DISCORD_TOKEN",
+                                "value": "discord-token-value",
+                            }
+                        ],
+                    },
+                    mode="apply",
+                    actor="operator@example.com",
+                    source_label="discord-blue-secret-config",
+                )
+
+        self.assertEqual(caught.exception.code, "runtime_key_safety_failed")
+        self.assertEqual(len(store.secret_records), 0)
+        self.assertEqual(len(store.secret_versions), 0)
+
     def test_environments_import_command_is_not_available(self) -> None:
         result = CliRunner().invoke(main, ["environments", "import"])
 


### PR DESCRIPTION
## Summary

- retire disabled runtime managed-secret placeholders from active runtime lookups after product-config writes the configured secret
- make product-config fail closed if an existing configured duplicate would leave runtime key-safety ambiguous
- preserve configured bindings during product onboarding seed re-imports and keep existing binding creation timestamps stable
- document the placeholder-to-managed-secret lifecycle

## Validation

- `uv run --extra dev ruff check control_plane/product_config.py control_plane/workflows/product_onboarding.py tests/test_runtime_environments.py tests/test_product_onboarding.py tests/test_product_onboarding_service.py`
- `uv run --extra dev ruff format --check control_plane/product_config.py control_plane/workflows/product_onboarding.py tests/test_runtime_environments.py tests/test_product_onboarding.py tests/test_product_onboarding_service.py`
- `uv run --extra dev mypy control_plane tests`
- `npx --yes markdownlint-cli2 docs/secrets.md`
- `uv run python -m unittest tests.test_runtime_environments tests.test_product_onboarding tests.test_product_onboarding_service`
- `uv run python -m unittest` (1,971 tests)

## Review

- Agent review found a real configured-duplicate gap in the first implementation; this PR now fails closed before writing if that post-apply state would be ambiguous.
- Agent review also found created-at churn on onboarding re-import; this PR now preserves existing binding creation timestamps.

## Follow-up after deploy

- Configure the real `DISCORD_TOKEN` managed secret for `discord-blue/prod` through product-config/operator UI or a private local-operator source.
- Re-run live-target-runtime dry-run/apply for `discord-blue/prod`.
