### PR TITLE
Remove workflow topology defaults

### DIFF
--- a/.github/workflows/odoo-config-parameter-override.yml
+++ b/.github/workflows/odoo-config-parameter-override.yml
@@ -7,22 +7,18 @@ name: Odoo Config Parameter Override
       product:
         description: Odoo product profile key.
         required: true
-        default: odoo-tenant-cm
         type: string
       context:
         description: Launchplane Odoo context.
         required: true
-        default: cm
-        type: choice
-        options:
-          - cm
+        type: string
       instance:
         description: Stable Odoo instance to update.
         required: true
-        default: testing
         type: choice
         options:
           - testing
+          - prod
       key:
         description: Odoo config parameter key.
         required: true
@@ -33,7 +29,6 @@ name: Odoo Config Parameter Override
       value:
         description: Non-secret config parameter value.
         required: true
-        default: https://cm-testing.shinycomputers.com
         type: string
 
 permissions:
@@ -67,10 +62,6 @@ jobs:
           : "${INSTANCE:?Missing instance input}"
           : "${KEY_NAME:?Missing key input}"
           : "${VALUE:?Missing value input}"
-          if [ "$CONTEXT_NAME" != "cm" ] || [ "$INSTANCE" != "testing" ]; then
-            echo 'This workflow currently writes only cm/testing Odoo overrides.' >&2
-            exit 1
-          fi
           if [ "$KEY_NAME" != "web.base.url" ]; then
             echo 'Only web.base.url is currently service-writable.' >&2
             exit 1

--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -7,17 +7,14 @@ name: Odoo Stable Bootstrap
       product:
         description: Odoo product profile key.
         required: true
-        default: odoo-tenant-cm
         type: string
       context:
         description: Launchplane Odoo context.
         required: true
-        default: cm
         type: string
       instance:
         description: Stable Odoo instance to bootstrap.
         required: true
-        default: testing
         type: string
       confirmation:
         description: Type the lane policy confirmation to confirm destructive bootstrap.

--- a/.github/workflows/odoo-target-replacement-apply.yml
+++ b/.github/workflows/odoo-target-replacement-apply.yml
@@ -7,7 +7,6 @@ name: Odoo Target Replacement Apply
       product:
         description: Odoo product profile key.
         required: true
-        default: odoo-tenant-cm
         type: string
       instance:
         description: Stable Odoo instance to recreate in place.

--- a/.github/workflows/odoo-target-replacement-plan.yml
+++ b/.github/workflows/odoo-target-replacement-plan.yml
@@ -7,7 +7,6 @@ name: Odoo Target Replacement Plan
       product:
         description: Odoo product profile key.
         required: true
-        default: odoo-tenant-cm
         type: string
       instance:
         description: Stable Odoo instance to inspect.

--- a/.github/workflows/odoo-website-bootstrap-override.yml
+++ b/.github/workflows/odoo-website-bootstrap-override.yml
@@ -7,20 +7,14 @@ name: Odoo Website Bootstrap Override
       product:
         description: Odoo product profile key.
         required: true
-        default: odoo-tenant-cm
         type: string
       context:
         description: Launchplane Odoo context.
         required: true
-        default: cm
-        type: choice
-        options:
-          - cm
-          - opw
+        type: string
       instance:
         description: Stable Odoo instance to update.
         required: true
-        default: testing
         type: choice
         options:
           - testing
@@ -59,15 +53,6 @@ jobs:
           : "${CONTEXT_NAME:?Missing context input}"
           : "${INSTANCE:?Missing instance input}"
           : "${WEBSITE_BOOTSTRAP_PAYLOAD:?Missing website bootstrap payload input}"
-          target_key="$PRODUCT:$CONTEXT_NAME:$INSTANCE"
-          allowed_targets=" odoo-tenant-cm:cm:testing odoo-tenant-opw:opw:testing odoo-tenant-opw:opw:prod "
-          if [[ "$allowed_targets" != *" $target_key "* ]]; then
-            echo 'Unsupported Odoo website bootstrap override target.' >&2
-            exit 1
-          fi
-          if [ "$PRODUCT" = "odoo-tenant-opw" ] && [ "$INSTANCE" = "prod" ]; then
-            echo 'OPW prod bootstrap override allowed for canonical URL correction.' >&2
-          fi
           if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
             echo 'Missing Launchplane service URL repository variable.' >&2
             exit 1

