### PR TITLE
Extract generic web preview verification dispatch

### DIFF
--- a/control_plane/drivers/dispatch.py
+++ b/control_plane/drivers/dispatch.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Generic, TypeVar
+from typing import Callable, Generic, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict
 
@@ -10,6 +10,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
 )
+from control_plane.contracts.promotion_record import ReleaseStatus
 from control_plane.service_auth import LaunchplaneIdentity
 
 
@@ -51,6 +52,43 @@ class _DescriptorDriverDispatchResult:
 class _ResolvedProductDriverContext:
     profile: LaunchplaneProductProfileRecord | None
     lane: ProductLaneProfile | None = None
+
+
+def _validate_driver_envelope_product(product: str, *, label: str) -> None:
+    if not product.strip():
+        raise ValueError(f"{label} requires product.")
+
+
+class ProductDriverMismatchError(ValueError):
+    pass
+
+
+def _normalize_release_status(value: object, *, label: str) -> ReleaseStatus:
+    normalized = str(value or "").strip().lower()
+    if normalized in {"success", "passed", "pass"}:
+        return "pass"
+    if normalized in {"failure", "failed", "fail", "cancelled", "canceled", "timed_out"}:
+        return "fail"
+    if normalized in {"skipped", "not-run", "not_run", ""}:
+        return "skipped"
+    if normalized in {"pending", "in_progress", "in-progress"}:
+        return "pending"
+    raise ValueError(f"{label} must be pass, fail, skipped, or pending.")
+
+
+def _normalize_preview_verification_checked_urls(value: object, *, label: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple)):
+        raw_values = tuple(value)
+    else:
+        raise ValueError(f"{label} checked_urls must be a list.")
+    if any(not isinstance(item, str) for item in raw_values):
+        raise ValueError(f"{label} checked_urls must be strings.")
+    checked_urls = tuple(item.strip() for item in cast(tuple[str, ...], raw_values))
+    if any(not item for item in checked_urls):
+        raise ValueError(f"{label} checked_urls cannot contain blanks.")
+    return checked_urls
 
 
 _DescriptorDriverDispatchContextResolver = Callable[

--- a/control_plane/drivers/generic_web_preview_dispatch.py
+++ b/control_plane/drivers/generic_web_preview_dispatch.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, cast
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from control_plane.contracts.preview_generation_record import (
+    PreviewGenerationRecord,
+    PreviewGenerationState,
+)
+from control_plane.contracts.preview_mutation_request import (
+    PreviewGenerationMutationRequest,
+    PreviewMutationRequest,
+)
+from control_plane.contracts.preview_record import PreviewState
+from control_plane.contracts.promotion_record import ReleaseStatus
+from control_plane.drivers.dispatch import (
+    _DescriptorDriverDispatchResult,
+    _DriverRouteExecutionMetadata,
+    _ProductRouteEnvelope,
+    _ResolvedProductDriverContext,
+    _normalize_preview_verification_checked_urls,
+    _normalize_release_status,
+    _validate_driver_envelope_product,
+)
+from control_plane.launchplane_mutations import (
+    LaunchplaneMutationStore,
+    apply_launchplane_generation_evidence,
+)
+from control_plane.workflows.launchplane import find_preview_record
+
+
+class GenericWebPreviewVerificationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    anchor_repo: str
+    anchor_pr_number: int = Field(ge=1)
+    verification_status: ReleaseStatus
+    verified_at: str
+    checked_urls: tuple[str, ...] = ()
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    failure_summary: str = ""
+
+    @field_validator("verification_status", mode="before")
+    @classmethod
+    def _normalize_status(cls, value: object) -> ReleaseStatus:
+        return _normalize_release_status(value, label="Generic web preview verification status")
+
+    @field_validator("checked_urls", mode="before")
+    @classmethod
+    def _normalize_checked_urls(cls, value: object) -> tuple[str, ...]:
+        return _normalize_preview_verification_checked_urls(
+            value, label="Generic web preview verification"
+        )
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebPreviewVerificationRequest":
+        if not self.context.strip():
+            raise ValueError("Generic web preview verification requires context.")
+        if not self.anchor_repo.strip():
+            raise ValueError("Generic web preview verification requires anchor_repo.")
+        if self.verification_status not in {"pass", "fail"}:
+            raise ValueError("Generic web preview verification status must be pass or fail.")
+        if not self.verified_at.strip():
+            raise ValueError("Generic web preview verification requires verified_at.")
+        if self.checked_urls and self.timeout_seconds is None:
+            raise ValueError(
+                "Generic web preview verification checked_urls require timeout_seconds."
+            )
+        return self
+
+
+class GenericWebPreviewVerificationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    preview_id: str
+    preview_generation_id: str
+    preview_state: str
+    generation_state: str
+    verification_status: ReleaseStatus
+    verified_at: str
+    checked_urls: tuple[str, ...] = ()
+    timeout_seconds: int | None = None
+    failure_summary: str = ""
+
+
+class GenericWebPreviewVerificationEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    verification: GenericWebPreviewVerificationRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebPreviewVerificationEnvelope":
+        _validate_driver_envelope_product(self.product, label="Generic web preview verification")
+        return self
+
+
+_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/generic-web/preview-verification",
+    envelope_model=GenericWebPreviewVerificationEnvelope,
+    denial_message=(
+        "Workflow cannot write generic web preview verification for the requested product/context."
+    ),
+)
+
+
+class _PreviewGenerationMutationStore(LaunchplaneMutationStore, Protocol):
+    def read_preview_generation_record(self, generation_id: str) -> PreviewGenerationRecord: ...
+
+
+def _preview_generation_mutation_store(
+    record_store: object,
+) -> _PreviewGenerationMutationStore:
+    required_methods = (
+        "list_preview_records",
+        "list_preview_generation_records",
+        "read_preview_generation_record",
+        "write_preview_record",
+        "write_preview_generation_record",
+    )
+    if all(hasattr(record_store, method_name) for method_name in required_methods):
+        return cast(_PreviewGenerationMutationStore, record_store)
+    raise TypeError("record store does not support Launchplane preview generation mutations")
+
+
+def _handle_generic_web_preview_verification(
+    request: GenericWebPreviewVerificationEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del resolved_context
+    return _DescriptorDriverDispatchResult(
+        result=_apply_generic_web_preview_verification_records(
+            control_plane_root_path=control_plane_root_path,
+            record_store=record_store,
+            request=request.verification,
+        )
+    )
+
+
+def _apply_generic_web_preview_verification_records(
+    *,
+    control_plane_root_path: Path,
+    record_store: object,
+    request: GenericWebPreviewVerificationRequest,
+    result_key: str = "generic_web_preview_verification",
+    default_failure_summary: str = "Preview verification failed.",
+) -> dict[str, object]:
+    typed_record_store = _preview_generation_mutation_store(record_store)
+    preview = find_preview_record(
+        record_store=typed_record_store,
+        context_name=request.context,
+        anchor_repo=request.anchor_repo,
+        anchor_pr_number=request.anchor_pr_number,
+    )
+    if preview is None:
+        raise click.ClickException(
+            f"No Launchplane preview found for {request.context}/{request.anchor_repo}/pr-{request.anchor_pr_number}."
+        )
+    generation_id = preview.latest_generation_id or preview.active_generation_id
+    if not generation_id:
+        raise click.ClickException(
+            f"No Launchplane preview generation found for {preview.preview_id}."
+        )
+    generation = typed_record_store.read_preview_generation_record(generation_id)
+    verified_at = request.verified_at.strip()
+    verification_passed = request.verification_status == "pass"
+    failure_summary = request.failure_summary.strip() or default_failure_summary
+    preview_state: PreviewState = "active" if verification_passed else "failed"
+    generation_state: PreviewGenerationState = "ready" if verification_passed else "failed"
+    result = apply_launchplane_generation_evidence(
+        control_plane_root_path=control_plane_root_path,
+        record_store=typed_record_store,
+        preview_request=PreviewMutationRequest(
+            context=preview.context,
+            anchor_repo=preview.anchor_repo,
+            anchor_pr_number=preview.anchor_pr_number,
+            anchor_pr_url=preview.anchor_pr_url,
+            canonical_url=preview.canonical_url,
+            state=preview_state,
+            created_at=preview.created_at,
+            updated_at=verified_at,
+            eligible_at=preview.eligible_at,
+        ),
+        generation_request=PreviewGenerationMutationRequest(
+            context=preview.context,
+            anchor_repo=preview.anchor_repo,
+            anchor_pr_number=preview.anchor_pr_number,
+            anchor_pr_url=preview.anchor_pr_url,
+            anchor_head_sha=generation.anchor_summary.head_sha,
+            sequence=generation.sequence,
+            generation_id=generation.generation_id,
+            state=generation_state,
+            requested_reason=generation.requested_reason,
+            requested_at=generation.requested_at,
+            started_at=generation.started_at,
+            ready_at=verified_at if verification_passed else "",
+            finished_at=verified_at,
+            failed_at="" if verification_passed else verified_at,
+            resolved_manifest_fingerprint=generation.resolved_manifest_fingerprint,
+            artifact_id=generation.artifact_id,
+            baseline_release_tuple_id=generation.baseline_release_tuple_id,
+            source_map=generation.source_map,
+            companion_summaries=generation.companion_summaries,
+            deploy_status=generation.deploy_status,
+            verify_status="pass" if verification_passed else "fail",
+            overall_health_status="pass" if verification_passed else "fail",
+            failure_stage="" if verification_passed else "verify",
+            failure_summary="" if verification_passed else failure_summary,
+        ),
+    )
+    verification_result = GenericWebPreviewVerificationResult(
+        preview_id=preview.preview_id,
+        preview_generation_id=generation.generation_id,
+        preview_state=preview_state,
+        generation_state=generation_state,
+        verification_status=request.verification_status,
+        verified_at=verified_at,
+        checked_urls=request.checked_urls,
+        timeout_seconds=request.timeout_seconds if request.checked_urls else None,
+        failure_summary="" if verification_passed else failure_summary,
+    )
+    result["preview_state"] = preview_state
+    result["preview_generation_id"] = generation.generation_id
+    result["verification_status"] = request.verification_status
+    result["verified_at"] = verified_at
+    result[result_key] = verification_result.model_dump(mode="json")
+    return result

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -146,10 +146,6 @@ from control_plane.contracts.preview_mutation_request import (
     PreviewGenerationMutationRequest,
     PreviewMutationRequest,
 )
-from control_plane.contracts.preview_generation_record import (
-    PreviewGenerationRecord,
-    PreviewGenerationState,
-)
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_inventory_scan_record import (
     PreviewInventoryScanRecord,
@@ -164,7 +160,6 @@ from control_plane.contracts.preview_pr_feedback_record import (
     PreviewPrFeedbackRecord,
     PreviewPrFeedbackStatus,
 )
-from control_plane.contracts.preview_record import PreviewState
 from control_plane.contracts.preview_readiness_read_model import (
     build_preview_readiness_read_model,
 )
@@ -211,6 +206,18 @@ from control_plane.drivers.dispatch import (
     _DriverRouteExecutionMetadata as _DriverRouteExecutionMetadata,
     _ProductRouteEnvelope as _ProductRouteEnvelope,
     _ResolvedProductDriverContext as _ResolvedProductDriverContext,
+    _normalize_preview_verification_checked_urls as _normalize_preview_verification_checked_urls,
+    _normalize_release_status as _normalize_release_status,
+    _validate_driver_envelope_product as _validate_driver_envelope_product,
+    ProductDriverMismatchError as ProductDriverMismatchError,
+)
+from control_plane.drivers.generic_web_preview_dispatch import (
+    GenericWebPreviewVerificationEnvelope as GenericWebPreviewVerificationEnvelope,
+    GenericWebPreviewVerificationRequest as GenericWebPreviewVerificationRequest,
+    GenericWebPreviewVerificationResult as GenericWebPreviewVerificationResult,
+    _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE as _GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE,
+    _apply_generic_web_preview_verification_records as _apply_generic_web_preview_verification_records,
+    _handle_generic_web_preview_verification as _handle_generic_web_preview_verification,
 )
 from control_plane.launchplane_mutations import (
     LaunchplaneMutationStore,
@@ -388,7 +395,6 @@ from control_plane.workflows.launchplane import (
     ProductProfileListStore,
     create_github_issue_comment,
     find_github_issue_comment_by_marker,
-    find_preview_record,
     _github_comment_url,
     launchplane_anchor_repo_context,
     resolve_launchplane_github_token,
@@ -1184,81 +1190,6 @@ _GENERIC_WEB_PREVIEW_DESTROY_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
-class GenericWebPreviewVerificationRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    context: str
-    anchor_repo: str
-    anchor_pr_number: int = Field(ge=1)
-    verification_status: ReleaseStatus
-    verified_at: str
-    checked_urls: tuple[str, ...] = ()
-    timeout_seconds: int | None = Field(default=None, ge=1)
-    failure_summary: str = ""
-
-    @field_validator("verification_status", mode="before")
-    @classmethod
-    def _normalize_status(cls, value: object) -> ReleaseStatus:
-        return _normalize_release_status(value, label="Generic web preview verification status")
-
-    @field_validator("checked_urls", mode="before")
-    @classmethod
-    def _normalize_checked_urls(cls, value: object) -> tuple[str, ...]:
-        return _normalize_preview_verification_checked_urls(
-            value, label="Generic web preview verification"
-        )
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "GenericWebPreviewVerificationRequest":
-        if not self.context.strip():
-            raise ValueError("Generic web preview verification requires context.")
-        if not self.anchor_repo.strip():
-            raise ValueError("Generic web preview verification requires anchor_repo.")
-        if self.verification_status not in {"pass", "fail"}:
-            raise ValueError("Generic web preview verification status must be pass or fail.")
-        if not self.verified_at.strip():
-            raise ValueError("Generic web preview verification requires verified_at.")
-        if self.checked_urls and self.timeout_seconds is None:
-            raise ValueError(
-                "Generic web preview verification checked_urls require timeout_seconds."
-            )
-        return self
-
-
-class GenericWebPreviewVerificationResult(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    preview_id: str
-    preview_generation_id: str
-    preview_state: str
-    generation_state: str
-    verification_status: ReleaseStatus
-    verified_at: str
-    checked_urls: tuple[str, ...] = ()
-    timeout_seconds: int | None = None
-    failure_summary: str = ""
-
-
-class GenericWebPreviewVerificationEnvelope(_ProductRouteEnvelope):
-    schema_version: int = Field(default=1, ge=1)
-    verification: GenericWebPreviewVerificationRequest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "GenericWebPreviewVerificationEnvelope":
-        _validate_driver_envelope_product(self.product, label="Generic web preview verification")
-        return self
-
-
-_GENERIC_WEB_PREVIEW_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/generic-web/preview-verification",
-    envelope_model=GenericWebPreviewVerificationEnvelope,
-    denial_message=(
-        "Workflow cannot write generic web preview verification for the requested product/context."
-    ),
-)
-
-
 class OdooPreviewApplyEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     apply: OdooPreviewDokployApplyRequest
@@ -1582,15 +1513,6 @@ class PromotionEvidenceEnvelope(BaseModel):
         if not self.product.strip():
             raise ValueError("promotion evidence requires product")
         return self
-
-
-def _validate_driver_envelope_product(product: str, *, label: str) -> None:
-    if not product.strip():
-        raise ValueError(f"{label} requires product.")
-
-
-class ProductDriverMismatchError(ValueError):
-    pass
 
 
 class NpmplusIngressApplyEnvelope(_ProductRouteEnvelope):
@@ -1974,34 +1896,6 @@ class VeriReelTestingDeployEnvelope(_ProductRouteEnvelope):
         if self.deploy.instance != "testing":
             raise ValueError("VeriReel testing deploy requires instance 'testing'.")
         return self
-
-
-def _normalize_release_status(value: object, *, label: str) -> ReleaseStatus:
-    normalized = str(value or "").strip().lower()
-    if normalized in {"success", "passed", "pass"}:
-        return "pass"
-    if normalized in {"failure", "failed", "fail", "cancelled", "canceled", "timed_out"}:
-        return "fail"
-    if normalized in {"skipped", "not-run", "not_run", ""}:
-        return "skipped"
-    if normalized in {"pending", "in_progress", "in-progress"}:
-        return "pending"
-    raise ValueError(f"{label} must be pass, fail, skipped, or pending.")
-
-
-def _normalize_preview_verification_checked_urls(value: object, *, label: str) -> tuple[str, ...]:
-    if value is None:
-        return ()
-    if isinstance(value, (list, tuple)):
-        raw_values = tuple(value)
-    else:
-        raise ValueError(f"{label} checked_urls must be a list.")
-    if any(not isinstance(item, str) for item in raw_values):
-        raise ValueError(f"{label} checked_urls must be strings.")
-    checked_urls = tuple(item.strip() for item in cast(tuple[str, ...], raw_values))
-    if any(not item for item in checked_urls):
-        raise ValueError(f"{label} checked_urls cannot contain blanks.")
-    return checked_urls
 
 
 def _validate_stable_verification_request(
@@ -3476,22 +3370,6 @@ def _handle_odoo_preview_apply(
     return _DescriptorDriverDispatchResult(
         result=driver_result.model_dump(mode="json"),
         driver_result=driver_result,
-    )
-
-
-def _handle_generic_web_preview_verification(
-    request: GenericWebPreviewVerificationEnvelope,
-    resolved_context: _ResolvedProductDriverContext,
-    record_store: object,
-    control_plane_root_path: Path,
-) -> _DescriptorDriverDispatchResult:
-    del resolved_context
-    return _DescriptorDriverDispatchResult(
-        result=_apply_generic_web_preview_verification_records(
-            control_plane_root_path=control_plane_root_path,
-            record_store=record_store,
-            request=request.verification,
-        )
     )
 
 
@@ -5060,10 +4938,6 @@ class _EveryCodeWorkRequestStore(Protocol):
     ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
 
 
-class _PreviewGenerationMutationStore(LaunchplaneMutationStore, Protocol):
-    def read_preview_generation_record(self, generation_id: str) -> PreviewGenerationRecord: ...
-
-
 class _AgentWriteIntentRecordStore(Protocol):
     def write_agent_write_intent_record(self, record: AgentWriteIntentRecord) -> object: ...
 
@@ -5095,19 +4969,6 @@ def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkReques
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_EveryCodeWorkRequestStore, record_store)
     raise TypeError("record store does not support Every Code work requests")
-
-
-def _preview_generation_mutation_store(record_store: object) -> _PreviewGenerationMutationStore:
-    required_methods = (
-        "list_preview_records",
-        "list_preview_generation_records",
-        "read_preview_generation_record",
-        "write_preview_record",
-        "write_preview_generation_record",
-    )
-    if all(hasattr(record_store, method_name) for method_name in required_methods):
-        return cast(_PreviewGenerationMutationStore, record_store)
-    raise TypeError("record store does not support Launchplane preview generation mutations")
 
 
 def _agent_write_intent_record_store(record_store: object) -> _AgentWriteIntentRecordStore:
@@ -9546,96 +9407,6 @@ def _apply_verireel_preview_verification_records(
         result_key="verireel_preview_verification",
         default_failure_summary="Preview E2E verification failed.",
     )
-
-
-def _apply_generic_web_preview_verification_records(
-    *,
-    control_plane_root_path: Path,
-    record_store: object,
-    request: GenericWebPreviewVerificationRequest,
-    result_key: str = "generic_web_preview_verification",
-    default_failure_summary: str = "Preview verification failed.",
-) -> dict[str, object]:
-    typed_record_store = _preview_generation_mutation_store(record_store)
-    preview = find_preview_record(
-        record_store=typed_record_store,
-        context_name=request.context,
-        anchor_repo=request.anchor_repo,
-        anchor_pr_number=request.anchor_pr_number,
-    )
-    if preview is None:
-        raise click.ClickException(
-            f"No Launchplane preview found for {request.context}/{request.anchor_repo}/pr-{request.anchor_pr_number}."
-        )
-    generation_id = preview.latest_generation_id or preview.active_generation_id
-    if not generation_id:
-        raise click.ClickException(
-            f"No Launchplane preview generation found for {preview.preview_id}."
-        )
-    generation = typed_record_store.read_preview_generation_record(generation_id)
-    verified_at = request.verified_at.strip()
-    verification_passed = request.verification_status == "pass"
-    failure_summary = request.failure_summary.strip() or default_failure_summary
-    preview_state: PreviewState = "active" if verification_passed else "failed"
-    generation_state: PreviewGenerationState = "ready" if verification_passed else "failed"
-    result = apply_launchplane_generation_evidence(
-        control_plane_root_path=control_plane_root_path,
-        record_store=typed_record_store,
-        preview_request=PreviewMutationRequest(
-            context=preview.context,
-            anchor_repo=preview.anchor_repo,
-            anchor_pr_number=preview.anchor_pr_number,
-            anchor_pr_url=preview.anchor_pr_url,
-            canonical_url=preview.canonical_url,
-            state=preview_state,
-            created_at=preview.created_at,
-            updated_at=verified_at,
-            eligible_at=preview.eligible_at,
-        ),
-        generation_request=PreviewGenerationMutationRequest(
-            context=preview.context,
-            anchor_repo=preview.anchor_repo,
-            anchor_pr_number=preview.anchor_pr_number,
-            anchor_pr_url=preview.anchor_pr_url,
-            anchor_head_sha=generation.anchor_summary.head_sha,
-            sequence=generation.sequence,
-            generation_id=generation.generation_id,
-            state=generation_state,
-            requested_reason=generation.requested_reason,
-            requested_at=generation.requested_at,
-            started_at=generation.started_at,
-            ready_at=verified_at if verification_passed else "",
-            finished_at=verified_at,
-            failed_at="" if verification_passed else verified_at,
-            resolved_manifest_fingerprint=generation.resolved_manifest_fingerprint,
-            artifact_id=generation.artifact_id,
-            baseline_release_tuple_id=generation.baseline_release_tuple_id,
-            source_map=generation.source_map,
-            companion_summaries=generation.companion_summaries,
-            deploy_status=generation.deploy_status,
-            verify_status="pass" if verification_passed else "fail",
-            overall_health_status="pass" if verification_passed else "fail",
-            failure_stage="" if verification_passed else "verify",
-            failure_summary="" if verification_passed else failure_summary,
-        ),
-    )
-    verification_result = GenericWebPreviewVerificationResult(
-        preview_id=preview.preview_id,
-        preview_generation_id=generation.generation_id,
-        preview_state=preview_state,
-        generation_state=generation_state,
-        verification_status=request.verification_status,
-        verified_at=verified_at,
-        checked_urls=request.checked_urls,
-        timeout_seconds=request.timeout_seconds if request.checked_urls else None,
-        failure_summary="" if verification_passed else failure_summary,
-    )
-    result["preview_state"] = preview_state
-    result["preview_generation_id"] = generation.generation_id
-    result["verification_status"] = request.verification_status
-    result["verified_at"] = verified_at
-    result[result_key] = verification_result.model_dump(mode="json")
-    return result
 
 
 def _stable_verification_health_evidence(

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -36,6 +36,8 @@ Each driver should have these pieces:
 
 - Descriptor metadata in `control_plane/drivers/registry.py`.
 - Shared descriptor-dispatch plumbing from `control_plane/drivers/dispatch.py`.
+- Generic-web preview-verification dispatch in
+  `control_plane/drivers/generic_web_preview_dispatch.py`.
 - Typed request and result models in a workflow module.
 - Service routes under `/v1/drivers/{driver_id}/...`.
 - Authz actions that match the driver actions and safety level.
@@ -135,6 +137,8 @@ secrets, or driver-owned derivation.
 4. Wire descriptor-backed service dispatch using the shared route primitives in
    `control_plane/drivers/dispatch.py`; keep driver-family handlers cohesive
    instead of growing unrelated `service.py` route tables.
+   Generic-web preview-verification route changes belong in
+   `control_plane/drivers/generic_web_preview_dispatch.py`.
 5. Write records through existing storage contracts when possible.
 6. Add focused unit tests for validation, authorization, execution, and failure
    evidence.

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -116,6 +116,7 @@ from control_plane.service import (
     GenericWebPreviewVerificationRequest,
     create_launchplane_service_app as _create_launchplane_service_app,
 )
+from control_plane.drivers import generic_web_preview_dispatch
 from control_plane.service_auth import (
     GitHubActionsIdentity,
     GitHubHumanIdentity,
@@ -19514,7 +19515,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service._apply_generic_web_preview_verification_records",
+                "control_plane.drivers.generic_web_preview_dispatch._apply_generic_web_preview_verification_records",
                 return_value={
                     "transition": "ready",
                     "preview_state": "active",
@@ -19588,7 +19589,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service._apply_generic_web_preview_verification_records",
+                "control_plane.drivers.generic_web_preview_dispatch._apply_generic_web_preview_verification_records",
                 return_value={"transition": "ready"},
             ) as apply_records:
                 status_code, payload = _invoke_app(
@@ -19669,7 +19670,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             }
 
             with patch(
-                "control_plane.service._apply_generic_web_preview_verification_records",
+                "control_plane.drivers.generic_web_preview_dispatch._apply_generic_web_preview_verification_records",
                 return_value={"transition": "ready"},
             ) as apply_records:
                 first_status_code, first_payload = _invoke_app(
@@ -19731,6 +19732,77 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(
             tuple_request.checked_urls,
             ("https://pr-42.cm-preview.example.test/cell-mechanic",),
+        )
+
+    def test_generic_web_preview_verification_records_reject_missing_preview(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            request = GenericWebPreviewVerificationRequest.model_validate(
+                {
+                    "schema_version": 1,
+                    "context": "cm",
+                    "anchor_repo": "odoo-tenant-cm",
+                    "anchor_pr_number": 42,
+                    "verification_status": "pass",
+                    "verified_at": "2026-05-09T15:08:00Z",
+                }
+            )
+
+            with self.assertRaises(ClickException) as raised:
+                generic_web_preview_dispatch._apply_generic_web_preview_verification_records(
+                    control_plane_root_path=root,
+                    record_store=store,
+                    request=request,
+                )
+
+        self.assertEqual(
+            str(raised.exception),
+            "No Launchplane preview found for cm/odoo-tenant-cm/pr-42.",
+        )
+
+    def test_generic_web_preview_verification_records_reject_missing_generation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-cm-odoo-tenant-cm-pr-42",
+                    context="cm",
+                    anchor_repo="odoo-tenant-cm",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/cbusillo/odoo-tenant-cm/pull/42",
+                    preview_label="preview",
+                    canonical_url="https://pr-42.cm-preview.example.test",
+                    state="pending",
+                    created_at="2026-05-09T15:00:00Z",
+                    updated_at="2026-05-09T15:05:00Z",
+                    eligible_at="2026-05-09T15:00:00Z",
+                )
+            )
+            request = GenericWebPreviewVerificationRequest.model_validate(
+                {
+                    "schema_version": 1,
+                    "context": "cm",
+                    "anchor_repo": "odoo-tenant-cm",
+                    "anchor_pr_number": 42,
+                    "verification_status": "pass",
+                    "verified_at": "2026-05-09T15:08:00Z",
+                }
+            )
+
+            with self.assertRaises(ClickException) as raised:
+                generic_web_preview_dispatch._apply_generic_web_preview_verification_records(
+                    control_plane_root_path=root,
+                    record_store=store,
+                    request=request,
+                )
+
+        self.assertEqual(
+            str(raised.exception),
+            "No Launchplane preview generation found for preview-cm-odoo-tenant-cm-pr-42.",
         )
 
     def test_odoo_preview_apply_route_resolves_runtime_environment_values(self) -> None:


### PR DESCRIPTION
## Summary
- Move generic-web preview verification request/result/envelope, route metadata, handler, and record writer into `control_plane/drivers/generic_web_preview_dispatch.py`.
- Move shared dispatch validation helpers and `ProductDriverMismatchError` into `control_plane/drivers/dispatch.py`, with service compatibility re-exports.
- Add direct missing-preview and missing-generation tests for the moved record writer and update route mock targets.
- Document the new generic-web preview-verification dispatch home.

## Validation
- `uv run python -m unittest`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_route_accepts_odoo_base_driver_profile tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_route_does_not_require_lane tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_route_rejects_unauthorized_context tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_replay_revalidates_preview_profile tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_request_accepts_explicit_url_collections tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_records_reject_missing_preview tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_records_reject_missing_generation tests.test_driver_descriptors`
- `uv run --extra dev ruff check --diff control_plane/drivers/dispatch.py control_plane/drivers/generic_web_preview_dispatch.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/drivers/dispatch.py control_plane/drivers/generic_web_preview_dispatch.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/drivers/dispatch.py control_plane/drivers/generic_web_preview_dispatch.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev markdownlint-cli2 docs/driver-development.md`

## Review
- Narrow non-Claude reviews (OpenAI and Antigravity) reported no findings.
- Repo auto-review failed before findings because its background diff scope exceeded the configured size limit; no actionable auto-review finding was produced.
