### PR TITLE
Require VeriReel maintenance intent

### DIFF
--- a/control_plane/workflows/verireel_app_maintenance.py
+++ b/control_plane/workflows/verireel_app_maintenance.py
@@ -22,7 +22,6 @@ VeriReelAppMaintenanceAction = Literal[
     "reset-testing",
 ]
 VeriReelAppMaintenanceIntent = Literal[
-    "",
     "stable-testing-migration",
     "stable-testing-reset",
     "remote-e2e-grant-sponsored",
@@ -57,7 +56,7 @@ class VeriReelAppMaintenanceRequest(BaseModel):
     context: Literal["verireel", "verireel-testing"] = "verireel"
     instance: Literal["testing", "preview"] = "testing"
     action: VeriReelAppMaintenanceAction
-    intent: VeriReelAppMaintenanceIntent = ""
+    intent: VeriReelAppMaintenanceIntent
     email: str = ""
     application_name: str = ""
     preview_slug: str = ""
@@ -107,14 +106,13 @@ class VeriReelAppMaintenanceRequest(BaseModel):
             )
         if self.action not in {"migrate", "reset-testing"} and not self.email:
             raise ValueError(f"VeriReel app maintenance action '{self.action}' requires email.")
-        if self.intent:
-            required_action, required_context = APP_MAINTENANCE_INTENT_REQUIREMENTS[self.intent]
-            if self.action != required_action or self.context != required_context:
-                raise ValueError(
-                    "VeriReel app maintenance intent "
-                    f"'{self.intent}' requires action '{required_action}' "
-                    f"in context '{required_context}'."
-                )
+        required_action, required_context = APP_MAINTENANCE_INTENT_REQUIREMENTS[self.intent]
+        if self.action != required_action or self.context != required_context:
+            raise ValueError(
+                "VeriReel app maintenance intent "
+                f"'{self.intent}' requires action '{required_action}' "
+                f"in context '{required_context}'."
+            )
         return self
 
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -62,6 +62,9 @@ Keep a compatibility surface only when it is one of these:
   `preview-apply-inputs` and `preview-apply` for isolated provider mutation,
   and common preview read/planning/evidence callers use the inherited
   generic-web routes.
+- VeriReel app-maintenance action-only payload compatibility is retired. Product
+  workflows must pass the scoped `intent` matching the requested maintenance
+  action and stable or preview lane.
 - The Odoo-shaped stable verification alias is retired. Odoo stable smoke
   follow-ups use `POST /v1/drivers/generic-web/stable-verification`.
 - The Odoo-shaped rollback-plan alias is retired. Odoo rollback planning uses

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -151,8 +151,9 @@ live authority across DB, files, and process env:
   inventory routes resolve Dokploy host, token, preview URL shape, app identity,
   and target identity from Launchplane-managed secrets plus DB-backed runtime
   and target records. `LAUNCHPLANE_PREVIEW_BASE_URL` is a context-level runtime
-  value. Product-repo workflows may pass operation intent, preview slug, and
-  GitHub OIDC identity, but not Dokploy credentials or preview domain topology.
+  value. Product-repo app-maintenance workflows must pass operation intent;
+  product-repo workflows may pass preview slug and GitHub OIDC identity, but not
+  Dokploy credentials or preview domain topology.
 - VeriReel stable environment metadata, including testing/prod target names,
   target ids, base URLs, and health URLs, is served by Launchplane from
   DB-backed target/runtime records. Product-repo workflows should ask

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1100,13 +1100,13 @@ evidence so product workflows and PR feedback can surface the actionable reason
 instead of a generic `invalid_request` rejection. Malformed request payloads and
 unauthorized calls still fail closed before provider mutation.
 
-VeriReel app maintenance accepts an optional `intent` alongside the allow-listed
-action. Smoke/E2E helpers should set the narrow intent, such as
+VeriReel app maintenance requires an `intent` alongside the allow-listed
+action. Smoke/E2E helpers set the narrow intent, such as
 `remote-e2e-grant-sponsored`, `remote-e2e-delete-user`,
 `owner-route-promote-owner`, or `owner-route-delete-user`, so Launchplane can
 validate the requested action against the expected stable or preview lane before
-it touches Dokploy schedules. The legacy action-only payload remains accepted
-for compatibility, but new product calls should prefer the intent-based contract.
+it touches Dokploy schedules. Legacy action-only maintenance payloads are
+retired and fail request validation.
 
 The first Odoo driver cuts are intentionally narrow as well: Launchplane owns the
 artifact publish handoff, remote post-deploy data-workflow trigger, and prod

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24088,6 +24088,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 return_value=VeriReelAppMaintenanceResult(
                     maintenance_status="pass",
                     action="migrate",
+                    intent="stable-testing-migration",
                     context="verireel",
                     instance="testing",
                     application_name="ver-testing-app",
@@ -24107,6 +24108,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "context": "verireel",
                             "instance": "testing",
                             "action": "migrate",
+                            "intent": "stable-testing-migration",
                         },
                     },
                 )
@@ -24160,12 +24162,64 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "context": "verireel",
                         "instance": "testing",
                         "action": "migrate",
