### PR TITLE
Migrate Odoo target replacement plan dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2402,6 +2402,7 @@ _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES = frozenset(
     {
         _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path,
         _ODOO_PREVIEW_APPLY_INPUTS_ROUTE.route_path,
+        _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path,
         _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path,
         _VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
         _VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
@@ -2897,6 +2898,24 @@ def _handle_odoo_prod_rollback(
         },
         driver_result=driver_result,
     )
+
+
+def _handle_odoo_target_replacement_plan(
+    request: OdooTargetReplacementPlanEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    if resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Odoo target replacement plan requires a known product lane."
+        )
+    driver_result = build_odoo_stable_target_replacement_plan(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(OdooStableTargetReplacementStore, record_store),
+        request=request.replacement,
+    )
+    return _DescriptorDriverDispatchResult(result={}, driver_result=driver_result)
 
 
 def _handle_odoo_post_deploy(
@@ -3459,6 +3478,16 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_odoo_prod_rollback,
         ),
+        _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_TARGET_REPLACEMENT_PLAN_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                instance=request.replacement.instance,
+                require_profile=True,
+            ),
+            handler=_handle_odoo_target_replacement_plan,
+        ),
         _ODOO_POST_DEPLOY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_ODOO_POST_DEPLOY_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3643,6 +3672,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path,
             _ODOO_PROD_BACKUP_GATE_ROUTE.route_path,
             _ODOO_PROD_ROLLBACK_ROUTE.route_path,
+            _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path,
             _ODOO_POST_DEPLOY_ROUTE.route_path,
             _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path,
             _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path,
@@ -14249,42 +14279,6 @@ def create_launchplane_service_app(
                     "post_deploy_status": driver_result.post_deploy_status,
                     "destination_health_status": driver_result.destination_health_status,
                 }
-            elif path == _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path:
-                odoo_replacement_plan_request = (
-                    _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.envelope_model.model_validate(payload)
-                )
-                profile = record_store.read_product_profile_record(
-                    odoo_replacement_plan_request.product
-                )
-                replacement_plan_lane = _find_product_profile_lane(
-                    profile=profile,
-                    context="",
-                    instance=odoo_replacement_plan_request.replacement.instance,
-                )
-                if replacement_plan_lane is None:
-                    raise click.ClickException(
-                        "Odoo target replacement plan requires a known product lane."
-                    )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_TARGET_REPLACEMENT_PLAN_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_replacement_plan_request.product,
-                    authorization_context=replacement_plan_lane.context,
-                    descriptor_context=replacement_plan_lane.context,
-                    descriptor_instance=replacement_plan_lane.instance,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                driver_result = build_odoo_stable_target_replacement_plan(
-                    control_plane_root=resolved_root,
-                    record_store=cast(OdooStableTargetReplacementStore, record_store),
-                    request=odoo_replacement_plan_request.replacement,
-                )
-                result = {}
             elif path == _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path:
                 odoo_replacement_apply_request = (
                     _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.envelope_model.model_validate(payload)

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -429,13 +429,13 @@ handler is explicitly registered for the same descriptor route. Generic-web
 deploy, promotion workflow dispatch, stable verification, rollback planning,
 rollback apply, preview verification, Odoo artifact publish inputs and evidence
 ingestion, Odoo prod promotion input reads, Odoo prod backup gate, prod
-rollback, post-deploy, config/website override hooks, Odoo preview apply and
-inputs, and the VeriReel testing and prod deploys, prod backup gate, prod
-promotion, prod rollback, app maintenance, preview refresh, preview inventory
-reads, preview destroy, plus testing and preview verification writebacks use
-descriptor-backed dispatch. This keeps descriptor metadata as the route/authz
-source of truth while preventing an advertised descriptor action from becoming
-executable without implementation.
+rollback, target replacement planning, post-deploy, config/website override
+hooks, Odoo preview apply and inputs, and the VeriReel testing and prod
+deploys, prod backup gate, prod promotion, prod rollback, app maintenance,
+preview refresh, preview inventory reads, preview destroy, plus testing and
+preview verification use descriptor-backed dispatch. This keeps descriptor
+metadata as the route/authz source of truth while preventing an advertised
+descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -508,6 +508,10 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             control_plane_service._ODOO_PROD_ROLLBACK_ROUTE.route_path,
             dispatch_routes,
         )
