### PR TITLE
Allow ingress dry-run host discovery

### DIFF
--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -29,9 +29,10 @@ name: Ingress Route Dry Run
         required: true
         type: number
       expected_host_id:
-        description: Existing provider host id that must own the domain.
-        required: true
-        type: number
+        description: Optional existing provider host id that must own the domain.
+        required: false
+        default: ""
+        type: string
       reason:
         description: Operator reason recorded with the Launchplane request.
         required: true
@@ -69,6 +70,8 @@ jobs:
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     steps:
+      - uses: actions/checkout@v6
+
       - name: Build ingress route dry run payload
         id: payload
         shell: bash
@@ -94,14 +97,29 @@ jobs:
             --arg forward_scheme "$FORWARD_SCHEME" \
             --arg forward_host "$FORWARD_HOST" \
             --arg route_options_json "$ROUTE_OPTIONS_JSON" \
-            --argjson expected_host_id "$EXPECTED_HOST_ID" \
+            --arg expected_host_id "$EXPECTED_HOST_ID" \
             --argjson forward_port "$FORWARD_PORT" \
             --argjson certificate_id "$CERTIFICATE_ID" \
             '($route_options_json | fromjson) as $options |
+            ($expected_host_id |
+              if . == "" then
+                null
+              elif . == "null" then
+                error("expected_host_id must be blank or a JSON number")
+              else
+                try fromjson catch error(
+                  "expected_host_id must be a JSON number when provided"
+                )
+              end) as $expected_host_id_value |
             def option($key; $default):
               if $options | has($key) then $options[$key] else $default end;
             if ($options | type) != "object" then
               error("route_options_json must be a JSON object")
+            elif (
+              $expected_host_id_value != null
+              and ($expected_host_id_value | type) != "number"
+            ) then
+              error("expected_host_id must be a number when provided")
             elif ([
               $options
               | keys[]
@@ -159,7 +177,7 @@ jobs:
               ingress: {
                 schema_version: 1,
                 mode: "dry-run",
-                expected_host_id: $expected_host_id,
+                expected_host_id: $expected_host_id_value,
                 require_exact_expected_host_domains: option("require_exact_expected_host_domains"; false),
                 allow_create: option("allow_create"; true),
                 allow_update: option("allow_update"; true),
@@ -173,7 +191,7 @@ jobs:
 
       - name: Request ingress route dry run
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: ./.github/actions/launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           method: POST
@@ -185,6 +203,10 @@ jobs:
 
       - name: Summarize dry run
         shell: bash
+        env:
+          PRODUCT: ${{ inputs.product }}
+          CONTEXT: ${{ inputs.context }}
+          DOMAIN: ${{ inputs.domain }}
         run: |
           set -euo pipefail
           result_file="ingress-route-dry-run.json"
@@ -192,9 +214,9 @@ jobs:
           {
             echo '## Ingress route dry run'
             echo
-            echo "- Product: ${{ inputs.product }}"
-            echo "- Context: ${{ inputs.context }}"
-            echo "- Domain: ${{ inputs.domain }}"
+            echo "- Product: $PRODUCT"
+            echo "- Context: $CONTEXT"
+            echo "- Domain: $DOMAIN"
             echo "- Status: $(jq -r '.result.status' "$result_file")"
             echo "- Dry run: $(jq -r '.result.dry_run' "$result_file")"
             echo

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -231,6 +231,14 @@ can carry NPMplus `locations` inside `route_json.route`. Use it for
 product-specific path routing only after the dry-run plan is reviewed and the
 target product/context has an `ingress_route.apply` grant.
 
+The `Ingress Route Dry Run` workflow can discover the existing provider host for
+a domain before an apply. Leave `expected_host_id` blank to ask Launchplane to
+match by requested domain without mutation; pass `expected_host_id` after review
+when you want the dry-run or apply to fail closed unless that specific provider
+host owns the domain. Keep `require_exact_expected_host_domains` disabled during
+initial discovery, then enable it for reviewed update-only applies when exact
+domain ownership is known.
+
 The `Ingress Route Canary Apply` workflow is the matching apply proof path. It
 uses the same canary-scoped product/context grant, reads the expected provider
 host id and canary route tuple from repository variables, and requires an explicit

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -707,14 +707,41 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
 
         self.assertIn('($options | type) != "object"', workflow_text)
         self.assertIn('error("route_options_json must be a JSON object")', workflow_text)
+        self.assertIn("expected_host_id:", workflow_text)
+        self.assertIn("Optional existing provider host id", workflow_text)
+        self.assertIn("EXPECTED_HOST_ID: ${{ inputs.expected_host_id }}", workflow_text)
+        self.assertIn("--arg expected_host_id \"$EXPECTED_HOST_ID\"", workflow_text)
+        self.assertIn('if . == "" then', workflow_text)
+        self.assertIn('elif . == "null" then', workflow_text)
+        self.assertIn(
+            'error("expected_host_id must be blank or a JSON number")',
+            workflow_text,
+        )
+        self.assertIn("expected_host_id: $expected_host_id_value", workflow_text)
+        self.assertIn(
+            'error("expected_host_id must be a number when provided")',
+            workflow_text,
+        )
         self.assertIn(
             'error("route_options_json contains unsupported route option key(s)")',
             workflow_text,
         )
         inputs_section = workflow_text.split("permissions:", maxsplit=1)[0]
         self.assertEqual(inputs_section.count("        description:"), 10)
+        self.assertIn('default: ""', inputs_section)
         self.assertNotIn("identity_access_provider:", inputs_section)
         self.assertNotIn("identity_access_send_basic_auth:", inputs_section)
+        self.assertIn("uses: actions/checkout@v6", workflow_text)
+        self.assertIn("uses: ./.github/actions/launchplane-request", workflow_text)
+        self.assertIn("PRODUCT: ${{ inputs.product }}", workflow_text)
+        self.assertIn("CONTEXT: ${{ inputs.context }}", workflow_text)
+        self.assertIn("DOMAIN: ${{ inputs.domain }}", workflow_text)
+        self.assertIn('echo "- Product: $PRODUCT"', workflow_text)
+        self.assertIn('echo "- Context: $CONTEXT"', workflow_text)
+        self.assertIn('echo "- Domain: $DOMAIN"', workflow_text)
+        self.assertNotIn('echo "- Product: ${{ inputs.product }}"', workflow_text)
+        self.assertNotIn('echo "- Context: ${{ inputs.context }}"', workflow_text)
+        self.assertNotIn('echo "- Domain: ${{ inputs.domain }}"', workflow_text)
         self.assertIn("categories=\\($categories)", workflow_text)
         self.assertIn(
             "npmplus_noindex: false",


### PR DESCRIPTION
## Summary
- make ingress dry-run `expected_host_id` optional so Launchplane can discover an existing provider host by domain without mutation
- keep the workflow self-contained with checkout plus the local `launchplane-request` action
- harden summary shell input handling and document the discovery flow

## Verification
- `actionlint -config-file .github/actionlint.yaml .github/workflows/ingress-route-dry-run.yml`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_dry_run_workflow_rejects_non_object_options`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run --extra dev mypy tests/test_product_onboarding.py`
- `uv run python -m unittest tests.test_product_onboarding tests.test_npmplus_ingress_workflow`

## Reviews
- Claude review: no blockers
- Gemini/Antigravity review: no blockers
