### PR TITLE
Dispatch VeriReel prod deploy via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2766,6 +2766,24 @@ def _handle_verireel_testing_deploy(
     )
 
 
+def _handle_verireel_prod_deploy(
+    request: VeriReelProdDeployEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_verireel_stable_deploy(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(VeriReelStableDeployStore, record_store),
+        request=request.deploy,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={"deployment_record_id": driver_result.deployment_record_id},
+        driver_result=driver_result,
+    )
+
+
 def _handle_verireel_stable_environment(
     request: VeriReelStableEnvironmentEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2880,6 +2898,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_testing_deploy,
         ),
+        _VERIREEL_PROD_DEPLOY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_PROD_DEPLOY_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.deploy.context,
+                instance=request.deploy.instance,
+            ),
+            handler=_handle_verireel_prod_deploy,
+        ),
         _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_STABLE_ENVIRONMENT_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -2910,6 +2937,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
+            _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
             _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
             _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
         )
@@ -14160,46 +14188,6 @@ def create_launchplane_service_app(
                     request=verireel_maintenance_request.maintenance,
                 )
                 result = driver_result.model_dump(mode="json")
-            elif path == _VERIREEL_PROD_DEPLOY_ROUTE.route_path:
-                verireel_prod_deploy_request = (
-                    _VERIREEL_PROD_DEPLOY_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_prod_deploy_request.product,
-                    context=verireel_prod_deploy_request.deploy.context,
-                    instance=verireel_prod_deploy_request.deploy.instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_prod_deploy_request.product,
-                    context=verireel_prod_deploy_request.deploy.context,
-                    denial_message=_VERIREEL_PROD_DEPLOY_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_verireel_stable_deploy(
-                    control_plane_root=resolved_root,
-                    record_store=cast(VeriReelStableDeployStore, record_store),
-                    request=verireel_prod_deploy_request.deploy,
-                )
-                result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == _VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path:
                 verireel_prod_backup_gate_request = (
                     _VERIREEL_PROD_BACKUP_GATE_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,7 +418,7 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
-testing deploy plus testing and preview verification writebacks use
+testing and prod deploys plus testing and preview verification writebacks use
 descriptor-backed dispatch. This keeps descriptor metadata as the route/authz
 source of truth while preventing an advertised descriptor action from becoming
 executable without implementation.

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -489,6 +489,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_prod_deploy_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_PROD_DEPLOY_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_stable_read_routes_registered_in_descriptor_dispatch(
         self,
     ) -> None:
@@ -680,6 +689,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_prod_deploy_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_prod_deploy = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_PROD_DEPLOY_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_prod_deploy,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_stable_read_dispatch_registration_requires_descriptor_route(
         self,
     ) -> None:
@@ -756,6 +795,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_TESTING_DEPLOY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_prod_deploy_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_PROD_DEPLOY_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -27389,9 +27389,27 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "source_git_ref": "abcdef1234567890",
                         },
                     },
+                    headers={"Idempotency-Key": "verireel-prod-deploy-run-12345"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-deploy",
+                    payload={
+                        "product": "verireel",
+                        "deploy": {
+                            "instance": "prod",
+                            "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                            "source_git_ref": "abcdef1234567890",
+                        },
+                    },
+                    headers={"Idempotency-Key": "verireel-prod-deploy-run-12345"},
                 )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(replay_status_code, 202)
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(payload["records"], replay_payload["records"])
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(
                 payload["records"],


### PR DESCRIPTION
## Summary
- route VeriReel prod deploy through descriptor-backed dispatch
- preserve deploy driver execution, authz, idempotency, and accepted response shape
- add descriptor drift coverage plus route-specific idempotency replay coverage
- update descriptor docs to include VeriReel prod deploy dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_prod_deploy_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_prod_deploy_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Review
- GPT reviewer found one docs drift issue; fixed before commit.
- Claude reviewer unavailable due to session rate limit.