### PR TITLE
Dispatch VeriReel prod promotion via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2855,6 +2855,43 @@ def _handle_verireel_prod_rollback(
     )
 
 
+def _validate_verireel_prod_promotion_target_lane(
+    request: VeriReelProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> None:
+    del resolved_context, control_plane_root_path
+    _resolve_descriptor_product_driver_context(
+        record_store=record_store,
+        route_path=_VERIREEL_PROD_PROMOTION_ROUTE.route_path,
+        product=request.product,
+        context=request.promotion.context,
+        instance=request.promotion.to_instance,
+    )
+
+
+def _handle_verireel_prod_promotion(
+    request: VeriReelProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_verireel_prod_promotion(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(VeriReelProdPromotionStore, record_store),
+        request=request.promotion,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={
+            "promotion_record_id": driver_result.promotion_record_id,
+            "deployment_record_id": driver_result.deployment_record_id,
+        },
+        driver_result=driver_result,
+    )
+
+
 def _handle_verireel_stable_environment(
     request: VeriReelStableEnvironmentEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3013,6 +3050,16 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_prod_deploy,
         ),
+        _VERIREEL_PROD_PROMOTION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_PROD_PROMOTION_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.promotion.context,
+                instance=request.promotion.from_instance,
+            ),
+            handler=_handle_verireel_prod_promotion,
+            pre_idempotency_validator=_validate_verireel_prod_promotion_target_lane,
+        ),
         _VERIREEL_PROD_ROLLBACK_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_PROD_ROLLBACK_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3064,6 +3111,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
             _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
+            _VERIREEL_PROD_PROMOTION_ROUTE.route_path,
             _VERIREEL_PROD_ROLLBACK_ROUTE.route_path,
             _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
             _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
@@ -14321,56 +14369,6 @@ def create_launchplane_service_app(
                     run_async=True,
                 )
                 result = {"backup_gate_record_id": driver_result.backup_record_id}
-            elif path == _VERIREEL_PROD_PROMOTION_ROUTE.route_path:
-                verireel_prod_promotion_request = (
-                    _VERIREEL_PROD_PROMOTION_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_prod_promotion_request.product,
-                    context=verireel_prod_promotion_request.promotion.context,
-                    instance=verireel_prod_promotion_request.promotion.from_instance,
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_prod_promotion_request.product,
-                    context=verireel_prod_promotion_request.promotion.context,
-                    instance=verireel_prod_promotion_request.promotion.to_instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_prod_promotion_request.product,
-                    context=verireel_prod_promotion_request.promotion.context,
-                    denial_message=_VERIREEL_PROD_PROMOTION_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_verireel_prod_promotion(
-                    control_plane_root=resolved_root,
-                    record_store=cast(VeriReelProdPromotionStore, record_store),
-                    request=verireel_prod_promotion_request.promotion,
-                )
-                result = {
-                    "promotion_record_id": driver_result.promotion_record_id,
-                    "deployment_record_id": driver_result.deployment_record_id,
-                }
             elif path == _VERIREEL_PREVIEW_REFRESH_ROUTE.route_path:
                 verireel_preview_refresh_request = (
                     _VERIREEL_PREVIEW_REFRESH_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,11 +418,11 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
-testing and prod deploys, prod rollback, app maintenance, preview inventory
-reads, preview destroy, plus testing and preview verification writebacks use
-descriptor-backed dispatch. This keeps descriptor metadata as the route/authz
-source of truth while preventing an advertised descriptor action from becoming
-executable without implementation.
+testing and prod deploys, prod promotion, prod rollback, app maintenance,
+preview inventory reads, preview destroy, plus testing and preview verification
+writebacks use descriptor-backed dispatch. This keeps descriptor metadata as the
+route/authz source of truth while preventing an advertised descriptor action
+from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -518,6 +518,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_prod_promotion_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_PROD_PROMOTION_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_prod_rollback_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
@@ -817,6 +826,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_prod_promotion_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_prod_promotion = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_PROD_PROMOTION_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_prod_promotion,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_prod_rollback_dispatch_registration_requires_descriptor_route(
         self,
     ) -> None:
@@ -980,6 +1019,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_PROD_DEPLOY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_prod_promotion_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_PROD_PROMOTION_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -27583,23 +27583,38 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     provider_target_type="application",
                 ),
             ) as execute_mock:
+                promotion_payload = {
+                    "product": "verireel",
+                    "promotion": {
+                        "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
+                        "source_git_ref": "abcdef1234567890",
+                        "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
+                        "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
+                        "source_health_status": "success",
+                    },
+                }
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
                     path="/v1/drivers/verireel/prod-promotion",
