### PR TITLE
Migrate generic-web promotion workflow to descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2736,6 +2736,28 @@ def _handle_generic_web_deploy(
     )
 
 
+def _handle_generic_web_promotion_workflow(
+    request: GenericWebPromotionWorkflowEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del record_store
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Generic web promotion workflow requires a product profile lane."
+        )
+    driver_result = dispatch_generic_web_promotion_workflow(
+        control_plane_root=control_plane_root_path,
+        profile=resolved_context.profile,
+        request=request.workflow,
+    )
+    return _DescriptorDriverDispatchResult(
+        result=driver_result.model_dump(mode="json"),
+        driver_result=driver_result,
+    )
+
+
 def _handle_generic_web_rollback(
     request: GenericWebRollbackEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3318,6 +3340,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_generic_web_deploy,
         ),
+        _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.workflow.context,
+                require_profile=True,
+            ),
+            handler=_handle_generic_web_promotion_workflow,
+        ),
         _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3568,6 +3599,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
     return frozenset(
         (
             _GENERIC_WEB_DEPLOY_ROUTE.route_path,
+            _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
             _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
             _GENERIC_WEB_ROLLBACK_ROUTE.route_path,
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
@@ -13847,54 +13879,6 @@ def create_launchplane_service_app(
                     "release_url": driver_result.release_url,
                     "dry_run": driver_result.dry_run,
                 }
-            elif path == _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path:
-                generic_web_workflow_request = (
-                    _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.envelope_model.model_validate(
-                        payload
-                    )
-                )
-                resolved_driver_context = _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=generic_web_workflow_request.product,
-                    context=generic_web_workflow_request.workflow.context,
-                    require_profile=True,
-                )
-                if resolved_driver_context.profile is None or resolved_driver_context.lane is None:
-                    raise ProductDriverMismatchError(
-                        "Generic web promotion workflow requires a product profile lane."
-                    )
-                profile = resolved_driver_context.profile
-                lane = resolved_driver_context.lane
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=profile.product,
-                    context=lane.context,
-                    denial_message=_GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = dispatch_generic_web_promotion_workflow(
-                    control_plane_root=resolved_root,
-                    profile=profile,
-                    request=generic_web_workflow_request.workflow,
-                )
-                result = driver_result.model_dump(mode="json")
             elif path in _PREVIEW_DESIRED_STATE_ROUTE_PATHS:
                 generic_web_desired_state_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -160,6 +160,13 @@ prod inventory after successful verified deploys. Product-specific drivers such
 as VeriReel or Odoo can wrap this common action when they need additional gates
 such as backups, migrations, rollout checks, or tenant-specific validation.
 
+The `prod_promotion_workflow` action routes to
+`POST /v1/drivers/generic-web/prod-promotion-workflow`. It dispatches the
+product repository promotion workflow after resolving the requested stable lane
+from DB-backed product profile records. This route is registered through
+descriptor-backed dispatch, so descriptor/handler drift fails closed before the
+service starts.
+
 The `prod_rollback_plan` action routes to
 `POST /v1/drivers/generic-web/prod-rollback-plan`. It is a safe-write planner:
 Launchplane reads the product profile, destination lane, selected deployment
@@ -419,14 +426,14 @@ descriptor route metadata, so new drivers do not need a second hardcoded router
 allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
-deploy, stable verification, rollback planning, preview verification, Odoo
-artifact publish inputs and evidence ingestion, Odoo prod promotion input reads,
-Odoo prod backup gate, post-deploy, config/website override hooks, Odoo preview
-apply and inputs, and the VeriReel testing and prod deploys, prod backup gate,
-prod promotion, prod rollback, app maintenance,
-preview refresh, preview inventory reads, preview destroy, plus testing and
-preview verification writebacks use descriptor-backed dispatch. This keeps
-descriptor metadata as the route/authz source of truth while preventing an
+deploy, promotion workflow dispatch, stable verification, rollback planning,
+rollback apply, preview verification, Odoo artifact publish inputs and evidence
+ingestion, Odoo prod promotion input reads, Odoo prod backup gate, post-deploy,
+config/website override hooks, Odoo preview apply and inputs, and the VeriReel
+testing and prod deploys, prod backup gate, prod promotion, prod rollback, app
+maintenance, preview refresh, preview inventory reads, preview destroy, plus
+testing and preview verification writebacks use descriptor-backed dispatch. This
+keeps descriptor metadata as the route/authz source of truth while preventing an
 advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -449,6 +449,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
+    def test_generic_web_promotion_workflow_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
     def test_rollback_plan_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
@@ -706,6 +715,47 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_promotion_workflow_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(
+            control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path
+        )
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_promotion_workflow_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_promotion_workflow = registry.GENERIC_WEB_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.GENERIC_WEB_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_promotion_workflow,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "generic-web"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_generic_web_rollback_dispatch_registration_requires_descriptor_route(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()


### PR DESCRIPTION
## Summary
- route generic-web promotion workflow through descriptor-backed dispatch
- preserve profile/lane authorization, human-session dispatch behavior, and result/idempotency shape
- add fail-closed descriptor registration tests and docs wording

## Validation
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_promotion_workflow_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_promotion_workflow_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_promotion_workflow_dispatch_registration_requires_descriptor_route tests.test_service.LaunchplaneServiceTests.test_human_session_can_dispatch_generic_web_promotion_workflow tests.test_service.LaunchplaneServiceTests.test_human_session_dispatches_generic_web_promotion_workflow_with_padded_lane_context tests.test_service.LaunchplaneServiceTests.test_generic_web_promotion_workflow_rejects_unauthorized_human tests.test_service.LaunchplaneServiceTests.test_generic_web_promotion_workflow_accepts_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_promotion_workflow_rejects_unowned_context_before_authz tests.test_service.LaunchplaneServiceTests.test_generic_web_promotion_workflow_rejects_token_unowned_context_before_authz
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Reviews
- code-gpt-5.5 branch review: no findings
- Claude skipped: user reported rate limit