### PR TITLE
Allow Launchplane-owned Odoo artifact publish dispatch

### DIFF
--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -18,6 +18,23 @@ name: Reusable Odoo Artifact Publish
         required: false
         default: ""
         type: string
+      product_repository:
+        description: >-
+          Source repository to publish. Defaults to the caller repository.
+        required: false
+        default: ""
+        type: string
+      source_git_ref:
+        description: >-
+          Source ref attached to the artifact. Defaults to the caller SHA.
+        required: false
+        default: ""
+        type: string
+      confirmation:
+        description: Optional dispatch confirmation, unused by workflow callers.
+        required: false
+        default: ""
+        type: string
       timeout-ms:
         description: Launchplane request timeout in milliseconds.
         required: false
@@ -52,7 +69,53 @@ name: Reusable Odoo Artifact Publish
       source_commit:
         description: Source commit recorded in the artifact manifest.
         value: ${{ jobs.artifact-publish.outputs.source_commit }}
-
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Launchplane product profile key.
+        required: true
+        type: string
+      context:
+        description: Launchplane Odoo context.
+        required: true
+        type: string
+      instance:
+        description: Odoo instance whose artifact should be published.
+        required: true
+        default: testing
+        type: choice
+        options:
+          - testing
+          - prod
+      product_repository:
+        description: Product source repository, formatted as owner/name.
+        required: true
+        type: string
+      source_git_ref:
+        description: Source ref or commit SHA attached to the artifact.
+        required: true
+        type: string
+      confirmation:
+        description: Type PUBLISH LAUNCHPLANE ODOO ARTIFACT to confirm.
+        required: true
+        type: string
+      timeout-ms:
+        description: Launchplane request timeout in milliseconds.
+        required: false
+        default: "600000"
+        type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
 permissions:
   contents: read
   id-token: write
@@ -68,10 +131,61 @@ jobs:
       image_digest: ${{ steps.launchplane.outputs.image_digest }}
       source_commit: ${{ steps.launchplane.outputs.source_commit }}
     steps:
