### PR TITLE
Migrate generic-web rollback to descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -332,7 +332,10 @@ from control_plane.workflows.generic_web_promotion_workflow import (
     GenericWebPromotionWorkflowRequest,
     dispatch_generic_web_promotion_workflow,
 )
-from control_plane.workflows.generic_web_rollback import execute_generic_web_rollback
+from control_plane.workflows.generic_web_rollback import (
+    GenericWebRollbackApplyStore,
+    execute_generic_web_rollback,
+)
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
     GenericWebPreviewDestroyRequest,
@@ -2733,6 +2736,34 @@ def _handle_generic_web_deploy(
     )
 
 
+def _handle_generic_web_rollback(
+    request: GenericWebRollbackEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError("Generic web rollback requires a product profile lane.")
+    driver_result = execute_generic_web_rollback(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(GenericWebRollbackApplyStore, record_store),
+        request=request.rollback,
+        post_deploy_executor=_generic_web_post_deploy_executor_for_profile(
+            resolved_context.profile
+        ),
+    )
+    return _DescriptorDriverDispatchResult(
+        result={
+            "generic_web_rollback_plan_id": driver_result.plan_id,
+            "deployment_record_id": driver_result.deployment_record_id,
+            "rollback_status": driver_result.rollback_status,
+            "deploy_status": driver_result.deploy_status,
+            "post_deploy_status": driver_result.post_deploy_status,
+        },
+        driver_result=driver_result,
+    )
+
+
 def _handle_odoo_artifact_publish(
     request: OdooArtifactPublishEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3297,6 +3328,16 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_generic_web_rollback_plan,
         ),
+        _GENERIC_WEB_ROLLBACK_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_GENERIC_WEB_ROLLBACK_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.rollback.product,
+                context="",
+                instance=request.rollback.instance,
+                require_profile=True,
+            ),
+            handler=_handle_generic_web_rollback,
+        ),
         _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_GENERIC_WEB_STABLE_VERIFICATION_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3528,6 +3569,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
         (
             _GENERIC_WEB_DEPLOY_ROUTE.route_path,
             _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
+            _GENERIC_WEB_ROLLBACK_ROUTE.route_path,
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE.route_path,
             _ODOO_ARTIFACT_PUBLISH_ROUTE.route_path,
@@ -13853,59 +13895,6 @@ def create_launchplane_service_app(
                     request=generic_web_workflow_request.workflow,
                 )
                 result = driver_result.model_dump(mode="json")
-            elif path == _GENERIC_WEB_ROLLBACK_ROUTE.route_path:
-                generic_web_rollback_apply_request = (
-                    _GENERIC_WEB_ROLLBACK_ROUTE.envelope_model.model_validate(payload)
-                )
-                resolved_driver_context = _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=generic_web_rollback_apply_request.rollback.product,
-                    instance=generic_web_rollback_apply_request.rollback.instance,
-                    require_profile=True,
-                )
-                if resolved_driver_context.profile is None or resolved_driver_context.lane is None:
-                    raise ProductDriverMismatchError(
-                        "Generic web rollback requires a product profile lane."
-                    )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=resolved_driver_context.profile.product,
-                    context=resolved_driver_context.lane.context,
-                    denial_message=_GENERIC_WEB_ROLLBACK_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_generic_web_rollback(
-                    control_plane_root=resolved_root,
-                    record_store=record_store,
-                    request=generic_web_rollback_apply_request.rollback,
-                    post_deploy_executor=_generic_web_post_deploy_executor_for_profile(
-                        resolved_driver_context.profile
-                    ),
-                )
-                result = {
-                    "generic_web_rollback_plan_id": driver_result.plan_id,
-                    "deployment_record_id": driver_result.deployment_record_id,
-                    "rollback_status": driver_result.rollback_status,
-                    "deploy_status": driver_result.deploy_status,
-                    "post_deploy_status": driver_result.post_deploy_status,
-                }
             elif path in _PREVIEW_DESIRED_STATE_ROUTE_PATHS:
                 generic_web_desired_state_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -175,10 +175,12 @@ validation, persists the plan record, and applies ready plans through the normal
 generic-web deploy path using the previous immutable artifact identity. Generic
 rollback also forwards the generic deploy post-deploy extension hook, so a
 based driver can keep product-only post-deploy checks while reusing the common
-rollback deployment path once its other invariants are represented. Product
-drivers keep their own `prod_rollback` action only when they need additional
-product-specific gates, such as Odoo backup, release tuple, manifest, migration,
-or post-deploy checks. Odoo keeps `POST /v1/drivers/odoo/prod-rollback` as its
+rollback deployment path once its other invariants are represented. This route
+is registered through descriptor-backed dispatch, so descriptor/handler drift
+fails closed before the service starts. Product drivers keep their own
+`prod_rollback` action only when they need additional product-specific gates,
+such as Odoo backup, release tuple, manifest, migration, or post-deploy checks.
+Odoo keeps `POST /v1/drivers/odoo/prod-rollback` as its
 product-specific apply route, but that route delegates provider mutation to
 Odoo stable target replacement so runtime identity, post-deploy maintenance,
 canonical/logo verification, deployment records, inventory, and release tuples

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -458,6 +458,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_generic_web_rollback_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._GENERIC_WEB_ROLLBACK_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_preview_verification_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
@@ -681,6 +690,41 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "_DESCRIPTORS",
             (
                 descriptor_without_rollback_plan,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "generic-web"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_rollback_descriptor_requires_dispatch_registration(self) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._GENERIC_WEB_ROLLBACK_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_rollback_dispatch_registration_requires_descriptor_route(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_rollback = registry.GENERIC_WEB_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.GENERIC_WEB_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._GENERIC_WEB_ROLLBACK_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_rollback,
                 *(
                     descriptor
                     for descriptor in registry._DESCRIPTORS


### PR DESCRIPTION
## Summary
- route generic-web prod rollback through descriptor-backed dispatch
- preserve rollback response/idempotency shape and post-deploy adapter forwarding
- add fail-closed descriptor registration tests and docs wording

## Validation
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_rollback_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_rollback_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_rollback_dispatch_registration_requires_descriptor_route tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_route_applies_ready_plan tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_route_passes_odoo_post_deploy_adapter_for_odoo_profile tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_route_replays_idempotent_response_shape tests.test_service.LaunchplaneServiceTests.test_generic_web_rollback_route_rejects_unauthorized_context
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Reviews
- code-gpt-5.5 branch review: no findings
- Claude skipped: user reported rate limit