### PR TITLE
Declare Discord Blue expected runtime config

### DIFF
--- a/import-material/launchplane/seed-imports/catalog.json
+++ b/import-material/launchplane/seed-imports/catalog.json
@@ -53,6 +53,22 @@
             "instance": "prod"
           }
         ],
+        "expected_config": {
+          "runtime_environment_keys": [
+            {
+              "key": "DISCORD_BLUE_STATE_DIR",
+              "context": "discord-blue",
+              "instance": "prod"
+            }
+          ],
+          "managed_secret_bindings": [
+            {
+              "binding_key": "DISCORD_TOKEN",
+              "context": "discord-blue",
+              "instance": "prod"
+            }
+          ]
+        },
         "source_label": "import-material:discord-blue-product-onboarding"
       }
     },


### PR DESCRIPTION
## Summary
- add Discord Blue expected runtime config to the seed onboarding manifest
- declare `DISCORD_BLUE_STATE_DIR` as the runtime env key for `discord-blue/prod`
- declare `DISCORD_TOKEN` as the runtime managed-secret binding for `discord-blue/prod`

## Why
After PR #1116 deployed product-scoped live target runtime sync, `discord-blue/prod` dry-run failed closed with `runtime_environment_empty` because the product profile did not declare expected runtime keys. The runtime record and managed secret binding exist, but the product profile contract did not yet name them as the allowed sync boundary.

Failing dry-run evidence: Live Target Runtime run `26840123776`, trace `launchplane_req_46f4a65112934f75a0b7d03598f669f7`.

## Validation
- `npx --yes prettier --check import-material/launchplane/seed-imports/catalog.json`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_seed_import_catalog_validates_contracts tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_seed_import_workflow_owns_seed_writes tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_seed_import_script_requires_target_id_env tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_seed_import_script_patches_provider_targets`
