### PR TITLE
Clean up merge train candidate refs

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -135,7 +135,9 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
             update={"required_checks_status": check_status, "status": candidate_status}
         )
 
-    def land_batch_candidate(self, *, landing_plan: MergeTrainBatchLandingPlan) -> MergeTrainBatchLandingPlan:
+    def land_batch_candidate(
+        self, *, landing_plan: MergeTrainBatchLandingPlan
+    ) -> MergeTrainBatchLandingPlan:
         repository_path = _repository_path(landing_plan.repository)
         expected_base_sha = landing_plan.entries[0].expected_base_sha
         merged_entries = []
@@ -186,9 +188,7 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                 merge_method=entry.merge_method,
             )
             merged_entries.append(
-                entry.model_copy(
-                    update={"status": "merged", "merge_commit_sha": merge_commit_sha}
-                )
+                entry.model_copy(update={"status": "merged", "merge_commit_sha": merge_commit_sha})
             )
             expected_base_sha = merge_commit_sha
         current_base_sha = _base_branch_sha(
@@ -200,6 +200,10 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
             raise MergeTrainGitHubStaleHeadError(
                 "Base branch moved outside the batch landing plan.", status_code=409
             )
+        self._delete_reference_if_present(
+            repository_path=repository_path,
+            reference=landing_plan.candidate_ref,
+        )
         return landing_plan.model_copy(update={"entries": tuple(merged_entries)})
 
     def _already_merged_landing_entry(
@@ -282,9 +286,7 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
             )
         return merge_commit_sha
 
-    def comment_pull_request(
-        self, *, repository: str, pull_request_number: int, body: str
-    ) -> str:
+    def comment_pull_request(self, *, repository: str, pull_request_number: int, body: str) -> str:
         repository_path = _repository_path(repository)
         payload = self.transport.request(
             method="POST",
@@ -303,9 +305,7 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
         expected_sha = _required_value(
             expected_head_sha, "Expected pull request head SHA is required."
         )
-        current_head_sha = self._pull_request_head_sha(
-            pull_request_path=pull_request_path
-        )
+        current_head_sha = self._pull_request_head_sha(pull_request_path=pull_request_path)
         if current_head_sha != _required_value(
             expected_head_sha, "Expected pull request head SHA is required."
         ):
@@ -390,6 +390,17 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                 path=f"/repos/{repository_path}/git/refs/{reference_path}",
                 body={"sha": normalized_sha, "force": True},
             )
+
+    def _delete_reference_if_present(self, *, repository_path: str, reference: str) -> None:
+        try:
+            self.transport.request(
+                method="DELETE",
+                path=f"/repos/{repository_path}/git/refs/{_reference_path(reference)}",
+            )
+        except MergeTrainGitHubError as error:
+            if error.status_code == 404:
+                return
+            raise
 
     def _pull_request_head_sha(self, *, pull_request_path: str) -> str:
         pull_request = _json_object(
@@ -486,12 +497,8 @@ class GitHubMergeTrainSnapshotReader:
         head = _json_object(source.get("head"), "GitHub pull request head")
         base = _json_object(source.get("base"), "GitHub pull request base")
         head_sha = _required_text(head.get("sha"), "GitHub pull request head requires sha.")
-        head_repository = _repository_full_name(
-            head.get("repo"), "GitHub pull request head repo"
-        )
-        base_repository = _repository_full_name(
-            base.get("repo"), "GitHub pull request base repo"
-        )
+        head_repository = _repository_full_name(head.get("repo"), "GitHub pull request head repo")
+        base_repository = _repository_full_name(base.get("repo"), "GitHub pull request base repo")
         user = _json_object(source.get("user"), "GitHub pull request user")
         actor_role = self._actor_role_for_pull_request(
             repository_path=repository_path,
@@ -635,9 +642,7 @@ def _base_rooted_pull_requests(
     relevant_numbers: set[int] = set()
     for pull_request in pull_requests:
         base = _json_object(pull_request.get("base"), "GitHub pull request base")
-        base_repository = _repository_full_name(
-            base.get("repo"), "GitHub pull request base repo"
-        )
+        base_repository = _repository_full_name(base.get("repo"), "GitHub pull request base repo")
         if base_repository != repository:
             continue
         base_ref = _required_text(base.get("ref"), "GitHub pull request base requires ref.")
@@ -669,9 +674,7 @@ def _base_rooted_pull_requests(
     return tuple(
         pull_request
         for pull_request in pull_requests
-        if _required_int(
-            pull_request.get("number"), "GitHub pull request entry requires number."
-        )
+        if _required_int(pull_request.get("number"), "GitHub pull request entry requires number.")
         in relevant_numbers
     )
 

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -503,6 +503,10 @@ with a different head SHA than the landing plan recorded, Launchplane writes
 terminal stale landing evidence for the plan. That stale evidence does not count
 as a successful Launchplane landing, but it does retire the stale plan so a fresh
 controller pass can read current GitHub state and admit later eligible work.
+After a landing plan reaches the recorded final base SHA, Launchplane deletes
+the generated `launchplane/train/...` candidate branch ref. Missing candidate
+refs are treated as already-clean so landing retries remain idempotent; stale or
+failed landing attempts leave the ref in place for investigation.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/docs/records.md
+++ b/docs/records.md
@@ -941,8 +941,10 @@ preflights.
   `launchplane_merge_train_batch_candidates` records. Each record stores the
   repository/base branch, observed base SHA, ordered PR entries, candidate ref,
   candidate SHA when available, policy key and digest, candidate status, check
-  status summary, source, and update timestamp. These records are the durable
-  evidence for a speculative batch candidate, not checked-in configuration.
+  status summary, source, and update timestamp. Successful landing deletes the
+  generated GitHub candidate ref after final base-sha validation; the record
+  remains as durable evidence for the speculative batch candidate, not
+  checked-in configuration.
 - Full batch train landing plans are persisted as
   `launchplane_merge_train_batch_landing_plans` records. Each record stores the
   candidate identity, repository/base branch, candidate SHA, policy key and

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -193,8 +193,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                         "base": "feature/root",
                         "head": "child-head",
                         "commit_message": (
-                            "Launchplane stack collapse collapse-123: merge PR "
-                            "#11 into PR #10"
+                            "Launchplane stack collapse collapse-123: merge PR #11 into PR #10"
                         ),
                     },
                 ),
@@ -374,6 +373,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
                 _github_branch(sha="merge-sha-2"),
+                {},
             )
         )
 
@@ -381,9 +381,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             landing_plan=landing_plan
         )
 
