### PR TITLE
Retire target type response aliases

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -5163,6 +5163,22 @@ def _accepted_payload_extra_record_keys(*, route_path: str) -> frozenset[str]:
     return frozenset()
 
 
+def _driver_result_payload_for_idempotency_replay(
+    *, route_path: str, driver_result: dict[str, object]
+) -> dict[str, object]:
+    replay_payload = dict(driver_result)
+    if route_path in {
+        _GENERIC_WEB_DEPLOY_ROUTE.route_path,
+        _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
+        _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
+        _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
+        _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
+        _VERIREEL_PROD_PROMOTION_ROUTE.route_path,
+    }:
+        replay_payload.pop("target_type", None)
+    return replay_payload
+
+
 def _operation_payload(
     operation: OdooStableBootstrapOperationRecord,
 ) -> dict[str, object]:
@@ -5589,7 +5605,14 @@ def _replay_idempotent_response(
     result_payload = _accepted_payload(
         trace_id=trace_id,
         result=dict(stored_payload.get("records") or {}),
-        driver_result=stored_driver_result if isinstance(stored_driver_result, dict) else None,
+        driver_result=(
+            _driver_result_payload_for_idempotency_replay(
+                route_path=stored_record.route_path,
+                driver_result=stored_driver_result,
+            )
+            if isinstance(stored_driver_result, dict)
+            else None
+        ),
         extra_record_keys=_accepted_payload_extra_record_keys(route_path=stored_record.route_path),
         replayed=True,
         original_trace_id=stored_record.response_trace_id,

--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -75,7 +75,6 @@ class GenericWebDeployResult(BaseModel):
     target_category: DeployTargetCategory = "unknown"
     provider_id: str = ""
     provider_target_type: str = ""
-    target_type: str = ""
     post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
     error_message: str = ""
 
@@ -83,9 +82,6 @@ class GenericWebDeployResult(BaseModel):
     def _validate_result(self) -> "GenericWebDeployResult":
         self.provider_id = self.provider_id.strip().lower()
         self.provider_target_type = self.provider_target_type.strip().lower()
-        self.target_type = self.target_type.strip().lower()
-        if not self.target_type:
-            self.target_type = self.provider_target_type or self.target_category
         return self
 
 
@@ -501,7 +497,6 @@ def execute_generic_web_deploy(
             target_category=target_fields.target_category,
             provider_id=target_fields.provider_id,
             provider_target_type=target_fields.provider_target_type,
-            target_type=target_fields.target_type,
             post_deploy_status=_generic_web_deploy_post_deploy_status(post_deploy_update),
             error_message=str(exc),
         )
@@ -547,7 +542,6 @@ def execute_generic_web_deploy(
         target_category=target_fields.target_category,
         provider_id=target_fields.provider_id,
         provider_target_type=target_fields.provider_target_type,
-        target_type=target_fields.target_type,
         post_deploy_status=_generic_web_deploy_post_deploy_status(post_deploy_update),
     )
 

--- a/control_plane/workflows/generic_web_promotion.py
+++ b/control_plane/workflows/generic_web_promotion.py
@@ -136,7 +136,6 @@ class GenericWebProdPromotionResult(BaseModel):
     target_category: DeployTargetCategory = "unknown"
     provider_id: str = ""
     provider_target_type: str = ""
-    target_type: str = ""
     dry_run: bool = False
     error_message: str = ""
 
@@ -144,18 +143,13 @@ class GenericWebProdPromotionResult(BaseModel):
     def _validate_result(self) -> "GenericWebProdPromotionResult":
         self.provider_id = self.provider_id.strip().lower()
         self.provider_target_type = self.provider_target_type.strip().lower()
-        self.target_type = self.target_type.strip().lower()
-        if not self.provider_target_type and self.target_type:
-            self.provider_target_type = self.target_type
         if self.target_category == "unknown":
-            if self.provider_target_type == "application" or self.target_type == "application":
+            if self.provider_target_type == "application":
                 self.target_category = "application"
-            elif self.provider_target_type == "compose" or self.target_type == "compose":
+            elif self.provider_target_type == "compose":
                 self.target_category = "compose"
         if not self.provider_id and self.target_category in {"application", "compose"}:
             self.provider_id = "dokploy"
-        if not self.target_type:
-            self.target_type = self.provider_target_type or self.target_category
         return self
 
 
@@ -334,7 +328,9 @@ def execute_generic_web_prod_promotion(
                 deployment_status="fail",
                 target_name=deploy_result.target_name,
                 target_type=_promotion_target_type(
-                    deploy_result_target_type=deploy_result.target_type,
+                    deploy_result_target_type=(
+                        deploy_result.provider_target_type or deploy_result.target_category
+                    ),
                     deployment_record=deployment_record,
                 ),
                 deployment_record_id=deploy_result.deployment_record_id,
@@ -368,7 +364,8 @@ def execute_generic_web_prod_promotion(
         deployment_status=deploy_result.deploy_status,
         target_name=deploy_result.target_name,
         target_type=_promotion_target_type(
-            deploy_result_target_type=deploy_result.target_type,
+            deploy_result_target_type=deploy_result.provider_target_type
+            or deploy_result.target_category,
             deployment_record=deployment_record,
         ),
         deployment_record_id=deploy_result.deployment_record_id,
@@ -989,7 +986,6 @@ def _result_from_record(
         target_category=target_fields.target_category,
         provider_id=target_fields.provider_id,
         provider_target_type=target_fields.provider_target_type,
-        target_type=target_fields.target_type,
         dry_run=dry_run,
         error_message=error_message,
     )

--- a/control_plane/workflows/verireel_prod_promotion.py
+++ b/control_plane/workflows/verireel_prod_promotion.py
@@ -117,23 +117,17 @@ class VeriReelProdPromotionResult(BaseModel):
     target_category: DeployTargetCategory = "unknown"
     provider_id: str = "dokploy"
     provider_target_type: str = ""
-    target_type: str = ""
     error_message: str = ""
 
     @model_validator(mode="after")
     def _validate_result(self) -> "VeriReelProdPromotionResult":
         self.provider_id = self.provider_id.strip().lower()
         self.provider_target_type = self.provider_target_type.strip().lower()
-        self.target_type = self.target_type.strip().lower()
-        if not self.provider_target_type and self.target_type:
-            self.provider_target_type = self.target_type
         if self.target_category == "unknown":
-            if self.provider_target_type == "application" or self.target_type == "application":
+            if self.provider_target_type == "application":
                 self.target_category = "application"
-            elif self.provider_target_type == "compose" or self.target_type == "compose":
+            elif self.provider_target_type == "compose":
                 self.target_category = "compose"
-        if not self.target_type:
-            self.target_type = self.provider_target_type or self.target_category
         return self
 
 
@@ -191,7 +185,7 @@ def _target_result_fields_from_deployment(
         target_category=deployment_result.target_category,
         provider_id=deployment_result.provider_id,
         provider_target_type=deployment_result.provider_target_type,
-        target_type=deployment_result.target_type,
+        target_type=deployment_result.provider_target_type or deployment_result.target_category,
     )
 
 
@@ -275,8 +269,8 @@ def _legacy_dokploy_target_type(
 ) -> DokployTargetType:
     if deployment_result.target_category in {"application", "compose"}:
         return cast(DokployTargetType, deployment_result.target_category)
-    if deployment_result.target_type in {"application", "compose"}:
-        return cast(DokployTargetType, deployment_result.target_type)
+    if deployment_result.provider_target_type in {"application", "compose"}:
+        return cast(DokployTargetType, deployment_result.provider_target_type)
     return _default_target_type()
 
 
@@ -309,7 +303,6 @@ def _build_result(
         target_category=target_fields.target_category,
         provider_id=target_fields.provider_id,
         provider_target_type=target_fields.provider_target_type,
-        target_type=target_fields.target_type,
         error_message=error_message,
     )
 

--- a/control_plane/workflows/verireel_stable_deploy.py
+++ b/control_plane/workflows/verireel_stable_deploy.py
@@ -78,7 +78,6 @@ class VeriReelStableDeployResult(BaseModel):
     target_category: DeployTargetCategory = "unknown"
     provider_id: str = "dokploy"
     provider_target_type: str = ""
-    target_type: str = ""
     rollout_status: ReleaseStatus = "skipped"
     rollout_base_url: str = ""
     rollout_health_urls: tuple[str, ...] = ()
@@ -90,16 +89,11 @@ class VeriReelStableDeployResult(BaseModel):
     def _validate_result(self) -> "VeriReelStableDeployResult":
         self.provider_id = self.provider_id.strip().lower()
         self.provider_target_type = self.provider_target_type.strip().lower()
-        self.target_type = self.target_type.strip().lower()
-        if not self.provider_target_type and self.target_type:
-            self.provider_target_type = self.target_type
         if self.target_category == "unknown":
-            if self.provider_target_type == "application" or self.target_type == "application":
+            if self.provider_target_type == "application":
                 self.target_category = "application"
-            elif self.provider_target_type == "compose" or self.target_type == "compose":
+            elif self.provider_target_type == "compose":
                 self.target_category = "compose"
-        if not self.target_type:
-            self.target_type = self.provider_target_type or self.target_category
         return self
 
 
@@ -216,7 +210,6 @@ def _build_result(
         target_category=target_fields.target_category,
         provider_id=target_fields.provider_id,
         provider_target_type=target_fields.provider_target_type,
-        target_type=target_fields.target_type,
         rollout_status=rollout_status,
         rollout_base_url=rollout_base_url,
         rollout_health_urls=rollout_health_urls,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -52,6 +52,11 @@ Keep a compatibility surface only when it is one of these:
   responses expose only neutral `provider_target*` summary keys. Seed import
   material must use `provider_targets`; the import helper no longer falls back
   to `dokploy_targets`.
+- Generic-web and VeriReel driver result payloads no longer expose the
+  response-only `target_type` alias. Responses use `target_category`,
+  `provider_id`, and `provider_target_type`; internal Dokploy execution config
+  keeps target-type fields only where application-vs-compose behavior is still
+  required.
 - `control_plane` remains the Python package name for now. Do not add public
   `odoo-control-plane` names, env vars, or docs; prefer Launchplane wording for
   product/operator surfaces.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -899,9 +899,9 @@ observation.
 
 Generic web deploy and prod-promotion responses expose provider-neutral target
 metadata with `target_category`, `provider_id`, and `provider_target_type`.
-The legacy `target_type` response field remains as a compatibility alias for
-older workflow callers, but provider-neutral callers should read
-`target_category` first.
+The legacy response-only `target_type` alias is retired; Dokploy execution
+configuration still uses provider-specific target type fields internally where
+application-vs-compose behavior is required.
 
 Generic web preview desired-state discovery uses
 `POST /v1/drivers/generic-web/preview-desired-state`. The request names the
@@ -1271,9 +1271,9 @@ rendered promotion evidence payload for fields the driver can derive.
 
 VeriReel deploy and prod-promotion responses expose provider-neutral target
 metadata with `target_category`, `provider_id`, and `provider_target_type`.
-The legacy `target_type` response field remains as a compatibility alias for
-older workflow callers, but provider-neutral callers should read
-`target_category` first.
+The legacy response-only `target_type` alias is retired; Dokploy execution
+configuration still uses provider-specific target type fields internally where
+application-vs-compose behavior is required.
 
 Recommended first success shape:
 

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -276,7 +276,7 @@ class GenericWebDeployTests(unittest.TestCase):
         self.assertEqual(result.target_category, "service")
         self.assertEqual(result.provider_id, "fake-cloud")
         self.assertEqual(result.provider_target_type, "managed-service")
-        self.assertEqual(result.target_type, "managed-service")
+        self.assertFalse(hasattr(result, "target_type"))
         self.assertEqual(len(store.deployments), 1)
         self.assertEqual(store.deployments[0].deploy.status, "pass")
         self.assertEqual(store.deployments[0].post_deploy_update.status, "skipped")

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -210,8 +210,10 @@ def _deploy_result(*, deploy_status: Literal["pass", "fail"] = "pass") -> Generi
         context="sellyouroutboard-testing",
         instance="prod",
         target_name="syo-prod-app",
-        target_type="application",
         target_id="app-123",
+        target_category="application",
+        provider_id="dokploy",
+        provider_target_type="application",
         error_message="provider failed" if deploy_status == "fail" else "",
     )
 
@@ -289,7 +291,7 @@ class GenericWebProdPromotionTests(unittest.TestCase):
         self.assertEqual(result.target_category, "application")
         self.assertEqual(result.provider_id, "dokploy")
         self.assertEqual(result.provider_target_type, "application")
-        self.assertEqual(result.target_type, "application")
+        self.assertFalse(hasattr(result, "target_type"))
         self.assertEqual(len(store.promotions), 1)
         promotion = next(iter(store.promotions.values()))
         self.assertEqual(promotion.backup_gate.status, "skipped")

--- a/tests/test_generic_web_rollback.py
+++ b/tests/test_generic_web_rollback.py
@@ -230,7 +230,9 @@ class GenericWebRollbackPlanTests(unittest.TestCase):
             context="sellyouroutboard-testing",
             instance="prod",
             target_name="syo-prod-app",
-            target_type="application",
+            target_category="application",
+            provider_id="dokploy",
+            provider_target_type="application",
             target_id="app-prod",
         )
 
@@ -272,7 +274,9 @@ class GenericWebRollbackPlanTests(unittest.TestCase):
             context="sellyouroutboard-testing",
             instance="prod",
             target_name="syo-prod-app",
-            target_type="application",
+            target_category="application",
+            provider_id="dokploy",
+            provider_target_type="application",
             target_id="app-prod",
             post_deploy_status="pass",
         )
@@ -307,7 +311,9 @@ class GenericWebRollbackPlanTests(unittest.TestCase):
             context="sellyouroutboard-testing",
             instance="prod",
             target_name="syo-prod-app",
-            target_type="application",
+            target_category="application",
+            provider_id="dokploy",
+            provider_target_type="application",
             target_id="app-prod",
             post_deploy_status="fail",
             error_message="post deploy failed",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -15745,8 +15745,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 context="sellyouroutboard-testing",
                 instance="testing",
                 target_name="syo-testing",
-                target_type="application",
                 target_id="app-syo-testing",
+                target_category="application",
+                provider_id="dokploy",
+                provider_target_type="application",
                 post_deploy_status="fail",
                 error_message="post-deploy failed after deploy passed",
             )
@@ -16667,8 +16669,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     source_health_status="pass",
                     destination_health_status="pass",
                     target_name="syo-prod-app",
-                    target_type="application",
                     target_id="app-123",
+                    target_category="application",
+                    provider_id="dokploy",
+                    provider_target_type="application",
                 ),
             ) as execute_mock:
                 status_code, payload = _invoke_app(
@@ -16698,7 +16702,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["target_category"], "application")
         self.assertEqual(payload["result"]["provider_id"], "dokploy")
         self.assertEqual(payload["result"]["provider_target_type"], "application")
