### PR TITLE
Dispatch VeriReel preview refresh via descriptors

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2781,6 +2781,44 @@ def _handle_verireel_preview_destroy(
     )
 
 
+def _handle_verireel_preview_refresh(
+    request: VeriReelPreviewRefreshEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    try:
+        driver_result = execute_verireel_preview_refresh(
+            control_plane_root=control_plane_root_path,
+            record_store=record_store if isinstance(record_store, PostgresRecordStore) else None,
+            request=request.refresh,
+        )
+    except VeriReelPreviewRefreshConfigError as error:
+        now = _utc_now_timestamp()
+        error_message = (
+            str(error).strip() or "VeriReel preview refresh configuration is incomplete."
+        )
+        driver_result = VeriReelPreviewRefreshResult(
+            refresh_status="fail",
+            refresh_started_at=now,
+            refresh_finished_at=now,
+            application_name="",
+            application_id="",
+            preview_url=_verireel_preview_url_for_failed_records(request=request.refresh),
+            error_message=error_message,
+        )
+    return _DescriptorDriverDispatchResult(
+        result=_apply_verireel_preview_refresh_records(
+            control_plane_root_path=control_plane_root_path,
+            record_store=record_store,
+            request=request.refresh,
+            driver_result=driver_result,
+        ),
+        driver_result=driver_result,
+    )
+
+
 def _handle_verireel_testing_verification(
     request: VeriReelTestingVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3042,6 +3080,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_verireel_preview_destroy,
         ),
+        _VERIREEL_PREVIEW_REFRESH_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_VERIREEL_PREVIEW_REFRESH_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.refresh.context,
+            ),
+            handler=_handle_verireel_preview_refresh,
+        ),
         _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_TESTING_VERIFICATION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3136,6 +3183,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
             _VERIREEL_PREVIEW_DESTROY_ROUTE.route_path,
+            _VERIREEL_PREVIEW_REFRESH_ROUTE.route_path,
             _VERIREEL_TESTING_VERIFICATION_ROUTE.route_path,
             _VERIREEL_TESTING_DEPLOY_ROUTE.route_path,
             _VERIREEL_PROD_DEPLOY_ROUTE.route_path,
@@ -14357,85 +14405,6 @@ def create_launchplane_service_app(
                         and replacement_operation.result.release_tuple_id
                     ):
                         result["release_tuple_id"] = replacement_operation.result.release_tuple_id
-            elif path == _VERIREEL_PREVIEW_REFRESH_ROUTE.route_path:
-                verireel_preview_refresh_request = (
-                    _VERIREEL_PREVIEW_REFRESH_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=verireel_preview_refresh_request.product,
-                )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=verireel_preview_refresh_request.product,
-                    context=verireel_preview_refresh_request.refresh.context,
-                    denial_message=_VERIREEL_PREVIEW_REFRESH_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                try:
-                    driver_result = execute_verireel_preview_refresh(
-                        control_plane_root=resolved_root,
-                        record_store=record_store
-                        if isinstance(record_store, PostgresRecordStore)
-                        else None,
-                        request=verireel_preview_refresh_request.refresh,
-                    )
-                except VeriReelPreviewRefreshTransportError as error:
-                    error_message = (
-                        str(error).strip() or "VeriReel preview refresh backend request failed."
-                    )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=502,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "preview_refresh_backend_unavailable",
-                                "message": error_message,
-                            },
-                        },
-                    )
-                except VeriReelPreviewRefreshConfigError as error:
-                    now = _utc_now_timestamp()
-                    error_message = (
-                        str(error).strip()
-                        or "VeriReel preview refresh configuration is incomplete."
-                    )
-                    driver_result = VeriReelPreviewRefreshResult(
-                        refresh_status="fail",
-                        refresh_started_at=now,
-                        refresh_finished_at=now,
-                        application_name="",
-                        application_id="",
-                        preview_url=_verireel_preview_url_for_failed_records(
-                            request=verireel_preview_refresh_request.refresh
-                        ),
-                        error_message=error_message,
-                    )
-                result = _apply_verireel_preview_refresh_records(
-                    control_plane_root_path=resolved_root,
-                    record_store=record_store,
-                    request=verireel_preview_refresh_request.refresh,
-                    driver_result=driver_result,
-                )
             elif path == _ODOO_PREVIEW_APPLY_ROUTE.route_path:
                 odoo_preview_apply_request = (
                     _ODOO_PREVIEW_APPLY_ROUTE.envelope_model.model_validate(payload)
@@ -15265,6 +15234,20 @@ def create_launchplane_service_app(
                     "error": {
                         "code": "product_driver_mismatch",
                         "message": "Product is not configured for the requested driver route.",
+                    },
+                },
+            )
+        except VeriReelPreviewRefreshTransportError as error:
+            error_message = str(error).strip() or "VeriReel preview refresh backend request failed."
+            return _json_response(
+                start_response=start_response,
+                status_code=502,
+                payload={
+                    "status": "rejected",
+                    "trace_id": request_trace_id,
+                    "error": {
+                        "code": "preview_refresh_backend_unavailable",
+                        "message": error_message,
                     },
                 },
             )

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -419,10 +419,10 @@ Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, and the VeriReel
 testing and prod deploys, prod backup gate, prod promotion, prod rollback, app
