### PR TITLE
Add Launchplane-owned Dokploy target setup

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -72,6 +72,7 @@
     "Security",
     "CodeQL",
     "Deploy Launchplane",
+    "Dokploy Target Setup",
     "Ingress Route Canary Apply",
     "Ingress Route Apply",
     "Ingress Route Audit Read",

--- a/.github/workflows/dokploy-target-setup.yml
+++ b/.github/workflows/dokploy-target-setup.yml
@@ -1,0 +1,329 @@
+---
+name: Dokploy Target Setup
+
+"on":
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Target setup mode.
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - apply
+      operation:
+        description: Target setup operation.
+        required: true
+        default: create-compose
+        type: choice
+        options:
+          - adopt
+          - create-application
+          - create-compose
+      context:
+        description: Launchplane target context.
+        required: true
+        type: string
+      instance:
+        description: Launchplane target instance.
+        required: true
+        type: string
+      target_type:
+        description: Target type when operation=adopt.
+        required: false
+        default: compose
+        type: choice
+        options:
+          - compose
+          - application
+      target_id:
+        description: Existing Dokploy target id when operation=adopt.
+        required: false
+        default: ""
+        type: string
+      target_name:
+        description: Dokploy target display name.
+        required: false
+        default: ""
+        type: string
+      project_id:
+        description: Existing Dokploy project id.
+        required: false
+        default: ""
+        type: string
+      project_name:
+        description: Dokploy project name to create or record.
+        required: false
+        default: ""
+        type: string
+      environment_id:
+        description: Existing Dokploy environment id.
+        required: false
+        default: ""
+        type: string
+      environment_name:
+        description: Dokploy environment name to create.
+        required: false
+        default: ""
+        type: string
+      server_id:
+        description: Dokploy server id for compose targets.
+        required: false
+        default: ""
+        type: string
+      app_name:
+        description: Optional provider app name.
+        required: false
+        default: ""
+        type: string
+      description:
+        description: Optional provider target description.
+        required: false
+        default: ""
+        type: string
+      source_git_ref:
+        description: Source ref to store in the Launchplane target record.
+        required: false
+        default: origin/main
+        type: string
+      source_type:
+        description: Source type to store for compose targets.
+        required: false
+        default: raw
+        type: string
+      compose_path:
+        description: Compose path to store for compose targets.
+        required: false
+        default: docker-compose.yml
+        type: string
+      domain:
+        description: Optional comma-separated domain hosts to store/reconcile.
+        required: false
+        default: ""
+        type: string
+      runtime_port:
+        description: Optional runtime port for compose domain reconciliation.
+        required: false
+        default: ""
+        type: string
+      healthcheck_path:
+        description: Optional target healthcheck path.
+        required: false
+        default: /web/health
+        type: string
+      deploy_timeout_seconds:
+        description: Optional deploy timeout to store.
+        required: false
+        default: "900"
+        type: string
+      confirmation:
+        description: Type APPLY DOKPLOY TARGET SETUP when mode=apply.
+        required: false
+        default: ""
+        type: string
+      reason:
+        description: Operator reason. Required when mode=apply.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: dokploy-target-setup-${{ inputs.context }}-${{ inputs.instance }}
+  cancel-in-progress: false
+
+jobs:
+  setup:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      MODE: ${{ inputs.mode }}
+      OPERATION: ${{ inputs.operation }}
+      CONTEXT: ${{ inputs.context }}
+      INSTANCE: ${{ inputs.instance }}
+      TARGET_TYPE: ${{ inputs.target_type }}
+      TARGET_ID: ${{ inputs.target_id }}
+      TARGET_NAME: ${{ inputs.target_name }}
+      PROJECT_ID: ${{ inputs.project_id }}
+      PROJECT_NAME: ${{ inputs.project_name }}
+      ENVIRONMENT_ID: ${{ inputs.environment_id }}
+      ENVIRONMENT_NAME: ${{ inputs.environment_name }}
+      SERVER_ID: ${{ inputs.server_id }}
+      APP_NAME: ${{ inputs.app_name }}
+      DESCRIPTION: ${{ inputs.description }}
+      SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
+      SOURCE_TYPE: ${{ inputs.source_type }}
+      COMPOSE_PATH: ${{ inputs.compose_path }}
+      DOMAIN: ${{ inputs.domain }}
+      RUNTIME_PORT: ${{ inputs.runtime_port }}
+      HEALTHCHECK_PATH: ${{ inputs.healthcheck_path }}
+      DEPLOY_TIMEOUT_SECONDS: ${{ inputs.deploy_timeout_seconds }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve service endpoint
+        id: service
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+          origin="${LAUNCHPLANE_URL%/}"
+          without_scheme="${origin#*://}"
+          audience="${without_scheme%%/*}"
+          audience="${audience%%:*}"
+          if [ -z "$audience" ] || [ "$audience" = "$origin" ]; then
+            echo "LAUNCHPLANE_URL must be an absolute URL." >&2
+            exit 1
+          fi
+          {
+            echo "origin=$origin"
+            echo "audience=$audience"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate apply guard
+        if: env.MODE == 'apply'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRMATION" != "APPLY DOKPLOY TARGET SETUP" ]; then
+            echo "Exact confirmation text is required." >&2
+            exit 1
+          fi
+          if [ -z "$(printf '%s' "$REASON" | xargs)" ]; then
+            echo "reason is required when mode=apply." >&2
+            exit 1
+          fi
+
+      - name: Request target setup
+        env:
+          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
+          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
+            echo "GitHub OIDC token response did not include a token value." >&2
+            exit 1
+          fi
+
+          domains_json="$({
+            jq -Rsc '
+              split(",")
+              | map(gsub("^\\s+|\\s+$"; ""))
+              | map(select(length > 0))
+            ' <<< "$DOMAIN"
+          })"
+          payload="$({
+            jq -n \
+              --arg mode "$MODE" \
+              --arg operation "$OPERATION" \
+              --arg context "$CONTEXT" \
+              --arg instance "$INSTANCE" \
+              --arg target_type "$TARGET_TYPE" \
+              --arg target_id "$TARGET_ID" \
+              --arg target_name "$TARGET_NAME" \
+              --arg project_id "$PROJECT_ID" \
+              --arg project_name "$PROJECT_NAME" \
+              --arg environment_id "$ENVIRONMENT_ID" \
+              --arg environment_name "$ENVIRONMENT_NAME" \
+              --arg server_id "$SERVER_ID" \
+              --arg app_name "$APP_NAME" \
+              --arg description "$DESCRIPTION" \
+              --arg source_git_ref "$SOURCE_GIT_REF" \
+              --arg source_type "$SOURCE_TYPE" \
+              --arg compose_path "$COMPOSE_PATH" \
+              --arg healthcheck_path "$HEALTHCHECK_PATH" \
+              --arg confirmation "$CONFIRMATION" \
+              --arg reason "$REASON" \
+              --argjson domains "$domains_json" \
+              '{schema_version:1,
+                mode:$mode,
+                operation:$operation,
+                product:"launchplane",
+                context:$context,
+                instance:$instance,
+                target_type:$target_type,
+                target_id:$target_id,
+                target_name:$target_name,
+                project_id:$project_id,
+                project_name:$project_name,
+                environment_id:$environment_id,
+                environment_name:$environment_name,
+                server_id:$server_id,
+                app_name:$app_name,
+                description:$description,
+                source_git_ref:$source_git_ref,
+                source_type:$source_type,
+                compose_path:$compose_path,
+                healthcheck_path:$healthcheck_path,
+                domains:$domains,
+                confirmation:$confirmation,
+                reason:$reason}'
+          })"
+          if [ -n "$(printf '%s' "$RUNTIME_PORT" | xargs)" ]; then
+            payload="$(
+              jq --argjson runtime_port "$RUNTIME_PORT" \
+                '.runtime_port = $runtime_port' <<< "$payload"
+            )"
+          fi
+          if [ -n "$(printf '%s' "$DEPLOY_TIMEOUT_SECONDS" | xargs)" ]; then
+            payload="$(
+              jq --argjson timeout "$DEPLOY_TIMEOUT_SECONDS" \
+                '.deploy_timeout_seconds = $timeout' <<< "$payload"
+            )"
+          fi
+          idempotency_key="dokploy-target-setup:${OPERATION}:"
+          idempotency_key+="${CONTEXT}:${INSTANCE}:"
+          idempotency_key+="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          status_code="$({
+            curl -sS \
+              -o dokploy-target-setup.json \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Content-Type: application/json' \
+              -H "Idempotency-Key: ${idempotency_key}" \
+              --data "$payload" \
+              "${SERVICE_ORIGIN%/}/v1/dokploy-targets/setup"
+          })"
+          jq . dokploy-target-setup.json
+          if [ "$status_code" != "202" ]; then
+            echo "Dokploy target setup failed with HTTP ${status_code}." >&2
+            exit 1
+          fi
+
+      - name: Upload setup evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dokploy-target-setup-result
+          path: dokploy-target-setup.json
+          if-no-files-found: error
+
+      - name: Summarize setup
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Dokploy target setup"
+            echo
+            echo "- Mode: $MODE"
+            echo "- Operation: $OPERATION"
+            echo "- Route: $CONTEXT/$INSTANCE"
+            echo "- Evidence artifact: dokploy-target-setup-result"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -396,6 +396,14 @@ from control_plane.workflows.odoo_preview_runtime import (
     build_odoo_preview_apply_inputs,
     execute_odoo_preview_dokploy_apply,
 )