-        self.assertEqual(payload["result"]["target_type"], "application")
+        self.assertNotIn("target_type", payload["result"])
         execute_mock.assert_called_once()
 
     def test_generic_web_prod_promotion_route_rejects_wrong_product_context(self) -> None:
@@ -16819,8 +16823,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     source_health_status="pass",
                     destination_health_status="pass",
                     target_name="odoo-prod-app",
-                    target_type="application",
                     target_id="app-odoo",
+                    target_category="application",
+                    provider_id="dokploy",
+                    provider_target_type="application",
                 ),
             ) as execute_mock:
                 status_code, payload = _invoke_app(
@@ -16848,7 +16854,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["target_category"], "application")
         self.assertEqual(payload["result"]["provider_id"], "dokploy")
         self.assertEqual(payload["result"]["provider_target_type"], "application")
-        self.assertEqual(payload["result"]["target_type"], "application")
+        self.assertNotIn("target_type", payload["result"])
         execute_mock.assert_called_once()
 
     def test_generic_web_prod_promotion_route_accepts_padded_lane_context(self) -> None:
@@ -16913,8 +16919,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     source_health_status="pass",
                     destination_health_status="pass",
                     target_name="syo-prod-app",
-                    target_type="application",
                     target_id="app-123",
+                    target_category="application",
+                    provider_id="dokploy",
+                    provider_target_type="application",
                 ),
             ) as execute_mock:
                 status_code, payload = _invoke_app(
@@ -16940,7 +16948,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["target_category"], "application")
         self.assertEqual(payload["result"]["provider_id"], "dokploy")
         self.assertEqual(payload["result"]["provider_target_type"], "application")