-                    payload={
-                        "product": "verireel",
-                        "promotion": {
-                            "artifact_id": "ghcr.io/every/verireel-app:sha-abcdef1234567890",
-                            "source_git_ref": "abcdef1234567890",
-                            "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1",
-                            "promotion_record_id": "promotion-verireel-testing-to-prod-run-12345-attempt-1",
-                            "source_health_status": "success",
-                        },
-                    },
+                    payload=promotion_payload,
+                    headers={"Idempotency-Key": "verireel-prod-promotion-run-12345"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-promotion",
+                    payload=promotion_payload,
+                    headers={"Idempotency-Key": "verireel-prod-promotion-run-12345"},
                 )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(replay_status_code, 202)
+            self.assertEqual(replay_payload["status"], "accepted")
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(replay_payload["original_trace_id"], payload["trace_id"])
+            self.assertEqual(replay_payload["records"], payload["records"])
+            self.assertEqual(replay_payload["result"], payload["result"])
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(
                 payload["records"],
@@ -27620,6 +27635,170 @@ class LaunchplaneServiceTests(unittest.TestCase):
             execute_mock.assert_called_once()
             request = execute_mock.call_args.kwargs["request"]
             self.assertEqual(request.source_health_status, "pass")
+
+    def test_verireel_prod_promotion_route_accepts_product_profile_driver_id(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _generic_site_profile_payload(product="video-site")
+            profile_payload["display_name"] = "Video Site"
+            profile_payload["driver_id"] = "verireel"
+            profile_payload["preview"] = {
+                "enabled": False,
+                "context": "",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/video-site",
+                            "workflow_refs": [
+                                "every/video-site/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["video-site"],
+                            "contexts": ["video-site"],
+                            "actions": ["verireel_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/video-site",
+                        workflow_ref=(
+                            "every/video-site/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.execute_verireel_prod_promotion",
+                return_value=VeriReelProdPromotionResult(
+                    promotion_record_id="promotion-video-testing-to-prod-run-12345-attempt-1",
+                    deployment_record_id="deployment-video-prod-run-12345-attempt-1",
+                    backup_record_id="backup-gate-video-prod-run-12345-attempt-1",
+                    deploy_status="pass",
+                    deploy_started_at="2026-04-21T18:20:00Z",
+                    deploy_finished_at="2026-04-21T18:21:15Z",
+                    target_name="video-prod-app",
+                    target_id="prod-app-123",
+                    target_category="application",
+                    provider_id="dokploy",
+                    provider_target_type="application",
+                ),
+            ) as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-promotion",
+                    payload={
+                        "product": "video-site",
+                        "promotion": {
+                            "context": "video-site",
+                            "artifact_id": "ghcr.io/every/video-site:sha-abcdef1234567890",
+                            "source_git_ref": "abcdef1234567890",
+                            "backup_record_id": "backup-gate-video-prod-run-12345-attempt-1",
+                            "promotion_record_id": "promotion-video-testing-to-prod-run-12345-attempt-1",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 202)
+            self.assertEqual(
+                payload["records"]["promotion_record_id"],
+                "promotion-video-testing-to-prod-run-12345-attempt-1",
+            )
+            execute_mock.assert_called_once()
+
+    def test_verireel_prod_promotion_route_rejects_unowned_target_lane(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _generic_site_profile_payload(product="video-site")
+            profile_payload["display_name"] = "Video Site"
+            profile_payload["driver_id"] = "verireel"
+            profile_payload["lanes"] = (
+                {
+                    "instance": "testing",
+                    "context": "video-site",
+                    "base_url": "https://testing.video.example",
+                    "health_url": "https://testing.video.example/healthz",
+                },
+            )
+            profile_payload["preview"] = {
+                "enabled": False,
+                "context": "",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/video-site",
+                            "workflow_refs": [
+                                "every/video-site/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["video-site"],
+                            "contexts": ["video-site"],
+                            "actions": ["verireel_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/video-site",
+                        workflow_ref=(
+                            "every/video-site/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch("control_plane.service.execute_verireel_prod_promotion") as execute_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-promotion",
+                    payload={
+                        "product": "video-site",
+                        "promotion": {
+                            "context": "video-site",
+                            "artifact_id": "ghcr.io/every/video-site:sha-abcdef1234567890",
+                            "source_git_ref": "abcdef1234567890",
+                            "backup_record_id": "backup-gate-video-prod-run-12345-attempt-1",
+                            "promotion_record_id": "promotion-video-testing-to-prod-run-12345-attempt-1",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
+            execute_mock.assert_not_called()
 
     def test_odoo_post_deploy_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- route VeriReel prod promotion through descriptor-backed service dispatch
- preserve source and target lane validation before authorization/idempotency
- add descriptor/dispatch drift coverage plus prod-promotion replay and profile-lane service coverage
- update descriptor docs to include prod promotion in descriptor-backed dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_prod_promotion_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_prod_promotion_route_accepts_product_profile_driver_id tests.test_service.LaunchplaneServiceTests.test_verireel_prod_promotion_route_rejects_unowned_target_lane tests.test_service.LaunchplaneServiceTests.test_verireel_prod_promotion_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Reviews
- code-gpt-5.5 review: no findings
- antigravity review: no findings
- Claude skipped because it is rate-limited