### PR TITLE
Fix protected artifact whole-product auth

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -477,6 +477,7 @@ from control_plane.workflows.verireel_preview_driver import (
 
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+_WHOLE_PRODUCT_CONTEXT = "*"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _MERGE_TRAIN_ADMISSION_ROUTE = "/v1/work-graph/merge-train/admission"
 _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE = "/v1/work-graph/merge-train/controller/status"
@@ -1946,9 +1947,7 @@ _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
-_PREVIEW_VERIFICATION_ROUTE_PATHS = frozenset(
-    {_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path}
-)
+_PREVIEW_VERIFICATION_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path})
 _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS = frozenset(
     _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS
     | _PREVIEW_VERIFICATION_ROUTE_PATHS
@@ -7749,6 +7748,7 @@ def _apply_generic_web_stable_verification_records(
 
     return result
 
+
 def _testing_post_deploy_detail(status: ReleaseStatus) -> str:
     if status == "pass":
         return "Prisma migrations completed on testing."
@@ -8460,7 +8460,7 @@ def create_launchplane_service_app(
                             },
                         )
                     authz_product = requested_product
-                    authz_context = requested_context or _LAUNCHPLANE_SERVICE_CONTEXT
+                    authz_context = requested_context or _WHOLE_PRODUCT_CONTEXT
                     if not authz_policy.allows(
                         identity=identity,
                         action=action,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -477,6 +477,7 @@ from control_plane.workflows.verireel_preview_driver import (
 
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+_WHOLE_PRODUCT_CONTEXT = "__whole_product__"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _MERGE_TRAIN_ADMISSION_ROUTE = "/v1/work-graph/merge-train/admission"
 _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE = "/v1/work-graph/merge-train/controller/status"
@@ -1946,9 +1947,7 @@ _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
-_PREVIEW_VERIFICATION_ROUTE_PATHS = frozenset(
-    {_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path}
-)
+_PREVIEW_VERIFICATION_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path})
 _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS = frozenset(
     _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS
     | _PREVIEW_VERIFICATION_ROUTE_PATHS
@@ -7749,6 +7748,7 @@ def _apply_generic_web_stable_verification_records(
 
     return result
 
+
 def _testing_post_deploy_detail(status: ReleaseStatus) -> str:
     if status == "pass":
         return "Prisma migrations completed on testing."
@@ -8460,7 +8460,7 @@ def create_launchplane_service_app(
                             },
                         )
                     authz_product = requested_product
-                    authz_context = requested_context or _LAUNCHPLANE_SERVICE_CONTEXT
+                    authz_context = requested_context or _WHOLE_PRODUCT_CONTEXT
                     if not authz_policy.allows(
                         identity=identity,
                         action=action,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2109,6 +2109,129 @@ class LaunchplaneServiceTests(unittest.TestCase):
             protected_artifacts["image_references"],
         )
 
+    def test_protected_artifacts_endpoint_requires_wildcard_context_for_whole_product(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = _local_operator_policy(
+                actions=("artifact_protection.read",),
+                products=("verireel",),
+                contexts=("verireel",),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/artifacts/protected",
+                    query_string="product=verireel",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_protected_artifacts_endpoint_allows_scoped_context_read(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = _local_operator_policy(
+                actions=("artifact_protection.read",),
+                products=("verireel",),
+                contexts=("verireel",),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/artifacts/protected",
+                    query_string="product=verireel&context=verireel",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(status_code, 200)
+        protected_artifacts = payload["protected_artifacts"]
+        self.assertEqual(protected_artifacts["product"], "verireel")
+        self.assertEqual(protected_artifacts["context"], "verireel")
+
+    def test_protected_artifacts_endpoint_allows_human_wildcard_context_whole_product_read(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["read_only"],
+                            "products": ["verireel"],
+                            "contexts": ["*"],
+                            "actions": ["artifact_protection.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=record_store,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity()),
+            )
+            cookie = _signed_in_cookie(app)
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/artifacts/protected",
+                query_string="product=verireel",
+                authorization="",
+                headers={"Cookie": cookie},
+            )
+
+        self.assertEqual(status_code, 200)
+        protected_artifacts = payload["protected_artifacts"]
+        self.assertEqual(protected_artifacts["product"], "verireel")
+        self.assertEqual(protected_artifacts["context"], "")
+
     def test_protected_artifacts_endpoint_rejects_wrong_product_scope(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2109,6 +2109,84 @@ class LaunchplaneServiceTests(unittest.TestCase):
             protected_artifacts["image_references"],
         )
 
+    def test_protected_artifacts_endpoint_requires_wildcard_context_for_whole_product(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = _local_operator_policy(
+                actions=("artifact_protection.read",),
+                products=("verireel",),
+                contexts=("verireel",),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/artifacts/protected",
+                    query_string="product=verireel",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_protected_artifacts_endpoint_allows_scoped_context_read(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir)
+            seed_protected_artifact_store(record_store)
+            policy = _local_operator_policy(
+                actions=("artifact_protection.read",),
+                products=("verireel",),
+                contexts=("verireel",),
+            )
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/artifacts/protected",
+                    query_string="product=verireel&context=verireel",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(status_code, 200)
+        protected_artifacts = payload["protected_artifacts"]
+        self.assertEqual(protected_artifacts["product"], "verireel")
+        self.assertEqual(protected_artifacts["context"], "verireel")
+
     def test_protected_artifacts_endpoint_rejects_wrong_product_scope(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- require whole-product protected-artifact reads to authorize through a wildcard-only context sentinel
- keep context-scoped protected-artifact reads authorized against their concrete context
- add service tests for wildcard-required whole-product reads and concrete-context reads

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_protected_artifacts_endpoint_returns_launchplane_inventory tests.test_service.LaunchplaneServiceTests.test_protected_artifacts_endpoint_requires_wildcard_context_for_whole_product tests.test_service.LaunchplaneServiceTests.test_protected_artifacts_endpoint_allows_scoped_context_read tests.test_service.LaunchplaneServiceTests.test_protected_artifacts_endpoint_rejects_wrong_product_scope tests.test_service.LaunchplaneServiceTests.test_protected_artifacts_endpoint_rejects_every_code_worker_token tests.test_service.LaunchplaneServiceTests.test_protected_artifacts_endpoint_requires_product_scope`
- `uv run --extra dev mypy control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check --no-fix control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py`

Addresses auto-review run `6460c17c-e26e-46bd-aea7-0dcc91cc074e` / finding `f1`.
