### PR TITLE
Dispatch VeriReel preview destroy via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1441,6 +1441,12 @@ _PREVIEW_INVENTORY_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_INVENTORY_ROUTE
 _PREVIEW_REFRESH_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_REFRESH_ROUTE.route_path})
 _PREVIEW_READINESS_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path})
 _PREVIEW_DESTROY_ROUTE_PATHS = frozenset({_GENERIC_WEB_PREVIEW_DESTROY_ROUTE.route_path})
+_PREVIEW_DESTROY_IDEMPOTENCY_ROUTE_PATHS = frozenset(
+    {
+        _GENERIC_WEB_PREVIEW_DESTROY_ROUTE.route_path,
+        "/v1/drivers/verireel/preview-destroy",
+    }
+)
 _GENERIC_WEB_BASE_DRIVER_SHARED_ROUTE_PATHS = frozenset(
     {
         _GENERIC_WEB_DEPLOY_ROUTE.route_path,
@@ -2754,6 +2760,27 @@ def _handle_verireel_preview_inventory(
     )
 
 
+def _handle_verireel_preview_destroy(
+    request: VeriReelPreviewDestroyEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_verireel_preview_destroy(
+        control_plane_root=control_plane_root_path,
+        request=request.destroy,
+    )
+    return _DescriptorDriverDispatchResult(
+        result=_apply_verireel_preview_destroy_records(
+            record_store=record_store,
+            request=request.destroy,
+            driver_result=driver_result,
+        ),
+        driver_result=driver_result,
+    )
+
+
 def _handle_verireel_testing_verification(
     request: VeriReelTestingVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2950,6 +2977,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_preview_inventory,
         ),
+        _VERIREEL_PREVIEW_DESTROY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_PREVIEW_DESTROY_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.destroy.context,
+            ),
+            handler=_handle_verireel_preview_destroy,
+        ),
         _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_TESTING_VERIFICATION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3024,6 +3060,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
+            _VERIREEL_PREVIEW_DESTROY_ROUTE.route_path,
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
             _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
@@ -5442,7 +5479,7 @@ def _request_fingerprint(payload: dict[str, object]) -> str:
 def _canonical_request_payload_for_idempotency(
     *, route_path: str, payload: dict[str, object]
 ) -> dict[str, object]:
-    if route_path not in _PREVIEW_DESTROY_ROUTE_PATHS:
+    if route_path not in _PREVIEW_DESTROY_IDEMPOTENCY_ROUTE_PATHS:
         return payload
     canonical_payload = json.loads(json.dumps(payload))
     destroy_payload = canonical_payload.get("destroy")
@@ -14411,47 +14448,6 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     record_store=record_store,
                     request=verireel_preview_refresh_request.refresh,
-                    driver_result=driver_result,
-                )
-            elif path == _VERIREEL_PREVIEW_DESTROY_ROUTE.route_path:
-                verireel_preview_destroy_request = (
-                    _VERIREEL_PREVIEW_DESTROY_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_preview_destroy_request.product,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_preview_destroy_request.product,
-                    context=verireel_preview_destroy_request.destroy.context,
-                    denial_message=_VERIREEL_PREVIEW_DESTROY_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_verireel_preview_destroy(
-                    control_plane_root=resolved_root,
-                    request=verireel_preview_destroy_request.destroy,
-                )
-                result = _apply_verireel_preview_destroy_records(
-                    record_store=record_store,
-                    request=verireel_preview_destroy_request.destroy,
                     driver_result=driver_result,
                 )
             elif path == _ODOO_PREVIEW_APPLY_ROUTE.route_path:

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -419,10 +419,10 @@ Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
 testing and prod deploys, prod rollback, app maintenance, preview inventory
-reads, plus testing and preview verification writebacks use descriptor-backed
-dispatch. This keeps descriptor metadata as the route/authz source of truth
-while preventing an advertised descriptor action from becoming executable
-without implementation.
+reads, preview destroy, plus testing and preview verification writebacks use
+descriptor-backed dispatch. This keeps descriptor metadata as the route/authz
+source of truth while preventing an advertised descriptor action from becoming
+executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -480,6 +480,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_preview_destroy_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_PREVIEW_DESTROY_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_testing_verification_registered_in_descriptor_dispatch(
         self,
     ) -> None:
@@ -678,6 +687,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "_DESCRIPTORS",
             (
                 descriptor_without_preview_inventory,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_preview_destroy_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_preview_destroy = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_PREVIEW_DESTROY_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_preview_destroy,
                 *(
                     descriptor
                     for descriptor in registry._DESCRIPTORS
@@ -905,6 +944,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_preview_destroy_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_PREVIEW_DESTROY_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31578,6 +31578,21 @@ class LaunchplaneServiceTests(unittest.TestCase):
                             "destroy_reason": "external_preview_pull_request_closed",
                         },
                     },
+                    headers={"Idempotency-Key": "verireel-preview-destroy-pr-123"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/preview-destroy",
+                    payload={
+                        "product": "verireel",
+                        "destroy": {
+                            "anchor_pr_number": 123,
+                            "preview_slug": "pr-123",
+                            "destroy_reason": "external_preview_janitor_cleanup_completed",
+                        },
+                    },
+                    headers={"Idempotency-Key": "verireel-preview-destroy-pr-123"},
                 )
 
             self.assertEqual(status_code, 202)
@@ -31588,6 +31603,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["records"]["transition"], "destroyed")
             self.assertEqual(payload["result"]["destroy_status"], "pass")
             self.assertEqual(payload["result"]["application_id"], "preview-app-123")
+            self.assertEqual(replay_status_code, 202)
+            self.assertEqual(replay_payload["status"], "accepted")
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(replay_payload["original_trace_id"], payload["trace_id"])
+            self.assertEqual(replay_payload["records"], payload["records"])
+            self.assertEqual(replay_payload["result"], payload["result"])
             preview = store.read_preview_record("preview-verireel-testing-verireel-pr-123")
             self.assertEqual(preview.state, "destroyed")
             self.assertEqual(preview.destroy_reason, "external_preview_pull_request_closed")


### PR DESCRIPTION
## Summary
- route VeriReel preview destroy through descriptor-backed service dispatch
- add descriptor/dispatch drift coverage and idempotency replay coverage
- preserve destroy_reason-insensitive idempotency replay without broadening generic-web routing
- update descriptor docs to include preview destroy in descriptor-backed dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_preview_destroy_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_destroy_driver_executes_for_authorized_janitor_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_destroy_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Reviews
- code-gpt-5.5/antigravity review: found destroy_reason idempotency canonicalization gap; fixed
- code-gpt-5.5/antigravity re-review: no findings
- Claude skipped because it is rate-limited