### PR TITLE
Evaluate effective runtime secret binding

### DIFF
--- a/control_plane/runtime_key_safety.py
+++ b/control_plane/runtime_key_safety.py
@@ -116,7 +116,8 @@ def evaluate_runtime_key_safety(
                 )
             )
             continue
-        if len(bindings) > 1:
+        effective_bindings = _effective_bindings_for_target(bindings, target=target)
+        if len(effective_bindings) > 1:
             findings.append(
                 RuntimeKeySafetyFinding(
                     code="ambiguous_binding",
@@ -126,7 +127,7 @@ def evaluate_runtime_key_safety(
             )
             continue
 
-        binding = bindings[0]
+        binding = effective_bindings[0]
         if binding.status != "configured":
             findings.append(
                 RuntimeKeySafetyFinding(
@@ -191,6 +192,25 @@ def _bindings_by_binding_key(
     for binding in secret_bindings:
         grouped.setdefault(binding.binding_key, []).append(binding)
     return {key: tuple(bindings) for key, bindings in grouped.items()}
+
+
+def _effective_bindings_for_target(
+    bindings: tuple[SecretBinding, ...], *, target: RuntimeKeySafetyTarget
+) -> tuple[SecretBinding, ...]:
+    highest_rank = max(_binding_route_rank(binding=binding, target=target) for binding in bindings)
+    return tuple(
+        binding
+        for binding in bindings
+        if _binding_route_rank(binding=binding, target=target) == highest_rank
+    )
+
+
+def _binding_route_rank(*, binding: SecretBinding, target: RuntimeKeySafetyTarget) -> int:
+    if binding.context == target.context and binding.instance == target.instance:
+        return 2
+    if binding.context == target.context and not binding.instance:
+        return 1
+    return 0
 
 
 def _evaluate_binding_rule(

--- a/tests/test_runtime_key_safety.py
+++ b/tests/test_runtime_key_safety.py
@@ -180,6 +180,72 @@ class RuntimeKeySafetyTests(unittest.TestCase):
         self.assertEqual(disabled_evaluation.status, "fail")
         self.assertEqual(disabled_evaluation.findings[0].code, "binding_disabled")
 
+    def test_more_specific_binding_satisfies_target_when_context_binding_also_exists(
+        self,
+    ) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+            secret_bindings=(
+                _binding(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    binding_id="binding-context-token",
+                    secret_id="secret-context-token",
+                ).model_copy(update={"instance": ""}),
+                _binding(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    binding_id="binding-instance-token",
+                    secret_id="secret-instance-token",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="testing",
+                    allowed_contexts=("opw",),
+                    allowed_instances=("testing",),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "pass")
+        self.assertEqual(evaluation.findings, ())
+
+    def test_equally_specific_duplicate_bindings_remain_ambiguous(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("SHOPIFY_ACCESS_TOKEN",),
+            secret_bindings=(
+                _binding(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    binding_id="binding-first-token",
+                    secret_id="secret-first-token",
+                ),
+                _binding(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    binding_id="binding-second-token",
+                    secret_id="secret-second-token",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="SHOPIFY_ACCESS_TOKEN",
+                    secret_class="testing",
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(evaluation.findings[0].code, "ambiguous_binding")
+
     def test_context_and_instance_restrictions_fail_closed(self) -> None:
         evaluation = evaluate_runtime_key_safety(
             target=RuntimeKeySafetyTarget(


### PR DESCRIPTION
## Summary

- evaluate the effective runtime secret binding for a target when broader and narrower configured bindings both match
- keep fail-closed `ambiguous_binding` behavior for true duplicates at the same route specificity
- add unit coverage for context+instance coexistence and equally-specific duplicates

## Motivation

After PR #1121 retired disabled placeholders, Odoo CM testing still failed live-target-runtime dry-run with `ambiguous_binding`:

- run: `26847996707`
- trace: `launchplane_req_beb763e5c10c48c7a2dc10ad2057b96c`

Secret value resolution already allows context-level and instance-level records to coexist, with the more specific value winning. Runtime key-safety should evaluate the same effective binding instead of treating broader+narrower coexistence as ambiguous.

## Validation

- `uv run python -m unittest tests.test_runtime_key_safety tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_dry_run_returns_redacted_delta tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_requires_expected_managed_secret_values`
- `uv run --extra dev ruff check control_plane/runtime_key_safety.py tests/test_runtime_key_safety.py`
- `uv run --extra dev ruff format --check control_plane/runtime_key_safety.py tests/test_runtime_key_safety.py`
- `uv run --extra dev mypy control_plane tests`
