### PR TITLE
Fix runner Buildx plugin path observation

### DIFF
--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -40,6 +40,7 @@ from control_plane.merge_train_github import UrllibMergeTrainGitHubTransport
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
 from control_plane.runner_queue_wait_github import GitHubRunnerQueueWaitReader
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandRunner
 from control_plane.workflows.runner_host_hygiene_executor import build_local_command_runner
 from control_plane.workflows.runner_host_hygiene_executor import (
@@ -1175,12 +1176,7 @@ def _runner_baseline_docker_toolchain(
             (
                 "sh",
                 "-c",
-                "command -v docker-buildx 2>/dev/null || "
-                "for path in /usr/libexec/docker/cli-plugins/docker-buildx "
-                "/usr/local/lib/docker/cli-plugins/docker-buildx "
-                "$HOME/.docker/cli-plugins/docker-buildx; do "
-                '[ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; '
-                "done",
+                DOCKER_BUILDX_PLUGIN_PATH_COMMAND,
             ),
             timeout_seconds=docker_toolchain_timeout_seconds,
         )

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -55,6 +55,20 @@ _DOCKER_SIZE_UNITS = {
     "gib": Decimal(1024**3),
     "tib": Decimal(1024**4),
 }
+DOCKER_BUILDX_PLUGIN_PATH_COMMAND = (
+    "docker info --format "
+    '\'{{range .ClientInfo.Plugins}}{{if eq .Name "buildx"}}'
+    '{{.Path}}{{"\\n"}}{{end}}{{end}}\' 2>/dev/null | '
+    "awk 'NF { print; found=1; exit } END { exit found ? 0 : 1 }' || "
+    "command -v docker-buildx 2>/dev/null || "
+    "for path in $HOME/.docker/cli-plugins/docker-buildx "
+    "/usr/local/lib/docker/cli-plugins/docker-buildx "
+    "/usr/local/libexec/docker/cli-plugins/docker-buildx "
+    "/usr/lib/docker/cli-plugins/docker-buildx "
+    "/usr/libexec/docker/cli-plugins/docker-buildx; do "
+    '[ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; '
+    "done"
+)
 
 
 @dataclass(frozen=True)
@@ -532,12 +546,7 @@ def _collect_docker_toolchain(
             (
                 "sh",
                 "-c",
-                "command -v docker-buildx 2>/dev/null || "
-                "for path in /usr/libexec/docker/cli-plugins/docker-buildx "
-                "/usr/local/lib/docker/cli-plugins/docker-buildx "
-                "$HOME/.docker/cli-plugins/docker-buildx; do "
-                '[ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; '
-                "done",
+                DOCKER_BUILDX_PLUGIN_PATH_COMMAND,
             ),
             request.timeout_seconds,
         ).stdout

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import subprocess
 from tempfile import TemporaryDirectory
 from collections.abc import Sequence
 from typing import cast
@@ -27,6 +28,7 @@ from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hyg
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_adapter_boundary
 from control_plane.cli_runner_lanes import _runner_host_hygiene_bearer_token
+from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
 from control_plane.workflows.runner_host_hygiene_executor import collect_runner_host_hygiene_report
@@ -191,7 +193,7 @@ class RunnerHostHygieneTests(unittest.TestCase):
             (
                 "sh",
                 "-c",
-                'command -v docker-buildx 2>/dev/null || for path in /usr/libexec/docker/cli-plugins/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx $HOME/.docker/cli-plugins/docker-buildx; do [ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; done',
+                DOCKER_BUILDX_PLUGIN_PATH_COMMAND,
             ): "/usr/libexec/docker/cli-plugins/docker-buildx\n",
             (
                 "sh",
@@ -232,6 +234,114 @@ class RunnerHostHygieneTests(unittest.TestCase):
         )
         self.assertEqual(report.docker_toolchain.docker_buildx_source, "system package")
         self.assertEqual(report.docker_toolchain.buildkit_version, "0.30.0")
+
+    def test_executor_report_uses_active_managed_buildx_plugin_path(self) -> None:
+        outputs: dict[tuple[str, ...], str] = {
+            ("hostname",): "chris-testing\n",
+            (
+                "df",
+                "-B1",
+                "-P",
+                "/",
+            ): "Filesystem 1B-blocks Used Available Use% Mounted on\n/dev/root 1000 100 900 10% /\n",
+            (
+                "docker",
+                "system",
+                "df",
+                "--format",
+                "{{.Type}} {{.TotalCount}} {{.Size}} {{.Reclaimable}}",
+            ): "Images 1 10MB 0B\nBuild Cache 1 10MB 0B\n",
+            ("docker", "system", "df", "-v"): "",
+            ("docker", "builder", "ls"): "",
+            ("docker", "volume", "ls", "-q"): "",
+            (
+                "docker",
+                "image",
+                "ls",
+                "--all",
+                "--no-trunc",
+                "--format",
+                "{{json .}}",
+            ): "",
+            ("docker", "ps", "--all", "--no-trunc", "--format", "{{json .}}"): "",
+            (
+                "bash",
+                "-lc",
+                "docker volume ls -q | xargs -r docker volume inspect",
+            ): "",
+            (
+                "bash",
+                "-lc",
+                "find /opt/actions-runners -mindepth 2 -maxdepth 2 -type d -name _work -exec du -sb {} + 2>/dev/null | awk '{ total += $1 } END { print total + 0 }'",
+            ): "0\n",
+            ("docker", "version", "--format", "{{.Server.Version}}"): "26.1.5+dfsg1\n",
+            ("docker", "version", "--format", "{{.Client.Version}}"): "26.1.5+dfsg1\n",
+            ("docker", "buildx", "version"): "github.com/docker/buildx v0.23.0 abcdef\n",
+            ("docker", "buildx", "inspect"): "Driver: docker-container\nBuildKit: v0.30.0\n",
+            (
+                "sh",
+                "-c",
+                DOCKER_BUILDX_PLUGIN_PATH_COMMAND,
+            ): "/usr/local/lib/docker/cli-plugins/docker-buildx\n",
+            (
+                "sh",
+                "-c",
+                "dpkg-query -W -f='${Package} ${Version}' docker-buildx 2>/dev/null",
+            ): "docker-buildx 0.13.1+ds1-3",
+            ("sh", "-c", "rpm -q docker-buildx 2>/dev/null"): "",
+        }
+
+        def runner(command: Sequence[str], _timeout: int) -> RemoteCommandResult:
+            command_tuple = tuple(command)
+            if command_tuple[:3] == ("docker", "volume", "inspect"):
+                return RemoteCommandResult(returncode=1)
+            return RemoteCommandResult(returncode=0, stdout=outputs.get(command_tuple, ""))
+
+        report = collect_runner_host_hygiene_report(
+            request=RunnerHostHygieneExecutorRequest(
+                action="prune_docker_cache",
+                host_name="chris-testing",
+                execution_lane="chris-testing-ops-gate",
+                service_user="gha",
+                repository_scope="cbusillo/launchplane",
+                audit_record_key="runner-host-hygiene/2026-06-04/chris-testing",
+                retained_warm_builders=("odoo-docker-chris-testing",),
+            ),
+            remote_runner=runner,
+        )
+
+        self.assertIsNotNone(report.docker_toolchain)
+        assert report.docker_toolchain is not None
+        self.assertEqual(
+            report.docker_toolchain.docker_buildx_plugin_path,
+            "/usr/local/lib/docker/cli-plugins/docker-buildx",
+        )
+        self.assertEqual(report.docker_toolchain.docker_buildx_source, "managed plugin")
+        self.assertEqual(
+            report.docker_toolchain.docker_buildx_package, "docker-buildx 0.13.1+ds1-3"
+        )
+
+    def test_buildx_plugin_path_probe_falls_back_when_docker_info_has_no_path(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            plugin_path = Path(temp_dir) / "docker-buildx"
+            plugin_path.write_text("#!/bin/sh\n", encoding="utf-8")
+            plugin_path.chmod(0o755)
+            probe = DOCKER_BUILDX_PLUGIN_PATH_COMMAND.replace(
+                "$HOME/.docker/cli-plugins/docker-buildx",
+                str(plugin_path),
+            )
+            result = subprocess.run(
+                ["sh", "-c", probe],
+                check=False,
+                capture_output=True,
+                text=True,
+                env={"PATH": "/usr/bin:/bin", "HOME": temp_dir},
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), str(plugin_path))
 
     def test_executor_report_omits_empty_docker_toolchain_evidence(self) -> None:
         outputs: dict[tuple[str, ...], str] = {

--- a/tests/test_runner_lane_baseline.py
+++ b/tests/test_runner_lane_baseline.py
@@ -14,6 +14,7 @@ from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselineObser
 from control_plane.contracts.runner_lane_baseline import RunnerLaneBaselinePolicy
 from control_plane.contracts.runner_lane_baseline import RunnerLaneDockerToolchainObservation
 from control_plane.contracts.runner_lane_baseline import evaluate_runner_lane_baseline
+from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
 
 
@@ -434,7 +435,7 @@ class RunnerLaneBaselineCliTests(unittest.TestCase):
             (
                 "sh",
                 "-c",
-                'command -v docker-buildx 2>/dev/null || for path in /usr/libexec/docker/cli-plugins/docker-buildx /usr/local/lib/docker/cli-plugins/docker-buildx $HOME/.docker/cli-plugins/docker-buildx; do [ -x "$path" ] && { printf \'%s\\n\' "$path"; break; }; done',
+                DOCKER_BUILDX_PLUGIN_PATH_COMMAND,
             ): "/usr/libexec/docker/cli-plugins/docker-buildx\n",
             (
                 "sh",
@@ -489,6 +490,68 @@ class RunnerLaneBaselineCliTests(unittest.TestCase):
             payload["observation"]["docker_toolchain"]["docker_buildx_source"], "system package"
         )
         self.assertEqual(payload["observation"]["docker_toolchain"]["buildkit_version"], "0.30.0")
+
+    def test_cli_reports_active_managed_buildx_plugin_path(self) -> None:
+        outputs: dict[tuple[str, ...], str] = {
+            ("docker", "version", "--format", "{{.Server.Version}}"): "26.1.5+dfsg1\n",
+            ("docker", "version", "--format", "{{.Client.Version}}"): "26.1.5+dfsg1\n",
+            ("docker", "buildx", "version"): "github.com/docker/buildx v0.23.0 abcdef\n",
+            ("docker", "buildx", "inspect"): "Driver: docker-container\nBuildKit: v0.30.0\n",
+            (
+                "sh",
+                "-c",
+                DOCKER_BUILDX_PLUGIN_PATH_COMMAND,
+            ): "/usr/local/lib/docker/cli-plugins/docker-buildx\n",
+            (
+                "sh",
+                "-c",
+                "dpkg-query -W -f='${Package} ${Version}' docker-buildx 2>/dev/null",
+            ): "docker-buildx 0.13.1+ds1-3",
+            ("sh", "-c", "rpm -q docker-buildx 2>/dev/null"): "",
+        }
+
+        def runner(command: Sequence[str], _timeout: int) -> RemoteCommandResult:
+            return RemoteCommandResult(returncode=0, stdout=outputs.get(tuple(command), ""))
+
+        with patch(
+            "control_plane.cli_runner_lanes.build_local_command_runner", return_value=runner
+        ):
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-baseline-observe",
+                    "--runner-name",
+                    "chris-testing-ops-gate",
+                    "--label",
+                    "self-hosted",
+                    "--label",
+                    "launchplane",
+                    "--docker-config-isolated",
+                    "--observe-docker-toolchain",
+                    "--require-docker-toolchain-observation",
+                    "--minimum-docker-buildx-version",
+                    "0.23.0",
+                    "--observed-at",
+                    "2026-06-04T18:40:00Z",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertTrue(payload["readiness"]["ready"])
+        self.assertEqual(
+            payload["observation"]["docker_toolchain"]["docker_buildx_plugin_path"],
+            "/usr/local/lib/docker/cli-plugins/docker-buildx",
+        )
+        self.assertEqual(
+            payload["observation"]["docker_toolchain"]["docker_buildx_source"],
+            "managed plugin",
+        )
+        self.assertEqual(
+            payload["observation"]["docker_toolchain"]["docker_buildx_package"],
+            "docker-buildx 0.13.1+ds1-3",
+        )
 
     def test_cli_fails_closed_without_docker_isolation_evidence(self) -> None:
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- report Docker's active Buildx CLI plugin path from `docker info` before filesystem fallback
- share the plugin-path probe between runner baseline readiness and host hygiene evidence
- keep package evidence visible so managed `/usr/local` plugins can coexist with stale Debian package metadata
- add regression coverage for active managed plugin reporting and empty Docker-info fallback

## Validation
- `uv run python -m unittest tests.test_runner_lane_baseline.RunnerLaneBaselineCliTests.test_cli_observes_docker_toolchain_with_read_only_probe tests.test_runner_lane_baseline.RunnerLaneBaselineCliTests.test_cli_reports_active_managed_buildx_plugin_path tests.test_runner_host_hygiene.RunnerHostHygieneTests.test_executor_report_preserves_docker_toolchain_evidence tests.test_runner_host_hygiene.RunnerHostHygieneTests.test_executor_report_uses_active_managed_buildx_plugin_path tests.test_runner_host_hygiene.RunnerHostHygieneTests.test_buildx_plugin_path_probe_falls_back_when_docker_info_has_no_path`
- `uv run --extra dev mypy control_plane/cli_runner_lanes.py control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_lane_baseline.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff check --no-fix control_plane/cli_runner_lanes.py control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_lane_baseline.py tests/test_runner_host_hygiene.py`
- `uv run --extra dev ruff format --check control_plane/cli_runner_lanes.py control_plane/workflows/runner_host_hygiene_executor.py tests/test_runner_lane_baseline.py tests/test_runner_host_hygiene.py`

Part of #1141 follow-through after standardizing the live runner Buildx plugin.
