### PR TITLE
Add Odoo driver route smoke workflow

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -74,6 +74,7 @@
     "Live Target Runtime",
     "Merge Train Runner",
     "Odoo Config Parameter Override",
+    "Odoo Driver Route Smoke",
     "Odoo Website Bootstrap Override",
     "Odoo Stable Bootstrap",
     "Reusable Odoo Artifact Publish",

--- a/.github/workflows/odoo-driver-route-smoke.yml
+++ b/.github/workflows/odoo-driver-route-smoke.yml
@@ -1,0 +1,179 @@
+---
+name: Odoo Driver Route Smoke
+
+"on":
+  workflow_call:
+    inputs:
+      product:
+        description: Launchplane product profile key to smoke.
+        required: true
+        type: string
+      context:
+        description: Launchplane Odoo context to smoke.
+        required: true
+        type: string
+      instance:
+        description: Odoo instance whose publish inputs should resolve.
+        required: true
+        type: string
+      source_git_ref:
+        description: Source ref attached to the smoke request.
+        required: true
+        type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Launchplane product profile key to smoke.
+        required: true
+        type: string
+      context:
+        description: Launchplane Odoo context to smoke.
+        required: true
+        type: string
+      instance:
+        description: Odoo instance whose publish inputs should resolve.
+        required: true
+        default: testing
+        type: choice
+        options:
+          - testing
+          - prod
+      source_git_ref:
+        description: Source ref attached to the smoke request.
+        required: true
+        type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: >-
+    launchplane-odoo-driver-route-smoke-${{ inputs.product }}-${{
+    inputs.context }}-${{ inputs.instance }}
+  cancel-in-progress: false
+
+jobs:
+  route-smoke:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: >-
+        ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+      LAUNCHPLANE_AUDIENCE: ${{ inputs.launchplane_audience }}
+      PRODUCT: ${{ inputs.product }}
+      CONTEXT_NAME: ${{ inputs.context }}
+      INSTANCE: ${{ inputs.instance }}
+      SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
+    steps:
+      - name: Check public route registration
+        env:
+          ROUTE_PATHS: >-
+            /v1/drivers/odoo/artifact-publish-inputs
+            /v1/drivers/odoo/preview-apply-inputs
+            /v1/drivers/odoo/preview-apply
+            /v1/previews/pr-feedback
+        run: |
+          set -euo pipefail
+          if [ -z "$LAUNCHPLANE_URL" ]; then
+            echo "LAUNCHPLANE_PUBLIC_URL or launchplane_url is required." >&2
+            exit 1
+          fi
+
+          for route_path in $ROUTE_PATHS; do
+            route_slug="${route_path//\//-}"
+            response_file="$RUNNER_TEMP/route-smoke-${GITHUB_RUN_ID}"
+            response_file="${response_file}-${GITHUB_RUN_ATTEMPT}-${route_slug}.json"
+            status_code="$(curl -sS \
+              --connect-timeout 10 \
+              --max-time 30 \
+              -o "$response_file" \
+              -w '%{http_code}' \
+              -X POST \
+              -H 'content-type: application/json' \
+              --data '{"schema_version":1}' \
+              "${LAUNCHPLANE_URL%/}${route_path}")"
+            echo "${route_path} returned HTTP ${status_code}"
+            if [ "$status_code" = "404" ]; then
+              echo "${route_path} is not registered on Launchplane." >&2
+              cat "$response_file" >&2
+              exit 1
+            fi
+            if [ "$status_code" -ge 500 ]; then
+              echo "${route_path} returned a Launchplane service error." >&2
+              cat "$response_file" >&2
+              exit 1
+            fi
+          done
+
+      - name: Resolve Odoo artifact publish inputs through GitHub OIDC
+        id: publish_inputs
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ env.LAUNCHPLANE_AUDIENCE }}
+          route-path: /v1/drivers/odoo/artifact-publish-inputs
+          payload: >-
+            {"schema_version":1,"inputs":{"schema_version":1}}
+          payload-fields: |-
+            product=${{ env.PRODUCT }}
+            inputs.context=${{ env.CONTEXT_NAME }}
+            inputs.instance=${{ env.INSTANCE }}
+            inputs.source_git_ref=${{ env.SOURCE_GIT_REF }}
+          idempotency-key: >-
+            odoo-driver-route-smoke:${{ env.PRODUCT }}:${{
+            env.CONTEXT_NAME }}:${{ env.INSTANCE }}:run-${{
+            github.run_id }}-attempt-${{ github.run_attempt }}
+          timeout-ms: "600000"
+          output-paths: >-
+            trace_id=trace_id,
+            preview_slug=result.preview_slug,
+            image_repository=result.image_repository,
+            image_tag=result.image_tag,
+            error_message=result.error_message
+
+      - name: Report route smoke
+        env:
+          TRACE_ID: ${{ steps.publish_inputs.outputs.trace_id }}
+          PREVIEW_SLUG: ${{ steps.publish_inputs.outputs.preview_slug }}
+          IMAGE_REPOSITORY: ${{ steps.publish_inputs.outputs.image_repository }}
+          IMAGE_TAG: ${{ steps.publish_inputs.outputs.image_tag }}
+          ERROR_MESSAGE: ${{ steps.publish_inputs.outputs.error_message }}
+        run: |
+          set -euo pipefail
+          if [ -z "$IMAGE_REPOSITORY" ] || [ -z "$IMAGE_TAG" ]; then
+            echo "Publish inputs did not include image outputs." >&2
+            if [ -n "$ERROR_MESSAGE" ]; then
+              echo "$ERROR_MESSAGE" >&2
+            fi
+            exit 1
+          fi
+          echo "trace_id=$TRACE_ID"
+          echo "preview_slug=$PREVIEW_SLUG"
+          echo "image_repository=$IMAGE_REPOSITORY"
+          echo "image_tag=$IMAGE_TAG"

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1072,6 +1072,15 @@ current handlers include:
 - `POST /v1/drivers/verireel/preview-inventory`
 - `POST /v1/drivers/verireel/preview-destroy`
 
