### PR TITLE
Migrate Odoo target replacement apply dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -844,6 +844,20 @@ _DescriptorDriverDispatchHandler = Callable[
     ],
     _DescriptorDriverDispatchResult,
 ]
+_DescriptorDriverCustomDispatchHandler = Callable[
+    [
+        _DriverRouteEnvelopeT,
+        _ResolvedProductDriverContext,
+        object,
+        Path,
+        str,
+        str,
+        str,
+        _StartResponse,
+        str,
+    ],
+    tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes],
+]
 _DescriptorDriverDispatchValidator = Callable[
     [
         _DriverRouteEnvelopeT,
@@ -859,10 +873,13 @@ _DescriptorDriverDispatchValidator = Callable[
 class _DescriptorDriverDispatchRoute(Generic[_DriverRouteEnvelopeT]):
     execution_metadata: _DriverRouteExecutionMetadata[_DriverRouteEnvelopeT]
     context_resolver: _DescriptorDriverDispatchContextResolver[_DriverRouteEnvelopeT]
-    handler: _DescriptorDriverDispatchHandler[_DriverRouteEnvelopeT]
+    handler: _DescriptorDriverDispatchHandler[_DriverRouteEnvelopeT] | None = None
     pre_idempotency_validator: _DescriptorDriverDispatchValidator[_DriverRouteEnvelopeT] | None = (
         None
     )
+    custom_dispatch_handler: (
+        _DescriptorDriverCustomDispatchHandler[_DriverRouteEnvelopeT] | None
+    ) = None
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -2918,6 +2935,114 @@ def _handle_odoo_target_replacement_plan(
     return _DescriptorDriverDispatchResult(result={}, driver_result=driver_result)
 
 
+def _dispatch_odoo_target_replacement_apply(
+    request: OdooTargetReplacementApplyEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+    request_scope: str,
+    request_idempotency_key: str,
+    request_fingerprint: str,
+    start_response: _StartResponse,
+    trace_id: str,
+) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
+    if resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Odoo target replacement apply requires a known product lane."
+        )
+    if not request_idempotency_key:
+        return _json_response(
+            start_response=start_response,
+            status_code=400,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "idempotency_key_required",
+                    "message": "Odoo target replacement operations require an Idempotency-Key header.",
+                },
+            },
+        )
+
+    replacement_operation_store = _odoo_stable_target_replacement_operation_store(record_store)
+    existing_replacement_operation = (
+        _find_odoo_stable_target_replacement_operation_by_idempotency_key(
+            operation_store=replacement_operation_store,
+            idempotency_key=request_idempotency_key,
+            idempotency_scope=request_scope,
+        )
+    )
+    result: dict[str, object]
+    if existing_replacement_operation is not None:
+        if existing_replacement_operation.request_fingerprint != request_fingerprint:
+            return _json_response(
+                start_response=start_response,
+                status_code=409,
+                payload={
+                    "status": "rejected",
+                    "trace_id": trace_id,
+                    "error": {
+                        "code": "idempotency_key_reused",
+                        "message": "Idempotency-Key was already used for a different Odoo target replacement request.",
+                    },
+                },
+            )
+        driver_result = _target_replacement_operation_payload(existing_replacement_operation)
+        result = {
+            "odoo_stable_target_replacement_operation_id": existing_replacement_operation.operation_id,
+            **(
+                {"deployment_record_id": existing_replacement_operation.deployment_record_id}
+                if existing_replacement_operation.deployment_record_id
+                else {}
+            ),
+        }
+    else:
+        replacement_operation = _build_odoo_stable_target_replacement_operation_record(
+            replacement_request=request.replacement,
+            context=resolved_context.lane.context,
+            idempotency_key=request_idempotency_key,
+            idempotency_scope=request_scope,
+            request_fingerprint=request_fingerprint,
+            created_at=_utc_now_timestamp(),
+        )
+        replacement_operation, created_replacement_operation = (
+            replacement_operation_store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
+                replacement_operation
+            )
+        )
+        if not created_replacement_operation:
+            return _json_response(
+                start_response=start_response,
+                status_code=409,
+                payload={
+                    "status": "rejected",
+                    "trace_id": trace_id,
+                    "error": {
+                        "code": "odoo_stable_target_replacement_operation_active",
+                        "message": "An Odoo target replacement operation is already active for this product/context/instance.",
+                    },
+                    "operation": _target_replacement_operation_payload(replacement_operation),
+                },
+            )
+        _start_odoo_stable_target_replacement_operation_worker(
+            operation_id=replacement_operation.operation_id,
+            control_plane_root_path=control_plane_root_path,
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        driver_result = _target_replacement_operation_payload(replacement_operation)
+        result = {"odoo_stable_target_replacement_operation_id": replacement_operation.operation_id}
+        if replacement_operation.deployment_record_id:
+            result["deployment_record_id"] = replacement_operation.deployment_record_id
+        if (
+            replacement_operation.result is not None
+            and replacement_operation.result.release_tuple_id
+        ):
+            result["release_tuple_id"] = replacement_operation.result.release_tuple_id
+
+    return result, driver_result
+
+
 def _handle_odoo_post_deploy(
     request: OdooPostDeployEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3488,6 +3613,16 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_odoo_target_replacement_plan,
         ),
+        _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_TARGET_REPLACEMENT_APPLY_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                instance=request.replacement.instance,
+                require_profile=True,
+            ),
+            custom_dispatch_handler=_dispatch_odoo_target_replacement_apply,
+        ),
         _ODOO_POST_DEPLOY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_ODOO_POST_DEPLOY_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3673,6 +3808,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _ODOO_PROD_BACKUP_GATE_ROUTE.route_path,
             _ODOO_PROD_ROLLBACK_ROUTE.route_path,
             _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path,
