### PR TITLE
Dispatch VeriReel prod backup gate via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2834,6 +2834,25 @@ def _handle_verireel_prod_deploy(
     )
 
 
+def _handle_verireel_prod_backup_gate(
+    request: VeriReelProdBackupGateEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_verireel_prod_backup_gate(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(VeriReelProdBackupGateStore, record_store),
+        request=request.backup_gate,
+        run_async=True,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={"backup_gate_record_id": driver_result.backup_record_id},
+        driver_result=driver_result,
+    )
+
+
 def _handle_verireel_prod_rollback(
     request: VeriReelProdRollbackEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3050,6 +3069,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_prod_deploy,
         ),
+        _VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_PROD_BACKUP_GATE_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.backup_gate.context,
+                instance=request.backup_gate.instance,
+            ),
+            handler=_handle_verireel_prod_backup_gate,
+        ),
         _VERIREEL_PROD_PROMOTION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_PROD_PROMOTION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3111,6 +3139,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
             _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
+            _VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path,
             _VERIREEL_PROD_PROMOTION_ROUTE.route_path,
             _VERIREEL_PROD_ROLLBACK_ROUTE.route_path,
             _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
@@ -14328,47 +14357,6 @@ def create_launchplane_service_app(
                         and replacement_operation.result.release_tuple_id
                     ):
                         result["release_tuple_id"] = replacement_operation.result.release_tuple_id
-            elif path == _VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path:
-                verireel_prod_backup_gate_request = (
-                    _VERIREEL_PROD_BACKUP_GATE_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_prod_backup_gate_request.product,
-                    context=verireel_prod_backup_gate_request.backup_gate.context,
-                    instance=verireel_prod_backup_gate_request.backup_gate.instance,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_prod_backup_gate_request.product,
-                    context=verireel_prod_backup_gate_request.backup_gate.context,
-                    denial_message=_VERIREEL_PROD_BACKUP_GATE_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_verireel_prod_backup_gate(
-                    control_plane_root=resolved_root,
-                    record_store=cast(VeriReelProdBackupGateStore, record_store),
-                    request=verireel_prod_backup_gate_request.backup_gate,
-                    run_async=True,
-                )
-                result = {"backup_gate_record_id": driver_result.backup_record_id}
             elif path == _VERIREEL_PREVIEW_REFRESH_ROUTE.route_path:
                 verireel_preview_refresh_request = (
                     _VERIREEL_PREVIEW_REFRESH_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,11 +418,11 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
-testing and prod deploys, prod promotion, prod rollback, app maintenance,
-preview inventory reads, preview destroy, plus testing and preview verification
-writebacks use descriptor-backed dispatch. This keeps descriptor metadata as the
-route/authz source of truth while preventing an advertised descriptor action
-from becoming executable without implementation.
+testing and prod deploys, prod backup gate, prod promotion, prod rollback, app
+maintenance, preview inventory reads, preview destroy, plus testing and preview
+verification writebacks use descriptor-backed dispatch. This keeps descriptor
+metadata as the route/authz source of truth while preventing an advertised
+descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -518,6 +518,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_prod_backup_gate_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_prod_promotion_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
@@ -826,6 +835,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
                 control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_prod_backup_gate_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_prod_backup_gate = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_prod_backup_gate,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_prod_promotion_dispatch_registration_requires_descriptor_route(
         self,
     ) -> None:
@@ -1019,6 +1058,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_PROD_DEPLOY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_prod_backup_gate_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_PROD_BACKUP_GATE_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31115,6 +31115,80 @@ class LaunchplaneServiceTests(unittest.TestCase):
             execute_mock.assert_called_once()
             self.assertTrue(execute_mock.call_args.kwargs["run_async"])
 
+    def test_verireel_prod_backup_gate_retry_runs_again_after_pending_result(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel"],
+                            "actions": ["verireel_prod_backup_gate.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/promote-image.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            backup_gate_payload = {
+                "product": "verireel",
+                "backup_gate": {
+                    "backup_record_id": "backup-gate-verireel-prod-run-12345-attempt-1"
+                },
+            }
+
+            with patch(
+                "control_plane.service.execute_verireel_prod_backup_gate",
+                return_value=VeriReelProdBackupGateResult(
+                    backup_record_id="backup-gate-verireel-prod-run-12345-attempt-1",
+                    backup_status="pending",
+                ),
+            ) as execute_mock:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-backup-gate",
+                    payload=backup_gate_payload,
+                    headers={"Idempotency-Key": "verireel-prod-backup-gate-pending"},
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/prod-backup-gate",
+                    payload=backup_gate_payload,
+                    headers={"Idempotency-Key": "verireel-prod-backup-gate-pending"},
+                )
+
+            self.assertEqual(first_status_code, 202)
+            self.assertEqual(second_status_code, 202)
+            self.assertEqual(first_payload["result"]["backup_status"], "pending")
+            self.assertEqual(second_payload["result"]["backup_status"], "pending")
+            self.assertNotIn("replayed", first_payload)
+            self.assertNotIn("replayed", second_payload)
+            self.assertEqual(execute_mock.call_count, 2)
+            for call in execute_mock.call_args_list:
+                self.assertTrue(call.kwargs["run_async"])
+
     def test_verireel_prod_backup_gate_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- route VeriReel prod backup gate through descriptor-backed service dispatch
- preserve lane validation, run_async=True, and pending-result idempotency behavior
- add descriptor/dispatch drift coverage plus pending retry service coverage
- update descriptor docs to include prod backup gate in descriptor-backed dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_prod_backup_gate_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_prod_backup_gate_retry_runs_again_after_pending_result tests.test_service.LaunchplaneServiceTests.test_verireel_prod_backup_gate_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Reviews
- code-gpt-5.5 review: no findings
- antigravity review: no findings
- Claude skipped because it is rate-limited