### PR TITLE
Migrate Odoo prod promotion dispatch

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -851,6 +851,8 @@ _DescriptorDriverCustomDispatchHandler = Callable[
         _ResolvedProductDriverContext,
         object,
         Path,
+        Path,
+        str | None,
         LaunchplaneIdentity,
         str,
         str,
@@ -2797,6 +2799,8 @@ def _dispatch_generic_web_prod_promotion(
     resolved_context: _ResolvedProductDriverContext,
     record_store: object,
     control_plane_root_path: Path,
+    state_dir: Path,
+    database_url: str | None,
     identity: LaunchplaneIdentity,
     request_scope: str,
     request_idempotency_key: str,
@@ -2804,7 +2808,7 @@ def _dispatch_generic_web_prod_promotion(
     start_response: _StartResponse,
     trace_id: str,
 ) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
-    del identity
+    del state_dir, database_url, identity
     if resolved_context.profile is None or resolved_context.lane is None:
         raise ProductDriverMismatchError(
             "Generic web prod promotion requires a product profile lane."
@@ -3002,6 +3006,84 @@ def _handle_odoo_prod_backup_gate(
     )
 
 
+def _dispatch_odoo_prod_promotion_run(
+    request: OdooProdPromotionRunEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+    state_dir: Path,
+    database_url: str | None,
+    identity: LaunchplaneIdentity,
+    request_scope: str,
+    request_idempotency_key: str,
+    request_fingerprint: str,
+    start_response: _StartResponse,
+    trace_id: str,
+) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
+    del (
+        resolved_context,
+        identity,
+        request_scope,
+        request_idempotency_key,
+        request_fingerprint,
+        start_response,
+        trace_id,
+    )
+    driver_result = execute_odoo_prod_promotion_run(
+        control_plane_root=control_plane_root_path,
+        state_dir=state_dir,
+        database_url=database_url,
+        record_store=cast(OdooProdPromotionRunStore, record_store),
+        request=request.run,
+    )
+    return driver_result.model_dump(mode="json"), driver_result
+
+
+def _dispatch_odoo_prod_promotion(
+    request: OdooProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+    state_dir: Path,
+    database_url: str | None,
+    identity: LaunchplaneIdentity,
+    request_scope: str,
+    request_idempotency_key: str,
+    request_fingerprint: str,
+    start_response: _StartResponse,
+    trace_id: str,
+) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
+    del (
+        resolved_context,
+        identity,
+        request_scope,
+        request_idempotency_key,
+        request_fingerprint,
+        start_response,
+        trace_id,
+    )
+    driver_result = execute_odoo_prod_promotion(
+        control_plane_root=control_plane_root_path,
+        state_dir=state_dir,
+        database_url=database_url,
+        record_store=cast(OdooProdPromotionStore, record_store),
+        request=request.promotion,
+    )
+    return (
+        {
+            "promotion_record_id": driver_result.promotion_record_id,
+            "deployment_record_id": driver_result.deployment_record_id,
+            "backup_record_id": driver_result.backup_record_id,
+            "release_tuple_id": driver_result.release_tuple_id,
+            "promotion_status": driver_result.promotion_status,
+            "deployment_status": driver_result.deployment_status,
+            "post_deploy_status": driver_result.post_deploy_status,
+            "destination_health_status": driver_result.destination_health_status,
+        },
+        driver_result,
+    )
+
+
 def _handle_odoo_prod_rollback(
     request: OdooProdRollbackEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3050,6 +3132,8 @@ def _dispatch_odoo_target_replacement_apply(
     resolved_context: _ResolvedProductDriverContext,
     record_store: object,
     control_plane_root_path: Path,
+    state_dir: Path,
+    database_url: str | None,
     identity: LaunchplaneIdentity,
     request_scope: str,
     request_idempotency_key: str,
@@ -3057,7 +3141,7 @@ def _dispatch_odoo_target_replacement_apply(
     start_response: _StartResponse,
     trace_id: str,
 ) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
-    del identity
+    del state_dir, database_url, identity
     if resolved_context.lane is None:
         raise ProductDriverMismatchError(
             "Odoo target replacement apply requires a known product lane."
@@ -3719,6 +3803,24 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_odoo_prod_backup_gate,
         ),
+        _ODOO_PROD_PROMOTION_RUN_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_PROD_PROMOTION_RUN_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.run.context,
+            ),
+            custom_dispatch_handler=_dispatch_odoo_prod_promotion_run,
+        ),
+        _ODOO_PROD_PROMOTION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_PROD_PROMOTION_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context="",
+                authorization_context=request.promotion.context,
+            ),
+            custom_dispatch_handler=_dispatch_odoo_prod_promotion,
+        ),
         _ODOO_PROD_ROLLBACK_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_ODOO_PROD_ROLLBACK_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -3932,6 +4034,8 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path,
             _ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path,
             _ODOO_PROD_BACKUP_GATE_ROUTE.route_path,
+            _ODOO_PROD_PROMOTION_RUN_ROUTE.route_path,
+            _ODOO_PROD_PROMOTION_ROUTE.route_path,
             _ODOO_PROD_ROLLBACK_ROUTE.route_path,
             _ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path,
             _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path,
@@ -3970,6 +4074,8 @@ def _dispatch_descriptor_driver_route(
     start_response: _StartResponse,
     trace_id: str,
     control_plane_root_path: Path,
+    state_dir: Path,
+    database_url: str | None,
 ) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
     route_metadata = dispatch_route.execution_metadata
     descriptor_route_metadata = _driver_route_metadata_from_descriptors().get(
@@ -4057,6 +4163,8 @@ def _dispatch_descriptor_driver_route(
             resolved_driver_context,
             record_store,
             control_plane_root_path,
+            state_dir,
+            database_url,
             identity,
             request_scope,
             request_idempotency_key,
@@ -14123,6 +14231,8 @@ def create_launchplane_service_app(
                     payload=payload,
                     record_store=record_store,
                     control_plane_root_path=resolved_root,
+                    state_dir=state_dir,
+                    database_url=database_url,
                     authz_policy=authz_policy,
                     identity=identity,
                     request_scope=request_scope,
@@ -14425,85 +14535,6 @@ def create_launchplane_service_app(
                     )
                     driver_result = _operation_payload(operation)
                     result = {"odoo_stable_bootstrap_operation_id": operation.operation_id}
-            elif path == _ODOO_PROD_PROMOTION_RUN_ROUTE.route_path:
-                odoo_promotion_run_request = (
-                    _ODOO_PROD_PROMOTION_RUN_ROUTE.envelope_model.model_validate(payload)
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_PROD_PROMOTION_RUN_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_promotion_run_request.product,
-                    authorization_context=odoo_promotion_run_request.run.context,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_odoo_prod_promotion_run(
-                    control_plane_root=resolved_root,
-                    state_dir=state_dir,
-                    database_url=database_url,
-                    record_store=cast(OdooProdPromotionRunStore, record_store),
-                    request=odoo_promotion_run_request.run,
-                )
-                result = driver_result.model_dump(mode="json")
-            elif path == _ODOO_PROD_PROMOTION_ROUTE.route_path:
-                odoo_promotion_request = _ODOO_PROD_PROMOTION_ROUTE.envelope_model.model_validate(
-                    payload
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_PROD_PROMOTION_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_promotion_request.product,
-                    authorization_context=odoo_promotion_request.promotion.context,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = execute_odoo_prod_promotion(
-                    control_plane_root=resolved_root,
-                    state_dir=state_dir,
-                    database_url=database_url,
-                    record_store=cast(OdooProdPromotionStore, record_store),
-                    request=odoo_promotion_request.promotion,
-                )
-                result = {
-                    "promotion_record_id": driver_result.promotion_record_id,
-                    "deployment_record_id": driver_result.deployment_record_id,
-                    "backup_record_id": driver_result.backup_record_id,
-                    "release_tuple_id": driver_result.release_tuple_id,
-                    "promotion_status": driver_result.promotion_status,
-                    "deployment_status": driver_result.deployment_status,
-                    "post_deploy_status": driver_result.post_deploy_status,
-                    "destination_health_status": driver_result.destination_health_status,
-                }
             elif path == "/v1/product-profiles/context-cutover/apply":
                 context_cutover_request = control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(
                     payload

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -429,10 +429,11 @@ handler is explicitly registered for the same descriptor route. Generic-web
 deploy, prod promotion, promotion workflow dispatch, stable verification,
 rollback planning, rollback apply, preview verification, Odoo artifact publish
 inputs and evidence ingestion, Odoo prod promotion input reads, Odoo prod backup
-gate, prod rollback, target replacement planning, target replacement apply,
-post-deploy, config/website override hooks, Odoo preview apply and inputs, and
-the VeriReel testing and prod deploys, prod backup gate, prod promotion, prod
-rollback, app maintenance, preview refresh, preview inventory reads, preview
+gate, prod promotion run, direct prod promotion, prod rollback, target
+replacement planning, target replacement apply, post-deploy, config/website
+override hooks, Odoo preview apply and inputs, and the VeriReel testing and prod
+deploys, prod backup gate, prod promotion, prod rollback, app maintenance,
+preview refresh, preview inventory reads, preview
 destroy, plus testing and preview verification use descriptor-backed dispatch.
 This keeps
 descriptor metadata as the route/authz source of truth while preventing an

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -479,6 +479,8 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             _resolved_context: control_plane_service._ResolvedProductDriverContext,
             _record_store: object,
             _root_path: Path,
+            _state_dir: Path,
+            _database_url: str | None,
             _identity: Any,
             _request_scope: str,
             _request_idempotency_key: str,
@@ -600,6 +602,14 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         self.assertIn(
             control_plane_service._ODOO_PROD_BACKUP_GATE_ROUTE.route_path,
+            dispatch_routes,
+        )
+        self.assertIn(
+            control_plane_service._ODOO_PROD_PROMOTION_RUN_ROUTE.route_path,
+            dispatch_routes,
+        )
+        self.assertIn(
+            control_plane_service._ODOO_PROD_PROMOTION_ROUTE.route_path,
             dispatch_routes,
         )
         self.assertIn(
@@ -1360,6 +1370,8 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_PROMOTION_INPUTS_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_BACKUP_GATE_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_PROD_PROMOTION_RUN_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_PROD_PROMOTION_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_PROD_ROLLBACK_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_TARGET_REPLACEMENT_PLAN_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path)
@@ -1390,6 +1402,66 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "_DESCRIPTORS",
             (
                 descriptor_without_prod_rollback,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "odoo"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_odoo_prod_promotion_run_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_prod_promotion_run = registry.ODOO_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.ODOO_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._ODOO_PROD_PROMOTION_RUN_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_prod_promotion_run,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "odoo"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_odoo_prod_promotion_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_prod_promotion = registry.ODOO_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.ODOO_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._ODOO_PROD_PROMOTION_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_prod_promotion,
                 *(
                     descriptor
                     for descriptor in registry._DESCRIPTORS

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -30624,6 +30624,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             execute_mock.assert_called_once()
+            run_call = execute_mock.call_args.kwargs
+            self.assertEqual(run_call["control_plane_root"], root)
+            self.assertEqual(run_call["state_dir"], root / "state")
+            self.assertIsNone(run_call["database_url"])
+            self.assertEqual(run_call["request"].context, "cm")
+            self.assertEqual(run_call["request"].request_id, "run-123-attempt-1")
 
     def test_odoo_prod_promotion_run_allows_reusable_launchplane_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -30705,6 +30711,93 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 202)
             self.assertEqual(payload["status"], "accepted")
             self.assertEqual(payload["result"]["run_status"], "pass")
+
+    def test_odoo_prod_promotion_run_driver_replays_idempotent_response(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/odoo-prod-promotion.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_prod_promotion_run.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/odoo-prod-promotion.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo",
+                "run": {
+                    "context": "cm",
+                    "request_id": "run-123-attempt-1",
+                },
+            }
+
+            with patch(
+                "control_plane.service.execute_odoo_prod_promotion_run",
+                return_value=OdooProdPromotionRunResult(
+                    context="cm",
+                    from_instance="testing",
+                    to_instance="prod",
+                    request_id="run-123-attempt-1",
+                    run_status="pass",
+                    input_status="ready",
+                    backup_status="pass",
+                    promotion_status="pass",
+                    deployment_status="pass",
+                    post_deploy_status="pass",
+                    destination_health_status="pass",
+                    artifact_id="artifact-cm-new",
+                    source_git_ref="848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                    backup_record_id="backup-gate-cm-prod-run-123-attempt-1",
+                    promotion_record_id="promotion-cm-testing-to-prod",
+                    deployment_record_id="deployment-cm-prod",
+                    release_tuple_id="cm-prod-artifact-cm-new",
+                    image_repository="ghcr.io/cbusillo/odoo-tenant-cm",
+                    image_digest="sha256:new",
+                ),
+            ) as execute_mock:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/prod-promotion-run",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "odoo-prod-promotion-run-cm"},
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/prod-promotion-run",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "odoo-prod-promotion-run-cm"},
+                )
+
+            self.assertEqual(first_status_code, 202)
+            self.assertEqual(second_status_code, 202)
+            self.assertEqual(first_payload["records"], second_payload["records"])
+            self.assertEqual(first_payload["result"], second_payload["result"])
+            self.assertTrue(second_payload["replayed"])
+            execute_mock.assert_called_once()
 
     def test_odoo_prod_promotion_run_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -30839,7 +30932,97 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(payload["result"]["promotion_status"], "pass")
             self.assertEqual(payload["result"]["destination_health_status"], "pass")
             execute_mock.assert_called_once()
-            self.assertIn("database_url", execute_mock.call_args.kwargs)
+            promotion_call = execute_mock.call_args.kwargs
+            self.assertEqual(promotion_call["control_plane_root"], root)
+            self.assertEqual(promotion_call["state_dir"], root / "state")
+            self.assertIsNone(promotion_call["database_url"])
+            self.assertEqual(promotion_call["request"].context, "cm")
+            self.assertEqual(promotion_call["request"].from_instance, "testing")
+            self.assertEqual(promotion_call["request"].to_instance, "prod")
+
+    def test_odoo_prod_promotion_driver_replays_idempotent_response(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo",
+                "promotion": {
+                    "context": "cm",
+                    "from_instance": "testing",
+                    "to_instance": "prod",
+                    "artifact_id": "artifact-cm-new",
+                    "backup_record_id": "backup-gate-cm-prod-run-1",
+                    "source_git_ref": "848bf1b69ff3adbe9b255c61c7b8f5ca04efbcbb",
+                },
+            }
+
+            with patch(
+                "control_plane.service.execute_odoo_prod_promotion",
+                return_value=OdooProdPromotionResult(
+                    context="cm",
+                    from_instance="testing",
+                    to_instance="prod",
+                    artifact_id="artifact-cm-new",
+                    backup_record_id="backup-gate-cm-prod-run-1",
+                    promotion_record_id="promotion-cm-testing-to-prod",
+                    deployment_record_id="deployment-cm-prod",
+                    release_tuple_id="cm-prod-artifact-cm-new",
+                    promotion_status="pass",
+                    deployment_status="pass",
+                    post_deploy_status="pass",
+                    destination_health_status="pass",
+                ),
+            ) as execute_mock:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/prod-promotion",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "odoo-prod-promotion-cm"},
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/prod-promotion",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "odoo-prod-promotion-cm"},
+                )
+
+            self.assertEqual(first_status_code, 202)
+            self.assertEqual(second_status_code, 202)
+            self.assertEqual(first_payload["records"], second_payload["records"])
+            self.assertEqual(first_payload["result"], second_payload["result"])
+            self.assertTrue(second_payload["replayed"])
+            execute_mock.assert_called_once()
 
     def test_odoo_prod_promotion_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- Move Odoo prod promotion run and direct prod promotion routes into descriptor-backed dispatch
- Pass state_dir and database_url through custom descriptor dispatch handlers
- Add descriptor registration/fail-closed tests and idempotency replay coverage for both migrated routes
- Update descriptor dispatch docs inventory

## Verification
- uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_descriptor_dispatch_registration_requires_exactly_one_handler tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_routes_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_low_risk_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_prod_promotion_run_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_prod_promotion_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_artifact_execution_metadata_matches_descriptors tests.test_service.LaunchplaneServiceTests.test_verireel_prod_promotion_route_accepts_product_profile_driver_id tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_allows_reusable_launchplane_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_driver_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_driver_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_driver_rejects_unauthorized_workflow
- uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests

## Review
- Fresh non-Claude reviews completed with code-gpt-5.5, code-gpt-5.4-mini, and Antigravity. One misplaced test assertion was found and fixed; follow-up replay coverage was added.