### PR TITLE
Dispatch VeriReel testing verification via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2731,6 +2731,23 @@ def _handle_verireel_preview_verification(
     )
 
 
+def _handle_verireel_testing_verification(
+    request: VeriReelTestingVerificationEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context, control_plane_root_path
+    return _DescriptorDriverDispatchResult(
+        result=dict[str, object](
+            _apply_verireel_testing_verification_records(
+                record_store=record_store,
+                request=request.verification,
+            )
+        )
+    )
+
+
 def _validate_generic_web_preview_verification_profile(
     request: GenericWebPreviewVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2799,6 +2816,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_preview_verification,
         ),
+        _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_TESTING_VERIFICATION_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.verification.context,
+                instance=request.verification.instance,
+            ),
+            handler=_handle_verireel_testing_verification,
+        ),
     }
 
 
@@ -2809,6 +2835,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
+            _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
         )
     )
 
@@ -14060,46 +14087,6 @@ def create_launchplane_service_app(
                     request=verireel_testing_deploy_request.deploy,
                 )
                 result = {"deployment_record_id": driver_result.deployment_record_id}
-            elif path == _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path:
-                verireel_testing_verification_request = (
-                    _VERIREEL_TESTING_VERIFICATION_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_testing_verification_request.product,
-                    context=verireel_testing_verification_request.verification.context,
-                    instance=verireel_testing_verification_request.verification.instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_testing_verification_request.product,
-                    context=verireel_testing_verification_request.verification.context,
-                    denial_message=_VERIREEL_TESTING_VERIFICATION_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                result = dict[str, object](
-                    _apply_verireel_testing_verification_records(
-                        record_store=record_store,
-                        request=verireel_testing_verification_request.verification,
-                    )
-                )
             elif path == _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path:
                 verireel_environment_request = (
                     _VERIREEL_STABLE_ENVIRONMENT_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,8 +418,8 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
-preview verification writeback use descriptor-backed dispatch. This keeps
-descriptor metadata as the route/authz source of truth while preventing an
+testing and preview verification writebacks use descriptor-backed dispatch. This
+keeps descriptor metadata as the route/authz source of truth while preventing an
 advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -469,6 +469,17 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_testing_verification_registered_in_descriptor_dispatch(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_dispatch_registration_requires_descriptor_route(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
         descriptor_without_stable_verification = registry.GENERIC_WEB_DRIVER.model_copy(
@@ -585,6 +596,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_testing_verification_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_testing_verification = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_TESTING_VERIFICATION_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_testing_verification,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_descriptor_requires_dispatch_registration(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes({})
@@ -610,6 +651,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_testing_verification_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_TESTING_VERIFICATION_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24982,9 +24982,28 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "owner_routes_status": "success",
                     },
                 },
+                headers={"Idempotency-Key": "verireel-testing-verification-run-12345"},
+            )
+            replay_status_code, replay_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/testing-verification",
+                payload={
+                    "product": "verireel",
+                    "verification": {
+                        "deployment_record_id": "deployment-verireel-testing-run-12345-attempt-1",
+                        "migration_status": "success",
+                        "verification_status": "success",
+                        "owner_routes_status": "success",
+                    },
+                },
+                headers={"Idempotency-Key": "verireel-testing-verification-run-12345"},
             )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(replay_status_code, 202)
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(payload["records"], replay_payload["records"])
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(
                 payload["records"],
@@ -25081,6 +25100,59 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             self.assertEqual(deployment.post_deploy_update.status, "pass")
             self.assertEqual(deployment.destination_health.status, "fail")
+
+    def test_verireel_testing_verification_driver_rejects_unauthorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["other-context"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/verireel/testing-verification",
+                payload={
+                    "product": "verireel",
+                    "verification": {
+                        "deployment_record_id": "deployment-verireel-testing-run-12345-attempt-1",
+                        "migration_status": "success",
+                        "verification_status": "success",
+                        "owner_routes_status": "success",
+                    },
+                },
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_verireel_testing_deploy_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- route VeriReel testing verification through descriptor-backed dispatch
- preserve the existing record writeback, authz, and idempotency behavior
- add descriptor drift coverage plus route-specific authz denial and idempotency replay tests
- update descriptor docs to note VeriReel testing verification dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_testing_verification_driver_updates_deployment_record tests.test_service.LaunchplaneServiceTests.test_verireel_testing_verification_driver_marks_product_check_failure tests.test_service.LaunchplaneServiceTests.test_verireel_testing_verification_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md