### PR TITLE
Migrate generic-web prod promotion dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -325,6 +325,7 @@ from control_plane.workflows.generic_web_deploy import (
 )
 from control_plane.workflows.generic_web_promotion import (
     GenericWebProdPromotionRequest,
+    GenericWebPromotionStore,
     execute_generic_web_prod_promotion,
     resolve_generic_web_promotion_lanes,
 )
@@ -850,6 +851,7 @@ _DescriptorDriverCustomDispatchHandler = Callable[
         _ResolvedProductDriverContext,
         object,
         Path,
+        LaunchplaneIdentity,
         str,
         str,
         str,
@@ -867,6 +869,16 @@ _DescriptorDriverDispatchValidator = Callable[
     ],
     None,
 ]
+_DescriptorDriverPreAuthorizationValidator = Callable[
+    [
+        _DriverRouteEnvelopeT,
+        _ResolvedProductDriverContext,
+        LaunchplaneIdentity,
+        _StartResponse,
+        str,
+    ],
+    list[bytes] | None,
+]
 
 
 @dataclass(frozen=True)
@@ -877,9 +889,13 @@ class _DescriptorDriverDispatchRoute(Generic[_DriverRouteEnvelopeT]):
     pre_idempotency_validator: _DescriptorDriverDispatchValidator[_DriverRouteEnvelopeT] | None = (
         None
     )
+    pre_authorization_validator: (
+        _DescriptorDriverPreAuthorizationValidator[_DriverRouteEnvelopeT] | None
+    ) = None
     custom_dispatch_handler: (
         _DescriptorDriverCustomDispatchHandler[_DriverRouteEnvelopeT] | None
     ) = None
+    skip_pre_idempotency_check: bool = False
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -2776,6 +2792,100 @@ def _handle_generic_web_promotion_workflow(
     )
 
 
