### PR TITLE
Dispatch VeriReel app maintenance via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2812,6 +2812,23 @@ def _handle_verireel_runtime_verification(
     return _DescriptorDriverDispatchResult(result={}, driver_result=driver_result)
 
 
+def _handle_verireel_app_maintenance(
+    request: VeriReelAppMaintenanceEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context, record_store
+    driver_result = execute_verireel_app_maintenance(
+        control_plane_root=control_plane_root_path,
+        request=request.maintenance,
+    )
+    return _DescriptorDriverDispatchResult(
+        result=driver_result.model_dump(mode="json"),
+        driver_result=driver_result,
+    )
+
+
 def _validate_generic_web_preview_verification_profile(
     request: GenericWebPreviewVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2925,6 +2942,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_runtime_verification,
         ),
+        _VERIREEL_APP_MAINTENANCE_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_APP_MAINTENANCE_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.maintenance.context,
+            ),
+            handler=_handle_verireel_app_maintenance,
+        ),
     }
 
 
@@ -2940,6 +2966,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
             _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
             _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
+            _VERIREEL_APP_MAINTENANCE_ROUTE.route_path,
         )
     )
 
@@ -14151,43 +14178,6 @@ def create_launchplane_service_app(
                         and replacement_operation.result.release_tuple_id
                     ):
                         result["release_tuple_id"] = replacement_operation.result.release_tuple_id
-            elif path == _VERIREEL_APP_MAINTENANCE_ROUTE.route_path:
-                verireel_maintenance_request = (
-                    _VERIREEL_APP_MAINTENANCE_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_maintenance_request.product,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_maintenance_request.product,
-                    context=verireel_maintenance_request.maintenance.context,
-                    denial_message=_VERIREEL_APP_MAINTENANCE_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_verireel_app_maintenance(
-                    control_plane_root=resolved_root,
-                    request=verireel_maintenance_request.maintenance,
-                )
-                result = driver_result.model_dump(mode="json")
             elif path == _VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path:
                 verireel_prod_backup_gate_request = (
                     _VERIREEL_PROD_BACKUP_GATE_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,10 +418,10 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
-testing and prod deploys plus testing and preview verification writebacks use
-descriptor-backed dispatch. This keeps descriptor metadata as the route/authz
-source of truth while preventing an advertised descriptor action from becoming
-executable without implementation.
+testing and prod deploys, app maintenance, plus testing and preview
+verification writebacks use descriptor-backed dispatch. This keeps descriptor
+metadata as the route/authz source of truth while preventing an advertised
+descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -498,6 +498,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_app_maintenance_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_APP_MAINTENANCE_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_stable_read_routes_registered_in_descriptor_dispatch(
         self,
     ) -> None:
@@ -719,6 +728,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_app_maintenance_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_app_maintenance = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_APP_MAINTENANCE_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_app_maintenance,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_stable_read_dispatch_registration_requires_descriptor_route(
         self,
     ) -> None:
@@ -804,6 +843,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_PROD_DEPLOY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_app_maintenance_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_APP_MAINTENANCE_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -25498,12 +25498,32 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "intent": "stable-testing-migration",
                         },
                     },
+                    headers={"Idempotency-Key": "verireel-app-maintenance-migrate"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/app-maintenance",
+                    payload={
+                        "product": "verireel",
+                        "maintenance": {
+                            "context": "verireel",
+                            "instance": "testing",
+                            "action": "migrate",
+                            "intent": "stable-testing-migration",
+                        },
+                    },
+                    headers={"Idempotency-Key": "verireel-app-maintenance-migrate"},
                 )
 
             self.assertEqual(status_code, 202)
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(payload["result"]["maintenance_status"], "pass")
             self.assertEqual(payload["result"]["application_id"], "testing-app-123")
+            self.assertEqual(replay_status_code, 202)
+            self.assertEqual(replay_payload["status"], "accepted")
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(replay_payload["result"], payload["result"])
             execute_mock.assert_called_once()
 
     def test_verireel_app_maintenance_driver_accepts_stable_e2e_grant_intent(self) -> None:


### PR DESCRIPTION
## Summary
- route VeriReel app-maintenance through descriptor-backed service dispatch
- add descriptor/dispatch drift tests and idempotency replay coverage
- update descriptor docs to include app maintenance in descriptor-backed dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_accepts_stable_e2e_grant_intent tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_app_maintenance_driver_rejects_action_only_payload
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Reviews
- code-gpt-5.5 review: no findings
- antigravity review: completed with empty result file
- Claude skipped because it is rate-limited