### PR TITLE
Fix merge train candidate ref cleanup ordering

### DIFF
--- a/control_plane/merge_train_github.py
+++ b/control_plane/merge_train_github.py
@@ -200,11 +200,14 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
             raise MergeTrainGitHubStaleHeadError(
                 "Base branch moved outside the batch landing plan.", status_code=409
             )
-        self._delete_reference_if_present(
+        return landing_plan.model_copy(update={"entries": tuple(merged_entries)})
+
+    def cleanup_batch_candidate_ref(self, *, landing_plan: MergeTrainBatchLandingPlan) -> bool:
+        repository_path = _repository_path(landing_plan.repository)
+        return self._delete_reference_if_present(
             repository_path=repository_path,
             reference=landing_plan.candidate_ref,
         )
-        return landing_plan.model_copy(update={"entries": tuple(merged_entries)})
 
     def _already_merged_landing_entry(
         self, *, repository_path: str, entry: MergeTrainBatchLandingEntry
@@ -391,7 +394,7 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
                 body={"sha": normalized_sha, "force": True},
             )
 
-    def _delete_reference_if_present(self, *, repository_path: str, reference: str) -> None:
+    def _delete_reference_if_present(self, *, repository_path: str, reference: str) -> bool:
         try:
             self.transport.request(
                 method="DELETE",
@@ -399,8 +402,9 @@ class GitHubMergeTrainClient(MergeTrainStackCollapseBranchClient):
             )
         except MergeTrainGitHubError as error:
             if error.status_code == 404:
-                return
+                return False
             raise
+        return True
 
     def _pull_request_head_sha(self, *, pull_request_path: str) -> str:
         pull_request = _json_object(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -3983,6 +3983,38 @@ def _validate_stack_collapse_record_for_landing(
         raise ValueError("merge train stack collapse root PR head no longer matches")
 
 
+def _cleanup_merge_train_batch_candidate_ref(
+    *,
+    github_client: GitHubMergeTrainClient,
+    landing_plan: MergeTrainBatchLandingPlan,
+    request_trace_id: str,
+) -> dict[str, object]:
+    try:
+        deleted = github_client.cleanup_batch_candidate_ref(landing_plan=landing_plan)
+    except MergeTrainGitHubError as error:
+        message = str(error).strip() or "GitHub candidate ref cleanup failed."
+        _LOGGER.warning(
+            "Merge train candidate ref cleanup failed after landing persistence",
+            extra={
+                "trace_id": request_trace_id,
+                "repository": landing_plan.repository,
+                "base_branch": landing_plan.base_branch,
+                "candidate_ref": landing_plan.candidate_ref,
+                "github_status_code": error.status_code,
+            },
+        )
+        result: dict[str, object] = {
+            "candidate_ref_cleanup_status": "failed",
+            "candidate_ref_cleanup_message": message,
+        }
+        if error.status_code is not None:
+            result["candidate_ref_cleanup_github_status_code"] = error.status_code
+        return result
+    return {
+        "candidate_ref_cleanup_status": "deleted" if deleted else "already_missing",
+    }
+
+
 def _stack_collapse_expected_root_head_sha(plan: MergeTrainStackCollapsePlan) -> str:
     for mutation in plan.mutations:
         if mutation.parent_pull_request_number == plan.root_pull_request_number:
@@ -10144,6 +10176,7 @@ def create_launchplane_service_app(
                 recorded_at = _utc_now_timestamp()
                 collapse_record: MergeTrainStackCollapsePlanRecord | None = None
                 reconciled_collapse_plan: MergeTrainStackCollapsePlan | None = None
+                candidate_ref_cleanup_result: dict[str, object] = {}
                 if landing_request.mode == "plan":
                     candidate_record = _read_merge_train_batch_candidate_record(
                         record_store=candidate_store,
@@ -10194,6 +10227,11 @@ def create_launchplane_service_app(
                         updated_at=recorded_at,
                     )
                     landing_store.write_merge_train_batch_landing_plan_record(landing_record)
+                    candidate_ref_cleanup_result = _cleanup_merge_train_batch_candidate_ref(
+                        github_client=github_client,
+                        landing_plan=landing_plan,
+                        request_trace_id=request_trace_id,
+                    )
                     if collapse_existing_record is not None:
                         root_entry = next(
                             (
@@ -10246,6 +10284,9 @@ def create_launchplane_service_app(
                     "mode": landing_request.mode,
                     "landing_plan": result["landing_plan"],
                 }
+                if landing_request.mode == "land":
+                    result.update(candidate_ref_cleanup_result)
+                    driver_result.update(candidate_ref_cleanup_result)
                 if "stack_collapse_plan" in result:
                     driver_result["stack_collapse_plan"] = result["stack_collapse_plan"]
             elif path == _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE:
@@ -10552,6 +10593,11 @@ def create_launchplane_service_app(
                                 updated_at=recorded_at,
                             )
                             landing_store.write_merge_train_batch_landing_plan_record(landed_record)
+                            candidate_ref_cleanup_result = _cleanup_merge_train_batch_candidate_ref(
+                                github_client=github_client,
+                                landing_plan=landed_plan,
+                                request_trace_id=request_trace_id,
+                            )
                             result = {
                                 "merge_train_batch_landing_plan_record_id": landed_record.record_id,
                                 "repository": landed_plan.repository,
@@ -10559,6 +10605,7 @@ def create_launchplane_service_app(
                                 "mode": "land",
                                 "controller_action": "land_batch",
                                 "landing_plan": landed_plan.model_dump(mode="json"),
+                                **candidate_ref_cleanup_result,
                             }
                             if collapse_record is not None:
                                 root_entry = next(

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -503,10 +503,12 @@ with a different head SHA than the landing plan recorded, Launchplane writes
 terminal stale landing evidence for the plan. That stale evidence does not count
 as a successful Launchplane landing, but it does retire the stale plan so a fresh
 controller pass can read current GitHub state and admit later eligible work.
-After a landing plan reaches the recorded final base SHA, Launchplane deletes
-the generated `launchplane/train/...` candidate branch ref. Missing candidate
-refs are treated as already-clean so landing retries remain idempotent; stale or
-failed landing attempts leave the ref in place for investigation.
+After Launchplane persists a landing plan at the recorded final base SHA, it
+attempts best-effort cleanup of the generated `launchplane/train/...` candidate
+branch ref. Missing candidate refs are treated as already-clean so landing
+retries remain idempotent. Cleanup failures are reported in the landing response
+without failing the persisted landing result, and stale or failed landing
+attempts leave the ref in place for investigation.
 
 Scheduler admission is a deterministic decision over the latest stored
 `launchplane_merge_train_runs` record for the repository/base branch. Dry-run

--- a/docs/records.md
+++ b/docs/records.md
@@ -941,10 +941,11 @@ preflights.
   `launchplane_merge_train_batch_candidates` records. Each record stores the
   repository/base branch, observed base SHA, ordered PR entries, candidate ref,
   candidate SHA when available, policy key and digest, candidate status, check
-  status summary, source, and update timestamp. Successful landing deletes the
-  generated GitHub candidate ref after final base-sha validation; the record
-  remains as durable evidence for the speculative batch candidate, not
-  checked-in configuration.
+  status summary, source, and update timestamp. After successful landing is
+  persisted, Launchplane attempts best-effort cleanup of the generated GitHub
+  candidate ref; cleanup failure leaves the persisted landing result intact and
+  the candidate record remains as durable evidence for the speculative batch
+  candidate, not checked-in configuration.
 - Full batch train landing plans are persisted as
   `launchplane_merge_train_batch_landing_plans` records. Each record stores the
   candidate identity, repository/base branch, candidate SHA, policy key and

--- a/tests/test_merge_train_github.py
+++ b/tests/test_merge_train_github.py
@@ -373,7 +373,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
                 _github_branch(sha="merge-sha-2"),
-                {},
             )
         )
 
@@ -402,52 +401,47 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
-                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
-    def test_land_batch_candidate_tolerates_already_deleted_candidate_ref(self) -> None:
+    def test_cleanup_batch_candidate_ref_deletes_candidate_ref(self) -> None:
         landing_plan = _landing_plan()
-        transport = RecordingMergeTrainGitHubTransport(
-            responses=(
-                _github_branch(sha="base-main"),
-                {"sha": "merge-sha-1"},
-                _github_branch(sha="merge-sha-1"),
-                {"sha": "merge-sha-2"},
-                _github_branch(sha="merge-sha-2"),
-                MergeTrainGitHubError("candidate ref missing", status_code=404),
-            )
-        )
+        transport = RecordingMergeTrainGitHubTransport()
 
-        landed_plan = GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+        deleted = GitHubMergeTrainClient(transport=transport).cleanup_batch_candidate_ref(
             landing_plan=landing_plan
         )
 
-        self.assertEqual([entry.status for entry in landed_plan.entries], ["merged", "merged"])
-        self.assertEqual(
-            [entry.merge_commit_sha for entry in landed_plan.entries],
-            ["merge-sha-1", "merge-sha-2"],
-        )
+        self.assertTrue(deleted)
         self.assertEqual(
             (transport.requests[-1].method, transport.requests[-1].path),
             ("DELETE", _candidate_ref_path(landing_plan)),
         )
 
-    def test_land_batch_candidate_fails_closed_on_candidate_ref_delete_error(self) -> None:
+    def test_cleanup_batch_candidate_ref_tolerates_already_deleted_candidate_ref(self) -> None:
         landing_plan = _landing_plan()
         transport = RecordingMergeTrainGitHubTransport(
-            responses=(
-                _github_branch(sha="base-main"),
-                {"sha": "merge-sha-1"},
-                _github_branch(sha="merge-sha-1"),
-                {"sha": "merge-sha-2"},
-                _github_branch(sha="merge-sha-2"),
-                MergeTrainGitHubError("candidate ref delete failed", status_code=500),
-            )
+            responses=(MergeTrainGitHubError("candidate ref missing", status_code=404),)
+        )
+
+        deleted = GitHubMergeTrainClient(transport=transport).cleanup_batch_candidate_ref(
+            landing_plan=landing_plan
+        )
+
+        self.assertFalse(deleted)
+        self.assertEqual(
+            (transport.requests[-1].method, transport.requests[-1].path),
+            ("DELETE", _candidate_ref_path(landing_plan)),
+        )
+
+    def test_cleanup_batch_candidate_ref_fails_closed_on_delete_error(self) -> None:
+        landing_plan = _landing_plan()
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=(MergeTrainGitHubError("candidate ref delete failed", status_code=500),)
         )
 
         with self.assertRaisesRegex(MergeTrainGitHubError, "delete failed"):
-            GitHubMergeTrainClient(transport=transport).land_batch_candidate(
+            GitHubMergeTrainClient(transport=transport).cleanup_batch_candidate_ref(
                 landing_plan=landing_plan
             )
 
@@ -494,7 +488,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
-                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
@@ -521,7 +514,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ),
                 _github_branch(sha="merge-sha-2"),
                 _github_branch(sha="merge-sha-2"),
-                {},
             )
         )
 
@@ -540,7 +532,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ("GET", "/repos/example/merge-train-repo/pulls/1", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
-                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
@@ -610,7 +601,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     merge_commit_sha="merge-sha-2",
                 ),
                 _github_branch(sha="merge-sha-2"),
-                {},
             )
         )
 
@@ -631,7 +621,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 ("GET", "/repos/example/merge-train-repo/pulls/2", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
-                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
@@ -651,7 +640,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 _github_branch(sha="merge-sha-1"),
                 {"sha": "merge-sha-2"},
                 _github_branch(sha="merge-sha-2"),
-                {},
             )
         )
 
@@ -676,7 +664,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     {"sha": "head-2", "merge_method": "merge"},
                 ),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
