### PR TITLE
Dispatch VeriReel preview verification via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2715,6 +2715,22 @@ def _handle_generic_web_preview_verification(
     )
 
 
+def _handle_verireel_preview_verification(
+    request: VeriReelPreviewVerificationEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    return _DescriptorDriverDispatchResult(
+        result=_apply_verireel_preview_verification_records(
+            control_plane_root_path=control_plane_root_path,
+            record_store=record_store,
+            request=request.verification,
+        )
+    )
+
+
 def _validate_generic_web_preview_verification_profile(
     request: GenericWebPreviewVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2774,6 +2790,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             handler=_handle_generic_web_preview_verification,
             pre_idempotency_validator=_validate_generic_web_preview_verification_profile,
         ),
+        _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_PREVIEW_VERIFICATION_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.verification.context,
+            ),
+            handler=_handle_verireel_preview_verification,
+        ),
     }
 
 
@@ -2783,6 +2808,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
+            _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
         )
     )
 
@@ -14492,43 +14518,6 @@ def create_launchplane_service_app(
                     record_store=record_store,
                     request=verireel_preview_destroy_request.destroy,
                     driver_result=driver_result,
-                )
-            elif path == _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path:
-                verireel_preview_verification_request = (
-                    _VERIREEL_PREVIEW_VERIFICATION_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_preview_verification_request.product,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_preview_verification_request.product,
-                    context=verireel_preview_verification_request.verification.context,
-                    denial_message=_VERIREEL_PREVIEW_VERIFICATION_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                result = _apply_verireel_preview_verification_records(
-                    control_plane_root_path=resolved_root,
-                    record_store=record_store,
-                    request=verireel_preview_verification_request.verification,
                 )
             elif path == _ODOO_PREVIEW_APPLY_ROUTE.route_path:
                 odoo_preview_apply_request = (

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -395,7 +395,7 @@ VeriReel exposes:
 - prod backup gate
 - testing-to-prod promotion
 - prod rollback
-- preview refresh/inventory/destroy
+- preview refresh/inventory/destroy/verification
 
 These descriptors intentionally reference Launchplane routes, not runtime
 provider concepts, as the future GUI-facing action surface.
@@ -416,7 +416,9 @@ route-alias paths and reads product-driver handler authorization actions from
 descriptor route metadata, so new drivers do not need a second hardcoded router
 allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
-handler is explicitly registered for the same descriptor route. This keeps
+handler is explicitly registered for the same descriptor route. Generic-web
+stable verification, rollback planning, preview verification, and the VeriReel
+preview verification writeback use descriptor-backed dispatch. This keeps
 descriptor metadata as the route/authz source of truth while preventing an
 advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -458,6 +458,17 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_preview_verification_registered_in_descriptor_dispatch(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_dispatch_registration_requires_descriptor_route(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
         descriptor_without_stable_verification = registry.GENERIC_WEB_DRIVER.model_copy(
@@ -544,6 +555,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_preview_verification_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_preview_verification = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_preview_verification,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_descriptor_requires_dispatch_registration(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes({})
@@ -560,6 +601,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes.pop(
             control_plane_service._GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path
         )
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_preview_verification_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31192,9 +31192,27 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "verified_at": "2026-04-21T01:38:00Z",
                     },
                 },
+                headers={"Idempotency-Key": "verireel-preview-verification-pr-123"},
+            )
+            replay_status_code, replay_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/preview-verification",
+                payload={
+                    "product": "verireel",
+                    "verification": {
+                        "anchor_pr_number": 123,
+                        "verification_status": "pass",
+                        "verified_at": "2026-04-21T01:38:00Z",
+                    },
+                },
+                headers={"Idempotency-Key": "verireel-preview-verification-pr-123"},
             )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(replay_status_code, 202)
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(payload["records"], replay_payload["records"])
             self.assertEqual(payload["records"]["transition"], "ready")
             preview = store.read_preview_record("preview-verireel-testing-verireel-pr-123")
             generation = store.read_preview_generation_record(


### PR DESCRIPTION
## Summary
- route VeriReel preview verification through descriptor-backed dispatch
- preserve the existing no-product-profile VeriReel writeback behavior and result shape
- add descriptor drift coverage plus idempotency replay coverage for the migrated route
- update descriptor docs to note VeriReel preview verification dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_preview_verification_driver_marks_latest_generation_ready
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md