-maintenance, preview inventory reads, preview destroy, plus testing and preview
-verification writebacks use descriptor-backed dispatch. This keeps descriptor
-metadata as the route/authz source of truth while preventing an advertised
-descriptor action from becoming executable without implementation.
+maintenance, preview refresh, preview inventory reads, preview destroy, plus
+testing and preview verification writebacks use descriptor-backed dispatch. This
+keeps descriptor metadata as the route/authz source of truth while preventing an
+advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -489,6 +489,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_verireel_preview_refresh_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._VERIREEL_PREVIEW_REFRESH_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_testing_verification_registered_in_descriptor_dispatch(
         self,
     ) -> None:
@@ -735,6 +744,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "_DESCRIPTORS",
             (
                 descriptor_without_preview_destroy,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "verireel"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_preview_refresh_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_preview_refresh = registry.VERIREEL_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.VERIREEL_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._VERIREEL_PREVIEW_REFRESH_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_preview_refresh,
                 *(
                     descriptor
                     for descriptor in registry._DESCRIPTORS
@@ -1031,6 +1070,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     ) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._VERIREEL_PREVIEW_DESTROY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_verireel_preview_refresh_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._VERIREEL_PREVIEW_REFRESH_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -31274,24 +31274,39 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     preview_url="https://pr-123.ver-preview.shinycomputers.com",
                 ),
             ) as execute_mock:
+                refresh_payload = {
+                    "product": "verireel",
+                    "refresh": {
+                        "anchor_pr_number": 123,
+                        "anchor_pr_url": "https://github.com/every/verireel/pull/123",
+                        "anchor_head_sha": "6b3c9d7e8f901234567890abcdef1234567890ab",
+                        "preview_slug": "pr-123",
+                        "preview_url": "https://pr-123.ver-preview.shinycomputers.com",
+                        "image_reference": "ghcr.io/every/verireel-app:pr-123-sha-6b3c9d7",
+                    },
+                }
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
                     path="/v1/drivers/verireel/preview-refresh",
-                    payload={
-                        "product": "verireel",
-                        "refresh": {
-                            "anchor_pr_number": 123,
-                            "anchor_pr_url": "https://github.com/every/verireel/pull/123",
-                            "anchor_head_sha": "6b3c9d7e8f901234567890abcdef1234567890ab",
-                            "preview_slug": "pr-123",
-                            "preview_url": "https://pr-123.ver-preview.shinycomputers.com",
-                            "image_reference": "ghcr.io/every/verireel-app:pr-123-sha-6b3c9d7",
-                        },
-                    },
+                    payload=refresh_payload,
+                    headers={"Idempotency-Key": "verireel-preview-refresh-pr-123"},
+                )
+                replay_status_code, replay_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/verireel/preview-refresh",
+                    payload=refresh_payload,
+                    headers={"Idempotency-Key": "verireel-preview-refresh-pr-123"},
                 )
 
             self.assertEqual(status_code, 202)
+            self.assertEqual(replay_status_code, 202)
+            self.assertEqual(replay_payload["status"], "accepted")
+            self.assertTrue(replay_payload["replayed"])
+            self.assertEqual(replay_payload["original_trace_id"], payload["trace_id"])
+            self.assertEqual(replay_payload["records"], payload["records"])
+            self.assertEqual(replay_payload["result"], payload["result"])
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(
                 payload["records"]["preview_id"], "preview-verireel-testing-verireel-pr-123"


### PR DESCRIPTION
## Summary
- route VeriReel preview refresh through descriptor-backed service dispatch
- preserve config-error failed-generation records and transport-error 502 responses
- add descriptor/dispatch drift coverage plus preview-refresh replay coverage
- update descriptor docs to include preview refresh in descriptor-backed dispatch

## Tests
- uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_driver_writes_failed_generation_record tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_config_error_is_recorded_as_failed_generation tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_transport_error_rejects_without_records tests.test_service.LaunchplaneServiceTests.test_verireel_preview_refresh_payload_validation_still_rejects_bad_slug
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev mypy control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md

## Reviews
- code-gpt-5.5 review: no findings
- antigravity review: no findings
- Claude skipped because it is rate-limited