+from control_plane.workflows.dokploy_target_adoption import (
+    DokployComposeTargetCreateResult,
+    DokployTargetAdoptionResult,
+    DokployTargetCreateResult,
+    adopt_dokploy_target,
+    create_dokploy_application_target,
+    create_dokploy_compose_target,
+)
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.public_ingress_monitor import (
     PublicIngressNotificationDriverSet,
@@ -2088,6 +2096,83 @@ class ProductOnboardingApplyEnvelope(BaseModel):
         return self
 
 
+class DokployTargetSetupEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: Literal["dry-run", "apply"] = "dry-run"
+    operation: Literal["adopt", "create-application", "create-compose"]
+    product: str = "launchplane"
+    context: str
+    instance: str
+    target_type: Literal["application", "compose"] = "compose"
+    target_id: str = ""
+    target_name: str = ""
+    project_id: str = ""
+    project_name: str = ""
+    project_description: str = ""
+    environment_id: str = ""
+    environment_name: str = ""
+    environment_description: str = ""
+    server_id: str = ""
+    app_name: str = ""
+    description: str = ""
+    source_git_ref: str = "origin/main"
+    source_type: str = "raw"
+    compose_path: str = "docker-compose.yml"
+    healthcheck_path: str = ""
+    domains: tuple[str, ...] = ()
+    runtime_port: int | None = Field(default=None, ge=1, le=65535)
+    deploy_timeout_seconds: int | None = Field(default=None, ge=1)
+    confirmation: str = ""
+    reason: str = ""
+
+    @model_validator(mode="after")
+    def _validate_setup(self) -> "DokployTargetSetupEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Dokploy target setup requires product 'launchplane'.")
+        self.product = "launchplane"
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        self.target_id = self.target_id.strip()
+        self.target_name = self.target_name.strip()
+        self.project_id = self.project_id.strip()
+        self.project_name = self.project_name.strip()
+        self.environment_id = self.environment_id.strip()
+        self.environment_name = self.environment_name.strip()
+        self.server_id = self.server_id.strip()
+        self.app_name = self.app_name.strip()
+        self.source_git_ref = self.source_git_ref.strip() or "origin/main"
+        self.source_type = self.source_type.strip() or "raw"
+        self.compose_path = self.compose_path.strip() or "docker-compose.yml"
+        self.healthcheck_path = self.healthcheck_path.strip()
+        self.confirmation = self.confirmation.strip()
+        self.reason = self.reason.strip()
+        self.domains = tuple(domain.strip() for domain in self.domains if domain.strip())
+        if not self.context:
+            raise ValueError("Dokploy target setup requires context.")
+        if not self.instance:
+            raise ValueError("Dokploy target setup requires instance.")
+        if self.operation == "adopt" and not self.target_id:
+            raise ValueError("Dokploy target adoption requires target_id.")
+        if self.operation == "create-application" and not self.target_name:
+            raise ValueError("Dokploy application target creation requires target_name.")
+        if self.operation == "create-compose":
+            if not self.target_name:
+                raise ValueError("Dokploy compose target creation requires target_name.")
+            if not self.server_id:
+                raise ValueError("Dokploy compose target creation requires server_id.")
+        if self.runtime_port is not None and self.operation != "create-compose":
+            raise ValueError(
+                "Dokploy target setup runtime_port is only supported for create-compose."
+            )
+        if self.runtime_port is not None and not self.domains:
+            raise ValueError("Dokploy target setup runtime_port requires at least one domain.")
+        if self.healthcheck_path and not self.healthcheck_path.startswith("/"):
+            raise ValueError("Dokploy target setup healthcheck_path must start with /.")
+        return self
+
+
 class LiveTargetRuntimeApplyEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -2326,6 +2411,161 @@ def _handle_odoo_artifact_publish_inputs(
         product_profile=resolved_context.profile,
     )
     return _DescriptorDriverDispatchResult(result=driver_result, driver_result=driver_result)