+      - name: Resolve artifact source
+        id: source
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          INPUT_PRODUCT_REPOSITORY: ${{ inputs.product_repository }}
+          INPUT_SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
+          DEFAULT_REPOSITORY: ${{ github.repository }}
+          DEFAULT_SOURCE_GIT_REF: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          repository="$INPUT_PRODUCT_REPOSITORY"
+          source_git_ref="$INPUT_SOURCE_GIT_REF"
+          if [ -z "$repository" ]; then
+            repository="$DEFAULT_REPOSITORY"
+          fi
+          if [ -z "$source_git_ref" ]; then
+            source_git_ref="$DEFAULT_SOURCE_GIT_REF"
+          fi
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$CONFIRMATION" != "PUBLISH LAUNCHPLANE ODOO ARTIFACT" ]; then
+              echo "confirmation must be PUBLISH LAUNCHPLANE ODOO ARTIFACT" >&2
+              exit 1
+            fi
+            if [ -z "$INPUT_PRODUCT_REPOSITORY" ]; then
+              echo "product_repository is required for Launchplane dispatch." \
+                >&2
+              exit 1
+            fi
+            if [ -z "$INPUT_SOURCE_GIT_REF" ]; then
+              echo "source_git_ref is required for Launchplane dispatch." >&2
+              exit 1
+            fi
+          fi
+          if ! [[ "$repository" =~ ^[^/[:space:]]+/[^/[:space:]]+$ ]]; then
+            echo "product_repository must be formatted as owner/name." >&2
+            exit 1
+          fi
+          if [ -z "${source_git_ref// }" ]; then
+            echo "source_git_ref is required." >&2
+            exit 1
+          fi
+          {
+            echo "repository=$repository"
+            echo "source_git_ref=$source_git_ref"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Checkout tenant repo
         uses: actions/checkout@v6
         with:
+          repository: ${{ steps.source.outputs.repository }}
+          ref: ${{ steps.source.outputs.source_git_ref }}
           path: tenant
+          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
           persist-credentials: false
 
       - name: Checkout devkit repo
@@ -140,7 +254,8 @@ jobs:
         id: publish_inputs
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/artifact-publish-inputs
           payload: >-
@@ -149,7 +264,7 @@ jobs:
             product=${{ steps.product.outputs.product }}
             inputs.context=${{ inputs.context }}
             inputs.instance=${{ inputs.instance }}
-            inputs.source_git_ref=${{ github.sha }}
+            inputs.source_git_ref=${{ steps.source.outputs.source_git_ref }}
           idempotency-key: >-
             ${{ steps.product.outputs.publish_inputs_idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
@@ -182,6 +297,7 @@ jobs:
           GHCR_TOKEN: ${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
           ODOO_SOURCE_GITHUB_TOKEN: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
+          CONTEXT_NAME: ${{ inputs.context }}
           PUBLISH_INPUTS_FILE: >-
             ${{ steps.publish_inputs_file.outputs.inputs_file }}
         run: |
@@ -205,7 +321,7 @@ jobs:
             echo "Launchplane publish inputs did not return image_tag." >&2
             exit 1
           fi
-          output_file="$RUNNER_TEMP/${{ inputs.context }}-artifact.json"
+          output_file="$RUNNER_TEMP/${CONTEXT_NAME}-artifact.json"
           manifest_path="$PWD/workspace.toml"
           uv --directory ../odoo-devkit run platform runtime publish \
             --manifest "$manifest_path" \
@@ -220,7 +336,8 @@ jobs:
         id: launchplane
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/artifact-publish
           payload: >-

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -195,6 +195,15 @@ read the Launchplane service URL from `LAUNCHPLANE_PUBLIC_URL` by default and
 derive the GitHub OIDC audience from that URL host unless the caller passes an
 explicit `launchplane_audience` input.
 
+When a product repo does not have an eligible self-hosted runner lane, operators
+may dispatch `reusable-odoo-artifact-publish.yml` directly from Launchplane with
+an explicit `product_repository`, `source_git_ref`, product, context, instance,
+and confirmation phrase. That path checks out the product source on a
+Launchplane-owned runner and uses Launchplane-owned publish/source secrets, while
+still sending the same Odoo driver requests and recording the artifact through
+Launchplane. It is an operator execution path, not a reason for product repos to
+own provider runtime state or duplicate Launchplane request wiring.
+
 Odoo testing deploys follow the same ownership shape. Tenant repos own the
 manual dispatch confirmation and pass an explicit stored `artifact_id` plus
 `source_git_ref` into `reusable-odoo-testing-deploy.yml`; the reusable workflow

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -547,7 +547,11 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         )
 
         self.assertIn("workflow_call", workflow_text)
+        self.assertIn("workflow_dispatch:", workflow_text)
         self.assertIn("product:", workflow_text)
+        self.assertIn("product_repository:", workflow_text)
+        self.assertIn("source_git_ref:", workflow_text)
+        self.assertIn("PUBLISH LAUNCHPLANE ODOO ARTIFACT", workflow_text)
         self.assertIn('product="odoo-tenant-${CONTEXT_NAME}"', workflow_text)
         self.assertIn("/v1/drivers/odoo/artifact-publish-inputs", workflow_text)
         self.assertIn("/v1/drivers/odoo/artifact-publish", workflow_text)
@@ -561,8 +565,15 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("${{ steps.product.outputs.publish_idempotency_key }}", workflow_text)
         self.assertIn("fail-result-paths: result.input_status", workflow_text)
         self.assertIn("fail-result-paths: result.status,result.publish_status", workflow_text)
+        self.assertIn("repository: ${{ steps.source.outputs.repository }}", workflow_text)
+        self.assertIn("ref: ${{ steps.source.outputs.source_git_ref }}", workflow_text)
         self.assertIn("token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}", workflow_text)
-        self.assertIn("inputs.source_git_ref=${{ github.sha }}", workflow_text)
+        self.assertIn(
+            "inputs.source_git_ref=${{ steps.source.outputs.source_git_ref }}",
+            workflow_text,
+        )
+        self.assertIn("CONTEXT_NAME: ${{ inputs.context }}", workflow_text)
+        self.assertIn('output_file="$RUNNER_TEMP/${CONTEXT_NAME}-artifact.json"', workflow_text)
         self.assertIn(
             "RESOLVED_IMAGE_REPOSITORY: >-\n"
             "            ${{ steps.publish_inputs.outputs.image_repository }}",


### PR DESCRIPTION
## Summary
- make the reusable Odoo artifact publish workflow dispatchable directly from Launchplane
- allow operators to provide product repository and source ref so the publish runs on Launchplane-owned runners
- keep workflow_call callers backward-compatible while documenting the operator path

## Validation
- `actionlint -config-file .github/actionlint.yaml .github/workflows/reusable-odoo-artifact-publish.yml`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_reusable_odoo_artifact_publish_standardizes_request_shape`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run --extra dev mypy tests/test_product_onboarding.py`

## Review
- Claude final review: no blockers
- Antigravity final review: no blockers