-        self.assertEqual(
-            [entry.status for entry in landed_plan.entries], ["merged", "merged"]
-        )
+        self.assertEqual([entry.status for entry in landed_plan.entries], ["merged", "merged"])
         self.assertEqual(
             [entry.merge_commit_sha for entry in landed_plan.entries],
             ["merge-sha-1", "merge-sha-2"],
@@ -404,12 +402,65 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
+    def test_land_batch_candidate_tolerates_already_deleted_candidate_ref(self) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="base-main"),
+                {"sha": "merge-sha-1"},
+                _github_branch(sha="merge-sha-1"),
+                {"sha": "merge-sha-2"},
+                _github_branch(sha="merge-sha-2"),
+                MergeTrainGitHubError("candidate ref missing", status_code=404),
+            )
+        )
+
+        landed_plan = GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            landing_plan=landing_plan
+        )
+
+        self.assertEqual([entry.status for entry in landed_plan.entries], ["merged", "merged"])
+        self.assertEqual(
+            [entry.merge_commit_sha for entry in landed_plan.entries],
+            ["merge-sha-1", "merge-sha-2"],
+        )
+        self.assertEqual(
+            (transport.requests[-1].method, transport.requests[-1].path),
+            ("DELETE", _candidate_ref_path(landing_plan)),
+        )
+
+    def test_land_batch_candidate_fails_closed_on_candidate_ref_delete_error(self) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(
+                _github_branch(sha="base-main"),
+                {"sha": "merge-sha-1"},
+                _github_branch(sha="merge-sha-1"),
+                {"sha": "merge-sha-2"},
+                _github_branch(sha="merge-sha-2"),
+                MergeTrainGitHubError("candidate ref delete failed", status_code=500),
+            )
+        )
+
+        with self.assertRaisesRegex(MergeTrainGitHubError, "delete failed"):
+            GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+                landing_plan=landing_plan
+            )
+
+        self.assertEqual(
+            (transport.requests[-1].method, transport.requests[-1].path),
+            ("DELETE", _candidate_ref_path(landing_plan)),
+        )
+
     def test_land_batch_candidate_skips_persisted_merged_entries_on_retry(self) -> None:
