### PR TITLE
Migrate Odoo stable bootstrap dispatch

### DIFF
--- a/control_plane/contracts/odoo_stable_bootstrap_operation.py
+++ b/control_plane/contracts/odoo_stable_bootstrap_operation.py
@@ -25,9 +25,9 @@ _TERMINAL_OPERATION_STATUSES: tuple[OdooStableBootstrapOperationStatus, ...] = (
     "pass",
     "fail",
 )
-ODOO_STABLE_BOOTSTRAP_TERMINAL_OPERATION_STATUSES: frozenset[
-    OdooStableBootstrapOperationStatus
-] = frozenset(_TERMINAL_OPERATION_STATUSES)
+ODOO_STABLE_BOOTSTRAP_TERMINAL_OPERATION_STATUSES: frozenset[OdooStableBootstrapOperationStatus] = (
+    frozenset(_TERMINAL_OPERATION_STATUSES)
+)
 
 
 class OdooStableBootstrapOperationRecord(BaseModel):
@@ -95,19 +95,22 @@ class OdooStableBootstrapOperationRecord(BaseModel):
             if not self.finished_at:
                 raise ValueError("Terminal Odoo stable bootstrap operations require finished_at.")
             if self.status == "pass" and self.error_message:
-                raise ValueError("Passing Odoo stable bootstrap operations must not include error_message.")
+                raise ValueError(
+                    "Passing Odoo stable bootstrap operations must not include error_message."
+                )
             if self.status == "fail" and not self.error_message:
                 raise ValueError("Failed Odoo stable bootstrap operations require error_message.")
         return self
 
 
 def build_odoo_stable_bootstrap_operation_id(
-    *, product: str, context: str, instance: str, created_at: str
+    *, product: str, context: str, instance: str, created_at: str, idempotency_key: str
 ) -> str:
     normalized_product = product.strip().lower().replace("/", "-")
     normalized_context = context.strip().lower()
     normalized_instance = instance.strip().lower()
     normalized_created_at = created_at.strip().replace(":", "").replace("+", "z")
+    normalized_idempotency_key = idempotency_key.strip()
     digest = hashlib.sha256(
         "|".join(
             (
@@ -115,6 +118,7 @@ def build_odoo_stable_bootstrap_operation_id(
                 normalized_context,
                 normalized_instance,
                 normalized_created_at,
+                normalized_idempotency_key,
             )
         ).encode("utf-8")
     ).hexdigest()[:16]

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -744,6 +744,10 @@ class _OdooStableBootstrapOperationStore(Protocol):
         self, record: OdooStableBootstrapOperationRecord
     ) -> object: ...
 
+    def create_odoo_stable_bootstrap_operation_record_if_no_active_lane(
+        self, record: OdooStableBootstrapOperationRecord
+    ) -> tuple[OdooStableBootstrapOperationRecord, bool]: ...
+
     def read_odoo_stable_bootstrap_operation_record(
         self, operation_id: str
     ) -> OdooStableBootstrapOperationRecord: ...
@@ -817,6 +821,7 @@ class _DescriptorDriverDispatchContext:
     context: str
     authorization_context: str = ""
     use_preview_context_for_authorization: bool = False
+    use_resolved_profile_product_for_authorization: bool = True
     instance: str = ""
     require_profile: bool = False
 
