### PR TITLE
Dispatch VeriReel testing deploy via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2748,6 +2748,24 @@ def _handle_verireel_testing_verification(
     )
 
 
+def _handle_verireel_testing_deploy(
+    request: VeriReelTestingDeployEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_verireel_stable_deploy(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(VeriReelStableDeployStore, record_store),
+        request=request.deploy,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={"deployment_record_id": driver_result.deployment_record_id},
+        driver_result=driver_result,
+    )
+
+
 def _validate_generic_web_preview_verification_profile(
     request: GenericWebPreviewVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2825,6 +2843,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_testing_verification,
         ),
+        _VERIREEL_TESTING_DEPLOY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_TESTING_DEPLOY_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.deploy.context,
+                instance=request.deploy.instance,
+            ),
+            handler=_handle_verireel_testing_deploy,
+        ),
     }
 
 
@@ -2836,6 +2863,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
+            _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
         )
     )
 
@@ -14047,46 +14075,6 @@ def create_launchplane_service_app(
                         and replacement_operation.result.release_tuple_id
                     ):
                         result["release_tuple_id"] = replacement_operation.result.release_tuple_id
-            elif path == _VERIREEL_TESTING_DEPLOY_ROUTE.route_path:
-                verireel_testing_deploy_request = (
-                    _VERIREEL_TESTING_DEPLOY_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_testing_deploy_request.product,
-                    context=verireel_testing_deploy_request.deploy.context,
-                    instance=verireel_testing_deploy_request.deploy.instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_testing_deploy_request.product,
-                    context=verireel_testing_deploy_request.deploy.context,
-                    denial_message=_VERIREEL_TESTING_DEPLOY_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_verireel_stable_deploy(
-                    control_plane_root=resolved_root,
-                    record_store=cast(VeriReelStableDeployStore, record_store),
-                    request=verireel_testing_deploy_request.deploy,
-                )
-                result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path:
                 verireel_environment_request = (
                     _VERIREEL_STABLE_ENVIRONMENT_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,9 +418,10 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
-testing and preview verification writebacks use descriptor-backed dispatch. This
-keeps descriptor metadata as the route/authz source of truth while preventing an
-advertised descriptor action from becoming executable without implementation.
+testing deploy plus testing and preview verification writebacks use
+descriptor-backed dispatch. This keeps descriptor metadata as the route/authz
+source of truth while preventing an advertised descriptor action from becoming
+executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -480,6 +480,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_testing_deploy_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_dispatch_registration_requires_descriptor_route(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
         descriptor_without_stable_verification = registry.GENERIC_WEB_DRIVER.model_copy(
@@ -626,6 +635,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_testing_deploy_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_testing_deploy = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_TESTING_DEPLOY_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_testing_deploy,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_descriptor_requires_dispatch_registration(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes({})
@@ -660,6 +699,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_TESTING_VERIFICATION_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_testing_deploy_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_TESTING_DEPLOY_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24890,9 +24890,26 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "source_git_ref": "abcdef1234567890",
                         },
                     },
+                    headers={"Idempotency-Key": "verireel-testing-deploy-run-12345"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/testing-deploy",
+                    payload={
+                        "product": "verireel",
+                        "deploy": {
+                            "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                            "source_git_ref": "abcdef1234567890",
+                        },
+                    },
+                    headers={"Idempotency-Key": "verireel-testing-deploy-run-12345"},
                 )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(replay_status_code, 202)
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(payload["records"], replay_payload["records"])
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(
                 payload["records"],


### PR DESCRIPTION
## Summary
- route VeriReel testing deploy through descriptor-backed dispatch
- preserve deploy driver execution, authz, idempotency, and accepted response shape
- add descriptor drift coverage plus route-specific idempotency replay coverage
- update descriptor docs to note VeriReel testing deploy dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_testing_deploy_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_testing_deploy_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Review
- GPT reviewer completed with no findings; Claude reviewer was unavailable due to session rate limit.