### PR TITLE
Allow Odoo prod runtime secret bindings

### DIFF
--- a/import-material/launchplane/seed-imports/catalog.json
+++ b/import-material/launchplane/seed-imports/catalog.json
@@ -834,21 +834,21 @@
         },
         {
           "binding_key": "ODOO_ADMIN_PASSWORD",
-          "secret_class": "testing",
+          "secret_class": "shared_safe",
           "allowed_contexts": ["cm", "opw"],
-          "allowed_instances": ["testing"]
+          "allowed_instances": ["testing", "prod"]
         },
         {
           "binding_key": "ODOO_DB_PASSWORD",
-          "secret_class": "testing",
+          "secret_class": "shared_safe",
           "allowed_contexts": ["cm", "opw"],
-          "allowed_instances": ["testing"]
+          "allowed_instances": ["testing", "prod"]
         },
         {
           "binding_key": "ODOO_MASTER_PASSWORD",
-          "secret_class": "testing",
+          "secret_class": "shared_safe",
           "allowed_contexts": ["cm", "opw"],
-          "allowed_instances": ["testing"]
+          "allowed_instances": ["testing", "prod"]
         }
       ]
     }

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -323,6 +323,17 @@ class ProductOnboardingTests(unittest.TestCase):
                         "ODOO_MASTER_PASSWORD",
                     ],
                 )
+                odoo_rules = {
+                    rule["binding_key"]: rule
+                    for rule in entry["rules"]
+                    if rule["binding_key"].startswith("ODOO_")
+                }
+                for binding_key in ODOO_SECRET_KEYS:
+                    self.assertEqual(odoo_rules[binding_key]["secret_class"], "shared_safe")
+                    self.assertEqual(odoo_rules[binding_key]["allowed_contexts"], ["cm", "opw"])
+                    self.assertEqual(
+                        odoo_rules[binding_key]["allowed_instances"], ["testing", "prod"]
+                    )
             else:
                 self.fail(f"Unexpected seed import kind: {entry['kind']}")
 


### PR DESCRIPTION
## Summary
- classify the Odoo runtime secret bindings as shared-safe for the stable CM/OPW lanes
- allow those bindings for both testing and prod instances in the runtime key-safety seed
- add seed catalog assertions so the policy keeps matching the prod runtime contract

## Validation
- uv run python scripts/deploy/apply-launchplane-seed-imports.py --catalog import-material/launchplane/seed-imports/catalog.json --output-dir /tmp/launchplane-seed-policy-dryrun --kind runtime_key_safety_policy --import-id launchplane-runtime-key-safety-policy
- uv run python -m unittest tests.test_product_onboarding
- uv run --extra dev ruff check --exit-zero tests/test_product_onboarding.py
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev mypy tests/test_product_onboarding.py
- git diff --check