+            _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path,
             _ODOO_POST_DEPLOY_ROUTE.route_path,
             _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path,
             _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path,
@@ -3776,6 +3912,22 @@ def _dispatch_descriptor_driver_route(
         )
         if idempotent_response is not None:
             return idempotent_response
+    if dispatch_route.custom_dispatch_handler is not None:
+        return dispatch_route.custom_dispatch_handler(
+            request,
+            resolved_driver_context,
+            record_store,
+            control_plane_root_path,
+            request_scope,
+            request_idempotency_key,
+            request_fingerprint,
+            start_response,
+            trace_id,
+        )
+    if dispatch_route.handler is None:
+        raise ValueError(
+            f"Descriptor-backed dispatch route {route_metadata.route_path} must register a handler."
+        )
     dispatch_result = dispatch_route.handler(
         request,
         resolved_driver_context,
@@ -4098,6 +4250,12 @@ def _validate_descriptor_driver_dispatch_routes(
         if route_path != dispatch_route.execution_metadata.route_path:
             raise ValueError(
                 f"Descriptor-backed dispatch route {route_path} must match execution metadata."
+            )
+        has_standard_handler = dispatch_route.handler is not None
+        has_custom_handler = dispatch_route.custom_dispatch_handler is not None
+        if has_standard_handler == has_custom_handler:
+            raise ValueError(
+                f"Descriptor-backed dispatch route {route_path} must register exactly one handler."
             )
         descriptor_route = descriptor_routes.get(route_path)
         if descriptor_route is None:
@@ -14279,133 +14437,6 @@ def create_launchplane_service_app(
                     "post_deploy_status": driver_result.post_deploy_status,
                     "destination_health_status": driver_result.destination_health_status,
                 }
-            elif path == _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path:
-                odoo_replacement_apply_request = (
-                    _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.envelope_model.model_validate(payload)
-                )
-                profile = record_store.read_product_profile_record(
-                    odoo_replacement_apply_request.product
-                )
-                replacement_apply_lane = _find_product_profile_lane(
-                    profile=profile,
-                    context="",
-                    instance=odoo_replacement_apply_request.replacement.instance,
-                )
-                if replacement_apply_lane is None:
-                    raise click.ClickException(
-                        "Odoo target replacement apply requires a known product lane."
-                    )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_TARGET_REPLACEMENT_APPLY_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_replacement_apply_request.product,
-                    authorization_context=replacement_apply_lane.context,
-                    descriptor_context=replacement_apply_lane.context,
-                    descriptor_instance=replacement_apply_lane.instance,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                if not request_idempotency_key:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "idempotency_key_required",
-                                "message": "Odoo target replacement operations require an Idempotency-Key header.",
-                            },
-                        },
-                    )
-                replacement_operation_store = _odoo_stable_target_replacement_operation_store(
-                    record_store
-                )
-                existing_replacement_operation = (
-                    _find_odoo_stable_target_replacement_operation_by_idempotency_key(
-                        operation_store=replacement_operation_store,
-                        idempotency_key=request_idempotency_key,
-                        idempotency_scope=request_scope,
-                    )
-                )
-                if existing_replacement_operation is not None:
-                    if existing_replacement_operation.request_fingerprint != request_fingerprint:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=409,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "idempotency_key_reused",
-                                    "message": "Idempotency-Key was already used for a different Odoo target replacement request.",
-                                },
-                            },
-                        )
-                    driver_result = _target_replacement_operation_payload(
-                        existing_replacement_operation
-                    )
-                    result = {
-                        "odoo_stable_target_replacement_operation_id": existing_replacement_operation.operation_id,
-                        **(
-                            {
-                                "deployment_record_id": existing_replacement_operation.deployment_record_id
-                            }
-                            if existing_replacement_operation.deployment_record_id
-                            else {}
-                        ),
-                    }
-                else:
-                    replacement_operation = _build_odoo_stable_target_replacement_operation_record(
-                        replacement_request=odoo_replacement_apply_request.replacement,
-                        context=replacement_apply_lane.context,
-                        idempotency_key=request_idempotency_key,
-                        idempotency_scope=request_scope,
-                        request_fingerprint=request_fingerprint,
-                        created_at=_utc_now_timestamp(),
-                    )
-                    replacement_operation, created_replacement_operation = (
-                        replacement_operation_store.create_odoo_stable_target_replacement_operation_record_if_no_active_lane(
-                            replacement_operation
-                        )
-                    )
-                    if not created_replacement_operation:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=409,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "odoo_stable_target_replacement_operation_active",
-                                    "message": "An Odoo target replacement operation is already active for this product/context/instance.",
-                                },
-                                "operation": _target_replacement_operation_payload(
-                                    replacement_operation
-                                ),
-                            },
-                        )
-                    _start_odoo_stable_target_replacement_operation_worker(
-                        operation_id=replacement_operation.operation_id,
-                        control_plane_root_path=resolved_root,
-                        record_store=record_store,
-                        trace_id=request_trace_id,
-                    )
-                    driver_result = _target_replacement_operation_payload(replacement_operation)
-                    result = {
-                        "odoo_stable_target_replacement_operation_id": replacement_operation.operation_id
-                    }
-                    if replacement_operation.deployment_record_id:
-                        result["deployment_record_id"] = replacement_operation.deployment_record_id
-                    if (
-                        replacement_operation.result is not None
-                        and replacement_operation.result.release_tuple_id
-                    ):
-                        result["release_tuple_id"] = replacement_operation.result.release_tuple_id
             elif path == "/v1/product-profiles/context-cutover/apply":
                 context_cutover_request = control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(
                     payload

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -429,13 +429,13 @@ handler is explicitly registered for the same descriptor route. Generic-web
 deploy, promotion workflow dispatch, stable verification, rollback planning,
 rollback apply, preview verification, Odoo artifact publish inputs and evidence
 ingestion, Odoo prod promotion input reads, Odoo prod backup gate, prod
-rollback, target replacement planning, post-deploy, config/website override
-hooks, Odoo preview apply and inputs, and the VeriReel testing and prod
-deploys, prod backup gate, prod promotion, prod rollback, app maintenance,
-preview refresh, preview inventory reads, preview destroy, plus testing and
-preview verification use descriptor-backed dispatch. This keeps descriptor
-metadata as the route/authz source of truth while preventing an advertised
-descriptor action from becoming executable without implementation.
+rollback, target replacement planning, target replacement apply, post-deploy,
+config/website override hooks, Odoo preview apply and inputs, and the VeriReel
+testing and prod deploys, prod backup gate, prod promotion, prod rollback, app
+maintenance, preview refresh, preview inventory reads, preview destroy, plus
+testing and preview verification use descriptor-backed dispatch. This keeps
+descriptor metadata as the route/authz source of truth while preventing an
+advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
@@ -431,6 +432,93 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     {"/v1/drivers/fake-dispatch/ping": route}
                 )
 
