### PR TITLE
Extract generic web prod promotion dispatch

### DIFF
--- a/control_plane/drivers/dispatch.py
+++ b/control_plane/drivers/dispatch.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from pathlib import Path
 import re
 from typing import Callable, Generic, TypeVar, cast
@@ -23,6 +24,38 @@ class _ProductRouteEnvelope(BaseModel):
 
 _DriverRouteEnvelopeT = TypeVar("_DriverRouteEnvelopeT", bound=_ProductRouteEnvelope)
 _StartResponse = Callable[[str, list[tuple[str, str]]], None]
+
+
+def _http_status_text(status_code: int) -> str:
+    return {
+        200: "OK",
+        202: "Accepted",
+        400: "Bad Request",
+        401: "Unauthorized",
+        403: "Forbidden",
+        404: "Not Found",
+        405: "Method Not Allowed",
+        409: "Conflict",
+        500: "Internal Server Error",
+    }.get(status_code, "OK")
+
+
+def _json_response(
+    *,
+    start_response: _StartResponse,
+    status_code: int,
+    payload: dict[str, object],
+    headers: list[tuple[str, str]] | None = None,
+) -> list[bytes]:
+    encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
+    status_line = f"{status_code} {_http_status_text(status_code)}"
+    response_headers = [
+        ("Content-Type", "application/json"),
+        ("Content-Length", str(len(encoded))),
+    ]
+    response_headers.extend(headers or [])
+    start_response(status_line, response_headers)
+    return [encoded]
 
 
 @dataclass(frozen=True)

--- a/control_plane/drivers/generic_web_dispatch.py
+++ b/control_plane/drivers/generic_web_dispatch.py
@@ -19,10 +19,13 @@ from control_plane.drivers.dispatch import (
     _ProductRouteEnvelope,
     _ResolvedProductDriverContext,
     ProductDriverMismatchError,
+    _StartResponse,
+    _json_response,
     _normalize_preview_verification_checked_urls,
     _normalize_release_status,
     _validate_driver_envelope_product,
 )