-        self.assertEqual(payload["result"]["target_type"], "application")
+        self.assertNotIn("target_type", payload["result"])
         execute_mock.assert_called_once()
 
     def test_human_session_can_dry_run_generic_web_prod_promotion(self) -> None:
@@ -24403,8 +24411,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     deploy_started_at="2026-04-20T18:20:00Z",
                     deploy_finished_at="2026-04-20T18:21:15Z",
                     target_name="ver-testing-app",
-                    target_type="application",
                     target_id="testing-app-123",
+                    target_category="application",
+                    provider_id="dokploy",
+                    provider_target_type="application",
                 ),
             ) as execute_mock:
                 status_code, payload = _invoke_app(
@@ -24431,7 +24441,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["result"]["target_category"], "application")
             self.assertEqual(payload["result"]["provider_id"], "dokploy")
             self.assertEqual(payload["result"]["provider_target_type"], "application")
-            self.assertEqual(payload["result"]["target_type"], "application")
+            self.assertNotIn("target_type", payload["result"])
             execute_mock.assert_called_once()
 
     def test_verireel_testing_verification_driver_updates_deployment_record(self) -> None:
@@ -26596,8 +26606,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     deploy_started_at="2026-04-20T19:20:00Z",
                     deploy_finished_at="2026-04-20T19:21:15Z",
                     target_name="ver-prod-app",
