### PR TITLE
Add VeriReel stable E2E grant intent

### DIFF
--- a/control_plane/workflows/verireel_app_maintenance.py
+++ b/control_plane/workflows/verireel_app_maintenance.py
@@ -24,6 +24,7 @@ VeriReelAppMaintenanceAction = Literal[
 VeriReelAppMaintenanceIntent = Literal[
     "stable-testing-migration",
     "stable-testing-reset",
+    "stable-testing-remote-e2e-grant-sponsored",
     "remote-e2e-grant-sponsored",
     "remote-e2e-delete-user",
     "owner-route-promote-owner",
@@ -36,6 +37,7 @@ APP_MAINTENANCE_INTENT_REQUIREMENTS: dict[
 ] = {
     "stable-testing-migration": ("migrate", "verireel"),
     "stable-testing-reset": ("reset-testing", "verireel"),
+    "stable-testing-remote-e2e-grant-sponsored": ("grant-sponsored", "verireel"),
     "remote-e2e-grant-sponsored": ("grant-sponsored", "verireel-testing"),
     "remote-e2e-delete-user": ("delete-user", "verireel-testing"),
     "owner-route-promote-owner": ("promote-owner", "verireel"),

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1102,11 +1102,11 @@ unauthorized calls still fail closed before provider mutation.
 
 VeriReel app maintenance requires an `intent` alongside the allow-listed
 action. Smoke/E2E helpers set the narrow intent, such as
-`remote-e2e-grant-sponsored`, `remote-e2e-delete-user`,
-`owner-route-promote-owner`, or `owner-route-delete-user`, so Launchplane can
-validate the requested action against the expected stable or preview lane before
-it touches Dokploy schedules. Legacy action-only maintenance payloads are
-retired and fail request validation.
+`stable-testing-remote-e2e-grant-sponsored`, `remote-e2e-grant-sponsored`,
+`remote-e2e-delete-user`, `owner-route-promote-owner`, or
+`owner-route-delete-user`, so Launchplane can validate the requested action
+against the expected stable or preview lane before it touches Dokploy schedules.
+Legacy action-only maintenance payloads are retired and fail request validation.
 
 The first Odoo driver cuts are intentionally narrow as well: Launchplane owns the
 artifact publish handoff, remote post-deploy data-workflow trigger, and prod

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24242,6 +24242,75 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["result"]["application_id"], "testing-app-123")
             execute_mock.assert_called_once()
 
+    def test_verireel_app_maintenance_driver_accepts_stable_e2e_grant_intent(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_app_maintenance.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_app_maintenance",
+                return_value=VeriReelAppMaintenanceResult(
+                    maintenance_status="pass",
+                    action="grant-sponsored",
+                    intent="stable-testing-remote-e2e-grant-sponsored",
+                    context="verireel",
+                    instance="testing",
+                    application_name="ver-testing-app",
+                    application_id="testing-app-123",
+                    schedule_name="ver-remote-e2e-grant-sponsored",
+                    started_at="2026-04-25T19:00:00Z",
+                    finished_at="2026-04-25T19:01:00Z",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/app-maintenance",
+                    payload={
+                        "product": "verireel",
+                        "maintenance": {
+                            "context": "verireel",
+                            "instance": "testing",
+                            "action": "grant-sponsored",
+                            "intent": "stable-testing-remote-e2e-grant-sponsored",
+                            "email": "creator@example.com",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(payload["result"]["maintenance_status"], "pass")
+            execute_mock.assert_called_once()
+
     def test_verireel_app_maintenance_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_verireel_app_maintenance.py
+++ b/tests/test_verireel_app_maintenance.py
@@ -103,6 +103,67 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
 
         self.assertEqual(request.intent, "remote-e2e-grant-sponsored")
 
+    def test_accepts_stable_testing_remote_e2e_grant_intent(self) -> None:
+        request = VeriReelAppMaintenanceRequest(
+            context="verireel",
+            instance="testing",
+            action="grant-sponsored",
+            intent="stable-testing-remote-e2e-grant-sponsored",
+            email="creator@example.com",
+        )
+
+        self.assertEqual(request.intent, "stable-testing-remote-e2e-grant-sponsored")
+
+    def test_executes_stable_testing_remote_e2e_grant_through_stable_app(self) -> None:
+        request = VeriReelAppMaintenanceRequest(
+            context="verireel",
+            instance="testing",
+            action="grant-sponsored",
+            intent="stable-testing-remote-e2e-grant-sponsored",
+            email="creator+e2e@example.com",
+        )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            with (
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.test", "managed-token"),
+                ),
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._resolve_stable_testing_application",
+                    return_value=("ver-testing-app", "app-123"),
+                ) as stable_resolve_mock,
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._resolve_preview_application",
+                    return_value=("ver-preview-pr-42-app", "app-preview-42"),
+                ) as preview_resolve_mock,
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._run_application_command_with_retries"
+                ) as run_mock,
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._trigger_application_deploy"
+                ) as deploy_mock,
+            ):
+                result = execute_verireel_app_maintenance(
+                    control_plane_root=Path(temporary_directory_name),
+                    request=request,
+                )
+
+        self.assertEqual(result.maintenance_status, "pass")
+        self.assertEqual(result.application_id, "app-123")
+        self.assertEqual(result.intent, "stable-testing-remote-e2e-grant-sponsored")
+        stable_resolve_mock.assert_called_once()
+        preview_resolve_mock.assert_not_called()
+        run_mock.assert_called_once_with(
+            host="https://dokploy.example.test",
+            token="managed-token",
+            application_id="app-123",
+            schedule_name="ver-remote-e2e-grant-sponsored",
+            command="node scripts/ops/remote-owner-admin.mjs --action grant-sponsored --email creator+e2e@example.com",
+            timeout_seconds=300,
+        )
+        deploy_mock.assert_not_called()
+
     def test_rejects_intent_that_does_not_match_action_and_context(self) -> None:
         with self.assertRaises(ValueError):
             VeriReelAppMaintenanceRequest(


### PR DESCRIPTION
## Summary

- add a scoped stable-testing intent for VeriReel remote E2E `grant-sponsored`
- cover the app-maintenance service route shape that VeriReel shared-testing verification sends
- document the stable and preview E2E grant intents separately

Fixes #1145.

## Validation

- `uv run python -m unittest tests.test_verireel_app_maintenance tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_accepts_stable_e2e_grant_intent tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_rejects_action_only_payload`
- `uv run --extra dev ruff format --check control_plane/workflows/verireel_app_maintenance.py tests/test_verireel_app_maintenance.py tests/test_service.py`
- `uv run --extra dev ruff check --diff control_plane/workflows/verireel_app_maintenance.py tests/test_verireel_app_maintenance.py tests/test_service.py`
