### PR TITLE
Extract generic web stable verification dispatch

### DIFF
--- a/control_plane/drivers/generic_web_dispatch.py
+++ b/control_plane/drivers/generic_web_dispatch.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol, cast
+
+import click
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from control_plane.contracts.promotion_record import HealthcheckEvidence, ReleaseStatus
+from control_plane.drivers.dispatch import (
+    _DescriptorDriverDispatchResult,
+    _DriverRouteExecutionMetadata,
+    _ProductRouteEnvelope,
+    _ResolvedProductDriverContext,
+    ProductDriverMismatchError,
+    _normalize_preview_verification_checked_urls,
+    _normalize_release_status,
+    _validate_driver_envelope_product,
+)
+from control_plane.workflows.evidence_ingestion import (
+    EvidenceIngestionStore,
+    apply_deployment_evidence,
+    apply_promotion_evidence,
+)
+
+
+class _StableVerificationRequest(Protocol):
+    context: str
+    instance: str
+    deployment_record_id: str
+    verification_status: ReleaseStatus
+    verified_at: str
+    checked_urls: tuple[str, ...]
+    timeout_seconds: int | None
+
+
+def _validate_stable_verification_request(
+    request: _StableVerificationRequest,
+    *,
+    label: str,
+) -> None:
+    if not request.context.strip():
+        raise ValueError(f"{label} requires context.")
+    if not request.instance.strip():
+        raise ValueError(f"{label} requires instance.")
+    if not request.deployment_record_id.strip():
+        raise ValueError(f"{label} requires deployment_record_id.")
+    if request.verification_status not in {"pass", "fail"}:
+        raise ValueError(f"{label} status must be pass or fail.")
+    if not request.verified_at.strip():
+        raise ValueError(f"{label} requires verified_at.")
+    if request.checked_urls and request.timeout_seconds is None:
+        raise ValueError(f"{label} checked_urls require timeout_seconds.")
+
+
+class GenericWebStableVerificationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str
+    deployment_record_id: str
+    promotion_record_id: str = ""
+    verification_status: ReleaseStatus
+    verified_at: str
+    checked_urls: tuple[str, ...] = ()
+    timeout_seconds: int | None = Field(default=None, ge=1)
+    failure_summary: str = ""
+
+    @field_validator("verification_status", mode="before")
+    @classmethod
+    def _normalize_status(cls, value: object) -> ReleaseStatus:
+        return _normalize_release_status(value, label="Generic web stable verification status")
+
+    @field_validator("checked_urls", mode="before")
+    @classmethod
+    def _normalize_checked_urls(cls, value: object) -> tuple[str, ...]:
+        return _normalize_preview_verification_checked_urls(
+            value, label="Generic web stable verification"
+        )
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "GenericWebStableVerificationRequest":
+        _validate_stable_verification_request(self, label="Generic web stable verification")
+        return self
+
+
+class GenericWebStableVerificationEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    verification: GenericWebStableVerificationRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebStableVerificationEnvelope":
+        _validate_driver_envelope_product(self.product, label="Generic web stable verification")
+        return self
+
+
+_GENERIC_WEB_STABLE_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/generic-web/stable-verification",
+    envelope_model=GenericWebStableVerificationEnvelope,
+    denial_message=(
+        "Workflow cannot write generic web stable verification for the requested product/context."
+    ),
+)
+
+
+def _stable_verification_health_evidence(
+    *, request: GenericWebStableVerificationRequest
+) -> HealthcheckEvidence:
+    return HealthcheckEvidence(
+        verified=bool(request.checked_urls),
+        urls=request.checked_urls,
+        timeout_seconds=request.timeout_seconds if request.checked_urls else None,
+        status=request.verification_status,
+    )
+
+
+def _apply_generic_web_stable_verification_records(
+    *,
+    record_store: object,
+    request: GenericWebStableVerificationRequest,
+    label: str = "Generic web stable verification",
+) -> dict[str, object]:
+    evidence_store = cast(EvidenceIngestionStore, record_store)
+    try:
+        deployment_record = evidence_store.read_deployment_record(request.deployment_record_id)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"No Launchplane deployment record found for {request.deployment_record_id}."
+        ) from exc
+    if deployment_record.context != request.context:
+        raise click.ClickException(f"{label} context does not match deployment record context.")
+    if deployment_record.instance != request.instance:
+        raise click.ClickException(f"{label} instance does not match deployment record instance.")
+
+    health_evidence = _stable_verification_health_evidence(request=request)
+    updated_deployment = deployment_record.model_copy(
+        update={"destination_health": health_evidence}
+    )
+    result: dict[str, object] = dict(
+        apply_deployment_evidence(
+            record_store=evidence_store,
+            deployment_record=updated_deployment,
+        )
+    )
+    result["deployment_health_status"] = request.verification_status
+
+    promotion_record_id = request.promotion_record_id.strip()
+    if promotion_record_id:
+        try:
+            promotion_record = evidence_store.read_promotion_record(promotion_record_id)
+        except FileNotFoundError as exc:
+            raise click.ClickException(
+                f"No Launchplane promotion record found for {promotion_record_id}."
+            ) from exc
+        if promotion_record.context != request.context:
+            raise click.ClickException(f"{label} context does not match promotion record context.")
+        if promotion_record.to_instance != request.instance:
+            raise click.ClickException(
+                f"{label} instance does not match promotion destination instance."
+            )
+        if promotion_record.deployment_record_id.strip() not in {
+            "",
+            request.deployment_record_id,
+        }:
+            raise click.ClickException(
+                f"{label} deployment_record_id does not match linked promotion record."
+            )
+        updated_promotion = promotion_record.model_copy(
+            update={"destination_health": health_evidence}
+        )
+        result.update(
+            apply_promotion_evidence(
+                record_store=evidence_store,
+                promotion_record=updated_promotion,
+            )
+        )
+        result["promotion_health_status"] = request.verification_status
+
+    return result
+
+
+def _handle_generic_web_stable_verification(
+    request: GenericWebStableVerificationEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del control_plane_root_path
+    if resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Generic web stable verification requires a product profile lane."
+        )
+    return _DescriptorDriverDispatchResult(
+        result=_apply_generic_web_stable_verification_records(
+            record_store=record_store,
+            request=request.verification,
+        )
+    )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -209,6 +209,15 @@ from control_plane.drivers.dispatch import (
     _validate_driver_envelope_product as _validate_driver_envelope_product,
     ProductDriverMismatchError as ProductDriverMismatchError,
 )