@@ -3239,6 +3244,127 @@ def _dispatch_odoo_target_replacement_apply(
     return result, driver_result
 
 
+def _dispatch_odoo_stable_bootstrap(
+    request: OdooStableBootstrapEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+    state_dir: Path,
+    database_url: str | None,
+    identity: LaunchplaneIdentity,
+    request_scope: str,
+    request_idempotency_key: str,
+    request_fingerprint: str,
+    start_response: _StartResponse,
+    trace_id: str,
+) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
+    del resolved_context, state_dir, database_url, identity, request_scope
+    if not request_idempotency_key:
+        return _json_response(
+            start_response=start_response,
+            status_code=400,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "idempotency_key_required",
+                    "message": "Odoo stable bootstrap operations require an Idempotency-Key header.",
+                },
+            },
+        )
+
+    operation_store = _odoo_stable_bootstrap_operation_store(record_store)
+    existing_operation = _find_odoo_stable_bootstrap_operation_by_idempotency_key(
+        operation_store=operation_store,
+        product=request.product,
+        context=request.bootstrap.context,
+        instance=request.bootstrap.instance,
+        idempotency_key=request_idempotency_key,
+    )
+    if existing_operation is not None:
+        if existing_operation.request_fingerprint != request_fingerprint:
+            return _json_response(
+                start_response=start_response,
+                status_code=409,
+                payload={
+                    "status": "rejected",
+                    "trace_id": trace_id,
+                    "error": {
+                        "code": "idempotency_key_reused",
+                        "message": "Idempotency-Key was already used for a different Odoo stable bootstrap request.",
+                    },
+                },
+            )
+        driver_result = _operation_payload(existing_operation)
+        result: dict[str, object] = {
+            "odoo_stable_bootstrap_operation_id": existing_operation.operation_id,
+            **(
+                {"deployment_record_id": existing_operation.deployment_record_id}
+                if existing_operation.deployment_record_id
+                else {}
+            ),
+        }
+        return result, driver_result
+
+    operation = _build_odoo_stable_bootstrap_operation_record(
+        bootstrap_request=request.bootstrap,
+        idempotency_key=request_idempotency_key,
+        request_fingerprint=request_fingerprint,
+        created_at=_utc_now_timestamp(),
+    )
+    operation, created_operation = (
+        operation_store.create_odoo_stable_bootstrap_operation_record_if_no_active_lane(operation)
+    )
+    if not created_operation:
+        if operation.idempotency_key == request_idempotency_key:
+            if operation.request_fingerprint != request_fingerprint:
+                return _json_response(
+                    start_response=start_response,
+                    status_code=409,
+                    payload={
+                        "status": "rejected",
+                        "trace_id": trace_id,
+                        "error": {
+                            "code": "idempotency_key_reused",
+                            "message": "Idempotency-Key was already used for a different Odoo stable bootstrap request.",
+                        },
+                    },
+                )
+            driver_result = _operation_payload(operation)
+            result = {
+                "odoo_stable_bootstrap_operation_id": operation.operation_id,
+                **(
+                    {"deployment_record_id": operation.deployment_record_id}
+                    if operation.deployment_record_id
+                    else {}
+                ),
+            }
+            return result, driver_result
+        return _json_response(
+            start_response=start_response,
+            status_code=409,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "odoo_stable_bootstrap_operation_active",
+                    "message": "An Odoo stable bootstrap operation is already active for this product/context/instance.",
+                },
+                "operation": _operation_payload(operation),
+            },
+        )
+
+    _start_odoo_stable_bootstrap_operation_worker(
+        operation_id=operation.operation_id,
+        control_plane_root_path=control_plane_root_path,
+        record_store=record_store,
+        trace_id=trace_id,
+    )
+    driver_result = _operation_payload(operation)
+    result = {"odoo_stable_bootstrap_operation_id": operation.operation_id}
+    return result, driver_result
+
+
 def _handle_odoo_post_deploy(
     request: OdooPostDeployEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -3877,6 +4003,17 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_odoo_website_bootstrap_override,
         ),
+        _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path: _DescriptorDriverDispatchRoute(
+            execution_metadata=_ODOO_STABLE_BOOTSTRAP_ROUTE,
+            context_resolver=lambda request: _DescriptorDriverDispatchContext(
+                product=request.product,
+                context=request.bootstrap.context,
+                instance=request.bootstrap.instance,
+                authorization_context=request.bootstrap.context,
+                use_resolved_profile_product_for_authorization=False,
+            ),
+            custom_dispatch_handler=_dispatch_odoo_stable_bootstrap,
+        ),
         _ODOO_PREVIEW_APPLY_INPUTS_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -4042,6 +4179,7 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _ODOO_POST_DEPLOY_ROUTE.route_path,
             _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path,
             _ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path,
+            _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path,
             _ODOO_PREVIEW_APPLY_INPUTS_ROUTE.route_path,
             _ODOO_PREVIEW_APPLY_ROUTE.route_path,
             _VERIREEL_PREVIEW_VERIFICATION_ROUTE.route_path,
