### PR TITLE
Add tracked compose target log inspection

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -96,6 +96,7 @@
     "Product Environment Evidence",
     "Product Legacy Context Cleanup",
     "Provider Target Operations",
+    "Tracked Target Logs",
     "Work Graph Snapshot Validate",
     "Dependency Graph"
   ],

--- a/.github/workflows/tracked-target-logs.yml
+++ b/.github/workflows/tracked-target-logs.yml
@@ -1,0 +1,139 @@
+---
+name: Tracked Target Logs
+
+"on":
+  workflow_dispatch:
+    inputs:
+      context:
+        description: Launchplane runtime context.
+        required: true
+        type: string
+      instance:
+        description: Launchplane runtime instance.
+        required: true
+        type: string
+      lines:
+        description: Number of log lines to request.
+        required: true
+        default: "200"
+        type: string
+      since:
+        description: Log duration window, such as all, 5m, 2h, or 1d.
+        required: true
+        default: 1h
+        type: string
+      search:
+        description: Optional Dokploy log search text.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  read:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+      CONTEXT: ${{ inputs.context }}
+      INSTANCE: ${{ inputs.instance }}
+      LINES: ${{ inputs.lines }}
+      SINCE: ${{ inputs.since }}
+      SEARCH: ${{ inputs.search }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${CONTEXT:?Missing context input}"
+          : "${INSTANCE:?Missing instance input}"
+          if ! [[ "$LINES" =~ ^[0-9]+$ ]]; then
+            echo 'lines must be a positive integer.' >&2
+            exit 1
+          fi
+          if [ "$LINES" -lt 1 ] || [ "$LINES" -gt 1000 ]; then
+            echo 'lines must be between 1 and 1000.' >&2
+            exit 1
+          fi
+          if ! [[ "$SINCE" =~ ^(all|[0-9]+[smhd])$ ]]; then
+            echo "since must be 'all' or a duration like 5m, 2h, or 1d." >&2
+            exit 1
+          fi
+          if ! [[ "$SEARCH" =~ ^[a-zA-Z0-9\ ._-]{0,500}$ ]]; then
+            echo 'search may contain only safe plain-text characters.' >&2
+            exit 1
+          fi
+
+      - name: Build logs route
+        id: route
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq -n \
+            --arg context "$CONTEXT" \
+            --arg instance "$INSTANCE" \
+            --arg lines "$LINES" \
+            --arg since "$SINCE" \
+            --arg search "$SEARCH" \
+            '{
+              context: $context,
+              instance: $instance,
+              lines: $lines,
+              since: $since,
+              search: $search
+            }' \
+            > tracked-target-logs-request.json
+          route_path="$({
+            jq -r \
+              '"/v1/contexts/\(.context | @uri)" +
+               "/instances/\(.instance | @uri)/logs" +
+               "?lines=\(.lines | @uri)&since=\(.since | @uri)" +
+               "&search=\(.search | @uri)"' \
+              tracked-target-logs-request.json
+          })"
+          echo "route_path=${route_path}" >>"$GITHUB_OUTPUT"
+
+      - name: Read tracked target logs
+        uses: ./.github/actions/launchplane-request
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_SERVICE_URL }}
+          route-path: ${{ steps.route.outputs.route_path }}
+          method: GET
+          audience: ${{ env.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          response-output-file: tracked-target-logs.json
+          output-paths: >-
+            trace_id=trace_id
+
+      - name: Show redacted log summary
+        shell: bash
+        run: |
+          set -euo pipefail
+          jq '{
+            status,
+            trace_id,
+            context,
+            instance,
+            target,
+            request,
+            logs: {
+              line_count: .logs.line_count,
+              redacted: .logs.redacted
+            }
+          }' \
+            tracked-target-logs.json
+
+      - name: Upload tracked target logs
+        uses: actions/upload-artifact@v7
+        with:
+          name: tracked-target-logs-${{ inputs.context }}-${{ inputs.instance }}
+          path: |
+            tracked-target-logs-request.json
+            tracked-target-logs.json
+          if-no-files-found: error

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -72,6 +72,9 @@ _SINGLE_QUOTED_SECRET_LOG_VALUE_PATTERN = re.compile(
     r"(?i)('?\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY|DATABASE_URL)[A-Z0-9_]*'?\s*[=:]\s*)'[^'\r\n]*'"
 )
 _BEARER_LOG_VALUE_PATTERN = re.compile(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+")
+_DATABASE_URI_CREDENTIAL_PATTERN = re.compile(
+    r"(?i)\b((?:postgres(?:ql)?|mysql|mariadb)://[^:\s/@]+:)[^@\s]+(@)"
+)
 _DOKPLOY_LOG_SINCE_PATTERN = re.compile(r"^(all|\d+[smhd])$")
 _DOKPLOY_LOG_SEARCH_PATTERN = re.compile(r"^[a-zA-Z0-9 ._-]{0,500}$")
 
@@ -826,7 +829,8 @@ def redact_dokploy_log_line(raw_line: str) -> str:
     redacted_line = _DOUBLE_QUOTED_SECRET_LOG_VALUE_PATTERN.sub(r'\1"[redacted]"', raw_line)
     redacted_line = _SINGLE_QUOTED_SECRET_LOG_VALUE_PATTERN.sub(r"\1'[redacted]'", redacted_line)
     redacted_line = _LIKELY_SECRET_LOG_VALUE_PATTERN.sub(r"\1[redacted]", redacted_line)
-    return _BEARER_LOG_VALUE_PATTERN.sub(r"\1[redacted]", redacted_line)
+    redacted_line = _BEARER_LOG_VALUE_PATTERN.sub(r"\1[redacted]", redacted_line)
+    return _DATABASE_URI_CREDENTIAL_PATTERN.sub(r"\1[redacted]\2", redacted_line)
 
 
 def normalize_dokploy_log_payload(payload: JsonValue) -> tuple[str, ...]:
@@ -890,6 +894,76 @@ def fetch_dokploy_application_logs(
     )
     lines = normalize_dokploy_log_payload(payload)
     return lines[-normalized_line_count:]
+
+
+def fetch_dokploy_compose_logs(
+    *,
+    host: str,
+    token: str,
+    compose_id: str,
+    app_name: str = "",
+    server_id: str = "",
+    line_count: int = DEFAULT_DOKPLOY_LOG_LINE_COUNT,
+    since: str = "all",
+    search: str = "",
+) -> tuple[str, ...]:
+    normalized_compose_id = compose_id.strip()
+    if not normalized_compose_id:
+        raise click.ClickException("Dokploy compose logs require a compose id.")
+    normalized_line_count = normalize_dokploy_log_line_count(line_count)
+    normalized_since = normalize_dokploy_log_since(since)
+    normalized_search = normalize_dokploy_log_search(search)
+    normalized_app_name = app_name.strip()
+    normalized_server_id = server_id.strip()
+    query: dict[str, str | int] = {
+        "composeId": normalized_compose_id,
+        "tail": normalized_line_count,
+        "since": normalized_since,
+    }
+    if normalized_app_name:
+        container_query: dict[str, str | int] = {
+            "appName": normalized_app_name,
+            "appType": "docker-compose",
+        }
+        if normalized_server_id:
+            container_query["serverId"] = normalized_server_id
+        containers_payload = dokploy_request(
+            host=host,
+            token=token,
+            path="/api/docker.getContainersByAppNameMatch",
+            query=container_query,
+        )
+        containers = (
+            _collect_object_items(containers_payload)
+            if isinstance(containers_payload, list)
+            else []
+        )
+        web_container = _select_compose_log_container(containers)
+        container_id = str(web_container.get("containerId") or "").strip()
+        if container_id:
+            query["containerId"] = container_id
+    if normalized_search:
+        query["search"] = normalized_search
+    payload = dokploy_request(
+        host=host,
+        token=token,
+        path="/api/compose.readLogs",
+        query=query,
+    )
+    lines = normalize_dokploy_log_payload(payload)
+    return lines[-normalized_line_count:]
+
+
+def _select_compose_log_container(containers: list[JsonObject]) -> JsonObject:
+    for container in containers:
+        service_name = str(container.get("serviceName") or "").strip().lower()
+        container_name = str(container.get("name") or "").strip().lower()
+        if service_name == "web" or container_name.endswith("-web-1"):
+            return container
+    for container in containers:
+        if str(container.get("containerId") or "").strip():
+            return container
+    return {}
 
 
 def parse_dokploy_env_text(raw_env_text: str) -> dict[str, str]:

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -45,9 +45,9 @@ def build_tracked_target_logs_payload(
         raise ValueError(
             "Missing DB-backed tracked Dokploy target records for requested context/instance."
         ) from error
-    if target_record.target_type != "application":
+    if target_record.target_type not in {"application", "compose"}:
         raise ValueError(
-            "Tracked target logs currently support Dokploy application targets only. "
+            "Tracked target logs currently support Dokploy application and compose targets only. "
             f"Configured target_type={target_record.target_type}."
         )
 
@@ -61,16 +61,28 @@ def build_tracked_target_logs_payload(
         target_type=target_record.target_type,
         target_id=target_id_record.target_id,
     )
-    logs = control_plane_dokploy.fetch_dokploy_application_logs(
-        host=host,
-        token=token,
-        application_id=target_id_record.target_id,
-        line_count=normalized_line_count,
-        since=normalized_since,
-        search=normalized_search,
-    )
     app_name = str(target_payload.get("appName") or "").strip()
     server_id = str(target_payload.get("serverId") or "").strip()
+    if target_record.target_type == "application":
+        logs = control_plane_dokploy.fetch_dokploy_application_logs(
+            host=host,
+            token=token,
+            application_id=target_id_record.target_id,
+            line_count=normalized_line_count,
+            since=normalized_since,
+            search=normalized_search,
+        )
+    else:
+        logs = control_plane_dokploy.fetch_dokploy_compose_logs(
+            host=host,
+            token=token,
+            compose_id=target_id_record.target_id,
+            app_name=app_name,
+            server_id=server_id,
+            line_count=normalized_line_count,
+            since=normalized_since,
+            search=normalized_search,
+        )
     return {
         "context": normalized_context,
         "instance": normalized_instance,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -630,13 +630,18 @@ Current derived-state behavior:
   routes are present, or the tracked target records omit a required target id.
 - `environments logs --context <context> --instance <instance> --lines <n>`
   resolves the DB-backed tracked Dokploy target and target id before fetching
-  bounded application logs. The first cut supports Dokploy `application`
-  targets, includes route/target/app/server metadata, accepts optional
-  `--since` and `--search`, and redacts likely secret values from returned log
-  lines.
+  bounded logs. It supports Dokploy `application` and `compose` targets,
+  includes route/target/app/server metadata, accepts optional `--since` and
+  `--search`, and redacts likely secret values from returned log lines.
 - `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200` exposes the
   same tracked-target log reader through the authenticated service API using
   action `target_logs.read`.
+- The manual Tracked Target Logs workflow calls that service route with GitHub
+  OIDC and uploads the redacted JSON result, so operators can inspect compose
+  target boot failures without local Dokploy credentials. Tenant contexts need a
+  matching `target_logs.read` GitHub Actions grant in
+  `LAUNCHPLANE_AUTHZ_GRANTS_JSON`; do not broaden this workflow to read all
+  contexts by default.
 
 ## Runtime Environment Contracts
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1120,8 +1120,8 @@ state, not runtime-provider primitives.
 
 The logs route is the exception to the `driver.read` action because it reads live
 provider output. It uses action `target_logs.read`, resolves DB-backed tracked
-target records by context/instance, supports bounded Dokploy `application` logs,
-and redacts likely secret values before returning lines.
+target records by context/instance, supports bounded Dokploy `application` and
+`compose` logs, and redacts likely secret values before returning lines.
 
 The preview driver cut stays intentionally narrow but keeps topology in
 Launchplane: Launchplane owns preview URL derivation from the

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -209,7 +209,8 @@ class DokployConfigTests(unittest.TestCase):
                     "started",
                     (
                         "RESEND_API_KEY=re_123 Bearer abc.def "
-                        "SMTP_PASSWORD=smtp-secret LAUNCHPLANE_DATABASE_URL=postgresql://secret"
+                        "SMTP_PASSWORD=smtp-secret LAUNCHPLANE_DATABASE_URL=postgresql://secret "
+                        "postgresql://odoo:db-secret@database/cm"
                     ),
                 ]
             }
@@ -220,9 +221,11 @@ class DokployConfigTests(unittest.TestCase):
         self.assertIn("Bearer [redacted]", lines[1])
         self.assertIn("SMTP_PASSWORD=[redacted]", lines[1])
         self.assertIn("LAUNCHPLANE_DATABASE_URL=[redacted]", lines[1])
+        self.assertIn("postgresql://odoo:[redacted]@database/cm", lines[1])
         self.assertNotIn("re_123", lines[1])
         self.assertNotIn("smtp-secret", lines[1])
         self.assertNotIn("postgresql://secret", lines[1])
+        self.assertNotIn("db-secret", lines[1])
 
     def test_redact_dokploy_log_line_redacts_quoted_secret_fields(self) -> None:
         redacted_line = control_plane_dokploy.redact_dokploy_log_line(
@@ -268,6 +271,56 @@ class DokployConfigTests(unittest.TestCase):
         self.assertEqual(requests[0]["path"], "/api/application.readLogs")
         self.assertEqual(
             requests[0]["query"], {"applicationId": "app-123", "tail": 2, "since": "all"}
+        )
+        self.assertEqual(lines, ("two", "THREE_TOKEN=[redacted]"))
+
+    def test_fetch_compose_logs_calls_dokploy_read_logs_endpoint(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "database-container", "name": "cm-database-1"},
+                    {"containerId": "web-container", "name": "cm-web-1"},
+                ]
+            return {"logs": "one\ntwo\nTHREE_TOKEN=secret"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="cm-testing-iul0ql",
+                server_id="server-1",
+                line_count=2,
+                since="5m",
+                search="odoo",
+            )
+
+        self.assertEqual(len(requests), 2)
+        self.assertEqual(requests[0]["path"], "/api/docker.getContainersByAppNameMatch")
+        self.assertEqual(
+            requests[0]["query"],
+            {
+                "appName": "cm-testing-iul0ql",
+                "appType": "docker-compose",
+                "serverId": "server-1",
+            },
+        )
+        self.assertEqual(requests[1]["path"], "/api/compose.readLogs")
+        self.assertEqual(
+            requests[1]["query"],
+            {
+                "composeId": "compose-123",
+                "containerId": "web-container",
+                "tail": 2,
+                "since": "5m",
+                "search": "odoo",
+            },
         )
         self.assertEqual(lines, ("two", "THREE_TOKEN=[redacted]"))
 
@@ -362,7 +415,7 @@ target_name = "syo-testing-app"
         self.assertIn("Missing DB-backed tracked Dokploy target records", result.output)
         self.assertNotIn("Traceback", result.output)
 
-    def test_environments_logs_rejects_compose_targets(self) -> None:
+    def test_environments_logs_resolves_tracked_compose_and_redacts_output(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(
@@ -385,22 +438,56 @@ target_name = "opw-testing"
             )
             store.close()
 
-            result = runner.invoke(
-                main,
-                [
-                    "environments",
-                    "logs",
-                    "--database-url",
-                    database_url,
-                    "--context",
-                    "opw",
-                    "--instance",
-                    "testing",
-                ],
-            )
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "opw-testing-iul0ql", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_compose_logs",
+                    return_value=("started", "ODOO_DB_PASSWORD=[redacted]"),
+                ) as logs_mock,
+            ):
+                result = runner.invoke(
+                    main,
+                    [
+                        "environments",
+                        "logs",
+                        "--database-url",
+                        database_url,
+                        "--context",
+                        "opw",
+                        "--instance",
+                        "testing",
+                        "--lines",
+                        "2",
+                        "--since",
+                        "5m",
+                    ],
+                )
 
-        self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("application targets only", result.output)
+        self.assertEqual(result.exit_code, 0, result.output)
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            compose_id="compose-123",
+            app_name="opw-testing-iul0ql",
+            server_id="server-1",
+            line_count=2,
+            since="5m",
+            search="",
+        )
+        payload = json.loads(result.output)
+        self.assertEqual(payload["context"], "opw")
+        self.assertEqual(payload["target"]["target_id"], "compose-123")
+        self.assertEqual(payload["target"]["target_type"], "compose")
+        self.assertEqual(payload["target"]["app_name"], "opw-testing-iul0ql")
+        self.assertEqual(payload["logs"]["lines"], ["started", "ODOO_DB_PASSWORD=[redacted]"])
+        self.assertNotIn("secret-token", result.output)
 
     def test_update_application_env_includes_empty_build_fields_when_missing(self) -> None:
         requests: list[dict[str, object]] = []

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -12914,6 +12914,80 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["logs"]["lines"], ["ok", "RESEND_API_KEY=[redacted]"])
         self.assertNotIn("secret-token", json.dumps(payload))
 
