### PR TITLE
Route Odoo promotion inputs via descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2743,6 +2743,31 @@ def _handle_odoo_artifact_publish_inputs(
     return _DescriptorDriverDispatchResult(result=driver_result, driver_result=driver_result)
 
 
+def _handle_odoo_prod_promotion_inputs(
+    request: OdooProdPromotionInputsEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context, control_plane_root_path
+    driver_result = resolve_odoo_prod_promotion_inputs(
+        record_store=cast(OdooProdPromotionInputsStore, record_store),
+        request=request.inputs,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={
+            "artifact_id": driver_result.artifact_id,
+            "backup_record_id": driver_result.backup_record_id,
+            "release_tuple_id": driver_result.release_tuple_id,
+            "source_git_ref": driver_result.source_git_ref,
+            "image_repository": driver_result.image_repository,
+            "image_digest": driver_result.image_digest,
+            "input_status": driver_result.input_status,
+        },
+        driver_result=driver_result,
+    )
+
+
 def _handle_generic_web_preview_verification(
     request: GenericWebPreviewVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3109,6 +3134,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_odoo_artifact_publish_inputs,
         ),
+        _ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_PROD_PROMOTION_INPUTS_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.inputs.context,
+            ),
+            handler=_handle_odoo_prod_promotion_inputs,
+        ),
         _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_PREVIEW_VERIFICATION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3238,6 +3272,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
             _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path,
             _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path,
+            _ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path,
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
             _VERIREEL_PREVIEW_DESTROY_ROUTE.route_path,
@@ -14065,46 +14100,6 @@ def create_launchplane_service_app(
                     "database_dump_path": driver_result.database_dump_path,
                     "filestore_archive_path": driver_result.filestore_archive_path,
                     "manifest_path": driver_result.manifest_path,
-                }
-            elif path == _ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path:
-                odoo_prod_inputs_request = (
-                    _ODOO_PROD_PROMOTION_INPUTS_ROUTE.envelope_model.model_validate(payload)
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_PROD_PROMOTION_INPUTS_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_prod_inputs_request.product,
-                    authorization_context=odoo_prod_inputs_request.inputs.context,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = resolve_odoo_prod_promotion_inputs(
-                    record_store=cast(OdooProdPromotionInputsStore, record_store),
-                    request=odoo_prod_inputs_request.inputs,
-                )
-                result = {
-                    "artifact_id": driver_result.artifact_id,
-                    "backup_record_id": driver_result.backup_record_id,
-                    "release_tuple_id": driver_result.release_tuple_id,
-                    "source_git_ref": driver_result.source_git_ref,
-                    "image_repository": driver_result.image_repository,
-                    "image_digest": driver_result.image_digest,
-                    "input_status": driver_result.input_status,
                 }
             elif path == _ODOO_PROD_PROMOTION_RUN_ROUTE.route_path:
                 odoo_promotion_run_request = (

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,10 +418,11 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, Odoo artifact
-publish inputs and evidence ingestion, and the VeriReel testing and prod
-deploys, prod backup gate, prod promotion, prod rollback, app maintenance,
-preview refresh, preview inventory reads, preview destroy, plus testing and
-preview verification writebacks use descriptor-backed dispatch. This keeps
+publish inputs and evidence ingestion, Odoo prod promotion input reads, and the
+VeriReel testing and prod deploys, prod backup gate, prod promotion, prod
+rollback, app maintenance, preview refresh, preview inventory reads, preview
+destroy, plus testing and preview verification writebacks use descriptor-backed
+dispatch. This keeps
 descriptor metadata as the route/authz source of truth while preventing an
 advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -458,7 +458,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
-    def test_odoo_artifact_routes_registered_in_descriptor_dispatch(self) -> None:
+    def test_odoo_low_risk_routes_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
         self.assertIn(
@@ -467,6 +467,10 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         self.assertIn(
             control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path,
+            dispatch_routes,
+        )
+        self.assertIn(
+            control_plane_service._ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path,
             dispatch_routes,
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
@@ -1060,10 +1064,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
-    def test_odoo_artifact_descriptor_requires_dispatch_registration(self) -> None:
+    def test_odoo_low_risk_descriptor_requires_dispatch_registration(self) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -30096,6 +30096,86 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["result"]["image_digest"], "sha256:new")
             resolve_mock.assert_called_once()
 
+    def test_odoo_prod_promotion_inputs_driver_replays_idempotent_response(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/odoo-prod-promotion.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_prod_promotion_inputs.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/odoo-prod-promotion.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo",
+                "inputs": {
+                    "context": "cm",
+                    "from_instance": "testing",
+                    "to_instance": "prod",
+                    "request_id": "run-123-attempt-1",
+                },
+            }
+
+            with patch(
+                "control_plane.service.resolve_odoo_prod_promotion_inputs",
+                return_value=OdooProdPromotionInputsResult(
+                    context="cm",
+                    from_instance="testing",
+                    to_instance="prod",
+                    request_id="run-123-attempt-1",
+                    input_status="ready",
+                    artifact_id="artifact-cm-new",
+                    source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                    backup_record_id="backup-gate-cm-prod-run-123-attempt-1",
+                    release_tuple_id="cm-testing-artifact-cm-new",
+                    image_repository="ghcr.io/cbusillo/odoo-tenant-cm",
+                    image_digest="sha256:new",
+                ),
+            ) as resolve_mock:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/prod-promotion-inputs",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "odoo-prod-promotion-inputs-cm"},
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/prod-promotion-inputs",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "odoo-prod-promotion-inputs-cm"},
+                )
+
+            self.assertEqual(first_status_code, 202)
+            self.assertEqual(second_status_code, 202)
+            self.assertEqual(first_payload["records"], second_payload["records"])
+            self.assertTrue(second_payload["replayed"])
+            resolve_mock.assert_called_once()
+
     def test_odoo_prod_promotion_inputs_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- move Odoo prod promotion input reads onto descriptor-backed dispatch
- add descriptor fail-closed coverage plus idempotency replay coverage for the route
- update driver descriptor docs for the new Odoo descriptor dispatch surface

## Validation
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_routes_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_descriptor_requires_dispatch_registration tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_inputs_driver_resolves_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_inputs_driver_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_inputs_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Reviews
- GPT branch review: no findings
- Antigravity branch review: no findings