### PR TITLE
Allow VeriReel runtime bindings in testing

### DIFF
--- a/import-material/launchplane/seed-imports/catalog.json
+++ b/import-material/launchplane/seed-imports/catalog.json
@@ -411,25 +411,25 @@
         },
         {
           "binding_key": "BETTER_AUTH_SECRET",
-          "secret_class": "prod_only",
+          "secret_class": "shared_safe",
           "allowed_contexts": ["verireel"],
           "allowed_instances": ["testing", "prod"]
         },
         {
           "binding_key": "VERIREEL_SECRETS_MASTER_KEY",
-          "secret_class": "prod_only",
+          "secret_class": "shared_safe",
           "allowed_contexts": ["verireel"],
           "allowed_instances": ["testing", "prod"]
         },
         {
           "binding_key": "VERIREEL_CRON_SECRET",
-          "secret_class": "prod_only",
+          "secret_class": "shared_safe",
           "allowed_contexts": ["verireel"],
           "allowed_instances": ["testing", "prod"]
         },
         {
           "binding_key": "POSTGRES_PASSWORD",
-          "secret_class": "prod_only",
+          "secret_class": "shared_safe",
           "allowed_contexts": ["verireel"],
           "allowed_instances": ["testing", "prod"]
         },


### PR DESCRIPTION
## Summary
- correct VeriReel runtime key-safety rules from `prod_only` to `shared_safe`
- keep the rules restricted to context `verireel` and instances `testing`/`prod`

## Why
PR #1118 added the missing VeriReel binding classifications, but the policy model disallows `prod_only` for testing targets. VeriReel uses the same binding keys for testing and prod, so the active policy needs a class allowed in both runtime classes while still tightly scoped by context and instance.

Failure evidence after #1118 seed import: product-config dry-run for VeriReel testing private values still failed with `runtime_key_safety_failed`, trace `launchplane_req_fc7e3218b0fb456c8fb37cfa9fcf4e81`.

## Validation
- `npx --yes prettier --check import-material/launchplane/seed-imports/catalog.json`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_seed_import_catalog_validates_contracts tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_seed_import_script_requires_target_id_env tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_seed_import_script_patches_provider_targets`
