### PR TITLE
Extract descriptor dispatch primitives

### DIFF
--- a/control_plane/drivers/dispatch.py
+++ b/control_plane/drivers/dispatch.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Generic, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.service_auth import LaunchplaneIdentity
+
+
+class _ProductRouteEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+
+
+_DriverRouteEnvelopeT = TypeVar("_DriverRouteEnvelopeT", bound=_ProductRouteEnvelope)
+_StartResponse = Callable[[str, list[tuple[str, str]]], None]
+
+
+@dataclass(frozen=True)
+class _DriverRouteExecutionMetadata(Generic[_DriverRouteEnvelopeT]):
+    route_path: str
+    envelope_model: type[_DriverRouteEnvelopeT]
+    denial_message: str
+
+
+@dataclass(frozen=True)
+class _DescriptorDriverDispatchContext:
+    product: str
+    context: str
+    authorization_context: str = ""
+    use_preview_context_for_authorization: bool = False
+    use_resolved_profile_product_for_authorization: bool = True
+    instance: str = ""
+    require_profile: bool = False
+
+
+@dataclass(frozen=True)
+class _DescriptorDriverDispatchResult:
+    result: dict[str, object]
+    driver_result: BaseModel | dict[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class _ResolvedProductDriverContext:
+    profile: LaunchplaneProductProfileRecord | None
+    lane: ProductLaneProfile | None = None
+
+
+_DescriptorDriverDispatchContextResolver = Callable[
+    [_DriverRouteEnvelopeT], _DescriptorDriverDispatchContext
+]
+_DescriptorDriverAuthorizationActionResolver = Callable[[_DriverRouteEnvelopeT], str]
+_DescriptorDriverDispatchHandler = Callable[
+    [
+        _DriverRouteEnvelopeT,
+        _ResolvedProductDriverContext,
+        object,
+        Path,
+    ],
+    _DescriptorDriverDispatchResult,
+]
+_DescriptorDriverCustomDispatchHandler = Callable[
+    [
+        _DriverRouteEnvelopeT,
+        _ResolvedProductDriverContext,
+        object,
+        Path,
+        Path,
+        str | None,
+        LaunchplaneIdentity,
+        str,
+        str,
+        str,
+        _StartResponse,
+        str,
+    ],
+    tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes],
+]
+_DescriptorDriverDispatchValidator = Callable[
+    [
+        _DriverRouteEnvelopeT,
+        _ResolvedProductDriverContext,
+        object,
+        Path,
+    ],
+    None,
+]
+_DescriptorDriverPreAuthorizationValidator = Callable[
+    [
+        _DriverRouteEnvelopeT,
+        _ResolvedProductDriverContext,
+        LaunchplaneIdentity,
+        _StartResponse,
+        str,
+    ],
+    list[bytes] | None,
+]
+
+
+@dataclass(frozen=True)
+class _DescriptorDriverDispatchRoute(Generic[_DriverRouteEnvelopeT]):
+    execution_metadata: _DriverRouteExecutionMetadata[_DriverRouteEnvelopeT]
+    context_resolver: _DescriptorDriverDispatchContextResolver[_DriverRouteEnvelopeT]
+    handler: _DescriptorDriverDispatchHandler[_DriverRouteEnvelopeT] | None = None
+    pre_idempotency_validator: _DescriptorDriverDispatchValidator[_DriverRouteEnvelopeT] | None = (
+        None
+    )
+    pre_authorization_validator: (
+        _DescriptorDriverPreAuthorizationValidator[_DriverRouteEnvelopeT] | None
+    ) = None
+    authorization_action_resolver: (
+        _DescriptorDriverAuthorizationActionResolver[_DriverRouteEnvelopeT] | None
+    ) = None
+    custom_dispatch_handler: (
+        _DescriptorDriverCustomDispatchHandler[_DriverRouteEnvelopeT] | None
+    ) = None
+    skip_pre_idempotency_check: bool = False
+    skip_driver_context_resolution: bool = False

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -13,7 +13,7 @@ import threading
 from socketserver import ThreadingMixIn
 import uuid
 from pathlib import Path
-from typing import Any, BinaryIO, Callable, Generic, Iterable, Literal, Protocol, TypeVar, cast
+from typing import Any, BinaryIO, Callable, Iterable, Literal, Protocol, cast
 from urllib.parse import parse_qs
 from wsgiref.simple_server import WSGIServer, make_server
 from wsgiref.types import WSGIApplication
