### PR TITLE
Route Odoo config hooks via descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2768,6 +2768,68 @@ def _handle_odoo_prod_promotion_inputs(
     )
 
 
+def _handle_odoo_post_deploy(
+    request: OdooPostDeployEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_odoo_post_deploy(
+        control_plane_root=control_plane_root_path,
+        record_store=record_store,
+        request=request.post_deploy,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={
+            "transition": (
+                f"odoo-post-deploy:{driver_result.context}:{driver_result.instance}:{driver_result.phase}"
+            )
+        },
+        driver_result=driver_result,
+    )
+
+
+def _handle_odoo_config_parameter_override(
+    request: OdooConfigParameterOverrideEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context, control_plane_root_path
+    override_record = _write_odoo_config_parameter_override(
+        record_store=cast(_OdooInstanceOverrideStore, record_store),
+        request=request.override,
+    )
+    result: dict[str, object] = {
+        "context": override_record.context,
+        "instance": override_record.instance,
+        "config_parameter_keys": sorted(
+            override.key for override in override_record.config_parameters
+        ),
+    }
+    return _DescriptorDriverDispatchResult(result=result, driver_result=result)
+
+
+def _handle_odoo_website_bootstrap_override(
+    request: OdooWebsiteBootstrapOverrideEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context, control_plane_root_path
+    override_record = _write_odoo_website_bootstrap_override(
+        record_store=cast(_OdooInstanceOverrideStore, record_store),
+        request=request.override,
+    )
+    result: dict[str, object] = {
+        "context": override_record.context,
+        "instance": override_record.instance,
+        "website_bootstrap": override_record.website_bootstrap is not None,
+    }
+    return _DescriptorDriverDispatchResult(result=result, driver_result=result)
+
+
 def _handle_generic_web_preview_verification(
     request: GenericWebPreviewVerificationEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3143,6 +3205,33 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_odoo_prod_promotion_inputs,
         ),
+        _ODOO_POST_DEPLOY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_POST_DEPLOY_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.post_deploy.context,
+            ),
+            handler=_handle_odoo_post_deploy,
+        ),
+        _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.override.context,
+                instance=request.override.instance,
+            ),
+            handler=_handle_odoo_config_parameter_override,
+        ),
+        _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.override.context,
+                instance=request.override.instance,
+            ),
+            handler=_handle_odoo_website_bootstrap_override,
+        ),
         _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_VERIREEL_PREVIEW_VERIFICATION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3273,6 +3362,9 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path,
             _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path,
             _ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path,
+            _ODOO_POST_DEPLOY_ROUTE.route_path,
+            _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path,
+            _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path,
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
             _VERIREEL_PREVIEW_INVENTORY_ROUTE.route_path,
             _VERIREEL_PREVIEW_DESTROY_ROUTE.route_path,
@@ -13843,129 +13935,6 @@ def create_launchplane_service_app(
                     profile=profile,
                 )
                 result = {}
-            elif path == _ODOO_POST_DEPLOY_ROUTE.route_path:
-                odoo_post_deploy_request = _ODOO_POST_DEPLOY_ROUTE.envelope_model.model_validate(
-                    payload
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_POST_DEPLOY_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_post_deploy_request.product,
-                    authorization_context=odoo_post_deploy_request.post_deploy.context,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_odoo_post_deploy(
-                    control_plane_root=resolved_root,
-                    record_store=record_store,
-                    request=odoo_post_deploy_request.post_deploy,
-                )
-                result = {
-                    "transition": (
-                        f"odoo-post-deploy:{driver_result.context}:{driver_result.instance}:{driver_result.phase}"
-                    )
-                }
-            elif path == _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path:
-                odoo_override_request = (
-                    _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.envelope_model.model_validate(payload)
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_override_request.product,
-                    authorization_context=odoo_override_request.override.context,
-                    descriptor_context=odoo_override_request.override.context,
-                    descriptor_instance=odoo_override_request.override.instance,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                override_record = _write_odoo_config_parameter_override(
-                    record_store=cast(_OdooInstanceOverrideStore, record_store),
-                    request=odoo_override_request.override,
-                )
-                driver_result = {
-                    "context": override_record.context,
-                    "instance": override_record.instance,
-                    "config_parameter_keys": sorted(
-                        override.key for override in override_record.config_parameters
-                    ),
-                }
-                result = {
-                    "context": override_record.context,
-                    "instance": override_record.instance,
-                    "config_parameter_keys": sorted(
-                        override.key for override in override_record.config_parameters
-                    ),
-                }
-            elif path == _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path:
-                odoo_website_override_request = (
-                    _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.envelope_model.model_validate(payload)
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_website_override_request.product,
-                    authorization_context=odoo_website_override_request.override.context,
-                    descriptor_context=odoo_website_override_request.override.context,
-                    descriptor_instance=odoo_website_override_request.override.instance,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                override_record = _write_odoo_website_bootstrap_override(
-                    record_store=cast(_OdooInstanceOverrideStore, record_store),
-                    request=odoo_website_override_request.override,
-                )
-                result = {
-                    "context": override_record.context,
-                    "instance": override_record.instance,
-                    "website_bootstrap": override_record.website_bootstrap is not None,
-                }
-                driver_result = result
             elif path == _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path:
                 odoo_bootstrap_request = _ODOO_STABLE_BOOTSTRAP_ROUTE.envelope_model.model_validate(
                     payload

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -418,11 +418,11 @@ allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 stable verification, rollback planning, preview verification, Odoo artifact
-publish inputs and evidence ingestion, Odoo prod promotion input reads, and the
-VeriReel testing and prod deploys, prod backup gate, prod promotion, prod
-rollback, app maintenance, preview refresh, preview inventory reads, preview
-destroy, plus testing and preview verification writebacks use descriptor-backed
-dispatch. This keeps
+publish inputs and evidence ingestion, Odoo prod promotion input reads, Odoo
+post-deploy and config/website override hooks, and the VeriReel testing and prod
+deploys, prod backup gate, prod promotion, prod rollback, app maintenance,
+preview refresh, preview inventory reads, preview destroy, plus testing and
+preview verification writebacks use descriptor-backed dispatch. This keeps
 descriptor metadata as the route/authz source of truth while preventing an
 advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -473,6 +473,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             control_plane_service._ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path,
             dispatch_routes,
         )
+        self.assertIn(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path, dispatch_routes)
+        self.assertIn(
+            control_plane_service._ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path,
+            dispatch_routes,
+        )
+        self.assertIn(
+            control_plane_service._ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path,
+            dispatch_routes,
+        )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_verireel_preview_verification_registered_in_descriptor_dispatch(
@@ -1069,6 +1078,9 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)


### PR DESCRIPTION
## Summary
- route Odoo post-deploy, config-parameter override, and website-bootstrap override through descriptor-backed dispatch
- preserve legacy authorization contexts, idempotency, and response record shapes
- extend descriptor dispatch registration/fail-closed coverage and docs

## Validation
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_routes_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_descriptor_requires_dispatch_registration tests.test_service.LaunchplaneServiceTests.test_odoo_post_deploy_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_post_deploy_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_config_parameter_override_driver_writes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_config_parameter_override_driver_keeps_existing_phases_and_adds_deploy tests.test_service.LaunchplaneServiceTests.test_odoo_website_bootstrap_override_driver_writes_typed_payload tests.test_service.LaunchplaneServiceTests.test_odoo_config_parameter_override_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_config_parameter_override_driver_rejects_unsupported_key
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests
- non-Claude agent reviews: GPT and Antigravity, no findings