### PR TITLE
Retire Odoo preview planning aliases

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -701,21 +701,6 @@ ODOO_DRIVER = DriverDescriptor(
     ),
     route_aliases=(
         _route_alias(
-            "preview_desired_state",
-            "/v1/drivers/odoo/preview-desired-state",
-            "preview_desired_state.discover",
-        ),
-        _route_alias(
-            "preview_inventory",
-            "/v1/drivers/odoo/preview-inventory",
-            "preview_inventory.read",
-        ),
-        _route_alias(
-            "preview_readiness",
-            "/v1/drivers/odoo/preview-readiness",
-            "preview_readiness.evaluate",
-        ),
-        _route_alias(
             "preview_verification",
             "/v1/drivers/odoo/preview-verification",
             "preview_generation.write",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1267,29 +1267,6 @@ _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
-_ODOO_PREVIEW_DESIRED_STATE_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/odoo/preview-desired-state",
-    envelope_model=GenericWebPreviewDesiredStateEnvelope,
-    denial_message=(
-        "Workflow cannot discover Odoo preview desired state for the requested product/context."
-    ),
-)
-
-
-_ODOO_PREVIEW_INVENTORY_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/odoo/preview-inventory",
-    envelope_model=GenericWebPreviewInventoryEnvelope,
-    denial_message="Workflow cannot read Odoo preview inventory for the requested product/context.",
-)
-
-
-_ODOO_PREVIEW_READINESS_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/odoo/preview-readiness",
-    envelope_model=GenericWebPreviewReadinessEnvelope,
-    denial_message="Workflow cannot evaluate Odoo preview readiness for the requested product/context.",
-)
-
-
 class OdooPreviewApplyEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     apply: OdooPreviewDokployApplyRequest
@@ -1414,18 +1391,11 @@ _ODOO_PREVIEW_APPLY_INPUTS_ROUTE = _DriverRouteExecutionMetadata(
 
 
 _PREVIEW_DESIRED_STATE_ROUTE_PATHS = frozenset(
-    {
-        _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path,
-        _ODOO_PREVIEW_DESIRED_STATE_ROUTE.route_path,
-    }
+    {_GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path}
 )
-_PREVIEW_INVENTORY_ROUTE_PATHS = frozenset(
-    {_GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path, _ODOO_PREVIEW_INVENTORY_ROUTE.route_path}
-)
+_PREVIEW_INVENTORY_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path})
 _PREVIEW_REFRESH_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_REFRESH_ROUTE.route_path})
