### PR TITLE
Retire Odoo generic route aliases

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -699,23 +699,6 @@ ODOO_DRIVER = DriverDescriptor(
             writes_records=("deployment", "inventory", "release_tuple"),
         ),
     ),
-    route_aliases=(
-        _route_alias(
-            "preview_verification",
-            "/v1/drivers/odoo/preview-verification",
-            "preview_generation.write",
-        ),
-        _route_alias(
-            "stable_verification",
-            "/v1/drivers/odoo/stable-verification",
-            "deployment.write",
-        ),
-        _route_alias(
-            "prod_rollback_plan",
-            "/v1/drivers/odoo/prod-rollback-plan",
-            "generic_web_prod_rollback.plan",
-        ),
-    ),
     setting_groups=(
         DriverSettingGroupDescriptor(
             group_id="runtime_environment",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1001,13 +1001,6 @@ _GENERIC_WEB_ROLLBACK_PLAN_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
-_ODOO_ROLLBACK_PLAN_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/odoo/prod-rollback-plan",
-    envelope_model=GenericWebRollbackPlanEnvelope,
-    denial_message="Workflow cannot plan the Odoo prod rollback for the requested product/context.",
-)
-
-
 class GenericWebRollbackEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     rollback: GenericWebRollbackPlanRequest
@@ -1403,7 +1396,6 @@ _GENERIC_WEB_BASE_DRIVER_SHARED_ROUTE_PATHS = frozenset(
         _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
         _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
         _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
-        _ODOO_ROLLBACK_PLAN_ROUTE.route_path,
         _GENERIC_WEB_ROLLBACK_ROUTE.route_path,
         _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
     }
@@ -1954,81 +1946,8 @@ _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
-class OdooPreviewVerificationRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    context: str
-    anchor_repo: str
-    anchor_pr_number: int = Field(ge=1)
-    verification_status: ReleaseStatus
-    verified_at: str
-    checked_urls: tuple[str, ...] = ()
-    timeout_seconds: int | None = Field(default=None, ge=1)
-    failure_summary: str = ""
-
-    @field_validator("verification_status", mode="before")
-    @classmethod
-    def _normalize_status(cls, value: object) -> ReleaseStatus:
-        return _normalize_release_status(value, label="Odoo preview verification status")
-
-    @field_validator("checked_urls", mode="before")
-    @classmethod
-    def _normalize_checked_urls(cls, value: object) -> tuple[str, ...]:
-        return _normalize_preview_verification_checked_urls(
-            value, label="Odoo preview verification"
-        )
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "OdooPreviewVerificationRequest":
-        if not self.context.strip():
-            raise ValueError("Odoo preview verification requires context.")
-        if not self.anchor_repo.strip():
-            raise ValueError("Odoo preview verification requires anchor_repo.")
-        if self.verification_status not in {"pass", "fail"}:
-            raise ValueError("Odoo preview verification status must be pass or fail.")
-        if not self.verified_at.strip():
-            raise ValueError("Odoo preview verification requires verified_at.")
-        if self.checked_urls and self.timeout_seconds is None:
-            raise ValueError("Odoo preview verification checked_urls require timeout_seconds.")
-        return self
-
-
-class OdooPreviewVerificationResult(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    preview_id: str
-    preview_generation_id: str
-    preview_state: str
-    generation_state: str
-    verification_status: ReleaseStatus
-    verified_at: str
-    checked_urls: tuple[str, ...] = ()
-    timeout_seconds: int | None = None
-    failure_summary: str = ""
-
-
-class OdooPreviewVerificationEnvelope(_ProductRouteEnvelope):
-    schema_version: int = Field(default=1, ge=1)
-    verification: OdooPreviewVerificationRequest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "OdooPreviewVerificationEnvelope":
-        _validate_driver_envelope_product(self.product, label="Odoo preview verification")
-        return self
-
-
-_ODOO_PREVIEW_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/odoo/preview-verification",
-    envelope_model=OdooPreviewVerificationEnvelope,
-    denial_message="Workflow cannot write Odoo preview verification for the requested product/context.",
-)
-
 _PREVIEW_VERIFICATION_ROUTE_PATHS = frozenset(
-    {
-        _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
-        _ODOO_PREVIEW_VERIFICATION_ROUTE.route_path,
-    }
+    {_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path}
 )
 _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS = frozenset(
     _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS
@@ -2039,53 +1958,6 @@ _GENERIC_WEB_BASE_DRIVER_ROUTE_PATHS = frozenset(
     _GENERIC_WEB_BASE_DRIVER_SHARED_ROUTE_PATHS
     | _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS
     | {_ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path}
-)
-
-
-class OdooStableVerificationRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    context: str
-    instance: Literal["testing", "prod"]
-    deployment_record_id: str
-    promotion_record_id: str = ""
-    verification_status: ReleaseStatus
-    verified_at: str
-    checked_urls: tuple[str, ...] = ()
-    timeout_seconds: int | None = Field(default=None, ge=1)
-    failure_summary: str = ""
-
-    @field_validator("verification_status", mode="before")
-    @classmethod
-    def _normalize_status(cls, value: object) -> ReleaseStatus:
-        return _normalize_release_status(value, label="Odoo stable verification status")
-
-    @field_validator("checked_urls", mode="before")
-    @classmethod
-    def _normalize_checked_urls(cls, value: object) -> tuple[str, ...]:
-        return _normalize_preview_verification_checked_urls(value, label="Odoo stable verification")
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "OdooStableVerificationRequest":
-        _validate_stable_verification_request(self, label="Odoo stable verification")
-        return self
-
-
-class OdooStableVerificationEnvelope(_ProductRouteEnvelope):
-    schema_version: int = Field(default=1, ge=1)
-    verification: OdooStableVerificationRequest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "OdooStableVerificationEnvelope":
-        _validate_driver_envelope_product(self.product, label="Odoo stable verification")
-        return self
-
-
-_ODOO_STABLE_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/odoo/stable-verification",
-    envelope_model=OdooStableVerificationEnvelope,
-    denial_message="Workflow cannot write Odoo stable verification for the requested product/context.",
 )
 
 
@@ -2130,7 +2002,7 @@ def _normalize_preview_verification_checked_urls(value: object, *, label: str) -
 
 
 def _validate_stable_verification_request(
-    request: GenericWebStableVerificationRequest | OdooStableVerificationRequest,
+    request: GenericWebStableVerificationRequest,
     *,
     label: str,
 ) -> None:
@@ -5078,7 +4950,6 @@ def _accepted_payload(
         "verification_status",
         "verified_at",
         "generic_web_preview_verification",
-        "odoo_preview_verification",
         "request_id",
         "feedback_id",
         "state",
@@ -7803,55 +7674,8 @@ def _apply_generic_web_preview_verification_records(
     return result
 
 
-def _apply_odoo_preview_verification_records(
-    *,
-    control_plane_root_path: Path,
-    record_store: object,
-    request: OdooPreviewVerificationRequest,
-) -> dict[str, object]:
-    generic_request = GenericWebPreviewVerificationRequest(
-        context=request.context,
-        anchor_repo=request.anchor_repo,
-        anchor_pr_number=request.anchor_pr_number,
-        verification_status=request.verification_status,
-        verified_at=request.verified_at,
-        checked_urls=request.checked_urls,
-        timeout_seconds=request.timeout_seconds,
-        failure_summary=request.failure_summary,
-    )
-    result = _apply_generic_web_preview_verification_records(
-        control_plane_root_path=control_plane_root_path,
-        record_store=record_store,
-        request=generic_request,
-        result_key="odoo_preview_verification",
-        default_failure_summary="Odoo preview verification failed.",
-    )
-    preview_generation_id = str(result["preview_generation_id"])
-    preview_state = str(result["preview_state"])
-    generation_state = "ready" if request.verification_status == "pass" else "failed"
-    verification_result = OdooPreviewVerificationResult(
-        preview_id=str(result["preview_id"]),
-        preview_generation_id=preview_generation_id,
-        preview_state=preview_state,
-        generation_state=generation_state,
-        verification_status=request.verification_status,
-        verified_at=request.verified_at.strip(),
-        checked_urls=request.checked_urls,
-        timeout_seconds=request.timeout_seconds if request.checked_urls else None,
-        failure_summary=(
-            ""
-            if request.verification_status == "pass"
-            else str(
-                cast(dict[str, object], result["odoo_preview_verification"])["failure_summary"]
-            )
-        ),
-    )
-    result["odoo_preview_verification"] = verification_result.model_dump(mode="json")
-    return result
-
-
 def _stable_verification_health_evidence(
-    *, request: GenericWebStableVerificationRequest | OdooStableVerificationRequest
+    *, request: GenericWebStableVerificationRequest
 ) -> HealthcheckEvidence:
     return HealthcheckEvidence(
         verified=bool(request.checked_urls),
@@ -7864,7 +7688,7 @@ def _stable_verification_health_evidence(
 def _apply_generic_web_stable_verification_records(
     *,
     record_store: object,
-    request: GenericWebStableVerificationRequest | OdooStableVerificationRequest,
+    request: GenericWebStableVerificationRequest,
     label: str = "Generic web stable verification",
 ) -> dict[str, object]:
     evidence_store = cast(EvidenceIngestionStore, record_store)
@@ -7924,19 +7748,6 @@ def _apply_generic_web_stable_verification_records(
         result["promotion_health_status"] = request.verification_status
 
     return result
-
-
-def _apply_odoo_stable_verification_records(
-    *,
-    record_store: object,
-    request: OdooStableVerificationRequest,
-) -> dict[str, object]:
-    return _apply_generic_web_stable_verification_records(
-        record_store=record_store,
-        request=request,
-        label="Odoo stable verification",
-    )
-
 
 def _testing_post_deploy_detail(status: ReleaseStatus) -> str:
     if status == "pass":
@@ -12960,16 +12771,10 @@ def create_launchplane_service_app(
                     request=generic_web_workflow_request.workflow,
                 )
                 result = driver_result.model_dump(mode="json")
-            elif path in {
-                _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
-                _ODOO_ROLLBACK_PLAN_ROUTE.route_path,
-            }:
-                route_metadata = (
-                    _ODOO_ROLLBACK_PLAN_ROUTE
-                    if path == _ODOO_ROLLBACK_PLAN_ROUTE.route_path
-                    else _GENERIC_WEB_ROLLBACK_PLAN_ROUTE
+            elif path == _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path:
+                generic_web_rollback_request = (
+                    _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.envelope_model.model_validate(payload)
                 )
-                generic_web_rollback_request = route_metadata.envelope_model.model_validate(payload)
                 resolved_driver_context = _resolve_descriptor_product_driver_context(
                     record_store=record_store,
                     route_path=path,
@@ -12987,7 +12792,7 @@ def create_launchplane_service_app(
                     route_path=path,
                     product=resolved_driver_context.profile.product,
                     context=resolved_driver_context.lane.context,
-                    denial_message=route_metadata.denial_message,
+                    denial_message=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE.denial_message,
                     start_response=start_response,
                     trace_id=request_trace_id,
                 )
@@ -14492,43 +14297,6 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     request=verireel_preview_verification_request.verification,
                 )
-            elif path == _ODOO_PREVIEW_VERIFICATION_ROUTE.route_path:
-                odoo_preview_verification_request = (
-                    _ODOO_PREVIEW_VERIFICATION_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=odoo_preview_verification_request.product,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=odoo_preview_verification_request.product,
-                    context=odoo_preview_verification_request.verification.context,
-                    denial_message=_ODOO_PREVIEW_VERIFICATION_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                result = _apply_odoo_preview_verification_records(
-                    control_plane_root_path=resolved_root,
-                    record_store=record_store,
-                    request=odoo_preview_verification_request.verification,
-                )
             elif path == _ODOO_PREVIEW_APPLY_ROUTE.route_path:
                 odoo_preview_apply_request = (
                     _ODOO_PREVIEW_APPLY_ROUTE.envelope_model.model_validate(payload)
@@ -14629,44 +14397,6 @@ def create_launchplane_service_app(
                     database_url=database_url,
                 )
                 result = driver_result
-            elif path == _ODOO_STABLE_VERIFICATION_ROUTE.route_path:
-                odoo_stable_verification_request = (
-                    _ODOO_STABLE_VERIFICATION_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=odoo_stable_verification_request.product,
-                    context=odoo_stable_verification_request.verification.context,
-                    instance=odoo_stable_verification_request.verification.instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=odoo_stable_verification_request.product,
-                    context=odoo_stable_verification_request.verification.context,
-                    denial_message=_ODOO_STABLE_VERIFICATION_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                result = _apply_odoo_stable_verification_records(
-                    record_store=record_store,
-                    request=odoo_stable_verification_request.verification,
-                )
             elif path == "/v1/product-profiles/context-cutover/apply":
                 context_cutover_request = control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(
                     payload

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -57,10 +57,15 @@ Keep a compatibility surface only when it is one of these:
   `provider_id`, and `provider_target_type`; internal Dokploy execution config
   keeps target-type fields only where application-vs-compose behavior is still
   required.
-- Odoo-shaped preview desired-state, inventory, readiness, refresh, and destroy
-  aliases are retired. Odoo preview workflows use `preview-apply-inputs` and
-  `preview-apply` for isolated provider mutation, and common preview
-  read/planning callers use the inherited generic-web routes.
+- Odoo-shaped preview desired-state, inventory, readiness, verification,
+  refresh, and destroy aliases are retired. Odoo preview workflows use
+  `preview-apply-inputs` and `preview-apply` for isolated provider mutation,
+  and common preview read/planning/evidence callers use the inherited
+  generic-web routes.
+- The Odoo-shaped stable verification alias is retired. Odoo stable smoke
+  follow-ups use `POST /v1/drivers/generic-web/stable-verification`.
+- The Odoo-shaped rollback-plan alias is retired. Odoo rollback planning uses
+  `POST /v1/drivers/generic-web/prod-rollback-plan`.
 - `control_plane` remains the Python package name for now. Do not add public
   `odoo-control-plane` names, env vars, or docs; prefer Launchplane wording for
   product/operator surfaces.

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -199,9 +199,9 @@ such as Odoo can keep a product-specific rollback action while they still need
 extra gates around backups, release tuples, manifests, migrations, or post-deploy
 validation.
 
-Odoo accepts `POST /v1/drivers/odoo/prod-rollback-plan` as a compatibility alias
-for the generic-web rollback planner. The alias is plan-only: it writes the same
-generic rollback-plan record and does not change Odoo's product-specific
+Odoo rollback planning uses
+`POST /v1/drivers/generic-web/prod-rollback-plan`. The former Odoo-shaped
+rollback-plan alias is retired; this does not change Odoo's product-specific
 `POST /v1/drivers/odoo/prod-rollback` apply route.
 
 Required planner input:

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -158,10 +158,9 @@ The `prod_rollback_plan` action routes to
 `POST /v1/drivers/generic-web/prod-rollback-plan`. It is a safe-write planner:
 Launchplane reads the product profile, destination lane, selected deployment
 record, and optional backup gate evidence, then writes a
-`GenericWebRollbackPlanRecord`. It does not mutate the provider. Odoo also
-accepts `POST /v1/drivers/odoo/prod-rollback-plan` as a non-operator
-compatibility alias for existing Odoo-shaped automation; the canonical action
-and persisted record remain generic-web-owned.
+`GenericWebRollbackPlanRecord`. It does not mutate the provider. Odoo rollback
+planning uses this generic-web route; the former Odoo-shaped rollback-plan alias
+is retired.
 
 The `prod_rollback` action routes to
 `POST /v1/drivers/generic-web/prod-rollback`. It re-runs the same rollback-plan
@@ -183,9 +182,8 @@ The `stable_verification` action routes to
 `POST /v1/drivers/generic-web/stable-verification`. Product workflows submit the
 deployment record, optional promotion record, checked URLs, and pass/fail status;
 Launchplane updates deployment, promotion, and inventory evidence without
-mutating provider state. Product-shaped stable verification paths, such as
-`POST /v1/drivers/odoo/stable-verification`, are compatibility aliases unless a
-driver documents additional product-specific evidence.
+mutating provider state. Odoo stable smoke follow-ups use this generic-web route;
+the former Odoo-shaped stable verification alias is retired.
 
 The `preview_desired_state` action routes to
 `POST /v1/drivers/generic-web/preview-desired-state`. Product workflows provide
@@ -226,10 +224,9 @@ Odoo declares `base_driver_id="generic-web"` and inherits generic-web preview
 actions as its advertised lifecycle surface. The Odoo-specific preview mutation
 surface is the isolated compose planner/apply pair, not Odoo-shaped
 `preview-refresh` or `preview-destroy` compatibility aliases. Odoo preview
-desired-state, inventory, and readiness aliases are retired; callers should use
-the inherited generic-web routes for common read/planning actions. Odoo preview
-verification remains a non-operator route alias while it preserves typed Odoo
-evidence without mutating provider state.
+desired-state, inventory, readiness, and verification aliases are retired;
+callers should use the inherited generic-web routes for common
+read/planning/evidence actions.
 New tenant workflows should call `POST /v1/drivers/odoo/preview-apply-inputs`
 and then `POST /v1/drivers/odoo/preview-apply` for refresh and destroy. The
 lower-level `POST /v1/drivers/odoo/preview-apply` route applies a ready isolated-preview
@@ -264,9 +261,10 @@ The
 standard refresh/destroy routes use the generic-web preview request schema, live
 URL derivation, and record writer so Odoo PR previews land in the same
 Launchplane preview and preview-generation records as generic-web previews.
-The compatibility preview-verification route accepts optional checked URL
-evidence and returns a typed `odoo_preview_verification` result while delegating
-the durable record mutation to the same generic-web preview verification writer.
+Preview smoke follow-ups use
+`POST /v1/drivers/generic-web/preview-verification`, which accepts optional
+checked URL evidence and returns a typed `generic_web_preview_verification`
+result while writing durable status to the shared preview records.
 Odoo's staged compose preview MVP is now retired. Generic-web preview readiness
 blocks compose template lanes, including historical Odoo bootstrap-mode compose
 profiles; Odoo PR previews must enter through `plan_odoo_preview_runtime` and
@@ -324,7 +322,7 @@ failed through the same preview-generation records without mutating provider
 state.
 Stable smoke follow-ups should use
 `POST /v1/drivers/generic-web/stable-verification`; the Odoo-shaped stable
-verification route remains a compatibility alias for existing workflows.
+verification route is retired.
 
 Odoo also exposes `POST /v1/drivers/odoo/stable-bootstrap` as a destructive
 instance-scoped action. It is enabled per product-profile lane through

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -140,9 +140,8 @@ timeout, and optional failure summary. Launchplane resolves generic-web base
 driver compatibility from the product profile, updates the latest preview
 generation, and returns a typed `generic_web_preview_verification` result while
 preserving durable status/failure evidence in the same preview records used by
-refresh. Product-specific preview verification routes, such as
-`POST /v1/drivers/odoo/preview-verification`, are compatibility aliases unless a
-driver document names additional product-specific evidence.
+refresh. Odoo preview verification uses this generic-web route; the former
+Odoo-shaped preview verification alias is retired.
 
 Preview destroy routes receive the PR number, source/run metadata, and an
 explicit destroy reason such as `pull_request_closed`, `preview_label_removed`,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -116,10 +116,8 @@ VeriReel product paths:
   - `POST /v1/drivers/odoo/target-replacement-apply`
   - `POST /v1/drivers/odoo/preview-apply-inputs`
   - `POST /v1/drivers/odoo/preview-apply`
-  - `POST /v1/drivers/odoo/stable-verification`
   - `POST /v1/drivers/odoo/prod-backup-gate`
   - `POST /v1/drivers/odoo/prod-promotion`
-  - `POST /v1/drivers/odoo/prod-rollback-plan`
   - `POST /v1/drivers/odoo/prod-rollback`
   - `POST /v1/drivers/verireel/testing-deploy`
   - `POST /v1/drivers/verireel/testing-verification`
@@ -1327,26 +1325,25 @@ secret material.
 The route is idempotency-keyed and intended for approved non-production Odoo
 preview targets while the isolated runtime migration is being exercised.
 
-For
-Odoo preview smoke follow-ups, `POST /v1/drivers/odoo/preview-verification`
-remains a compatibility alias for the generic-web preview verification action.
-It accepts the product, context, anchor repo/PR, `verification_status`,
-`verified_at`, optional checked URLs as an explicit list plus
-`timeout_seconds`, and an optional failure summary, then marks the latest preview
-generation ready or failed. Scalar or object-shaped `checked_urls` payloads are
-rejected. The accepted response includes an `odoo_preview_verification` result
-with the generation identity, final states, status, checked URLs, timeout, and
-failure summary. The route is safe-write evidence ingestion only; it does not
-mutate provider state.
+For Odoo preview smoke follow-ups,
+`POST /v1/drivers/generic-web/preview-verification` accepts the product,
+context, anchor repo/PR, `verification_status`, `verified_at`, optional checked
+URLs as an explicit list plus `timeout_seconds`, and an optional failure
+summary, then marks the latest preview generation ready or failed. Scalar or
+object-shaped `checked_urls` payloads are rejected. The accepted response
+includes a `generic_web_preview_verification` result with the generation
+identity, final states, status, checked URLs, timeout, and failure summary. The
+Odoo-shaped preview verification alias is retired. The route is safe-write
+evidence ingestion only; it does not mutate provider state.
 
 For stable smoke follow-ups,
 `POST /v1/drivers/generic-web/stable-verification` accepts the product, context,
 instance, deployment record, optional promotion record, checked URLs,
 `verification_status`, `verified_at`, and optional failure summary. Launchplane
 updates deployment health evidence and, when a promotion record is supplied,
-promotion/inventory evidence. Product-shaped routes such as
-`POST /v1/drivers/odoo/stable-verification` remain compatibility aliases. The
-route is safe-write evidence ingestion only; it does not mutate provider state.
+promotion/inventory evidence. The former Odoo-shaped stable verification alias
+is retired. The route is safe-write evidence ingestion only; it does not mutate
+provider state.
 
 `POST /v1/evidence/previews/generations`
 

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -169,16 +169,9 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertNotIn("preview_inventory", route_aliases)
         self.assertNotIn("preview_readiness", route_aliases)
         self.assertNotIn("preview_verification", actions)
-        self.assertEqual(
-            route_aliases["preview_verification"].route_path,
-            "/v1/drivers/odoo/preview-verification",
-        )
-        self.assertFalse(route_aliases["preview_verification"].operator_visible)
-        self.assertEqual(
-            route_aliases["prod_rollback_plan"].route_path,
-            "/v1/drivers/odoo/prod-rollback-plan",
-        )
-        self.assertFalse(route_aliases["prod_rollback_plan"].operator_visible)
+        self.assertNotIn("preview_verification", route_aliases)
+        self.assertNotIn("stable_verification", route_aliases)
+        self.assertNotIn("prod_rollback_plan", route_aliases)
         self.assertEqual(actions["stable_bootstrap"].safety, "destructive")
         self.assertEqual(
             actions["stable_bootstrap"].route_path,
@@ -335,16 +328,8 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertFalse(
             route_actions["/v1/drivers/generic-web/stable-verification"].operator_visible
         )
-        self.assertEqual(
-            route_actions["/v1/drivers/odoo/preview-verification"].authz_action,
-            "preview_generation.write",
-        )
-        self.assertFalse(route_actions["/v1/drivers/odoo/preview-verification"].operator_visible)
-        self.assertEqual(
-            route_actions["/v1/drivers/odoo/stable-verification"].authz_action,
-            "deployment.write",
-        )
-        self.assertFalse(route_actions["/v1/drivers/odoo/stable-verification"].operator_visible)
+        self.assertNotIn("/v1/drivers/odoo/preview-verification", route_actions)
+        self.assertNotIn("/v1/drivers/odoo/stable-verification", route_actions)
 
     def test_service_accepts_descriptor_post_driver_routes(self) -> None:
         descriptor_post_route_metadata = {
@@ -534,25 +519,17 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "/v1/drivers/odoo/preview-readiness",
             control_plane_service._driver_route_metadata_from_descriptors(),
         )
-        self.assertEqual(
-            control_plane_service._driver_route_metadata_from_descriptors()[
-                "/v1/drivers/odoo/preview-verification"
-            ].action_id,
-            "preview_verification",
+        self.assertNotIn(
+            "/v1/drivers/odoo/preview-verification",
+            control_plane_service._driver_route_metadata_from_descriptors(),
         )
-        self.assertEqual(
-            control_plane_service._driver_route_metadata_from_descriptors()[
-                "/v1/drivers/odoo/prod-rollback-plan"
-            ].action_id,
-            "prod_rollback_plan",
+        self.assertNotIn(
+            "/v1/drivers/odoo/prod-rollback-plan",
+            control_plane_service._driver_route_metadata_from_descriptors(),
         )
-        self.assertIn(
+        self.assertNotIn(
             "/v1/drivers/odoo/prod-rollback-plan",
             control_plane_service._build_write_routes(),
-        )
-        self.assertIs(
-            control_plane_service._ODOO_PREVIEW_VERIFICATION_ROUTE.envelope_model,
-            control_plane_service.OdooPreviewVerificationEnvelope,
         )
         self.assert_route_metadata_matches_descriptor(
             driver_id="odoo",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -110,7 +110,7 @@ from control_plane.merge_train import MergeTrainCheckStatus
 from control_plane.merge_train import build_merge_train_dry_run_result
 from control_plane.merge_train import discover_merge_train_stack
 from control_plane.service import (
-    OdooPreviewVerificationRequest,
+    GenericWebPreviewVerificationRequest,
     create_launchplane_service_app as _create_launchplane_service_app,
 )
 from control_plane.service_auth import (
@@ -16164,70 +16164,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
-    def test_odoo_rollback_plan_alias_writes_generic_plan_record(self) -> None:
+    def test_odoo_rollback_plan_alias_is_retired(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(
-                    _odoo_profile_payload_with_prod_lane()
-                )
-            )
-            deployment_record = DeploymentRecord(
-                record_id="deployment-cm-prod-previous",
-                artifact_identity=ArtifactIdentityReference(
-                    artifact_id="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123"
-                ),
-                context="cm",
-                instance="prod",
-                source_git_ref="abc123",
-                destination_health=HealthcheckEvidence(status="pass"),
-                resolved_target=ResolvedTargetEvidence(
-                    target_type="application",
-                    target_id="app-cm-prod",
-                    target_name="cm-prod-app",
-                ),
-                deploy=DeploymentEvidence(
-                    target_name="cm-prod-app",
-                    target_type="application",
-                    deploy_mode="dokploy-application-api",
-                    deployment_id="deployment-provider-1",
-                    status="pass",
-                    started_at="2026-05-25T12:00:00Z",
-                    finished_at="2026-05-25T12:01:00Z",
-                ),
-            )
-            store.write_deployment_record(deployment_record)
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/odoo-tenant-cm",
-                            "workflow_refs": [
-                                "cbusillo/odoo-tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["generic_web_prod_rollback.plan"],
-                        }
-                    ]
-                }
-            )
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
                 state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/odoo-tenant-cm",
-                        workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
             )
 
             status_code, payload = _invoke_app(
@@ -16247,79 +16190,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 headers={"Idempotency-Key": "odoo-rollback-plan-cm-prod"},
             )
 
-            plans = store.list_generic_web_rollback_plan_records(
-                context_name="cm",
-                instance_name="prod",
-                limit=1,
-            )
-            plan = plans[0]
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["records"]["generic_web_rollback_plan_id"], plan.plan_id)
-        self.assertEqual(plan.status, "ready")
-        self.assertEqual(plan.product, "odoo-tenant-cm")
-        self.assertEqual(plan.context, "cm")
-        self.assertEqual(plan.rollback_deployment_record_id, "deployment-cm-prod-previous")
-
-    def test_odoo_rollback_plan_alias_rejects_unauthorized_context(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(
-                    _odoo_profile_payload_with_prod_lane()
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/odoo-tenant-cm",
-                            "workflow_refs": [
-                                "cbusillo/odoo-tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["other-context"],
-                            "actions": ["generic_web_prod_rollback.plan"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/odoo-tenant-cm",
-                        workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/prod-rollback-plan",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "rollback_plan": {
-                        "schema_version": 1,
-                        "product": "odoo-tenant-cm",
-                        "instance": "prod",
-                        "rollback_deployment_record_id": "deployment-cm-prod-previous",
-                    },
-                },
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_generic_web_rollback_route_applies_ready_plan(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -18235,82 +18107,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     self.assertEqual(status_code, 404)
                     self.assertEqual(payload["error"]["code"], "not_found")
 
-    def test_odoo_preview_verification_driver_marks_latest_generation_ready(self) -> None:
+    def test_odoo_preview_verification_route_is_retired(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
-            store.write_preview_record(
-                PreviewRecord(
-                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
-                    context="cm",
-                    anchor_repo="odoo-tenant-cm",
-                    anchor_pr_number=42,
-                    anchor_pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
-                    preview_label="preview",
-                    canonical_url="https://pr-42.cm-preview.example.test",
-                    state="pending",
-                    created_at="2026-05-09T15:00:00Z",
-                    updated_at="2026-05-09T15:05:00Z",
-                    eligible_at="2026-05-09T15:00:00Z",
-                    active_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
-                    latest_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
-                    latest_manifest_fingerprint="odoo-preview-manifest-pr-42-abc123",
-                )
-            )
-            store.write_preview_generation_record(
-                PreviewGenerationRecord(
-                    generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
-                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
-                    sequence=1,
-                    state="verifying",
-                    requested_reason="external_preview_refresh",
-                    requested_at="2026-05-09T15:00:00Z",
-                    started_at="2026-05-09T15:00:00Z",
-                    resolved_manifest_fingerprint="odoo-preview-manifest-pr-42-abc123",
-                    artifact_id="ghcr.io/cbusillo/odoo-tenant-cm:sha",
-                    anchor_summary=PreviewPullRequestSummary(
-                        repo="odoo-tenant-cm",
-                        pr_number=42,
-                        head_sha="abc123",
-                        pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
-                    ),
-                    deploy_status="pass",
-                    verify_status="pending",
-                    overall_health_status="pending",
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/odoo-tenant-cm",
-                            "workflow_refs": [
-                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["preview_generation.write"],
-                        }
-                    ]
-                }
-            )
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
                 state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/odoo-tenant-cm",
-                        workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
             )
 
             status_code, payload = _invoke_app(
@@ -18337,33 +18140,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 headers={"Idempotency-Key": "odoo-preview-verification:cm:42:run-1"},
             )
 
-            self.assertEqual(status_code, 202)
-            self.assertEqual(payload["records"]["transition"], "ready")
-            self.assertEqual(payload["records"]["preview_state"], "active")
-            self.assertEqual(
-                payload["records"]["preview_generation_id"],
-                "preview-cm-odoo-tenant-cm-pr-42-generation-0001",
-            )
-            self.assertEqual(payload["records"]["verification_status"], "pass")
-            self.assertEqual(payload["records"]["verified_at"], "2026-05-09T15:08:00Z")
-            self.assertEqual(
-                payload["records"]["odoo_preview_verification"]["checked_urls"],
-                [
-                    "https://pr-42.cm-preview.example.test/web/health",
-                    "https://pr-42.cm-preview.example.test/cell-mechanic",
-                ],
-            )
-            self.assertEqual(payload["records"]["odoo_preview_verification"]["timeout_seconds"], 30)
-            preview = store.read_preview_record("preview-cm-odoo-tenant-cm-pr-42")
-            generation = store.read_preview_generation_record(
-                "preview-cm-odoo-tenant-cm-pr-42-generation-0001"
-            )
-            self.assertEqual(preview.state, "active")
-            self.assertEqual(preview.serving_generation_id, generation.generation_id)
-            self.assertEqual(generation.state, "ready")
-            self.assertEqual(generation.verify_status, "pass")
-            self.assertEqual(generation.overall_health_status, "pass")
-            self.assertEqual(generation.ready_at, "2026-05-09T15:08:00Z")
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_generic_web_preview_verification_route_accepts_odoo_base_driver_profile(
         self,
@@ -18484,316 +18262,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(generation.verify_status, "pass")
             self.assertEqual(generation.overall_health_status, "pass")
 
-    def test_odoo_preview_verification_driver_marks_latest_generation_failed(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(
-                    _odoo_profile_payload_with_prod_lane()
-                )
-            )
-            store.write_preview_record(
-                PreviewRecord(
-                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
-                    context="cm",
-                    anchor_repo="odoo-tenant-cm",
-                    anchor_pr_number=42,
-                    anchor_pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
-                    preview_label="preview",
-                    canonical_url="https://pr-42.cm-preview.example.test",
-                    state="active",
-                    created_at="2026-05-09T15:00:00Z",
-                    updated_at="2026-05-09T15:05:00Z",
-                    eligible_at="2026-05-09T15:00:00Z",
-                    active_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
-                    serving_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
-                    latest_generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
-                    latest_manifest_fingerprint="odoo-preview-manifest-pr-42-abc123",
-                )
-            )
-            store.write_preview_generation_record(
-                PreviewGenerationRecord(
-                    generation_id="preview-cm-odoo-tenant-cm-pr-42-generation-0001",
-                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
-                    sequence=1,
-                    state="verifying",
-                    requested_reason="external_preview_refresh",
-                    requested_at="2026-05-09T15:00:00Z",
-                    started_at="2026-05-09T15:00:00Z",
-                    resolved_manifest_fingerprint="odoo-preview-manifest-pr-42-abc123",
-                    artifact_id="ghcr.io/cbusillo/odoo-tenant-cm:sha",
-                    anchor_summary=PreviewPullRequestSummary(
-                        repo="odoo-tenant-cm",
-                        pr_number=42,
-                        head_sha="abc123",
-                        pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
-                    ),
-                    deploy_status="pass",
-                    verify_status="pending",
-                    overall_health_status="pending",
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/odoo-tenant-cm",
-                            "workflow_refs": [
-                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["preview_generation.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/odoo-tenant-cm",
-                        workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/preview-verification",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "verification": {
-                        "schema_version": 1,
-                        "context": "cm",
-                        "anchor_repo": "odoo-tenant-cm",
-                        "anchor_pr_number": 42,
-                        "verification_status": "fail",
-                        "verified_at": "2026-05-09T15:08:00Z",
-                        "checked_urls": ["https://pr-42.cm-preview.example.test/cell-mechanic"],
-                        "timeout_seconds": 20,
-                        "failure_summary": "Odoo preview page did not include Cell Mechanic.",
-                    },
-                },
-                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:run-1"},
-            )
-
-            self.assertEqual(status_code, 202)
-            self.assertEqual(payload["records"]["transition"], "failed")
-            self.assertEqual(payload["records"]["preview_state"], "failed")
-            self.assertEqual(payload["records"]["verification_status"], "fail")
-            self.assertEqual(
-                payload["records"]["odoo_preview_verification"]["failure_summary"],
-                "Odoo preview page did not include Cell Mechanic.",
-            )
-            preview = store.read_preview_record("preview-cm-odoo-tenant-cm-pr-42")
-            generation = store.read_preview_generation_record(
-                "preview-cm-odoo-tenant-cm-pr-42-generation-0001"
-            )
-            self.assertEqual(preview.state, "failed")
-            self.assertEqual(generation.state, "failed")
-            self.assertEqual(generation.verify_status, "fail")
-            self.assertEqual(generation.overall_health_status, "fail")
-            self.assertEqual(generation.failure_stage, "verify")
-            self.assertIn("Cell Mechanic", generation.failure_summary)
-
-    def test_odoo_preview_verification_driver_rejects_checked_urls_without_timeout(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            state_dir = Path(temporary_directory_name) / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/odoo-tenant-cm",
-                            "workflow_refs": [
-                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["preview_generation.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/odoo-tenant-cm",
-                        workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=policy,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/preview-verification",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "verification": {
-                        "schema_version": 1,
-                        "context": "cm",
-                        "anchor_repo": "odoo-tenant-cm",
-                        "anchor_pr_number": 42,
-                        "verification_status": "pass",
-                        "verified_at": "2026-05-09T15:08:00Z",
-                        "checked_urls": ["https://pr-42.cm-preview.example.test/web/health"],
-                    },
-                },
-                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:missing-timeout"},
-            )
-
-            self.assertEqual(status_code, 400)
-            self.assertEqual(payload["error"]["code"], "invalid_request")
-
-    def test_odoo_preview_verification_driver_rejects_checked_url_mapping(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            state_dir = Path(temporary_directory_name) / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/odoo-tenant-cm",
-                            "workflow_refs": [
-                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["preview_generation.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/odoo-tenant-cm",
-                        workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=policy,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/preview-verification",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "verification": {
-                        "schema_version": 1,
-                        "context": "cm",
-                        "anchor_repo": "odoo-tenant-cm",
-                        "anchor_pr_number": 42,
-                        "verification_status": "pass",
-                        "verified_at": "2026-05-09T15:08:00Z",
-                        "checked_urls": {
-                            "health": "https://pr-42.cm-preview.example.test/web/health"
-                        },
-                        "timeout_seconds": 30,
-                    },
-                },
-                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:mapping"},
-            )
-
-            self.assertEqual(status_code, 400)
-            self.assertEqual(payload["error"]["code"], "invalid_request")
-
-    def test_odoo_preview_verification_driver_rejects_scalar_checked_url(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            state_dir = Path(temporary_directory_name) / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/odoo-tenant-cm",
-                            "workflow_refs": [
-                                "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["preview_generation.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/odoo-tenant-cm",
-                        workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=policy,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/preview-verification",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "verification": {
-                        "schema_version": 1,
-                        "context": "cm",
-                        "anchor_repo": "odoo-tenant-cm",
-                        "anchor_pr_number": 42,
-                        "verification_status": "pass",
-                        "verified_at": "2026-05-09T15:08:00Z",
-                        "checked_urls": "https://pr-42.cm-preview.example.test/web/health",
-                        "timeout_seconds": 30,
-                    },
-                },
-                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:scalar"},
-            )
-
-            self.assertEqual(status_code, 400)
-            self.assertEqual(payload["error"]["code"], "invalid_request")
-
-    def test_odoo_preview_verification_request_accepts_explicit_url_collections(
+    def test_generic_web_preview_verification_request_accepts_explicit_url_collections(
         self,
     ) -> None:
         base_payload = {
@@ -18806,13 +18275,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             "timeout_seconds": 30,
         }
 
-        list_request = OdooPreviewVerificationRequest.model_validate(
+        list_request = GenericWebPreviewVerificationRequest.model_validate(
             {
                 **base_payload,
                 "checked_urls": [" https://pr-42.cm-preview.example.test/web/health "],
             }
         )
-        tuple_request = OdooPreviewVerificationRequest.model_validate(
+        tuple_request = GenericWebPreviewVerificationRequest.model_validate(
             {
                 **base_payload,
                 "checked_urls": ("https://pr-42.cm-preview.example.test/cell-mechanic",),
@@ -19537,63 +19006,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 headers={
                     "Idempotency-Key": "odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123"
                 },
-            )
-
-            self.assertEqual(status_code, 403)
-            self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_odoo_preview_verification_driver_rejects_unauthorized_workflow(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            state_dir = Path(temporary_directory_name) / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/odoo-tenant-cm",
-                        workflow_ref=(
-                            "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate(
-                    {
-                        "github_actions": [
-                            {
-                                "repository": "cbusillo/odoo-tenant-cm",
-                                "workflow_refs": [
-                                    "cbusillo/odoo-tenant-cm/.github/workflows/preview.yml@refs/heads/main"
-                                ],
-                                "event_names": ["pull_request"],
-                                "products": ["odoo-tenant-cm"],
-                                "contexts": ["cm"],
-                                "actions": ["preview_refresh.execute"],
-                            }
-                        ]
-                    }
-                ),
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/preview-verification",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "verification": {
-                        "schema_version": 1,
-                        "context": "cm",
-                        "anchor_repo": "odoo-tenant-cm",
-                        "anchor_pr_number": 42,
-                        "verification_status": "pass",
-                        "verified_at": "2026-05-09T15:08:00Z",
-                    },
-                },
-                headers={"Idempotency-Key": "odoo-preview-verification:cm:42:run-1"},
             )
 
             self.assertEqual(status_code, 403)
@@ -23335,62 +22747,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(inventory.deployment_record_id, deployment.record_id)
             self.assertEqual(inventory.promotion_record_id, "")
 
-    def test_odoo_stable_verification_driver_updates_testing_deployment_record(self) -> None:
+    def test_odoo_stable_verification_route_is_retired(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
-            store.write_deployment_record(
-                DeploymentRecord(
-                    record_id="deployment-20260420T153000Z-cm-testing",
-                    artifact_identity=ArtifactIdentityReference(
-                        artifact_id="artifact-20260420-a1b2c3d4"
-                    ),
-                    context="cm",
-                    instance="testing",
-                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
-                    deploy=DeploymentEvidence(
-                        target_name="cm-testing",
-                        target_type="compose",
-                        deploy_mode="dokploy-compose-api",
-                        deployment_id="delegated-compose-ship",
-                        status="pass",
-                    ),
-                    destination_health=HealthcheckEvidence(status="pending"),
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/tenant-cm",
-                            "workflow_refs": [
-                                "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["deployment.write"],
-                        }
-                    ]
-                }
-            )
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
                 state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="every/tenant-cm",
-                        workflow_ref=(
-                            "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
             )
 
             status_code, payload = _invoke_app(
@@ -23414,48 +22777,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 headers={"Idempotency-Key": "odoo-stable-verification:cm:testing:1"},
             )
 
-            self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2))
-            self.assertEqual(payload["status"], "accepted")
-            self.assertEqual(
-                payload["records"],
-                {
-                    "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
-                    "inventory_record_id": "cm-testing",
-                },
-            )
-            deployment = store.read_deployment_record("deployment-20260420T153000Z-cm-testing")
-            inventory = store.read_environment_inventory(context_name="cm", instance_name="testing")
-            self.assertEqual(deployment.destination_health.status, "pass")
-            self.assertEqual(
-                deployment.destination_health.urls,
-                ("https://cm-testing.example.com/web/health",),
-            )
-            self.assertEqual(inventory.deployment_record_id, deployment.record_id)
-
-            replay_status, replay_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/stable-verification",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "verification": {
-                        "schema_version": 1,
-                        "context": "cm",
-                        "instance": "testing",
-                        "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
-                        "verification_status": "success",
-                        "verified_at": "2026-04-20T15:35:00Z",
-                        "checked_urls": ["https://cm-testing.example.com/web/health"],
-                        "timeout_seconds": 45,
-                    },
-                },
-                headers={"Idempotency-Key": "odoo-stable-verification:cm:testing:1"},
-            )
-
-            self.assertEqual(replay_status, 202, msg=json.dumps(replay_payload, indent=2))
-            self.assertTrue(replay_payload["replayed"])
-            self.assertEqual(replay_payload["records"], payload["records"])
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_generic_web_stable_verification_route_accepts_odoo_base_driver_profile(
         self,
@@ -23555,211 +22878,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ("https://cm-testing.example.com/web/health",),
             )
             self.assertEqual(inventory.deployment_record_id, deployment.record_id)
-
-    def test_odoo_stable_verification_driver_updates_prod_promotion_record(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            profile_payload = _odoo_preview_profile_payload("odoo-tenant-cm")
-            lanes = list(cast(tuple[dict[str, object], ...], profile_payload["lanes"]))
-            lanes.append(
-                {
-                    "instance": "prod",
-                    "context": "cm",
-                    "base_url": "https://cm.example.com",
-                    "health_url": "https://cm.example.com/web/health",
-                }
-            )
-            profile_payload["lanes"] = tuple(lanes)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(profile_payload)
-            )
-            store.write_deployment_record(
-                DeploymentRecord(
-                    record_id="deployment-20260420T160500Z-cm-prod",
-                    artifact_identity=ArtifactIdentityReference(
-                        artifact_id="artifact-20260420-a1b2c3d4"
-                    ),
-                    context="cm",
-                    instance="prod",
-                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
-                    deploy=DeploymentEvidence(
-                        target_name="cm-prod",
-                        target_type="compose",
-                        deploy_mode="dokploy-compose-api",
-                        deployment_id="delegated-compose-ship",
-                        status="pass",
-                    ),
-                    destination_health=HealthcheckEvidence(status="pending"),
-                )
-            )
-            store.write_promotion_record(
-                PromotionRecord(
-                    record_id="promotion-20260420T160500Z-cm-testing-to-prod",
-                    artifact_identity=ArtifactIdentityReference(
-                        artifact_id="artifact-20260420-a1b2c3d4"
-                    ),
-                    deployment_record_id="deployment-20260420T160500Z-cm-prod",
-                    backup_record_id="backup-cm-prod-20260420T155000Z",
-                    context="cm",
-                    from_instance="testing",
-                    to_instance="prod",
-                    deploy=DeploymentEvidence(
-                        target_name="cm-prod",
-                        target_type="compose",
-                        deploy_mode="dokploy-compose-api",
-                        deployment_id="delegated-compose-ship",
-                        status="pass",
-                    ),
-                    destination_health=HealthcheckEvidence(status="pending"),
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/tenant-cm",
-                            "workflow_refs": [
-                                "every/tenant-cm/.github/workflows/prod-smoke.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["deployment.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="every/tenant-cm",
-                        workflow_ref=(
-                            "every/tenant-cm/.github/workflows/prod-smoke.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/stable-verification",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "verification": {
-                        "schema_version": 1,
-                        "context": "cm",
-                        "instance": "prod",
-                        "deployment_record_id": "deployment-20260420T160500Z-cm-prod",
-                        "promotion_record_id": "promotion-20260420T160500Z-cm-testing-to-prod",
-                        "verification_status": "failure",
-                        "verified_at": "2026-04-20T16:12:00Z",
-                        "checked_urls": ["https://cm.example.com/web/health"],
-                        "timeout_seconds": 45,
-                        "failure_summary": "Prod smoke failed.",
-                    },
-                },
-            )
-
-            self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2))
-            self.assertEqual(
-                payload["records"]["deployment_record_id"],
-                "deployment-20260420T160500Z-cm-prod",
-            )
-            self.assertEqual(
-                payload["records"]["promotion_record_id"],
-                "promotion-20260420T160500Z-cm-testing-to-prod",
-            )
-            deployment = store.read_deployment_record("deployment-20260420T160500Z-cm-prod")
-            promotion = store.read_promotion_record("promotion-20260420T160500Z-cm-testing-to-prod")
-            inventory = store.read_environment_inventory(context_name="cm", instance_name="prod")
-            self.assertEqual(deployment.destination_health.status, "fail")
-            self.assertEqual(promotion.destination_health.status, "fail")
-            self.assertEqual(inventory.promotion_record_id, promotion.record_id)
-            self.assertEqual(inventory.promoted_from_instance, "testing")
-
-    def test_odoo_stable_verification_driver_rejects_mismatched_deployment(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(
-                    _odoo_profile_payload_with_prod_lane()
-                )
-            )
-            store.write_deployment_record(
-                DeploymentRecord(
-                    record_id="deployment-20260420T153000Z-cm-testing",
-                    context="cm",
-                    instance="testing",
-                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
-                    deploy=DeploymentEvidence(
-                        target_name="cm-testing",
-                        target_type="compose",
-                        deploy_mode="dokploy-compose-api",
-                        status="pass",
-                    ),
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/tenant-cm",
-                            "workflow_refs": [
-                                "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["deployment.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="every/tenant-cm",
-                        workflow_ref=(
-                            "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/odoo/stable-verification",
-                payload={
-                    "schema_version": 1,
-                    "product": "odoo-tenant-cm",
-                    "verification": {
-                        "schema_version": 1,
-                        "context": "cm",
-                        "instance": "prod",
-                        "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
-                        "verification_status": "success",
-                        "verified_at": "2026-04-20T16:12:00Z",
-                    },
-                },
-            )
-
-            self.assertEqual(status_code, 400)
-            self.assertEqual(payload["error"]["code"], "invalid_request")
 
     def test_deployment_endpoint_replays_idempotent_write(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- retire Odoo-shaped preview verification, stable verification, and rollback-plan compatibility routes
- keep the canonical generic-web routes as the supported inherited Odoo surface
- update docs and tests to assert retired Odoo routes fail closed with 404

## Verification
- uv run python -m unittest
- agent review batch ff030228: no findings from code-gpt-5.5 and claude-sonnet-4.6