-        first_entry = _landing_plan().entries[0].model_copy(
-            update={"status": "merged", "merge_commit_sha": "merge-sha-1"}
+        first_entry = (
+            _landing_plan()
+            .entries[0]
+            .model_copy(update={"status": "merged", "merge_commit_sha": "merge-sha-1"})
         )
         landing_plan = _landing_plan().model_copy(
             update={"entries": (first_entry, _landing_plan().entries[1])}
@@ -420,6 +471,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
                 _github_branch(sha="merge-sha-2"),
+                {},
             )
         )
 
@@ -442,19 +494,22 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
     def test_land_batch_candidate_reconciles_all_already_merged_entries(self) -> None:
-        first_entry = _landing_plan().entries[0].model_copy(
-            update={"status": "merged", "merge_commit_sha": "merge-sha-1"}
+        first_entry = (
+            _landing_plan()
+            .entries[0]
+            .model_copy(update={"status": "merged", "merge_commit_sha": "merge-sha-1"})
         )
-        second_entry = _landing_plan().entries[1].model_copy(
-            update={"status": "merged", "merge_commit_sha": "merge-sha-2"}
+        second_entry = (
+            _landing_plan()
+            .entries[1]
+            .model_copy(update={"status": "merged", "merge_commit_sha": "merge-sha-2"})
         )
-        landing_plan = _landing_plan().model_copy(
-            update={"entries": (first_entry, second_entry)}
-        )
+        landing_plan = _landing_plan().model_copy(update={"entries": (first_entry, second_entry)})
         transport = RecordingMergeTrainGitHubTransport(
             responses=(
                 _github_branch(sha="merge-sha-2"),
@@ -466,6 +521,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ),
                 _github_branch(sha="merge-sha-2"),
                 _github_branch(sha="merge-sha-2"),
+                {},
             )
         )
 
@@ -484,12 +540,15 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ("GET", "/repos/example/merge-train-repo/pulls/1", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
     def test_land_batch_candidate_revalidates_persisted_merged_entry_base(self) -> None:
-        first_entry = _landing_plan().entries[0].model_copy(
-            update={"status": "merged", "merge_commit_sha": "merge-sha-1"}
+        first_entry = (
+            _landing_plan()
+            .entries[0]
+            .model_copy(update={"status": "merged", "merge_commit_sha": "merge-sha-1"})
         )
         landing_plan = _landing_plan().model_copy(
             update={"entries": (first_entry, _landing_plan().entries[1])}
@@ -526,8 +585,10 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
     def test_land_batch_candidate_reconciles_partially_persisted_plan_at_final_base(
         self,
     ) -> None:
-        first_entry = _landing_plan().entries[0].model_copy(
-            update={"status": "merged", "merge_commit_sha": "merge-sha-1"}
+        first_entry = (
+            _landing_plan()
+            .entries[0]
+            .model_copy(update={"status": "merged", "merge_commit_sha": "merge-sha-1"})
         )
         landing_plan = _landing_plan().model_copy(
             update={"entries": (first_entry, _landing_plan().entries[1])}
@@ -549,6 +610,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     merge_commit_sha="merge-sha-2",
                 ),
                 _github_branch(sha="merge-sha-2"),
+                {},
             )
         )
 
@@ -556,9 +618,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             landing_plan=landing_plan
         )
 
-        self.assertEqual(
-            [entry.status for entry in landed_plan.entries], ["merged", "merged"]
-        )
+        self.assertEqual([entry.status for entry in landed_plan.entries], ["merged", "merged"])
         self.assertEqual(
             [entry.merge_commit_sha for entry in landed_plan.entries],
             ["merge-sha-1", "merge-sha-2"],
@@ -571,6 +631,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 ("GET", "/repos/example/merge-train-repo/pulls/2", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
@@ -590,6 +651,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
                 _github_branch(sha="merge-sha-2"),
+                {},
             )
         )
 
@@ -597,9 +659,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             landing_plan=landing_plan
         )
 
-        self.assertEqual(
-            [entry.status for entry in landed_plan.entries], ["merged", "merged"]
-        )
+        self.assertEqual([entry.status for entry in landed_plan.entries], ["merged", "merged"])
         self.assertEqual(
             [entry.merge_commit_sha for entry in landed_plan.entries],
             ["merge-sha-1", "merge-sha-2"],
@@ -616,6 +676,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
@@ -640,6 +701,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     merge_commit_sha="merge-sha-2",
                 ),
                 _github_branch(sha="merge-sha-2"),
+                {},
             )
         )
 