@@ -202,6 +202,15 @@ from control_plane.drivers.registry import (
     build_driver_context_view,
     list_driver_descriptors,
     read_driver_descriptor,
+)
+from control_plane.drivers.dispatch import (
+    _DescriptorDriverDispatchContext as _DescriptorDriverDispatchContext,
+    _DescriptorDriverDispatchRoute as _DescriptorDriverDispatchRoute,
+    _DescriptorDriverDispatchResult as _DescriptorDriverDispatchResult,
+    _DriverRouteEnvelopeT as _DriverRouteEnvelopeT,
+    _DriverRouteExecutionMetadata as _DriverRouteExecutionMetadata,
+    _ProductRouteEnvelope as _ProductRouteEnvelope,
+    _ResolvedProductDriverContext as _ResolvedProductDriverContext,
 )
 from control_plane.launchplane_mutations import (
     LaunchplaneMutationStore,
@@ -702,15 +711,6 @@ class _DriverRouteMetadata:
     operator_visible: bool
 
 
-class _ProductRouteEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    product: str
-
-
-_DriverRouteEnvelopeT = TypeVar("_DriverRouteEnvelopeT", bound=_ProductRouteEnvelope)
-
-
 class _IdempotencyCapableStore(Protocol):
     def read_idempotency_record(
         self,
@@ -805,108 +805,6 @@ class _IngressRouteAuditRecordStore(Protocol):
 
 _StartResponse = Callable[[str, list[tuple[str, str]]], None]
 _WsgiApp = Callable[[dict[str, object], _StartResponse], list[bytes]]
-
-
-@dataclass(frozen=True)
-class _DriverRouteExecutionMetadata(Generic[_DriverRouteEnvelopeT]):
-    route_path: str
-    envelope_model: type[_DriverRouteEnvelopeT]
-    denial_message: str
-
-
-@dataclass(frozen=True)
-class _DescriptorDriverDispatchContext:
-    product: str
-    context: str
-    authorization_context: str = ""
-    use_preview_context_for_authorization: bool = False
-    use_resolved_profile_product_for_authorization: bool = True
-    instance: str = ""
-    require_profile: bool = False
-
-
-@dataclass(frozen=True)
-class _DescriptorDriverDispatchResult:
-    result: dict[str, object]
-    driver_result: BaseModel | dict[str, object] | None = None
-
-
-@dataclass(frozen=True)
-class _ResolvedProductDriverContext:
-    profile: LaunchplaneProductProfileRecord | None
-    lane: ProductLaneProfile | None = None
-
-
-_DescriptorDriverDispatchContextResolver = Callable[
-    [_DriverRouteEnvelopeT], _DescriptorDriverDispatchContext
-]
-_DescriptorDriverAuthorizationActionResolver = Callable[[_DriverRouteEnvelopeT], str]
-_DescriptorDriverDispatchHandler = Callable[
-    [
-        _DriverRouteEnvelopeT,
-        _ResolvedProductDriverContext,
-        object,
-        Path,
-    ],
-    _DescriptorDriverDispatchResult,
-]
-_DescriptorDriverCustomDispatchHandler = Callable[
-    [
-        _DriverRouteEnvelopeT,
-        _ResolvedProductDriverContext,
-        object,
-        Path,
-        Path,
-        str | None,
-        LaunchplaneIdentity,
-        str,
-        str,
-        str,
-        _StartResponse,
-        str,
-    ],
-    tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes],
-]
-_DescriptorDriverDispatchValidator = Callable[
-    [
-        _DriverRouteEnvelopeT,
-        _ResolvedProductDriverContext,
-        object,
-        Path,
-    ],
-    None,
-]
-_DescriptorDriverPreAuthorizationValidator = Callable[
-    [
-        _DriverRouteEnvelopeT,
-        _ResolvedProductDriverContext,
-        LaunchplaneIdentity,
-        _StartResponse,
-        str,
-    ],
-    list[bytes] | None,
-]
-
-
-@dataclass(frozen=True)
-class _DescriptorDriverDispatchRoute(Generic[_DriverRouteEnvelopeT]):
-    execution_metadata: _DriverRouteExecutionMetadata[_DriverRouteEnvelopeT]
-    context_resolver: _DescriptorDriverDispatchContextResolver[_DriverRouteEnvelopeT]
-    handler: _DescriptorDriverDispatchHandler[_DriverRouteEnvelopeT] | None = None
-    pre_idempotency_validator: _DescriptorDriverDispatchValidator[_DriverRouteEnvelopeT] | None = (
-        None
-    )
-    pre_authorization_validator: (
-        _DescriptorDriverPreAuthorizationValidator[_DriverRouteEnvelopeT] | None
-    ) = None
-    authorization_action_resolver: (
-        _DescriptorDriverAuthorizationActionResolver[_DriverRouteEnvelopeT] | None
-    ) = None
-    custom_dispatch_handler: (
-        _DescriptorDriverCustomDispatchHandler[_DriverRouteEnvelopeT] | None
-    ) = None
-    skip_pre_idempotency_check: bool = False
-    skip_driver_context_resolution: bool = False
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -3608,15 +3506,18 @@ def _validate_generic_web_preview_profile(
     if profile is None:
         raise ProductDriverMismatchError("Generic web preview routes require a product profile.")
     if not product_profile_uses_generic_web_base(profile):
-        raise ProductDriverMismatchError(
-            "Generic web preview routes require a generic-web compatible product profile."
+        raise click.ClickException(
+            f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, "
+            "not generic-web or a generic-web based driver."
         )
     if not profile.preview.enabled:
-        raise ProductDriverMismatchError(
-            "Generic web preview routes require previews to be enabled."
+        raise click.ClickException(
+            f"Product {profile.product!r} does not have generic-web previews enabled."
         )
     if not profile.preview.context.strip():
-        raise ProductDriverMismatchError("Generic web preview routes require a preview context.")
+        raise click.ClickException(
+            f"Product {profile.product!r} does not define a preview context."
+        )
 
 
 def _handle_generic_web_preview_desired_state(

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -35,6 +35,7 @@ capability to model.
 Each driver should have these pieces:
 
 - Descriptor metadata in `control_plane/drivers/registry.py`.
+- Shared descriptor-dispatch plumbing from `control_plane/drivers/dispatch.py`.
 - Typed request and result models in a workflow module.
 - Service routes under `/v1/drivers/{driver_id}/...`.
 - Authz actions that match the driver actions and safety level.
@@ -131,7 +132,9 @@ secrets, or driver-owned derivation.
 2. Add or extend the driver descriptor in the registry.
 3. Add typed request/result models and executor functions in
    `control_plane/workflows/`.
-4. Wire service routes and authz action checks in `control_plane/service.py`.
+4. Wire descriptor-backed service dispatch using the shared route primitives in
+   `control_plane/drivers/dispatch.py`; keep driver-family handlers cohesive
+   instead of growing unrelated `service.py` route tables.
 5. Write records through existing storage contracts when possible.
 6. Add focused unit tests for validation, authorization, execution, and failure
    evidence.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18778,6 +18778,75 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
+    def test_generic_web_preview_desired_state_route_keeps_profile_errors_invalid_request(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            profile_payload = _product_profile_payload()
+            profile_payload["preview"] = {
+                "enabled": False,
+                "context": "sellyouroutboard-testing",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_desired_state.discover"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.service.discover_generic_web_preview_desired_state"
+            ) as discover:
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/preview-desired-state",
+                    payload={
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "desired_state": {
+                            "schema_version": 1,
+                            "product": "sellyouroutboard",
+                        },
+                    },
+                    headers={"Idempotency-Key": "generic-web-preview-disabled:syo"},
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        discover.assert_not_called()
+
     def test_generic_web_preview_inventory_route_writes_scan_from_driver_result(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- move descriptor dispatch primitives into `control_plane/drivers/dispatch.py`
- re-export the private dispatch types from `control_plane.service` for compatibility while handlers remain centralized
- update driver development docs to point future driver work at the shared dispatch primitives
- preserve the existing 400 `invalid_request` response for generic-web preview profile misconfiguration errors after descriptor dispatch migration

## Verification
- `uv run python -m unittest tests.test_driver_descriptors tests.test_service.LaunchplaneServiceTests.test_unregistered_descriptor_driver_route_fails_closed tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_desired_state_route_keeps_profile_errors_invalid_request tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_desired_state_route_uses_profile_context`
- `uv run python -m unittest`
- `uv run --extra dev ruff check control_plane/service.py control_plane/drivers/dispatch.py tests/test_service.py --diff`
- `uv run --extra dev ruff check control_plane/service.py control_plane/drivers/dispatch.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/drivers/dispatch.py tests/test_service.py`
- `uv run --extra dev markdownlint-cli2 docs/driver-development.md`
- `uv run --extra dev mypy control_plane tests`

## Review
- Non-Claude planning agents agreed the safest first extraction slice is shared dispatch primitives only, before driver-family handlers.
- Non-Claude review agents found no actionable issues with the extraction; residual risk is future tests still importing compatibility re-exports from `control_plane.service`.
- Auto-review finding `[P2] Preserve the existing 400 response for generic-web preview profile errors` is addressed here by restoring `click.ClickException` semantics for generic-web preview profile misconfiguration and adding a focused regression test.
