### PR TITLE
Route Odoo artifact publish via descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2705,6 +2705,44 @@ def _handle_generic_web_rollback_plan(
     )
 
 
+def _handle_odoo_artifact_publish(
+    request: OdooArtifactPublishEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context, control_plane_root_path
+    driver_result = ingest_odoo_artifact_publish_evidence(
+        record_store=cast(OdooArtifactPublishEvidenceStore, record_store),
+        request=request.publish,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={
+            "artifact_id": driver_result.artifact_id,
+            "publish_status": driver_result.status,
+            "image_repository": driver_result.image_repository,
+            "image_digest": driver_result.image_digest,
+            "source_commit": driver_result.source_commit,
+        },
+        driver_result=driver_result,
+    )
+
+
+def _handle_odoo_artifact_publish_inputs(
+    request: OdooArtifactPublishInputsEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del record_store
+    driver_result = build_odoo_artifact_publish_inputs(
+        control_plane_root=control_plane_root_path,
+        request=request.inputs,
+        product_profile=resolved_context.profile,
+    )
+    return _DescriptorDriverDispatchResult(result=driver_result, driver_result=driver_result)
+
+
 def _handle_generic_web_preview_verification(
     request: GenericWebPreviewVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3053,6 +3091,24 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             handler=_handle_generic_web_preview_verification,
             pre_idempotency_validator=_validate_generic_web_preview_verification_profile,
         ),
+        _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_ARTIFACT_PUBLISH_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.publish.context,
+            ),
+            handler=_handle_odoo_artifact_publish,
+        ),
+        _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.inputs.context,
+                instance=request.inputs.instance,
+            ),
+            handler=_handle_odoo_artifact_publish_inputs,
+        ),
         _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_PREVIEW_VERIFICATION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3180,6 +3236,8 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
+            _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path,
+            _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path,
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
             _VERIREEL_PREVIEW_DESTROY_ROUTE.route_path,
@@ -13968,81 +14026,6 @@ def create_launchplane_service_app(
                     )
                     driver_result = _operation_payload(operation)
                     result = {"odoo_stable_bootstrap_operation_id": operation.operation_id}