@@ -647,9 +709,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
             landing_plan=landing_plan
         )
 
-        self.assertEqual(
-            [entry.status for entry in landed_plan.entries], ["merged", "merged"]
-        )
+        self.assertEqual([entry.status for entry in landed_plan.entries], ["merged", "merged"])
         self.assertEqual(
             [entry.merge_commit_sha for entry in landed_plan.entries],
             ["merge-sha-1", "merge-sha-2"],
@@ -662,6 +722,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 ("GET", "/repos/example/merge-train-repo/pulls/2", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
+                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
@@ -708,6 +769,7 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
         self.assertEqual(
             [request.method for request in transport.requests], ["GET", "PUT", "GET", "GET"]
         )
+        self.assertNotIn("DELETE", [request.method for request in transport.requests])
 
     def test_land_batch_candidate_rejects_moved_base_branch(self) -> None:
         landing_plan = _landing_plan()
@@ -1048,6 +1110,13 @@ def _landing_plan() -> MergeTrainBatchLandingPlan:
         candidate=candidate,
         merge_method="merge",
         created_at="2026-05-14T01:10:00Z",
+    )
+
+
+def _candidate_ref_path(landing_plan: MergeTrainBatchLandingPlan) -> str:
+    return (
+        "/repos/example/merge-train-repo/git/refs/heads/launchplane/train/"
+        f"example/merge-train-repo/main/{landing_plan.batch_id}"
     )
 
 


### PR DESCRIPTION
## Summary
- delete generated `launchplane/train/...` candidate refs after successful batch landing final-base validation
- tolerate missing candidate refs so landing retries remain idempotent
- keep stale base/head failure paths fail-closed and leave candidate refs intact for investigation
- document merge-train candidate ref cleanup and persistent record evidence

## Validation
- `uv run python -m unittest tests.test_merge_train_github`
- `uv run python -m unittest tests.test_merge_train_controller tests.test_merge_train_controller_feedback tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_lands_existing_plan tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_persists_root_merge_before_child_record_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_terminalizes_stale_landing_state`
- `uv run --extra dev ruff check control_plane/merge_train_github.py tests/test_merge_train_github.py`
- `uv run --extra dev ruff format --check control_plane/merge_train_github.py tests/test_merge_train_github.py`
- `uv run --extra dev mypy control_plane/merge_train_github.py tests/test_merge_train_github.py`
- `npx --yes markdownlint-cli2 docs/merge-train-policy.md docs/records.md`

## Reviews
- Review agents (Code, Claude, Antigravity/Gemini-family) reviewed the diff.
- Follow-up test added for non-404 DELETE failures after review.

Refs #949
