### PR TITLE
Add descriptor-backed driver dispatch seam

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -804,9 +804,42 @@ class _DriverRouteExecutionMetadata(Generic[_DriverRouteEnvelopeT]):
 
 
 @dataclass(frozen=True)
+class _DescriptorDriverDispatchContext:
+    product: str
+    context: str
+    instance: str = ""
+    require_profile: bool = False
+
+
+@dataclass(frozen=True)
+class _DescriptorDriverDispatchResult:
+    result: dict[str, object]
+    driver_result: BaseModel | dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
 class _ResolvedProductDriverContext:
     profile: LaunchplaneProductProfileRecord | None
     lane: ProductLaneProfile | None = None
+
+
+_DescriptorDriverDispatchContextResolver = Callable[
+    [_DriverRouteEnvelopeT], _DescriptorDriverDispatchContext
+]
+_DescriptorDriverDispatchHandler = Callable[
+    [
+        _DriverRouteEnvelopeT,
+        _ResolvedProductDriverContext,
+    ],
+    _DescriptorDriverDispatchResult,
+]
+
+
+@dataclass(frozen=True)
+class _DescriptorDriverDispatchRoute(Generic[_DriverRouteEnvelopeT]):
+    execution_metadata: _DriverRouteExecutionMetadata[_DriverRouteEnvelopeT]
+    context_resolver: _DescriptorDriverDispatchContextResolver[_DriverRouteEnvelopeT]
+    handler: _DescriptorDriverDispatchHandler[_DriverRouteEnvelopeT]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -2609,6 +2642,76 @@ def _resolve_and_authorize_descriptor_route(
     return resolved_driver_context, authorization_response
 
 
+def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchRoute[Any]]:
+    return {}
+
+
+def _dispatch_descriptor_driver_route(
+    *,
+    dispatch_route: _DescriptorDriverDispatchRoute[Any],
+    payload: dict[str, object],
+    record_store: object,
+    authz_policy: LaunchplaneAuthzPolicy,
+    identity: LaunchplaneIdentity,
+    request_scope: str,
+    request_idempotency_key: str,
+    request_fingerprint: str,
+    start_response: _StartResponse,
+    trace_id: str,
+) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
+    route_metadata = dispatch_route.execution_metadata
+    descriptor_route_metadata = _driver_route_metadata_from_descriptors().get(
+        route_metadata.route_path
+    )
+    if descriptor_route_metadata is None:
+        raise ValueError(
+            f"Descriptor-backed dispatch route {route_metadata.route_path} "
+            "must be declared by a driver descriptor."
+        )
+    if descriptor_route_metadata.method != "POST":
+        raise ValueError(
+            f"Descriptor-backed dispatch route {route_metadata.route_path} must use POST."
+        )
+    request = route_metadata.envelope_model.model_validate(payload)
+    dispatch_context = dispatch_route.context_resolver(request)
+    resolved_driver_context = _resolve_descriptor_product_driver_context(
+        record_store=record_store,
+        route_path=route_metadata.route_path,
+        product=dispatch_context.product,
+        context=dispatch_context.context,
+        instance=dispatch_context.instance,
+        require_profile=dispatch_context.require_profile,
+    )
+    authorization_context = dispatch_context.context
+    if not authorization_context and resolved_driver_context.lane is not None:
+        authorization_context = resolved_driver_context.lane.context
+    authorization_response = _driver_route_authorization_response(
+        authz_policy=authz_policy,
+        identity=identity,
+        route_path=route_metadata.route_path,
+        product=dispatch_context.product,
+        context=authorization_context,
+        denial_message=route_metadata.denial_message,
+        start_response=start_response,
+        trace_id=trace_id,
+    )
+    if authorization_response is not None:
+        return authorization_response
+    idempotent_response = _check_idempotent_request(
+        record_store=record_store,
+        scope=request_scope,
+        route_path=route_metadata.route_path,
+        idempotency_key=request_idempotency_key,
+        request_fingerprint=request_fingerprint,
+        start_response=start_response,
+        trace_id=trace_id,
+    )
+    if idempotent_response is not None:
+        return idempotent_response
+    dispatch_result = dispatch_route.handler(request, resolved_driver_context)
+    return dispatch_result.result, dispatch_result.driver_result
+
+
 def _authorize_generic_web_preview_route(
     *,
     route_metadata: _DriverRouteExecutionMetadata[_DriverRouteEnvelopeT],
@@ -2904,6 +3007,26 @@ def _descriptor_driver_authz_action(route_path: str) -> str:
         return _driver_route_metadata_from_descriptors()[route_path].authz_action
     except KeyError as exc:
         raise ValueError(f"Unknown descriptor-backed driver route: {route_path}") from exc
+
+
+def _validate_descriptor_driver_dispatch_routes(
+    dispatch_routes: dict[str, _DescriptorDriverDispatchRoute[Any]],
+) -> None:
+    descriptor_routes = _driver_route_metadata_from_descriptors()
+    for route_path, dispatch_route in dispatch_routes.items():
+        if route_path != dispatch_route.execution_metadata.route_path:
+            raise ValueError(
+                f"Descriptor-backed dispatch route {route_path} must match execution metadata."
+            )
+        descriptor_route = descriptor_routes.get(route_path)
+        if descriptor_route is None:
+            raise ValueError(
+                f"Descriptor-backed dispatch route {route_path} must be declared by a driver descriptor."
+            )
+        if descriptor_route.method != "POST":
+            raise ValueError(
+                f"Descriptor-backed dispatch route {route_path} must be declared as POST."
+            )
 
 
 def _driver_write_routes_from_descriptors() -> frozenset[str]:
@@ -7918,6 +8041,8 @@ def create_launchplane_service_app(
             else None
         )
     )
