### PR TITLE
Register preview verification descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -320,6 +320,7 @@ from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployRequest,
     GenericWebPostDeployExecutor,
     execute_generic_web_deploy,
+    product_profile_uses_generic_web_base,
 )
 from control_plane.workflows.generic_web_promotion import (
     GenericWebProdPromotionRequest,
@@ -808,6 +809,7 @@ class _DriverRouteExecutionMetadata(Generic[_DriverRouteEnvelopeT]):
 class _DescriptorDriverDispatchContext:
     product: str
     context: str
+    authorization_context: str = ""
     instance: str = ""
     require_profile: bool = False
 
@@ -832,8 +834,18 @@ _DescriptorDriverDispatchHandler = Callable[
         _DriverRouteEnvelopeT,
         _ResolvedProductDriverContext,
         object,
+        Path,
     ],
     _DescriptorDriverDispatchResult,
+]
+_DescriptorDriverDispatchValidator = Callable[
+    [
+        _DriverRouteEnvelopeT,
+        _ResolvedProductDriverContext,
+        object,
+        Path,
+    ],
+    None,
 ]
 
 
@@ -842,6 +854,9 @@ class _DescriptorDriverDispatchRoute(Generic[_DriverRouteEnvelopeT]):
     execution_metadata: _DriverRouteExecutionMetadata[_DriverRouteEnvelopeT]
     context_resolver: _DescriptorDriverDispatchContextResolver[_DriverRouteEnvelopeT]
     handler: _DescriptorDriverDispatchHandler[_DriverRouteEnvelopeT]
+    pre_idempotency_validator: _DescriptorDriverDispatchValidator[_DriverRouteEnvelopeT] | None = (
+        None
+    )
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -2648,7 +2663,9 @@ def _handle_generic_web_stable_verification(
     request: GenericWebStableVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
     record_store: object,
+    control_plane_root_path: Path,
 ) -> _DescriptorDriverDispatchResult:
+    del control_plane_root_path
     if resolved_context.lane is None:
         raise ProductDriverMismatchError(
             "Generic web stable verification requires a product profile lane."
@@ -2665,7 +2682,9 @@ def _handle_generic_web_rollback_plan(
     request: GenericWebRollbackPlanEnvelope,
     resolved_context: _ResolvedProductDriverContext,
     record_store: object,
+    control_plane_root_path: Path,
 ) -> _DescriptorDriverDispatchResult:
+    del control_plane_root_path
     if resolved_context.profile is None or resolved_context.lane is None:
         raise ProductDriverMismatchError(
             "Generic web rollback plan requires a product profile lane."
@@ -2678,6 +2697,49 @@ def _handle_generic_web_rollback_plan(
         result={"generic_web_rollback_plan_id": driver_result.plan_id},
         driver_result=driver_result,
     )
+
+
+def _handle_generic_web_preview_verification(
+    request: GenericWebPreviewVerificationEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    return _DescriptorDriverDispatchResult(
+        result=_apply_generic_web_preview_verification_records(
+            control_plane_root_path=control_plane_root_path,
+            record_store=record_store,
+            request=request.verification,
+        )
+    )
+
+
+def _validate_generic_web_preview_verification_profile(
+    request: GenericWebPreviewVerificationEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> None:
+    del request, record_store, control_plane_root_path
+    profile = resolved_context.profile
+    if profile is None:
+        raise ProductDriverMismatchError(
+            "Generic web preview verification requires a product profile."
+        )
+    if not product_profile_uses_generic_web_base(profile):
+        raise click.ClickException(
+            f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, "
+            "not generic-web or a generic-web based driver."
+        )
+    if not profile.preview.enabled:
+        raise click.ClickException(
+            f"Product {profile.product!r} does not have generic-web previews enabled."
+        )
+    if not profile.preview.context.strip():
+        raise click.ClickException(
+            f"Product {profile.product!r} does not define a preview context."
+        )
 
 
 def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchRoute[Any]]:
@@ -2701,6 +2763,17 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_generic_web_stable_verification,
         ),
+        _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.verification.context,
+                require_profile=True,
+            ),
+            handler=_handle_generic_web_preview_verification,
+            pre_idempotency_validator=_validate_generic_web_preview_verification_profile,
+        ),
     }
 
 
@@ -2709,6 +2782,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
         (
             _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
+            _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
         )
     )
 
