### PR TITLE
Add Launchplane protected artifact inventory

### DIFF
--- a/control_plane/cli_records.py
+++ b/control_plane/cli_records.py
@@ -11,6 +11,7 @@ from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.protected_artifacts import build_protected_artifact_set
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -138,6 +139,34 @@ def artifacts_ingest(
         input_file=input_file,
         command_label="artifacts ingest",
     )
+
+
+@artifacts.command("protected")
+@click.option(
+    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
+)
+@click.option("--database-url", default="", show_default=False)
+@click.option("--local-rehearsal", is_flag=True, default=False)
+@click.option("--product", "product_name", default="", show_default=False)
+@click.option("--context", "context_name", default="", show_default=False)
+def artifacts_protected(
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    product_name: str,
+    context_name: str,
+) -> None:
+    execution_database_url = _resolve_record_mutation_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label="artifacts protected",
+    )
+    protected = build_protected_artifact_set(
+        _store(state_dir, database_url=execution_database_url),
+        product=product_name,
+        context_name=context_name,
+    )
+    click.echo(json.dumps(protected.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 def _write_artifact_manifest_command(

--- a/control_plane/contracts/protected_artifacts.py
+++ b/control_plane/contracts/protected_artifacts.py
@@ -1,0 +1,466 @@
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+
+
+ProtectedArtifactReason = Literal[
+    "stable-inventory",
+    "release-tuple",
+    "active-preview-generation",
+    "active-preview-feedback",
+]
+
+
+class ProtectedArtifactEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str = ""
+    context: str
+    instance: str = ""
+    environment_kind: Literal["stable", "preview"]
+    artifact_id: str = ""
+    image_references: tuple[str, ...] = ()
+    source_git_ref: str = ""
+    reason: ProtectedArtifactReason
+    source_record_type: str
+    source_record_id: str
+    image_repository: str = ""
+    image_digest: str = ""
+    preview_id: str = ""
+    preview_generation_id: str = ""
+    anchor_repo: str = ""
+    anchor_pr_number: int = 0
+
+    @model_validator(mode="after")
+    def _validate_entry(self) -> "ProtectedArtifactEntry":
+        if not self.context.strip():
+            raise ValueError("protected artifact entry requires context")
+        if self.environment_kind == "stable" and not self.instance.strip():
+            raise ValueError("stable protected artifact entry requires instance")
+        if self.environment_kind == "preview" and not self.preview_id.strip():
+            raise ValueError("preview protected artifact entry requires preview_id")
+        if not self.artifact_id.strip() and not self.image_references:
+            raise ValueError("protected artifact entry requires artifact_id or image_references")
+        if not self.source_record_type.strip():
+            raise ValueError("protected artifact entry requires source_record_type")
+        if not self.source_record_id.strip():
+            raise ValueError("protected artifact entry requires source_record_id")
+        return self
+
+
+class ProtectedArtifactSet(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str = ""
+    context: str = ""
+    entries: tuple[ProtectedArtifactEntry, ...] = ()
+    artifact_ids: tuple[str, ...] = ()
+    image_references: tuple[str, ...] = ()
+    image_digests: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+class ProtectedArtifactStore(Protocol):
+    def list_artifact_manifests(self) -> tuple[ArtifactIdentityManifest, ...]: ...
+
+    def list_environment_inventory(self) -> tuple[EnvironmentInventory, ...]: ...
+
+    def list_product_profile_records(self) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
+
+    def list_release_tuple_records(self) -> tuple[ReleaseTupleRecord, ...]: ...
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewRecord, ...]: ...
+
+    def list_preview_generation_records(
+        self,
+        *,
+        preview_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewGenerationRecord, ...]: ...
+
+    def list_preview_pr_feedback_records(
+        self,
+        *,
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewPrFeedbackRecord, ...]: ...
+
+
+_ACTIVE_PREVIEW_STATES = {"pending", "active", "failed", "paused", "teardown_pending"}
+_PROTECTED_PREVIEW_GENERATION_STATES = {
+    "resolving",
+    "building",
+    "deploying",
+    "verifying",
+    "ready",
+}
+_READY_PREVIEW_FEEDBACK_STATUSES = {"ready"}
+
+
+def _normalized_values(values: list[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for value in values:
+        stripped_value = value.strip()
+        if stripped_value and stripped_value not in normalized:
+            normalized.append(stripped_value)
+    return tuple(sorted(normalized))
+
+
+def _profile_by_context(
+    profiles: tuple[LaunchplaneProductProfileRecord, ...],
+) -> dict[str, LaunchplaneProductProfileRecord]:
+    by_context: dict[str, LaunchplaneProductProfileRecord] = {}
+    for profile in profiles:
+        for lane in profile.lanes:
+            by_context.setdefault(lane.context, profile)
+        if profile.preview.enabled and profile.preview.context:
+            by_context.setdefault(profile.preview.context, profile)
+    return by_context
+
+
+def _manifest_by_artifact_id(
+    manifests: tuple[ArtifactIdentityManifest, ...],
+) -> dict[str, ArtifactIdentityManifest]:
+    return {manifest.artifact_id: manifest for manifest in manifests}
+
+
+def _product_for_context(
+    profile_map: dict[str, LaunchplaneProductProfileRecord], context: str
+) -> str:
+    profile = profile_map.get(context)
+    return profile.product if profile is not None else ""
+
+
+def _manifest_image_references(manifest: ArtifactIdentityManifest | None) -> tuple[str, ...]:
+    if manifest is None:
+        return ()
+    references = [f"{manifest.image.repository}@{manifest.image.digest}"]
+    references.extend(
+        f"{manifest.image.repository}:{tag}" for tag in manifest.image.tags if tag.strip()
+    )
+    return _normalized_values(references)
+
+
+def _entry_image_references(
+    *,
+    manifest: ArtifactIdentityManifest | None,
+    runtime_image_reference: str = "",
+    extra_image_references: list[str] | None = None,
+) -> tuple[str, ...]:
+    references = list(_manifest_image_references(manifest))
+    references.append(runtime_image_reference)
+    references.extend(extra_image_references or [])
+    return _normalized_values(references)
+
+
+def _missing_manifest_warning(artifact_id: str, source_label: str) -> str:
+    return (
+        f"Protected artifact {artifact_id} from {source_label} has no stored artifact "
+        "manifest; cleanup consumers must still treat the artifact id as protected."
+    )
+
+
+def _unresolved_live_artifact_warning(source_label: str, source_record_id: str) -> str:
+    return (
+        f"Live {source_label} record {source_record_id} has no artifact id or image "
+        "reference; cleanup consumers must fail closed for this scope."
+    )
+
+
+def _active_preview_records(
+    record_store: ProtectedArtifactStore,
+    *,
+    context_name: str,
+) -> tuple[PreviewRecord, ...]:
+    records = record_store.list_preview_records(context_name=context_name)
+    return tuple(record for record in records if record.state in _ACTIVE_PREVIEW_STATES)
+
+
+def _protected_preview_generations(
+    record_store: ProtectedArtifactStore, preview: PreviewRecord
+) -> tuple[PreviewGenerationRecord, ...]:
+    candidate_ids = (
+        preview.serving_generation_id,
+        preview.active_generation_id,
+        preview.latest_generation_id,
+    )
+    generations_by_id = {
+        generation.generation_id: generation
+        for generation in record_store.list_preview_generation_records(
+            preview_id=preview.preview_id
+        )
+    }
+    generations: list[PreviewGenerationRecord] = []
+    for generation_id in candidate_ids:
+        generation = generations_by_id.get(generation_id)
+        if (
+            generation is not None
+            and generation.state in _PROTECTED_PREVIEW_GENERATION_STATES
+            and generation not in generations
+        ):
+            generations.append(generation)
+    if generations:
+        return tuple(generations)
+    return tuple(
+        generation for generation in generations_by_id.values() if generation.state == "ready"
+    )
+
+
+def _latest_ready_preview_feedback(
+    record_store: ProtectedArtifactStore, preview: PreviewRecord
+) -> PreviewPrFeedbackRecord | None:
+    records = record_store.list_preview_pr_feedback_records(context_name=preview.context)
+    for record in records:
+        if (
+            record.anchor_repo == preview.anchor_repo
+            and record.anchor_pr_number == preview.anchor_pr_number
+            and record.status in _READY_PREVIEW_FEEDBACK_STATUSES
+        ):
+            return record
+    return None
+
+
+def _stable_inventory_entries(
+    record_store: ProtectedArtifactStore,
+    *,
+    profile_map: dict[str, LaunchplaneProductProfileRecord],
+    manifests: dict[str, ArtifactIdentityManifest],
+    product: str,
+    context_name: str,
+) -> tuple[list[ProtectedArtifactEntry], list[str]]:
+    entries: list[ProtectedArtifactEntry] = []
+    warnings: list[str] = []
+    for inventory in record_store.list_environment_inventory():
+        inventory_product = _product_for_context(profile_map, inventory.context)
+        if product and inventory_product != product:
+            continue
+        if context_name and inventory.context != context_name:
+            continue
+        artifact_id = inventory.artifact_identity.artifact_id if inventory.artifact_identity else ""
+        manifest = manifests.get(artifact_id)
+        if artifact_id and manifest is None:
+            warnings.append(_missing_manifest_warning(artifact_id, "environment_inventory"))
+        runtime_image_reference = ""
+        if inventory.runtime_identity and inventory.runtime_identity.image_reference:
+            runtime_image_reference = inventory.runtime_identity.image_reference
+        image_references = _entry_image_references(
+            manifest=manifest,
+            runtime_image_reference=runtime_image_reference,
+        )
+        source_record_id = f"{inventory.context}-{inventory.instance}"
+        if not artifact_id and not image_references:
+            warnings.append(
+                _unresolved_live_artifact_warning("environment_inventory", source_record_id)
+            )
+            continue
+        entries.append(
+            ProtectedArtifactEntry(
+                product=inventory_product,
+                context=inventory.context,
+                instance=inventory.instance,
+                environment_kind="stable",
+                artifact_id=artifact_id,
+                image_references=image_references,
+                source_git_ref=inventory.source_git_ref,
+                reason="stable-inventory",
+                source_record_type="environment_inventory",
+                source_record_id=source_record_id,
+                image_repository=manifest.image.repository if manifest is not None else "",
+                image_digest=manifest.image.digest if manifest is not None else "",
+            )
+        )
+    return entries, warnings
+
+
+def _release_tuple_entries(
+    record_store: ProtectedArtifactStore,
+    *,
+    profile_map: dict[str, LaunchplaneProductProfileRecord],
+    manifests: dict[str, ArtifactIdentityManifest],
+    product: str,
+    context_name: str,
+) -> tuple[list[ProtectedArtifactEntry], list[str]]:
+    entries: list[ProtectedArtifactEntry] = []
+    warnings: list[str] = []
+    for record in record_store.list_release_tuple_records():
+        release_product = _product_for_context(profile_map, record.context)
+        if product and release_product != product:
+            continue
+        if context_name and record.context != context_name:
+            continue
+        manifest = manifests.get(record.artifact_id)
+        if manifest is None:
+            warnings.append(_missing_manifest_warning(record.artifact_id, "release_tuple"))
+        repository = record.image_repository or (manifest.image.repository if manifest else "")
+        digest = record.image_digest or (manifest.image.digest if manifest else "")
+        image_references = []
+        if repository and digest:
+            image_references.append(f"{repository}@{digest}")
+        image_references.extend(_manifest_image_references(manifest))
+        entries.append(
+            ProtectedArtifactEntry(
+                product=release_product,
+                context=record.context,
+                instance=record.channel,
+                environment_kind="stable",
+                artifact_id=record.artifact_id,
+                image_references=_normalized_values(image_references),
+                source_git_ref=next(iter(record.repo_shas.values()), ""),
+                reason="release-tuple",
+                source_record_type="release_tuple",
+                source_record_id=record.tuple_id,
+                image_repository=repository,
+                image_digest=digest,
+            )
+        )
+    return entries, warnings
+
+
+def _preview_entries(
+    record_store: ProtectedArtifactStore,
+    *,
+    profile_map: dict[str, LaunchplaneProductProfileRecord],
+    manifests: dict[str, ArtifactIdentityManifest],
+    product: str,
+    context_name: str,
+) -> tuple[list[ProtectedArtifactEntry], list[str]]:
+    entries: list[ProtectedArtifactEntry] = []
+    warnings: list[str] = []
+    contexts = sorted(
+        context_name
+        for context_name, profile in profile_map.items()
+        if profile.preview.enabled and profile.preview.context == context_name
+    )
+    if context_name:
+        contexts = [context_name]
+    for preview_context in contexts:
+        preview_product = _product_for_context(profile_map, preview_context)
+        if product and preview_product != product:
+            continue
+        for preview in _active_preview_records(record_store, context_name=preview_context):
+            for generation in _protected_preview_generations(record_store, preview):
+                artifact_id = generation.artifact_id.strip()
+                manifest = manifests.get(artifact_id)
+                runtime_image_reference = ""
+                if generation.runtime_identity and generation.runtime_identity.image_reference:
+                    runtime_image_reference = generation.runtime_identity.image_reference
+                image_references = _entry_image_references(
+                    manifest=manifest,
+                    runtime_image_reference=runtime_image_reference,
+                )
+                if artifact_id and manifest is None:
+                    warnings.append(_missing_manifest_warning(artifact_id, "preview_generation"))
+                if not artifact_id and not image_references:
+                    warnings.append(
+                        _unresolved_live_artifact_warning(
+                            "preview_generation", generation.generation_id
+                        )
+                    )
+                    continue
+                entries.append(
+                    ProtectedArtifactEntry(
+                        product=preview_product,
+                        context=preview.context,
+                        environment_kind="preview",
+                        artifact_id=artifact_id,
+                        image_references=image_references,
+                        source_git_ref=generation.anchor_summary.head_sha,
+                        reason="active-preview-generation",
+                        source_record_type="preview_generation",
+                        source_record_id=generation.generation_id,
+                        preview_id=preview.preview_id,
+                        preview_generation_id=generation.generation_id,
+                        anchor_repo=preview.anchor_repo,
+                        anchor_pr_number=preview.anchor_pr_number,
+                        image_repository=manifest.image.repository if manifest is not None else "",
+                        image_digest=manifest.image.digest if manifest is not None else "",
+                    )
+                )
+            feedback = _latest_ready_preview_feedback(record_store, preview)
+            if feedback is not None:
+                feedback_image_references = _normalized_values(
+                    [feedback.immutable_image_reference, feedback.refresh_image_reference]
+                )
+                if feedback_image_references:
+                    entries.append(
+                        ProtectedArtifactEntry(
+                            product=preview_product or feedback.product,
+                            context=preview.context,
+                            environment_kind="preview",
+                            image_references=feedback_image_references,
+                            source_git_ref=feedback.revision,
+                            reason="active-preview-feedback",
+                            source_record_type="preview_pr_feedback",
+                            source_record_id=feedback.feedback_id,
+                            preview_id=preview.preview_id,
+                            anchor_repo=preview.anchor_repo,
+                            anchor_pr_number=preview.anchor_pr_number,
+                        )
+                    )
+    return entries, warnings
+
+
+def build_protected_artifact_set(
+    record_store: ProtectedArtifactStore,
+    *,
+    product: str = "",
+    context_name: str = "",
+) -> ProtectedArtifactSet:
+    normalized_product = product.strip()
+    normalized_context = context_name.strip()
+    profiles = record_store.list_product_profile_records()
+    profile_map = _profile_by_context(profiles)
+    manifests = _manifest_by_artifact_id(record_store.list_artifact_manifests())
+    stable_entries, stable_warnings = _stable_inventory_entries(
+        record_store,
+        profile_map=profile_map,
+        manifests=manifests,
+        product=normalized_product,
+        context_name=normalized_context,
+    )
+    release_tuple_entries, release_tuple_warnings = _release_tuple_entries(
+        record_store,
+        profile_map=profile_map,
+        manifests=manifests,
+        product=normalized_product,
+        context_name=normalized_context,
+    )
+    preview_entries, preview_warnings = _preview_entries(
+        record_store,
+        profile_map=profile_map,
+        manifests=manifests,
+        product=normalized_product,
+        context_name=normalized_context,
+    )
+    entries = [*stable_entries, *release_tuple_entries, *preview_entries]
+    artifact_ids = _normalized_values([entry.artifact_id for entry in entries])
+    image_references = _normalized_values(
+        [image_reference for entry in entries for image_reference in entry.image_references]
+    )
+    image_digests = _normalized_values([entry.image_digest for entry in entries])
+    warnings = _normalized_values([*stable_warnings, *release_tuple_warnings, *preview_warnings])
+    return ProtectedArtifactSet(
+        product=normalized_product,
+        context=normalized_context,
+        entries=tuple(entries),
+        artifact_ids=artifact_ids,
+        image_references=image_references,
+        image_digests=image_digests,
+        warnings=warnings,
+    )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -167,6 +167,7 @@ from control_plane.contracts.preview_record import PreviewState
 from control_plane.contracts.preview_readiness_read_model import (
     build_preview_readiness_read_model,
 )
+from control_plane.contracts.protected_artifacts import build_protected_artifact_set
 from control_plane.contracts.product_environment_read_model import ProductReadModelStore
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
@@ -2898,6 +2899,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "every_code_work_request.read", {"request_id": segments[3]}
     if len(segments) == 2 and segments == ["v1", "drivers"]:
         return "driver.read", {}
+    if len(segments) == 3 and segments == ["v1", "artifacts", "protected"]:
+        return "artifact_protection.read", {}
     if len(segments) == 3 and segments[:2] == ["v1", "drivers"]:
         return "driver.read", {"driver_id": segments[2]}
     if (
@@ -8640,6 +8643,64 @@ def create_launchplane_service_app(
                             "drivers": [
                                 descriptor.model_dump(mode="json") for descriptor in descriptors
                             ],
+                        },
+                    )
+                if action == "artifact_protection.read":
+                    requested_product = _query_string_value(query, "product")
+                    requested_context = _query_string_value(query, "context")
+                    if not requested_product:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=400,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "invalid_query",
+                                    "message": "Protected artifact inventory requires a product query parameter.",
+                                },
+                            },
+                        )
+                    authz_product = requested_product
+                    authz_context = requested_context or _LAUNCHPLANE_SERVICE_CONTEXT
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product=authz_product,
+                        context=authz_context,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read protected artifact inventory.",
+                                },
+                                "authz": _authz_diagnostic_payload(
+                                    identity=identity,
+                                    authz_policy_sha256_value=resolved_authz_policy_sha256,
+                                    authz_policy_source=resolved_authz_policy_source,
+                                    action=action,
+                                    product=authz_product,
+                                    context=authz_context,
+                                ),
+                            },
+                        )
+                    protected = build_protected_artifact_set(
+                        record_store,
+                        product=requested_product,
+                        context_name=requested_context,
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "protected_artifacts": protected.model_dump(mode="json"),
                         },
                     )
                 if action == "ingress_route.plan":

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -15,7 +15,8 @@ deployed service API with GitHub OIDC or the operator UI that calls it. If a liv
 mutation still exists only as a local CLI command, stop and add or use a service
 API path instead of running the local command from an arbitrary checkout.
 
