### PR TITLE
Route generic web deploy via descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -318,6 +318,7 @@ from control_plane.workflows.evidence_ingestion import (
 )
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployRequest,
+    GenericWebDeployStore,
     GenericWebPostDeployExecutor,
     execute_generic_web_deploy,
     product_profile_uses_generic_web_base,
@@ -2708,6 +2709,30 @@ def _handle_generic_web_rollback_plan(
     )
 
 
+def _handle_generic_web_deploy(
+    request: GenericWebDeployEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError("Generic web deploy requires a product profile lane.")
+    driver_result = execute_generic_web_deploy(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(GenericWebDeployStore, record_store),
+        request=request.deploy,
+        profile=resolved_context.profile,
+        lane=resolved_context.lane,
+        post_deploy_executor=_generic_web_post_deploy_executor_for_profile(
+            resolved_context.profile
+        ),
+    )
+    return _DescriptorDriverDispatchResult(
+        result={"deployment_record_id": driver_result.deployment_record_id},
+        driver_result=driver_result,
+    )
+
+
 def _handle_odoo_artifact_publish(
     request: OdooArtifactPublishEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3252,6 +3277,16 @@ def _validate_generic_web_preview_verification_profile(
 
 def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchRoute[Any]]:
     return {
+        _GENERIC_WEB_DEPLOY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_GENERIC_WEB_DEPLOY_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.deploy.product,
+                context="",
+                instance=request.deploy.instance,
+                require_profile=True,
+            ),
+            handler=_handle_generic_web_deploy,
+        ),
         _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3491,6 +3526,7 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
 def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
     return frozenset(
         (
+            _GENERIC_WEB_DEPLOY_ROUTE.route_path,
             _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
@@ -13696,55 +13732,6 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     request=self_deploy_request.deploy,
                 ).model_dump(mode="json")
-            elif path == _GENERIC_WEB_DEPLOY_ROUTE.route_path:
-                generic_web_deploy_request = (
-                    _GENERIC_WEB_DEPLOY_ROUTE.envelope_model.model_validate(payload)
-                )
-                resolved_driver_context = _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=generic_web_deploy_request.deploy.product,
-                    instance=generic_web_deploy_request.deploy.instance,
-                    require_profile=True,
-                )
-                if resolved_driver_context.profile is None or resolved_driver_context.lane is None:
-                    raise ProductDriverMismatchError(
-                        "Generic web deploy requires a product profile lane."
-                    )
-                profile = resolved_driver_context.profile
-                lane = resolved_driver_context.lane
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=profile.product,
-                    context=lane.context,
-                    denial_message=_GENERIC_WEB_DEPLOY_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_generic_web_deploy(
-                    control_plane_root=resolved_root,
-                    record_store=record_store,
-                    request=generic_web_deploy_request.deploy,
-                    profile=profile,
-                    lane=lane,
-                    post_deploy_executor=_generic_web_post_deploy_executor_for_profile(profile),
-                )
-                result = {"deployment_record_id": driver_result.deployment_record_id}
             elif path == _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path:
                 generic_web_promotion_request = (
                     _GENERIC_WEB_PROD_PROMOTION_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -417,11 +417,11 @@ descriptor route metadata, so new drivers do not need a second hardcoded router
 allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
-stable verification, rollback planning, preview verification, Odoo artifact
-publish inputs and evidence ingestion, Odoo prod promotion input reads, Odoo
-prod backup gate, post-deploy, config/website override hooks, Odoo preview apply
-and inputs, and the VeriReel testing and prod deploys, prod backup gate, prod
-promotion, prod rollback, app maintenance,
+deploy, stable verification, rollback planning, preview verification, Odoo
+artifact publish inputs and evidence ingestion, Odoo prod promotion input reads,
+Odoo prod backup gate, post-deploy, config/website override hooks, Odoo preview
+apply and inputs, and the VeriReel testing and prod deploys, prod backup gate,
+prod promotion, prod rollback, app maintenance,
 preview refresh, preview inventory reads, preview destroy, plus testing and
 preview verification writebacks use descriptor-backed dispatch. This keeps
 descriptor metadata as the route/authz source of truth while preventing an

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -440,6 +440,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_generic_web_deploy_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._GENERIC_WEB_DEPLOY_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_rollback_plan_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
@@ -1078,6 +1087,13 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     def test_stable_verification_descriptor_requires_dispatch_registration(self) -> None:
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes({})
+
+    def test_generic_web_deploy_descriptor_requires_dispatch_registration(self) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._GENERIC_WEB_DEPLOY_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_rollback_plan_descriptor_requires_dispatch_registration(self) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())


### PR DESCRIPTION
## Summary
- route generic-web deploy through descriptor-backed dispatch
- preserve profile/lane authorization, base-driver post-deploy adapter behavior, idempotency replay, and accepted response shape
- extend descriptor registration/fail-closed coverage and docs

## Validation
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_deploy_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_deploy_descriptor_requires_dispatch_registration tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_uses_profile_lane_for_authorization tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_accepts_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_keeps_literal_generic_products_without_post_deploy_adapter tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_replays_post_deploy_failure_after_deploy_pass tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_replay_scrubs_retired_target_type_alias tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_rejects_unknown_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_accepts_padded_lane_context tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_resolves_literal_generic_web_profile tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_rejects_wrong_product_context
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests
- non-Claude reviews: GPT and Antigravity, no findings