### PR TITLE
Register rollback plan descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -77,6 +77,7 @@ from control_plane.contracts.every_code_summary_read_model import (
 )
 from control_plane.contracts.generic_web_rollback import (
     GenericWebRollbackPlanRequest,
+    GenericWebRollbackPlanStore,
     execute_generic_web_rollback_plan,
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
@@ -2660,8 +2661,37 @@ def _handle_generic_web_stable_verification(
     )
 
 
+def _handle_generic_web_rollback_plan(
+    request: GenericWebRollbackPlanEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+) -> _DescriptorDriverDispatchResult:
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Generic web rollback plan requires a product profile lane."
+        )
+    driver_result = execute_generic_web_rollback_plan(
+        record_store=cast(GenericWebRollbackPlanStore, record_store),
+        request=request.rollback_plan,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={"generic_web_rollback_plan_id": driver_result.plan_id},
+        driver_result=driver_result,
+    )
+
+
 def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchRoute[Any]]:
     return {
+        _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                instance=request.rollback_plan.instance,
+                require_profile=True,
+            ),
+            handler=_handle_generic_web_rollback_plan,
+        ),
         _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_GENERIC_WEB_STABLE_VERIFICATION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -2675,7 +2705,12 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
 
 
 def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
-    return frozenset((_GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,))
+    return frozenset(
+        (
+            _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
+            _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
+        )
+    )
 
 
 def _dispatch_descriptor_driver_route(
@@ -13003,49 +13038,6 @@ def create_launchplane_service_app(
                     request=generic_web_workflow_request.workflow,
                 )
                 result = driver_result.model_dump(mode="json")
-            elif path == _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path:
-                generic_web_rollback_request = (
-                    _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.envelope_model.model_validate(payload)
-                )
-                resolved_driver_context = _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=generic_web_rollback_request.rollback_plan.product,
-                    instance=generic_web_rollback_request.rollback_plan.instance,
-                    require_profile=True,
-                )
-                if resolved_driver_context.profile is None or resolved_driver_context.lane is None:
-                    raise ProductDriverMismatchError(
-                        "Generic web rollback plan requires a product profile lane."
-                    )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=resolved_driver_context.profile.product,
-                    context=resolved_driver_context.lane.context,
-                    denial_message=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_generic_web_rollback_plan(
-                    record_store=record_store,
-                    request=generic_web_rollback_request.rollback_plan,
-                )
-                result = {"generic_web_rollback_plan_id": driver_result.plan_id}
             elif path == _GENERIC_WEB_ROLLBACK_ROUTE.route_path:
                 generic_web_rollback_apply_request = (
                     _GENERIC_WEB_ROLLBACK_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -166,7 +166,8 @@ Launchplane reads the product profile, destination lane, selected deployment
 record, and optional backup gate evidence, then writes a
 `GenericWebRollbackPlanRecord`. It does not mutate the provider. Odoo rollback
 planning uses this generic-web route; the former Odoo-shaped rollback-plan alias
-is retired.
+is retired. This route is registered through descriptor-backed dispatch, so
+descriptor/handler drift fails closed before the service starts.
 
 The `prod_rollback` action routes to
 `POST /v1/drivers/generic-web/prod-rollback`. It re-runs the same rollback-plan

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -440,6 +440,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_rollback_plan_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_dispatch_registration_requires_descriptor_route(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
         descriptor_without_stable_verification = registry.GENERIC_WEB_DRIVER.model_copy(
@@ -468,9 +477,44 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_rollback_plan_dispatch_registration_requires_descriptor_route(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_rollback_plan = registry.GENERIC_WEB_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.GENERIC_WEB_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_rollback_plan,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "generic-web"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_descriptor_requires_dispatch_registration(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes({})
+
+    def test_rollback_plan_descriptor_requires_dispatch_registration(self) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_generic_web_execution_metadata_matches_descriptors(self) -> None:
         self.assert_route_metadata_matches_descriptor(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -16994,6 +16994,149 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_generic_web_rollback_plan_route_rejects_unknown_lane(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_rollback.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-rollback-plan",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "rollback_plan": {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "instance": "missing",
+                        "rollback_deployment_record_id": "deployment-syo-prod-previous",
+                    },
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
+
+    def test_generic_web_rollback_plan_route_replays_idempotent_response(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-syo-prod-previous",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123"
+                    ),
+                    context="sellyouroutboard-testing",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    destination_health=HealthcheckEvidence(status="pass"),
+                    resolved_target=ResolvedTargetEvidence(
+                        target_type="application",
+                        target_id="app-prod",
+                        target_name="syo-prod-app",
+                    ),
+                    deploy=DeploymentEvidence(
+                        target_name="syo-prod-app",
+                        target_type="application",
+                        deploy_mode="dokploy-application-api",
+                        deployment_id="deployment-provider-1",
+                        status="pass",
+                        started_at="2026-05-25T12:00:00Z",
+                        finished_at="2026-05-25T12:01:00Z",
+                    ),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_rollback.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "rollback_plan": {
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "instance": "prod",
+                    "rollback_deployment_record_id": "deployment-syo-prod-previous",
+                },
+            }
+
+            first_status_code, first_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-rollback-plan",
+                payload=request_payload,
+                headers={"Idempotency-Key": "generic-web-rollback-plan-syo-prod"},
+            )
+            second_status_code, second_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-rollback-plan",
+                payload=request_payload,
+                headers={"Idempotency-Key": "generic-web-rollback-plan-syo-prod"},
+            )
+            plans = store.list_generic_web_rollback_plan_records(
+                context_name="sellyouroutboard-testing",
+                instance_name="prod",
+                limit=10,
+            )
+
+        self.assertEqual(first_status_code, 202)
+        self.assertEqual(second_status_code, 202)
+        self.assertEqual(first_payload["records"], second_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(len(plans), 1)
+
     def test_odoo_rollback_plan_alias_is_retired(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"


### PR DESCRIPTION
## Summary
- register generic-web prod rollback planning through descriptor-backed dispatch
- require rollback-plan dispatch registration at startup alongside stable verification
- add descriptor drift, missing-lane, and idempotent replay coverage

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_plan_route_writes_plan_record tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_plan_route_rejects_unauthorized_context tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_plan_route_rejects_unknown_lane tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_plan_route_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_odoo_rollback_plan_alias_is_retired tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_route_applies_ready_plan tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_fake_route_executes_authorized_handler tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_route_requires_descriptor_declaration tests.test_service.LaunchplaneServiceTests.test_unregistered_descriptor_driver_route_fails_closed
- uv run --extra dev ruff check --exit-zero control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- git diff --check
- uv run python -m unittest