### PR TITLE
Dispatch VeriReel preview inventory via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2731,6 +2731,29 @@ def _handle_verireel_preview_verification(
     )
 
 
+def _handle_verireel_preview_inventory(
+    request: VeriReelPreviewInventoryEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_verireel_preview_inventory(
+        control_plane_root=control_plane_root_path,
+        request=request.inventory,
+    )
+    preview_inventory_scan_id = _write_preview_inventory_scan_if_supported(
+        record_store=record_store,
+        context=driver_result.context,
+        source="verireel-preview-inventory",
+        preview_slugs=tuple(item.previewSlug for item in driver_result.previews),
+    )
+    return _DescriptorDriverDispatchResult(
+        result={"preview_inventory_scan_id": preview_inventory_scan_id},
+        driver_result=driver_result,
+    )
+
+
 def _handle_verireel_testing_verification(
     request: VeriReelTestingVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2897,6 +2920,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_preview_verification,
         ),
+        _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_PREVIEW_INVENTORY_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.inventory.context,
+            ),
+            handler=_handle_verireel_preview_inventory,
+        ),
         _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_TESTING_VERIFICATION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -2961,6 +2993,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
+            _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
             _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
@@ -3033,17 +3066,18 @@ def _dispatch_descriptor_driver_route(
     )
     if authorization_response is not None:
         return authorization_response
