### PR TITLE
Restrict runtime placeholder retirement scope

### DIFF
--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -600,13 +600,19 @@ def _retire_disabled_runtime_secret_placeholders(
         != control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION
     ):
         return
+    context_name = configured_binding.context.strip()
+    instance_name = configured_binding.instance.strip()
+    if not context_name or not instance_name:
+        return
     for binding in record_store.list_secret_bindings(
         integration=configured_binding.integration,
-        context_name=configured_binding.context,
-        instance_name=configured_binding.instance,
+        context_name=context_name,
+        instance_name=instance_name,
         limit=None,
     ):
         if binding.binding_id == configured_binding.binding_id:
+            continue
+        if binding.context != context_name or binding.instance != instance_name:
             continue
         if binding.binding_key != configured_binding.binding_key:
             continue

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -442,6 +442,42 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertEqual(retired_placeholder.binding_key, "DISCORD_TOKEN")
         self.assertEqual(retired_placeholder.status, "disabled")
 
+    def test_runtime_secret_placeholder_retirement_requires_exact_route(self) -> None:
+        store = _FakeProductConfigStore()
+        store.write_secret_binding(
+            SecretBinding(
+                binding_id="binding-unrelated-placeholder",
+                secret_id="secret-unrelated-placeholder",
+                integration="runtime_environment",
+                binding_key="DISCORD_TOKEN",
+                context="discord-blue",
+                instance="prod",
+                status="disabled",
+                created_at="2026-05-01T00:00:00Z",
+                updated_at="2026-05-01T00:00:00Z",
+            )
+        )
+
+        control_plane_product_config._retire_disabled_runtime_secret_placeholders(
+            record_store=store,
+            configured_binding=SecretBinding(
+                binding_id="binding-global-discord-token",
+                secret_id="secret-global-discord-token",
+                integration="runtime_environment",
+                binding_key="DISCORD_TOKEN",
+                context="",
+                instance="",
+                status="configured",
+                created_at="2026-05-02T00:00:00Z",
+                updated_at="2026-05-02T00:00:00Z",
+            ),
+            updated_at="2026-05-02T00:00:00Z",
+        )
+
+        unrelated_placeholder = store.secret_bindings["binding-unrelated-placeholder"]
+        self.assertEqual(unrelated_placeholder.integration, "runtime_environment")
+        self.assertEqual(unrelated_placeholder.status, "disabled")
+
     def test_product_config_rejects_existing_configured_runtime_secret_duplicate(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- require runtime-secret placeholder retirement to have a nonblank context and instance route
- keep retirement constrained to bindings whose context and instance exactly match the configured secret
- add a regression test for broad/blank-route retirement leaving unrelated placeholders untouched

## Validation
- `uv run python -m unittest tests.test_runtime_environments`
- `uv run --extra dev ruff check --fix --diff control_plane/product_config.py tests/test_runtime_environments.py`
- `uv run --extra dev ruff check control_plane/product_config.py tests/test_runtime_environments.py`
- `uv run --extra dev ruff format --check control_plane/product_config.py tests/test_runtime_environments.py`
- `uv run --extra dev mypy control_plane/product_config.py tests/test_runtime_environments.py`
- `uv run python -m unittest`