+def _dispatch_generic_web_prod_promotion(
+    request: GenericWebProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+    identity: LaunchplaneIdentity,
+    request_scope: str,
+    request_idempotency_key: str,
+    request_fingerprint: str,
+    start_response: _StartResponse,
+    trace_id: str,
+) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
+    del identity
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Generic web prod promotion requires a product profile lane."
+        )
+    idempotent_response = _check_idempotent_request(
+        record_store=record_store,
+        scope=request_scope,
+        route_path=_GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
+        idempotency_key=request_idempotency_key,
+        request_fingerprint=request_fingerprint,
+        start_response=start_response,
+        trace_id=trace_id,
+    )
+    if idempotent_response is not None:
+        return idempotent_response
+    driver_result = execute_generic_web_prod_promotion(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(GenericWebPromotionStore, record_store),
+        request=request.promotion,
+    )
+    return (
+        {
+            "promotion_record_id": driver_result.promotion_record_id,
+            "deployment_record_id": driver_result.deployment_record_id,
+            "backup_record_id": driver_result.backup_record_id,
+            "inventory_record_id": driver_result.inventory_record_id,
+            "promotion_status": driver_result.promotion_status,
+            "deployment_status": driver_result.deployment_status,
+            "source_health_status": driver_result.source_health_status,
+            "destination_health_status": driver_result.destination_health_status,
+            "backup_status": driver_result.backup_status,
+            "release_status": driver_result.release_status,
+            "release_tag": driver_result.release_tag,
+            "release_url": driver_result.release_url,
+            "dry_run": driver_result.dry_run,
+        },
+        driver_result,
+    )
+
+
+def _validate_generic_web_prod_promotion_lanes(
+    request: GenericWebProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> None:
+    del control_plane_root_path
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Generic web prod promotion requires a product profile lane."
+        )
+    resolve_generic_web_promotion_lanes(
+        record_store=cast(GenericWebPromotionStore, record_store),
+        request=request.promotion,
+    )
+
+
+def _reject_human_live_generic_web_prod_promotion(
+    request: GenericWebProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    identity: LaunchplaneIdentity,
+    start_response: _StartResponse,
+    trace_id: str,
+) -> list[bytes] | None:
+    del resolved_context
+    if not isinstance(identity, GitHubHumanIdentity) or request.promotion.dry_run:
+        return None
+    return _json_response(
+        start_response=start_response,
+        status_code=403,
+        payload={
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {
+                "code": "authorization_denied",
+                "message": "Launchplane UI can only dry-run generic-web prod promotions.",
+            },
+        },
+    )
+
+
 def _handle_generic_web_rollback(
     request: GenericWebRollbackEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -2940,12 +3050,14 @@ def _dispatch_odoo_target_replacement_apply(
     resolved_context: _ResolvedProductDriverContext,
     record_store: object,
     control_plane_root_path: Path,
+    identity: LaunchplaneIdentity,
     request_scope: str,
     request_idempotency_key: str,
     request_fingerprint: str,
     start_response: _StartResponse,
     trace_id: str,
 ) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
+    del identity
     if resolved_context.lane is None:
         raise ProductDriverMismatchError(
             "Odoo target replacement apply requires a known product lane."
@@ -3518,6 +3630,19 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_generic_web_promotion_workflow,
         ),
+        _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_GENERIC_WEB_PROD_PROMOTION_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                instance=request.promotion.to_instance,
+                require_profile=True,
+            ),
+            pre_idempotency_validator=_validate_generic_web_prod_promotion_lanes,
+            pre_authorization_validator=_reject_human_live_generic_web_prod_promotion,
+            custom_dispatch_handler=_dispatch_generic_web_prod_promotion,
+            skip_pre_idempotency_check=True,
+        ),
         _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3797,6 +3922,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
     return frozenset(
         (
             _GENERIC_WEB_DEPLOY_ROUTE.route_path,
+            _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
             _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE.route_path,
             _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
             _GENERIC_WEB_ROLLBACK_ROUTE.route_path,
@@ -3875,6 +4001,16 @@ def _dispatch_descriptor_driver_route(
             record_store,
             control_plane_root_path,
         )
+    if dispatch_route.pre_authorization_validator is not None:
+        pre_authorization_response = dispatch_route.pre_authorization_validator(
+            request,
+            resolved_driver_context,
+            identity,
+            start_response,
+            trace_id,
+        )
+        if pre_authorization_response is not None:
+            return pre_authorization_response
     authorization_product = dispatch_context.product
     if resolved_driver_context.profile is not None:
         authorization_product = resolved_driver_context.profile.product
@@ -3900,7 +4036,10 @@ def _dispatch_descriptor_driver_route(
     )
     if authorization_response is not None:
         return authorization_response
-    if route_metadata.route_path not in _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES:
+    if (
+        route_metadata.route_path not in _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES
+        and not dispatch_route.skip_pre_idempotency_check
+    ):
         idempotent_response = _check_idempotent_request(
             record_store=record_store,
             scope=request_scope,
@@ -3918,6 +4057,7 @@ def _dispatch_descriptor_driver_route(
             resolved_driver_context,
             record_store,
             control_plane_root_path,
+            identity,
             request_scope,
             request_idempotency_key,
             request_fingerprint,
@@ -14029,79 +14169,6 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     request=self_deploy_request.deploy,
                 ).model_dump(mode="json")
-            elif path == _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path:
-                generic_web_promotion_request = (
-                    _GENERIC_WEB_PROD_PROMOTION_ROUTE.envelope_model.model_validate(payload)
-                )
-                _resolve_descriptor_product_driver_context(
-                    record_store=record_store,
-                    route_path=path,
-                    product=generic_web_promotion_request.product,
-                    require_profile=True,
-                )
-                _profile, _source_lane, destination_lane = resolve_generic_web_promotion_lanes(
-                    record_store=record_store,
-                    request=generic_web_promotion_request.promotion,
-                )
-                if (
-                    isinstance(identity, GitHubHumanIdentity)
-                    and not generic_web_promotion_request.promotion.dry_run
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Launchplane UI can only dry-run generic-web prod promotions.",
-                            },
-                        },
-                    )
-                authorization_response = _driver_route_authorization_response(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    route_path=path,
-                    product=generic_web_promotion_request.product,
-                    context=destination_lane.context,
-                    denial_message=_GENERIC_WEB_PROD_PROMOTION_ROUTE.denial_message,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_generic_web_prod_promotion(
-                    control_plane_root=resolved_root,
-                    record_store=record_store,
-                    request=generic_web_promotion_request.promotion,
-                )
-                result = {
-                    "promotion_record_id": driver_result.promotion_record_id,
-                    "deployment_record_id": driver_result.deployment_record_id,
-                    "backup_record_id": driver_result.backup_record_id,
-                    "inventory_record_id": driver_result.inventory_record_id,
-                    "promotion_status": driver_result.promotion_status,
-                    "deployment_status": driver_result.deployment_status,
-                    "source_health_status": driver_result.source_health_status,
-                    "destination_health_status": driver_result.destination_health_status,
-                    "backup_status": driver_result.backup_status,
-                    "release_status": driver_result.release_status,
-                    "release_tag": driver_result.release_tag,
-                    "release_url": driver_result.release_url,
-                    "dry_run": driver_result.dry_run,
-                }
             elif path in _PREVIEW_DESIRED_STATE_ROUTE_PATHS:
                 generic_web_desired_state_request, profile, authorization_response = (
                     _authorize_generic_web_preview_route(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -426,14 +426,15 @@ descriptor route metadata, so new drivers do not need a second hardcoded router
 allowlist or authz-action entry.
 Routes can also opt into descriptor-backed service dispatch when a backend
 handler is explicitly registered for the same descriptor route. Generic-web
-deploy, promotion workflow dispatch, stable verification, rollback planning,
-rollback apply, preview verification, Odoo artifact publish inputs and evidence
-ingestion, Odoo prod promotion input reads, Odoo prod backup gate, prod
-rollback, target replacement planning, target replacement apply, post-deploy,
-config/website override hooks, Odoo preview apply and inputs, and the VeriReel
-testing and prod deploys, prod backup gate, prod promotion, prod rollback, app
-maintenance, preview refresh, preview inventory reads, preview destroy, plus
-testing and preview verification use descriptor-backed dispatch. This keeps
+deploy, prod promotion, promotion workflow dispatch, stable verification,
+rollback planning, rollback apply, preview verification, Odoo artifact publish
+inputs and evidence ingestion, Odoo prod promotion input reads, Odoo prod backup
+gate, prod rollback, target replacement planning, target replacement apply,
+post-deploy, config/website override hooks, Odoo preview apply and inputs, and
+the VeriReel testing and prod deploys, prod backup gate, prod promotion, prod
+rollback, app maintenance, preview refresh, preview inventory reads, preview
+destroy, plus testing and preview verification use descriptor-backed dispatch.
+This keeps
 descriptor metadata as the route/authz source of truth while preventing an
 advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -478,7 +478,8 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             _request: Any,
             _resolved_context: control_plane_service._ResolvedProductDriverContext,
             _record_store: object,
-            _root_path: object,
+            _root_path: Path,
+            _identity: Any,
             _request_scope: str,
             _request_idempotency_key: str,
             _request_fingerprint: str,
@@ -533,6 +534,15 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
 
         self.assertIn(
             control_plane_service._GENERIC_WEB_DEPLOY_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_prod_promotion_registered_in_descriptor_dispatch(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertIn(
+            control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
             dispatch_routes,
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
@@ -826,6 +836,45 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_prod_promotion_descriptor_requires_dispatch_registration(
+        self,
+    ) -> None:
+        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
+        dispatch_routes.pop(control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path)
+
+        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_prod_promotion_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_prod_promotion = registry.GENERIC_WEB_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.GENERIC_WEB_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_prod_promotion,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "generic-web"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_generic_web_promotion_workflow_dispatch_registration_requires_descriptor_route(
         self,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18037,6 +18037,82 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_human_session_cannot_replay_live_generic_web_prod_promotion(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                github_oauth_config=_github_oauth_config(),
+                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+            )
+            request_payload = {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "promotion": {
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                    "source_git_ref": "abc123",
+                    "dry_run": False,
+                },
+            }
+            idempotency_key = "generic-web-prod-promotion-human-live"
+            store.write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id="idempotency-generic-web-prod-promotion-human-live",
+                    scope="|".join(("github-human", "alice", "123")),
+                    route_path="/v1/drivers/generic-web/prod-promotion",
+                    idempotency_key=idempotency_key,
+                    request_fingerprint=control_plane_service._idempotency_request_fingerprint(
+                        route_path="/v1/drivers/generic-web/prod-promotion",
+                        payload=request_payload,
+                    ),
+                    response_status_code=202,
+                    response_trace_id="generic-web-prod-promotion-human-live",
+                    recorded_at="2026-06-05T22:00:00Z",
+                    response_payload={
+                        "status": "accepted",
+                        "trace_id": "generic-web-prod-promotion-human-live",
+                        "records": {"promotion_record_id": "promotion-live"},
+                        "result": {"promotion_status": "pass", "dry_run": False},
+                    },
+                )
+            )
+            cookie = _signed_in_cookie(app)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-promotion",
+                payload=request_payload,
+                authorization="",
+                headers={"Cookie": cookie, "Idempotency-Key": idempotency_key},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_human_session_can_dispatch_generic_web_promotion_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- move generic-web prod promotion into descriptor-backed dispatch
- preserve destination-lane authz, source/destination lane validation, and human dry-run/live-execute behavior
- add a regression that GitHub humans cannot replay live prod promotion through idempotency

## Tests
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_prod_promotion_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_prod_promotion_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_prod_promotion_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_promotion_workflow_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_descriptor_dispatch_registration_requires_exactly_one_handler tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_executes_for_authorized_product_context tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_rejects_wrong_product_context tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_accepts_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_accepts_padded_lane_context tests.test_service.LaunchplaneServiceTests.test_human_session_can_dry_run_generic_web_prod_promotion tests.test_service.LaunchplaneServiceTests.test_human_session_cannot_live_execute_generic_web_prod_promotion tests.test_service.LaunchplaneServiceTests.test_human_session_cannot_replay_live_generic_web_prod_promotion
- uv run --extra dev ruff check --diff control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- npx --no-install markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Review
- antigravity review: intentional replay/lane-validation ordering noted, no blocking current-branch finding
- compact code-gpt-5.4-mini review: clean