--- a/.github/workflows/product-context-cutover-audit.yml
+++ b/.github/workflows/product-context-cutover-audit.yml
@@ -7,17 +7,14 @@ name: Product Context Cutover Audit
       product:
         description: Product profile key to audit.
         required: true
-        default: sellyouroutboard
         type: string
       source_context:
         description: Legacy context to inspect.
         required: true
-        default: sellyouroutboard-testing
         type: string
       target_context:
         description: Canonical context to inspect.
         required: true
-        default: sellyouroutboard
         type: string
       preview_context:
         description: Optional preview context override.

--- a/.github/workflows/product-context-cutover.yml
+++ b/.github/workflows/product-context-cutover.yml
@@ -7,22 +7,19 @@ name: Product Context Cutover
       product:
         description: Product profile key to cut over.
         required: true
-        default: sellyouroutboard
         type: string
       source_context:
         description: Legacy context to copy current-authority records from.
         required: true
-        default: sellyouroutboard-testing
         type: string
       target_context:
-        description: Canonical product context to copy current-authority records to.
+        description: >-
+          Canonical product context to copy current-authority records to.
         required: true
-        default: sellyouroutboard
         type: string
       display_name:
         description: Product display name to write with the profile cutover.
         required: true
-        default: SellYourOutboard
         type: string
       dry_run:
         description: Plan only when true; write records and profile when false.

--- a/.github/workflows/product-legacy-context-cleanup.yml
+++ b/.github/workflows/product-legacy-context-cleanup.yml
@@ -7,18 +7,15 @@ name: Product Legacy Context Cleanup
       product:
         description: Product profile key to clean up.
         required: true
-        default: sellyouroutboard
         type: string
       source_context:
         description: Legacy context to clean up after cutover.
         required: true
-        default: sellyouroutboard-testing
         type: string
       target_context:
         description: >-
           Canonical product context that must already hold replacement records.
         required: true
-        default: sellyouroutboard
         type: string
       dry_run:
         description: >-

