### PR TITLE
Include SYO in provider-target sweep

### DIFF
--- a/.github/workflows/provider-target-operations.yml
+++ b/.github/workflows/provider-target-operations.yml
@@ -130,6 +130,8 @@ jobs:
               cat > "$routes_file" <<'JSON'
           [
             {"context":"discord-blue","instance":"prod"},
+            {"context":"sellyouroutboard","instance":"testing"},
+            {"context":"sellyouroutboard","instance":"prod"},
             {"context":"verireel","instance":"testing"},
             {"context":"verireel","instance":"prod"},
             {"context":"cm","instance":"testing"},

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -58,8 +58,9 @@ authorized through DB-backed `provider_target.audit` and
 first in `audit` or `backfill-dry-run` mode, review the artifact, then run
 `backfill-apply` only with the exact confirmation phrase and an operator reason.
 The initial Phase Two target set is ordered from the lower-risk proof lane into
-live production lanes: `discord-blue/prod`, `verireel/testing`,
-`verireel/prod`, `cm/testing`, `cm/prod`, `opw/testing`, and `opw/prod`.
+live production lanes: `discord-blue/prod`, `sellyouroutboard/testing`,
+`sellyouroutboard/prod`, `verireel/testing`, `verireel/prod`, `cm/testing`,
+`cm/prod`, `opw/testing`, and `opw/prod`.
 
 The local CLI remains a DB-backed inspection and rehearsal helper. Local
 provider-target data changes must start with a read-only audit:


### PR DESCRIPTION
## Summary
- include SellYourOutboard testing/prod in the Provider Target Operations phase-two sweep
- update operations docs so the durable target set matches the workflow

## Live validation
- Existing phase-two audit before this patch passed for discord-blue, verireel, cm, and opw: run 26925329855
- SellYourOutboard testing provider-target audit/backfill/apply/re-audit completed cleanly; testing deploy rerun passed
- SellYourOutboard prod provider-target audit/backfill/apply/re-audit completed cleanly

## Local validation
- actionlint -config-file .github/actionlint.yaml .github/workflows/provider-target-operations.yml
- jq empty .github/github.json
- uv run python -m unittest tests.test_provider_target_audit tests.test_provider_target_backfill