### PR TITLE
Scope Odoo replacement runtime safety

### DIFF
--- a/control_plane/live_target_runtime.py
+++ b/control_plane/live_target_runtime.py
@@ -24,9 +24,16 @@ from control_plane.storage.postgres import PostgresRecordStore
 
 
 class LiveTargetRuntimeError(Exception):
-    def __init__(self, message: str, *, code: str = "live_target_runtime_failed") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "live_target_runtime_failed",
+        summary: dict[str, object] | None = None,
+    ) -> None:
         super().__init__(message)
         self.code = code
+        self.summary = summary or {}
 
 
 class DokployDeployTrigger(Protocol):
@@ -79,7 +86,7 @@ def evaluate_runtime_key_safety_for_live_target_sync(
     context_name: str,
     instance_name: str,
     require_policy: bool = True,
-    required_binding_keys: tuple[str, ...] = (),
+    required_binding_keys: tuple[str, ...] | None = None,
 ) -> dict[str, object]:
     all_runtime_bindings = record_store.list_secret_bindings(
         integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
@@ -95,7 +102,11 @@ def evaluate_runtime_key_safety_for_live_target_sync(
             instance_name=instance_name,
         )
     )
-    binding_keys = required_binding_keys or tuple(binding.binding_key for binding in bindings)
+    binding_keys = (
+        required_binding_keys
+        if required_binding_keys is not None
+        else tuple(binding.binding_key for binding in bindings)
+    )
     if not binding_keys:
         return {"required": False, "status": "skipped", "checked_binding_keys": []}
     try:
@@ -105,7 +116,7 @@ def evaluate_runtime_key_safety_for_live_target_sync(
             instance=instance_name,
             environment_class=runtime_key_safety_environment_class(instance_name),
         )
