### PR TITLE
Enforce runner Docker toolchain baseline

### DIFF
--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -13,6 +13,7 @@ from pydantic import ValidationError
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObservation
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselinePolicy
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineReadiness
+from control_plane.contracts.runner_lane_baseline import RunnerLaneDockerToolchainObservation
 from control_plane.contracts.runner_lane_baseline import evaluate_runner_lane_baseline
 from control_plane.contracts.runner_lane_control import RunnerLaneControlAction
 from control_plane.contracts.runner_lane_control import RunnerLaneControlPolicy
@@ -39,6 +40,7 @@ from control_plane.merge_train_github import UrllibMergeTrainGitHubTransport
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
 from control_plane.runner_queue_wait_github import GitHubRunnerQueueWaitReader
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandRunner
 from control_plane.workflows.runner_host_hygiene_executor import build_local_command_runner
 from control_plane.workflows.runner_host_hygiene_executor import (
     build_refreshing_service_audit_poster,
@@ -207,6 +209,30 @@ def runner_queue_wait(
     ),
 )
 @click.option(
+    "--observe-docker-toolchain/--skip-docker-toolchain-observation",
+    default=False,
+    show_default=True,
+    help="Collect read-only Docker Engine, CLI, Buildx, and BuildKit version evidence.",
+)
+@click.option(
+    "--docker-toolchain-timeout-seconds",
+    default=10,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Timeout for each Docker toolchain observation command.",
+)
+@click.option("--docker-engine-version", default="", help="Observed Docker Engine version.")
+@click.option("--docker-cli-version", default="", help="Observed Docker CLI version.")
+@click.option("--docker-buildx-version", default="", help="Observed Docker Buildx version.")
+@click.option(
+    "--docker-buildx-plugin-path", default="", help="Observed Docker Buildx CLI plugin path."
+)
+@click.option(
+    "--docker-buildx-package", default="", help="Observed Docker Buildx package name/version."
+)
+@click.option("--docker-buildx-source", default="", help="Observed Docker Buildx source.")
+@click.option("--buildkit-version", default="", help="Observed BuildKit version.")
+@click.option(
     "--service-user",
     default="",
     help="Observed service user. Defaults to USER, LOGNAME, or GITHUB_ACTOR.",
@@ -239,28 +265,63 @@ def runner_queue_wait(
     multiple=True,
     help="Allowed home directory root. Repeat for each allowed root.",
 )
+@click.option(
+    "--require-docker-toolchain-observation/--allow-missing-docker-toolchain-observation",
+    default=False,
+    show_default=True,
+    help="Require Docker toolchain observation evidence in baseline readiness.",
+)
+@click.option(
+    "--minimum-docker-buildx-version",
+    default="",
+    help="Minimum Docker Buildx CLI plugin version accepted by baseline readiness.",
+)
 def runner_baseline_observe(
     runner_name: str,
     labels: tuple[str, ...],
     docker_config_isolated: bool | None,
+    observe_docker_toolchain: bool,
+    docker_toolchain_timeout_seconds: int,
+    docker_engine_version: str,
+    docker_cli_version: str,
+    docker_buildx_version: str,
+    docker_buildx_plugin_path: str,
+    docker_buildx_package: str,
+    docker_buildx_source: str,
+    buildkit_version: str,
     service_user: str,
     home_directory: str,
     observed_at: str,
     required_labels: tuple[str, ...],
     allowed_service_users: tuple[str, ...],
     allowed_home_roots: tuple[str, ...],
+    require_docker_toolchain_observation: bool,
+    minimum_docker_buildx_version: str,
 ) -> None:
     try:
         observation = RunnerLaneBaselineObservation(
             runner_name=_runner_baseline_runner_name(runner_name),
             labels=_runner_baseline_labels(labels),
             docker_config_isolated=_runner_baseline_docker_config_isolated(docker_config_isolated),
+            docker_toolchain=_runner_baseline_docker_toolchain(
+                observe_docker_toolchain=observe_docker_toolchain,
+                docker_toolchain_timeout_seconds=docker_toolchain_timeout_seconds,
+                docker_engine_version=docker_engine_version,
+                docker_cli_version=docker_cli_version,
+                docker_buildx_version=docker_buildx_version,
+                docker_buildx_plugin_path=docker_buildx_plugin_path,
+                docker_buildx_package=docker_buildx_package,
+                docker_buildx_source=docker_buildx_source,
+                buildkit_version=buildkit_version,
+            ),
             service_user=_runner_baseline_service_user(service_user),
             home_directory=_runner_baseline_home_directory(home_directory),
             observed_at=observed_at.strip() or utc_now_timestamp(),
         )
         policy = RunnerLaneBaselinePolicy(
             required_labels=required_labels or ("self-hosted", "launchplane"),
+            require_docker_toolchain_observation=require_docker_toolchain_observation,
+            minimum_docker_buildx_version=minimum_docker_buildx_version,
             allowed_service_users=allowed_service_users,
             allowed_home_roots=allowed_home_roots,
         )
@@ -1081,6 +1142,146 @@ def _runner_baseline_docker_config_isolated(value: bool | None) -> bool | None:
     if docker_config and isolated_config and docker_config == isolated_config:
         return True
     return None
+
+
+def _runner_baseline_docker_toolchain(
+    *,
+    observe_docker_toolchain: bool,
+    docker_toolchain_timeout_seconds: int,
+    docker_engine_version: str,
+    docker_cli_version: str,
+    docker_buildx_version: str,
+    docker_buildx_plugin_path: str,
+    docker_buildx_package: str,
+    docker_buildx_source: str,
+    buildkit_version: str,
+) -> RunnerLaneDockerToolchainObservation | None:
+    explicit = RunnerLaneDockerToolchainObservation(
+        docker_engine_version=docker_engine_version,
+        docker_cli_version=docker_cli_version,
+        docker_buildx_version=docker_buildx_version,
+        docker_buildx_plugin_path=docker_buildx_plugin_path,
+        docker_buildx_package=docker_buildx_package,
+        docker_buildx_source=docker_buildx_source,
+        buildkit_version=buildkit_version,
+    )
+    if not observe_docker_toolchain:
+        return explicit if explicit.has_evidence() else None
+
+    runner = build_local_command_runner()
+    observed_buildx_plugin_path = _first_line(
+        _docker_command_output(
+            runner,
+            (
+                "sh",
+                "-c",
+                "command -v docker-buildx 2>/dev/null || "
+                "for path in /usr/libexec/docker/cli-plugins/docker-buildx "
+                "/usr/local/lib/docker/cli-plugins/docker-buildx "
+                "$HOME/.docker/cli-plugins/docker-buildx; do "
+                '[ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; '
+                "done",
+            ),
+            timeout_seconds=docker_toolchain_timeout_seconds,
+        )
+    )
+    observed = RunnerLaneDockerToolchainObservation(
+        docker_engine_version=_docker_command_output(
+            runner,
+            ("docker", "version", "--format", "{{.Server.Version}}"),
+            timeout_seconds=docker_toolchain_timeout_seconds,
+        ),
+        docker_cli_version=_docker_command_output(
+            runner,
+            ("docker", "version", "--format", "{{.Client.Version}}"),
+            timeout_seconds=docker_toolchain_timeout_seconds,
+        ),
+        docker_buildx_version=_first_version(
+            _docker_command_output(
+                runner,
+                ("docker", "buildx", "version"),
+                timeout_seconds=docker_toolchain_timeout_seconds,
+            )
+        ),
+        docker_buildx_plugin_path=observed_buildx_plugin_path,
+        docker_buildx_package=_docker_buildx_package(
+            runner=runner, timeout_seconds=docker_toolchain_timeout_seconds
+        ),
+        docker_buildx_source=_docker_buildx_source(observed_buildx_plugin_path),
+        buildkit_version=_first_version(
+            _docker_command_output(
+                runner,
+                ("docker", "buildx", "inspect"),
+                timeout_seconds=docker_toolchain_timeout_seconds,
+            )
+        ),
+    )
+    if not explicit.has_evidence():
+        return observed if observed.has_evidence() else None
+    return RunnerLaneDockerToolchainObservation(
+        docker_engine_version=explicit.docker_engine_version or observed.docker_engine_version,
+        docker_cli_version=explicit.docker_cli_version or observed.docker_cli_version,
+        docker_buildx_version=explicit.docker_buildx_version or observed.docker_buildx_version,
+        docker_buildx_plugin_path=(
+            explicit.docker_buildx_plugin_path or observed.docker_buildx_plugin_path
+        ),
+        docker_buildx_package=explicit.docker_buildx_package or observed.docker_buildx_package,
+        docker_buildx_source=explicit.docker_buildx_source or observed.docker_buildx_source,
+        buildkit_version=explicit.buildkit_version or observed.buildkit_version,
+    )
+
+
+def _docker_command_output(
+    runner: RemoteCommandRunner,
+    command_args: tuple[str, ...],
+    *,
+    timeout_seconds: int,
+) -> str:
+    result = runner(command_args, timeout_seconds)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _docker_buildx_package(*, runner: RemoteCommandRunner, timeout_seconds: int) -> str:
+    package = _docker_command_output(
+        runner,
+        ("sh", "-c", "dpkg-query -W -f='${Package} ${Version}' docker-buildx 2>/dev/null"),
+        timeout_seconds=timeout_seconds,
+    )
+    if package:
+        return package
+    return _docker_command_output(
+        runner,
+        ("sh", "-c", "rpm -q docker-buildx 2>/dev/null"),
+        timeout_seconds=timeout_seconds,
+    )
+
+
+def _docker_buildx_source(plugin_path: str) -> str:
+    if plugin_path.startswith("/usr/libexec/") or plugin_path.startswith("/usr/lib/"):
+        return "system package"
+    if plugin_path.startswith("/usr/local/"):
+        return "managed plugin"
+    if "/.docker/cli-plugins/" in plugin_path:
+        return "user plugin"
+    return ""
+
+
+def _first_line(value: str) -> str:
+    for line in value.splitlines():
+        stripped_line = line.strip()
+        if stripped_line:
+            return stripped_line
+    return ""
+
+
+def _first_version(value: str) -> str:
+    for token in value.replace(",", " ").split():
+        normalized = token.strip().removeprefix("v")
+        if normalized and normalized[0].isdigit() and "." in normalized:
+            return normalized
+    return ""
 
 
 def _runner_baseline_service_user(value: str) -> str:

--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -94,6 +94,7 @@ class RunnerHostHygieneObservation(BaseModel):
     free_disk_bytes: int = Field(ge=0)
     docker_reclaimable_bytes: int = Field(default=0, ge=0)
     runner_workdir_bytes: int = Field(default=0, ge=0)
+    docker_toolchain: "RunnerHostDockerToolchainObservation | None" = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple["RunnerHostHygieneImageInventoryItem", ...] = ()
     volume_inventory: tuple["RunnerHostHygieneVolumeInventoryItem", ...] = ()
@@ -114,6 +115,42 @@ class RunnerHostHygieneObservation(BaseModel):
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
         self.notes = tuple(note.strip() for note in self.notes if note.strip())
         return self
+
+
+class RunnerHostDockerToolchainObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    docker_engine_version: str = ""
+    docker_cli_version: str = ""
+    docker_buildx_version: str = ""
+    docker_buildx_plugin_path: str = ""
+    docker_buildx_package: str = ""
+    docker_buildx_source: str = ""
+    buildkit_version: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_toolchain(self) -> "RunnerHostDockerToolchainObservation":
+        self.docker_engine_version = self.docker_engine_version.strip().removeprefix("v")
+        self.docker_cli_version = self.docker_cli_version.strip().removeprefix("v")
+        self.docker_buildx_version = self.docker_buildx_version.strip().removeprefix("v")
+        self.docker_buildx_plugin_path = self.docker_buildx_plugin_path.strip()
+        self.docker_buildx_package = self.docker_buildx_package.strip()
+        self.docker_buildx_source = self.docker_buildx_source.strip()
+        self.buildkit_version = self.buildkit_version.strip().removeprefix("v")
+        return self
+
+    def has_evidence(self) -> bool:
+        return any(
+            (
+                self.docker_engine_version,
+                self.docker_cli_version,
+                self.docker_buildx_version,
+                self.docker_buildx_plugin_path,
+                self.docker_buildx_package,
+                self.docker_buildx_source,
+                self.buildkit_version,
+            )
+        )
 
 
 class RunnerHostHygieneImageInventoryItem(BaseModel):
@@ -184,6 +221,7 @@ class RunnerHostHygieneReport(BaseModel):
     free_disk_bytes: int = Field(default=0, ge=0)
     docker_reclaimable_bytes: int = Field(default=0, ge=0)
     runner_workdir_bytes: int = Field(default=0, ge=0)
+    docker_toolchain: RunnerHostDockerToolchainObservation | None = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple[RunnerHostHygieneImageInventoryItem, ...] = ()
     volume_inventory: tuple[RunnerHostHygieneVolumeInventoryItem, ...] = ()
@@ -567,6 +605,7 @@ def evaluate_runner_host_hygiene(
         free_disk_bytes=observation.free_disk_bytes,
         docker_reclaimable_bytes=observation.docker_reclaimable_bytes,
         runner_workdir_bytes=observation.runner_workdir_bytes,
+        docker_toolchain=observation.docker_toolchain,
         warm_builders=observation.warm_builders,
         image_inventory=observation.image_inventory,
         volume_inventory=observation.volume_inventory,

--- a/control_plane/contracts/runner_lane_baseline.py
+++ b/control_plane/contracts/runner_lane_baseline.py
@@ -9,6 +9,9 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 RunnerLaneBaselineViolationCode = Literal[
     "docker_config_isolation_missing",
+    "docker_toolchain_missing",
+    "docker_buildx_version_below_minimum",
+    "docker_buildx_version_invalid",
     "home_directory_outside_allowed_roots",
     "required_label_missing",
     "service_user_not_allowed",
@@ -21,15 +24,59 @@ class RunnerLaneBaselinePolicy(BaseModel):
     schema_version: int = Field(default=1, ge=1)
     required_labels: tuple[str, ...] = ("self-hosted", "launchplane")
     require_docker_config_isolation: bool = True
+    require_docker_toolchain_observation: bool = False
+    minimum_docker_buildx_version: str = ""
     allowed_service_users: tuple[str, ...] = ()
     allowed_home_roots: tuple[str, ...] = ()
 
     @model_validator(mode="after")
     def _normalize_policy(self) -> "RunnerLaneBaselinePolicy":
         self.required_labels = _normalized_tokens(self.required_labels)
+        self.minimum_docker_buildx_version = _normalized_version_text(
+            self.minimum_docker_buildx_version
+        )
         self.allowed_service_users = _normalized_tokens(self.allowed_service_users)
         self.allowed_home_roots = _normalized_paths(self.allowed_home_roots)
         return self
+
+
+class RunnerLaneDockerToolchainObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    docker_engine_version: str = ""
+    docker_cli_version: str = ""
+    docker_buildx_version: str = ""
+    docker_buildx_plugin_path: str = ""
+    docker_buildx_package: str = ""
+    docker_buildx_source: str = ""
+    buildkit_version: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_toolchain(self) -> "RunnerLaneDockerToolchainObservation":
+        self.docker_engine_version = _normalized_version_text(self.docker_engine_version)
+        self.docker_cli_version = _normalized_version_text(self.docker_cli_version)
+        self.docker_buildx_version = _normalized_version_text(self.docker_buildx_version)
+        self.docker_buildx_plugin_path = self.docker_buildx_plugin_path.strip()
+        self.docker_buildx_package = self.docker_buildx_package.strip()
+        self.docker_buildx_source = self.docker_buildx_source.strip()
+        self.buildkit_version = _normalized_version_text(self.buildkit_version)
+        return self
+
+    def has_evidence(self) -> bool:
+        return any(
+            (
+                self.docker_engine_version,
+                self.docker_cli_version,
+                self.docker_buildx_version,
+                self.docker_buildx_plugin_path,
+                self.docker_buildx_package,
+                self.docker_buildx_source,
+                self.buildkit_version,
+            )
+        )
+
+    def has_buildx_version(self) -> bool:
+        return bool(self.docker_buildx_version)
 
 
 class RunnerLaneBaselineObservation(BaseModel):
@@ -38,6 +85,7 @@ class RunnerLaneBaselineObservation(BaseModel):
     runner_name: str
     labels: tuple[str, ...] = ()
     docker_config_isolated: bool | None = None
+    docker_toolchain: RunnerLaneDockerToolchainObservation | None = None
     service_user: str = ""
     home_directory: str = ""
     observed_at: str
@@ -145,6 +193,52 @@ def _evaluate_observation(
                 message="runner lane lacks verified per-job Docker credential isolation",
             )
         )
+    minimum_buildx_version = policy.minimum_docker_buildx_version
+    if policy.require_docker_toolchain_observation or minimum_buildx_version:
+        if observation.docker_toolchain is None or not observation.docker_toolchain.has_evidence():
+            violations.append(
+                RunnerLaneBaselineViolation(
+                    runner_name=observation.runner_name,
+                    code="docker_toolchain_missing",
+                    message="runner lane lacks Docker toolchain observation evidence",
+                )
+            )
+        elif (
+            policy.require_docker_toolchain_observation
+            and not observation.docker_toolchain.has_buildx_version()
+        ):
+            violations.append(
+                RunnerLaneBaselineViolation(
+                    runner_name=observation.runner_name,
+                    code="docker_buildx_version_invalid",
+                    message="runner lane Docker Buildx version was not observed",
+                )
+            )
+        elif minimum_buildx_version:
+            buildx_version = observation.docker_toolchain.docker_buildx_version
+            comparison = _compare_versions(buildx_version, minimum_buildx_version)
+            if comparison is None:
+                violations.append(
+                    RunnerLaneBaselineViolation(
+                        runner_name=observation.runner_name,
+                        code="docker_buildx_version_invalid",
+                        message=(
+                            "runner lane Docker Buildx version could not be compared: "
+                            f"{buildx_version or '<missing>'}"
+                        ),
+                    )
+                )
+            elif comparison < 0:
+                violations.append(
+                    RunnerLaneBaselineViolation(
+                        runner_name=observation.runner_name,
+                        code="docker_buildx_version_below_minimum",
+                        message=(
+                            "runner lane Docker Buildx version is below the configured "
+                            f"minimum: {buildx_version} < {minimum_buildx_version}"
+                        ),
+                    )
+                )
     if (
         policy.allowed_service_users
         and observation.service_user not in policy.allowed_service_users
@@ -206,11 +300,55 @@ def _resolved_path(value: str) -> str:
 
 
 def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(sorted({normalized for value in values if (normalized := _normalized_token(value))}))
+    return tuple(
+        sorted({normalized for value in values if (normalized := _normalized_token(value))})
+    )
 
 
 def _normalized_token(value: str) -> str:
     return value.strip().lower()
+
+
+def _normalized_version_text(value: str) -> str:
+    return value.strip().removeprefix("v")
+
+
+def _compare_versions(left: str, right: str) -> int | None:
+    left_parts = _version_parts(left)
+    right_parts = _version_parts(right)
+    if left_parts is None or right_parts is None:
+        return None
+    if left_parts < right_parts:
+        return -1
+    if left_parts > right_parts:
+        return 1
+    return 0
+
+
+def _version_parts(value: str) -> tuple[int, int, int] | None:
+    normalized_value = _normalized_version_text(value)
+    parts: list[int] = []
+    current = ""
+    for character in normalized_value:
+        if character.isdigit():
+            current += character
+            continue
+        if current:
+            parts.append(int(current))
+            current = ""
+            if len(parts) == 3:
+                break
+        elif character in {".", "-", "_", "+"}:
+            continue
+        else:
+            continue
+    if current and len(parts) < 3:
+        parts.append(int(current))
+    if not parts:
+        return None
+    while len(parts) < 3:
+        parts.append(0)
+    return (parts[0], parts[1], parts[2])
 
 
 def _required_text(value: str, message: str) -> str:

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -20,6 +20,7 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAu
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPlan
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
+from control_plane.contracts.runner_host_hygiene import RunnerHostDockerToolchainObservation
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneImageInventoryItem
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
@@ -357,6 +358,10 @@ def collect_runner_host_hygiene_report(
             request=request,
             remote_runner=remote_runner,
         ),
+        docker_toolchain=_collect_docker_toolchain(
+            request=request,
+            remote_runner=remote_runner,
+        ),
         warm_builders=warm_builders,
         image_inventory=image_inventory,
         volume_inventory=volume_inventory,
@@ -515,6 +520,113 @@ def _parse_df_available_bytes(output: str) -> int:
     if not available.isdigit():
         raise click.ClickException("runner host hygiene df available bytes was not numeric")
     return int(available)
+
+
+def _collect_docker_toolchain(
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+) -> RunnerHostDockerToolchainObservation | None:
+    buildx_plugin_path = _first_existing_path(
+        remote_runner(
+            (
+                "sh",
+                "-c",
+                "command -v docker-buildx 2>/dev/null || "
+                "for path in /usr/libexec/docker/cli-plugins/docker-buildx "
+                "/usr/local/lib/docker/cli-plugins/docker-buildx "
+                "$HOME/.docker/cli-plugins/docker-buildx; do "
+                '[ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; '
+                "done",
+            ),
+            request.timeout_seconds,
+        ).stdout
+    )
+    toolchain = RunnerHostDockerToolchainObservation(
+        docker_engine_version=_command_output(
+            remote_runner,
+            ("docker", "version", "--format", "{{.Server.Version}}"),
+            request.timeout_seconds,
+        ),
+        docker_cli_version=_command_output(
+            remote_runner,
+            ("docker", "version", "--format", "{{.Client.Version}}"),
+            request.timeout_seconds,
+        ),
+        docker_buildx_version=_first_version(
+            _command_output(
+                remote_runner,
+                ("docker", "buildx", "version"),
+                request.timeout_seconds,
+            )
+        ),
+        docker_buildx_plugin_path=buildx_plugin_path,
+        docker_buildx_package=_docker_buildx_package(
+            remote_runner=remote_runner,
+            timeout_seconds=request.timeout_seconds,
+        ),
+        docker_buildx_source=_docker_buildx_source(buildx_plugin_path),
+        buildkit_version=_first_version(
+            _command_output(
+                remote_runner,
+                ("docker", "buildx", "inspect"),
+                request.timeout_seconds,
+            )
+        ),
+    )
+    return toolchain if toolchain.has_evidence() else None
+
+
+def _command_output(
+    remote_runner: RemoteCommandRunner,
+    command_args: tuple[str, ...],
+    timeout_seconds: int,
+) -> str:
+    result = remote_runner(command_args, timeout_seconds)
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _first_existing_path(output: str) -> str:
+    for line in output.splitlines():
+        value = line.strip()
+        if value:
+            return value
+    return ""
+
+
+def _docker_buildx_package(*, remote_runner: RemoteCommandRunner, timeout_seconds: int) -> str:
+    package = _command_output(
+        remote_runner,
+        ("sh", "-c", "dpkg-query -W -f='${Package} ${Version}' docker-buildx 2>/dev/null"),
+        timeout_seconds,
+    )
+    if package:
+        return package
+    return _command_output(
+        remote_runner,
+        ("sh", "-c", "rpm -q docker-buildx 2>/dev/null"),
+        timeout_seconds,
+    )
+
+
+def _docker_buildx_source(plugin_path: str) -> str:
+    if plugin_path.startswith("/usr/libexec/") or plugin_path.startswith("/usr/lib/"):
+        return "system package"
+    if plugin_path.startswith("/usr/local/"):
+        return "managed plugin"
+    if "/.docker/cli-plugins/" in plugin_path:
+        return "user plugin"
+    return ""
+
+
+def _first_version(value: str) -> str:
+    for token in value.replace(",", " ").split():
+        normalized = token.strip().removeprefix("v")
+        if normalized and normalized[0].isdigit() and "." in normalized:
+            return normalized
+    return ""
 
 
 def _collect_image_inventory(

--- a/docs/records.md
+++ b/docs/records.md
@@ -196,8 +196,9 @@ an ORM column/table or remains only in the evidence payload.
 - Runner host hygiene audit: modeled fields are `audit_record_key`,
   `host_name`, `action`, `status`, and `mutate`. The payload carries the typed
   request, plan, pre/post hygiene reports, retained warm-builder evidence, and
-  operator message. Host-command output, Docker summaries, and rollout notes stay
-  payload-only until they need queryable operational views.
+  operator message. Docker toolchain evidence, host-command output, Docker
+  summaries, and rollout notes stay payload-only until they need queryable
+  operational views.
 - Ingress route audit: modeled fields are `record_id`, `product`, `context`,
   `mode`, `status`, `provider_host_id`, and `recorded_at`. The payload carries
   the typed requested domains, expected provider host id, dry-run/apply mode,
@@ -950,7 +951,8 @@ preflights.
 - Runner lane baseline readiness is represented by typed policy, observation,
   violation, and readiness contracts in
   `control_plane.contracts.runner_lane_baseline`. These contracts are evidence
-  about whether a self-hosted runner lane satisfies Launchplane's host baseline;
+  about whether a self-hosted runner lane satisfies Launchplane's host baseline,
+  including Docker credential isolation and Docker toolchain/version policy;
   they are not product deploy authority and they do not replace route-specific
   authorization, promotion, backup-gate, or provider safety checks.
 - Scoped agent write-intent evaluation is exposed at

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -33,8 +33,9 @@ policy from observation:
   whether orphan BuildKit artifacts are tolerated.
 - `RunnerHostHygieneObservation` records facts collected by an approved
   read-only probe, including host name, free disk, Docker reclaimable bytes,
-  runner work-directory bytes, warm builders, read-only image and volume
-  inventory, and orphan BuildKit counts.
+  runner work-directory bytes, Docker Engine/CLI/Buildx/BuildKit toolchain
+  evidence, warm builders, read-only image and volume inventory, and orphan
+  BuildKit counts.
 - `evaluate_runner_host_hygiene(...)` returns a structured report with
   `healthy` or `attention` status, findings, and non-mutating next steps.
 
@@ -44,8 +45,9 @@ budget, and orphan BuildKit artifacts all produce `attention` unless policy
 explicitly permits that condition.
 Reports also carry the typed observation counters used for evaluation, so audit
 records preserve free disk, Docker reclaimable bytes, runner work-directory
-bytes, warm builders, and orphan BuildKit counts instead of relying only on raw
-operator notes. Executor-written reports also include read-only resource
+bytes, Docker toolchain evidence, warm builders, and orphan BuildKit counts
+instead of relying only on raw operator notes. Executor-written reports also
+include read-only resource
 inventory for Docker images and volumes. Image rows preserve repository, tag,
 image ID, size, creation timestamp, dangling status, in-use hints, and whether
 the image is one of the retained warm builders. Volume rows preserve name,
@@ -53,6 +55,13 @@ driver, mountpoint, labels, size when Docker exposes it, reference count when
 Docker exposes it, and dangling status. These inventory fields are evidence for
 operator review only; aggregate reclaimable totals are not enough to approve
 destructive volume or image pruning.
+
+Docker toolchain evidence is preserved for operator review and runner-readiness
+follow-up. The hygiene report records Docker Engine version, Docker CLI version,
+Docker Buildx CLI plugin version, plugin path/package/source, and BuildKit
+version when the read-only probe can observe them. Hygiene does not decide lane
+admission from those versions; [runner-lane-baseline.md](runner-lane-baseline.md)
+owns the fail-closed Buildx minimum policy.
 
 ## CLI
 
@@ -198,8 +207,9 @@ Use this sequence when replacing `chris-testing` or standing up a parallel host:
    receive the ops-gate label.
 4. Run `runner-baseline-observe` from a job on the replacement host and evaluate
    the baseline readiness. The result must show required labels, the expected
-   service user/home-root constraints when configured, and positive isolated
-   Docker credential evidence.
+   service user/home-root constraints when configured, positive isolated Docker
+   credential evidence, and Docker toolchain evidence that satisfies the
+   configured Buildx minimum.
 5. Run the runner-host hygiene workflow manually with `mutate=false`, no target
    volumes, and a replacement-specific audit key. The run must write an
    accepted planned audit, block only on `mutate_not_requested`, observe the

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -21,6 +21,11 @@ treated as ready for shared product automation:
 - Docker registry credentials are isolated per job. The readiness contract fails
   closed unless there is positive evidence that jobs do not share a mutable
   host-level Docker config.
+- Shared product lanes that run Docker image builds record Docker Engine, Docker
+  CLI, Docker Buildx CLI plugin, plugin path/package/source, and BuildKit
+  version evidence. Policies can require that evidence and can enforce a
+  minimum Buildx CLI plugin version for workflows that depend on modern
+  `docker/build-push-action` behavior.
 - Optional host checks may constrain the service user and home-directory roots
   used by managed runner lanes.
 
@@ -34,9 +39,11 @@ The typed contract in `control_plane.contracts.runner_lane_baseline` separates
 policy from observation:
 
 - `RunnerLaneBaselinePolicy` records required labels, whether Docker credential
-  isolation is mandatory, and optional service-user or home-root constraints.
+  isolation is mandatory, optional Docker toolchain evidence requirements,
+  minimum Docker Buildx CLI version, and optional service-user or home-root
+  constraints.
 - `RunnerLaneBaselineObservation` records observed lane facts from a host or
-  runner bootstrap check.
+  runner bootstrap check, including Docker toolchain evidence when supplied.
 - `evaluate_runner_lane_baseline(...)` returns `RunnerLaneBaselineReadiness`
   with a fail-closed summary and structured violations.
 
@@ -47,6 +54,14 @@ roots, so traversal segments such as `..` cannot satisfy a configured root by
 string prefix alone. Readiness counts lanes by unique runner name, so duplicate
 observations for the same runner do not inflate the observed or compliant lane
 totals.
+
+When a policy requires Docker toolchain observation, missing toolchain evidence
+or missing Buildx CLI version evidence is not ready. When it sets a
+`minimum_docker_buildx_version`, an unparsable Buildx version is not ready, and
+a stale Buildx CLI plugin is not ready. The `0.13.1+ds1` Debian-packaged Buildx
+plugin observed on `chris-testing` fails a `0.23.0` minimum even when the
+workflow's BuildKit builder container is newer; the readiness gate is about the
+host-side Docker CLI plugin used by `docker buildx build --load`.
 
 ## Operations
 
@@ -81,7 +96,11 @@ To emit baseline observation evidence from a self-hosted runner job, run:
 ```bash
 uv run launchplane work-graph runner-baseline-observe \
   --allowed-service-user gha \
-  --allowed-home-root /opt/actions-runners
+  --allowed-home-root /opt/actions-runners \
+  --observe-docker-toolchain \
+  --docker-toolchain-timeout-seconds 30 \
+  --require-docker-toolchain-observation \
+  --minimum-docker-buildx-version 0.23.0
 ```
 
 The observation command is read-only. By default it reads `RUNNER_NAME`,
@@ -92,6 +111,16 @@ isolation is considered present only when the job exposes matching
 `DOCKER_CONFIG` and `LAUNCHPLANE_ISOLATED_DOCKER_CONFIG` values, or when an
 operator passes explicit `--docker-config-isolated` evidence. Missing evidence
 for labels or Docker isolation still fails closed.
+
+Docker toolchain observation is read-only. `--observe-docker-toolchain` collects
+Docker Engine and CLI versions, `docker buildx version`, standard Buildx plugin
+paths, Debian/RPM package evidence when available, and `docker buildx inspect`
+BuildKit evidence. Operators can also pass those values explicitly with
+`--docker-engine-version`, `--docker-cli-version`, `--docker-buildx-version`,
+`--docker-buildx-plugin-path`, `--docker-buildx-package`,
+`--docker-buildx-source`, and `--buildkit-version` for fixture-driven or
+permission-limited checks. Use `--docker-toolchain-timeout-seconds` to raise the
+per-command timeout on cold or busy Docker daemons.
 
 For live products, use a non-production runner or a read-only observation path
 until the operator explicitly approves host changes. VeriReel production must

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -2,6 +2,7 @@ import json
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from collections.abc import Sequence
 from typing import cast
 import unittest
 from unittest.mock import patch
@@ -26,6 +27,9 @@ from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hyg
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_adapter_boundary
 from control_plane.cli_runner_lanes import _runner_host_hygiene_bearer_token
+from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
+from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import collect_runner_host_hygiene_report
 
 
 CLI_MAIN = cast(Command, main)
@@ -142,6 +146,154 @@ class RunnerHostHygieneTests(unittest.TestCase):
         )
 
         self.assertEqual(report.status, "healthy")
+
+    def test_executor_report_preserves_docker_toolchain_evidence(self) -> None:
+        outputs: dict[tuple[str, ...], str] = {
+            (
+                "df",
+                "-B1",
+                "-P",
+                "/",
+            ): "Filesystem 1B-blocks Used Available Use% Mounted on\n/dev/root 1000 100 900 10% /\n",
+            (
+                "docker",
+                "system",
+                "df",
+                "--format",
+                "{{.Type}} {{.TotalCount}} {{.Size}} {{.Reclaimable}}",
+            ): "Images 1 10MB 0B\nBuild Cache 1 10MB 0B\n",
+            ("docker", "system", "df", "-v"): "",
+            ("docker", "image", "inspect", "odoo-docker-chris-testing"): "{}",
+            (
+                "docker",
+                "image",
+                "ls",
+                "--all",
+                "--no-trunc",
+                "--format",
+                "{{json .}}",
+            ): "",
+            ("docker", "ps", "--all", "--no-trunc", "--format", "{{json .}}"): "",
+            (
+                "bash",
+                "-lc",
+                "docker volume ls -q | xargs -r docker volume inspect",
+            ): "",
+            (
+                "bash",
+                "-lc",
+                "find /opt/actions-runners -mindepth 2 -maxdepth 2 -type d -name _work -exec du -sb {} + 2>/dev/null | awk '{ total += $1 } END { print total + 0 }'",
+            ): "0\n",
+            ("docker", "version", "--format", "{{.Server.Version}}"): "26.1.5+dfsg1\n",
+            ("docker", "version", "--format", "{{.Client.Version}}"): "26.1.5+dfsg1\n",
+            ("docker", "buildx", "version"): "github.com/docker/buildx 0.13.1+ds1 0.13.1+ds1-3\n",
+            ("docker", "buildx", "inspect"): "Driver: docker-container\nBuildKit: v0.30.0\n",
+            (
+                "sh",
+                "-c",
+                'command -v docker-buildx 2>/dev/null || for path in /usr/libexec/docker/cli-plugins/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx $HOME/.docker/cli-plugins/docker-buildx; do [ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; done',
+            ): "/usr/libexec/docker/cli-plugins/docker-buildx\n",
+            (
+                "sh",
+                "-c",
+                "dpkg-query -W -f='${Package} ${Version}' docker-buildx 2>/dev/null",
+            ): "docker-buildx 0.13.1+ds1-3",
+            ("sh", "-c", "rpm -q docker-buildx 2>/dev/null"): "",
+        }
+
+        def runner(command: Sequence[str], _timeout: int) -> RemoteCommandResult:
+            command_tuple = tuple(command)
+            if command_tuple[:3] == ("docker", "volume", "inspect"):
+                return RemoteCommandResult(returncode=1)
+            return RemoteCommandResult(returncode=0, stdout=outputs.get(command_tuple, ""))
+
+        report = collect_runner_host_hygiene_report(
+            request=RunnerHostHygieneExecutorRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+                execution_lane="chris-testing-ops-gate",
+                service_user="gha",
+                repository_scope="cbusillo/launchplane",
+                audit_record_key="runner-host-hygiene/2026-06-04/chris-testing",
+                retained_warm_builders=("odoo-docker-chris-testing",),
+            ),
+            remote_runner=runner,
+        )
+
+        self.assertIsNotNone(report.docker_toolchain)
+        assert report.docker_toolchain is not None
+        self.assertEqual(report.docker_toolchain.docker_buildx_version, "0.13.1+ds1")
+        self.assertEqual(
+            report.docker_toolchain.docker_buildx_plugin_path,
+            "/usr/libexec/docker/cli-plugins/docker-buildx",
+        )
+        self.assertEqual(
+            report.docker_toolchain.docker_buildx_package, "docker-buildx 0.13.1+ds1-3"
+        )
+        self.assertEqual(report.docker_toolchain.docker_buildx_source, "system package")
+        self.assertEqual(report.docker_toolchain.buildkit_version, "0.30.0")
+
+    def test_executor_report_omits_empty_docker_toolchain_evidence(self) -> None:
+        outputs: dict[tuple[str, ...], str] = {
+            (
+                "df",
+                "-B1",
+                "-P",
+                "/",
+            ): "Filesystem 1B-blocks Used Available Use% Mounted on\n/dev/root 1000 100 900 10% /\n",
+            (
+                "docker",
+                "system",
+                "df",
+                "--format",
+                "{{.Type}} {{.TotalCount}} {{.Size}} {{.Reclaimable}}",
+            ): "Images 1 10MB 0B\nBuild Cache 1 10MB 0B\n",
+            ("docker", "system", "df", "-v"): "",
+            ("docker", "image", "inspect", "odoo-docker-chris-testing"): "{}",
+            (
+                "docker",
+                "image",
+                "ls",
+                "--all",
+                "--no-trunc",
+                "--format",
+                "{{json .}}",
+            ): "",
+            ("docker", "ps", "--all", "--no-trunc", "--format", "{{json .}}"): "",
+            (
+                "bash",
+                "-lc",
+                "docker volume ls -q | xargs -r docker volume inspect",
+            ): "",
+            (
+                "bash",
+                "-lc",
+                "find /opt/actions-runners -mindepth 2 -maxdepth 2 -type d -name _work -exec du -sb {} + 2>/dev/null | awk '{ total += $1 } END { print total + 0 }'",
+            ): "0\n",
+        }
+
+        def runner(command: Sequence[str], _timeout: int) -> RemoteCommandResult:
+            command_tuple = tuple(command)
+            if command_tuple[:3] == ("docker", "volume", "inspect"):
+                return RemoteCommandResult(returncode=1)
+            if command_tuple in outputs:
+                return RemoteCommandResult(returncode=0, stdout=outputs[command_tuple])
+            return RemoteCommandResult(returncode=1, stderr="not installed")
+
+        report = collect_runner_host_hygiene_report(
+            request=RunnerHostHygieneExecutorRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+                execution_lane="chris-testing-ops-gate",
+                service_user="gha",
+                repository_scope="cbusillo/launchplane",
+                audit_record_key="runner-host-hygiene/2026-06-04/chris-testing",
+                retained_warm_builders=("odoo-docker-chris-testing",),
+            ),
+            remote_runner=runner,
+        )
+
+        self.assertIsNone(report.docker_toolchain)
 
 
 class RunnerHostHygieneCliTests(unittest.TestCase):

--- a/tests/test_runner_lane_baseline.py
+++ b/tests/test_runner_lane_baseline.py
@@ -1,8 +1,10 @@
 import json
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from collections.abc import Sequence
 from typing import cast
 import unittest
+from unittest.mock import patch
 
 from click import Command
 from click.testing import CliRunner
@@ -10,7 +12,9 @@ from click.testing import CliRunner
 from control_plane.cli import main
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObservation
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselinePolicy
+from control_plane.contracts.runner_lane_baseline import RunnerLaneDockerToolchainObservation
 from control_plane.contracts.runner_lane_baseline import evaluate_runner_lane_baseline
+from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
 
 
 CLI_MAIN = cast(Command, main)
@@ -108,6 +112,127 @@ class RunnerLaneBaselineTests(unittest.TestCase):
         self.assertEqual(
             [violation.code for violation in readiness.violations],
             ["home_directory_outside_allowed_roots", "service_user_not_allowed"],
+        )
+
+    def test_readiness_rejects_stale_docker_buildx_toolchain(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(minimum_docker_buildx_version="0.23.0"),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="chris-testing-runtime-smoke",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    docker_toolchain=RunnerLaneDockerToolchainObservation(
+                        docker_engine_version="26.1.5+dfsg1",
+                        docker_cli_version="26.1.5+dfsg1",
+                        docker_buildx_version="0.13.1+ds1",
+                        docker_buildx_plugin_path="/usr/libexec/docker/cli-plugins/docker-buildx",
+                        docker_buildx_package="docker-buildx 0.13.1+ds1-3",
+                        docker_buildx_source="Debian trixie",
+                        buildkit_version="0.30.0",
+                    ),
+                    observed_at="2026-06-04T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(readiness.compliant_lanes, 0)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["docker_buildx_version_below_minimum"],
+        )
+        self.assertIn("0.13.1+ds1 < 0.23.0", readiness.violations[0].message)
+
+    def test_readiness_accepts_current_docker_buildx_toolchain(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(
+                require_docker_toolchain_observation=True,
+                minimum_docker_buildx_version="0.23.0",
+            ),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    docker_toolchain=RunnerLaneDockerToolchainObservation(
+                        docker_engine_version="27.5.1",
+                        docker_cli_version="27.5.1",
+                        docker_buildx_version="0.23.0",
+                        docker_buildx_plugin_path="/usr/local/lib/docker/cli-plugins/docker-buildx",
+                        docker_buildx_source="managed plugin",
+                        buildkit_version="0.23.2",
+                    ),
+                    observed_at="2026-06-04T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertTrue(readiness.ready)
+        self.assertEqual(readiness.violations, ())
+
+    def test_readiness_requires_docker_toolchain_when_policy_requests_it(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(require_docker_toolchain_observation=True),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    observed_at="2026-06-04T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["docker_toolchain_missing"],
+        )
+
+    def test_readiness_requires_buildx_version_when_toolchain_is_required(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(require_docker_toolchain_observation=True),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    docker_toolchain=RunnerLaneDockerToolchainObservation(
+                        docker_engine_version="27.5.1",
+                    ),
+                    observed_at="2026-06-04T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["docker_buildx_version_invalid"],
+        )
+
+    def test_readiness_rejects_invalid_buildx_version_for_minimum_policy(self) -> None:
+        readiness = evaluate_runner_lane_baseline(
+            policy=RunnerLaneBaselinePolicy(minimum_docker_buildx_version="0.23.0"),
+            observations=(
+                RunnerLaneBaselineObservation(
+                    runner_name="launchplane-runner-1",
+                    labels=("self-hosted", "launchplane"),
+                    docker_config_isolated=True,
+                    docker_toolchain=RunnerLaneDockerToolchainObservation(
+                        docker_buildx_version="unknown",
+                        docker_buildx_plugin_path="/usr/local/lib/docker/cli-plugins/docker-buildx",
+                    ),
+                    observed_at="2026-06-04T12:00:00Z",
+                ),
+            ),
+        )
+
+        self.assertFalse(readiness.ready)
+        self.assertEqual(
+            [violation.code for violation in readiness.violations],
+            ["docker_buildx_version_invalid"],
         )
 
     def test_readiness_rejects_home_directory_traversal_outside_allowed_roots(
@@ -248,6 +373,122 @@ class RunnerLaneBaselineCliTests(unittest.TestCase):
         self.assertTrue(payload["observation"]["docker_config_isolated"])
         self.assertTrue(payload["readiness"]["ready"])
         self.assertEqual(payload["readiness"]["violations"], [])
+
+    def test_cli_enforces_minimum_docker_buildx_version_from_explicit_evidence(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-baseline-observe",
+                    "--runner-name",
+                    "chris-testing-runtime-smoke",
+                    "--label",
+                    "self-hosted",
+                    "--label",
+                    "launchplane",
+                    "--docker-config-isolated",
+                    "--docker-engine-version",
+                    "26.1.5+dfsg1",
+                    "--docker-cli-version",
+                    "26.1.5+dfsg1",
+                    "--docker-buildx-version",
+                    "0.13.1+ds1",
+                    "--docker-buildx-plugin-path",
+                    "/usr/libexec/docker/cli-plugins/docker-buildx",
+                    "--docker-buildx-package",
+                    "docker-buildx 0.13.1+ds1-3",
+                    "--docker-buildx-source",
+                    "Debian trixie",
+                    "--buildkit-version",
+                    "0.30.0",
+                    "--minimum-docker-buildx-version",
+                    "0.23.0",
+                    "--home-directory",
+                    temp_dir,
+                    "--observed-at",
+                    "2026-06-04T12:00:00Z",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertFalse(payload["readiness"]["ready"])
+        self.assertEqual(
+            [violation["code"] for violation in payload["readiness"]["violations"]],
+            ["docker_buildx_version_below_minimum"],
+        )
+        self.assertEqual(
+            payload["observation"]["docker_toolchain"]["docker_buildx_plugin_path"],
+            "/usr/libexec/docker/cli-plugins/docker-buildx",
+        )
+
+    def test_cli_observes_docker_toolchain_with_read_only_probe(self) -> None:
+        outputs: dict[tuple[str, ...], str] = {
+            ("docker", "version", "--format", "{{.Server.Version}}"): "26.1.5+dfsg1\n",
+            ("docker", "version", "--format", "{{.Client.Version}}"): "26.1.5+dfsg1\n",
+            ("docker", "buildx", "version"): "github.com/docker/buildx 0.13.1+ds1 0.13.1+ds1-3\n",
+            ("docker", "buildx", "inspect"): "Driver: docker-container\nBuildKit: v0.30.0\n",
+            (
+                "sh",
+                "-c",
+                'command -v docker-buildx 2>/dev/null || for path in /usr/libexec/docker/cli-plugins/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx $HOME/.docker/cli-plugins/docker-buildx; do [ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; done',
+            ): "/usr/libexec/docker/cli-plugins/docker-buildx\n",
+            (
+                "sh",
+                "-c",
+                "dpkg-query -W -f='${Package} ${Version}' docker-buildx 2>/dev/null",
+            ): "docker-buildx 0.13.1+ds1-3",
+            ("sh", "-c", "rpm -q docker-buildx 2>/dev/null"): "",
+        }
+
+        observed_timeouts: list[int] = []
+
+        def runner(command: Sequence[str], timeout: int) -> RemoteCommandResult:
+            observed_timeouts.append(timeout)
+            return RemoteCommandResult(returncode=0, stdout=outputs.get(tuple(command), ""))
+
+        with patch(
+            "control_plane.cli_runner_lanes.build_local_command_runner", return_value=runner
+        ):
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-baseline-observe",
+                    "--runner-name",
+                    "chris-testing-runtime-smoke",
+                    "--label",
+                    "self-hosted",
+                    "--label",
+                    "launchplane",
+                    "--docker-config-isolated",
+                    "--observe-docker-toolchain",
+                    "--docker-toolchain-timeout-seconds",
+                    "30",
+                    "--minimum-docker-buildx-version",
+                    "0.23.0",
+                    "--observed-at",
+                    "2026-06-04T12:00:00Z",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(set(observed_timeouts), {30})
+        self.assertFalse(payload["readiness"]["ready"])
+        self.assertEqual(
+            payload["observation"]["docker_toolchain"]["docker_engine_version"], "26.1.5+dfsg1"
+        )
+        self.assertEqual(
+            payload["observation"]["docker_toolchain"]["docker_buildx_version"], "0.13.1+ds1"
+        )
+        self.assertEqual(
+            payload["observation"]["docker_toolchain"]["docker_buildx_source"], "system package"
+        )
+        self.assertEqual(payload["observation"]["docker_toolchain"]["buildkit_version"], "0.30.0")
 
     def test_cli_fails_closed_without_docker_isolation_evidence(self) -> None:
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- add Docker toolchain evidence to runner lane baseline observations
- add fail-closed minimum Docker Buildx CLI plugin enforcement for runner readiness
- preserve Docker Engine/CLI/Buildx/BuildKit path/package/source evidence in runner-host hygiene reports
- document the runner readiness and hygiene toolchain contract

## Issue
- Starts Launchplane #1141 by adding the contract/evidence enforcement slice. The live chris-testing toolchain upgrade remains a follow-up host-maintenance action.

## Validation
- uv run python -m unittest tests.test_runner_lane_baseline tests.test_runner_host_hygiene
- uv run python -m unittest
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff check --no-fix control_plane/contracts/runner_lane_baseline.py control_plane/cli_runner_lanes.py control_plane/contracts/runner_host_hygiene.py control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_lane_baseline.py tests/test_runner_host_hygiene.py
- uv run --extra dev ruff check control_plane/contracts/runner_lane_baseline.py control_plane/cli_runner_lanes.py control_plane/contracts/runner_host_hygiene.py control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_lane_baseline.py tests/test_runner_host_hygiene.py
- uv run --extra dev ruff format --check control_plane/contracts/runner_lane_baseline.py control_plane/cli_runner_lanes.py control_plane/contracts/runner_host_hygiene.py control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_lane_baseline.py tests/test_runner_host_hygiene.py
- git diff --check