+    descriptor_driver_dispatch_routes = _descriptor_driver_dispatch_routes()
+    _validate_descriptor_driver_dispatch_routes(descriptor_driver_dispatch_routes)
     write_routes = _build_write_routes()
     resolved_ingress_provider_factory = ingress_provider_factory
     if resolved_ingress_provider_factory is None:
@@ -12566,6 +12691,22 @@ def create_launchplane_service_app(
                 assert isinstance(provider_target_result, ProviderTargetOperationRouteResult)
                 result = provider_target_result.result
                 driver_result = provider_target_result.driver_result
+            elif path in descriptor_driver_dispatch_routes:
+                dispatch_response = _dispatch_descriptor_driver_route(
+                    dispatch_route=descriptor_driver_dispatch_routes[path],
+                    payload=payload,
+                    record_store=record_store,
+                    authz_policy=authz_policy,
+                    identity=identity,
+                    request_scope=request_scope,
+                    request_idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if isinstance(dispatch_response, list):
+                    return dispatch_response
+                result, driver_result = dispatch_response
             elif path == "/v1/drivers/launchplane/self-deploy":
                 self_deploy_request = LaunchplaneSelfDeployEnvelope.model_validate(payload)
                 if not authz_policy.allows(
@@ -15017,6 +15158,21 @@ def create_launchplane_service_app(
                     request=preview_lifecycle_sweep_request,
                 )
                 result = {}
+            elif path.startswith("/v1/drivers/"):
+                return _json_response(
+                    start_response=start_response,
+                    status_code=500,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": request_trace_id,
+                        "error": {
+                            "code": "driver_route_not_registered",
+                            "message": (
+                                "Driver route is declared but has no registered service handler."
+                            ),
+                        },
+                    },
+                )
             else:
                 preview_destroyed_request = PreviewDestroyedEvidenceEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -9,8 +9,10 @@ discovery, operator read models, and future GUI action rendering. They describe
 what a product driver can do without making the UI understand the runtime
 provider that currently executes the work.
 
-This is a read-first contract. It does not execute actions and it does not add a
-frontend plugin system.
+This is a read-first contract and does not add a frontend plugin system.
+Descriptor presence alone does not execute actions; service dispatch requires a
+matching backend handler registration, and tests must fail closed when the
+descriptor route and handler registration drift.
 
 ## Provider Boundary
 
@@ -408,6 +410,10 @@ The HTTP service admits product-driver POST routes from descriptor action and
 route-alias paths and reads product-driver handler authorization actions from
 descriptor route metadata, so new drivers do not need a second hardcoded router
 allowlist or authz-action entry.
+Routes can also opt into descriptor-backed service dispatch when a backend
+handler is explicitly registered for the same descriptor route. This keeps
+descriptor metadata as the route/authz source of truth while preventing an
+advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from control_plane import service as control_plane_service
 from control_plane.contracts.driver_descriptor import (
+    DriverActionDescriptor,
     DriverCapabilityDescriptor,
     DriverDescriptor,
 )
@@ -371,6 +372,52 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "/v1/drivers/launchplane/self-deploy",
             control_plane_service._build_write_routes(),
         )
+
+    def test_descriptor_dispatch_registration_requires_descriptor_route(self) -> None:
+        descriptor = DriverDescriptor(
+            driver_id="fake-dispatch",
+            label="Fake dispatch",
+            product="fake-dispatch",
+            description="Test-only descriptor dispatch driver.",
+            provider_boundary="Test-only provider boundary.",
+            actions=(
+                DriverActionDescriptor(
+                    action_id="ping",
+                    label="Ping",
+                    description="Test descriptor-backed dispatch route.",
+                    safety="safe_write",
+                    scope="context",
+                    method="POST",
+                    route_path="/v1/drivers/fake-dispatch/ping",
+                    authz_action="fake_dispatch.ping",
+                ),
+            ),
+        )
+        route = control_plane_service._DescriptorDriverDispatchRoute(
+            execution_metadata=control_plane_service._DriverRouteExecutionMetadata(
+                route_path="/v1/drivers/fake-dispatch/ping",
+                envelope_model=control_plane_service.GenericWebStableVerificationEnvelope,
+                denial_message="Workflow cannot execute fake dispatch.",
+            ),
+            context_resolver=lambda request: control_plane_service._DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.verification.context,
+            ),
+            handler=lambda _request, _resolved_context: (
+                control_plane_service._DescriptorDriverDispatchResult(result={})
+            ),
+        )
+
+        with patch("control_plane.service.list_driver_descriptors", return_value=(descriptor,)):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(
+                {"/v1/drivers/fake-dispatch/ping": route}
+            )
+
+        with patch("control_plane.service.list_driver_descriptors", return_value=()):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(
+                    {"/v1/drivers/fake-dispatch/ping": route}
+                )
 
     def test_generic_web_execution_metadata_matches_descriptors(self) -> None:
         self.assert_route_metadata_matches_descriptor(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 
 from click import ClickException, Command
 from click.testing import CliRunner
+from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane.cli import main
 from control_plane import live_target_runtime as control_plane_live_target_runtime
@@ -32,6 +33,7 @@ from control_plane.contracts.every_code_preview_gate_record import EveryCodePrev
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.driver_descriptor import DriverActionDescriptor, DriverDescriptor
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
@@ -205,6 +207,86 @@ class _StubVerifier:
         if token != "valid-token":
             raise ValueError("OIDC bearer token is required.")
         return self.identity
+
+
+_FAKE_DESCRIPTOR_DRIVER_ID = "fake-descriptor"
+_FAKE_DESCRIPTOR_ROUTE_PATH = "/v1/drivers/fake-descriptor/ping"
+
+
+class _FakeDescriptorDispatchEnvelope(control_plane_service._ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str = ""
+    value: str = ""
+
+
+class _FakeDescriptorDispatchDriverResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    processed_value: str
+
+
+def _fake_descriptor_dispatch_descriptor() -> DriverDescriptor:
+    return DriverDescriptor(
+        driver_id=_FAKE_DESCRIPTOR_DRIVER_ID,
+        label="Fake descriptor dispatch",
+        product="fake-descriptor",
+        description="Test-only driver descriptor for descriptor dispatch coverage.",
+        context_patterns=("fake-context",),
+        provider_boundary="Test-only provider boundary.",
+        actions=(
+            DriverActionDescriptor(
+                action_id="ping",
+                label="Ping",
+                description="Test descriptor-backed dispatch route.",
+                safety="safe_write",
+                scope="instance",
+                method="POST",
+                route_path=_FAKE_DESCRIPTOR_ROUTE_PATH,
+                authz_action="fake_descriptor.ping",
+                writes_records=("fake_descriptor_result",),
+            ),
+        ),
+    )
+
+
+def _fake_descriptor_dispatch_route(
+    calls: list[tuple[_FakeDescriptorDispatchEnvelope, str]],
+) -> control_plane_service._DescriptorDriverDispatchRoute[_FakeDescriptorDispatchEnvelope]:
+    def context_resolver(
+        request: _FakeDescriptorDispatchEnvelope,
+    ) -> control_plane_service._DescriptorDriverDispatchContext:
+        return control_plane_service._DescriptorDriverDispatchContext(
+            product=request.product,
+            context=request.context,
+            instance=request.instance,
+            require_profile=True,
+        )
+
+    def handler(
+        request: _FakeDescriptorDispatchEnvelope,
+        resolved_context: control_plane_service._ResolvedProductDriverContext,
+    ) -> control_plane_service._DescriptorDriverDispatchResult:
+        lane_instance = resolved_context.lane.instance if resolved_context.lane is not None else ""
+        calls.append((request, lane_instance))
+        return control_plane_service._DescriptorDriverDispatchResult(
+            result={"request_id": f"fake-descriptor-{request.value}"},
+            driver_result=_FakeDescriptorDispatchDriverResult(
+                status="pass",
+                processed_value=f"{request.value}:{lane_instance}",
+            ),
+        )
+
+    return control_plane_service._DescriptorDriverDispatchRoute(
+        execution_metadata=control_plane_service._DriverRouteExecutionMetadata(
+            route_path=_FAKE_DESCRIPTOR_ROUTE_PATH,
+            envelope_model=_FakeDescriptorDispatchEnvelope,
+            denial_message="Workflow cannot execute fake descriptor dispatch.",
+        ),
+        context_resolver=context_resolver,
+        handler=handler,
+    )
 
 
 class _StubGitHubOAuthClient:
@@ -12020,6 +12102,306 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 404)
         self.assertEqual(payload["error"]["code"], "not_found")
+
+    def test_descriptor_dispatch_fake_route_executes_authorized_handler(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload("fake-product")
+            profile_payload["driver_id"] = _FAKE_DESCRIPTOR_DRIVER_ID
+            profile_payload["lanes"] = (
+                {
+                    "instance": "testing",
+                    "context": "fake-context",
+                    "base_url": "https://fake.example.test",
+                    "health_url": "https://fake.example.test/health",
+                },
+            )
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["fake-product"],
+                            "contexts": ["fake-context"],
+                            "actions": ["fake_descriptor.ping"],
+                        }
+                    ]
+                }
+            )
+            calls: list[tuple[_FakeDescriptorDispatchEnvelope, str]] = []
+            with (
+                patch(
+                    "control_plane.service.list_driver_descriptors",
+                    return_value=(_fake_descriptor_dispatch_descriptor(),),
+                ),
+                patch(
+                    "control_plane.service._descriptor_driver_dispatch_routes",
+                    return_value={
+                        _FAKE_DESCRIPTOR_ROUTE_PATH: _fake_descriptor_dispatch_route(calls)
+                    },
+                ),
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path=_FAKE_DESCRIPTOR_ROUTE_PATH,
+                    payload={
+                        "schema_version": 1,
+                        "product": "fake-product",
+                        "context": "fake-context",
+                        "instance": "testing",
+                        "value": "alpha",
+                    },
+                    headers={"Idempotency-Key": "fake-dispatch-alpha"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["request_id"], "fake-descriptor-alpha")
+        self.assertEqual(payload["result"], {"status": "pass", "processed_value": "alpha:testing"})
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][1], "testing")
+
+    def test_descriptor_dispatch_fake_route_rejects_unauthorized_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload("fake-product")
+            profile_payload["driver_id"] = _FAKE_DESCRIPTOR_DRIVER_ID
+            profile_payload["lanes"] = (
+                {
+                    "instance": "testing",
+                    "context": "fake-context",
+                    "base_url": "https://fake.example.test",
+                    "health_url": "https://fake.example.test/health",
+                },
+            )
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["fake-product"],
+                            "contexts": ["other-context"],
+                            "actions": ["fake_descriptor.ping"],
+                        }
+                    ]
+                }
+            )
+            calls: list[tuple[_FakeDescriptorDispatchEnvelope, str]] = []
+            with (
+                patch(
+                    "control_plane.service.list_driver_descriptors",
+                    return_value=(_fake_descriptor_dispatch_descriptor(),),
+                ),
+                patch(
+                    "control_plane.service._descriptor_driver_dispatch_routes",
+                    return_value={
+                        _FAKE_DESCRIPTOR_ROUTE_PATH: _fake_descriptor_dispatch_route(calls)
+                    },
+                ),
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path=_FAKE_DESCRIPTOR_ROUTE_PATH,
+                    payload={
+                        "schema_version": 1,
+                        "product": "fake-product",
+                        "context": "fake-context",
+                        "instance": "testing",
+                        "value": "alpha",
+                    },
+                    headers={"Idempotency-Key": "fake-dispatch-denied"},
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(calls, [])
+
+    def test_descriptor_dispatch_fake_route_replays_idempotent_response(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload("fake-product")
+            profile_payload["driver_id"] = _FAKE_DESCRIPTOR_DRIVER_ID
+            profile_payload["lanes"] = (
+                {
+                    "instance": "testing",
+                    "context": "fake-context",
+                    "base_url": "https://fake.example.test",
+                    "health_url": "https://fake.example.test/health",
+                },
+            )
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["fake-product"],
+                            "contexts": ["fake-context"],
+                            "actions": ["fake_descriptor.ping"],
+                        }
+                    ]
+                }
+            )
+            calls: list[tuple[_FakeDescriptorDispatchEnvelope, str]] = []
+            request_payload = {
+                "schema_version": 1,
+                "product": "fake-product",
+                "context": "fake-context",
+                "instance": "testing",
+                "value": "alpha",
+            }
+            with (
+                patch(
+                    "control_plane.service.list_driver_descriptors",
+                    return_value=(_fake_descriptor_dispatch_descriptor(),),
+                ),
+                patch(
+                    "control_plane.service._descriptor_driver_dispatch_routes",
+                    return_value={
+                        _FAKE_DESCRIPTOR_ROUTE_PATH: _fake_descriptor_dispatch_route(calls)
+                    },
+                ),
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=state_dir,
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                )
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path=_FAKE_DESCRIPTOR_ROUTE_PATH,
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "fake-dispatch-replay"},
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path=_FAKE_DESCRIPTOR_ROUTE_PATH,
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "fake-dispatch-replay"},
+                )
+
+        self.assertEqual(first_status_code, 202)
+        self.assertEqual(second_status_code, 202)
+        self.assertEqual(first_payload["records"], second_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(len(calls), 1)
+
+    def test_descriptor_dispatch_route_requires_descriptor_declaration(self) -> None:
+        calls: list[tuple[_FakeDescriptorDispatchEnvelope, str]] = []
+        policy = LaunchplaneAuthzPolicy.model_validate({"github_actions": []})
+
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch("control_plane.service.list_driver_descriptors", return_value=()),
+            patch(
+                "control_plane.service._descriptor_driver_dispatch_routes",
+                return_value={_FAKE_DESCRIPTOR_ROUTE_PATH: _fake_descriptor_dispatch_route(calls)},
+            ),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "must be declared by a driver descriptor",
+            ):
+                create_launchplane_service_app(
+                    state_dir=Path(temporary_directory_name) / "state",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=Path(temporary_directory_name),
+                )
+
+    def test_unregistered_descriptor_driver_route_fails_closed(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["fake-product"],
+                        "contexts": ["fake-context"],
+                        "actions": ["fake_descriptor.ping", "preview_destroyed.write"],
+                    }
+                ]
+            }
+        )
+
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.service.list_driver_descriptors",
+                return_value=(_fake_descriptor_dispatch_descriptor(),),
+            ),
+        ):
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path=_FAKE_DESCRIPTOR_ROUTE_PATH,
+                payload={
+                    "schema_version": 1,
+                    "product": "fake-product",
+                    "destroy": {
+                        "context": "fake-context",
+                        "anchor_repo": "cbusillo/fake-product",
+                        "anchor_pr_number": 1,
+                        "anchor_pr_url": "https://github.com/cbusillo/fake-product/pull/1",
+                    },
+                },
+                headers={"Idempotency-Key": "fake-unregistered-dispatch"},
+            )
+
+        self.assertEqual(status_code, 500)
+        self.assertEqual(payload["error"]["code"], "driver_route_not_registered")
 
     def test_tracked_target_logs_endpoint_returns_redacted_application_logs(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- Add an explicit descriptor-backed driver dispatch seam that validates handler registrations against descriptor route metadata at service startup.
- Keep production dispatch registration empty for this spike, leaving existing Odoo/generic-web/VeriReel routes untouched.
- Add fake descriptor route service tests for authorized dispatch, auth denial, idempotent replay, registration drift, and unregistered descriptor route fail-closed behavior.
- Document that descriptor presence alone does not execute a route; a backend handler must be explicitly registered.

## Validation

- `uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_driver_descriptor_endpoints_return_provider_neutral_metadata tests.test_service.LaunchplaneServiceTests.test_driver_descriptor_endpoint_returns_not_found_for_unknown_driver tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_fake_route_executes_authorized_handler tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_fake_route_rejects_unauthorized_context tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_fake_route_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_route_requires_descriptor_declaration tests.test_service.LaunchplaneServiceTests.test_unregistered_descriptor_driver_route_fails_closed`
- `uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py`
- `npx --yes markdownlint-cli2 docs/driver-descriptors.md`
- `git diff --check`

## Review

- Planned with Code, Claude, and Antigravity agents.
- Reviewed with Code, Claude, and Antigravity agents.
- Addressed review feedback by adding an unregistered descriptor-route fail-closed guard and regression test.

Refs #1047