+
+
+def _mutate_dokploy_payload_for_target_setup(
+    host: str,
+    token: str,
+    path: str,
+    payload: dict[str, control_plane_dokploy.JsonValue],
+) -> dict[str, control_plane_dokploy.JsonValue]:
+    response = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path=path,
+        method="POST",
+        payload=payload,
+    )
+    response_object = control_plane_dokploy.as_json_object(response)
+    if response_object is None:
+        raise click.ClickException(f"Dokploy API POST {path} returned an invalid response.")
+    return response_object
+
+
+def _fetch_dokploy_target_payload_for_setup(
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+) -> dict[str, control_plane_dokploy.JsonValue]:
+    return control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+
+
+def _dokploy_target_setup_result_payload(
+    result: BaseModel,
+) -> dict[str, object]:
+    payload = result.model_dump(mode="json")
+    record = payload.get("target_record")
+    if isinstance(record, dict):
+        env_payload = record.pop("env", None)
+        if isinstance(env_payload, dict):
+            record["env_keys"] = sorted(str(key) for key in env_payload)
+            record["env_value_count"] = len(env_payload)
+    return payload
+
+
+def _execute_dokploy_target_setup(
+    *,
+    control_plane_root_path: Path,
+    record_store: PostgresRecordStore,
+    request: DokployTargetSetupEnvelope,
+) -> dict[str, object]:
+    apply_changes = request.mode == "apply"
+    host, token = control_plane_dokploy.read_dokploy_config(
+        control_plane_root=control_plane_root_path
+    )
+    result: (
+        DokployTargetAdoptionResult | DokployTargetCreateResult | DokployComposeTargetCreateResult
+    )
+    if request.operation == "adopt":
+        result = adopt_dokploy_target(
+            record_store=record_store,
+            host=host,
+            token=token,
+            context=request.context,
+            instance=request.instance,
+            target_type=request.target_type,
+            target_id=request.target_id,
+            project_name=request.project_name,
+            target_name=request.target_name,
+            source_git_ref=request.source_git_ref,
+            healthcheck_path=request.healthcheck_path,
+            domains=request.domains,
+            deploy_timeout_seconds=request.deploy_timeout_seconds,
+            source_label="service:dokploy-targets:setup:adopt",
+            apply=apply_changes,
+            fetch_target_payload=_fetch_dokploy_target_payload_for_setup,
+        )
+    elif request.operation == "create-application":
+        result = create_dokploy_application_target(
+            record_store=record_store,
+            host=host,
+            token=token,
+            context=request.context,
+            instance=request.instance,
+            target_name=request.target_name,
+            project_id=request.project_id,
+            project_name=request.project_name,
+            project_description=request.project_description,
+            environment_id=request.environment_id,
+            environment_name=request.environment_name,
+            environment_description=request.environment_description,
+            server_id=request.server_id,
+            app_name=request.app_name,
+            application_description=request.description,
+            source_git_ref=request.source_git_ref,
+            healthcheck_path=request.healthcheck_path,
+            domains=request.domains,
+            deploy_timeout_seconds=request.deploy_timeout_seconds,
+            source_label="service:dokploy-targets:setup:create-application",
+            apply=apply_changes,
+            mutate_provider=_mutate_dokploy_payload_for_target_setup,
+            fetch_target_payload=_fetch_dokploy_target_payload_for_setup,
+        )
+    else:
+        result = create_dokploy_compose_target(
+            record_store=record_store,
+            host=host,
+            token=token,
+            context=request.context,
+            instance=request.instance,
+            target_name=request.target_name,
+            project_id=request.project_id,
+            project_name=request.project_name,
+            project_description=request.project_description,
+            environment_id=request.environment_id,
+            environment_name=request.environment_name,
+            environment_description=request.environment_description,
+            server_id=request.server_id,
+            app_name=request.app_name,
+            compose_description=request.description,
+            source_git_ref=request.source_git_ref,
+            source_type=request.source_type,
+            compose_path=request.compose_path,
+            healthcheck_path=request.healthcheck_path,
+            domains=request.domains,
+            deploy_timeout_seconds=request.deploy_timeout_seconds,
+            source_label="service:dokploy-targets:setup:create-compose",
+            apply=apply_changes,
+            mutate_provider=_mutate_dokploy_payload_for_target_setup,
+            fetch_target_payload=_fetch_dokploy_target_payload_for_setup,
+        )
+    route_domain_ids: list[str] = []
+    if apply_changes and request.operation == "create-compose" and request.runtime_port:
+        for domain in request.domains:
+            route_domain_ids.append(
+                control_plane_dokploy.ensure_compose_web_domain_route(
+                    host=host,
+                    token=token,
+                    compose_id=result.target_id_record.target_id,
+                    domain_host=domain,
+                    runtime_port=request.runtime_port,
+                )
+            )
+    return {
+        "mode": request.mode,
+        "operation": request.operation,
+        "context": request.context,
+        "instance": request.instance,
+        "applied": apply_changes,
+        "route_domain_ids": route_domain_ids,
+        "setup": _dokploy_target_setup_result_payload(result),
+    }
 
 
 def _handle_odoo_prod_promotion_inputs(
@@ -4105,6 +4345,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/runtime-key-safety/policies/apply",
         "/v1/live-target-runtime/apply",
         "/v1/product-onboarding/apply",
+        "/v1/dokploy-targets/setup",
         PROVIDER_TARGET_OPERATIONS_ROUTE,
         "/v1/product-config/apply",
         "/v1/product-profiles/context-cutover/apply",
@@ -13159,6 +13400,113 @@ def create_launchplane_service_app(
                         onboarding_result
                     )
                 )
