### PR TITLE
Include global bindings in store-backed runtime safety

### DIFF
--- a/control_plane/runtime_key_safety.py
+++ b/control_plane/runtime_key_safety.py
@@ -77,8 +77,6 @@ def evaluate_runtime_key_safety_from_store(
         required_binding_keys=required_binding_keys,
         secret_bindings=record_store.list_secret_bindings(
             integration="runtime_environment",
-            context_name=target.context,
-            instance_name=target.instance,
             limit=None,
         ),
         secret_rules=policy.rules,

--- a/tests/test_runtime_key_safety.py
+++ b/tests/test_runtime_key_safety.py
@@ -439,8 +439,49 @@ class RuntimeKeySafetyTests(unittest.TestCase):
         )
 
         self.assertEqual(evaluation.status, "pass")
-        self.assertEqual(store.requested_context, "opw")
-        self.assertEqual(store.requested_instance, "testing")
+        self.assertEqual(store.requested_context, "")
+        self.assertEqual(store.requested_instance, "")
+
+    def test_evaluate_from_store_allows_global_binding_candidates(self) -> None:
+        policy = RuntimeKeySafetyPolicyRecord(
+            record_id="runtime-key-safety-policy-20260505T200000Z-test",
+            status="active",
+            source="test",
+            updated_at="2026-05-05T20:00:00Z",
+            rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="ODOO_DB_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("cm", "opw"),
+                    allowed_instances=("testing", "prod"),
+                ),
+            ),
+        )
+        store = _FakeRuntimeKeySafetyStore(
+            policies=(policy,),
+            bindings=(
+                _binding(
+                    binding_key="ODOO_DB_PASSWORD",
+                    binding_id="binding-global-db-password",
+                    secret_id="secret-global-db-password",
+                ).model_copy(update={"context": "", "instance": ""}),
+            ),
+        )
+
+        evaluation = evaluate_runtime_key_safety_from_store(
+            record_store=store,
+            target=RuntimeKeySafetyTarget(
+                context="cm",
+                instance="prod",
+                environment_class="prod",
+            ),
+            required_binding_keys=("ODOO_DB_PASSWORD",),
+        )
+
+        self.assertEqual(evaluation.status, "pass")
+        self.assertEqual(evaluation.findings, ())
+        self.assertEqual(store.requested_context, "")
+        self.assertEqual(store.requested_instance, "")
 
     def test_missing_active_policy_fails_closed(self) -> None:
         store = _FakeRuntimeKeySafetyStore(policies=(), bindings=())


### PR DESCRIPTION
## Summary
- fetch runtime secret binding candidates broadly in the store-backed key-safety helper
- let the shared evaluator choose exact, context, or global bindings by route rank
- cover global store-backed bindings with a regression test

## Validation
- uv run --extra dev ruff check --exit-zero control_plane/runtime_key_safety.py tests/test_runtime_key_safety.py
- uv run python -m unittest tests.test_runtime_key_safety
- uv run --extra dev ruff check control_plane/runtime_key_safety.py tests/test_runtime_key_safety.py
- uv run --extra dev mypy control_plane/runtime_key_safety.py tests/test_runtime_key_safety.py
- git diff --check