### PR TITLE
Allow ingress apply create without host id

### DIFF
--- a/.github/workflows/ingress-route-apply.yml
+++ b/.github/workflows/ingress-route-apply.yml
@@ -90,27 +90,41 @@ jobs:
               error("route_json.route must be a JSON object")
             elif (($input.route.domain_names // []) | length) == 0 then
               error("route_json.route.domain_names must be non-empty")
-            elif ($input.expected_host_id | type) != "number" then
-              error("route_json.expected_host_id must be a number")
             else
-            {
-              schema_version: 1,
-              product: $product,
-              context: $context,
-              ingress: {
+              option("allow_create"; false) as $allow_create |
+              ($input.expected_host_id // null) as $expected_host_id |
+              if ($allow_create | type) != "boolean" then
+                error("route_json.allow_create must be a boolean")
+              elif ($expected_host_id == null and ($allow_create | not)) then
+                error(
+                  "route_json.expected_host_id must be a number "
+                  + "unless allow_create is true"
+                )
+              elif (
+                $expected_host_id != null
+                and ($expected_host_id | type) != "number"
+              ) then
+                error("route_json.expected_host_id must be a number or null")
+              else
+              {
                 schema_version: 1,
-                mode: "apply",
-                expected_host_id: $input.expected_host_id,
-                require_exact_expected_host_domains: option(
-                  "require_exact_expected_host_domains"; false
-                ),
-                allow_create: option("allow_create"; false),
-                allow_update: option("allow_update"; true),
-                allow_enable_disable: option("allow_enable_disable"; false),
-                reason: $reason,
-                route: $input.route
+                product: $product,
+                context: $context,
+                ingress: {
+                  schema_version: 1,
+                  mode: "apply",
+                  expected_host_id: $expected_host_id,
+                  require_exact_expected_host_domains: option(
+                    "require_exact_expected_host_domains"; false
+                  ),
+                  allow_create: $allow_create,
+                  allow_update: option("allow_update"; true),
+                  allow_enable_disable: option("allow_enable_disable"; false),
+                  reason: $reason,
+                  route: $input.route
+                }
               }
-            }
+              end
             end' >"$payload_file"
           echo "payload_file=$payload_file" >>"$GITHUB_OUTPUT"
 

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -225,11 +225,14 @@ legacy `npmplus_auth_request` values in route options.
 
 The `Ingress Route Apply` workflow is the generic operator mutation path for
 reviewed routes. It accepts `product`, `context`, a compact `route_json` desired
-state, an explicit idempotency key, and a confirmation phrase. It defaults to
-updating an existing expected provider host rather than creating a new one, and
-can carry NPMplus `locations` inside `route_json.route`. Use it for
-product-specific path routing only after the dry-run plan is reviewed and the
-target product/context has an `ingress_route.apply` grant.
+state, an explicit idempotency key, and a confirmation phrase. It defaults to an
+update-only guard that requires an expected provider host id. A reviewed create
+apply must set `allow_create: true` in `route_json` and may use
+`expected_host_id: null` only when the dry-run showed that no existing provider
+host owns the domain. The workflow can carry NPMplus `locations` inside
+`route_json.route`. Use it for product-specific path routing only after the
+dry-run plan is reviewed and the target product/context has an
+`ingress_route.apply` grant.
 
 The `Ingress Route Dry Run` workflow can discover the existing provider host for
 a domain before an apply. Leave `expected_host_id` blank to ask Launchplane to

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -833,8 +833,23 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("APPLY LAUNCHPLANE INGRESS ROUTE", workflow_text)
         self.assertIn("route_json:", workflow_text)
         self.assertIn("route_json.route.domain_names must be non-empty", workflow_text)
-        self.assertIn("route_json.expected_host_id must be a number", workflow_text)
-        self.assertIn("allow_create: option(\"allow_create\"; false)", workflow_text)
+        self.assertIn("option(\"allow_create\"; false) as $allow_create", workflow_text)
+        self.assertIn("($input.expected_host_id // null) as $expected_host_id", workflow_text)
+        self.assertIn("($allow_create | type) != \"boolean\"", workflow_text)
+        self.assertIn("route_json.allow_create must be a boolean", workflow_text)
+        self.assertIn("$expected_host_id == null", workflow_text)
+        self.assertIn("($allow_create | not)", workflow_text)
+        self.assertIn(
+            "route_json.expected_host_id must be a number ",
+            workflow_text,
+        )
+        self.assertIn("unless allow_create is true", workflow_text)
+        self.assertIn(
+            "route_json.expected_host_id must be a number or null",
+            workflow_text,
+        )
+        self.assertIn("expected_host_id: $expected_host_id", workflow_text)
+        self.assertIn("allow_create: $allow_create", workflow_text)
         self.assertIn("allow_update: option(\"allow_update\"; true)", workflow_text)
         self.assertIn("allow_enable_disable: option(\"allow_enable_disable\"; false)", workflow_text)
         self.assertIn("uses: ./.github/actions/launchplane-request", workflow_text)


### PR DESCRIPTION
## Summary
- allow reviewed ingress create applies to omit an existing provider host id when `allow_create` is explicitly true
- keep update-only applies fail-closed by requiring a numeric `expected_host_id`
- document the create-vs-update guard and cover the workflow shape in onboarding tests

## Validation
- `actionlint -config-file .github/actionlint.yaml .github/workflows/ingress-route-apply.yml`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_apply_workflow_requires_operator_guards`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run --extra dev mypy tests/test_product_onboarding.py`
- `uv run python -m unittest tests.test_product_onboarding tests.test_npmplus_ingress_workflow`

## Review
- Claude final review: no blockers
- Antigravity final review: no blockers