-                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 
@@ -701,7 +688,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                     merge_commit_sha="merge-sha-2",
                 ),
                 _github_branch(sha="merge-sha-2"),
-                {},
             )
         )
 
@@ -722,7 +708,6 @@ class GitHubMergeTrainClientTests(unittest.TestCase):
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
                 ("GET", "/repos/example/merge-train-repo/pulls/2", None),
                 ("GET", "/repos/example/merge-train-repo/branches/main", None),
-                ("DELETE", _candidate_ref_path(landing_plan), None),
             ],
         )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -398,6 +398,7 @@ class _FakeOAuth2Session:
 
 class _FakeMergeTrainGitHubClient:
     land_batch_candidate_calls = 0
+    cleanup_batch_candidate_ref_calls = 0
 
     def __init__(self, *, transport: object) -> None:
         self.transport = transport
@@ -452,6 +453,10 @@ class _FakeMergeTrainGitHubClient:
             }
         )
 
+    def cleanup_batch_candidate_ref(self, *, landing_plan: MergeTrainBatchLandingPlan) -> bool:
+        type(self).cleanup_batch_candidate_ref_calls += 1
+        return True
+
     def merge_stack_child_into_parent(
         self,
         *,
@@ -497,6 +502,30 @@ class _UnavailableLandingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
         raise MergeTrainGitHubError(
             "GitHub API request failed for /repos/example/repo", status_code=503
         )
+
+
+class _CleanupFailingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    cleanup_batch_candidate_ref_calls = 0
+
+    def cleanup_batch_candidate_ref(self, *, landing_plan: MergeTrainBatchLandingPlan) -> bool:
+        type(self).cleanup_batch_candidate_ref_calls += 1
+        raise MergeTrainGitHubError("candidate ref cleanup unavailable", status_code=503)
+
+
+class _CleanupAlreadyMissingMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    cleanup_batch_candidate_ref_calls = 0
+
+    def cleanup_batch_candidate_ref(self, *, landing_plan: MergeTrainBatchLandingPlan) -> bool:
+        type(self).cleanup_batch_candidate_ref_calls += 1
+        return False
+
+
+class _CleanupFailingWithoutStatusMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    cleanup_batch_candidate_ref_calls = 0
+
+    def cleanup_batch_candidate_ref(self, *, landing_plan: MergeTrainBatchLandingPlan) -> bool:
+        type(self).cleanup_batch_candidate_ref_calls += 1
+        raise MergeTrainGitHubError("candidate ref cleanup network unavailable")
 
 
 class _FailingChildDispositionMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
@@ -4287,6 +4316,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(landing_plan_payload["result"]["controller_action"], "plan_landing")
         self.assertEqual(land_status, 202)
         self.assertEqual(land_payload["result"]["controller_action"], "land_batch")
+        self.assertEqual(land_payload["result"]["candidate_ref_cleanup_status"], "deleted")
         self.assertEqual(land_payload["result"]["landing_plan"]["entries"][0]["status"], "merged")
         self.assertEqual(
             tuple(record.record_id for record in landing_records_after_retire),
@@ -4395,6 +4425,76 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(stale_record.landing_plan.entries[0].status, "stale")
         self.assertEqual(next_status_code, 202)
         self.assertNotEqual(next_payload["result"]["controller_action"], "land_batch")
+
+    def test_merge_train_controller_persists_land_before_cleanup_failure(self) -> None:
+        _CleanupFailingMergeTrainGitHubClient.cleanup_batch_candidate_ref_calls = 0
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with (
+                patch(
+                    "control_plane.service.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.service.GitHubMergeTrainClient",
+                    _CleanupFailingMergeTrainGitHubClient,
+                ),
+            ):
+                for _ in range(4):
+                    _invoke_app(
+                        app,
+                        method="POST",
+                        path="/v1/work-graph/merge-train/controller/run-once",
+                        payload={
+                            "schema_version": 1,
+                            "repository": "cbusillo/sellyouroutboard",
+                            "base_branch": "main",
+                            "mutate": True,
+                        },
+                    )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/controller/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mutate": True,
+                    },
+                )
+            landing_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_landing_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["controller_action"], "land_batch")
+        self.assertEqual(payload["result"]["candidate_ref_cleanup_status"], "failed")
+        self.assertEqual(
+            payload["result"]["candidate_ref_cleanup_message"],
+            "candidate ref cleanup unavailable",
+        )
+        self.assertEqual(payload["result"]["candidate_ref_cleanup_github_status_code"], 503)
+        self.assertEqual(_CleanupFailingMergeTrainGitHubClient.cleanup_batch_candidate_ref_calls, 1)
+        completed_record = next(
+            record
+            for record in landing_records
+            if record.record_id == payload["records"]["merge_train_batch_landing_plan_record_id"]
+        )
+        self.assertEqual(completed_record.landing_plan.entries[0].status, "merged")
+        self.assertEqual(completed_record.landing_plan.entries[0].merge_commit_sha, "merge-1")
 
     def test_merge_train_controller_reports_github_failure_details(self) -> None:
         with (
@@ -6263,9 +6363,208 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["mode"], "land")
+        self.assertEqual(payload["result"]["candidate_ref_cleanup_status"], "deleted")
         self.assertEqual(payload["result"]["landing_plan"]["entries"][0]["status"], "merged")
         self.assertEqual(
             payload["result"]["landing_plan"]["entries"][0]["merge_commit_sha"], "merge-1"
+        )
+
+    def test_merge_train_batch_landing_service_persists_land_before_cleanup_failure(
+        self,
+    ) -> None:
+        _CleanupFailingMergeTrainGitHubClient.cleanup_batch_candidate_ref_calls = 0
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            with patch(
+                "control_plane.service.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                _, candidate_plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            with patch(
+                "control_plane.service.GitHubMergeTrainClient",
+                _CleanupFailingMergeTrainGitHubClient,
+            ):
+                _, build_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": candidate_plan_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, observe_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "observe",
+                        "candidate_record_id": build_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                _, landing_plan_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                        "candidate_record_id": observe_payload["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/merge-train/batch-landing/run-once",
+                    payload={
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "land",
+                        "landing_plan_record_id": landing_plan_payload["records"][
+                            "merge_train_batch_landing_plan_record_id"
+                        ],
+                    },
+                )
+            landing_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_landing_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["candidate_ref_cleanup_status"], "failed")
+        self.assertEqual(
+            payload["result"]["candidate_ref_cleanup_message"],
+            "candidate ref cleanup unavailable",
+        )
+        self.assertEqual(payload["result"]["candidate_ref_cleanup_github_status_code"], 503)
+        self.assertEqual(_CleanupFailingMergeTrainGitHubClient.cleanup_batch_candidate_ref_calls, 1)
+        completed_record = next(
+            record
+            for record in landing_records
+            if record.record_id == payload["records"]["merge_train_batch_landing_plan_record_id"]
+        )
+        self.assertEqual(completed_record.landing_plan.entries[0].status, "merged")
+        self.assertEqual(completed_record.landing_plan.entries[0].merge_commit_sha, "merge-1")
+
+    def test_merge_train_batch_landing_candidate_ref_cleanup_reports_already_missing(
+        self,
+    ) -> None:
+        landing_plan = MergeTrainBatchLandingPlan.model_validate(
+            {
+                "plan_id": "merge-train-landing-example-repo-main-batch-1",
+                "batch_id": "merge-train-batch-example-repo-main-batch-1",
+                "repository": "example/repo",
+                "base_branch": "main",
+                "candidate_ref": "refs/heads/launchplane/train/example/repo/main/batch-1",
+                "candidate_sha": "candidate-sha",
+                "policy_key": "example:repo:main",
+                "policy_sha256": "policy-sha",
+                "created_at": "2026-05-14T00:00:00Z",
+                "entries": [
+                    {
+                        "pull_request_number": 1,
+                        "position": 1,
+                        "expected_head_sha": "head-1",
+                        "expected_base_sha": "base-1",
+                        "merge_method": "merge",
+                    }
+                ],
+            }
+        )
+        _CleanupAlreadyMissingMergeTrainGitHubClient.cleanup_batch_candidate_ref_calls = 0
+
+        result = control_plane_service._cleanup_merge_train_batch_candidate_ref(
+            github_client=cast(
+                Any, _CleanupAlreadyMissingMergeTrainGitHubClient(transport=object())
+            ),
+            landing_plan=landing_plan,
+            request_trace_id="test-trace",
+        )
+
+        self.assertEqual(result, {"candidate_ref_cleanup_status": "already_missing"})
+        self.assertEqual(
+            _CleanupAlreadyMissingMergeTrainGitHubClient.cleanup_batch_candidate_ref_calls, 1
+        )
+
+    def test_merge_train_batch_landing_candidate_ref_cleanup_reports_failure_without_status(
+        self,
+    ) -> None:
+        landing_plan = MergeTrainBatchLandingPlan.model_validate(
+            {
+                "plan_id": "merge-train-landing-example-repo-main-batch-1",
+                "batch_id": "merge-train-batch-example-repo-main-batch-1",
+                "repository": "example/repo",
+                "base_branch": "main",
+                "candidate_ref": "refs/heads/launchplane/train/example/repo/main/batch-1",
+                "candidate_sha": "candidate-sha",
+                "policy_key": "example:repo:main",
+                "policy_sha256": "policy-sha",
+                "created_at": "2026-05-14T00:00:00Z",
+                "entries": [
+                    {
+                        "pull_request_number": 1,
+                        "position": 1,
+                        "expected_head_sha": "head-1",
+                        "expected_base_sha": "base-1",
+                        "merge_method": "merge",
+                    }
+                ],
+            }
+        )
+        _CleanupFailingWithoutStatusMergeTrainGitHubClient.cleanup_batch_candidate_ref_calls = 0
+
+        result = control_plane_service._cleanup_merge_train_batch_candidate_ref(
+            github_client=cast(
+                Any, _CleanupFailingWithoutStatusMergeTrainGitHubClient(transport=object())
+            ),
+            landing_plan=landing_plan,
+            request_trace_id="test-trace",
+        )
+
+        self.assertEqual(result["candidate_ref_cleanup_status"], "failed")
+        self.assertEqual(
+            result["candidate_ref_cleanup_message"], "candidate ref cleanup network unavailable"
+        )
+        self.assertNotIn("candidate_ref_cleanup_github_status_code", result)
+        self.assertEqual(
+            _CleanupFailingWithoutStatusMergeTrainGitHubClient.cleanup_batch_candidate_ref_calls,
+            1,
         )
 
     def test_merge_train_batch_landing_service_closes_stack_children_after_root_lands(self) -> None:


