### PR TITLE
Classify descriptor route dependency misses

### DIFF
--- a/control_plane/drivers/dispatch.py
+++ b/control_plane/drivers/dispatch.py
@@ -36,6 +36,7 @@ def _http_status_text(status_code: int) -> str:
         404: "Not Found",
         405: "Method Not Allowed",
         409: "Conflict",
+        503: "Service Unavailable",
         500: "Internal Server Error",
     }.get(status_code, "OK")
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -3781,6 +3781,7 @@ def _http_status_text(status_code: int) -> str:
         404: "Not Found",
         405: "Method Not Allowed",
         409: "Conflict",
+        503: "Service Unavailable",
         500: "Internal Server Error",
     }.get(status_code, "OK")
 
@@ -13246,21 +13247,41 @@ def create_launchplane_service_app(
                 result = provider_target_result.result
                 driver_result = provider_target_result.driver_result
             elif path in descriptor_driver_dispatch_routes:
-                dispatch_response = _dispatch_descriptor_driver_route(
-                    dispatch_route=descriptor_driver_dispatch_routes[path],
-                    payload=payload,
-                    record_store=record_store,
-                    control_plane_root_path=resolved_root,
-                    state_dir=state_dir,
-                    database_url=database_url,
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    request_scope=request_scope,
-                    request_idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
+                try:
+                    dispatch_response = _dispatch_descriptor_driver_route(
+                        dispatch_route=descriptor_driver_dispatch_routes[path],
+                        payload=payload,
+                        record_store=record_store,
+                        control_plane_root_path=resolved_root,
+                        state_dir=state_dir,
+                        database_url=database_url,
+                        authz_policy=authz_policy,
+                        identity=identity,
+                        request_scope=request_scope,
+                        request_idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                    )
+                except FileNotFoundError:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "driver_route_dependency_not_found",
+                                "message": (
+                                    "Driver route is registered, but required"
+                                    " product or runtime records were not found."
+                                ),
+                            },
+                            "details": {
+                                "route_path": path,
+                            },
+                        },
+                    )
                 if isinstance(dispatch_response, list):
                     return dispatch_response
                 result, driver_result = dispatch_response

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -30862,6 +30862,60 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"ODOO_BASE_RUNTIME_IMAGE": "ghcr.io/cbusillo/runtime:19"},
             )
 
+    def test_odoo_artifact_publish_inputs_dependency_miss_is_not_route_missing(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/odoo-tenant-cm-website",
+                            "workflow_refs": [
+                                "cbusillo/odoo-tenant-cm-website/.github/workflows/odoo-preview.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["odoo-tenant-cm-website"],
+                            "contexts": ["cm_website"],
+                            "actions": ["odoo_artifact_publish_inputs.read"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/odoo-tenant-cm-website",
+                        workflow_ref=(
+                            "cbusillo/odoo-tenant-cm-website/.github/workflows/odoo-preview.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/artifact-publish-inputs",
+                payload={
+                    "product": "odoo-tenant-cm-website",
+                    "inputs": {"context": "cm_website", "instance": "testing"},
+                },
+            )
+
+            self.assertEqual(status_code, 503)
+            self.assertEqual(payload["error"]["code"], "driver_route_dependency_not_found")
+            self.assertEqual(payload["details"]["route_path"], "/v1/drivers/odoo/artifact-publish-inputs")
+            self.assertNotIn("missing", payload["details"])
+            self.assertNotIn("product_profiles", json.dumps(payload))
+            self.assertNotIn("No Launchplane route", payload["error"]["message"])
+            self.assertEqual(control_plane_service._http_status_text(503), "Service Unavailable")
+
     def test_odoo_prod_backup_gate_driver_executes_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

- return `503 driver_route_dependency_not_found` when a registered descriptor driver route is missing required product/runtime records
- stop mapping descriptor-route `FileNotFoundError` to the misleading `No Launchplane route` 404
- sanitize dependency-miss details and add `503 Service Unavailable` status text
- add a regression for missing Odoo product profile resolution on `/v1/drivers/odoo/artifact-publish-inputs`

Refs #1201
Refs #1199

## Evidence

The new Odoo driver route smoke merged in #1202 reproduced the live failure after deploy:

- run: https://github.com/cbusillo/launchplane/actions/runs/27076070721
- public route registration passed
- authenticated request-action call failed with route-missing 404
- trace: `launchplane_req_32be77296759493d92551629d6e9003d`

## Verification

```text
uv run python -m unittest \
  tests.test_service.LaunchplaneServiceTests.test_odoo_artifact_publish_inputs_returns_build_scoped_environment \
  tests.test_service.LaunchplaneServiceTests.test_odoo_artifact_publish_inputs_dependency_miss_is_not_route_missing \
  tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_route_policy_sets_use_execution_metadata
uv run --extra dev ruff check --diff control_plane/service.py control_plane/drivers/dispatch.py tests/test_service.py
uv run --extra dev ruff check control_plane/service.py control_plane/drivers/dispatch.py tests/test_service.py
```

## Review

Claude reviewed the first patch and flagged raw error leakage, a mocked test that missed the production path, missing 503 reason text, and broad catch risk. The patch was updated to sanitize details, exercise the real missing-profile path, and add 503 status text. Claude second-pass review reported no blockers.