+from control_plane.drivers.generic_web_dispatch import (
+    GenericWebStableVerificationEnvelope as GenericWebStableVerificationEnvelope,
+    GenericWebStableVerificationRequest as GenericWebStableVerificationRequest,
+    _GENERIC_WEB_STABLE_VERIFICATION_ROUTE as _GENERIC_WEB_STABLE_VERIFICATION_ROUTE,
+    _apply_generic_web_stable_verification_records as _apply_generic_web_stable_verification_records,
+    _handle_generic_web_stable_verification as _handle_generic_web_stable_verification,
+    _stable_verification_health_evidence as _stable_verification_health_evidence,
+    _validate_stable_verification_request as _validate_stable_verification_request,
+)
 from control_plane.drivers.generic_web_preview_dispatch import (
     GenericWebPreviewDesiredStateEnvelope as GenericWebPreviewDesiredStateEnvelope,
     GenericWebPreviewDestroyEnvelope as GenericWebPreviewDestroyEnvelope,
@@ -1045,57 +1054,6 @@ _GENERIC_WEB_ROLLBACK_ROUTE = _DriverRouteExecutionMetadata(
 )
 
 
-class GenericWebStableVerificationRequest(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    context: str
-    instance: str
-    deployment_record_id: str
-    promotion_record_id: str = ""
-    verification_status: ReleaseStatus
-    verified_at: str
-    checked_urls: tuple[str, ...] = ()
-    timeout_seconds: int | None = Field(default=None, ge=1)
-    failure_summary: str = ""
-
-    @field_validator("verification_status", mode="before")
-    @classmethod
-    def _normalize_status(cls, value: object) -> ReleaseStatus:
-        return _normalize_release_status(value, label="Generic web stable verification status")
-
-    @field_validator("checked_urls", mode="before")
-    @classmethod
-    def _normalize_checked_urls(cls, value: object) -> tuple[str, ...]:
-        return _normalize_preview_verification_checked_urls(
-            value, label="Generic web stable verification"
-        )
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "GenericWebStableVerificationRequest":
-        _validate_stable_verification_request(self, label="Generic web stable verification")
-        return self
-
-
-class GenericWebStableVerificationEnvelope(_ProductRouteEnvelope):
-    schema_version: int = Field(default=1, ge=1)
-    verification: GenericWebStableVerificationRequest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "GenericWebStableVerificationEnvelope":
-        _validate_driver_envelope_product(self.product, label="Generic web stable verification")
-        return self
-
-
-_GENERIC_WEB_STABLE_VERIFICATION_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/generic-web/stable-verification",
-    envelope_model=GenericWebStableVerificationEnvelope,
-    denial_message=(
-        "Workflow cannot write generic web stable verification for the requested product/context."
-    ),
-)
-
-
 class OdooPreviewApplyEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     apply: OdooPreviewDokployApplyRequest
@@ -1804,25 +1762,6 @@ class VeriReelTestingDeployEnvelope(_ProductRouteEnvelope):
         return self
 
 
-def _validate_stable_verification_request(
-    request: GenericWebStableVerificationRequest,
-    *,
-    label: str,
-) -> None:
-    if not request.context.strip():
-        raise ValueError(f"{label} requires context.")
-    if not request.instance.strip():
-        raise ValueError(f"{label} requires instance.")
-    if not request.deployment_record_id.strip():
-        raise ValueError(f"{label} requires deployment_record_id.")
-    if request.verification_status not in {"pass", "fail"}:
-        raise ValueError(f"{label} status must be pass or fail.")
-    if not request.verified_at.strip():
-        raise ValueError(f"{label} requires verified_at.")
-    if request.checked_urls and request.timeout_seconds is None:
-        raise ValueError(f"{label} checked_urls require timeout_seconds.")
-
-
 class VeriReelTestingVerificationRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -2416,25 +2355,6 @@ def _resolve_and_authorize_descriptor_route(
         trace_id=trace_id,
     )
     return resolved_driver_context, authorization_response
-
-
-def _handle_generic_web_stable_verification(
-    request: GenericWebStableVerificationEnvelope,
-    resolved_context: _ResolvedProductDriverContext,
-    record_store: object,
-    control_plane_root_path: Path,
-) -> _DescriptorDriverDispatchResult:
-    del control_plane_root_path
-    if resolved_context.lane is None:
-        raise ProductDriverMismatchError(
-            "Generic web stable verification requires a product profile lane."
-        )
-    return _DescriptorDriverDispatchResult(
-        result=_apply_generic_web_stable_verification_records(
-            record_store=record_store,
-            request=request.verification,
-        )
-    )
 
 
 def _handle_generic_web_rollback_plan(
@@ -8904,82 +8824,6 @@ def _apply_verireel_preview_verification_records(
         result_key="verireel_preview_verification",
         default_failure_summary="Preview E2E verification failed.",
     )
-
-
-def _stable_verification_health_evidence(
-    *, request: GenericWebStableVerificationRequest
-) -> HealthcheckEvidence:
-    return HealthcheckEvidence(
-        verified=bool(request.checked_urls),
-        urls=request.checked_urls,
-        timeout_seconds=request.timeout_seconds if request.checked_urls else None,
-        status=request.verification_status,
-    )
-
-
-def _apply_generic_web_stable_verification_records(
-    *,
-    record_store: object,
-    request: GenericWebStableVerificationRequest,
-    label: str = "Generic web stable verification",
-) -> dict[str, object]:
-    evidence_store = cast(EvidenceIngestionStore, record_store)
-    try:
-        deployment_record = evidence_store.read_deployment_record(request.deployment_record_id)
-    except FileNotFoundError as exc:
-        raise click.ClickException(
-            f"No Launchplane deployment record found for {request.deployment_record_id}."
-        ) from exc
-    if deployment_record.context != request.context:
-        raise click.ClickException(f"{label} context does not match deployment record context.")
-    if deployment_record.instance != request.instance:
-        raise click.ClickException(f"{label} instance does not match deployment record instance.")
-
-    health_evidence = _stable_verification_health_evidence(request=request)
-    updated_deployment = deployment_record.model_copy(
-        update={"destination_health": health_evidence}
-    )
-    result: dict[str, object] = dict(
-        apply_deployment_evidence(
-            record_store=evidence_store,
-            deployment_record=updated_deployment,
-        )
-    )
-    result["deployment_health_status"] = request.verification_status
-
-    promotion_record_id = request.promotion_record_id.strip()
-    if promotion_record_id:
-        try:
-            promotion_record = evidence_store.read_promotion_record(promotion_record_id)
-        except FileNotFoundError as exc:
-            raise click.ClickException(
-                f"No Launchplane promotion record found for {promotion_record_id}."
-            ) from exc
-        if promotion_record.context != request.context:
-            raise click.ClickException(f"{label} context does not match promotion record context.")
-        if promotion_record.to_instance != request.instance:
-            raise click.ClickException(
-                f"{label} instance does not match promotion destination instance."
-            )
-        if promotion_record.deployment_record_id.strip() not in {
-            "",
-            request.deployment_record_id,
-        }:
-            raise click.ClickException(
-                f"{label} deployment_record_id does not match linked promotion record."
-            )
-        updated_promotion = promotion_record.model_copy(
-            update={"destination_health": health_evidence}
-        )
-        result.update(
-            apply_promotion_evidence(
-                record_store=evidence_store,
-                promotion_record=updated_promotion,
-            )
-        )
-        result["promotion_health_status"] = request.verification_status
-
-    return result
 
 
 def _testing_post_deploy_detail(status: ReleaseStatus) -> str:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -24394,6 +24394,193 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             self.assertEqual(inventory.deployment_record_id, deployment.record_id)
 
+    def test_generic_web_stable_verification_requires_timeout_for_checked_urls(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/stable-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "instance": "testing",
+                        "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
+                        "verification_status": "pass",
+                        "verified_at": "2026-04-20T15:35:00Z",
+                        "checked_urls": ["https://cm-testing.example.com/web/health"],
+                    },
+                },
+                headers={
+                    "Idempotency-Key": "generic-stable-verification:cm:testing:missing-timeout"
+                },
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_generic_web_stable_verification_updates_linked_promotion_health(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+            )
+            store.write_deployment_record(
+                DeploymentRecord(
+                    record_id="deployment-20260420T153000Z-cm-testing",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="artifact-20260420-a1b2c3d4"
+                    ),
+                    context="cm",
+                    instance="testing",
+                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+                    deploy=DeploymentEvidence(
+                        target_name="cm-testing",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        deployment_id="delegated-compose-ship",
+                        status="pass",
+                    ),
+                    destination_health=HealthcheckEvidence(status="pending"),
+                )
+            )
+            store.write_promotion_record(
+                PromotionRecord(
+                    record_id="promotion-20260420T153500Z-cm-prod-to-testing",
+                    artifact_identity=ArtifactIdentityReference(
+                        artifact_id="artifact-20260420-a1b2c3d4"
+                    ),
+                    deployment_record_id="deployment-20260420T153000Z-cm-testing",
+                    backup_record_id="backup-cm-prod-20260420T152500Z",
+                    context="cm",
+                    from_instance="prod",
+                    to_instance="testing",
+                    deploy=DeploymentEvidence(
+                        target_name="cm-testing",
+                        target_type="compose",
+                        deploy_mode="dokploy-compose-api",
+                        deployment_id="delegated-compose-promote",
+                        status="pass",
+                    ),
+                    destination_health=HealthcheckEvidence(status="pending"),
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/tenant-cm",
+                            "workflow_refs": [
+                                "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm"],
+                            "contexts": ["cm"],
+                            "actions": ["deployment.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="every/tenant-cm",
+                        workflow_ref=(
+                            "every/tenant-cm/.github/workflows/stable-smoke.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/stable-verification",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "verification": {
+                        "schema_version": 1,
+                        "context": "cm",
+                        "instance": "testing",
+                        "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
+                        "promotion_record_id": "promotion-20260420T153500Z-cm-prod-to-testing",
+                        "verification_status": "fail",
+                        "verified_at": "2026-04-20T15:35:00Z",
+                    },
+                },
+                headers={"Idempotency-Key": "generic-stable-verification:cm:testing:promotion"},
+            )
+
+            deployment = store.read_deployment_record("deployment-20260420T153000Z-cm-testing")
+            promotion = store.read_promotion_record("promotion-20260420T153500Z-cm-prod-to-testing")
+            inventory = store.read_environment_inventory(context_name="cm", instance_name="testing")
+
+        self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2))
+        self.assertEqual(
+            payload["records"]["deployment_record_id"],
+            "deployment-20260420T153000Z-cm-testing",
+        )
+        self.assertEqual(
+            payload["records"]["promotion_record_id"],
+            "promotion-20260420T153500Z-cm-prod-to-testing",
+        )
+        self.assertEqual(payload["records"]["inventory_record_id"], "cm-testing")
+        self.assertEqual(deployment.destination_health.status, "fail")
+        self.assertEqual(promotion.destination_health.status, "fail")
+        self.assertEqual(inventory.deployment_record_id, deployment.record_id)
+        self.assertEqual(inventory.promotion_record_id, promotion.record_id)
+        self.assertEqual(inventory.promoted_from_instance, "prod")
+
     def test_deployment_endpoint_replays_idempotent_write(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- Add a non-preview generic-web dispatch module and move stable-verification request/envelope/route handling into it
- Preserve service compatibility re-exports for the moved stable-verification symbols
- Add focused coverage for checked-url timeout validation and linked promotion health updates

## Validation
- uv run --extra dev ruff check --diff control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff check control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff format --check control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_generic_web_stable_verification_route_accepts_odoo_base_driver_profile tests.test_service.LaunchplaneServiceTests.test_generic_web_stable_verification_requires_timeout_for_checked_urls tests.test_service.LaunchplaneServiceTests.test_generic_web_stable_verification_updates_linked_promotion_health tests.test_service.LaunchplaneServiceTests.test_odoo_stable_verification_route_is_retired tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_stable_verification_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_stable_verification_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_stable_verification_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_execution_metadata_matches_descriptors
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_service tests.test_driver_descriptors

## Review
- Non-Claude scoped planning completed; GPT plan recommended stable verification as the smallest non-preview slice
- Non-Claude scoped GPT review found no findings and suggested the added validation/promotion evidence tests
- Antigravity runs returned empty output, so they were not treated as review signal
- Background auto-review failed before findings due to configured diff size limit; no detached finding was produced