### PR TITLE
Add Odoo website onboarding seed

### DIFF
--- a/import-material/launchplane/seed-imports/catalog.json
+++ b/import-material/launchplane/seed-imports/catalog.json
@@ -780,6 +780,205 @@
       }
     },
     {
+      "kind": "product_onboarding",
+      "import_id": "odoo-cm-website-product-onboarding",
+      "manifest": {
+        "product": "odoo-tenant-cm-website",
+        "display_name": "Cell Mechanic Website Odoo",
+        "repository": "cbusillo/odoo-tenant-cm-website",
+        "driver_id": "odoo",
+        "image_repository": "ghcr.io/cbusillo/odoo-tenant-cm-website",
+        "runtime_port": 8069,
+        "health_path": "/cm-website/health",
+        "lanes": [
+          {
+            "instance": "testing",
+            "context": "cm_website",
+            "base_url": "https://cm-website-testing.shinycomputers.com",
+            "health_url": "https://cm-website-testing.shinycomputers.com/cm-website/health",
+            "odoo_data_policy": {
+              "data_authority": "resettable",
+              "allowed_rebuild_sources": ["empty"],
+              "requires_backup_before_destroy": false,
+              "requires_restore_proof": false,
+              "requires_runtime_identity": true
+            }
+          },
+          {
+            "instance": "prod",
+            "context": "cm_website",
+            "base_url": "https://www.cellmechanic.com",
+            "health_url": "https://www.cellmechanic.com/cm-website/health",
+            "odoo_data_policy": {
+              "data_authority": "resettable",
+              "allowed_rebuild_sources": ["empty"],
+              "requires_backup_before_destroy": false,
+              "requires_restore_proof": false,
+              "requires_runtime_identity": true
+            }
+          }
+        ],
+        "preview": {
+          "enabled": true,
+          "context": "cm_website",
+          "enable_label": "preview",
+          "slug_template": "pr-{number}",
+          "app_name_prefix": "cm-website-odoo-preview",
+          "template_instance": "testing",
+          "override_env": {
+            "ODOO_INSTALL_MODULES": "cm_website"
+          },
+          "preview_url_env_keys": ["WEB_BASE_URL"],
+          "data_transport_mode": "driver"
+        },
+        "runtime_environments": [
+          {
+            "scope": "instance",
+            "context": "cm_website",
+            "instance": "testing",
+            "env": {
+              "ODOO_DB_NAME": "cm_website_testing",
+              "ODOO_DB_USER": "odoo",
+              "ODOO_DATA_VOLUME": "cm_website_testing_odoo_data",
+              "ODOO_LOG_VOLUME": "cm_website_testing_odoo_logs",
+              "ODOO_DB_VOLUME": "cm_website_testing_odoo_db"
+            }
+          },
+          {
+            "scope": "instance",
+            "context": "cm_website",
+            "instance": "prod",
+            "env": {
+              "ODOO_DB_NAME": "cm_website_prod",
+              "ODOO_DB_USER": "odoo",
+              "ODOO_DATA_VOLUME": "cm_website_prod_odoo_data",
+              "ODOO_LOG_VOLUME": "cm_website_prod_odoo_logs",
+              "ODOO_DB_VOLUME": "cm_website_prod_odoo_db"
+            }
+          }
+        ],
+        "secret_bindings": [
+          {
+            "binding_key": "ODOO_ADMIN_PASSWORD",
+            "context": "cm_website",
+            "instance": "testing"
+          },
+          {
+            "binding_key": "ODOO_DB_PASSWORD",
+            "context": "cm_website",
+            "instance": "testing"
+          },
+          {
+            "binding_key": "ODOO_MASTER_PASSWORD",
+            "context": "cm_website",
+            "instance": "testing"
+          },
+          {
+            "binding_key": "ODOO_ADMIN_PASSWORD",
+            "context": "cm_website",
+            "instance": "prod"
+          },
+          {
+            "binding_key": "ODOO_DB_PASSWORD",
+            "context": "cm_website",
+            "instance": "prod"
+          },
+          {
+            "binding_key": "ODOO_MASTER_PASSWORD",
+            "context": "cm_website",
+            "instance": "prod"
+          }
+        ],
+        "expected_config": {
+          "runtime_environment_keys": [
+            {
+              "key": "ODOO_DB_NAME",
+              "context": "cm_website",
+              "instance": "testing"
+            },
+            {
+              "key": "ODOO_DB_USER",
+              "context": "cm_website",
+              "instance": "testing"
+            },
+            {
+              "key": "ODOO_DATA_VOLUME",
+              "context": "cm_website",
+              "instance": "testing"
+            },
+            {
+              "key": "ODOO_LOG_VOLUME",
+              "context": "cm_website",
+              "instance": "testing"
+            },
+            {
+              "key": "ODOO_DB_VOLUME",
+              "context": "cm_website",
+              "instance": "testing"
+            },
+            {
+              "key": "ODOO_DB_NAME",
+              "context": "cm_website",
+              "instance": "prod"
+            },
+            {
+              "key": "ODOO_DB_USER",
+              "context": "cm_website",
+              "instance": "prod"
+            },
+            {
+              "key": "ODOO_DATA_VOLUME",
+              "context": "cm_website",
+              "instance": "prod"
+            },
+            {
+              "key": "ODOO_LOG_VOLUME",
+              "context": "cm_website",
+              "instance": "prod"
+            },
+            {
+              "key": "ODOO_DB_VOLUME",
+              "context": "cm_website",
+              "instance": "prod"
+            }
+          ],
+          "managed_secret_bindings": [
+            {
+              "binding_key": "ODOO_ADMIN_PASSWORD",
+              "context": "cm_website",
+              "instance": "testing"
+            },
+            {
+              "binding_key": "ODOO_DB_PASSWORD",
+              "context": "cm_website",
+              "instance": "testing"
+            },
+            {
+              "binding_key": "ODOO_MASTER_PASSWORD",
+              "context": "cm_website",
+              "instance": "testing"
+            },
+            {
+              "binding_key": "ODOO_ADMIN_PASSWORD",
+              "context": "cm_website",
+              "instance": "prod"
+            },
+            {
+              "binding_key": "ODOO_DB_PASSWORD",
+              "context": "cm_website",
+              "instance": "prod"
+            },
+            {
+              "binding_key": "ODOO_MASTER_PASSWORD",
+              "context": "cm_website",
+              "instance": "prod"
+            }
+          ]
+        },
+        "source_label": "import-material:odoo-cm-website-product-onboarding"
+      }
+    },
+    {
       "kind": "runtime_key_safety_policy",
       "import_id": "launchplane-runtime-key-safety-policy",
       "source_label": "import-material:runtime-key-safety-policy",
@@ -835,19 +1034,19 @@
         {
           "binding_key": "ODOO_ADMIN_PASSWORD",
           "secret_class": "shared_safe",
-          "allowed_contexts": ["cm", "opw"],
+          "allowed_contexts": ["cm", "cm_website", "opw"],
           "allowed_instances": ["testing", "prod"]
         },
         {
           "binding_key": "ODOO_DB_PASSWORD",
           "secret_class": "shared_safe",
-          "allowed_contexts": ["cm", "opw"],
+          "allowed_contexts": ["cm", "cm_website", "opw"],
           "allowed_instances": ["testing", "prod"]
         },
         {
           "binding_key": "ODOO_MASTER_PASSWORD",
           "secret_class": "shared_safe",
-          "allowed_contexts": ["cm", "opw"],
+          "allowed_contexts": ["cm", "cm_website", "opw"],
           "allowed_instances": ["testing", "prod"]
         }
       ]

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -287,6 +287,7 @@ class ProductOnboardingTests(unittest.TestCase):
                 "verireel-product-onboarding",
                 "odoo-cm-product-onboarding",
                 "odoo-opw-product-onboarding",