+            elif path == "/v1/dokploy-targets/setup":
+                setup_request = DokployTargetSetupEnvelope.model_validate(payload)
+                if not isinstance(record_store, PostgresRecordStore):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=503,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "database_required",
+                                "message": "Dokploy target setup requires Launchplane database storage.",
+                            },
+                        },
+                    )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="dokploy_target.setup",
+                    product=setup_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot run Launchplane Dokploy target setup.",
+                            },
+                        },
+                    )
+                if setup_request.mode == "apply":
+                    if setup_request.confirmation != "APPLY DOKPLOY TARGET SETUP":
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=400,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "confirmation_required",
+                                    "message": "Dokploy target setup apply requires exact confirmation text.",
+                                },
+                            },
+                        )
+                    if not setup_request.reason:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=400,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "reason_required",
+                                    "message": "Dokploy target setup apply requires a reason.",
+                                },
+                            },
+                        )
+                    if not request_idempotency_key:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=400,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "idempotency_key_required",
+                                    "message": "Dokploy target setup apply requires an Idempotency-Key header.",
+                                },
+                            },
+                        )
+                    idempotent_response = _check_idempotent_request(
+                        record_store=record_store,
+                        scope=request_scope,
+                        route_path=path,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                    )
+                    if idempotent_response is not None:
+                        return idempotent_response
+                try:
+                    result = _execute_dokploy_target_setup(
+                        control_plane_root_path=resolved_root,
+                        record_store=record_store,
+                        request=setup_request,
+                    )
+                except ValueError as error:
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=400,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "invalid_dokploy_target_setup",
+                                "message": str(error),
+                            },
+                        },
+                    )
+                driver_result = {
+                    **result,
+                    "reason": setup_request.reason,
+                }
             elif path == PROVIDER_TARGET_OPERATIONS_ROUTE:
                 provider_target_request = ProviderTargetOperationEnvelope.model_validate(payload)
                 if not isinstance(record_store, PostgresRecordStore):

--- a/control_plane/workflows/dokploy_target_adoption.py
+++ b/control_plane/workflows/dokploy_target_adoption.py
@@ -61,6 +61,29 @@ class DokployTargetCreateResult(BaseModel):
     warnings: tuple[str, ...] = ()
 
 
+class DokployComposeTargetCreatePlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project: dict[str, str]
+    environment: dict[str, str]
+    compose: dict[str, str]
+
+
+class DokployComposeTargetCreateResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    applied: bool
+    plan: DokployComposeTargetCreatePlan
+    project_id: str = ""
+    environment_id: str = ""
+    target_record: DokployTargetRecord
+    target_id_record: DokployTargetIdRecord
+    provider_target_record: ProviderTargetRecord
+    provider_fields: dict[str, str | tuple[str, ...] | bool | int | None] = {}
+    provider_requests: tuple[dict[str, object], ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
 def adopt_dokploy_target(
     *,
     record_store: DokployTargetAdoptionRecordStore,
@@ -355,6 +378,221 @@ def create_dokploy_application_target(
     )
 
 
+def create_dokploy_compose_target(
+    *,
+    record_store: DokployTargetAdoptionRecordStore,
+    host: str,
+    token: str,
+    context: str,
+    instance: str,
+    target_name: str,
+    project_id: str = "",
+    project_name: str = "",
+    project_description: str = "",
+    environment_id: str = "",
+    environment_name: str = "",
+    environment_description: str = "",
+    server_id: str = "",
+    app_name: str = "",
+    compose_description: str = "",
+    source_git_ref: str = "origin/main",
+    source_type: str = "raw",
+    compose_path: str = "docker-compose.yml",
+    healthcheck_path: str = "",
+    domains: tuple[str, ...] = (),
+    deploy_timeout_seconds: int | None = None,
+    source_label: str = "cli:dokploy-targets:create-compose",
+    updated_at: str = "",
+    apply: bool = False,
+    mutate_provider: MutateDokployPayload,
+    fetch_target_payload: FetchDokployTargetPayload,
+) -> DokployComposeTargetCreateResult:
+    normalized_context = _normalize_route_part(context, "context")
+    normalized_instance = _normalize_route_part(instance, "instance")
+    normalized_target_name = _require_non_empty(target_name, "target_name")
+    normalized_project_id = project_id.strip()
+    normalized_project_name = project_name.strip()
+    normalized_environment_id = environment_id.strip()
+    normalized_environment_name = environment_name.strip() or normalized_instance
+    normalized_server_id = _require_non_empty(server_id, "server_id")
+    normalized_healthcheck_path = healthcheck_path.strip()
+    if normalized_healthcheck_path and not normalized_healthcheck_path.startswith("/"):
+        raise ValueError(
+            "Dokploy compose target creation requires --healthcheck-path to start with /"
+        )
+    if not normalized_environment_id and not normalized_project_id and not normalized_project_name:
+        raise ValueError(
+            "Dokploy compose target creation requires --project-id or --project-name when --environment-id is not supplied"
+        )
+
+    provider_requests = _planned_compose_provider_requests(
+        project_id=normalized_project_id,
+        project_name=normalized_project_name,
+        project_description=project_description,
+        environment_id=normalized_environment_id,
+        environment_name=normalized_environment_name,
+        environment_description=environment_description,
+        target_name=normalized_target_name,
+        app_name=app_name,
+        compose_description=compose_description,
+        server_id=normalized_server_id,
+        source_type=source_type,
+        compose_path=compose_path,
+    )
+    plan = DokployComposeTargetCreatePlan(
+        project={
+            "action": _project_plan_action(
+                project_id=normalized_project_id,
+                environment_id=normalized_environment_id,
+            ),
+            "project_id": normalized_project_id,
+            "project_name": normalized_project_name,
+        },
+        environment={
+            "action": "use_existing" if normalized_environment_id else "create",
+            "environment_id": normalized_environment_id,
+            "environment_name": normalized_environment_name,
+        },
+        compose={
+            "action": "create",
+            "target_name": normalized_target_name,
+            "app_name": app_name.strip(),
+            "server_id": normalized_server_id,
+            "source_type": source_type.strip() or "raw",
+            "compose_path": compose_path.strip() or "docker-compose.yml",
+        },
+    )
+
+    recorded_at = updated_at.strip() or utc_now_timestamp()
+    if not apply:
+        target_record = DokployTargetRecord(
+            context=normalized_context,
+            instance=normalized_instance,
+            project_name=normalized_project_name,
+            target_type="compose",
+            target_name=normalized_target_name,
+            source_git_ref=source_git_ref.strip() or "origin/main",
+            source_type=source_type.strip() or "raw",
+            compose_path=compose_path.strip() or "docker-compose.yml",
+            deploy_timeout_seconds=deploy_timeout_seconds,
+            healthcheck_path=normalized_healthcheck_path,
+            domains=domains,
+            updated_at=recorded_at,
+            source_label=source_label.strip() or "cli:dokploy-targets:create-compose",
+        )
+        target_id_record = DokployTargetIdRecord(
+            context=normalized_context,
+            instance=normalized_instance,
+            target_id="planned-compose-id",
+            updated_at=recorded_at,
+            source_label=target_record.source_label,
+        )
+        provider_target_record = ProviderTargetRecord.from_dokploy_records(
+            target_record=target_record,
+            target_id_record=target_id_record,
+        )
+        return DokployComposeTargetCreateResult(
+            applied=False,
+            plan=plan,
+            target_record=target_record,
+            target_id_record=target_id_record,
+            provider_target_record=provider_target_record,
+            provider_requests=provider_requests,
+            warnings=("dry run only; provider was not mutated and records were not written",),
+        )
+
+    _ensure_create_route_has_no_provider_target(
+        record_store=record_store,
+        context=normalized_context,
+        instance=normalized_instance,
+    )
+
+    created_project_id = normalized_project_id
+    if not created_project_id and not normalized_environment_id:
+        project_payload: JsonObject = {"name": normalized_project_name}
+        if project_description.strip():
+            project_payload["description"] = project_description.strip()
+        created_project = mutate_provider(host, token, "/api/project.create", project_payload)
+        created_project_id = _extract_provider_id(created_project, "projectId", "project")
+
+    created_environment_id = normalized_environment_id
+    if not created_environment_id:
+        environment_payload: JsonObject = {
+            "name": normalized_environment_name,
+            "projectId": created_project_id,
+        }
+        if environment_description.strip():
+            environment_payload["description"] = environment_description.strip()
+        created_environment = mutate_provider(
+            host, token, "/api/environment.create", environment_payload
+        )
+        created_environment_id = _extract_provider_id(
+            created_environment, "environmentId", "environment"
+        )
+
+    compose_payload: JsonObject = {
+        "name": normalized_target_name,
+        "appName": app_name.strip() or normalized_target_name,
+        "environmentId": created_environment_id,
+        "serverId": normalized_server_id,
+        "composeType": "docker-compose",
+    }
+    if compose_description.strip():
+        compose_payload["description"] = compose_description.strip()
+    created_compose = mutate_provider(host, token, "/api/compose.create", compose_payload)
+    compose_id = _extract_provider_id(created_compose, "composeId", "compose")
+
+    adoption = adopt_dokploy_target(
+        record_store=record_store,
+        host=host,
+        token=token,
+        context=normalized_context,
+        instance=normalized_instance,
+        target_type="compose",
+        target_id=compose_id,
+        project_name=normalized_project_name,
+        target_name=normalized_target_name,
+        source_git_ref=source_git_ref,
+        healthcheck_path=normalized_healthcheck_path,
+        domains=domains,
+        deploy_timeout_seconds=deploy_timeout_seconds,
+        source_label=source_label,
+        updated_at=updated_at,
+        apply=True,
+        fetch_target_payload=fetch_target_payload,
+    )
+    target_record = adoption.target_record.model_copy(
+        update={
+            "source_type": adoption.target_record.source_type or source_type.strip() or "raw",
+            "compose_path": adoption.target_record.compose_path
+            or compose_path.strip()
+            or "docker-compose.yml",
+        }
+    )
+    if target_record != adoption.target_record:
+        record_store.write_dokploy_target_record(target_record)
+        provider_target_record = prepare_provider_target_from_dokploy_records(
+            record_store=record_store,
+            target_record=target_record,
+            target_id_record=adoption.target_id_record,
+        )
+        record_store.write_provider_target_record(provider_target_record)
+    else:
+        provider_target_record = adoption.provider_target_record
+    return DokployComposeTargetCreateResult(
+        applied=True,
+        plan=plan,
+        project_id=created_project_id,
+        environment_id=created_environment_id,
+        target_record=target_record,
+        target_id_record=adoption.target_id_record,
+        provider_target_record=provider_target_record,
+        provider_fields=adoption.provider_fields,
+        provider_requests=provider_requests,
+        warnings=adoption.warnings,
+    )
+
+
 def _require_non_empty(value: str, field_name: str) -> str:
     normalized_value = value.strip()
     if not normalized_value:
@@ -441,6 +679,48 @@ def _planned_provider_requests(
     if server_id.strip():
         application_payload["serverId"] = server_id.strip()
     requests.append({"path": "/api/application.create", "payload": application_payload})
+    return tuple(requests)
+
+
+def _planned_compose_provider_requests(
+    *,
+    project_id: str,
+    project_name: str,
+    project_description: str,
+    environment_id: str,
+    environment_name: str,
+    environment_description: str,
+    target_name: str,
+    app_name: str,
+    compose_description: str,
+    server_id: str,
+    source_type: str,
+    compose_path: str,
+) -> tuple[dict[str, object], ...]:
+    requests: list[dict[str, object]] = []
+    if not environment_id and not project_id:
+        project_payload: dict[str, object] = {"name": project_name}
+        if project_description.strip():
+            project_payload["description"] = project_description.strip()
+        requests.append({"path": "/api/project.create", "payload": project_payload})
+    if not environment_id:
+        environment_payload: dict[str, object] = {
+            "name": environment_name,
+            "projectId": project_id or "<created-project-id>",
+        }
+        if environment_description.strip():
+            environment_payload["description"] = environment_description.strip()
+        requests.append({"path": "/api/environment.create", "payload": environment_payload})
+    compose_payload: dict[str, object] = {
+        "name": target_name,
+        "appName": app_name.strip() or target_name,
+        "environmentId": environment_id or "<created-environment-id>",
+        "serverId": server_id,
+        "composeType": "docker-compose",
+    }
+    if compose_description.strip():
+        compose_payload["description"] = compose_description.strip()
+    requests.append({"path": "/api/compose.create", "payload": compose_payload})
     return tuple(requests)
 
 

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -92,6 +92,20 @@ values. Use `--project-name`, `--target-name`, `--domain`, and
 `--healthcheck-path` when the provider payload does not expose enough redacted
 metadata for the record.
 
+For shared or production live mutations, use the manual `Dokploy Target Setup`
+workflow instead of local CLI commands. The workflow calls the deployed
+Launchplane service route `POST /v1/dokploy-targets/setup` with GitHub OIDC,
+supports dry-run and apply modes, and writes the Dokploy target, target-id, and
+provider-target records through Launchplane storage. `create-compose` is the
+stable Odoo setup path when no Dokploy compose target exists yet; provide the
+Dokploy project/environment or project name, server id, target name, optional
+domain hosts, runtime port, and an operator reason before applying. Runtime port
+is used only for `create-compose` domain reconciliation and requires at least
+one domain. If a provider create succeeds but the follow-up Launchplane record
+write fails, note the created Dokploy compose/application id from the workflow
+logs and re-run the workflow with `operation=adopt` for the same
+context/instance instead of creating another target.
+
 When the Dokploy application does not exist yet, let Launchplane plan and apply
 the provider mutation so the app id is captured in records immediately:
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -54,6 +54,8 @@ VeriReel product paths:
   - `POST /v1/product-config/apply`
 - product onboarding route:
   - `POST /v1/product-onboarding/apply`
+- Dokploy target setup route:
+  - `POST /v1/dokploy-targets/setup`
 - provider-target operation route:
   - `POST /v1/provider-targets/operations`
 - product context cutover route:
@@ -859,6 +861,20 @@ idempotency-keyed and write only complete non-conflicting Dokploy target/id
 projections; existing rows and conflicts are reported rather than overwritten.
 The manual `Provider Target Operations` workflow is the supported shared and
 production caller for Phase Two backfill evidence.
+
+Dokploy target setup uses `POST /v1/dokploy-targets/setup`. The route is the
+service-owned path for adopting an existing Dokploy target or creating a new
+application/compose target while immediately writing the matching Dokploy
+target, target-id, and provider-target records. It supports dry-run and apply
+modes, requires `dokploy_target.setup` authz for product/context `launchplane`,
+and requires exact confirmation, an operator reason, and an idempotency key for
+apply. The manual `Dokploy Target Setup` workflow is the supported shared and
+production caller; product repos must not store live target IDs or provider
+fixtures as setup authority. Runtime port is accepted only for `create-compose`
+domain reconciliation with at least one domain. If a provider create succeeds
+but the service fails before records are written, recover by re-running the
+workflow with `operation=adopt` and the created provider target id, not by
+creating a second target for the same lane.
 
 The manual `Product Environment Evidence` workflow is the supported read-only
 Phase Two caller for product environment read-model evidence. It uses GitHub

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -480,6 +480,14 @@ post_grant \
 	provider_target.backfill \
 	deploy:provider-target-operations-backfill-grant \
 	provider-target-operations-backfill
+post_grant \
+	"$GITHUB_REPOSITORY" \
+	dokploy-target-setup.yml \
+	launchplane \
+	launchplane \
+	dokploy_target.setup \
+	deploy:dokploy-target-setup-grant \
+	dokploy-target-setup
 post_terminal_agent_grant \
 	launchplane \
 	launchplane \

--- a/tests/test_dokploy_target_adoption.py
+++ b/tests/test_dokploy_target_adoption.py
@@ -16,6 +16,7 @@ from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.dokploy_target_adoption import (
     adopt_dokploy_target,
     create_dokploy_application_target,
+    create_dokploy_compose_target,
 )
 
 
@@ -649,6 +650,76 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertEqual(target_record.target_name, "discord-blue-prod")
         self.assertEqual(target_record.healthcheck_path, "/health")
         self.assertEqual(target_id_record.target_id, "app-123")
+
+    def test_create_compose_target_applies_provider_and_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            requests: list[tuple[str, JsonObject]] = []
+
+            def mutate_provider(
+                _host: str, _token: str, path: str, payload: JsonObject
+            ) -> JsonObject:
+                requests.append((path, payload))
+                if path == "/api/project.create":
+                    return {"projectId": "project-123"}
+                if path == "/api/environment.create":
+                    self.assertEqual(payload["projectId"], "project-123")
+                    return {"environmentId": "env-123"}
+                if path == "/api/compose.create":
+                    self.assertEqual(payload["environmentId"], "env-123")
+                    self.assertEqual(payload["serverId"], "server-123")
+                    return {"composeId": "compose-123"}
+                raise AssertionError(path)
+
+            result = create_dokploy_compose_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="cm_website",
+                instance="testing",
+                target_name="cm-website-testing",
+                project_name="Odoo",
+                environment_name="production",
+                server_id="server-123",
+                healthcheck_path="/web/health",
+                domains=("cm-website-testing.shinycomputers.com",),
+                updated_at="2026-05-04T23:10:00Z",
+                apply=True,
+                mutate_provider=mutate_provider,
+                fetch_target_payload=lambda *_args: {
+                    "name": "cm-website-testing",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "environment": {"project": {"name": "Odoo"}},
+                },
+            )
+            target_record = store.read_dokploy_target_record(
+                context_name="cm_website", instance_name="testing"
+            )
+            target_id_record = store.read_dokploy_target_id_record(
+                context_name="cm_website", instance_name="testing"
+            )
+            provider_target = store.read_provider_target_record(
+                context_name="cm_website", instance_name="testing"
+            )
+            store.close()
+
+        self.assertTrue(result.applied)
+        self.assertEqual(
+            [path for path, _payload in requests],
+            ["/api/project.create", "/api/environment.create", "/api/compose.create"],
+        )
+        self.assertEqual(target_record.target_type, "compose")
+        self.assertEqual(target_record.target_name, "cm-website-testing")
+        self.assertEqual(target_record.domains, ("cm-website-testing.shinycomputers.com",))
+        self.assertEqual(target_record.source_type, "raw")
+        self.assertEqual(target_record.compose_path, "docker-compose.yml")
+        self.assertEqual(target_id_record.target_id, "compose-123")
+        self.assertEqual(provider_target.provider_target_type, "compose")
+        self.assertEqual(provider_target.target_id, "compose-123")
 
     def test_create_application_target_canonicalizes_route_keys_before_persisting(
         self,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13454,6 +13454,552 @@ class LaunchplaneServiceTests(unittest.TestCase):
         assert provider_target is not None
         self.assertEqual(provider_target.target_id, "app-verireel-testing")
 
+    def test_dokploy_target_setup_endpoint_dry_run_does_not_persist(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            with patch(
+                "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.invalid", "token"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "dry-run",
+                        "operation": "create-compose",
+                        "product": "launchplane",
+                        "context": "cm_website",
+                        "instance": "testing",
+                        "target_name": "cm-website-testing",
+                        "project_name": "Odoo",
+                        "environment_name": "production",
+                        "server_id": "server-123",
+                        "domains": ["cm-website-testing.shinycomputers.com"],
+                        "runtime_port": 8069,
+                        "deploy_timeout_seconds": 900,
+                    },
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                target_records = store.list_dokploy_target_records()
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertFalse(payload["result"]["applied"])
+        self.assertEqual(
+            payload["result"]["setup"]["target_id_record"]["target_id"],
+            "planned-compose-id",
+        )
+        self.assertEqual(target_records, ())
+
+    def test_dokploy_target_setup_endpoint_applies_compose_target(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            provider_requests: list[tuple[str, dict[str, object]]] = []
+            domain_routes: list[tuple[str, int]] = []
+
+            def _mutate_provider(
+                _host: str, _token: str, path: str, payload: dict[str, object]
+            ) -> dict[str, object]:
+                provider_requests.append((path, payload))
+                if path == "/api/project.create":
+                    return {"projectId": "project-123"}
+                if path == "/api/environment.create":
+                    return {"environmentId": "env-123"}
+                if path == "/api/compose.create":
+                    return {"composeId": "compose-123"}
+                raise AssertionError(path)
+
+            def _fetch_target(
+                _host: str, _token: str, _target_type: str, _target_id: str
+            ) -> dict[str, object]:
+                return {
+                    "name": "cm-website-testing",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "environment": {"project": {"name": "Odoo"}},
+                }
+
+            def _ensure_domain(
+                *,
+                host: str,
+                token: str,
+                compose_id: str,
+                domain_host: str,
+                runtime_port: int,
+                certificate_type: str = "none",
+            ) -> str:
+                del host, token, compose_id, certificate_type
+                domain_routes.append((domain_host, runtime_port))
+                return "domain-123"
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service._mutate_dokploy_payload_for_target_setup",
+                    side_effect=_mutate_provider,
+                ),
+                patch(
+                    "control_plane.service._fetch_dokploy_target_payload_for_setup",
+                    side_effect=_fetch_target,
+                ),
+                patch(
+                    "control_plane.service.control_plane_dokploy.ensure_compose_web_domain_route",
+                    side_effect=_ensure_domain,
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "operation": "create-compose",
+                        "product": "launchplane",
+                        "context": "cm_website",
+                        "instance": "testing",
+                        "target_name": "cm-website-testing",
+                        "project_name": "Odoo",
+                        "environment_name": "production",
+                        "server_id": "server-123",
+                        "domains": ["cm-website-testing.shinycomputers.com"],
+                        "runtime_port": 8069,
+                        "deploy_timeout_seconds": 900,
+                        "confirmation": "APPLY DOKPLOY TARGET SETUP",
+                        "reason": "Create cm website testing target.",
+                    },
+                    headers={"Idempotency-Key": "dokploy-target-setup-cm-website"},
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                target_record = store.read_dokploy_target_record(
+                    context_name="cm_website", instance_name="testing"
+                )
+                target_id_record = store.read_dokploy_target_id_record(
+                    context_name="cm_website", instance_name="testing"
+                )
+                provider_target = store.read_provider_target_record(
+                    context_name="cm_website", instance_name="testing"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertTrue(payload["result"]["applied"])
+        self.assertEqual(payload["result"]["route_domain_ids"], ["domain-123"])
+        self.assertEqual(
+            [path for path, _payload in provider_requests],
+            ["/api/project.create", "/api/environment.create", "/api/compose.create"],
+        )
+        compose_payload = provider_requests[-1][1]
+        self.assertNotIn("sourceType", compose_payload)
+        self.assertNotIn("composePath", compose_payload)
+        self.assertEqual(domain_routes, [("cm-website-testing.shinycomputers.com", 8069)])
+        self.assertEqual(target_record.target_type, "compose")
+        self.assertEqual(target_record.target_name, "cm-website-testing")
+        self.assertEqual(target_id_record.target_id, "compose-123")
+        self.assertEqual(provider_target.target_id, "compose-123")
+
+    def test_dokploy_target_setup_endpoint_applies_adopt(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service._fetch_dokploy_target_payload_for_setup",
+                    return_value={
+                        "name": "existing-compose",
+                        "sourceType": "raw",
+                        "composePath": "docker-compose.yml",
+                        "environment": {"project": {"name": "Odoo"}},
+                    },
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "operation": "adopt",
+                        "product": "launchplane",
+                        "context": "cm_website",
+                        "instance": "testing",
+                        "target_type": "compose",
+                        "target_id": "compose-existing",
+                        "target_name": "cm-website-testing",
+                        "project_name": "Odoo",
+                        "domains": ["cm-website-testing.shinycomputers.com"],
+                        "confirmation": "APPLY DOKPLOY TARGET SETUP",
+                        "reason": "Adopt cm website testing target.",
+                    },
+                    headers={"Idempotency-Key": "dokploy-target-setup-adopt"},
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                target_id_record = store.read_dokploy_target_id_record(
+                    context_name="cm_website", instance_name="testing"
+                )
+                provider_target = store.read_provider_target_record(
+                    context_name="cm_website", instance_name="testing"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertTrue(payload["result"]["applied"])
+        self.assertEqual(payload["result"]["operation"], "adopt")
+        self.assertEqual(target_id_record.target_id, "compose-existing")
+        self.assertEqual(provider_target.target_id, "compose-existing")
+
+    def test_dokploy_target_setup_endpoint_applies_application_target(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            provider_requests: list[tuple[str, dict[str, object]]] = []
+
+            def _mutate_provider(
+                _host: str, _token: str, path: str, payload: dict[str, object]
+            ) -> dict[str, object]:
+                provider_requests.append((path, payload))
+                if path == "/api/application.create":
+                    return {"applicationId": "app-123"}
+                raise AssertionError(path)
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service._mutate_dokploy_payload_for_target_setup",
+                    side_effect=_mutate_provider,
+                ),
+                patch(
+                    "control_plane.service._fetch_dokploy_target_payload_for_setup",
+                    return_value={
+                        "name": "discord-blue-prod",
+                        "environment": {"project": {"name": "Discord Blue"}},
+                    },
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "operation": "create-application",
+                        "product": "launchplane",
+                        "context": "discord-blue",
+                        "instance": "prod",
+                        "target_name": "discord-blue-prod",
+                        "environment_id": "env-existing",
+                        "confirmation": "APPLY DOKPLOY TARGET SETUP",
+                        "reason": "Create discord target.",
+                    },
+                    headers={"Idempotency-Key": "dokploy-target-setup-app"},
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                provider_target = store.read_provider_target_record(
+                    context_name="discord-blue", instance_name="prod"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertTrue(payload["result"]["applied"])
+        self.assertEqual(payload["result"]["operation"], "create-application")
+        self.assertEqual(
+            [path for path, _payload in provider_requests], ["/api/application.create"]
+        )
+        self.assertEqual(provider_target.target_id, "app-123")
+        self.assertEqual(provider_target.provider_target_type, "application")
+
+    def test_dokploy_target_setup_rejects_runtime_port_for_adopt(self) -> None:
+        app = create_launchplane_service_app(
+            state_dir=Path("/tmp") / "launchplane-test-state",
+            verifier=_StubVerifier(
+                _identity(
+                    repository="cbusillo/launchplane",
+                    workflow_ref=(
+                        "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                    ),
+                    event_name="workflow_dispatch",
+                )
+            ),
+            authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+            control_plane_root_path=Path("/tmp"),
+        )
+
+        status_code, payload = _invoke_app(
+            app,
+            method="POST",
+            path="/v1/dokploy-targets/setup",
+            payload={
+                "schema_version": 1,
+                "mode": "dry-run",
+                "operation": "adopt",
+                "product": "launchplane",
+                "context": "cm_website",
+                "instance": "testing",
+                "target_type": "compose",
+                "target_id": "compose-existing",
+                "domains": ["cm-website-testing.shinycomputers.com"],
+                "runtime_port": 8069,
+            },
+        )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_dokploy_target_setup_rejects_runtime_port_without_domains(self) -> None:
+        app = create_launchplane_service_app(
+            state_dir=Path("/tmp") / "launchplane-test-state",
+            verifier=_StubVerifier(
+                _identity(
+                    repository="cbusillo/launchplane",
+                    workflow_ref=(
+                        "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                    ),
+                    event_name="workflow_dispatch",
+                )
+            ),
+            authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+            control_plane_root_path=Path("/tmp"),
+        )
+
+        status_code, payload = _invoke_app(
+            app,
+            method="POST",
+            path="/v1/dokploy-targets/setup",
+            payload={
+                "schema_version": 1,
+                "mode": "dry-run",
+                "operation": "create-compose",
+                "product": "launchplane",
+                "context": "cm_website",
+                "instance": "testing",
+                "target_name": "cm-website-testing",
+                "server_id": "server-123",
+                "runtime_port": 8069,
+            },
+        )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_dokploy_target_setup_endpoint_rejects_apply_without_authz(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+            finally:
+                store.close()
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/dokploy-targets/setup",
+                payload={
+                    "schema_version": 1,
+                    "mode": "apply",
+                    "operation": "create-compose",
+                    "product": "launchplane",
+                    "context": "cm_website",
+                    "instance": "testing",
+                    "target_name": "cm-website-testing",
+                    "project_name": "Odoo",
+                    "environment_name": "production",
+                    "server_id": "server-123",
+                    "confirmation": "APPLY DOKPLOY TARGET SETUP",
+                    "reason": "Create cm website testing target.",
+                },
+                headers={"Idempotency-Key": "dokploy-target-setup-denied"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
     def test_provider_target_operation_endpoint_rejects_apply_without_authz(
         self,
     ) -> None:
@@ -30910,7 +31456,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
             self.assertEqual(status_code, 503)
             self.assertEqual(payload["error"]["code"], "driver_route_dependency_not_found")
-            self.assertEqual(payload["details"]["route_path"], "/v1/drivers/odoo/artifact-publish-inputs")
+            self.assertEqual(
+                payload["details"]["route_path"], "/v1/drivers/odoo/artifact-publish-inputs"
+            )
             self.assertNotIn("missing", payload["details"])
             self.assertNotIn("product_profiles", json.dumps(payload))
             self.assertNotIn("No Launchplane route", payload["error"]["message"])
@@ -30926,9 +31474,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             profile_payload = _odoo_preview_profile_payload("odoo-tenant-cm-website")
             profile_payload["display_name"] = "Cell Mechanic Website Odoo"
             profile_payload["repository"] = "cbusillo/odoo-tenant-cm-website"
-            profile_payload["image"] = {
-                "repository": "ghcr.io/cbusillo/odoo-tenant-cm-website"
-            }
+            profile_payload["image"] = {"repository": "ghcr.io/cbusillo/odoo-tenant-cm-website"}
             lanes = list(cast(tuple[dict[str, object], ...], profile_payload["lanes"]))
             lanes[0]["context"] = "cm_website"
             profile_payload["lanes"] = tuple(lanes)


### PR DESCRIPTION
## Summary

- Add a DB-backed `POST /v1/dokploy-targets/setup` route for dry-run/apply target adoption and creation.
- Add the manual `Dokploy Target Setup` workflow and deploy authz grant reconciliation.
- Support compose target creation for stable Odoo lanes, with optional domain reconciliation and provider-target dual-write.
- Document the shared/prod setup path and orphan recovery guidance.

## Validation

- `uv run --extra dev ruff check control_plane/workflows/dokploy_target_adoption.py control_plane/service.py tests/test_dokploy_target_adoption.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/workflows/dokploy_target_adoption.py control_plane/service.py tests/test_dokploy_target_adoption.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/workflows/dokploy_target_adoption.py control_plane/service.py tests/test_dokploy_target_adoption.py tests/test_service.py`
- `uv run python -m unittest tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_create_compose_target_applies_provider_and_records tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_endpoint_dry_run_does_not_persist tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_endpoint_applies_compose_target tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_endpoint_applies_adopt tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_endpoint_applies_application_target tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_rejects_runtime_port_for_adopt tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_rejects_runtime_port_without_domains tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_endpoint_rejects_apply_without_authz`
- JSON/YAML parse check for `.github/github.json` and `.github/workflows/dokploy-target-setup.yml`

## Review

- Claude/Gemini initial review completed; findings addressed.
- Claude re-review: production code has no blockers; regression tests added for the non-blocking coverage suggestions.