### PR DESCRIPTION
## Summary
- move merge-train candidate ref deletion out of GitHubMergeTrainClient.land_batch_candidate
- run candidate-ref cleanup only after terminal landing records are persisted in service and controller landing paths
- report cleanup status in landing responses and document cleanup as best-effort post-persist behavior

## Verification
- uv run python -m unittest tests.test_merge_train_github tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_lands_existing_plan tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_persists_land_before_cleanup_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_candidate_ref_cleanup_reports_already_missing tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_candidate_ref_cleanup_reports_failure_without_status tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_persists_land_before_cleanup_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_terminalizes_stale_landing_state tests.test_service.LaunchplaneServiceTests.test_merge_train_controller_ignores_stale_stack_record_when_landing_batch
- uv run --extra dev ruff check control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_github.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_github.py tests/test_service.py
- uv run --extra dev mypy control_plane/merge_train_github.py control_plane/service.py tests/test_merge_train_github.py tests/test_service.py
- npx --yes markdownlint-cli2 docs/merge-train-policy.md docs/records.md
- git diff --check
- uv run python -m unittest

## Review
- agents reviewed the initial diff with Code, Claude, and Antigravity; follow-up coverage was added for controller cleanup failure and cleanup status variants
- final agents re-reviewed the tightened diff; no regressions found

Fixes auto-review P2: candidate-ref deletion must not make a successful landing request fail before terminal landing evidence is persisted.