@@ -4118,7 +4256,10 @@ def _dispatch_descriptor_driver_route(
         if pre_authorization_response is not None:
             return pre_authorization_response
     authorization_product = dispatch_context.product
-    if resolved_driver_context.profile is not None:
+    if (
+        dispatch_context.use_resolved_profile_product_for_authorization
+        and resolved_driver_context.profile is not None
+    ):
         authorization_product = resolved_driver_context.profile.product
     authorization_context = dispatch_context.authorization_context or dispatch_context.context
     if not authorization_context and resolved_driver_context.lane is not None:
@@ -6684,6 +6825,7 @@ def _odoo_stable_bootstrap_operation_store(
 ) -> _OdooStableBootstrapOperationStore:
     required_methods = (
         "write_odoo_stable_bootstrap_operation_record",
+        "create_odoo_stable_bootstrap_operation_record_if_no_active_lane",
         "read_odoo_stable_bootstrap_operation_record",
         "list_odoo_stable_bootstrap_operation_records",
     )
@@ -6781,27 +6923,16 @@ def _filter_ingress_route_audit_records(
 def _find_odoo_stable_bootstrap_operation_by_idempotency_key(
     *,
     operation_store: _OdooStableBootstrapOperationStore,
-    idempotency_key: str,
-) -> OdooStableBootstrapOperationRecord | None:
-    records = operation_store.list_odoo_stable_bootstrap_operation_records(
-        idempotency_key=idempotency_key,
-        limit=1,
-    )
-    return records[0] if records else None
-
-
-def _find_active_odoo_stable_bootstrap_operation(
-    *,
-    operation_store: _OdooStableBootstrapOperationStore,
     product: str,
     context: str,
     instance: str,
+    idempotency_key: str,
 ) -> OdooStableBootstrapOperationRecord | None:
     records = operation_store.list_odoo_stable_bootstrap_operation_records(
         product=product,
         context_name=context,
         instance_name=instance,
-        statuses=("pending", "running"),
+        idempotency_key=idempotency_key,
         limit=1,
     )
     return records[0] if records else None
@@ -6834,6 +6965,7 @@ def _build_odoo_stable_bootstrap_operation_record(
             context=bootstrap_request.context,
             instance=bootstrap_request.instance,
             created_at=created_at,
+            idempotency_key=idempotency_key,
         ),
         product=bootstrap_request.product,
         context=bootstrap_request.context,
@@ -14440,101 +14572,6 @@ def create_launchplane_service_app(
                     profile=profile,
                 )
                 result = {}
-            elif path == _ODOO_STABLE_BOOTSTRAP_ROUTE.route_path:
-                odoo_bootstrap_request = _ODOO_STABLE_BOOTSTRAP_ROUTE.envelope_model.model_validate(
-                    payload
-                )
-                _, authorization_response = _resolve_and_authorize_descriptor_route(
-                    route_metadata=_ODOO_STABLE_BOOTSTRAP_ROUTE,
-                    record_store=record_store,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    product=odoo_bootstrap_request.product,
-                    authorization_context=odoo_bootstrap_request.bootstrap.context,
-                    descriptor_context=odoo_bootstrap_request.bootstrap.context,
-                    descriptor_instance=odoo_bootstrap_request.bootstrap.instance,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if authorization_response is not None:
-                    return authorization_response
-                if not request_idempotency_key:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "idempotency_key_required",
-                                "message": "Odoo stable bootstrap operations require an Idempotency-Key header.",
-                            },
-                        },
-                    )
-                operation_store = _odoo_stable_bootstrap_operation_store(record_store)
-                existing_operation = _find_odoo_stable_bootstrap_operation_by_idempotency_key(
-                    operation_store=operation_store,
-                    idempotency_key=request_idempotency_key,
-                )
-                if existing_operation is not None:
-                    if existing_operation.request_fingerprint != request_fingerprint:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=409,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "idempotency_key_reused",
-                                    "message": "Idempotency-Key was already used for a different Odoo stable bootstrap request.",
-                                },
-                            },
-                        )
-                    driver_result = _operation_payload(existing_operation)
-                    result = {
-                        "odoo_stable_bootstrap_operation_id": existing_operation.operation_id,
-                        **(
-                            {"deployment_record_id": existing_operation.deployment_record_id}
-                            if existing_operation.deployment_record_id
-                            else {}
-                        ),
-                    }
-                else:
-                    active_operation = _find_active_odoo_stable_bootstrap_operation(
-                        operation_store=operation_store,
-                        product=odoo_bootstrap_request.product,
-                        context=odoo_bootstrap_request.bootstrap.context,
-                        instance=odoo_bootstrap_request.bootstrap.instance,
-                    )
-                    if active_operation is not None:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=409,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "odoo_stable_bootstrap_operation_active",
-                                    "message": "An Odoo stable bootstrap operation is already active for this product/context/instance.",
-                                },
-                                "operation": _operation_payload(active_operation),
-                            },
-                        )
-                    operation = _build_odoo_stable_bootstrap_operation_record(
-                        bootstrap_request=odoo_bootstrap_request.bootstrap,
-                        idempotency_key=request_idempotency_key,
-                        request_fingerprint=request_fingerprint,
-                        created_at=_utc_now_timestamp(),
-                    )
-                    operation_store.write_odoo_stable_bootstrap_operation_record(operation)
-                    _start_odoo_stable_bootstrap_operation_worker(
-                        operation_id=operation.operation_id,
-                        control_plane_root_path=resolved_root,
-                        record_store=record_store,
-                        trace_id=request_trace_id,
-                    )
-                    driver_result = _operation_payload(operation)
-                    result = {"odoo_stable_bootstrap_operation_id": operation.operation_id}
             elif path == "/v1/product-profiles/context-cutover/apply":
                 context_cutover_request = control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(
                     payload

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -66,6 +66,8 @@ RecordModel = TypeVar("RecordModel", bound=BaseModel)
 
 
 class FilesystemRecordStore:
+    odoo_stable_bootstrap_reservation_settle_timeout_seconds = 30.0
+    odoo_stable_bootstrap_reservation_poll_seconds = 0.01
     odoo_target_replacement_reservation_settle_timeout_seconds = 30.0
     odoo_target_replacement_reservation_poll_seconds = 0.01
 
@@ -787,6 +789,43 @@ class FilesystemRecordStore:
     ) -> Path:
         return self._write_model("odoo_stable_bootstrap_operations", record.operation_id, record)
 
