### PR TITLE
Remove public ingress token when absent

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -399,16 +399,26 @@ jobs:
             })"
             service_env_removals_json="$({
               jq -n \
+                --arg public_ingress_github_token "${LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN:-}" \
                 --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
-                'if $omit_npmplus_env then
-                  [
-                    "LAUNCHPLANE_NPMPLUS_BASE_URL",
-                    "LAUNCHPLANE_NPMPLUS_IDENTITY",
-                    "LAUNCHPLANE_NPMPLUS_SECRET"
-                  ]
-                else
-                  []
-                end'
+                '(
+                  if $omit_npmplus_env then
+                    [
+                      "LAUNCHPLANE_NPMPLUS_BASE_URL",
+                      "LAUNCHPLANE_NPMPLUS_IDENTITY",
+                      "LAUNCHPLANE_NPMPLUS_SECRET"
+                    ]
+                  else
+                    []
+                  end
+                )
+                + (
+                  if $public_ingress_github_token == "" then
+                    ["LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN"]
+                  else
+                    []
+                  end
+                )'
             })"
             request_payload="$({
               jq -n \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -748,6 +748,55 @@ class ProductOnboardingTests(unittest.TestCase):
             workflow_text,
         )
 
+        removals_block = workflow_text.split("service_env_removals_json=", 1)[1].split(
+            '            })"', 1
+        )[0]
+        jq_filter = removals_block.split("                '", 1)[1].rsplit("'", 1)[0]
+        self.assertIn("$public_ingress_github_token", jq_filter)
+        self.assertIn("LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN", jq_filter)
+
+        def evaluate_removals(
+            *, public_ingress_github_token: str, omit_npmplus_env: bool
+        ) -> list[str]:
+            result = subprocess.run(
+                [
+                    "jq",
+                    "-n",
+                    "--arg",
+                    "public_ingress_github_token",
+                    public_ingress_github_token,
+                    "--argjson",
+                    "omit_npmplus_env",
+                    json.dumps(omit_npmplus_env),
+                    jq_filter,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return cast(list[str], json.loads(result.stdout))
+
+        self.assertEqual(
+            evaluate_removals(public_ingress_github_token="", omit_npmplus_env=False),
+            ["LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN"],
+        )
+        self.assertEqual(
+            evaluate_removals(
+                public_ingress_github_token="public-ingress-token",
+                omit_npmplus_env=False,
+            ),
+            [],
+        )
+        self.assertEqual(
+            evaluate_removals(public_ingress_github_token="", omit_npmplus_env=True),
+            [
+                "LAUNCHPLANE_NPMPLUS_BASE_URL",
+                "LAUNCHPLANE_NPMPLUS_IDENTITY",
+                "LAUNCHPLANE_NPMPLUS_SECRET",
+                "LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN",
+            ],
+        )
+
     def test_deploy_launchplane_break_glass_rollback_uploads_evidence(self) -> None:
         workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- remove the deployed public-ingress GitHub token when the workflow secret is absent or blank
- keep the existing NPMplus env-removal behavior and compose both removal sets
- add an executable jq regression test for absent, present, and combined-removal cases

## Tests
- uv run python -m unittest tests.test_product_onboarding
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev ruff format --check tests/test_product_onboarding.py
- uv run --extra dev mypy tests/test_product_onboarding.py
- actionlint .github/workflows/deploy-launchplane.yml