### PR TITLE
Extract generic web promotion workflow dispatch

### DIFF
--- a/control_plane/drivers/generic_web_dispatch.py
+++ b/control_plane/drivers/generic_web_dispatch.py
@@ -34,6 +34,10 @@ from control_plane.workflows.generic_web_deploy import (
     GenericWebPostDeployExecutor,
     execute_generic_web_deploy,
 )
+from control_plane.workflows.generic_web_promotion_workflow import (
+    GenericWebPromotionWorkflowRequest,
+    dispatch_generic_web_promotion_workflow,
+)
 from control_plane.workflows.generic_web_rollback import (
     GenericWebRollbackApplyStore,
     execute_generic_web_rollback,
@@ -185,6 +189,29 @@ _GENERIC_WEB_ROLLBACK_ROUTE = _DriverRouteExecutionMetadata(
     envelope_model=GenericWebRollbackEnvelope,
     denial_message=(
         "Workflow cannot execute the generic web prod rollback for the requested product/context."
+    ),
+)
+
+
+class GenericWebPromotionWorkflowEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    workflow: GenericWebPromotionWorkflowRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebPromotionWorkflowEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web promotion workflow requires product")
+        if self.product.strip() != self.workflow.product.strip():
+            raise ValueError("generic web promotion workflow requires matching product values")
+        return self
+
+
+_GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/generic-web/prod-promotion-workflow",
+    envelope_model=GenericWebPromotionWorkflowEnvelope,
+    denial_message=(
+        "Caller cannot dispatch the generic web prod promotion workflow"
+        " for the requested product/context."
     ),
 )
 
@@ -359,5 +386,27 @@ def _handle_generic_web_rollback(
             "deploy_status": driver_result.deploy_status,
             "post_deploy_status": driver_result.post_deploy_status,
         },