+                "odoo-cm-website-product-onboarding",
                 "launchplane-runtime-key-safety-policy",
             },
         )
@@ -326,7 +327,10 @@ class ProductOnboardingTests(unittest.TestCase):
                 }
                 for binding_key in ODOO_SECRET_KEYS:
                     self.assertEqual(odoo_rules[binding_key]["secret_class"], "shared_safe")
-                    self.assertEqual(odoo_rules[binding_key]["allowed_contexts"], ["cm", "opw"])
+                    self.assertEqual(
+                        odoo_rules[binding_key]["allowed_contexts"],
+                        ["cm", "cm_website", "opw"],
+                    )
                     self.assertEqual(
                         odoo_rules[binding_key]["allowed_instances"], ["testing", "prod"]
                     )
@@ -1548,6 +1552,58 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             expected_database_names={"testing": "cm_testing", "prod": "cm"},
         )
         self.assertEqual(manifest.source_label, "import-material:odoo-cm-product-onboarding")
+
+    def test_seed_import_odoo_cm_website_onboarding_manifest_owns_preview_records(
+        self,
+    ) -> None:
+        manifest_payload = _seed_import_manifest("odoo-cm-website-product-onboarding")
+        manifest = ProductOnboardingManifest.model_validate(manifest_payload)
+
+        self.assertEqual(manifest.product, "odoo-tenant-cm-website")
+        self.assertEqual(manifest.display_name, "Cell Mechanic Website Odoo")
+        self.assertEqual(manifest.repository, "cbusillo/odoo-tenant-cm-website")
+        self.assertEqual(manifest.driver_id, "odoo")
+        self.assertEqual(manifest.image_repository, "ghcr.io/cbusillo/odoo-tenant-cm-website")
+        self.assertEqual(manifest.runtime_port, 8069)
+        self.assertEqual(manifest.health_path, "/cm-website/health")
+        self.assertEqual(
+            [
+                (lane.instance, lane.context, lane.base_url, lane.health_url)
+                for lane in manifest.lanes
+            ],
+            [
+                (
+                    "testing",
+                    "cm_website",
+                    "https://cm-website-testing.shinycomputers.com",
+                    "https://cm-website-testing.shinycomputers.com/cm-website/health",
+                ),
+                (
+                    "prod",
+                    "cm_website",
+                    "https://www.cellmechanic.com",
+                    "https://www.cellmechanic.com/cm-website/health",
+                ),
+            ],
+        )
+        self.assertTrue(manifest.preview.enabled)
+        self.assertEqual(manifest.preview.context, "cm_website")
+        self.assertEqual(manifest.preview.app_name_prefix, "cm-website-odoo-preview")
+        self.assertEqual(manifest.preview.template_instance, "testing")
+        self.assertEqual(manifest.preview.override_env, {"ODOO_INSTALL_MODULES": "cm_website"})
+        self.assertEqual(manifest.preview.preview_url_env_keys, ("WEB_BASE_URL",))
+        self.assertEqual(manifest.preview.data_transport_mode, "driver")
+        self.assertEqual(manifest.provider_targets, ())
+        _assert_odoo_stable_lane_runtime_contract(
+            self,
+            manifest=manifest,
+            context="cm_website",
+            expected_database_names={"testing": "cm_website_testing", "prod": "cm_website_prod"},
+        )
+        self.assertEqual(
+            manifest.source_label,
+            "import-material:odoo-cm-website-product-onboarding",
+        )
 
     def test_seed_import_odoo_cm_onboarding_manifest_requires_prod_target_id(self) -> None:
         with self.assertRaisesRegex(ValueError, "target requires target_id"):