+                        "intent": "stable-testing-migration",
                     },
                 },
             )
 
             self.assertEqual(status_code, 403)
             self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_verireel_app_maintenance_driver_rejects_action_only_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_app_maintenance.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/app-maintenance",
+                payload={
+                    "product": "verireel",
+                    "maintenance": {
+                        "context": "verireel",
+                        "instance": "testing",
+                        "action": "migrate",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "invalid_request")
+            self.assertEqual(payload["error"]["message"], "Request payload failed validation.")
 
     def test_verireel_preview_inventory_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_verireel_app_maintenance.py
+++ b/tests/test_verireel_app_maintenance.py
@@ -12,9 +12,23 @@ from control_plane.workflows.verireel_app_maintenance import (
 )
 
 
+def _stable_migration_request() -> VeriReelAppMaintenanceRequest:
+    return VeriReelAppMaintenanceRequest(
+        action="migrate",
+        intent="stable-testing-migration",
+    )
+
+
+def _stable_reset_request() -> VeriReelAppMaintenanceRequest:
+    return VeriReelAppMaintenanceRequest(
+        action="reset-testing",
+        intent="stable-testing-reset",
+    )
+
+
 class VeriReelAppMaintenanceTests(unittest.TestCase):
     def test_builds_allow_listed_prisma_migration_command(self) -> None:
-        request = VeriReelAppMaintenanceRequest(action="migrate")
+        request = _stable_migration_request()
 
         schedule_name, command = _command_for_request(request)
 
@@ -23,8 +37,12 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
 
     def test_builds_shell_quoted_remote_owner_command(self) -> None:
         request = VeriReelAppMaintenanceRequest(
+            context="verireel-testing",
+            instance="preview",
             action="grant-sponsored",
+            intent="remote-e2e-grant-sponsored",
             email="creator+e2e@example.com",
+            preview_slug="pr-42",
         )
 
         schedule_name, command = _command_for_request(request)
@@ -41,9 +59,14 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
                 context="verireel-testing",
                 instance="preview",
                 action="grant-sponsored",
+                intent="remote-e2e-grant-sponsored",
                 email="creator@example.com",
                 application_name="ver-testing-app",
             )
+
+    def test_rejects_action_only_request_without_intent(self) -> None:
+        with self.assertRaisesRegex(ValueError, "intent"):
+            VeriReelAppMaintenanceRequest.model_validate({"action": "migrate"})
 
     def test_rejects_migration_for_preview_context(self) -> None:
         with self.assertRaises(ValueError):
@@ -51,6 +74,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
                 context="verireel-testing",
                 instance="preview",
                 action="migrate",
+                intent="stable-testing-migration",
                 preview_slug="pr-42",
             )
 
@@ -59,6 +83,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
             context="verireel-testing",
             instance="preview",
             action="grant-sponsored",
+            intent="remote-e2e-grant-sponsored",
             email="creator@example.com",
             preview_slug="pr-42",
         )
@@ -89,7 +114,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
             )
 
     def test_builds_testing_reset_command(self) -> None:
-        request = VeriReelAppMaintenanceRequest(action="reset-testing")
+        request = _stable_reset_request()
 
         schedule_name, command = _command_for_request(request)
 
@@ -100,7 +125,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         )
 
     def test_executes_stable_testing_command_through_launchplane_dokploy_config(self) -> None:
-        request = VeriReelAppMaintenanceRequest(action="migrate")
+        request = _stable_migration_request()
 
         with TemporaryDirectory() as temporary_directory_name:
             with (
@@ -126,7 +151,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
 
         self.assertEqual(result.maintenance_status, "pass")
         self.assertEqual(result.application_id, "app-123")
-        self.assertEqual(result.intent, "")
+        self.assertEqual(result.intent, "stable-testing-migration")
         resolve_mock.assert_called_once()
         run_mock.assert_called_once_with(
             host="https://dokploy.example.test",
@@ -139,7 +164,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         deploy_mock.assert_not_called()
 
     def test_redeploys_after_testing_reset(self) -> None:
-        request = VeriReelAppMaintenanceRequest(action="reset-testing")
+        request = _stable_reset_request()
 
         with TemporaryDirectory() as temporary_directory_name:
             with (
@@ -172,7 +197,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         )
 
     def test_reports_failed_command_without_throwing(self) -> None:
-        request = VeriReelAppMaintenanceRequest(action="migrate")
+        request = _stable_migration_request()
 
         with TemporaryDirectory() as temporary_directory_name:
             with (


### PR DESCRIPTION
## Summary
- require scoped VeriReel app-maintenance intent on every maintenance request
- reject legacy action-only payloads at the service boundary
- update service/config/compatibility docs for the retired compatibility path

## Validation
- uv run python -m unittest tests.test_verireel_app_maintenance
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_rejects_action_only_payload
- uv run python -m unittest
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff check control_plane/workflows/verireel_app_maintenance.py tests/test_verireel_app_maintenance.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/workflows/verireel_app_maintenance.py tests/test_verireel_app_maintenance.py tests/test_service.py
- git diff --check

## Notes
- Checked sibling VeriReel workflows/scripts; active workflow callers already pass --intent.