### PR TITLE
Authorize product artifact cleanup workflows

### DIFF
--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -181,9 +181,9 @@ class GitHubActionsPolicyRule(BaseModel):
             return False
         if self.environments and identity.environment not in self.environments:
             return False
-        if self.products and product not in self.products:
+        if self.products and not self._matches_claim(product, self.products):
             return False
-        if self.contexts and context not in self.contexts:
+        if self.contexts and not self._matches_claim(context, self.contexts):
             return False
         if self.actions and action not in self.actions:
             return False

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -561,6 +561,23 @@ post_odoo_stable_grant() {
     "$job_workflow_ref"
 }
 
+post_product_artifact_protection_grant() {
+  local repository="$1"
+  local workflow_file="$2"
+  local product_name="$3"
+  local idempotency_suffix="$4"
+  local event_name="${5:-workflow_dispatch}"
+  post_grant \
+    "$repository" \
+    "$workflow_file" \
+    "$product_name" \
+    '*' \
+    artifact_protection.read \
+    "deploy:${idempotency_suffix}-artifact-protection-grant" \
+    "${idempotency_suffix}-artifact-protection" \
+    "$event_name"
+}
+
 post_launchplane_service_grant \
   public-ingress-monitor.yml \
   public_ingress_monitor.run_once \
@@ -845,6 +862,50 @@ post_launchplane_live_target_runtime_grants \
   odoo-tenant-opw \
   opw \
   odoo-opw
+post_product_artifact_protection_grant \
+  cbusillo/verireel \
+  cleanup-ghcr.yml \
+  verireel \
+  verireel-ghcr-cleanup-manual
+post_product_artifact_protection_grant \
+  cbusillo/verireel \
+  cleanup-ghcr.yml \
+  verireel \
+  verireel-ghcr-cleanup-schedule \
+  schedule
+post_product_artifact_protection_grant \
+  cbusillo/sellyouroutboard \
+  cleanup-ghcr.yml \
+  sellyouroutboard \
+  sellyouroutboard-ghcr-cleanup-manual
+post_product_artifact_protection_grant \
+  cbusillo/sellyouroutboard \
+  cleanup-ghcr.yml \
+  sellyouroutboard \
+  sellyouroutboard-ghcr-cleanup-schedule \
+  schedule
+post_product_artifact_protection_grant \
+  cbusillo/odoo-tenant-cm \
+  cleanup-ghcr.yml \
+  odoo-tenant-cm \
+  odoo-tenant-cm-ghcr-cleanup-manual
+post_product_artifact_protection_grant \
+  cbusillo/odoo-tenant-cm \
+  cleanup-ghcr.yml \
+  odoo-tenant-cm \
+  odoo-tenant-cm-ghcr-cleanup-schedule \
+  schedule
+post_product_artifact_protection_grant \
+  cbusillo/odoo-tenant-opw \
+  cleanup-ghcr.yml \
+  odoo-tenant-opw \
+  odoo-tenant-opw-ghcr-cleanup-manual
+post_product_artifact_protection_grant \
+  cbusillo/odoo-tenant-opw \
+  cleanup-ghcr.yml \
+  odoo-tenant-opw \
+  odoo-tenant-opw-ghcr-cleanup-schedule \
+  schedule
 post_grant \
   "$GITHUB_REPOSITORY" \
   odoo-target-replacement-plan.yml \

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -1146,6 +1146,51 @@ class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
             )
         )
 
+    def test_actions_policy_matches_product_and_context_patterns(self) -> None:
+        rule = GitHubActionsPolicyRule(
+            repository="cbusillo/verireel",
+            workflow_refs=(
+                "cbusillo/verireel/.github/workflows/cleanup-ghcr.yml@refs/heads/main",
+            ),
+            event_names=("schedule",),
+            products=("verireel",),
+            contexts=("*",),
+            actions=("artifact_protection.read",),
+        )
+
+        self.assertTrue(
+            rule.allows(
+                identity=_actions_identity(
+                    workflow_ref=(
+                        "cbusillo/verireel/.github/workflows/cleanup-ghcr.yml"
+                        "@refs/heads/main"
+                    ),
+                    event_name="schedule",
+                    ref="refs/heads/main",
+                    subject="repo:cbusillo/verireel:ref:refs/heads/main",
+                ),
+                action="artifact_protection.read",
+                product="verireel",
+                context="launchplane",
+            )
+        )
+        self.assertFalse(
+            rule.allows(
+                identity=_actions_identity(
+                    workflow_ref=(
+                        "cbusillo/verireel/.github/workflows/cleanup-ghcr.yml"
+                        "@refs/heads/main"
+                    ),
+                    event_name="schedule",
+                    ref="refs/heads/main",
+                    subject="repo:cbusillo/verireel:ref:refs/heads/main",
+                ),
+                action="artifact_protection.read",
+                product="sellyouroutboard",
+                context="launchplane",
+            )
+        )
+
     def test_human_policy_matches_team_and_role_scope(self) -> None:
         rule = GitHubHumanPolicyRule(
             organizations=("cbusillo",),


### PR DESCRIPTION
## Summary
- add Launchplane authz grants for product `cleanup-ghcr.yml` workflows to read protected artifact inventory
- make GitHub Actions product/context authz scopes honor fnmatch patterns so wildcard whole-product cleanup grants authorize correctly
- add regression coverage for `artifact_protection.read` wildcard context matching

## Validation
- `uv run python -m unittest tests.test_service_auth`
- `uv run --extra dev ruff check control_plane/service_auth.py tests/test_service_auth.py`
- `uv run --extra dev mypy control_plane/service_auth.py tests/test_service_auth.py`
- `shellcheck scripts/deploy/ensure-authz-grants.sh`

## Agent review
- Launchplane grant review found the wildcard context authz mismatch; fixed in `GitHubActionsPolicyRule` and covered by tests.