-                    target_type="application",
                     target_id="prod-app-123",
+                    target_category="application",
+                    provider_id="dokploy",
+                    provider_target_type="application",
                 ),
             ) as execute_mock:
                 status_code, payload = _invoke_app(
@@ -26625,7 +26637,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["result"]["target_category"], "application")
             self.assertEqual(payload["result"]["provider_id"], "dokploy")
             self.assertEqual(payload["result"]["provider_target_type"], "application")
-            self.assertEqual(payload["result"]["target_type"], "application")
+            self.assertNotIn("target_type", payload["result"])
             execute_mock.assert_called_once()
 
     def test_verireel_prod_deploy_driver_rejects_unauthorized_workflow(self) -> None:
@@ -26722,8 +26734,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     deploy_started_at="2026-04-21T18:20:00Z",
                     deploy_finished_at="2026-04-21T18:21:15Z",
                     target_name="ver-prod-app",
-                    target_type="application",
                     target_id="prod-app-123",
+                    target_category="application",
+                    provider_id="dokploy",
+                    provider_target_type="application",
                 ),
             ) as execute_mock:
                 status_code, payload = _invoke_app(
@@ -26759,7 +26773,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["result"]["target_category"], "application")
             self.assertEqual(payload["result"]["provider_id"], "dokploy")
             self.assertEqual(payload["result"]["provider_target_type"], "application")