-    idempotent_response = _check_idempotent_request(
-        record_store=record_store,
-        scope=request_scope,
-        route_path=route_metadata.route_path,
-        idempotency_key=request_idempotency_key,
-        request_fingerprint=request_fingerprint,
-        start_response=start_response,
-        trace_id=trace_id,
-    )
-    if idempotent_response is not None:
-        return idempotent_response
+    if route_metadata.route_path not in _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES:
+        idempotent_response = _check_idempotent_request(
+            record_store=record_store,
+            scope=request_scope,
+            route_path=route_metadata.route_path,
+            idempotency_key=request_idempotency_key,
+            request_fingerprint=request_fingerprint,
+            start_response=start_response,
+            trace_id=trace_id,
+        )
+        if idempotent_response is not None:
+            return idempotent_response
     dispatch_result = dispatch_route.handler(
         request,
         resolved_driver_context,
@@ -14391,38 +14425,6 @@ def create_launchplane_service_app(
                     request=verireel_preview_refresh_request.refresh,
                     driver_result=driver_result,
                 )
-            elif path == _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path:
-                verireel_preview_inventory_request = (
-                    _VERIREEL_PREVIEW_INVENTORY_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_preview_inventory_request.product,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_preview_inventory_request.product,
-                    context=verireel_preview_inventory_request.inventory.context,
-                    denial_message=_VERIREEL_PREVIEW_INVENTORY_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                driver_result = execute_verireel_preview_inventory(
-                    control_plane_root=resolved_root,
-                    request=verireel_preview_inventory_request.inventory,
-                )
-                preview_inventory_scan_id = _write_preview_inventory_scan_if_supported(
-                    record_store=record_store,
-                    context=driver_result.context,
-                    source="verireel-preview-inventory",
-                    preview_slugs=tuple(item.previewSlug for item in driver_result.previews),
-                )
-                result = {"preview_inventory_scan_id": preview_inventory_scan_id}
             elif path == _VERIREEL_PREVIEW_DESTROY_ROUTE.route_path:
                 verireel_preview_destroy_request = (
                     _VERIREEL_PREVIEW_DESTROY_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,10 +418,10 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
-testing and prod deploys, app maintenance, plus testing and preview
-verification writebacks use descriptor-backed dispatch. This keeps descriptor
-metadata as the route/authz source of truth while preventing an advertised
-descriptor action from becoming executable without implementation.
+testing and prod deploys, app maintenance, preview inventory reads, plus testing
+and preview verification writebacks use descriptor-backed dispatch. This keeps
+descriptor metadata as the route/authz source of truth while preventing an
+advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -469,6 +469,17 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_preview_inventory_registered_in_descriptor_dispatch(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_testing_verification_registered_in_descriptor_dispatch(
         self,
     ) -> None:
@@ -628,6 +639,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "_DESCRIPTORS",
             (
                 descriptor_without_preview_verification,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_preview_inventory_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_preview_inventory = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_preview_inventory,
                 *(
                     descriptor
                     for descriptor in registry._DESCRIPTORS
@@ -816,6 +857,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_preview_inventory_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -37,6 +37,7 @@ from control_plane.contracts.driver_descriptor import DriverActionDescriptor, Dr
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicy
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_policy import parse_merge_train_policy_toml
@@ -25797,10 +25798,47 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=root,
             )
-            request_payload = {
+            request_payload: dict[str, object] = {
                 "product": "verireel",
                 "inventory": {"context": "verireel-testing"},
             }
+            idempotency_key = "verireel-preview-inventory:verireel-testing"
+            FilesystemRecordStore(state_dir=root / "state").write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id="idempotency-stale-verireel-preview-inventory",
+                    scope="|".join(
+                        (
+                            "every/verireel",
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main",
+                            "repo:every/verireel:pull_request",
+                        )
+                    ),
+                    route_path="/v1/drivers/verireel/preview-inventory",
+                    idempotency_key=idempotency_key,
+                    request_fingerprint=control_plane_service._idempotency_request_fingerprint(
+                        route_path="/v1/drivers/verireel/preview-inventory",
+                        payload=request_payload,
+                    ),
+                    response_status_code=202,
+                    response_trace_id="stale-verireel-preview-inventory",
+                    recorded_at="2026-04-29T19:22:00Z",
+                    response_payload={
+                        "status": "accepted",
+                        "trace_id": "stale-verireel-preview-inventory",
+                        "records": {"preview_inventory_scan_id": "stale-scan"},
+                        "result": {
+                            "context": "verireel-testing",
+                            "previews": [
+                                {
+                                    "applicationId": "stale-app",
+                                    "applicationName": "stale-preview-app",
+                                    "previewSlug": "stale",
+                                }
+                            ],
+                        },
+                    },
+                )
+            )
 
             with patch(
                 "control_plane.service.execute_verireel_preview_inventory",
@@ -25823,20 +25861,22 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     method="POST",
                     path="/v1/drivers/verireel/preview-inventory",
                     payload=request_payload,
-                    headers={"Idempotency-Key": "verireel-preview-inventory:verireel-testing"},
+                    headers={"Idempotency-Key": idempotency_key},
                 )
                 second_status_code, second_payload = _invoke_app(
                     app,
                     method="POST",
                     path="/v1/drivers/verireel/preview-inventory",
                     payload=request_payload,
-                    headers={"Idempotency-Key": "verireel-preview-inventory:verireel-testing"},
+                    headers={"Idempotency-Key": idempotency_key},
                 )
 
             self.assertEqual(first_status_code, 202)
             self.assertEqual(second_status_code, 202)
             self.assertEqual(first_payload["result"]["previews"][0]["previewSlug"], "pr-93")
             self.assertEqual(second_payload["result"]["previews"], [])
+            self.assertNotIn("replayed", first_payload)
+            self.assertNotIn("replayed", second_payload)
             self.assertEqual(execute_mock.call_count, 2)
 
     def test_preview_lifecycle_plan_endpoint_records_report_only_plan(self) -> None:


### PR DESCRIPTION
## Summary
- route VeriReel preview-inventory through descriptor-backed service dispatch
- add descriptor/dispatch drift coverage for the route
- preserve non-idempotent inventory read behavior, including stale idempotency records
- update descriptor docs to include preview inventory reads

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_preview_inventory_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_inventory_driver_does_not_replay_cached_inventory
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Reviews
- code-gpt-5.5 review: found stale idempotency replay edge; fixed
- code-gpt-5.5 re-review: no findings
- antigravity reviews: completed with empty result files
- Claude skipped because it is rate-limited