@@ -2725,6 +2799,7 @@ def _dispatch_descriptor_driver_route(
     request_fingerprint: str,
     start_response: _StartResponse,
     trace_id: str,
+    control_plane_root_path: Path,
 ) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
     route_metadata = dispatch_route.execution_metadata
     descriptor_route_metadata = _driver_route_metadata_from_descriptors().get(
@@ -2749,14 +2824,24 @@ def _dispatch_descriptor_driver_route(
         instance=dispatch_context.instance,
         require_profile=dispatch_context.require_profile,
     )
-    authorization_context = dispatch_context.context
+    if dispatch_route.pre_idempotency_validator is not None:
+        dispatch_route.pre_idempotency_validator(
+            request,
+            resolved_driver_context,
+            record_store,
+            control_plane_root_path,
+        )
+    authorization_product = dispatch_context.product
+    if resolved_driver_context.profile is not None:
+        authorization_product = resolved_driver_context.profile.product
+    authorization_context = dispatch_context.authorization_context or dispatch_context.context
     if not authorization_context and resolved_driver_context.lane is not None:
         authorization_context = resolved_driver_context.lane.context
     authorization_response = _driver_route_authorization_response(
         authz_policy=authz_policy,
         identity=identity,
         route_path=route_metadata.route_path,
-        product=dispatch_context.product,
+        product=authorization_product,
         context=authorization_context,
         denial_message=route_metadata.denial_message,
         start_response=start_response,
@@ -2779,6 +2864,7 @@ def _dispatch_descriptor_driver_route(
         request,
         resolved_driver_context,
         record_store,
+        control_plane_root_path,
     )
     return dispatch_result.result, dispatch_result.driver_result
 
@@ -12822,6 +12908,7 @@ def create_launchplane_service_app(
                     dispatch_route=descriptor_driver_dispatch_routes[path],
                     payload=payload,
                     record_store=record_store,
+                    control_plane_root_path=resolved_root,
                     authz_policy=authz_policy,
                     identity=identity,
                     request_scope=request_scope,
@@ -13252,42 +13339,6 @@ def create_launchplane_service_app(
                     profile=profile,
                 )
                 result = {}
-            elif path == _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path:
-                generic_web_preview_verification_request = (
-                    _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.envelope_model.model_validate(payload)
-                )
-                profile = resolve_generic_web_preview_profile(
-                    record_store=record_store,
-                    product=generic_web_preview_verification_request.product,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=profile.product,
-                    context=generic_web_preview_verification_request.verification.context,
-                    denial_message=_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                result = _apply_generic_web_preview_verification_records(
-                    control_plane_root_path=resolved_root,
-                    record_store=record_store,
-                    request=generic_web_preview_verification_request.verification,
-                )
             elif path == _ODOO_POST_DEPLOY_ROUTE.route_path:
                 odoo_post_deploy_request = _ODOO_POST_DEPLOY_ROUTE.envelope_model.model_validate(
                     payload

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -215,7 +215,9 @@ product health path. Inventory and destroy scan and delete Dokploy applications
 by the product profile's preview application-name prefix. Verification records
 common post-refresh smoke evidence against the latest Launchplane preview
 generation and is available to any product profile that uses the generic-web
-base driver.
+base driver. Generic-web preview verification is registered through
+descriptor-backed dispatch, so descriptor/handler drift fails closed before the
+service starts.
 
 Preview resource cleanup uses a shared Launchplane destroy helper for Dokploy
 applications and compose previews. The generic helper owns domain lookup,

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -403,7 +403,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                 product=request.product,
                 context=request.verification.context,
             ),
-            handler=lambda _request, _resolved_context, _record_store: (
+            handler=lambda _request, _resolved_context, _record_store, _root_path: (
                 control_plane_service._DescriptorDriverDispatchResult(result={})
             ),
         )
@@ -445,6 +445,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
 
         self.assertIn(
             control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_preview_verification_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
             dispatch_routes,
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
@@ -505,6 +514,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_preview_verification_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_preview_verification = registry.GENERIC_WEB_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.GENERIC_WEB_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_preview_verification,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "generic-web"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_descriptor_requires_dispatch_registration(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes({})
@@ -512,6 +551,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     def test_rollback_plan_descriptor_requires_dispatch_registration(self) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_preview_verification_descriptor_requires_dispatch_registration(self) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(
+            control_plane_service._GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path
+        )
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -268,8 +268,9 @@ def _fake_descriptor_dispatch_route(
         request: _FakeDescriptorDispatchEnvelope,
         resolved_context: control_plane_service._ResolvedProductDriverContext,
         record_store: Any,
+        control_plane_root_path: Path,
     ) -> control_plane_service._DescriptorDriverDispatchResult:
-        del record_store
+        del record_store, control_plane_root_path
         lane_instance = resolved_context.lane.instance if resolved_context.lane is not None else ""
         calls.append((request, lane_instance))
         return control_plane_service._DescriptorDriverDispatchResult(
@@ -19234,6 +19235,234 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(generation.state, "ready")
             self.assertEqual(generation.verify_status, "pass")
             self.assertEqual(generation.overall_health_status, "pass")
+
+    def test_generic_web_preview_verification_route_does_not_require_lane(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload()
+            profile_payload["lanes"] = ()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service._apply_generic_web_preview_verification_records",
+                return_value={
+                    "transition": "ready",
+                    "preview_state": "active",
+                    "verification_status": "pass",
+                    "generic_web_preview_verification": {"checked_urls": ()},
+                },
+            ) as apply_records:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-verification",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "verification": {
+                            "schema_version": 1,
+                            "context": "sellyouroutboard-testing",
+                            "anchor_repo": "sellyouroutboard",
+                            "anchor_pr_number": 42,
+                            "verification_status": "pass",
+                            "verified_at": "2026-05-09T15:08:00Z",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-preview-verification:syo:42:no-lane"},
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["transition"], "ready")
+        apply_records.assert_called_once()
+        self.assertEqual(apply_records.call_args.kwargs["control_plane_root_path"], root)
+
+    def test_generic_web_preview_verification_route_rejects_unauthorized_context(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["other-context"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service._apply_generic_web_preview_verification_records",
+                return_value={"transition": "ready"},
+            ) as apply_records:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-verification",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "verification": {
+                            "schema_version": 1,
+                            "context": "sellyouroutboard-testing",
+                            "anchor_repo": "sellyouroutboard",
+                            "anchor_pr_number": 42,
+                            "verification_status": "pass",
+                            "verified_at": "2026-05-09T15:08:00Z",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-preview-verification:syo:42:denied"},
+                )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        apply_records.assert_not_called()
+
+    def test_generic_web_preview_verification_replay_revalidates_preview_profile(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_generation.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "verification": {
+                    "schema_version": 1,
+                    "context": "sellyouroutboard-testing",
+                    "anchor_repo": "sellyouroutboard",
+                    "anchor_pr_number": 42,
+                    "verification_status": "pass",
+                    "verified_at": "2026-05-09T15:08:00Z",
+                },
+            }
+
+            with patch(
+                "control_plane.service._apply_generic_web_preview_verification_records",
+                return_value={"transition": "ready"},
+            ) as apply_records:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-verification",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "generic-preview-verification:syo:42:replay"},
+                )
+                disabled_payload = dict(profile_payload)
+                disabled_payload["preview"] = {"enabled": False}
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(disabled_payload)
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-verification",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "generic-preview-verification:syo:42:replay"},
+                )
+
+        self.assertEqual(first_status_code, 202)
+        self.assertEqual(first_payload["records"]["transition"], "ready")
+        self.assertEqual(second_status_code, 400)
+        self.assertEqual(second_payload["error"]["code"], "invalid_request")
+        apply_records.assert_called_once()
 
     def test_generic_web_preview_verification_request_accepts_explicit_url_collections(
         self,


### PR DESCRIPTION
## Summary
- route generic-web preview verification through descriptor-backed dispatch
- thread the service root through descriptor handlers for preview evidence writes
- preserve preview-profile validation before idempotency replay and canonical product authorization
- add descriptor drift, no-lane, wrong-context, and disabled-preview replay coverage

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_fake_route_executes_authorized_handler tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_fake_route_rejects_unauthorized_context tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_fake_route_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_descriptor_dispatch_route_requires_descriptor_declaration tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_route_accepts_odoo_base_driver_profile tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_route_does_not_require_lane tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_route_rejects_unauthorized_context tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_replay_revalidates_preview_profile tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_request_accepts_explicit_url_collections
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- npx --yes markdownlint-cli2 docs/driver-descriptors.md