-- `artifacts`: write, ingest, and inspect artifact manifests.
+- `artifacts`: write, ingest, inspect artifact manifests, and emit protected
+  artifact inventories for registry cleanup deny sets.
 - `backup-gates`: write and inspect backup-gate records.
 - `deployments`: write and inspect deployment records.
 - `environments`: write, list, and resolve DB-backed runtime environment
@@ -151,6 +152,7 @@ as authority.
 Current implementation scope:
 
 - `GET /v1/health`
+- `GET /v1/artifacts/protected`
 - `POST /v1/evidence/backup-gates`
 - `POST /v1/evidence/deployments`
 - `POST /v1/evidence/promotions`
@@ -569,6 +571,17 @@ Current derived-state behavior:
   linkage to the deployment record that established the promoted state.
 - The same promotion evidence can also mint the destination stable-lane tuple
   when Launchplane already has the source tuple state for the promoted-from lane.
+- `artifacts protected` and `GET /v1/artifacts/protected` compose Launchplane's
+  current protected artifact inventory from stable environment inventory,
+  release tuples, active preview generations, and ready preview feedback.
+  Registry cleanup jobs for every product must consume this inventory before
+  deleting package versions and fail closed when the read fails or warns about a
+  live artifact without a stored manifest. Service callers must include
+  `product=`; callers that request a whole product without `context=` need an
+  `artifact_protection.read` grant with wildcard context. The CLI requires
+  `--database-url` or
+  `LAUNCHPLANE_DATABASE_URL` unless `--local-rehearsal` is explicitly passed for
+  non-authoritative local rehearsal.
 - The tracked Dokploy route catalog is only for stable remote lanes. If a pull
   request needs runtime state, Launchplane models that through preview records and
   preview generations instead of adding another long-lived route.

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -30,8 +30,9 @@ Launchplane
   - driver descriptors and driver routes
   - provider credentials and managed secrets
   - preview/deploy/promotion/rollback orchestration