+    def create_odoo_stable_bootstrap_operation_record_if_no_active_lane(
+        self, record: OdooStableBootstrapOperationRecord
+    ) -> tuple[OdooStableBootstrapOperationRecord, bool]:
+        reservation_id = _odoo_stable_bootstrap_lane_reservation_id(record)
+        reservation_path = self._record_path(
+            "odoo_stable_bootstrap_lane_reservations", reservation_id
+        )
+        reservation_path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            with reservation_path.open("x", encoding="utf-8") as reservation_file:
+                reservation_file.write(record.operation_id)
+                reservation_file.flush()
+                os.fsync(reservation_file.fileno())
+        except FileExistsError:
+            stale_reservation_deadline = (
+                time.monotonic() + self.odoo_stable_bootstrap_reservation_settle_timeout_seconds
+            )
+            reserved_operation_id = self._wait_for_odoo_stable_bootstrap_reservation_owner(
+                reservation_path, stale_reservation_deadline
+            )
+            if reserved_operation_id:
+                owner_record_deadline = (
+                    time.monotonic() + self.odoo_stable_bootstrap_reservation_settle_timeout_seconds
+                )
+                reserved_operation = self._wait_for_odoo_stable_bootstrap_reserved_operation(
+                    reserved_operation_id, owner_record_deadline
+                )
+                if reserved_operation is not None and reserved_operation.status in {
+                    "pending",
+                    "running",
+                }:
+                    return reserved_operation, False
+            reservation_path.unlink(missing_ok=True)
+            return self.create_odoo_stable_bootstrap_operation_record_if_no_active_lane(record)
+        self.write_odoo_stable_bootstrap_operation_record(record)
+        return record, True
+
     def read_odoo_stable_bootstrap_operation_record(
         self, operation_id: str
     ) -> OdooStableBootstrapOperationRecord:
@@ -824,6 +863,33 @@ class FilesystemRecordStore:
         if limit is not None:
             records = records[:limit]
         return tuple(records)
