### PR TITLE
Dispatch VeriReel prod rollback via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2807,6 +2807,27 @@ def _handle_verireel_prod_deploy(
     )
 
 
+def _handle_verireel_prod_rollback(
+    request: VeriReelProdRollbackEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_verireel_prod_rollback(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(VeriReelProdRollbackStore, record_store),
+        request=request.rollback,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={
+            "promotion_record_id": driver_result.promotion_record_id,
+            "backup_record_id": driver_result.backup_record_id,
+        },
+        driver_result=driver_result,
+    )
+
+
 def _handle_verireel_stable_environment(
     request: VeriReelStableEnvironmentEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2956,6 +2977,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_prod_deploy,
         ),
+        _VERIREEL_PROD_ROLLBACK_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_PROD_ROLLBACK_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.rollback.context,
+                instance=request.rollback.instance,
+            ),
+            handler=_handle_verireel_prod_rollback,
+        ),
         _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_STABLE_ENVIRONMENT_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -2997,6 +3027,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
             _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
+            _VERIREEL_PROD_ROLLBACK_ROUTE.route_path,
             _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
             _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
             _VERIREEL_APP_MAINTENANCE_ROUTE.route_path,
@@ -14302,49 +14333,6 @@ def create_launchplane_service_app(
                 result = {
                     "promotion_record_id": driver_result.promotion_record_id,
                     "deployment_record_id": driver_result.deployment_record_id,
-                }
-            elif path == _VERIREEL_PROD_ROLLBACK_ROUTE.route_path:
-                verireel_prod_rollback_request = (
-                    _VERIREEL_PROD_ROLLBACK_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_prod_rollback_request.product,
-                    context=verireel_prod_rollback_request.rollback.context,
-                    instance=verireel_prod_rollback_request.rollback.instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_prod_rollback_request.product,
-                    context=verireel_prod_rollback_request.rollback.context,
-                    denial_message=_VERIREEL_PROD_ROLLBACK_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_verireel_prod_rollback(
-                    control_plane_root=resolved_root,
-                    record_store=cast(VeriReelProdRollbackStore, record_store),
-                    request=verireel_prod_rollback_request.rollback,
-                )
-                result = {
-                    "promotion_record_id": driver_result.promotion_record_id,
-                    "backup_record_id": driver_result.backup_record_id,
                 }
             elif path == _VERIREEL_PREVIEW_REFRESH_ROUTE.route_path:
                 verireel_preview_refresh_request = (

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,10 +418,11 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
-testing and prod deploys, app maintenance, preview inventory reads, plus testing
-and preview verification writebacks use descriptor-backed dispatch. This keeps
-descriptor metadata as the route/authz source of truth while preventing an
-advertised descriptor action from becoming executable without implementation.
+testing and prod deploys, prod rollback, app maintenance, preview inventory
+reads, plus testing and preview verification writebacks use descriptor-backed
+dispatch. This keeps descriptor metadata as the route/authz source of truth
+while preventing an advertised descriptor action from becoming executable
+without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -509,6 +509,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_prod_rollback_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_PROD_ROLLBACK_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_app_maintenance_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
@@ -769,6 +778,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_prod_rollback_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_prod_rollback = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_PROD_ROLLBACK_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_prod_rollback,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_app_maintenance_dispatch_registration_requires_descriptor_route(
         self,
     ) -> None:
@@ -893,6 +932,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_PROD_DEPLOY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_prod_rollback_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_PROD_ROLLBACK_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -30554,6 +30554,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
                         },
                     },
+                    headers={"Idempotency-Key": "verireel-prod-rollback"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-rollback",
+                    payload={
+                        "product": "verireel",
+                        "rollback": {
+                            "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                            "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                        },
+                    },
+                    headers={"Idempotency-Key": "verireel-prod-rollback"},
                 )
 
             self.assertEqual(status_code, 202)
@@ -30566,6 +30580,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             self.assertEqual(payload["result"]["rollback_status"], "pass")
+            self.assertEqual(replay_status_code, 202)
+            self.assertEqual(replay_payload["status"], "accepted")
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(replay_payload["original_trace_id"], payload["trace_id"])
+            self.assertEqual(replay_payload["result"], payload["result"])
             execute_mock.assert_called_once()
 
     def test_verireel_driver_route_accepts_product_profile_driver_id(self) -> None:


### PR DESCRIPTION
## Summary
- route VeriReel prod rollback through descriptor-backed service dispatch
- add descriptor/dispatch drift coverage and idempotent replay coverage
- update descriptor docs to include prod rollback in descriptor-backed dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_prod_rollback_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_driver_route_accepts_product_profile_driver_id tests.test_service.LaunchplaneServiceTests.test_verireel_driver_route_rejects_unowned_profile_lane tests.test_service.LaunchplaneServiceTests.test_verireel_prod_rollback_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Reviews
- code-gpt-5.5 review: no findings
- antigravity review: no findings
- Claude skipped because it is rate-limited