### PR TITLE
Require POST descriptor dispatch coverage

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4521,6 +4521,10 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
     )
 
 
+def _descriptor_driver_dispatch_exempt_route_paths() -> frozenset[str]:
+    return frozenset()
+
+
 def _dispatch_descriptor_driver_route(
     *,
     dispatch_route: _DescriptorDriverDispatchRoute[Any],
@@ -4905,6 +4909,21 @@ def _validate_descriptor_driver_dispatch_routes(
         raise ValueError(
             "Descriptor-backed dispatch routes must be registered by the service: "
             f"{', '.join(missing_required_routes)}"
+        )
+    post_descriptor_routes = frozenset(
+        route_path
+        for route_path, route_metadata in descriptor_routes.items()
+        if route_metadata.method == "POST"
+    )
+    missing_post_descriptor_routes = sorted(
+        post_descriptor_routes
+        - _descriptor_driver_dispatch_exempt_route_paths()
+        - dispatch_routes.keys()
+    )
+    if missing_post_descriptor_routes:
+        raise ValueError(
+            "POST driver descriptor routes must be registered for descriptor-backed "
+            f"dispatch: {', '.join(missing_post_descriptor_routes)}"
         )
     for route_path, dispatch_route in dispatch_routes.items():
         if route_path != dispatch_route.execution_metadata.route_path:

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -426,20 +426,11 @@ The HTTP service admits product-driver POST routes from descriptor action and
 route-alias paths and reads product-driver handler authorization actions from
 descriptor route metadata, so new drivers do not need a second hardcoded router
 allowlist or authz-action entry.
-Routes can also opt into descriptor-backed service dispatch when a backend
-handler is explicitly registered for the same descriptor route. Generic-web
-deploy, prod promotion, promotion workflow dispatch, stable verification,
-rollback planning, rollback apply, preview desired-state, preview inventory,
-preview refresh, preview readiness, preview destroy, preview verification,
-ingress route apply, Odoo artifact publish inputs and evidence ingestion, Odoo
-prod promotion input reads, Odoo prod backup gate, prod promotion run, direct
-prod promotion, prod rollback, target replacement planning, target replacement
-apply, post-deploy, config/website override hooks, stable bootstrap, Odoo preview
-apply and inputs, and the VeriReel testing and prod deploys, prod backup gate,
-prod promotion, prod rollback, app maintenance, preview refresh, preview
-inventory reads, preview destroy, plus testing and preview verification use
-descriptor-backed dispatch.
-This keeps
+POST driver descriptor actions and route aliases use descriptor-backed service
+dispatch unless the service declares a narrow exemption for a deliberate
+non-dispatch route. The service validates this at startup, so adding a writable
+descriptor route without registering a backend handler fails closed instead of
+silently advertising an unimplemented action. This keeps
 descriptor metadata as the route/authz source of truth while preventing an
 advertised descriptor action from becoming executable without implementation.
 Descriptor route metadata and service compatibility policy also drive

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -359,6 +359,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertLessEqual(
             set(descriptor_post_route_metadata), control_plane_service._build_write_routes()
         )
+        self.assertEqual(
+            set(descriptor_post_route_metadata)
+            - control_plane_service._descriptor_driver_dispatch_exempt_route_paths(),
+            set(control_plane_service._descriptor_driver_dispatch_routes()),
+        )
         for route_path, (
             driver_id,
             action_id,
@@ -373,6 +378,53 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             "/v1/drivers/launchplane/self-deploy",
             control_plane_service._build_write_routes(),
         )
+
+    def test_post_descriptor_route_requires_dispatch_registration(self) -> None:
+        descriptor = DriverDescriptor(
+            driver_id="fake-dispatch",
+            label="Fake dispatch",
+            product="fake-dispatch",
+            description="Test-only descriptor dispatch driver.",
+            provider_boundary="Test-only provider boundary.",
+            actions=(
+                DriverActionDescriptor(
+                    action_id="ping",
+                    label="Ping",
+                    description="Test descriptor-backed dispatch route.",
+                    safety="safe_write",
+                    scope="context",
+                    method="POST",
+                    route_path="/v1/drivers/fake-dispatch/ping",
+                    authz_action="fake_dispatch.ping",
+                ),
+            ),
+        )
+
+        with (
+            patch("control_plane.service.list_driver_descriptors", return_value=(descriptor,)),
+            patch(
+                "control_plane.service._required_descriptor_driver_dispatch_route_paths",
+                return_value=frozenset(),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "POST driver descriptor routes must be registered for descriptor-backed dispatch",
+            ):
+                control_plane_service._validate_descriptor_driver_dispatch_routes({})
+
+        with (
+            patch("control_plane.service.list_driver_descriptors", return_value=(descriptor,)),
+            patch(
+                "control_plane.service._required_descriptor_driver_dispatch_route_paths",
+                return_value=frozenset(),
+            ),
+            patch(
+                "control_plane.service._descriptor_driver_dispatch_exempt_route_paths",
+                return_value=frozenset({"/v1/drivers/fake-dispatch/ping"}),
+            ),
+        ):
+            control_plane_service._validate_descriptor_driver_dispatch_routes({})
 
     def test_descriptor_dispatch_registration_requires_descriptor_route(self) -> None:
         descriptor = DriverDescriptor(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12761,6 +12761,37 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             root = Path(temporary_directory_name)
+            with self.assertRaisesRegex(
+                ValueError,
+                "POST driver descriptor routes must be registered for descriptor-backed dispatch",
+            ):
+                create_launchplane_service_app(
+                    state_dir=root / "state-startup-fail",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                )
+
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.service.list_driver_descriptors",
+                return_value=(_fake_descriptor_dispatch_descriptor(),),
+            ),
+            patch(
+                "control_plane.service._descriptor_driver_dispatch_routes",
+                return_value={},
+            ),
+            patch(
+                "control_plane.service._required_descriptor_driver_dispatch_route_paths",
+                return_value=frozenset(),
+            ),
+            patch(
+                "control_plane.service._descriptor_driver_dispatch_exempt_route_paths",
+                return_value=frozenset({_FAKE_DESCRIPTOR_ROUTE_PATH}),
+            ),
+        ):
+            root = Path(temporary_directory_name)
             app = create_launchplane_service_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),


### PR DESCRIPTION
## Summary
- fail closed at startup when a POST driver descriptor action or route alias lacks descriptor-backed dispatch registration
- add a narrow explicit exemption hook for deliberate non-dispatch POST descriptor routes
- add generic descriptor coverage tests plus startup/runtime fallback coverage for unregistered descriptor routes
- update descriptor docs to describe the invariant instead of maintaining a long hand-written route list

## Verification
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_unregistered_descriptor_driver_route_fails_closed`
- `uv run python -m unittest`
- `uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py --diff`
- `uv run --extra dev ruff check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_driver_descriptors.py tests/test_service.py`
- `uv run --extra dev markdownlint-cli2 docs/driver-descriptors.md`
- `uv run --extra dev mypy control_plane tests`

## Agent review
- Antigravity planning aligned with generic POST descriptor coverage hardening.
- Antigravity review found the full-suite startup-validation compatibility issue in `test_unregistered_descriptor_driver_route_fails_closed`; this PR updates that test to cover both startup fail-closed validation and the exempted runtime fallback.
- OpenAI-side agent attempts failed because `/Users/cbusillo/.local/bin/code` is missing in the agent environment.