+
+    def _wait_for_odoo_stable_bootstrap_reservation_owner(
+        self,
+        reservation_path: Path,
+        deadline: float,
+    ) -> str:
+        while True:
+            try:
+                reserved_operation_id = reservation_path.read_text(encoding="utf-8").strip()
+            except FileNotFoundError:
+                return ""
+            if reserved_operation_id:
+                return reserved_operation_id
+            if time.monotonic() >= deadline:
+                return ""
+            time.sleep(self.odoo_stable_bootstrap_reservation_poll_seconds)
+
+    def _wait_for_odoo_stable_bootstrap_reserved_operation(
+        self, operation_id: str, deadline: float
+    ) -> OdooStableBootstrapOperationRecord | None:
+        while True:
+            try:
+                return self.read_odoo_stable_bootstrap_operation_record(operation_id)
+            except (FileNotFoundError, JSONDecodeError):
+                if time.monotonic() >= deadline:
+                    return None
+                time.sleep(self.odoo_stable_bootstrap_reservation_poll_seconds)
 
     def write_odoo_stable_target_replacement_operation_record(
         self, record: OdooStableTargetReplacementOperationRecord
@@ -1296,6 +1362,14 @@ class FilesystemRecordStore:
 
 def _odoo_target_replacement_lane_reservation_id(
     record: OdooStableTargetReplacementOperationRecord,
+) -> str:
+    lane_key = "|".join((record.product, record.context, record.instance))
+    digest = hashlib.sha256(lane_key.encode()).hexdigest()[:16]
+    return f"{record.product}-{record.context}-{record.instance}".replace("/", "-") + f"-{digest}"
+
+
+def _odoo_stable_bootstrap_lane_reservation_id(
+    record: OdooStableBootstrapOperationRecord,
 ) -> str:
     lane_key = "|".join((record.product, record.context, record.instance))
     digest = hashlib.sha256(lane_key.encode()).hexdigest()[:16]

--- a/control_plane/storage/migrations/versions/c5e7f9a1b3d5_add_odoo_bootstrap_active_lane_index.py
+++ b/control_plane/storage/migrations/versions/c5e7f9a1b3d5_add_odoo_bootstrap_active_lane_index.py
@@ -1,0 +1,44 @@
+"""add Odoo bootstrap active lane reservation index
+
+Revision ID: c5e7f9a1b3d5
+Revises: b2d4f6a8c0e1
+Create Date: 2026-06-06 00:35:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "c5e7f9a1b3d5"
+down_revision: str | None = "b2d4f6a8c0e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_odoo_stable_bootstrap_operations"
+_ACTIVE_LANE_INDEX = "launchplane_odoo_bootstrap_active_lane_uidx"
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _index_exists(_TABLE, _ACTIVE_LANE_INDEX):
+        op.create_index(
+            _ACTIVE_LANE_INDEX,
+            _TABLE,
+            ["product", "context", "instance"],
+            unique=True,
+            postgresql_where=sa.text("status IN ('pending', 'running')"),
+            sqlite_where=sa.text("status IN ('pending', 'running')"),
+        )
+
+
+def downgrade() -> None:
+    if _index_exists(_TABLE, _ACTIVE_LANE_INDEX):
+        op.drop_index(_ACTIVE_LANE_INDEX, table_name=_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -993,6 +993,15 @@ class LaunchplaneOdooStableBootstrapOperationRow(Base):
             "idempotency_key",
             desc("updated_at"),
         ),
+        Index(
+            "launchplane_odoo_bootstrap_active_lane_uidx",
+            "product",
+            "context",
+            "instance",
+            unique=True,
+            postgresql_where=text("status IN ('pending', 'running')"),
+            sqlite_where=text("status IN ('pending', 'running')"),
+        ),
     )
 
     operation_id: Mapped[str] = mapped_column(String, primary_key=True)
@@ -1464,6 +1473,40 @@ class PostgresRecordStore(HumanSessionStore):
                 payload=self._payload_dict(record),
             )
         )
+
+    def create_odoo_stable_bootstrap_operation_record_if_no_active_lane(
+        self, record: OdooStableBootstrapOperationRecord
+    ) -> tuple[OdooStableBootstrapOperationRecord, bool]:
+        with self._session_factory() as session:
+            session.add(
+                LaunchplaneOdooStableBootstrapOperationRow(
+                    operation_id=record.operation_id,
+                    product=record.product,
+                    context=record.context,
+                    instance=record.instance,
+                    idempotency_key=record.idempotency_key,
+                    status=record.status,
+                    phase=record.phase,
+                    created_at=record.created_at,
+                    updated_at=record.updated_at,
+                    payload=self._payload_dict(record),
+                )
+            )
+            try:
+                session.commit()
+            except IntegrityError:
+                session.rollback()
+                active_records = self.list_odoo_stable_bootstrap_operation_records(
+                    product=record.product,
+                    context_name=record.context,
+                    instance_name=record.instance,
+                    statuses=("pending", "running"),
+                    limit=1,
+                )
+                if active_records:
+                    return active_records[0], False
+                return self.create_odoo_stable_bootstrap_operation_record_if_no_active_lane(record)
+        return record, True
 
     def read_odoo_stable_bootstrap_operation_record(
         self, operation_id: str

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -359,13 +359,15 @@ The POST route returns a durable operation record instead of holding the request
 open for the whole bootstrap. Callers poll
 `/v1/drivers/odoo/stable-bootstrap/operations/{operation_id}` and treat terminal
 `pass`/`fail` as the source of truth for workflow exit status and artifacts.
+Stable-bootstrap replay is scoped by the product/context/instance lane, operation
+`Idempotency-Key`, and request fingerprint.
 Odoo target replacement apply uses the same durable operation shape for the
 guarded `recreate-in-place` path: `POST /v1/drivers/odoo/target-replacement-apply`
 creates or replays an operation, and callers poll
 `/v1/drivers/odoo/target-replacement/operations/{operation_id}` until terminal.
-Replay is scoped to the authenticated caller identity, and storage reserves the
-product/context/instance lane before the worker starts so concurrent apply
-requests cannot launch duplicate replacements.
+Target-replacement replay is scoped to the authenticated caller identity, and
+storage reserves the product/context/instance lane before the worker starts so
+concurrent apply requests cannot launch duplicate replacements.
 
 Driver action routes are owned by the base driver contract. The service accepts
 any product key on Odoo and VeriReel action envelopes, then authorizes the call
@@ -431,9 +433,9 @@ rollback planning, rollback apply, preview verification, Odoo artifact publish
 inputs and evidence ingestion, Odoo prod promotion input reads, Odoo prod backup
 gate, prod promotion run, direct prod promotion, prod rollback, target
 replacement planning, target replacement apply, post-deploy, config/website
-override hooks, Odoo preview apply and inputs, and the VeriReel testing and prod
-deploys, prod backup gate, prod promotion, prod rollback, app maintenance,
-preview refresh, preview inventory reads, preview
+override hooks, stable bootstrap, Odoo preview apply and inputs, and the VeriReel
+testing and prod deploys, prod backup gate, prod promotion, prod rollback, app
+maintenance, preview refresh, preview inventory reads, preview
 destroy, plus testing and preview verification use descriptor-backed dispatch.
 This keeps
 descriptor metadata as the route/authz source of truth while preventing an

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -585,7 +585,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
-    def test_odoo_low_risk_routes_registered_in_descriptor_dispatch(self) -> None:
+    def test_odoo_routes_registered_in_descriptor_dispatch(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
         self.assertIn(
@@ -633,6 +633,27 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             control_plane_service._ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path,
             dispatch_routes,
         )
+        self.assertIn(
+            control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.route_path,
+            dispatch_routes,
+        )
+        stable_bootstrap_route = dispatch_routes[
+            control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.route_path
+        ]
+        stable_bootstrap_context = stable_bootstrap_route.context_resolver(
+            control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.envelope_model.model_validate(
+                {
+                    "product": "odoo-tenant-cm",
+                    "bootstrap": {
+                        "product": "odoo-tenant-cm",
+                        "context": "cm",
+                        "instance": "testing",
+                        "confirmation": "bootstrap cm testing",
+                    },
+                }
+            )
+        )
+        self.assertFalse(stable_bootstrap_context.use_resolved_profile_product_for_authorization)
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_odoo_preview_apply_inputs_registered_in_descriptor_dispatch(self) -> None:
@@ -1364,7 +1385,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
-    def test_odoo_low_risk_descriptor_requires_dispatch_registration(self) -> None:
+    def test_odoo_descriptor_requires_dispatch_registration(self) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
         dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE.route_path)
@@ -1378,6 +1399,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes.pop(control_plane_service._ODOO_POST_DEPLOY_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._ODOO_WEBSITE_BOOTSTRAP_OVERRIDE_ROUTE.route_path)
+        dispatch_routes.pop(control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.route_path)
 
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
@@ -1462,6 +1484,36 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "_DESCRIPTORS",
             (
                 descriptor_without_prod_promotion,
+                *(
+                    descriptor
+                    for descriptor in registry._DESCRIPTORS
+                    if descriptor.driver_id != "odoo"
+                ),
+            ),
+        ):
+            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
+                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_odoo_stable_bootstrap_dispatch_registration_requires_descriptor_route(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        descriptor_without_stable_bootstrap = registry.ODOO_DRIVER.model_copy(
+            update={
+                "actions": tuple(
+                    action
+                    for action in registry.ODOO_DRIVER.actions
+                    if action.route_path
+                    != control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.route_path
+                )
+            }
+        )
+
+        with patch.object(
+            registry,
+            "_DESCRIPTORS",
+            (
+                descriptor_without_stable_bootstrap,
                 *(
                     descriptor
                     for descriptor in registry._DESCRIPTORS

--- a/tests/test_odoo_stable_bootstrap_operation.py
+++ b/tests/test_odoo_stable_bootstrap_operation.py
@@ -1,4 +1,5 @@
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -47,16 +48,36 @@ class OdooStableBootstrapOperationRecordTests(unittest.TestCase):
             context="cm",
             instance="testing",
             created_at="2026-05-17T00:00:00Z",
+            idempotency_key="bootstrap-cm-testing",
         )
         second = build_odoo_stable_bootstrap_operation_id(
             product="odoo-tenant-cm",
             context="cm",
             instance="testing",
             created_at="2026-05-17T00:00:00Z",
+            idempotency_key="bootstrap-cm-testing",
         )
 
         self.assertEqual(first, second)
         self.assertTrue(first.startswith("odoo-stable-bootstrap-cm-testing-"))
+
+    def test_operation_id_distinguishes_same_second_idempotency_keys(self) -> None:
+        first = build_odoo_stable_bootstrap_operation_id(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            created_at="2026-05-17T00:00:00Z",
+            idempotency_key="bootstrap-cm-testing-a",
+        )
+        second = build_odoo_stable_bootstrap_operation_id(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            created_at="2026-05-17T00:00:00Z",
+            idempotency_key="bootstrap-cm-testing-b",
+        )
+
+        self.assertNotEqual(first, second)
 
     def test_filesystem_store_filters_operations(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -85,7 +106,44 @@ class OdooStableBootstrapOperationRecordTests(unittest.TestCase):
             )
 
             self.assertEqual(loaded.operation_id, active.operation_id)
-            self.assertEqual(tuple(record.operation_id for record in active_records), (active.operation_id,))
+            self.assertEqual(
+                tuple(record.operation_id for record in active_records), (active.operation_id,)
+            )
+
+    def test_filesystem_store_reserves_active_lane_atomically(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            records = [
+                OdooStableBootstrapOperationRecord.model_validate(
+                    {
+                        **_operation_payload(f"operation-cm-testing-{index}"),
+                        "idempotency_key": f"bootstrap-cm-testing-{index}",
+                    }
+                )
+                for index in range(2)
+            ]
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = tuple(
+                    executor.map(
+                        store.create_odoo_stable_bootstrap_operation_record_if_no_active_lane,
+                        records,
+                    )
+                )
+
+            created_results = tuple(created for _, created in results)
+            returned_ids = {record.operation_id for record, _ in results}
+            active_records = store.list_odoo_stable_bootstrap_operation_records(
+                product="odoo-tenant-cm",
+                context_name="cm",
+                instance_name="testing",
+                statuses=("pending", "running"),
+            )
+
+            self.assertEqual(created_results.count(True), 1)
+            self.assertEqual(created_results.count(False), 1)
+            self.assertEqual(len(returned_ids), 1)
+            self.assertEqual(len(active_records), 1)
 
     def test_postgres_store_round_trips_operation(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -103,7 +161,35 @@ class OdooStableBootstrapOperationRecordTests(unittest.TestCase):
             )
 
             self.assertEqual(loaded.operation_id, record.operation_id)
-            self.assertEqual(tuple(item.operation_id for item in active_records), (record.operation_id,))
+            self.assertEqual(
+                tuple(item.operation_id for item in active_records), (record.operation_id,)
+            )
+
+    def test_postgres_store_reserves_active_lane(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=f"sqlite:///{database_path}")
+            store.ensure_schema()
+            first = OdooStableBootstrapOperationRecord.model_validate(
+                _operation_payload("operation-cm-testing-a")
+            )
+            second = OdooStableBootstrapOperationRecord.model_validate(
+                {
+                    **_operation_payload("operation-cm-testing-b"),
+                    "idempotency_key": "bootstrap-cm-testing-b",
+                }
+            )
+
+            created_first = store.create_odoo_stable_bootstrap_operation_record_if_no_active_lane(
+                first
+            )
+            created_second = store.create_odoo_stable_bootstrap_operation_record_if_no_active_lane(
+                second
+            )
+
+            self.assertTrue(created_first[1])
+            self.assertFalse(created_second[1])
+            self.assertEqual(created_first[0].operation_id, created_second[0].operation_id)
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -28536,7 +28536,267 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 first_payload["records"]["odoo_stable_bootstrap_operation_id"],
                 second_payload["records"]["odoo_stable_bootstrap_operation_id"],
             )
+            self.assertEqual(first_payload["records"], second_payload["records"])
+            self.assertEqual(first_payload["result"], second_payload["result"])
             worker_mock.assert_called_once()
+
+    def test_odoo_stable_bootstrap_dispatch_replays_same_key_reservation_collision(
+        self,
+    ) -> None:
+        class SameKeyReservationStore:
+            def __init__(self, operation: OdooStableBootstrapOperationRecord) -> None:
+                self.operation = operation
+
+            def write_odoo_stable_bootstrap_operation_record(
+                self, record: OdooStableBootstrapOperationRecord
+            ) -> object:
+                self.operation = record
+                return None
+
+            def create_odoo_stable_bootstrap_operation_record_if_no_active_lane(
+                self, record: OdooStableBootstrapOperationRecord
+            ) -> tuple[OdooStableBootstrapOperationRecord, bool]:
+                return self.operation, False
+
+            def read_odoo_stable_bootstrap_operation_record(
+                self, operation_id: str
+            ) -> OdooStableBootstrapOperationRecord:
+                if operation_id != self.operation.operation_id:
+                    raise FileNotFoundError(operation_id)
+                return self.operation
+
+            def list_odoo_stable_bootstrap_operation_records(
+                self,
+                *,
+                product: str = "",
+                context_name: str = "",
+                instance_name: str = "",
+                idempotency_key: str = "",
+                statuses: tuple[str, ...] = (),
+                limit: int | None = None,
+            ) -> tuple[OdooStableBootstrapOperationRecord, ...]:
+                del product, context_name, instance_name, idempotency_key, statuses, limit
+                return ()
+
+        request = control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE.envelope_model.model_validate(
+            {
+                "product": "odoo-tenant-cm",
+                "bootstrap": {
+                    "product": "odoo-tenant-cm",
+                    "context": "cm",
+                    "instance": "testing",
+                    "confirmation": "bootstrap cm testing",
+                },
+            }
+        )
+        request_fingerprint = control_plane_service._request_fingerprint(
+            request.model_dump(mode="json")
+        )
+        operation = control_plane_service._build_odoo_stable_bootstrap_operation_record(
+            bootstrap_request=request.bootstrap,
+            idempotency_key="bootstrap-cm-testing",
+            request_fingerprint=request_fingerprint,
+            created_at="2026-05-17T00:00:00Z",
+        )
+        start_response_calls: list[tuple[str, list[tuple[str, str]]]] = []
+
+        result = control_plane_service._dispatch_odoo_stable_bootstrap(
+            request,
+            control_plane_service._ResolvedProductDriverContext(profile=None),
+            SameKeyReservationStore(operation),
+            Path("/tmp/launchplane-test-root"),
+            Path("/tmp/launchplane-test-state"),
+            None,
+            _identity(),
+            "github-actions|cbusillo/launchplane|workflow|subject",
+            "bootstrap-cm-testing",
+            request_fingerprint,
+            lambda status, headers: start_response_calls.append((status, headers)),
+            "trace-race",
+        )
+
+        if isinstance(result, list):
+            self.fail("Expected stable bootstrap dispatch to replay the operation.")
+        records, driver_result = result
+        if driver_result is None or isinstance(driver_result, BaseModel):
+            self.fail("Expected stable bootstrap dispatch to return an operation payload.")
+        self.assertIsInstance(driver_result, dict)
+        self.assertEqual(records["odoo_stable_bootstrap_operation_id"], operation.operation_id)
+        self.assertEqual(driver_result["operation_id"], operation.operation_id)
+        self.assertEqual(start_response_calls, [])
+
+    def test_odoo_stable_bootstrap_driver_rejects_reused_idempotency_key_for_different_payload(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_stable_bootstrap.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "product": "odoo-tenant-cm",
+                "bootstrap": {
+                    "product": "odoo-tenant-cm",
+                    "context": "cm",
+                    "instance": "testing",
+                    "confirmation": "bootstrap cm testing",
+                    "verify_health": True,
+                    "verify_canonical": True,
+                    "verify_logo": True,
+                },
+            }
+            changed_request_payload = {
+                "product": "odoo-tenant-cm",
+                "bootstrap": {
+                    "product": "odoo-tenant-cm",
+                    "context": "cm",
+                    "instance": "testing",
+                    "confirmation": "bootstrap cm testing",
+                    "verify_health": True,
+                    "verify_canonical": True,
+                    "verify_logo": False,
+                },
+            }
+
+            with patch(
+                "control_plane.service._start_odoo_stable_bootstrap_operation_worker"
+            ) as worker_mock:
+                first_status, _ = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "bootstrap-cm-testing"},
+                )
+                second_status, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload=changed_request_payload,
+                    headers={"Idempotency-Key": "bootstrap-cm-testing"},
+                )
+
+            self.assertEqual(first_status, 202)
+            self.assertEqual(second_status, 409)
+            self.assertEqual(second_payload["error"]["code"], "idempotency_key_reused")
+            worker_mock.assert_called_once()
+
+    def test_odoo_stable_bootstrap_driver_reuses_idempotency_key_across_lanes(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(
+                    _odoo_profile_payload_with_prod_lane()
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["odoo_stable_bootstrap.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service._start_odoo_stable_bootstrap_operation_worker"
+            ) as worker_mock:
+                first_status, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "bootstrap": {
+                            "product": "odoo-tenant-cm",
+                            "context": "cm",
+                            "instance": "testing",
+                            "confirmation": "bootstrap cm testing",
+                        },
+                    },
+                    headers={"Idempotency-Key": "bootstrap-cm"},
+                )
+                second_status, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/odoo/stable-bootstrap",
+                    payload={
+                        "product": "odoo-tenant-cm",
+                        "bootstrap": {
+                            "product": "odoo-tenant-cm",
+                            "context": "cm",
+                            "instance": "prod",
+                            "confirmation": "bootstrap cm prod",
+                        },
+                    },
+                    headers={"Idempotency-Key": "bootstrap-cm"},
+                )
+
+            self.assertEqual(first_status, 202)
+            self.assertEqual(second_status, 202)
+            self.assertNotEqual(
+                first_payload["records"]["odoo_stable_bootstrap_operation_id"],
+                second_payload["records"]["odoo_stable_bootstrap_operation_id"],
+            )
+            self.assertEqual(worker_mock.call_count, 2)
 
     def test_odoo_stable_bootstrap_driver_blocks_second_active_lane_operation(
         self,


### PR DESCRIPTION
## Summary
- move Odoo stable-bootstrap POST handling into descriptor-backed dispatch
- add lane-scoped operation replay and active-lane reservation for stable-bootstrap operations
- add the active-lane storage migration plus service/storage coverage

## Verification
- uv run python -m unittest tests.test_odoo_stable_bootstrap_operation tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_routes_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_stable_bootstrap_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_odoo_artifact_execution_metadata_matches_descriptors tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_creates_operation_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_replays_existing_operation tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_dispatch_replays_same_key_reservation_collision tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_rejects_reused_idempotency_key_for_different_payload tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_reuses_idempotency_key_across_lanes tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_blocks_second_active_lane_operation tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_driver_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_operation_status_reads_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_operation_worker_records_terminal_result tests.test_service.LaunchplaneServiceTests.test_odoo_stable_bootstrap_operation_worker_fails_partial_result
- uv run --extra dev ruff check --diff control_plane/service.py control_plane/contracts/odoo_stable_bootstrap_operation.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/c5e7f9a1b3d5_add_odoo_bootstrap_active_lane_index.py tests/test_driver_descriptors.py tests/test_service.py tests/test_odoo_stable_bootstrap_operation.py
- uv run --extra dev ruff check control_plane/service.py control_plane/contracts/odoo_stable_bootstrap_operation.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/c5e7f9a1b3d5_add_odoo_bootstrap_active_lane_index.py tests/test_driver_descriptors.py tests/test_service.py tests/test_odoo_stable_bootstrap_operation.py
- uv run --extra dev ruff format --check control_plane/service.py control_plane/contracts/odoo_stable_bootstrap_operation.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/c5e7f9a1b3d5_add_odoo_bootstrap_active_lane_index.py tests/test_driver_descriptors.py tests/test_service.py tests/test_odoo_stable_bootstrap_operation.py
- uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md
- uv run --extra dev mypy control_plane tests