### PR TITLE
Relax ingress apply host guard

### DIFF
--- a/.github/workflows/ingress-route-apply.yml
+++ b/.github/workflows/ingress-route-apply.yml
@@ -95,11 +95,6 @@ jobs:
               ($input.expected_host_id // null) as $expected_host_id |
               if ($allow_create | type) != "boolean" then
                 error("route_json.allow_create must be a boolean")
-              elif ($expected_host_id == null and ($allow_create | not)) then
-                error(
-                  "route_json.expected_host_id must be a number "
-                  + "unless allow_create is true"
-                )
               elif (
                 $expected_host_id != null
                 and ($expected_host_id | type) != "number"

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -226,10 +226,14 @@ legacy `npmplus_auth_request` values in route options.
 The `Ingress Route Apply` workflow is the generic operator mutation path for
 reviewed routes. It accepts `product`, `context`, a compact `route_json` desired
 state, an explicit idempotency key, and a confirmation phrase. It defaults to an
-update-only guard that requires an expected provider host id. A reviewed create
-apply must set `allow_create: true` in `route_json` and may use
-`expected_host_id: null` only when the dry-run showed that no existing provider
-host owns the domain. The workflow can carry NPMplus `locations` inside
+update-only guard, but `expected_host_id` is optional for ordinary domain-matched
+updates so the workflow is not stricter than the service route. Pass
+`expected_host_id` after review when the apply should fail closed unless one
+specific provider host owns the domain, and enable
+`require_exact_expected_host_domains` only when exact host/domain ownership is
+known. A reviewed create apply must set `allow_create: true` in `route_json` and
+may use `expected_host_id: null` only when the dry-run showed that no existing
+provider host owns the domain. The workflow can carry NPMplus `locations` inside
 `route_json.route`. Use it for product-specific path routing only after the
 dry-run plan is reviewed and the target product/context has an
 `ingress_route.apply` grant.

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -459,8 +459,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 "event_name": "push",
                 "workflow_ref_suffix": "refs/heads/release",
                 "job_workflow_ref": (
-                    "example-org/launchplane/.github/workflows/reusable.yml"
-                    "@refs/heads/main"
+                    "example-org/launchplane/.github/workflows/reusable.yml@refs/heads/main"
                 ),
             }
         ]
@@ -533,8 +532,14 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(len(grants), 1)
         grant = grants[0]
         self.assertEqual(grant["repository"], "example-org/example-product")
-        self.assertEqual(grant["workflow_refs"], ["example-org/example-product/.github/workflows/deploy.yml@refs/heads/release"])
-        self.assertEqual(grant["job_workflow_refs"], ["example-org/launchplane/.github/workflows/reusable.yml@refs/heads/main"])
+        self.assertEqual(
+            grant["workflow_refs"],
+            ["example-org/example-product/.github/workflows/deploy.yml@refs/heads/release"],
+        )
+        self.assertEqual(
+            grant["job_workflow_refs"],
+            ["example-org/launchplane/.github/workflows/reusable.yml@refs/heads/main"],
+        )
         self.assertEqual(grant["event_names"], ["push"])
         self.assertEqual(grant["products"], ["example-product"])
         self.assertEqual(grant["contexts"], ["example-context"])
@@ -636,11 +641,11 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         workflow_expectations = {
             "provider-target-operations.yml": (
                 "target_set=configured-json",
-                "JSON array of {\"context\",\"instance\"} routes",
+                'JSON array of {"context","instance"} routes',
             ),
             "product-environment-evidence.yml": (
                 "target_set=configured-json",
-                "JSON array of {\"product\",\"environment\"} routes",
+                'JSON array of {"product","environment"} routes',
             ),
         }
         forbidden_literals = (
@@ -655,9 +660,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         )
 
         for workflow_name, expected_snippets in workflow_expectations.items():
-            workflow_text = Path(f".github/workflows/{workflow_name}").read_text(
-                encoding="utf-8"
-            )
+            workflow_text = Path(f".github/workflows/{workflow_name}").read_text(encoding="utf-8")
             with self.subTest(workflow=workflow_name):
                 self.assertIn("routes_json:", workflow_text)
                 self.assertIn("configured-json", workflow_text)
@@ -728,7 +731,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("expected_host_id:", workflow_text)
         self.assertIn("Optional existing provider host id", workflow_text)
         self.assertIn("EXPECTED_HOST_ID: ${{ inputs.expected_host_id }}", workflow_text)
-        self.assertIn("--arg expected_host_id \"$EXPECTED_HOST_ID\"", workflow_text)
+        self.assertIn('--arg expected_host_id "$EXPECTED_HOST_ID"', workflow_text)
         self.assertIn('if . == "" then', workflow_text)
         self.assertIn('elif . == "null" then', workflow_text)
         self.assertIn(
@@ -851,25 +854,20 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("APPLY LAUNCHPLANE INGRESS ROUTE", workflow_text)
         self.assertIn("route_json:", workflow_text)
         self.assertIn("route_json.route.domain_names must be non-empty", workflow_text)
-        self.assertIn("option(\"allow_create\"; false) as $allow_create", workflow_text)
+        self.assertIn('option("allow_create"; false) as $allow_create', workflow_text)
         self.assertIn("($input.expected_host_id // null) as $expected_host_id", workflow_text)
-        self.assertIn("($allow_create | type) != \"boolean\"", workflow_text)
+        self.assertIn('($allow_create | type) != "boolean"', workflow_text)
         self.assertIn("route_json.allow_create must be a boolean", workflow_text)
-        self.assertIn("$expected_host_id == null", workflow_text)
-        self.assertIn("($allow_create | not)", workflow_text)
-        self.assertIn(
-            "route_json.expected_host_id must be a number ",
-            workflow_text,
-        )
-        self.assertIn("unless allow_create is true", workflow_text)
+        self.assertNotIn("$expected_host_id == null", workflow_text)
+        self.assertNotIn("unless allow_create is true", workflow_text)
         self.assertIn(
             "route_json.expected_host_id must be a number or null",
             workflow_text,
         )
         self.assertIn("expected_host_id: $expected_host_id", workflow_text)
         self.assertIn("allow_create: $allow_create", workflow_text)
-        self.assertIn("allow_update: option(\"allow_update\"; true)", workflow_text)
-        self.assertIn("allow_enable_disable: option(\"allow_enable_disable\"; false)", workflow_text)
+        self.assertIn('allow_update: option("allow_update"; true)', workflow_text)
+        self.assertIn('allow_enable_disable: option("allow_enable_disable"; false)', workflow_text)
         self.assertIn("uses: ./.github/actions/launchplane-request", workflow_text)
         self.assertIn("route-path: /v1/drivers/ingress/route-apply", workflow_text)
         self.assertIn("PRODUCT: ${{ inputs.product }}", workflow_text)


### PR DESCRIPTION
## Summary
- allow Ingress Route Apply to submit non-create domain-matched updates without expected_host_id
- keep expected_host_id type validation and service-side exact-domain guard behavior intact
- update workflow text tests and operator docs to describe expected_host_id as an opt-in fail-closed guard

## Validation
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_apply_workflow_requires_operator_guards
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev ruff format --check tests/test_product_onboarding.py
- uv run --extra dev mypy tests/test_product_onboarding.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ingress-route-apply.yml")'

Claude and Gemini reviewed the diff and found no blockers.