--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -198,8 +198,7 @@ def service() -> None:
 @click.option("--port", type=int, default=8080, show_default=True)
 @click.option(
     "--audience",
-    default="launchplane.shinycomputers.com",
-    show_default=True,
+    envvar="LAUNCHPLANE_SERVICE_AUDIENCE",
     help="Expected GitHub OIDC audience for Launchplane service tokens.",
 )
 @click.option(
@@ -220,6 +219,12 @@ def service_serve(
         raise click.ClickException(
             "Launchplane service refuses startup without --database-url or "
             "LAUNCHPLANE_DATABASE_URL. Filesystem state is local-only."
+        )
+    if audience is None or not audience.strip():
+        raise click.ClickException(
+            "Launchplane service refuses startup without --audience or "
+            "LAUNCHPLANE_SERVICE_AUDIENCE. The service audience is explicit "
+            "operator/process wiring."
         )
     serve_launchplane_service(
         state_dir=state_dir,
@@ -527,10 +532,8 @@ def service_inspect_config_boundary(control_plane_root: Path | None) -> None:
 )
 @click.option("--database-url", envvar=_DATABASE_URL_ENV_KEYS, default="", show_default=False)
 @click.option("--local-inspection", is_flag=True, default=False)
-@click.option("--context", "context_name", default="verireel", show_default=True)
-@click.option(
-    "--preview-context", "preview_context_name", default="verireel-testing", show_default=True
-)
+@click.option("--context", "context_name", required=True)
+@click.option("--preview-context", "preview_context_name", required=True)
 def service_inspect_data_freshness(
     state_dir: Path,
     database_url: str,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -150,14 +150,16 @@ The first implemented service command is:
 uv run launchplane service serve \
   --state-dir ./state \
   --database-url "$LAUNCHPLANE_DATABASE_URL" \
-  --policy-file ./bootstrap-policy.toml
+  --policy-file ./bootstrap-policy.toml \
+  --audience "$LAUNCHPLANE_SERVICE_AUDIENCE"
 ```
 
 The service needs an explicit minimal bootstrap policy input, but the repo no
 longer tracks the live policy. Product and workflow grants should be represented
 as DB-backed authz policy records. Omitting `--database-url` always fails closed,
 including loopback local development, rather than using file-backed JSON state
-as authority.
+as authority. The GitHub OIDC audience is explicit operator/process wiring;
+production code must not default it to a live domain.
 
 Current implementation scope:
 
@@ -288,11 +290,13 @@ GitHub `/user` API read outside Launchplane, and never print or paste the token
 itself into logs, issues, or records.
 
 The manual Product Context Cutover workflow plans or applies the same
-current-authority record move through the Launchplane service. Run it first with
-`dry_run=true`; run with `dry_run=false` only after the artifact shows the
-expected key/count metadata for runtime records, managed secrets, Dokploy
-targets, target IDs, inventories, release tuples, and the product profile lane
-contexts. The workflow intentionally leaves append-only deployments,
+current-authority record move through the Launchplane service. The workflow
+does not carry product/context defaults; operators must provide the product,
+legacy source context, canonical target context, and display name explicitly.
+Run it first with `dry_run=true`; run with `dry_run=false` only after the
+artifact shows the expected key/count metadata for runtime records, managed
+secrets, Dokploy targets, target IDs, inventories, release tuples, and the
+product profile lane contexts. The workflow intentionally leaves append-only deployments,
 promotions, backup gates, and preview history on their original contexts.
 
 After a cutover has been applied and the product profile no longer references
@@ -794,7 +798,10 @@ context only, and `context_instance` has both context and instance.
 - For shared/live targets, use the trusted `Odoo Config Parameter Override`
   workflow instead of local CLI writes. It calls
   `POST /v1/drivers/odoo/config-parameter-override` with GitHub Actions OIDC and
-  is currently limited to the non-secret `web.base.url` key for `cm/testing`.
+  requires explicit product, context, instance, key, and value inputs instead of
+  workflow-local product topology defaults. The current workflow only exposes
+  the non-secret `web.base.url` key; product/context/instance authority is
+  enforced by service authz and DB-backed product/runtime records.
   Service-written `web.base.url` records are always marked for `deploy` and
   `promotion` application so Odoo post-deploy and stable-bootstrap drivers can
   apply the canonical URL before verification.

--- a/tests/test_odoo_stable_authority.py
+++ b/tests/test_odoo_stable_authority.py
@@ -2,7 +2,43 @@ from pathlib import Path
 from unittest import TestCase
 
 
+_PRODUCTION_MUTATION_WORKFLOW_PATHS = (
+    Path(".github/workflows/product-context-cutover.yml"),
+    Path(".github/workflows/product-context-cutover-audit.yml"),
+    Path(".github/workflows/product-legacy-context-cleanup.yml"),
+    Path(".github/workflows/odoo-config-parameter-override.yml"),
+    Path(".github/workflows/odoo-target-replacement-plan.yml"),
+    Path(".github/workflows/odoo-target-replacement-apply.yml"),
+    Path(".github/workflows/odoo-stable-bootstrap.yml"),
+    Path(".github/workflows/odoo-website-bootstrap-override.yml"),
+)
+
+
 class OdooStableAuthorityTests(TestCase):
+    def test_production_mutation_workflows_do_not_default_to_real_topology(
+        self,
+    ) -> None:
+        forbidden_tokens = (
+            "default: sellyouroutboard",
+            "default: odoo-tenant-",
+            "default: cm",
+            "default: opw",
+            "SellYourOutboard",
+            "sellyouroutboard-testing",
+            "https://cm-testing.shinycomputers.com",
+            "allowed_targets=",
+            "odoo-tenant-cm:",
+            "odoo-tenant-opw:",
+        )
+        offenders: list[str] = []
+        for workflow_path in _PRODUCTION_MUTATION_WORKFLOW_PATHS:
+            workflow_text = workflow_path.read_text(encoding="utf-8")
+            for token in forbidden_tokens:
+                if token in workflow_text:
+                    offenders.append(f"{workflow_path.as_posix()}: {token}")
+
+        self.assertEqual(offenders, [])
+
     def test_reusable_testing_deploy_uses_target_replacement_apply(self) -> None:
         workflow = Path(".github/workflows/reusable-odoo-testing-deploy.yml").read_text(
             encoding="utf-8"

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -583,15 +583,18 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn('"instance":"testing"', workflow_text)
         self.assertIn("replacement.artifact_id=${{ inputs.artifact_id }}", workflow_text)
 
-    def test_odoo_website_bootstrap_override_workflow_allows_opw_targets(self) -> None:
+    def test_odoo_website_bootstrap_override_requires_explicit_target_inputs(self) -> None:
         workflow_text = Path(".github/workflows/odoo-website-bootstrap-override.yml").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("odoo-tenant-opw:opw:testing", workflow_text)
-        self.assertIn("odoo-tenant-opw:opw:prod", workflow_text)
-        self.assertIn("          - opw", workflow_text)
+        self.assertIn("PRODUCT: ${{ inputs.product }}", workflow_text)
+        self.assertIn("CONTEXT_NAME: ${{ inputs.context }}", workflow_text)
+        self.assertIn("INSTANCE: ${{ inputs.instance }}", workflow_text)
         self.assertIn("          - prod", workflow_text)
+        self.assertNotIn("allowed_targets=", workflow_text)
+        self.assertNotIn("odoo-tenant-opw:opw:testing", workflow_text)
+        self.assertNotIn("odoo-tenant-opw:opw:prod", workflow_text)
         self.assertNotIn("writes only cm/testing", workflow_text)
 
     def test_launchplane_workflows_do_not_hardcode_public_service_defaults(self) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12166,6 +12166,29 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(result.exit_code, 1, msg=result.output)
         self.assertIn("refuses startup without --database-url", result.output)
 
+    def test_service_serve_rejects_missing_audience(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            policy_file = Path(temporary_directory_name) / "policy.toml"
+            policy_file.write_text("schema_version = 1\n", encoding="utf-8")
+
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "serve",
+                    "--state-dir",
+                    str(Path(temporary_directory_name) / "state"),
+                    "--policy-file",
+                    str(policy_file),
+                    "--database-url",
+                    f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'state.sqlite3'}",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 1, msg=result.output)
+        self.assertIn("refuses startup without --audience", result.output)
+
     def test_service_runtime_endpoint_reports_current_image_reference(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             policy = LaunchplaneAuthzPolicy.model_validate(
@@ -21668,6 +21691,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "--local-inspection",
                     "--state-dir",
                     str(state_dir),
+                    "--context",
+                    "verireel",
+                    "--preview-context",
+                    "verireel-testing",
                 ],
             )
 
@@ -21696,6 +21723,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "inspect-data-freshness",
                     "--state-dir",
                     str(state_dir),
+                    "--context",
+                    "verireel",
+                    "--preview-context",
+                    "verireel-testing",
                 ],
             )
 
@@ -21728,6 +21759,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "--local-inspection",
                     "--state-dir",
                     str(state_dir),
+                    "--context",
+                    "verireel",
+                    "--preview-context",
+                    "verireel-testing",
                 ],
             )
 


### PR DESCRIPTION
## Summary
- remove real product/context/domain defaults and checked-in target allowlists from production-facing mutation workflows
- require explicit Launchplane service audience and explicit data-freshness contexts in CLI surfaces
- update operations docs and tests so workflow topology defaults stay out of production YAML

## Verification
- uv run python -m unittest tests.test_odoo_stable_authority tests.test_service
- ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts path }' .github/workflows/product-context-cutover.yml .github/workflows/product-context-cutover-audit.yml .github/workflows/product-legacy-context-cleanup.yml .github/workflows/odoo-config-parameter-override.yml .github/workflows/odoo-target-replacement-plan.yml .github/workflows/odoo-target-replacement-apply.yml .github/workflows/odoo-stable-bootstrap.yml .github/workflows/odoo-website-bootstrap-override.yml
- git diff --check
- uv run --extra dev ruff check control_plane/cli_service.py tests/test_service.py tests/test_odoo_stable_authority.py tests/test_product_onboarding.py
- uv run python -m unittest