-- health, readiness, inventory, cleanup, and feedback records or driver
-  responses
+  - health, readiness, inventory, cleanup, and feedback records or driver
+    responses
+  - protected artifact inventory for registry cleanup
   - PR feedback rendering and delivery
 ```
 
@@ -82,6 +83,8 @@ profile data.
 - PR feedback records, markdown rendering, comment delivery, and stale feedback
   cleanup.
 - Promotion, rollback, deployment, preview, inventory, and cleanup records.
+- Protected artifact inventory used by registry cleanup to identify live
+  testing, production, release-tuple, and active-preview image references.
 
 ## Minimal Trigger Inputs
 
@@ -205,6 +208,24 @@ Start with low-risk deletions and documentation, then replace active workflow
 behavior in small slices. Do not remove active backup, promotion, rollback,
 runtime health, or cleanup safety gates until Launchplane owns the equivalent
 behavior and tests.
+
+Registry artifact cleanup is a Launchplane-owned liveness question. Product
+repos may still perform provider-specific registry deletion, but they must first
+load Launchplane's protected artifact inventory, validate the response, and
+abort without deleting anything when the inventory is unavailable, unauthorized,
+or has unresolved live-artifact warnings for the registry being cleaned. Product
+cleanup jobs should treat Launchplane-protected image references and artifact
+ids as a deny set; they must not infer that testing, production, or active
+preview artifacts are deletable from local tag shape alone.
+
+Cleanup consumers must check both `artifact_ids` and `image_references` from the
+protected inventory. Some active-preview protections come from ready PR feedback
+records that carry immutable and refresh image references but no artifact id, so
+an artifact-id-only cleanup filter can still delete a live preview tag. Whole-
+product cleanup callers should request `GET /v1/artifacts/protected?product=...`
+with an `artifact_protection.read` grant that allows wildcard context for that
+product; context-specific cleanup may pass `context=` and use a matching scoped
+grant.
 
 ## Reusable Launchplane Request Action
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -64,6 +64,15 @@ These summaries are read models, not new durable record families. They compose
 existing ORM rows and contract payloads behind the storage boundary so the next
 driver descriptor and GUI slices can consume a stable API shape.
 
+- `ProtectedArtifactSet`: registry-cleanup read model built from current
+  environment inventory, release tuples, active preview generations, ready
+  preview feedback, product profiles, and artifact manifests. It is not a new
+  durable record family; it is the Launchplane-owned liveness projection that
+  cleanup consumers must load before deleting registry artifacts. Missing
+  manifests for live inventory, release, or preview artifacts are returned as
+  warnings while the artifact id remains protected, so cleanup stays fail-closed
+  instead of treating unresolved live images as deletable.
+
 ## Field Promotion Audit
 
 The current ORM tables already model the first layer of queryable operational

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -37,6 +37,8 @@ VeriReel product paths:
 
 - CLI: `uv run launchplane service serve`
 - health route: `GET /v1/health`
+- protected artifact inventory route:
+  - `GET /v1/artifacts/protected`
 - authenticated evidence routes:
   - `POST /v1/evidence/backup-gates`
   - `POST /v1/evidence/deployments`
@@ -943,6 +945,7 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/inventory/{context}/{instance}`
 - `GET /v1/promotions/{record_id}`
 - `GET /v1/deployments/{record_id}`
