### PR TITLE
Migrate Odoo prod rollback to descriptor dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2874,6 +2874,31 @@ def _handle_odoo_prod_backup_gate(
     )
 
 
+def _handle_odoo_prod_rollback(
+    request: OdooProdRollbackEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    driver_result = execute_odoo_prod_rollback(
+        control_plane_root=control_plane_root_path,
+        record_store=record_store,
+        request=request.rollback,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={
+            "promotion_record_id": driver_result.promotion_record_id,
+            "deployment_record_id": driver_result.deployment_record_id,
+            "release_tuple_id": driver_result.release_tuple_id,
+            "rollback_status": driver_result.rollback_status,
+            "rollback_health_status": driver_result.rollback_health_status,
+            "post_deploy_status": driver_result.post_deploy_status,
+        },
+        driver_result=driver_result,
+    )
+
+
 def _handle_odoo_post_deploy(
     request: OdooPostDeployEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3425,6 +3450,15 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_odoo_prod_backup_gate,
         ),
+        _ODOO_PROD_ROLLBACK_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_PROD_ROLLBACK_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.rollback.context,
+            ),
+            handler=_handle_odoo_prod_rollback,
+        ),
         _ODOO_POST_DEPLOY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_ODOO_POST_DEPLOY_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3608,6 +3642,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path,
             _ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path,
             _ODOO_PROD_BACKUP_GATE_ROUTE.route_path,
+            _ODOO_PROD_ROLLBACK_ROUTE.route_path,
             _ODOO_POST_DEPLOY_ROUTE.route_path,
             _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path,
             _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path,
@@ -14213,46 +14248,6 @@ def create_launchplane_service_app(
                     "deployment_status": driver_result.deployment_status,
                     "post_deploy_status": driver_result.post_deploy_status,
                     "destination_health_status": driver_result.destination_health_status,
-                }
-            elif path == _ODOO_PROD_ROLLBACK_ROUTE.route_path:
-                odoo_rollback_request = _ODOO_PROD_ROLLBACK_ROUTE.envelope_model.model_validate(
-                    payload
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_PROD_ROLLBACK_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_rollback_request.product,
-                    authorization_context=odoo_rollback_request.rollback.context,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_odoo_prod_rollback(
-                    control_plane_root=resolved_root,
-                    record_store=record_store,
-                    request=odoo_rollback_request.rollback,
-                )
-                result = {
-                    "promotion_record_id": driver_result.promotion_record_id,
-                    "deployment_record_id": driver_result.deployment_record_id,
-                    "release_tuple_id": driver_result.release_tuple_id,
-                    "rollback_status": driver_result.rollback_status,
-                    "rollback_health_status": driver_result.rollback_health_status,
-                    "post_deploy_status": driver_result.post_deploy_status,
                 }
             elif path == _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path:
                 odoo_replacement_plan_request = (

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -428,13 +428,14 @@ Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
 deploy, promotion workflow dispatch, stable verification, rollback planning,
 rollback apply, preview verification, Odoo artifact publish inputs and evidence
-ingestion, Odoo prod promotion input reads, Odoo prod backup gate, post-deploy,
-config/website override hooks, Odoo preview apply and inputs, and the VeriReel
-testing and prod deploys, prod backup gate, prod promotion, prod rollback, app
-maintenance, preview refresh, preview inventory reads, preview destroy, plus
-testing and preview verification writebacks use descriptor-backed dispatch. This
-keeps descriptor metadata as the route/authz source of truth while preventing an
-advertised descriptor action from becoming executable without implementation.
+ingestion, Odoo prod promotion input reads, Odoo prod backup gate, prod
+rollback, post-deploy, config/website override hooks, Odoo preview apply and
+inputs, and the VeriReel testing and prod deploys, prod backup gate, prod
+promotion, prod rollback, app maintenance, preview refresh, preview inventory
+reads, preview destroy, plus testing and preview verification writebacks use
+descriptor-backed dispatch. This keeps descriptor metadata as the route/authz
+source of truth while preventing an advertised descriptor action from becoming
+executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -504,6 +504,10 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             control_plane_service._ODOO_PROD_BACKUP_GATE_ROUTE.route_path,
             dispatch_routes,
         )
+        self.assertIn(
+            control_plane_service._ODOO_PROD_ROLLBACK_ROUTE.route_path,
+            dispatch_routes,
+        )
         self.assertIn(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path, dispatch_routes)
         self.assertIn(
             control_plane_service._ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path,
@@ -1211,12 +1215,43 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_BACKUP_GATE_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_PROD_ROLLBACK_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_odoo_prod_rollback_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_prod_rollback = registry.ODOO_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.ODOO_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._ODOO_PROD_ROLLBACK_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_prod_rollback,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "odoo"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_odoo_preview_lifecycle_descriptor_requires_dispatch_registration(
         self,


### PR DESCRIPTION
## Summary
- route Odoo prod rollback through descriptor-backed dispatch
- preserve literal product=odoo workflow authorization and rollback result/idempotency shape
- add fail-closed descriptor registration tests and docs wording

## Validation
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_routes_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_prod_rollback_dispatch_registration_requires_descriptor_route tests.test_service.LaunchplaneServiceTests.test_odoo_prod_rollback_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_rollback_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_rollback_driver_replays_idempotent_request
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Reviews
- code-gpt-5.5 branch review: no findings
- Claude skipped: user reported rate limit