-            self.assertEqual(payload["result"]["target_type"], "application")
+            self.assertNotIn("target_type", payload["result"])
             execute_mock.assert_called_once()
             request = execute_mock.call_args.kwargs["request"]
             self.assertEqual(request.source_health_status, "pass")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -15792,6 +15792,116 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertTrue(second_payload["replayed"])
         deploy.assert_called_once()
 
+    def test_generic_web_deploy_route_replay_scrubs_retired_target_type_alias(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            identity = _identity()
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            driver_result = GenericWebDeployResult(
+                deployment_record_id="deployment-syo-testing-retired-alias",
+                deploy_status="pass",
+                deploy_started_at="2026-05-26T02:00:00Z",
+                deploy_finished_at="2026-05-26T02:05:00Z",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_name="syo-testing",
+                target_id="app-syo-testing",
+                target_category="application",
+                provider_id="dokploy",
+                provider_target_type="application",
+            )
+            request_payload = {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "deploy": {
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "instance": "testing",
+                    "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                    "source_git_ref": "abc123",
+                },
+            }
+
+            with patch(
+                "control_plane.service.execute_generic_web_deploy",
+                return_value=driver_result,
+            ) as deploy:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/deploy",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "generic-web-deploy-retired-alias"},
+                )
+                idempotency_record = store.read_idempotency_record(
+                    scope="|".join(
+                        (
+                            identity.repository,
+                            identity.workflow_ref or identity.job_workflow_ref,
+                            identity.subject,
+                        )
+                    ),
+                    route_path="/v1/drivers/generic-web/deploy",
+                    idempotency_key="generic-web-deploy-retired-alias",
+                )
+                self.assertIsNotNone(idempotency_record)
+                assert idempotency_record is not None
+                legacy_response_payload = idempotency_record.response_payload
+                legacy_result_payload = legacy_response_payload.get("result")
+                self.assertIsInstance(legacy_result_payload, dict)
+                assert isinstance(legacy_result_payload, dict)
+                legacy_result_payload["target_type"] = "application"
+                store.write_idempotency_record(
+                    idempotency_record.model_copy(
+                        update={"response_payload": legacy_response_payload}, deep=True
+                    )
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/deploy",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "generic-web-deploy-retired-alias"},
+                )
+
+        self.assertEqual(first_status_code, 202)
+        self.assertNotIn("target_type", first_payload["result"])
+        self.assertEqual(second_status_code, 202)
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["result"]["target_category"], "application")
+        self.assertEqual(second_payload["result"]["provider_target_type"], "application")
+        self.assertNotIn("target_type", second_payload["result"])
+        deploy.assert_called_once()
+
     def test_generic_web_deploy_route_rejects_unknown_base_driver_product(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_verireel_prod_promotion.py
+++ b/tests/test_verireel_prod_promotion.py
@@ -87,8 +87,10 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                         deploy_started_at="2026-04-21T18:20:00Z",
                         deploy_finished_at="2026-04-21T18:21:15Z",
                         target_name="ver-prod-app",
-                        target_type="application",
                         target_id="prod-app-123",
+                        target_category="application",
+                        provider_id="dokploy",
+                        provider_target_type="application",
                         rollout_status="pass",
                         rollout_base_url="https://ver-prod.shinycomputers.com",
                         rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
@@ -134,7 +136,7 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             self.assertEqual(result.target_category, "service")
             self.assertEqual(result.provider_id, "runtime-provider")
             self.assertEqual(result.provider_target_type, "managed-service")
-            self.assertEqual(result.target_type, "application")
+            self.assertFalse(hasattr(result, "target_type"))
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
             )