-        if required_binding_keys:
+        if required_binding_keys is not None:
             evaluation = evaluate_runtime_key_safety(
                 target=target,
                 required_binding_keys=binding_keys,
@@ -145,6 +156,7 @@ def evaluate_runtime_key_safety_for_live_target_sync(
         raise LiveTargetRuntimeError(
             f"Runtime key-safety gate failed for live target sync{suffix}.",
             code="runtime_key_safety_failed",
+            summary=summary,
         )
     return summary
 
@@ -235,6 +247,40 @@ def _require_product_profile_runtime_secret_keys(
             instance_name=instance_name,
         )
     }
+
+
+def require_product_profile_runtime_secret_keys(
+    *,
+    record_store: LiveTargetRuntimeProfileStore,
+    product_name: str,
+    context_name: str,
+    instance_name: str,
+) -> set[str]:
+    return _require_product_profile_runtime_secret_keys(
+        record_store=record_store,
+        product_name=product_name,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
+
+
+def runtime_key_safety_error_message(error: LiveTargetRuntimeError) -> str:
+    summary = getattr(error, "summary", None)
+    if not isinstance(summary, dict):
+        return str(error)
+    findings = summary.get("findings")
+    if not isinstance(findings, list):
+        return str(error)
+    binding_keys = sorted(
+        {
+            str(finding.get("binding_key") or "")
+            for finding in findings
+            if isinstance(finding, dict) and str(finding.get("binding_key") or "").strip()
+        }
+    )
+    if not binding_keys:
+        return str(error)
+    return f"{error} Affected binding keys: {', '.join(binding_keys)}."
 
 
 def _expected_config_route_matches(

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1072,15 +1072,26 @@ def execute_odoo_stable_target_replacement_apply(
             )
         )
         try:
+            runtime_secret_binding_keys = (
+                control_plane_live_target_runtime.require_product_profile_runtime_secret_keys(
+                    record_store=record_store,
+                    product_name=plan.product,
+                    context_name=plan.context,
+                    instance_name=plan.instance,
+                )
+            )
             runtime_key_safety = (
                 control_plane_live_target_runtime.evaluate_runtime_key_safety_for_live_target_sync(
                     record_store=record_store,
                     context_name=plan.context,
                     instance_name=plan.instance,
+                    required_binding_keys=tuple(sorted(runtime_secret_binding_keys)),
                 )
             )
         except control_plane_live_target_runtime.LiveTargetRuntimeError as error:
-            raise click.ClickException(str(error)) from error
+            raise click.ClickException(
+                control_plane_live_target_runtime.runtime_key_safety_error_message(error)
+            ) from error
         runtime_source.update(
             {
                 f"runtime_key_safety_{key}": str(value)

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -17,11 +17,13 @@ from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
+    ProductExpectedConfigProfile,
     ProductImageProfile,
     ProductLaneProfile,
     ProductOdooLaneDataPolicy,
     ProductOdooPrelaunchRebuildPolicy,
     ProductPreviewProfile,
+    ProductSecretConfigRequirement,
 )
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -158,6 +160,24 @@ def _profile(driver_id: str = "odoo") -> LaunchplaneProductProfileRecord:
         preview=ProductPreviewProfile(enabled=True, context="cm"),
         updated_at="2026-05-09T00:00:00Z",
         source="test",
+    )
+
+
+def _profile_with_runtime_secret(
+    *, binding_key: str = "ODOO_DB_PASSWORD"
+) -> LaunchplaneProductProfileRecord:
+    return _profile().model_copy(
+        update={
+            "expected_config": ProductExpectedConfigProfile(
+                managed_secret_bindings=(
+                    ProductSecretConfigRequirement(
+                        binding_key=binding_key,
+                        context="cm",
+                        instance="testing",
+                    ),
+                )
+            )
+        }
     )
 
 
@@ -321,7 +341,13 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                     "sourceType": "raw",
                     "composePath": "docker-compose.yml",
                     "composeFile": "services: {}",
-                    "env": "",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
                 },
             ),
             patch(
@@ -367,7 +393,13 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                     "sourceType": "raw",
                     "composePath": "docker-compose.yml",
                     "composeFile": "services: {}",
-                    "env": "",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
                 },
             ),
             patch(
@@ -411,7 +443,13 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                     "sourceType": "raw",
                     "composePath": "docker-compose.yml",
                     "composeFile": "services: {}",
-                    "env": "",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
                 },
             ),
             patch(
@@ -455,7 +493,13 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                     "sourceType": "raw",
                     "composePath": "docker-compose.yml",
                     "composeFile": "services: {}",
-                    "env": "",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
                 },
             ),
             patch(
@@ -1176,6 +1220,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
 
     def test_apply_blocks_managed_runtime_secret_without_safety_policy(self) -> None:
         store = _Store(
+            profile=_profile_with_runtime_secret(),
             target_record=_target_record(),
             target_id_record=_target_id_record(),
             inventory=_inventory(),
@@ -1248,8 +1293,101 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         update_env.assert_not_called()
         trigger_deploy.assert_not_called()
 
-    def test_apply_records_runtime_key_safety_pass_evidence(self) -> None:
+    def test_apply_reports_disabled_runtime_secret_binding_key(self) -> None:
         store = _Store(
+            profile=_profile_with_runtime_secret(),
+            target_record=_target_record(),
+            target_id_record=_target_id_record(),
+            inventory=_inventory(),
+        )
+        store.secret_bindings = (
+            SecretBinding(
+                binding_id="secret-odoo-db-password-binding",
+                secret_id="secret-odoo-db-password",
+                integration="runtime_environment",
+                binding_key="ODOO_DB_PASSWORD",
+                context="cm",
+                instance="testing",
+                status="disabled",
+                created_at="2026-05-05T22:45:00Z",
+                updated_at="2026-05-05T22:45:00Z",
+            ),
+        )
+        store.runtime_key_safety_policy_records = (
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T22:45:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="ODOO_DB_PASSWORD",
+                        secret_class="testing",
+                        allowed_contexts=("cm",),
+                        allowed_instances=("testing",),
+                    ),
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "cm-testing",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "composeFile": "services: {}",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_DB_PASSWORD": "managed-secret-value"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
+            ) as sync_source,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env"
+            ) as update_env,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.trigger_deployment"
+            ) as trigger_deploy,
+        ):
+            result = execute_odoo_stable_target_replacement_apply(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=OdooStableTargetReplacementApplyRequest(
+                    product="odoo-tenant-cm", instance="testing"
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(result.deploy_status, "fail")
+        self.assertIn("binding_disabled", result.error_message)
+        self.assertIn("ODOO_DB_PASSWORD", result.error_message)
+        sync_source.assert_not_called()
+        update_env.assert_not_called()
+        trigger_deploy.assert_not_called()
+
+    def test_apply_reports_unclassified_runtime_secret_binding_key(self) -> None:
+        store = _Store(
+            profile=_profile_with_runtime_secret(),
             target_record=_target_record(),
             target_id_record=_target_id_record(),
             inventory=_inventory(),
@@ -1263,6 +1401,109 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 context="cm",
                 instance="testing",
                 status="configured",
+                created_at="2026-05-05T22:45:00Z",
+                updated_at="2026-05-05T22:45:00Z",
+            ),
+        )
+        store.runtime_key_safety_policy_records = (
+            RuntimeKeySafetyPolicyRecord(
+                record_id="runtime-key-safety-policy-test",
+                status="active",
+                source="test",
+                updated_at="2026-05-05T22:45:00Z",
+                rules=(
+                    RuntimeSecretSafetyRule(
+                        binding_key="OTHER_PASSWORD",
+                        secret_class="testing",
+                        allowed_contexts=("cm",),
+                        allowed_instances=("testing",),
+                    ),
+                ),
+            ),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "cm-testing",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "composeFile": "services: {}",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={"ODOO_DB_PASSWORD": "managed-secret-value"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.sync_dokploy_compose_raw_source"
+            ) as sync_source,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.update_dokploy_target_env"
+            ) as update_env,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_dokploy.trigger_deployment"
+            ) as trigger_deploy,
+        ):
+            result = execute_odoo_stable_target_replacement_apply(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=OdooStableTargetReplacementApplyRequest(
+                    product="odoo-tenant-cm", instance="testing"
+                ),
+                dokploy_request=cast(DokployRequest, _request),
+            )
+
+        self.assertEqual(result.deploy_status, "fail")
+        self.assertIn("unclassified_binding", result.error_message)
+        self.assertIn("ODOO_DB_PASSWORD", result.error_message)
+        sync_source.assert_not_called()
+        update_env.assert_not_called()
+        trigger_deploy.assert_not_called()
+
+    def test_apply_records_runtime_key_safety_pass_evidence(self) -> None:
+        store = _Store(
+            profile=_profile_with_runtime_secret(),
+            target_record=_target_record(),
+            target_id_record=_target_id_record(),
+            inventory=_inventory(),
+        )
+        store.secret_bindings = (
+            SecretBinding(
+                binding_id="secret-odoo-db-password-binding",
+                secret_id="secret-odoo-db-password",
+                integration="runtime_environment",
+                binding_key="ODOO_DB_PASSWORD",
+                context="cm",
+                instance="testing",
+                status="configured",
+                created_at="2026-05-05T22:45:00Z",
+                updated_at="2026-05-05T22:45:00Z",
+            ),
+            SecretBinding(
+                binding_id="secret-unrelated-token-binding",
+                secret_id="secret-unrelated-token",
+                integration="runtime_environment",
+                binding_key="UNRELATED_TOKEN",
+                context="cm",
+                instance="testing",
+                status="disabled",
                 created_at="2026-05-05T22:45:00Z",
                 updated_at="2026-05-05T22:45:00Z",
             ),


### PR DESCRIPTION
## Summary
- scope Odoo target replacement runtime key-safety checks to product-profile expected managed secret bindings
- preserve structured key-safety findings on LiveTargetRuntimeError and include affected binding keys in apply failures
- add focused replacement-apply regressions for disabled, unclassified, and unrelated runtime bindings

## Validation
- uv run python -m unittest tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_apply_blocks_managed_runtime_secret_without_safety_policy tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_apply_reports_disabled_runtime_secret_binding_key tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_apply_reports_unclassified_runtime_secret_binding_key tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests.test_apply_records_runtime_key_safety_pass_evidence
- uv run --extra dev ruff check control_plane/live_target_runtime.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev ruff format --check control_plane/live_target_runtime.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev mypy control_plane/live_target_runtime.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_stable_target_replacement.py

Claude and Gemini reviewed the diff and found no blockers. Residual operational caveat: live cm_website/testing still requires configured managed-secret values and an active key-safety policy covering those expected binding keys before deploy can pass.