+`Odoo Driver Route Smoke` is the Launchplane-owned route exposure gate for Odoo
+preview and artifact-publish handoff routes. It first sends unauthenticated
+public probes and fails when a registered route returns the Launchplane
+route-missing response. It then uses the shared request action and GitHub OIDC to
+resolve `/v1/drivers/odoo/artifact-publish-inputs` for the caller's product,
+context, instance, and source ref. Product repos should use that reusable smoke
+or Launchplane-owned reusable workflows instead of adding repo-local route setup
+or copied driver request contracts.
+
 The product-neutral preview lifecycle route should become the common boundary
 for preview desired/current-state comparison. Product-specific driver routes can
 continue to perform provider runtime work, but repos should not each reimplement

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -664,6 +664,37 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 )
                 self.assertIn("audience: ${{ inputs.launchplane_audience }}", workflow_text)
 
+    def test_odoo_driver_route_smoke_proves_public_and_oidc_paths(self) -> None:
+        workflow_text = Path(".github/workflows/odoo-driver-route-smoke.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("workflow_call:", workflow_text)
+        self.assertIn("id-token: write", workflow_text)
+        self.assertIn("LAUNCHPLANE_PUBLIC_URL", workflow_text)
+        self.assertIn("source_git_ref:", workflow_text)
+        self.assertIn("SOURCE_GIT_REF: ${{ inputs.source_git_ref }}", workflow_text)
+        self.assertIn('[ "$status_code" = "404" ]', workflow_text)
+        self.assertIn('[ "$status_code" -ge 500 ]', workflow_text)
+        self.assertIn("--connect-timeout 10", workflow_text)
+        self.assertIn("--max-time 30", workflow_text)
+        self.assertIn("${GITHUB_RUN_ID}", workflow_text)
+        self.assertIn("${GITHUB_RUN_ATTEMPT}", workflow_text)
+        self.assertIn("cbusillo/launchplane/.github/actions/launchplane-request@main", workflow_text)
+        self.assertIn("route-path: /v1/drivers/odoo/artifact-publish-inputs", workflow_text)
+        self.assertIn("/v1/drivers/odoo/preview-apply-inputs", workflow_text)
+        self.assertIn("/v1/drivers/odoo/preview-apply", workflow_text)
+        self.assertIn("/v1/previews/pr-feedback", workflow_text)
+        self.assertIn("product=${{ env.PRODUCT }}", workflow_text)
+        self.assertIn("inputs.context=${{ env.CONTEXT_NAME }}", workflow_text)
+        self.assertIn("inputs.instance=${{ env.INSTANCE }}", workflow_text)
+        self.assertIn("inputs.source_git_ref=${{ env.SOURCE_GIT_REF }}", workflow_text)
+        self.assertIn("image_repository=result.image_repository", workflow_text)
+        self.assertIn("image_tag=result.image_tag", workflow_text)
+        self.assertIn('[ -z "$IMAGE_REPOSITORY" ]', workflow_text)
+        self.assertIn('[ -z "$IMAGE_TAG" ]', workflow_text)
+        self.assertNotIn("input_status", workflow_text)
+
     def test_ingress_route_dry_run_workflow_rejects_non_object_options(self) -> None:
         workflow_text = Path(".github/workflows/ingress-route-dry-run.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary

- add a Launchplane-owned `Odoo Driver Route Smoke` workflow for route exposure and GitHub OIDC request-action verification
- cover Odoo artifact publish inputs plus preview route registration probes
- document the smoke gate and add workflow contract assertions

Refs #1201
Refs #1199

## Verification

```text
uv run python -m unittest \
  tests.test_product_onboarding.ProductOnboardingTests.test_odoo_driver_route_smoke_proves_public_and_oidc_paths \
  tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_workflows_do_not_hardcode_public_service_defaults
uv run --extra dev ruff check --diff tests/test_product_onboarding.py
uv run --extra dev ruff check tests/test_product_onboarding.py
ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/odoo-driver-route-smoke.yml
```

Docker was unavailable locally, so the configured Docker actionlint gate could not run before PR CI.

## Review

Claude reviewed the first draft and found blockers around inert `result.input_status`, probe failure handling, response file collisions, and curl timeouts. Those were fixed. Claude second-pass review reported no blockers.