@@ -227,7 +229,6 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                         target_category="service",
                         provider_id="runtime-provider",
                         provider_target_type="managed-service",
-                        target_type="application",
                         rollout_status="pass",
                         rollout_base_url="https://ver-prod.shinycomputers.com",
                         rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
@@ -328,8 +329,10 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                         deploy_started_at="2026-04-21T18:20:00Z",
                         deploy_finished_at="2026-04-21T18:21:15Z",
                         target_name="ver-prod-app",
-                        target_type="application",
                         target_id="prod-app-123",
+                        target_category="application",
+                        provider_id="dokploy",
+                        provider_target_type="application",
                         rollout_status="pass",
                         rollout_base_url="https://ver-prod.shinycomputers.com",
                         rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
@@ -367,7 +370,7 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             self.assertEqual(result.target_category, "application")
             self.assertEqual(result.provider_id, "dokploy")
             self.assertEqual(result.provider_target_type, "application")
-            self.assertEqual(result.target_type, "application")
+            self.assertFalse(hasattr(result, "target_type"))
             self.assertIn("Prisma migration", result.error_message)
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
@@ -415,8 +418,10 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                         deploy_started_at="2026-04-21T18:20:00Z",
                         deploy_finished_at="2026-04-21T18:21:15Z",
                         target_name="ver-prod-app",
-                        target_type="application",
                         target_id="prod-app-123",
+                        target_category="application",
+                        provider_id="dokploy",
+                        provider_target_type="application",
                         rollout_status="pass",
                         rollout_base_url="https://ver-prod.shinycomputers.com",
                         rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
@@ -454,7 +459,7 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             self.assertEqual(result.target_category, "application")
             self.assertEqual(result.provider_id, "dokploy")
             self.assertEqual(result.provider_target_type, "application")