+        driver_result=driver_result,
+    )
+
+
+def _handle_generic_web_promotion_workflow(
+    request: GenericWebPromotionWorkflowEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    del record_store
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Generic web promotion workflow requires a product profile lane."
+        )
+    driver_result = dispatch_generic_web_promotion_workflow(
+        control_plane_root=control_plane_root_path,
+        profile=resolved_context.profile,
+        request=request.workflow,
+    )
+    return _DescriptorDriverDispatchResult(
+        result=driver_result.model_dump(mode="json"),
         driver_result=driver_result,
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -206,17 +206,20 @@ from control_plane.drivers.dispatch import (
 )
 from control_plane.drivers.generic_web_dispatch import (
     GenericWebDeployEnvelope as GenericWebDeployEnvelope,
+    GenericWebPromotionWorkflowEnvelope as GenericWebPromotionWorkflowEnvelope,
     GenericWebRollbackEnvelope as GenericWebRollbackEnvelope,
     GenericWebRollbackPlanEnvelope as GenericWebRollbackPlanEnvelope,
     GenericWebStableVerificationEnvelope as GenericWebStableVerificationEnvelope,
     GenericWebStableVerificationRequest as GenericWebStableVerificationRequest,
     _GENERIC_WEB_DEPLOY_ROUTE as _GENERIC_WEB_DEPLOY_ROUTE,
+    _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE as _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE,
     _GENERIC_WEB_ROLLBACK_PLAN_ROUTE as _GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
     _GENERIC_WEB_ROLLBACK_ROUTE as _GENERIC_WEB_ROLLBACK_ROUTE,
     _GENERIC_WEB_STABLE_VERIFICATION_ROUTE as _GENERIC_WEB_STABLE_VERIFICATION_ROUTE,
     _apply_generic_web_stable_verification_records as _apply_generic_web_stable_verification_records,
     _generic_web_post_deploy_executor_for_profile as _generic_web_post_deploy_executor_for_profile,
     _handle_generic_web_deploy as _handle_generic_web_deploy,
+    _handle_generic_web_promotion_workflow as _handle_generic_web_promotion_workflow,
     _handle_generic_web_rollback as _handle_generic_web_rollback,
     _handle_generic_web_rollback_plan as _handle_generic_web_rollback_plan,
     _handle_generic_web_stable_verification as _handle_generic_web_stable_verification,
@@ -377,10 +380,6 @@ from control_plane.workflows.generic_web_promotion import (
     GenericWebPromotionStore,
     execute_generic_web_prod_promotion,
     resolve_generic_web_promotion_lanes,
-)
-from control_plane.workflows.generic_web_promotion_workflow import (
-    GenericWebPromotionWorkflowRequest,
-    dispatch_generic_web_promotion_workflow,
 )
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
@@ -952,29 +951,6 @@ _GENERIC_WEB_PROD_PROMOTION_ROUTE = _DriverRouteExecutionMetadata(
     envelope_model=GenericWebProdPromotionEnvelope,
     denial_message=(
         "Workflow cannot execute the generic web prod promotion driver"
-        " for the requested product/context."
-    ),
-)
-
-
-class GenericWebPromotionWorkflowEnvelope(_ProductRouteEnvelope):
-    schema_version: int = Field(default=1, ge=1)
-    workflow: GenericWebPromotionWorkflowRequest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "GenericWebPromotionWorkflowEnvelope":
-        if not self.product.strip():
-            raise ValueError("generic web promotion workflow requires product")
-        if self.product.strip() != self.workflow.product.strip():
-            raise ValueError("generic web promotion workflow requires matching product values")
-        return self
-
-
-_GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/generic-web/prod-promotion-workflow",
-    envelope_model=GenericWebPromotionWorkflowEnvelope,
-    denial_message=(
-        "Caller cannot dispatch the generic web prod promotion workflow"
         " for the requested product/context."
     ),
 )
@@ -2352,28 +2328,6 @@ def _handle_npmplus_ingress_apply(
         "ingress_dry_run": ingress_result.dry_run,
         "ingress_route_audit_record_id": ingress_audit_record.record_id,
     }, ingress_result
-
-
-def _handle_generic_web_promotion_workflow(
-    request: GenericWebPromotionWorkflowEnvelope,
-    resolved_context: _ResolvedProductDriverContext,
-    record_store: object,
-    control_plane_root_path: Path,
-) -> _DescriptorDriverDispatchResult:
-    del record_store
-    if resolved_context.profile is None or resolved_context.lane is None:
-        raise ProductDriverMismatchError(
-            "Generic web promotion workflow requires a product profile lane."
-        )
-    driver_result = dispatch_generic_web_promotion_workflow(
-        control_plane_root=control_plane_root_path,
-        profile=resolved_context.profile,
-        request=request.workflow,
-    )
-    return _DescriptorDriverDispatchResult(
-        result=driver_result.model_dump(mode="json"),
-        driver_result=driver_result,
-    )
 
 
 def _dispatch_generic_web_prod_promotion(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18236,7 +18236,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             cookie = _signed_in_cookie(app)
 
             with patch(
-                "control_plane.service.dispatch_generic_web_promotion_workflow",
+                "control_plane.drivers.generic_web_dispatch.dispatch_generic_web_promotion_workflow",
                 return_value=GenericWebPromotionWorkflowResult(
                     product="sellyouroutboard",
                     context="sellyouroutboard-testing",
@@ -18317,7 +18317,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             cookie = _signed_in_cookie(app)
 
             with patch(
-                "control_plane.service.dispatch_generic_web_promotion_workflow",
+                "control_plane.drivers.generic_web_dispatch.dispatch_generic_web_promotion_workflow",
                 return_value=GenericWebPromotionWorkflowResult(
                     product="sellyouroutboard",
                     context="sellyouroutboard-testing",
@@ -18437,7 +18437,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service.dispatch_generic_web_promotion_workflow",
+                "control_plane.drivers.generic_web_dispatch.dispatch_generic_web_promotion_workflow",
                 return_value=GenericWebPromotionWorkflowResult(
                     product="sellyouroutboard",
                     context="sellyouroutboard-testing",
@@ -18507,7 +18507,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             cookie = _signed_in_cookie(app)
 
             with patch(
-                "control_plane.service.dispatch_generic_web_promotion_workflow"
+                "control_plane.drivers.generic_web_dispatch.dispatch_generic_web_promotion_workflow"
             ) as dispatch_mock:
                 status_code, payload = _invoke_app(
                     app,
@@ -18574,7 +18574,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service.dispatch_generic_web_promotion_workflow"
+                "control_plane.drivers.generic_web_dispatch.dispatch_generic_web_promotion_workflow"
             ) as dispatch_mock:
                 status_code, payload = _invoke_app(
                     app,


### PR DESCRIPTION
## Summary
- Move generic-web prod-promotion-workflow envelope, route metadata, and handler into `control_plane.drivers.generic_web_dispatch`
- Keep direct generic-web prod-promotion execution in `service.py` because it still owns custom idempotency and human live-execution rejection
- Update workflow dispatch tests to patch the executor at the new dispatch module boundary

## Local gates
- `uv run --extra dev ruff check --diff control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run python -m unittest <10 focused promotion-workflow + descriptor tests>`
- `uv run --extra dev ruff check control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff format --check control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_service tests.test_driver_descriptors`
- `uv run python -m unittest`

## Review
- Two non-Claude planning agents recommended promotion workflow as the narrowest next slice
- Two scoped GPT review passes completed clean
- Background auto-review ledger only reported the known oversized-scope diagnostic before findings (`70940562-cd9c-4ce5-827a-9ee1a1b0360f`)