-            elif path == _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path:
-                odoo_publish_request = _ODOO_ARTIFACT_PUBLISH_ROUTE.envelope_model.model_validate(
-                    payload
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_ARTIFACT_PUBLISH_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_publish_request.product,
-                    authorization_context=odoo_publish_request.publish.context,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = ingest_odoo_artifact_publish_evidence(
-                    record_store=cast(OdooArtifactPublishEvidenceStore, record_store),
-                    request=odoo_publish_request.publish,
-                )
-                result = {
-                    "artifact_id": driver_result.artifact_id,
-                    "publish_status": driver_result.status,
-                    "image_repository": driver_result.image_repository,
-                    "image_digest": driver_result.image_digest,
-                    "source_commit": driver_result.source_commit,
-                }
-            elif path == _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path:
-                odoo_inputs_request = (
-                    _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.envelope_model.model_validate(payload)
-                )
-                resolved_driver_context, authorization_response = (
-                    _resolve_and_authorize_descriptor_route(
-                        route_metadata=_ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE,
-                        record_store=record_store,
-                        authz_policy=authz_policy,
-                        identity=identity,
-                        product=odoo_inputs_request.product,
-                        authorization_context=odoo_inputs_request.inputs.context,
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                        descriptor_context=odoo_inputs_request.inputs.context,
-                        descriptor_instance=odoo_inputs_request.inputs.instance,
-                    )
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                result = build_odoo_artifact_publish_inputs(
-                    control_plane_root=resolved_root,
-                    request=odoo_inputs_request.inputs,
-                    product_profile=resolved_driver_context.profile,
-                )
-                driver_result = result
             elif path == _ODOO_PROD_BACKUP_GATE_ROUTE.route_path:
                 odoo_backup_gate_request = (
                     _ODOO_PROD_BACKUP_GATE_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -417,11 +417,12 @@ descriptor route metadata, so new drivers do not need a second hardcoded router
 allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
-stable verification, rollback planning, preview verification, and the VeriReel
-testing and prod deploys, prod backup gate, prod promotion, prod rollback, app
-maintenance, preview refresh, preview inventory reads, preview destroy, plus
-testing and preview verification writebacks use descriptor-backed dispatch. This
-keeps descriptor metadata as the route/authz source of truth while preventing an
+stable verification, rollback planning, preview verification, Odoo artifact
+publish inputs and evidence ingestion, and the VeriReel testing and prod
+deploys, prod backup gate, prod promotion, prod rollback, app maintenance,
+preview refresh, preview inventory reads, preview destroy, plus testing and
+preview verification writebacks use descriptor-backed dispatch. This keeps
+descriptor metadata as the route/authz source of truth while preventing an
 advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -458,6 +458,19 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_odoo_artifact_routes_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._ODOO_ARTIFACT_PUBLISH_ROUTE.route_path,
+            dispatch_routes,
+        )
+        self.assertIn(
+            control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_verireel_preview_verification_registered_in_descriptor_dispatch(
         self,
     ) -> None:
@@ -1043,6 +1056,14 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes.pop(
             control_plane_service._GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path
         )
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_odoo_artifact_descriptor_requires_dispatch_registration(self) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -29541,6 +29541,89 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["result"]["status"], "pass")
             execute_mock.assert_called_once()
 
+    def test_odoo_artifact_publish_driver_replays_idempotent_response(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-opw",
+                            "workflow_refs": [
+                                "every/tenant-opw/.github/workflows/odoo-artifact-publish.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo"],
+                            "contexts": ["opw"],
+                            "actions": ["odoo_artifact_publish.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-opw",
+                        workflow_ref=(
+                            "every/tenant-opw/.github/workflows/odoo-artifact-publish.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo",
+                "publish": {
+                    "context": "opw",
+                    "instance": "testing",
+                    "manifest": {
+                        "artifact_id": "artifact-opw-new",
+                        "source_commit": "2719b363e1a434d890b2d75f0cb4ef629bc3a012",
+                        "enterprise_base_digest": "sha256:enterprise",
+                        "image": {
+                            "repository": "ghcr.io/cbusillo/odoo-tenant-opw",
+                            "digest": "sha256:new",
+                        },
+                    },
+                },
+            }
+
+            with patch(
+                "control_plane.service.ingest_odoo_artifact_publish_evidence",
+                return_value=OdooArtifactPublishResult(
+                    status="pass",
+                    context="opw",
+                    instance="testing",
+                    artifact_id="artifact-opw-new",
+                    image_repository="ghcr.io/cbusillo/odoo-tenant-opw",
+                    image_digest="sha256:new",
+                    source_commit="2719b363e1a434d890b2d75f0cb4ef629bc3a012",
+                ),
+            ) as execute_mock:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/artifact-publish",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "odoo-artifact-publish-opw"},
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/artifact-publish",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "odoo-artifact-publish-opw"},
+                )
+
+            self.assertEqual(first_status_code, 202)
+            self.assertEqual(second_status_code, 202)
+            self.assertEqual(first_payload["records"], second_payload["records"])
+            self.assertTrue(second_payload["replayed"])
+            execute_mock.assert_called_once()
+
     def test_odoo_artifact_publish_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- move Odoo artifact publish and artifact-publish-inputs onto descriptor-backed dispatch
- add fail-closed descriptor registration coverage and artifact publish replay coverage
- update driver descriptor docs for the Odoo artifact dispatch surface

## Validation
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_artifact_routes_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_artifact_descriptor_requires_dispatch_registration tests.test_service.LaunchplaneServiceTests.test_odoo_artifact_publish_driver_writes_manifest_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_artifact_publish_driver_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_odoo_artifact_publish_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_artifact_publish_inputs_returns_build_scoped_environment
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Reviews
- GPT branch review: no findings
- Antigravity branch review: no findings