### PR TITLE
Fall back to GitHub token for Odoo source checkout

### DIFF
--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -185,7 +185,7 @@ jobs:
           repository: ${{ steps.source.outputs.repository }}
           ref: ${{ steps.source.outputs.source_git_ref }}
           path: tenant
-          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
+          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN || github.token }}
           persist-credentials: false
 
       - name: Checkout devkit repo
@@ -193,7 +193,7 @@ jobs:
         with:
           repository: cbusillo/odoo-devkit
           path: odoo-devkit
-          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
+          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN || github.token }}
           persist-credentials: false
 
       - name: Checkout shared addons repo
@@ -201,7 +201,7 @@ jobs:
         with:
           repository: cbusillo/odoo-shared-addons
           path: odoo-shared-addons
-          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
+          token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN || github.token }}
           persist-credentials: false
 
       - name: Install uv
@@ -296,7 +296,8 @@ jobs:
           GHCR_USERNAME: ${{ github.repository_owner }}
           GHCR_TOKEN: ${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}
           GITHUB_TOKEN: ${{ github.token }}
-          ODOO_SOURCE_GITHUB_TOKEN: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}
+          ODOO_SOURCE_GITHUB_TOKEN: >-
+            ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN || github.token }}
           CONTEXT_NAME: ${{ inputs.context }}
           PUBLISH_INPUTS_FILE: >-
             ${{ steps.publish_inputs_file.outputs.inputs_file }}

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -567,9 +567,16 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("fail-result-paths: result.status,result.publish_status", workflow_text)
         self.assertIn("repository: ${{ steps.source.outputs.repository }}", workflow_text)
         self.assertIn("ref: ${{ steps.source.outputs.source_git_ref }}", workflow_text)
-        self.assertIn("token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}", workflow_text)
+        self.assertIn(
+            "token: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN || github.token }}",
+            workflow_text,
+        )
         self.assertIn(
             "inputs.source_git_ref=${{ steps.source.outputs.source_git_ref }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "${{ secrets.ODOO_SOURCE_GITHUB_TOKEN || github.token }}",
             workflow_text,
         )
         self.assertIn("CONTEXT_NAME: ${{ inputs.context }}", workflow_text)


### PR DESCRIPTION
## Summary
- fall back to the workflow `github.token` when the Odoo source token is unavailable in direct Launchplane dispatch
- keep the Odoo GHCR publish token unchanged
- update the workflow-shape test for the checkout/env token fallback

## Validation
- `actionlint -config-file .github/actionlint.yaml .github/workflows/reusable-odoo-artifact-publish.yml`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_reusable_odoo_artifact_publish_standardizes_request_shape`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run --extra dev mypy tests/test_product_onboarding.py`

## Review
- Claude final review: no blockers
- Antigravity final review: no blockers