-_PREVIEW_READINESS_ROUTE_PATHS = frozenset(
-    {_GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path, _ODOO_PREVIEW_READINESS_ROUTE.route_path}
-)
+_PREVIEW_READINESS_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path})
 _PREVIEW_DESTROY_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_DESTROY_ROUTE.route_path})
 _GENERIC_WEB_BASE_DRIVER_SHARED_ROUTE_PATHS = frozenset(
     {
@@ -2799,16 +2769,12 @@ def _authorize_generic_web_preview_route(
 def _generic_web_preview_desired_state_route_metadata(
     path: str,
 ) -> _DriverRouteExecutionMetadata[GenericWebPreviewDesiredStateEnvelope]:
-    if path == _ODOO_PREVIEW_DESIRED_STATE_ROUTE.route_path:
-        return _ODOO_PREVIEW_DESIRED_STATE_ROUTE
     return _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE
 
 
 def _generic_web_preview_inventory_route_metadata(
     path: str,
 ) -> _DriverRouteExecutionMetadata[GenericWebPreviewInventoryEnvelope]:
-    if path == _ODOO_PREVIEW_INVENTORY_ROUTE.route_path:
-        return _ODOO_PREVIEW_INVENTORY_ROUTE
     return _GENERIC_WEB_PREVIEW_INVENTORY_ROUTE
 
 
@@ -2821,8 +2787,6 @@ def _generic_web_preview_refresh_route_metadata(
 def _generic_web_preview_readiness_route_metadata(
     path: str,
 ) -> _DriverRouteExecutionMetadata[GenericWebPreviewReadinessEnvelope]:
-    if path == _ODOO_PREVIEW_READINESS_ROUTE.route_path:
-        return _ODOO_PREVIEW_READINESS_ROUTE
     return _GENERIC_WEB_PREVIEW_READINESS_ROUTE
 
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -57,6 +57,10 @@ Keep a compatibility surface only when it is one of these:
   `provider_id`, and `provider_target_type`; internal Dokploy execution config
   keeps target-type fields only where application-vs-compose behavior is still
   required.
+- Odoo-shaped preview desired-state, inventory, readiness, refresh, and destroy
+  aliases are retired. Odoo preview workflows use `preview-apply-inputs` and
+  `preview-apply` for isolated provider mutation, and common preview
+  read/planning callers use the inherited generic-web routes.
 - `control_plane` remains the Python package name for now. Do not add public
   `odoo-control-plane` names, env vars, or docs; prefer Launchplane wording for
   product/operator surfaces.

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -226,8 +226,10 @@ Odoo declares `base_driver_id="generic-web"` and inherits generic-web preview
 actions as its advertised lifecycle surface. The Odoo-specific preview mutation
 surface is the isolated compose planner/apply pair, not Odoo-shaped
 `preview-refresh` or `preview-destroy` compatibility aliases. Odoo preview
-desired-state, inventory, readiness, and verification remain non-operator route
-aliases where they preserve typed Odoo evidence without mutating provider state.
+desired-state, inventory, and readiness aliases are retired; callers should use
+the inherited generic-web routes for common read/planning actions. Odoo preview
+verification remains a non-operator route alias while it preserves typed Odoo
+evidence without mutating provider state.
 New tenant workflows should call `POST /v1/drivers/odoo/preview-apply-inputs`
 and then `POST /v1/drivers/odoo/preview-apply` for refresh and destroy. The
 lower-level `POST /v1/drivers/odoo/preview-apply` route applies a ready isolated-preview

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -165,6 +165,9 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertNotIn("preview_refresh", actions)
         self.assertNotIn("preview_refresh", route_aliases)
         self.assertNotIn("preview_destroy", route_aliases)
+        self.assertNotIn("preview_desired_state", route_aliases)
+        self.assertNotIn("preview_inventory", route_aliases)
+        self.assertNotIn("preview_readiness", route_aliases)
         self.assertNotIn("preview_verification", actions)
         self.assertEqual(
             route_aliases["preview_verification"].route_path,
@@ -517,6 +520,18 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         self.assertNotIn(
             "/v1/drivers/odoo/preview-destroy",
+            control_plane_service._driver_route_metadata_from_descriptors(),
+        )
+        self.assertNotIn(
+            "/v1/drivers/odoo/preview-desired-state",
+            control_plane_service._driver_route_metadata_from_descriptors(),
+        )
+        self.assertNotIn(
+            "/v1/drivers/odoo/preview-inventory",
+            control_plane_service._driver_route_metadata_from_descriptors(),
+        )
+        self.assertNotIn(
+            "/v1/drivers/odoo/preview-readiness",
             control_plane_service._driver_route_metadata_from_descriptors(),
         )
         self.assertEqual(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18208,6 +18208,33 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 404)
             self.assertEqual(payload["error"]["code"], "not_found")
 
+    def test_odoo_preview_read_planning_alias_routes_are_retired(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+
+            for route_path in (
+                "/v1/drivers/odoo/preview-desired-state",
+                "/v1/drivers/odoo/preview-inventory",
+                "/v1/drivers/odoo/preview-readiness",
+                "/v1/drivers/odoo/preview-destroy",
+            ):
+                with self.subTest(route_path=route_path):
+                    status_code, payload = _invoke_app(
+                        app,
+                        method="POST",
+                        path=route_path,
+                        payload={},
+                    )
+
+                    self.assertEqual(status_code, 404)
+                    self.assertEqual(payload["error"]["code"], "not_found")
+
     def test_odoo_preview_verification_driver_marks_latest_generation_ready(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- remove Odoo-shaped preview desired-state, inventory, and readiness alias paths from service routing
- stop advertising those aliases in the Odoo driver descriptor while preserving preview verification, stable verification, and rollback-plan aliases
- update compatibility docs and add 404 regressions for the retired paths

## Validation
- `uv run python -m unittest`
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_odoo_preview_refresh_route_is_not_supported tests.test_service.LaunchplaneServiceTests.test_odoo_preview_read_planning_alias_routes_are_retired tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_desired_state_route_uses_profile_context tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_inventory_route_writes_scan_from_driver_result tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_readiness_route_returns_driver_result`
- `uv run ruff format --check control_plane/service.py control_plane/drivers/registry.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run ruff check control_plane/service.py control_plane/drivers/registry.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run mypy control_plane/service.py control_plane/drivers/registry.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run markdownlint-cli2 docs/driver-descriptors.md docs/compatibility-retirement.md`