+        self.assertIn(
+            control_plane_service._ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path,
+            dispatch_routes,
+        )
         self.assertIn(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path, dispatch_routes)
         self.assertIn(
             control_plane_service._ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path,
@@ -1216,6 +1220,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes.pop(control_plane_service._ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_BACKUP_GATE_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_ROLLBACK_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path)
@@ -1243,6 +1248,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "_DESCRIPTORS",
             (
                 descriptor_without_prod_rollback,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "odoo"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_odoo_target_replacement_plan_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_target_replacement_plan = registry.ODOO_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.ODOO_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_target_replacement_plan,
                 *(
                     descriptor
                     for descriptor in registry._DESCRIPTORS
@@ -1663,6 +1698,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                 {
                     control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.route_path,
                     control_plane_service._ODOO_PREVIEW_APPLY_INPUTS_ROUTE.route_path,
+                    control_plane_service._ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path,
                     control_plane_service._ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path,
                     control_plane_service._VERIREEL_STABLE_ENVIRONMENT_ROUTE.route_path,
                     control_plane_service._VERIREEL_RUNTIME_VERIFICATION_ROUTE.route_path,
@@ -1672,6 +1708,10 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         self.assertIn(
             "/v1/drivers/verireel/preview-inventory",
+            control_plane_service._NON_IDEMPOTENT_DRIVER_RESULT_ROUTES,
+        )
+        self.assertIn(
+            "/v1/drivers/odoo/target-replacement-plan",
             control_plane_service._NON_IDEMPOTENT_DRIVER_RESULT_ROUTES,
         )
         self.assertEqual(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -28923,6 +28923,102 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 403)
             self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_odoo_target_replacement_plan_recomputes_with_idempotency_key(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-plan.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/launchplane",
+                                "workflow_refs": [
+                                    "cbusillo/launchplane/.github/workflows/odoo-target-replacement-plan.yml@refs/heads/main"
+                                ],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["odoo-tenant-cm"],
+                                "contexts": ["cm"],
+                                "actions": ["odoo_target_replacement_plan.read"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo-tenant-cm",
+                "replacement": {
+                    "product": "odoo-tenant-cm",
+                    "instance": "testing",
+                    "strategy": "recreate-in-place",
+                },
+            }
+
+            with patch(
+                "control_plane.service.build_odoo_stable_target_replacement_plan",
+                side_effect=(
+                    OdooStableTargetReplacementPlan(
+                        plan_status="ready",
+                        product="odoo-tenant-cm",
+                        context="cm",
+                        instance="testing",
+                        strategy="recreate-in-place",
+                        target_record_found=True,
+                        target_id_record_found=True,
+                        inventory_found=True,
+                        expected_next_target_name="cm-testing-a",
+                    ),
+                    OdooStableTargetReplacementPlan(
+                        plan_status="ready",
+                        product="odoo-tenant-cm",
+                        context="cm",
+                        instance="testing",
+                        strategy="recreate-in-place",
+                        target_record_found=True,
+                        target_id_record_found=True,
+                        inventory_found=True,
+                        expected_next_target_name="cm-testing-b",
+                    ),
+                ),
+            ) as plan_mock:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-plan",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "replacement-plan-cm-testing"},
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-plan",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "replacement-plan-cm-testing"},
+                )
+
+            self.assertEqual(first_status_code, 202)
+            self.assertEqual(second_status_code, 202)
+            self.assertEqual(first_payload["result"]["expected_next_target_name"], "cm-testing-a")
+            self.assertEqual(second_payload["result"]["expected_next_target_name"], "cm-testing-b")
+            self.assertEqual(plan_mock.call_count, 2)
+
     def test_odoo_target_replacement_apply_driver_creates_operation_for_authorized_workflow(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- move Odoo target replacement planning to descriptor-backed service dispatch
- preserve lane-context authorization and non-idempotent recompute behavior
- cover descriptor registration, route policy, service behavior, and docs

## Tests
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_routes_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_target_replacement_plan_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_route_policy_sets_use_execution_metadata tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_plan_driver_reads_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_plan_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_plan_recomputes_with_idempotency_key
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Review
- fresh non-Claude agent review: clean