+    def test_tracked_target_logs_endpoint_returns_redacted_compose_logs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm_website",
+                instance="testing",
+                target_id="compose-123",
+                target_type="compose",
+                target_name="cm-website-testing",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane"],
+                            "contexts": ["cm_website"],
+                            "actions": ["target_logs.read"],
+                        }
+                    ]
+                }
+            )
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "cm-website-testing-iul0ql", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_compose_logs",
+                    return_value=("booting", "ODOO_ADMIN_PASSWORD=[redacted]"),
+                ) as logs_mock,
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=root / "state",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    database_url=database_url,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/contexts/cm_website/instances/testing/logs",
+                    query_string="lines=2&since=5m",
+                )
+
+        self.assertEqual(status_code, 200)
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            compose_id="compose-123",
+            app_name="cm-website-testing-iul0ql",
+            server_id="server-1",
+            line_count=2,
+            since="5m",
+            search="",
+        )
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["target"]["target_type"], "compose")
+        self.assertEqual(payload["target"]["target_name"], "cm-website-testing")
+        self.assertEqual(payload["target"]["app_name"], "cm-website-testing-iul0ql")
+        self.assertEqual(payload["logs"]["lines"], ["booting", "ODOO_ADMIN_PASSWORD=[redacted]"])
+        self.assertNotIn("secret-token", json.dumps(payload))
+
     def test_tracked_target_logs_endpoint_requires_authz_action(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add sanitized Dokploy compose log reads to the tracked target logs API/CLI path
- add a manual Tracked Target Logs workflow that calls Launchplane via OIDC and uploads redacted log JSON
- document compose log support, per-context target_logs.read authz, and include the workflow in repo metadata

## Validation
- uv run python -m unittest tests.test_dokploy.DokployConfigTests.test_application_log_payload_normalization_redacts_likely_secrets tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_calls_dokploy_read_logs_endpoint tests.test_dokploy.DokployConfigTests.test_environments_logs_resolves_tracked_compose_and_redacts_output tests.test_service.LaunchplaneServiceTests.test_tracked_target_logs_endpoint_returns_redacted_compose_logs
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/tracked_target_logs.py tests/test_dokploy.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/dokploy.py control_plane/tracked_target_logs.py tests/test_dokploy.py tests/test_service.py
- uv run --extra dev mypy control_plane/dokploy.py control_plane/tracked_target_logs.py tests/test_dokploy.py tests/test_service.py
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tracked-target-logs.yml")'
- jq empty .github/github.json

## Agent Review
- Claude revised patch review: clean, ready to merge
- Gemini revised patch review: clean, ready to merge