+    def test_descriptor_dispatch_registration_requires_exactly_one_handler(self) -> None:
+        descriptor = DriverDescriptor(
+            driver_id="fake-dispatch",
+            label="Fake dispatch",
+            product="fake-dispatch",
+            description="Test-only descriptor dispatch driver.",
+            provider_boundary="Test-only provider boundary.",
+            actions=(
+                DriverActionDescriptor(
+                    action_id="ping",
+                    label="Ping",
+                    description="Test descriptor-backed dispatch route.",
+                    safety="safe_write",
+                    scope="context",
+                    method="POST",
+                    route_path="/v1/drivers/fake-dispatch/ping",
+                    authz_action="fake_dispatch.ping",
+                ),
+            ),
+        )
+        route_metadata = control_plane_service._DriverRouteExecutionMetadata(
+            route_path="/v1/drivers/fake-dispatch/ping",
+            envelope_model=control_plane_service.GenericWebStableVerificationEnvelope,
+            denial_message="Workflow cannot execute fake dispatch.",
+        )
+
+        def context_resolver(
+            request: control_plane_service.GenericWebStableVerificationEnvelope,
+        ) -> control_plane_service._DescriptorDriverDispatchContext:
+            return control_plane_service._DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.verification.context,
+            )
+
+        def standard_handler(
+            _request: Any,
+            _resolved_context: control_plane_service._ResolvedProductDriverContext,
+            _record_store: object,
+            _root_path: Path,
+        ) -> control_plane_service._DescriptorDriverDispatchResult:
+            return control_plane_service._DescriptorDriverDispatchResult(result={})
+
+        def custom_handler(
+            _request: Any,
+            _resolved_context: control_plane_service._ResolvedProductDriverContext,
+            _record_store: object,
+            _root_path: object,
+            _request_scope: str,
+            _request_idempotency_key: str,
+            _request_fingerprint: str,
+            _start_response: control_plane_service._StartResponse,
+            _trace_id: str,
+        ) -> tuple[dict[str, object], Any] | list[bytes]:
+            return {}, None
+
+        with (
+            patch("control_plane.service.list_driver_descriptors", return_value=(descriptor,)),
+            patch(
+                "control_plane.service._required_descriptor_driver_dispatch_route_paths",
+                return_value=frozenset(),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must register exactly one handler"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(
+                    {
+                        "/v1/drivers/fake-dispatch/ping": (
+                            control_plane_service._DescriptorDriverDispatchRoute(
+                                execution_metadata=route_metadata,
+                                context_resolver=context_resolver,
+                            )
+                        )
+                    }
+                )
+            with self.assertRaisesRegex(ValueError, "must register exactly one handler"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(
+                    {
+                        "/v1/drivers/fake-dispatch/ping": (
+                            control_plane_service._DescriptorDriverDispatchRoute(
+                                execution_metadata=route_metadata,
+                                context_resolver=context_resolver,
+                                handler=standard_handler,
+                                custom_dispatch_handler=custom_handler,
+                            )
+                        )
+                    }
+                )
+
     def test_stable_verification_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
@@ -510,6 +598,10 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         self.assertIn(
             control_plane_service._ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path,
+            dispatch_routes,
+        )
+        self.assertIn(
+            control_plane_service._ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path,
             dispatch_routes,
         )
         self.assertIn(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path, dispatch_routes)
@@ -1221,6 +1313,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes.pop(control_plane_service._ODOO_PROD_BACKUP_GATE_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_ROLLBACK_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path)
@@ -1278,6 +1371,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "_DESCRIPTORS",
             (
                 descriptor_without_target_replacement_plan,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "odoo"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_odoo_target_replacement_apply_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_target_replacement_apply = registry.ODOO_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.ODOO_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_target_replacement_apply,
                 *(
                     descriptor
                     for descriptor in registry._DESCRIPTORS

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -29175,6 +29175,144 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             worker_mock.assert_called_once()
 
+    def test_odoo_target_replacement_apply_driver_requires_idempotency_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/launchplane",
+                                "workflow_refs": [
+                                    "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                                ],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["odoo-tenant-cm"],
+                                "contexts": ["cm"],
+                                "actions": ["odoo_target_replacement_apply.execute"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service._start_odoo_stable_target_replacement_operation_worker"
+            ) as worker_mock:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "replacement": {
+                            "product": "odoo-tenant-cm",
+                            "instance": "testing",
+                            "strategy": "recreate-in-place",
+                        },
+                    },
+                )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "idempotency_key_required")
+            worker_mock.assert_not_called()
+
+    def test_odoo_target_replacement_apply_driver_rejects_reused_idempotency_key(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/launchplane",
+                                "workflow_refs": [
+                                    "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
+                                ],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["odoo-tenant-cm"],
+                                "contexts": ["cm"],
+                                "actions": ["odoo_target_replacement_apply.execute"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service._start_odoo_stable_target_replacement_operation_worker"
+            ) as worker_mock:
+                first_status, _ = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "replacement": {
+                            "product": "odoo-tenant-cm",
+                            "instance": "testing",
+                            "strategy": "recreate-in-place",
+                            "allow_empty_data": False,
+                        },
+                    },
+                    headers={"Idempotency-Key": "apply-cm-testing"},
+                )
+                second_status, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/target-replacement-apply",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "replacement": {
+                            "product": "odoo-tenant-cm",
+                            "instance": "testing",
+                            "strategy": "recreate-in-place",
+                            "allow_empty_data": True,
+                        },
+                    },
+                    headers={"Idempotency-Key": "apply-cm-testing"},
+                )
+
+            self.assertEqual(first_status, 202)
+            self.assertEqual(second_status, 409)
+            self.assertEqual(second_payload["error"]["code"], "idempotency_key_reused")
+            worker_mock.assert_called_once()
+
     def test_odoo_target_replacement_apply_driver_scopes_replay_to_caller(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- move Odoo target replacement apply into descriptor-backed dispatch
- preserve durable operation idempotency/replay, lane-scoped authorization, and worker startup
- fail-close descriptor dispatch registrations that do not declare exactly one implementation hook

## Tests
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_descriptor_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_descriptor_dispatch_registration_requires_exactly_one_handler tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_routes_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_target_replacement_apply_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_route_policy_sets_use_execution_metadata tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_creates_operation_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_replays_existing_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_requires_idempotency_key tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_rejects_reused_idempotency_key tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_scopes_replay_to_caller tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_blocks_second_active_lane_operation tests.test_service.LaunchplaneServiceTests.test_odoo_target_replacement_apply_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Review
- fresh non-Claude final review: clean