### PR DESCRIPTION
## Summary
- add Launchplane-owned product onboarding import material for odoo-tenant-cm-website / cm_website
- add runtime environment and managed secret binding placeholders for testing/prod lanes
- expand Odoo runtime key-safety metadata to include cm_website
- pin the seed contract in product onboarding tests

## Validation
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_launchplane_seed_import_catalog_validates_contracts tests.test_product_onboarding.ProductOnboardingTests.test_seed_import_odoo_cm_website_onboarding_manifest_owns_preview_records
- uv run python scripts/deploy/apply-launchplane-seed-imports.py --catalog import-material/launchplane/seed-imports/catalog.json --output-dir <tmp> --import-id odoo-cm-website-product-onboarding --reason "dry-run cm website onboarding seed"
- uv run python scripts/deploy/apply-launchplane-seed-imports.py --catalog import-material/launchplane/seed-imports/catalog.json --output-dir <tmp> --import-id launchplane-runtime-key-safety-policy --reason "dry-run cm website runtime safety expansion"
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run python -m unittest tests.test_product_onboarding
- uv run --extra dev mypy tests/test_product_onboarding.py

## Pre-merge review
- Claude Sonnet 4.6: no blockers
- Antigravity/Gemini: no code blockers; operational prerequisite is applying the seed imports after merge

Refs #1201