+from control_plane.service_auth import GitHubHumanIdentity, LaunchplaneIdentity
 from control_plane.workflows.evidence_ingestion import (
     EvidenceIngestionStore,
     apply_deployment_evidence,
@@ -33,6 +36,12 @@ from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployStore,
     GenericWebPostDeployExecutor,
     execute_generic_web_deploy,
+)
+from control_plane.workflows.generic_web_promotion import (
+    GenericWebProdPromotionRequest,
+    GenericWebPromotionStore,
+    execute_generic_web_prod_promotion,
+    resolve_generic_web_promotion_lanes,
 )
 from control_plane.workflows.generic_web_promotion_workflow import (
     GenericWebPromotionWorkflowRequest,
@@ -145,6 +154,29 @@ _GENERIC_WEB_DEPLOY_ROUTE = _DriverRouteExecutionMetadata(
     envelope_model=GenericWebDeployEnvelope,
     denial_message=(
         "Workflow cannot execute the generic web deploy driver for the requested product/context."
+    ),
+)
+
+
+class GenericWebProdPromotionEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    promotion: GenericWebProdPromotionRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "GenericWebProdPromotionEnvelope":
+        if not self.product.strip():
+            raise ValueError("generic web prod promotion requires product")
+        if self.product.strip() != self.promotion.product.strip():
+            raise ValueError("generic web prod promotion requires matching product values")
+        return self
+
+
+_GENERIC_WEB_PROD_PROMOTION_ROUTE = _DriverRouteExecutionMetadata(
+    route_path="/v1/drivers/generic-web/prod-promotion",
+    envelope_model=GenericWebProdPromotionEnvelope,
+    denial_message=(
+        "Workflow cannot execute the generic web prod promotion driver"
+        " for the requested product/context."
     ),
 )
 
@@ -362,6 +394,41 @@ def _handle_generic_web_deploy(
     )
 
 
+def _handle_generic_web_prod_promotion(
+    request: GenericWebProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _DescriptorDriverDispatchResult:
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Generic web prod promotion requires a product profile lane."
+        )
+    driver_result = execute_generic_web_prod_promotion(
+        control_plane_root=control_plane_root_path,
+        record_store=cast(GenericWebPromotionStore, record_store),
+        request=request.promotion,
+    )
+    return _DescriptorDriverDispatchResult(
+        result={
+            "promotion_record_id": driver_result.promotion_record_id,
+            "deployment_record_id": driver_result.deployment_record_id,
+            "backup_record_id": driver_result.backup_record_id,
+            "inventory_record_id": driver_result.inventory_record_id,
+            "promotion_status": driver_result.promotion_status,
+            "deployment_status": driver_result.deployment_status,
+            "source_health_status": driver_result.source_health_status,
+            "destination_health_status": driver_result.destination_health_status,
+            "backup_status": driver_result.backup_status,
+            "release_status": driver_result.release_status,
+            "release_tag": driver_result.release_tag,
+            "release_url": driver_result.release_url,
+            "dry_run": driver_result.dry_run,
+        },
+        driver_result=driver_result,
+    )
+
+
 def _handle_generic_web_rollback(
     request: GenericWebRollbackEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -409,4 +476,45 @@ def _handle_generic_web_promotion_workflow(
     return _DescriptorDriverDispatchResult(
         result=driver_result.model_dump(mode="json"),
         driver_result=driver_result,
+    )
+
+
+def _validate_generic_web_prod_promotion_lanes(
+    request: GenericWebProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    record_store: object,
+    control_plane_root_path: Path,
+) -> None:
+    del control_plane_root_path
+    if resolved_context.profile is None or resolved_context.lane is None:
+        raise ProductDriverMismatchError(
+            "Generic web prod promotion requires a product profile lane."
+        )
+    resolve_generic_web_promotion_lanes(
+        record_store=cast(GenericWebPromotionStore, record_store),
+        request=request.promotion,
+    )
+
+
+def _reject_human_live_generic_web_prod_promotion(
+    request: GenericWebProdPromotionEnvelope,
+    resolved_context: _ResolvedProductDriverContext,
+    identity: LaunchplaneIdentity,
+    start_response: _StartResponse,
+    trace_id: str,
+) -> list[bytes] | None:
+    del resolved_context
+    if not isinstance(identity, GitHubHumanIdentity) or request.promotion.dry_run:
+        return None
+    return _json_response(
+        start_response=start_response,
+        status_code=403,
+        payload={
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {
+                "code": "authorization_denied",
+                "message": "Launchplane UI can only dry-run generic-web prod promotions.",
+            },
+        },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -198,6 +198,7 @@ from control_plane.drivers.dispatch import (
     _ProductRouteEnvelope as _ProductRouteEnvelope,
     _ResolvedProductDriverContext as _ResolvedProductDriverContext,
     _image_reference_tail as _image_reference_tail,
+    _json_response as _json_response,
     _normalize_preview_verification_checked_urls as _normalize_preview_verification_checked_urls,
     _normalize_release_status as _normalize_release_status,
     _repo_token as _repo_token,
@@ -206,12 +207,14 @@ from control_plane.drivers.dispatch import (
 )
 from control_plane.drivers.generic_web_dispatch import (
     GenericWebDeployEnvelope as GenericWebDeployEnvelope,
+    GenericWebProdPromotionEnvelope as GenericWebProdPromotionEnvelope,
     GenericWebPromotionWorkflowEnvelope as GenericWebPromotionWorkflowEnvelope,
     GenericWebRollbackEnvelope as GenericWebRollbackEnvelope,
     GenericWebRollbackPlanEnvelope as GenericWebRollbackPlanEnvelope,
     GenericWebStableVerificationEnvelope as GenericWebStableVerificationEnvelope,
     GenericWebStableVerificationRequest as GenericWebStableVerificationRequest,
     _GENERIC_WEB_DEPLOY_ROUTE as _GENERIC_WEB_DEPLOY_ROUTE,
+    _GENERIC_WEB_PROD_PROMOTION_ROUTE as _GENERIC_WEB_PROD_PROMOTION_ROUTE,
     _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE as _GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE,
     _GENERIC_WEB_ROLLBACK_PLAN_ROUTE as _GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
     _GENERIC_WEB_ROLLBACK_ROUTE as _GENERIC_WEB_ROLLBACK_ROUTE,
@@ -219,12 +222,15 @@ from control_plane.drivers.generic_web_dispatch import (
     _apply_generic_web_stable_verification_records as _apply_generic_web_stable_verification_records,
     _generic_web_post_deploy_executor_for_profile as _generic_web_post_deploy_executor_for_profile,
     _handle_generic_web_deploy as _handle_generic_web_deploy,
+    _handle_generic_web_prod_promotion as _handle_generic_web_prod_promotion,
     _handle_generic_web_promotion_workflow as _handle_generic_web_promotion_workflow,
     _handle_generic_web_rollback as _handle_generic_web_rollback,
     _handle_generic_web_rollback_plan as _handle_generic_web_rollback_plan,
     _handle_generic_web_stable_verification as _handle_generic_web_stable_verification,
     _stable_verification_health_evidence as _stable_verification_health_evidence,
+    _reject_human_live_generic_web_prod_promotion as _reject_human_live_generic_web_prod_promotion,
     _validate_stable_verification_request as _validate_stable_verification_request,
+    _validate_generic_web_prod_promotion_lanes as _validate_generic_web_prod_promotion_lanes,
 )
 from control_plane.drivers.generic_web_preview_dispatch import (
     GenericWebPreviewDesiredStateEnvelope as GenericWebPreviewDesiredStateEnvelope,
@@ -374,12 +380,6 @@ from control_plane.workflows.evidence_ingestion import (
     EvidenceIngestionStore,
     apply_deployment_evidence,
     apply_promotion_evidence,
-)
-from control_plane.workflows.generic_web_promotion import (
-    GenericWebProdPromotionRequest,
-    GenericWebPromotionStore,
-    execute_generic_web_prod_promotion,
-    resolve_generic_web_promotion_lanes,
 )
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDesiredStateRequest,
@@ -931,29 +931,6 @@ class PublicIngressNotificationPolicyApplyEnvelope(BaseModel):
                 "public ingress notification policy apply requires product 'launchplane'"
             )
         return self
-
-
-class GenericWebProdPromotionEnvelope(_ProductRouteEnvelope):
-    schema_version: int = Field(default=1, ge=1)
-    promotion: GenericWebProdPromotionRequest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "GenericWebProdPromotionEnvelope":
-        if not self.product.strip():
-            raise ValueError("generic web prod promotion requires product")
-        if self.product.strip() != self.promotion.product.strip():
-            raise ValueError("generic web prod promotion requires matching product values")
-        return self
-
-
-_GENERIC_WEB_PROD_PROMOTION_ROUTE = _DriverRouteExecutionMetadata(
-    route_path="/v1/drivers/generic-web/prod-promotion",
-    envelope_model=GenericWebProdPromotionEnvelope,
-    denial_message=(
-        "Workflow cannot execute the generic web prod promotion driver"
-        " for the requested product/context."
-    ),
-)
 
 
 class OdooPreviewApplyEnvelope(_ProductRouteEnvelope):
@@ -2156,24 +2133,6 @@ class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
     daemon_threads = True
 
 
-def _json_response(
-    *,
-    start_response: _StartResponse,
-    status_code: int,
-    payload: dict[str, object],
-    headers: list[tuple[str, str]] | None = None,
-) -> list[bytes]:
-    encoded = json.dumps(payload, indent=2, sort_keys=True).encode("utf-8")
-    status_line = f"{status_code} {_http_status_text(status_code)}"
-    response_headers = [
-        ("Content-Type", "application/json"),
-        ("Content-Length", str(len(encoded))),
-    ]
-    response_headers.extend(headers or [])
-    start_response(status_line, response_headers)
-    return [encoded]
-
-
 def _redirect_response(
     *,
     start_response: _StartResponse,
@@ -2328,102 +2287,6 @@ def _handle_npmplus_ingress_apply(
         "ingress_dry_run": ingress_result.dry_run,
         "ingress_route_audit_record_id": ingress_audit_record.record_id,
     }, ingress_result
-
-
-def _dispatch_generic_web_prod_promotion(
-    request: GenericWebProdPromotionEnvelope,
-    resolved_context: _ResolvedProductDriverContext,
-    record_store: object,
-    control_plane_root_path: Path,
-    state_dir: Path,
-    database_url: str | None,
-    identity: LaunchplaneIdentity,
-    request_scope: str,
-    request_idempotency_key: str,
-    request_fingerprint: str,
-    start_response: _StartResponse,
-    trace_id: str,
-) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
-    del state_dir, database_url, identity
-    if resolved_context.profile is None or resolved_context.lane is None:
-        raise ProductDriverMismatchError(
-            "Generic web prod promotion requires a product profile lane."
-        )
-    idempotent_response = _check_idempotent_request(
-        record_store=record_store,
-        scope=request_scope,
-        route_path=_GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path,
-        idempotency_key=request_idempotency_key,
-        request_fingerprint=request_fingerprint,
-        start_response=start_response,
-        trace_id=trace_id,
-    )
-    if idempotent_response is not None:
-        return idempotent_response
-    driver_result = execute_generic_web_prod_promotion(
-        control_plane_root=control_plane_root_path,
-        record_store=cast(GenericWebPromotionStore, record_store),
-        request=request.promotion,
-    )
-    return (
-        {
-            "promotion_record_id": driver_result.promotion_record_id,
-            "deployment_record_id": driver_result.deployment_record_id,
-            "backup_record_id": driver_result.backup_record_id,
-            "inventory_record_id": driver_result.inventory_record_id,
-            "promotion_status": driver_result.promotion_status,
-            "deployment_status": driver_result.deployment_status,
-            "source_health_status": driver_result.source_health_status,
-            "destination_health_status": driver_result.destination_health_status,
-            "backup_status": driver_result.backup_status,
-            "release_status": driver_result.release_status,
-            "release_tag": driver_result.release_tag,
-            "release_url": driver_result.release_url,
-            "dry_run": driver_result.dry_run,
-        },
-        driver_result,
-    )
-
-
-def _validate_generic_web_prod_promotion_lanes(
-    request: GenericWebProdPromotionEnvelope,
-    resolved_context: _ResolvedProductDriverContext,
-    record_store: object,
-    control_plane_root_path: Path,
-) -> None:
-    del control_plane_root_path
-    if resolved_context.profile is None or resolved_context.lane is None:
-        raise ProductDriverMismatchError(
-            "Generic web prod promotion requires a product profile lane."
-        )
-    resolve_generic_web_promotion_lanes(
-        record_store=cast(GenericWebPromotionStore, record_store),
-        request=request.promotion,
-    )
-
-
-def _reject_human_live_generic_web_prod_promotion(
-    request: GenericWebProdPromotionEnvelope,
-    resolved_context: _ResolvedProductDriverContext,
-    identity: LaunchplaneIdentity,
-    start_response: _StartResponse,
-    trace_id: str,
-) -> list[bytes] | None:
-    del resolved_context
-    if not isinstance(identity, GitHubHumanIdentity) or request.promotion.dry_run:
-        return None
-    return _json_response(
-        start_response=start_response,
-        status_code=403,
-        payload={
-            "status": "rejected",
-            "trace_id": trace_id,
-            "error": {
-                "code": "authorization_denied",
-                "message": "Launchplane UI can only dry-run generic-web prod promotions.",
-            },
-        },
-    )
 
 
 def _handle_odoo_artifact_publish(
@@ -3359,8 +3222,7 @@ def _descriptor_driver_dispatch_routes(
             ),
             pre_idempotency_validator=_validate_generic_web_prod_promotion_lanes,
             pre_authorization_validator=_reject_human_live_generic_web_prod_promotion,
-            custom_dispatch_handler=_dispatch_generic_web_prod_promotion,
-            skip_pre_idempotency_check=True,
+            handler=_handle_generic_web_prod_promotion,
         ),
         _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -17701,7 +17701,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service.execute_generic_web_prod_promotion",
+                "control_plane.drivers.generic_web_dispatch.execute_generic_web_prod_promotion",
                 return_value=GenericWebProdPromotionResult(
                     product="sellyouroutboard",
                     context="sellyouroutboard-testing",
@@ -17751,6 +17751,102 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["provider_id"], "dokploy")
         self.assertEqual(payload["result"]["provider_target_type"], "application")
         self.assertNotIn("target_type", payload["result"])
+        execute_mock.assert_called_once()
+
+    def test_generic_web_prod_promotion_route_replays_idempotent_response(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/promote-prod.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["generic_web_prod_promotion.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/promote-prod.yml"
+                            "@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "promotion": {
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "artifact_id": "ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                    "source_git_ref": "abc123",
+                },
+            }
+
+            with patch(
+                "control_plane.drivers.generic_web_dispatch.execute_generic_web_prod_promotion",
+                return_value=GenericWebProdPromotionResult(
+                    product="sellyouroutboard",
+                    context="sellyouroutboard-testing",
+                    from_instance="testing",
+                    to_instance="prod",
+                    artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                    promotion_record_id="promotion-syo-testing-to-prod",
+                    deployment_record_id="deployment-syo-prod",
+                    inventory_record_id="sellyouroutboard-testing-prod",
+                    promotion_status="pass",
+                    deployment_status="pass",
+                    backup_status="skipped",
+                    source_health_status="pass",
+                    destination_health_status="pass",
+                    target_name="syo-prod-app",
+                    target_id="app-123",
+                    target_category="application",
+                    provider_id="dokploy",
+                    provider_target_type="application",
+                ),
+            ) as execute_mock:
+                first_status_code, first_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/prod-promotion",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "generic-web-prod-promotion-replay"},
+                )
+                second_status_code, second_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/drivers/generic-web/prod-promotion",
+                    payload=request_payload,
+                    headers={"Idempotency-Key": "generic-web-prod-promotion-replay"},
+                )
+
+        self.assertEqual(first_status_code, 202)
+        self.assertEqual(second_status_code, 202)
+        self.assertEqual(first_payload["records"], second_payload["records"])
+        self.assertEqual(first_payload["result"], second_payload["result"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertNotIn("target_type", second_payload["result"])
         execute_mock.assert_called_once()
 
     def test_generic_web_prod_promotion_route_rejects_wrong_product_context(self) -> None:
@@ -17855,7 +17951,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service.execute_generic_web_prod_promotion",
+                "control_plane.drivers.generic_web_dispatch.execute_generic_web_prod_promotion",
                 return_value=GenericWebProdPromotionResult(
                     product="sellyouroutboard",
                     context="sellyouroutboard-testing",
@@ -17951,7 +18047,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service.execute_generic_web_prod_promotion",
+                "control_plane.drivers.generic_web_dispatch.execute_generic_web_prod_promotion",
                 return_value=GenericWebProdPromotionResult(
                     product="sellyouroutboard",
                     context="sellyouroutboard-testing",
@@ -18031,7 +18127,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             cookie = _signed_in_cookie(app)
 
             with patch(
-                "control_plane.service.execute_generic_web_prod_promotion",
+                "control_plane.drivers.generic_web_dispatch.execute_generic_web_prod_promotion",
                 return_value=GenericWebProdPromotionResult(
                     product="sellyouroutboard",
                     context="sellyouroutboard-testing",


### PR DESCRIPTION
## Summary
- move direct generic-web prod-promotion envelope, route metadata, lane validation, human live rejection, and handler into generic_web_dispatch
- route direct prod-promotion through the normal descriptor handler path while preserving pre-idempotency lane validation and human live rejection hooks
- share JSON response helper from driver dispatch for moved pre-authorization rejection
- update prod-promotion tests to patch the moved handler dependency and add idempotent replay coverage

## Validation
- uv run --extra dev ruff check --diff control_plane/drivers/dispatch.py control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_executes_for_authorized_product_context tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_rejects_wrong_product_context tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_accepts_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_prod_promotion_route_accepts_padded_lane_context tests.test_service.LaunchplaneServiceTests.test_human_session_can_dry_run_generic_web_prod_promotion tests.test_service.LaunchplaneServiceTests.test_human_session_cannot_live_execute_generic_web_prod_promotion tests.test_service.LaunchplaneServiceTests.test_human_session_cannot_replay_live_generic_web_prod_promotion tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_prod_promotion_registered_in_descriptor_dispatch tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_prod_promotion_descriptor_requires_dispatch_registration tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_prod_promotion_dispatch_registration_requires_descriptor_route tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_generic_web_execution_metadata_matches_descriptors
- uv run --extra dev ruff check control_plane/drivers/dispatch.py control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py
- uv run --extra dev ruff format --check control_plane/drivers/dispatch.py control_plane/drivers/generic_web_dispatch.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_service tests.test_driver_descriptors
- uv run python -m unittest

## Review
- Scoped GPT reviewers completed; one clean, one raised a human-live replay concern already covered by existing intentional rejection test and pre-existing hook order.
- Background auto-review run 70940562-cd9c-4ce5-827a-9ee1a1b0360f failed before findings because its scope exceeded size limits; no proposal was produced.
