### PR TITLE
Dispatch VeriReel stable read routes via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2766,6 +2766,34 @@ def _handle_verireel_testing_deploy(
     )
 
 
+def _handle_verireel_stable_environment(
+    request: VeriReelStableEnvironmentEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context, record_store
+    driver_result = resolve_verireel_stable_environment(
+        control_plane_root=control_plane_root_path,
+        request=request.environment,
+    )
+    return _DescriptorDriverDispatchResult(result={}, driver_result=driver_result)
+
+
+def _handle_verireel_runtime_verification(
+    request: VeriReelRuntimeVerificationEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context, record_store
+    driver_result = execute_verireel_rollout_verification(
+        control_plane_root=control_plane_root_path,
+        request=request.verification,
+    )
+    return _DescriptorDriverDispatchResult(result={}, driver_result=driver_result)
+
+
 def _validate_generic_web_preview_verification_profile(
     request: GenericWebPreviewVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2852,6 +2880,24 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_testing_deploy,
         ),
+        _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_STABLE_ENVIRONMENT_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.environment.context,
+                instance=request.environment.instance,
+            ),
+            handler=_handle_verireel_stable_environment,
+        ),
+        _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_RUNTIME_VERIFICATION_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.verification.context,
+                instance=request.verification.instance,
+            ),
+            handler=_handle_verireel_runtime_verification,
+        ),
     }
 
 
@@ -2864,6 +2910,8 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
+            _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
+            _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
         )
     )
 
@@ -14075,62 +14123,6 @@ def create_launchplane_service_app(
                         and replacement_operation.result.release_tuple_id
                     ):
                         result["release_tuple_id"] = replacement_operation.result.release_tuple_id
-            elif path == _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path:
-                verireel_environment_request = (
-                    _VERIREEL_STABLE_ENVIRONMENT_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_environment_request.product,
-                    context=verireel_environment_request.environment.context,
-                    instance=verireel_environment_request.environment.instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_environment_request.product,
-                    context=verireel_environment_request.environment.context,
-                    denial_message=_VERIREEL_STABLE_ENVIRONMENT_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                driver_result = resolve_verireel_stable_environment(
-                    control_plane_root=resolved_root,
-                    request=verireel_environment_request.environment,
-                )
-                result = {}
-            elif path == _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path:
-                verireel_runtime_verification_request = (
-                    _VERIREEL_RUNTIME_VERIFICATION_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_runtime_verification_request.product,
-                    context=verireel_runtime_verification_request.verification.context,
-                    instance=verireel_runtime_verification_request.verification.instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_runtime_verification_request.product,
-                    context=verireel_runtime_verification_request.verification.context,
-                    denial_message=_VERIREEL_RUNTIME_VERIFICATION_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                driver_result = execute_verireel_rollout_verification(
-                    control_plane_root=resolved_root,
-                    request=verireel_runtime_verification_request.verification,
-                )
-                result = {}
             elif path == _VERIREEL_APP_MAINTENANCE_ROUTE.route_path:
                 verireel_maintenance_request = (
                     _VERIREEL_APP_MAINTENANCE_ROUTE.envelope_model.model_validate(payload)

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -489,6 +489,21 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_stable_read_routes_registered_in_descriptor_dispatch(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
+            dispatch_routes,
+        )
+        self.assertIn(
+            control_plane_service._VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_dispatch_registration_requires_descriptor_route(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
         descriptor_without_stable_verification = registry.GENERIC_WEB_DRIVER.model_copy(
@@ -665,6 +680,39 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_stable_read_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        stable_read_route_paths = {
+            control_plane_service._VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
+            control_plane_service._VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
+        }
+        descriptor_without_stable_read = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path not in stable_read_route_paths
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_stable_read,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_stable_verification_descriptor_requires_dispatch_registration(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes({})
@@ -708,6 +756,16 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_TESTING_DEPLOY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_stable_read_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -25275,15 +25275,28 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "product": "verireel",
                         "environment": {"context": "verireel", "instance": "testing"},
                     },
+                    headers={"Idempotency-Key": "verireel-stable-environment-read"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/stable-environment",
+                    payload={
+                        "product": "verireel",
+                        "environment": {"context": "verireel", "instance": "testing"},
+                    },
+                    headers={"Idempotency-Key": "verireel-stable-environment-read"},
                 )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(replay_status_code, 202)
+            self.assertNotIn("replayed", replay_payload)
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(payload["result"]["target_name"], "ver-testing-app")
             self.assertEqual(
                 payload["result"]["primary_base_url"], "https://ver-testing.shinycomputers.com"
             )
-            resolve_mock.assert_called_once()
+            self.assertEqual(resolve_mock.call_count, 2)
 
     def test_verireel_runtime_verification_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -25336,15 +25349,93 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "product": "verireel",
                         "verification": {"context": "verireel", "instance": "testing"},
                     },
+                    headers={"Idempotency-Key": "verireel-runtime-verification-read"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/runtime-verification",
+                    payload={
+                        "product": "verireel",
+                        "verification": {"context": "verireel", "instance": "testing"},
+                    },
+                    headers={"Idempotency-Key": "verireel-runtime-verification-read"},
                 )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(replay_status_code, 202)
+            self.assertNotIn("replayed", replay_payload)
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(payload["result"]["status"], "pass")
             self.assertEqual(
                 payload["result"]["base_url"], "https://ver-testing.shinycomputers.com"
             )
-            verify_mock.assert_called_once()
+            self.assertEqual(verify_mock.call_count, 2)
+
+    def test_verireel_stable_read_drivers_reject_unauthorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["push", "workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["other-context"],
+                            "actions": ["verireel_stable_environment.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/publish-image.yml@refs/heads/main"
+                        ),
+                        event_name="push",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with (
+                patch("control_plane.service.resolve_verireel_stable_environment") as resolve_mock,
+                patch("control_plane.service.execute_verireel_rollout_verification") as verify_mock,
+            ):
+                environment_status_code, environment_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/stable-environment",
+                    payload={
+                        "product": "verireel",
+                        "environment": {"context": "verireel", "instance": "testing"},
+                    },
+                )
+                runtime_status_code, runtime_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/runtime-verification",
+                    payload={
+                        "product": "verireel",
+                        "verification": {"context": "verireel", "instance": "testing"},
+                    },
+                )
+
+            self.assertEqual(environment_status_code, 403)
+            self.assertEqual(environment_payload["error"]["code"], "authorization_denied")
+            self.assertEqual(runtime_status_code, 403)
+            self.assertEqual(runtime_payload["error"]["code"], "authorization_denied")
+            resolve_mock.assert_not_called()
+            verify_mock.assert_not_called()
 
     def test_verireel_app_maintenance_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- route VeriReel stable environment and runtime verification through descriptor-backed dispatch
- preserve read-route authz and non-replay idempotency behavior
- add descriptor drift coverage for both routes
- add service coverage for repeated idempotency-key reads and route-specific authz denial

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_stable_environment_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_runtime_verification_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_stable_read_drivers_reject_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Review
- GPT reviewer completed with no findings; Claude reviewer unavailable due to session rate limit.