+- `GET /v1/artifacts/protected`
 - `GET /v1/contexts/{context}/secrets`
 - `GET /v1/contexts/{context}/instances/{instance}/secrets`
 - `GET /v1/secrets/{secret_id}`

--- a/tests/test_protected_artifacts.py
+++ b/tests/test_protected_artifacts.py
@@ -1,0 +1,412 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.artifact_identity import (
+    ArtifactIdentityManifest,
+    ArtifactImageReference,
+)
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.preview_generation_record import (
+    PreviewGenerationRecord,
+    PreviewGenerationState,
+    PreviewPullRequestSummary,
+)
+from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    DeploymentEvidence,
+)
+from control_plane.contracts.protected_artifacts import build_protected_artifact_set
+from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.storage.filesystem import FilesystemRecordStore
+
+
+def _deploy(target_name: str) -> DeploymentEvidence:
+    return DeploymentEvidence(
+        target_name=target_name,
+        target_type="application",
+        deploy_mode="dokploy",
+        status="pass",
+        started_at="2026-06-03T20:00:00Z",
+        finished_at="2026-06-03T20:01:00Z",
+    )
+
+
+def _runtime_identity(
+    *,
+    product: str,
+    context: str,
+    instance: str,
+    artifact_id: str,
+    source_git_ref: str,
+    image_reference: str,
+    environment_kind: str = "stable",
+    preview_id: str = "",
+    preview_generation_id: str = "",
+) -> RuntimeIdentity:
+    return RuntimeIdentity(
+        product=product,
+        context=context,
+        instance=instance,
+        environment_kind=environment_kind,
+        deployment_record_id=f"deployment-{context}-{instance}",
+        artifact_id=artifact_id,
+        source_git_ref=source_git_ref,
+        image_reference=image_reference,
+        preview_id=preview_id,
+        preview_generation_id=preview_generation_id,
+        deployed_at="2026-06-03T20:01:00Z",
+    )
+
+
+def _profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="verireel",
+        display_name="VeriReel",
+        repository="cbusillo/verireel",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/verireel-app"),
+        runtime_port=3000,
+        health_path="/api/health",
+        lanes=(
+            ProductLaneProfile(instance="testing", context="verireel"),
+            ProductLaneProfile(instance="prod", context="verireel"),
+        ),
+        preview=ProductPreviewProfile(enabled=True, context="verireel-testing"),
+        updated_at="2026-06-03T20:00:00Z",
+        source="test",
+    )
+
+
+def _manifest(artifact_id: str, source_git_ref: str, tag: str) -> ArtifactIdentityManifest:
+    return ArtifactIdentityManifest(
+        artifact_id=artifact_id,
+        source_commit=source_git_ref,
+        enterprise_base_digest="sha256:base123",
+        image=ArtifactImageReference(
+            repository="ghcr.io/cbusillo/verireel-app",
+            digest=f"sha256:{artifact_id.replace('-', '')[:16]}",
+            tags=(tag,),
+        ),
+    )
+
+
+def _inventory(*, instance: str, artifact_id: str, source_git_ref: str) -> EnvironmentInventory:
+    image_reference = f"ghcr.io/cbusillo/verireel-app:sha-{source_git_ref}"
+    return EnvironmentInventory(
+        context="verireel",
+        instance=instance,
+        artifact_identity=ArtifactIdentityReference(artifact_id=artifact_id),
+        source_git_ref=source_git_ref,
+        deploy=_deploy(f"verireel-{instance}"),
+        runtime_identity=_runtime_identity(
+            product="verireel",
+            context="verireel",
+            instance=instance,
+            artifact_id=artifact_id,
+            source_git_ref=source_git_ref,
+            image_reference=image_reference,
+        ),
+        updated_at="2026-06-03T20:02:00Z",
+        deployment_record_id=f"deployment-verireel-{instance}",
+    )
+
+
+def _active_preview() -> PreviewRecord:
+    return PreviewRecord(
+        preview_id="preview-verireel-pr-196",
+        context="verireel-testing",
+        anchor_repo="verireel",
+        anchor_pr_number=196,
+        anchor_pr_url="https://github.com/cbusillo/verireel/pull/196",
+        preview_label="pr-196",
+        canonical_url="https://pr-196.preview.example",
+        state="active",
+        created_at="2026-06-03T19:00:00Z",
+        updated_at="2026-06-03T20:00:00Z",
+        eligible_at="2026-06-03T19:00:00Z",
+        active_generation_id="preview-verireel-pr-196-generation-0001",
+        serving_generation_id="preview-verireel-pr-196-generation-0001",
+        latest_generation_id="preview-verireel-pr-196-generation-0001",
+    )
+
+
+def _destroyed_preview() -> PreviewRecord:
+    return _active_preview().model_copy(
+        update={
+            "preview_id": "preview-verireel-pr-195",
+            "anchor_pr_number": 195,
+            "state": "destroyed",
+            "destroyed_at": "2026-06-03T20:00:00Z",
+            "active_generation_id": "preview-verireel-pr-195-generation-0001",
+            "serving_generation_id": "preview-verireel-pr-195-generation-0001",
+            "latest_generation_id": "preview-verireel-pr-195-generation-0001",
+        }
+    )
+
+
+def _preview_generation(
+    preview: PreviewRecord,
+    *,
+    generation_id: str = "",
+    artifact_id: str = "",
+    state: PreviewGenerationState = "ready",
+) -> PreviewGenerationRecord:
+    resolved_generation_id = generation_id or preview.serving_generation_id
+    resolved_artifact_id = artifact_id or f"artifact-{preview.preview_id}"
+    source_git_ref = "abcdef1234567890abcdef1234567890abcdef12"
+    return PreviewGenerationRecord(
+        generation_id=resolved_generation_id,
+        preview_id=preview.preview_id,
+        sequence=1,
+        state=state,
+        requested_reason="pull_request",
+        requested_at="2026-06-03T19:00:00Z",
+        ready_at="2026-06-03T19:15:00Z",
+        finished_at="2026-06-03T19:15:00Z",
+        resolved_manifest_fingerprint="fingerprint-1",
+        artifact_id=resolved_artifact_id,
+        anchor_summary=PreviewPullRequestSummary(
+            repo="cbusillo/verireel",
+            pr_number=preview.anchor_pr_number,
+            head_sha=source_git_ref,
+            pr_url=preview.anchor_pr_url,
+        ),
+        deploy_status="pass",
+        verify_status="pass",
+        overall_health_status="pass",
+        runtime_identity=_runtime_identity(
+            product="verireel",
+            context=preview.context,
+            instance=preview.preview_label,
+            artifact_id=resolved_artifact_id,
+            source_git_ref=source_git_ref,
+            image_reference=(
+                f"ghcr.io/cbusillo/verireel-app:{preview.preview_label}-sha-{source_git_ref[:8]}"
+            ),
+            environment_kind="preview",
+            preview_id=preview.preview_id,
+            preview_generation_id=resolved_generation_id,
+        ),
+    )
+
+
+def _preview_feedback(preview: PreviewRecord) -> PreviewPrFeedbackRecord:
+    return PreviewPrFeedbackRecord(
+        feedback_id="preview-feedback-verireel-pr-196",
+        product="verireel",
+        context=preview.context,
+        source="workflow",
+        requested_at="2026-06-03T19:20:00Z",
+        repository="cbusillo/verireel",
+        anchor_repo=preview.anchor_repo,
+        anchor_pr_number=preview.anchor_pr_number,
+        anchor_pr_url=preview.anchor_pr_url,
+        status="ready",
+        marker="<!-- verireel-preview-control -->",
+        comment_markdown="<!-- verireel-preview-control -->\nReady.",
+        preview_url=preview.canonical_url,
+        immutable_image_reference="ghcr.io/cbusillo/verireel-app:pr-196-sha-abcdef12",
+        refresh_image_reference="ghcr.io/cbusillo/verireel-app:pr-196",
+        revision="abcdef12",
+        run_url="https://github.com/cbusillo/verireel/actions/runs/1",
+        delivery_status="delivered",
+    )
+
+
+def _seed_store(store: FilesystemRecordStore) -> None:
+    store.write_product_profile_record(_profile())
+    store.write_artifact_manifest(
+        _manifest(
+            "artifact-verireel-testing",
+            "87d6d02e1c8679992667d17f2558f7be5c537821",
+            "sha-87d6d02e1c8679992667d17f2558f7be5c537821",
+        )
+    )
+    store.write_artifact_manifest(
+        _manifest(
+            "artifact-verireel-prod",
+            "b6c883432baeaa4bf3dfe7c1c833265868da9346",
+            "sha-b6c883432baeaa4bf3dfe7c1c833265868da9346",
+        )
+    )
+    store.write_environment_inventory(
+        _inventory(
+            instance="testing",
+            artifact_id="artifact-verireel-testing",
+            source_git_ref="87d6d02e1c8679992667d17f2558f7be5c537821",
+        )
+    )
+    store.write_environment_inventory(
+        _inventory(
+            instance="prod",
+            artifact_id="artifact-verireel-prod",
+            source_git_ref="b6c883432baeaa4bf3dfe7c1c833265868da9346",
+        )
+    )
+    active_preview = _active_preview()
+    destroyed_preview = _destroyed_preview()
+    store.write_preview_record(active_preview)
+    store.write_preview_record(destroyed_preview)
+    store.write_preview_generation_record(_preview_generation(active_preview))
+    store.write_preview_generation_record(_preview_generation(destroyed_preview))
+    store.write_preview_pr_feedback_record(_preview_feedback(active_preview))
+    store.write_release_tuple_record(
+        ReleaseTupleRecord(
+            tuple_id="verireel-prod-artifact-verireel-prod",
+            context="verireel",
+            channel="prod",
+            artifact_id="artifact-verireel-prod",
+            repo_shas={"verireel": "b6c883432baeaa4bf3dfe7c1c833265868da9346"},
+            image_repository="ghcr.io/cbusillo/verireel-app",
+            image_digest="sha256:artifactverireel",
+            deployment_record_id="deployment-verireel-prod",
+            provenance="promotion",
+            promoted_from_channel="testing",
+            minted_at="2026-06-03T20:02:00Z",
+        )
+    )
+
+
+class ProtectedArtifactTests(TestCase):
+    def test_build_protected_artifact_set_includes_stable_and_active_preview_refs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            _seed_store(store)
+
+            protected = build_protected_artifact_set(store, product="verireel")
+
+        self.assertEqual(
+            protected.artifact_ids,
+            (
+                "artifact-preview-verireel-pr-196",
+                "artifact-verireel-prod",
+                "artifact-verireel-testing",
+            ),
+        )
+        self.assertIn(
+            "ghcr.io/cbusillo/verireel-app:sha-b6c883432baeaa4bf3dfe7c1c833265868da9346",
+            protected.image_references,
+        )
+        self.assertIn("sha256:artifactverireel", protected.image_digests)
+        self.assertIn(
+            "ghcr.io/cbusillo/verireel-app:pr-196",
+            protected.image_references,
+        )
+        self.assertNotIn("artifact-preview-verireel-pr-195", protected.artifact_ids)
+        self.assertEqual(
+            [entry.reason for entry in protected.entries],
+            [
+                "stable-inventory",
+                "stable-inventory",
+                "release-tuple",
+                "active-preview-generation",
+                "active-preview-feedback",
+            ],
+        )
+        self.assertTrue(
+            any("artifact-preview-verireel-pr-196" in warning for warning in protected.warnings)
+        )
+
+    def test_build_protected_artifact_set_keeps_linked_preview_rollout_images(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            _seed_store(store)
+            preview = _active_preview().model_copy(
+                update={
+                    "active_generation_id": "preview-verireel-pr-196-generation-0002",
+                    "latest_generation_id": "preview-verireel-pr-196-generation-0002",
+                }
+            )
+            store.write_preview_record(preview)
+            store.write_preview_generation_record(
+                _preview_generation(
+                    preview,
+                    generation_id="preview-verireel-pr-196-generation-0002",
+                    artifact_id="artifact-preview-verireel-pr-196-generation-0002",
+                    state="deploying",
+                )
+            )
+
+            protected = build_protected_artifact_set(store, product="verireel")
+
+        self.assertIn("artifact-preview-verireel-pr-196", protected.artifact_ids)
+        self.assertIn("artifact-preview-verireel-pr-196-generation-0002", protected.artifact_ids)
+        preview_generation_entries = [
+            entry for entry in protected.entries if entry.reason == "active-preview-generation"
+        ]
+        self.assertEqual(len(preview_generation_entries), 2)
+
+    def test_build_protected_artifact_set_warns_for_unresolved_live_inventory(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            store.write_product_profile_record(_profile())
+            store.write_environment_inventory(
+                EnvironmentInventory(
+                    context="verireel",
+                    instance="prod",
+                    source_git_ref="b6c883432baeaa4bf3dfe7c1c833265868da9346",
+                    deploy=_deploy("verireel-prod"),
+                    updated_at="2026-06-03T20:02:00Z",
+                    deployment_record_id="deployment-verireel-prod",
+                )
+            )
+
+            protected = build_protected_artifact_set(store, product="verireel")
+
+        self.assertEqual(protected.artifact_ids, ())
+        self.assertEqual(protected.image_references, ())
+        self.assertTrue(any("environment_inventory" in warning for warning in protected.warnings))
+
+    def test_protected_artifacts_cli_outputs_json_for_cleanup_consumers(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            _seed_store(FilesystemRecordStore(state_dir=state_dir))
+
+            result = runner.invoke(
+                main,
+                [
+                    "artifacts",
+                    "protected",
+                    "--state-dir",
+                    str(state_dir),
+                    "--local-rehearsal",
+                    "--product",
+                    "verireel",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["product"], "verireel")
+        self.assertIn("artifact-verireel-prod", payload["artifact_ids"])
+        self.assertIn(
+            "ghcr.io/cbusillo/verireel-app:pr-196-sha-abcdef12",
+            payload["image_references"],
+        )
+
+    def test_protected_artifacts_cli_requires_authoritative_state_by_default(
+        self,
+    ) -> None:
+        result = CliRunner().invoke(main, ["artifacts", "protected", "--product", "verireel"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("requires --database-url or LAUNCHPLANE_DATABASE_URL", result.output)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -171,6 +171,7 @@ from control_plane.workflows.odoo_stable_target_replacement import (
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_record
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
+from tests.test_protected_artifacts import _seed_store as seed_protected_artifact_store
 from control_plane.workflows.generic_web_promotion import GenericWebProdPromotionResult
 from control_plane.workflows.generic_web_deploy import GenericWebDeployResult
 from control_plane.workflows.generic_web_rollback import GenericWebRollbackApplyResult
@@ -2063,6 +2064,157 @@ class GitHubHumanAuthTests(unittest.TestCase):
 
 
 class LaunchplaneServiceTests(unittest.TestCase):
+    def test_protected_artifacts_endpoint_returns_launchplane_inventory(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = _local_operator_policy(
+                actions=("artifact_protection.read",),
+                products=("verireel",),
+                contexts=("*",),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/artifacts/protected",
+                    query_string="product=verireel",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(status_code, 200)
+        protected_artifacts = payload["protected_artifacts"]
+        self.assertEqual(protected_artifacts["product"], "verireel")
+        self.assertIn("artifact-verireel-prod", protected_artifacts["artifact_ids"])
+        self.assertIn("artifact-preview-verireel-pr-196", protected_artifacts["artifact_ids"])
+        self.assertNotIn("artifact-preview-verireel-pr-195", protected_artifacts["artifact_ids"])
+        self.assertIn(
+            "ghcr.io/cbusillo/verireel-app:sha-b6c883432baeaa4bf3dfe7c1c833265868da9346",
+            protected_artifacts["image_references"],
+        )
+
+    def test_protected_artifacts_endpoint_rejects_wrong_product_scope(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = _local_operator_policy(
+                actions=("artifact_protection.read",),
+                products=("other-product",),
+                contexts=("*",),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/artifacts/protected",
+                    query_string="product=verireel",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_protected_artifacts_endpoint_rejects_every_code_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = _local_operator_policy(
+                actions=("artifact_protection.read",),
+                products=("verireel",),
+                contexts=("*",),
+            )
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/artifacts/protected",
+                    query_string="product=verireel",
+                    authorization="Bearer worker-token",
+                )
+
+        self.assertEqual(status_code, 401)
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    def test_protected_artifacts_endpoint_requires_product_scope(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = _local_operator_policy(
+                actions=("artifact_protection.read",),
+                products=("launchplane",),
+                contexts=("launchplane",),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/artifacts/protected",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_query")
+
     def test_npmplus_ingress_route_apply_dry_run_returns_plan_without_mutation(self) -> None:
         client = _FakeNpmplusIngressClient()
         policy = LaunchplaneAuthzPolicy.model_validate(


### PR DESCRIPTION
## Summary

- add a typed `ProtectedArtifactSet` read model that composes protected artifact refs from current environment inventory, release tuples, active preview generations, ready preview feedback, product profiles, and artifact manifests
- expose the product-scoped inventory through `GET /v1/artifacts/protected?product=...` and `launchplane artifacts protected`, with the CLI failing closed unless authoritative DB state or explicit `--local-rehearsal` is used
- document the Launchplane-owned cleanup contract so product registry cleanup jobs consume both `artifact_ids` and `image_references` and fail closed on warnings/unavailable inventory

## Agent Review

- Planning agents recommended a Launchplane-owned protected-artifact inventory contract instead of product-local liveness rules or Launchplane-owned deletion execution.
- Operations review found rollout gaps around CLI local-state fallback, authz grant shape, route discoverability, and image-reference-only preview protections. Addressed with CLI fail-closed behavior, route/docs updates, and consumer guidance.
- Quick code review found an unfiltered service request could be authorized as `launchplane` but return all products. Addressed by requiring `product=` on the service endpoint and adding a regression test.

## Validation

- `uv run python -m unittest` (1994 tests)
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff format --check control_plane/contracts/protected_artifacts.py control_plane/cli_records.py control_plane/service.py tests/test_protected_artifacts.py tests/test_service.py`

Note: repo-wide `uv run --extra dev ruff format --check .` still reports a pre-existing unrelated formatting backlog outside the touched files.