-            self.assertEqual(result.target_type, "application")
+            self.assertFalse(hasattr(result, "target_type"))
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
             )
@@ -495,8 +500,10 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
                         deploy_started_at="2026-04-21T18:20:00Z",
                         deploy_finished_at="2026-04-21T18:21:15Z",
                         target_name="ver-prod-app",
-                        target_type="application",
                         target_id="prod-app-123",
+                        target_category="application",
+                        provider_id="dokploy",
+                        provider_target_type="application",
                         rollout_status="fail",
                         rollout_base_url="https://ver-prod.shinycomputers.com",
                         rollout_health_urls=("https://ver-prod.shinycomputers.com/api/health",),
@@ -522,7 +529,7 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             self.assertEqual(result.target_category, "application")
             self.assertEqual(result.provider_id, "dokploy")
             self.assertEqual(result.provider_target_type, "application")
-            self.assertEqual(result.target_type, "application")
+            self.assertFalse(hasattr(result, "target_type"))
             self.assertIn("rollout page verification", result.error_message)
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"
@@ -557,7 +564,7 @@ class VeriReelProdPromotionWorkflowTests(unittest.TestCase):
             self.assertEqual(result.target_category, "application")
             self.assertEqual(result.provider_id, "dokploy")
             self.assertEqual(result.provider_target_type, "application")
-            self.assertEqual(result.target_type, "application")
+            self.assertFalse(hasattr(result, "target_type"))
             self.assertIn("requires stored backup gate record", result.error_message)
             promotion = store.read_promotion_record(
                 "promotion-verireel-testing-to-prod-run-12345-attempt-1"

--- a/tests/test_verireel_testing_deploy.py
+++ b/tests/test_verireel_testing_deploy.py
@@ -90,7 +90,7 @@ class VeriReelTestingDeployWorkflowTests(unittest.TestCase):
             self.assertEqual(result.target_category, "application")
             self.assertEqual(result.provider_id, "dokploy")
             self.assertEqual(result.provider_target_type, "application")
-            self.assertEqual(result.target_type, "application")
+            self.assertFalse(hasattr(result, "target_type"))
             deployment = store.read_deployment_record(
                 "deployment-verireel-testing-run-12345-attempt-1"
             )


### PR DESCRIPTION
## Summary
- remove response-only `target_type` aliases from generic-web and VeriReel driver result models
- keep canonical `target_category`, `provider_id`, and `provider_target_type` fields in workflow/API payload tests
- document the retired response alias while preserving internal Dokploy target-type config where app-vs-compose behavior is required

## Validation
- `uv run python -m unittest`
- `uv run python -m unittest tests.test_generic_web_rollback tests.test_generic_web_deploy tests.test_generic_web_promotion tests.test_verireel_testing_deploy tests.test_verireel_prod_promotion`
- `uv run ruff format --check control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_promotion.py control_plane/workflows/verireel_prod_promotion.py control_plane/workflows/verireel_stable_deploy.py tests/test_generic_web_deploy.py tests/test_generic_web_promotion.py tests/test_generic_web_rollback.py tests/test_service.py tests/test_verireel_prod_promotion.py tests/test_verireel_testing_deploy.py`
- `uv run ruff check control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_promotion.py control_plane/workflows/verireel_prod_promotion.py control_plane/workflows/verireel_stable_deploy.py tests/test_generic_web_deploy.py tests/test_generic_web_promotion.py tests/test_generic_web_rollback.py tests/test_service.py tests/test_verireel_prod_promotion.py tests/test_verireel_testing_deploy.py`
- `uv run mypy control_plane/workflows/generic_web_deploy.py control_plane/workflows/generic_web_promotion.py control_plane/workflows/verireel_prod_promotion.py control_plane/workflows/verireel_stable_deploy.py tests/test_generic_web_deploy.py tests/test_generic_web_promotion.py tests/test_generic_web_rollback.py tests/test_service.py tests/test_verireel_prod_promotion.py tests/test_verireel_testing_deploy.py`
- `uv run markdownlint-cli2 docs/service-boundary.md docs/compatibility-retirement.md`