### PR TITLE
Preserve NPMplus Odoo edge config

### DIFF
--- a/control_plane/cli_ingress.py
+++ b/control_plane/cli_ingress.py
@@ -114,7 +114,11 @@ def ingress() -> None:
     default=False,
     help="Use the Authentik basic-auth forwarding mode for the identity/access binding.",
 )
-@click.option("--advanced-config", default="")
+@click.option(
+    "--advanced-config",
+    default=None,
+    help="NPMplus advanced nginx config. Omit to preserve an existing host value.",
+)
 @click.option("--allow-create/--no-allow-create", default=True, show_default=True)
 @click.option("--allow-update/--no-allow-update", default=True, show_default=True)
 @click.option("--allow-enable-disable/--no-allow-enable-disable", default=True, show_default=True)
@@ -143,7 +147,7 @@ def ingress_route_apply(
     auth_request: str,
     identity_access_provider: str,
     identity_access_send_basic_auth: bool,
-    advanced_config: str,
+    advanced_config: str | None,
     allow_create: bool,
     allow_update: bool,
     allow_enable_disable: bool,
@@ -216,7 +220,7 @@ def _route_apply_payload(
     auth_request: str,
     identity_access_provider: str,
     identity_access_send_basic_auth: bool,
-    advanced_config: str,
+    advanced_config: str | None,
     allow_create: bool,
     allow_update: bool,
     allow_enable_disable: bool,
@@ -254,9 +258,10 @@ def _route_apply_payload(
         "access_list_id": access_list_id,
         "npmplus_noindex": npmplus_noindex,
         "npmplus_auth_request": auth_request,
-        "advanced_config": advanced_config,
         "enabled": enabled,
     }
+    if advanced_config is not None:
+        route["advanced_config"] = advanced_config
     if identity_access:
         route["identity_access"] = identity_access
     if forward_port is not None:

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -956,14 +956,33 @@ def fetch_dokploy_compose_logs(
 
 def _select_compose_log_container(containers: list[JsonObject]) -> JsonObject:
     for container in containers:
-        service_name = str(container.get("serviceName") or "").strip().lower()
-        container_name = str(container.get("name") or "").strip().lower()
-        if service_name == "web" or container_name.endswith("-web-1"):
+        if _compose_log_container_is_web(container):
             return container
     for container in containers:
         if str(container.get("containerId") or "").strip():
             return container
     return {}
+
+
+def _compose_log_container_is_web(container: JsonObject) -> bool:
+    service_name = str(container.get("serviceName") or "").strip().lower()
+    if service_name == "web":
+        return True
+    labels = container.get("labels")
+    if isinstance(labels, dict):
+        label_service = str(labels.get("com.docker.compose.service") or "").strip().lower()
+        if label_service == "web":
+            return True
+    container_name = str(container.get("name") or "").strip().lower().strip("/")
+    if not container_name:
+        return False
+    name_parts = tuple(part for part in re.split(r"[-_.]+", container_name) if part)
+    if not name_parts:
+        return False
+    service_part = (
+        name_parts[-2] if len(name_parts) > 1 and name_parts[-1].isdigit() else name_parts[-1]
+    )
+    return service_part == "web"
 
 
 def parse_dokploy_env_text(raw_env_text: str) -> dict[str, str]:

--- a/control_plane/workflows/npmplus_ingress.py
+++ b/control_plane/workflows/npmplus_ingress.py
@@ -233,6 +233,11 @@ def apply_npmplus_ingress_route(
         expected_host_id=request.expected_host_id,
         require_exact_expected_host_domains=request.require_exact_expected_host_domains,
     )
+    desired_payload = _inherit_existing_npmplus_fields(
+        route=request.route,
+        desired_payload=desired_payload,
+        existing_host=existing_host,
+    )
     operations = _plan_operations(
         existing_host=existing_host,
         desired_payload=desired_payload,
@@ -277,6 +282,19 @@ def apply_npmplus_ingress_route(
         operations=operations,
         proxy_host=final_host,
     )
+
+
+def _inherit_existing_npmplus_fields(
+    *,
+    route: NpmplusIngressRouteDesiredState,
+    desired_payload: NpmplusProxyHostPayload,
+    existing_host: NpmplusProxyHost | None,
+) -> NpmplusProxyHostPayload:
+    # Omitted advanced_config inherits the live provider host value. Explicit
+    # values, including an empty string, replace or clear the provider value.
+    if existing_host is None or "advanced_config" in route.model_fields_set:
+        return desired_payload
+    return desired_payload.model_copy(update={"advanced_config": existing_host.advanced_config})
 
 
 def find_npmplus_proxy_host_by_domains(

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -238,6 +238,25 @@ provider host owns the domain. The workflow can carry NPMplus `locations` inside
 dry-run plan is reviewed and the target product/context has an
 `ingress_route.apply` grant.
 
+For existing NPMplus proxy hosts, omit `advanced_config` from the desired route
+when the provider host should keep its current advanced nginx config. This lets
+Odoo routes inherit the extra NPMplus config used for the current password-gated
+edge path. Passing `advanced_config` explicitly replaces the provider value;
+passing an explicit empty string clears it.
+
+Future edge-driver work should investigate Cloudflare Tunnel in #1215 as a
+Launchplane provider before deepening edge-provider assumptions beyond NPMplus.
+The intended spike is a shadow hostname routed through `cloudflared` running in
+or near Dokploy, with the Traefik service in the Dokploy compose network as the
+origin router and NPMplus kept as the active fallback until Cloudflare health
+evidence passes. The Cloudflare slice must model account/zone/tunnel identifiers,
+public hostname routes, managed credentials, connector placement, health
+evidence, and rollback state as Launchplane records. Keep Authentik as a
+separate identity/access layer;
+issue #1051 tracks provider-neutral `identity_access` bindings and future
+Cloudflare Access/OIDC integration, but public website edge routing should prove
+itself without requiring Authentik.
+
 The `Ingress Route Dry Run` workflow can discover the existing provider host for
 a domain before an apply. Leave `expected_host_id` blank to ask Launchplane to
 match by requested domain without mutation; pass `expected_host_id` after review

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -324,6 +324,130 @@ class DokployConfigTests(unittest.TestCase):
         )
         self.assertEqual(lines, ("two", "THREE_TOKEN=[redacted]"))
 
+    def test_fetch_compose_logs_prefers_web_container_name_variants(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "db", "name": "/tenant_database_1"},
+                    {"containerId": "script", "name": "tenant.script-runner.1"},
+                    {"containerId": "web", "name": "tenant_web_1"},
+                ]
+            return {"logs": "web log"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("web log",))
+        self.assertEqual(requests[1]["path"], "/api/compose.readLogs")
+        self.assertEqual(
+            requests[1]["query"],
+            {"composeId": "compose-123", "containerId": "web", "tail": 10, "since": "all"},
+        )
+
+    def test_fetch_compose_logs_ignores_web_named_sidecar_containers(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "worker", "name": "tenant_web_worker_1"},
+                    {"containerId": "web", "name": "tenant_web_1"},
+                ]
+            return {"logs": "web log"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("web log",))
+        self.assertEqual(
+            requests[1]["query"],
+            {"composeId": "compose-123", "containerId": "web", "tail": 10, "since": "all"},
+        )
+
+    def test_fetch_compose_logs_prefers_web_container_service_name(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "db", "serviceName": "database"},
+                    {"containerId": "web", "serviceName": "web"},
+                ]
+            return {"logs": "web log"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("web log",))
+        self.assertEqual(
+            requests[1]["query"],
+            {"composeId": "compose-123", "containerId": "web", "tail": 10, "since": "all"},
+        )
+
+    def test_fetch_compose_logs_prefers_web_container_label(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "db", "name": "tenant-db-1"},
+                    {
+                        "containerId": "web",
+                        "name": "tenant-runtime-1",
+                        "labels": {"com.docker.compose.service": "web"},
+                    },
+                ]
+            return {"logs": "web log"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("web log",))
+        query = cast(dict[str, object], requests[1]["query"])
+        self.assertEqual(query["containerId"], "web")
+
     def test_environments_logs_resolves_tracked_application_and_redacts_output(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_ingress_cli.py
+++ b/tests/test_ingress_cli.py
@@ -69,6 +69,7 @@ class IngressCliTests(unittest.TestCase):
         self.assertEqual(route["forward_port"], 8123)
         self.assertEqual(route["certificate_id"], 47)
         self.assertTrue(route["npmplus_noindex"])
+        self.assertNotIn("advanced_config", route)
         response_payload = json.loads(result.output)
         self.assertEqual(response_payload["result"]["status"], "planned")
 
@@ -106,6 +107,8 @@ class IngressCliTests(unittest.TestCase):
                     "new",
                     "--expected-host-id",
                     "78",
+                    "--advanced-config",
+                    "# explicit nginx config",
                     "--disable",
                     "--no-http3",
                     "--reason",
@@ -128,6 +131,7 @@ class IngressCliTests(unittest.TestCase):
         route = ingress["route"]
         assert isinstance(route, dict)
         self.assertEqual(route["certificate_id"], "new")
+        self.assertEqual(route["advanced_config"], "# explicit nginx config")
         self.assertFalse(route["enabled"])
         self.assertFalse(route["npmplus_http3_support"])
 
@@ -187,6 +191,52 @@ class IngressCliTests(unittest.TestCase):
                 "send_basic_auth": True,
             },
         )
+
+    def test_route_apply_sends_explicit_empty_advanced_config(self) -> None:
+        captured_request: dict[str, object] = {}
+
+        def fake_post(**kwargs: object) -> dict[str, object]:
+            captured_request.update(kwargs)
+            return {
+                "status": "accepted",
+                "result": {"status": "planned", "dry_run": True},
+            }
+
+        with (
+            patch.dict(os.environ, {"LAUNCHPLANE_SERVICE_TOKEN": "service-token"}),
+            patch("control_plane.cli._post_launchplane_service_json", side_effect=fake_post),
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "ingress",
+                    "route-apply",
+                    "--service-url",
+                    "https://launchplane.example",
+                    "--product",
+                    "launchplane",
+                    "--context",
+                    "reon-prod",
+                    "--domain",
+                    "ingress-canary.example.test",
+                    "--forward-host",
+                    "192.0.2.10",
+                    "--advanced-config",
+                    "",
+                    "--reason",
+                    "clear advanced config",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = captured_request["payload"]
+        assert isinstance(payload, dict)
+        ingress = payload["ingress"]
+        assert isinstance(ingress, dict)
+        route = ingress["route"]
+        assert isinstance(route, dict)
+        self.assertIn("advanced_config", route)
+        self.assertEqual(route["advanced_config"], "")
 
     def test_route_apply_rejects_conflicting_identity_access_binding(self) -> None:
         with patch.dict(os.environ, {"LAUNCHPLANE_SERVICE_TOKEN": "service-token"}):

--- a/tests/test_npmplus_ingress_workflow.py
+++ b/tests/test_npmplus_ingress_workflow.py
@@ -77,7 +77,7 @@ def _request(
     return NpmplusIngressApplyRequest.model_validate(
         {
             "mode": mode,
-            "route": (route or _desired_route()).model_dump(mode="json"),
+            "route": (route or _desired_route()).model_dump(mode="json", exclude_unset=True),
             "reason": "test ingress workflow",
             **overrides,
         }
@@ -177,6 +177,72 @@ class NpmplusIngressWorkflowTests(unittest.TestCase):
         self.assertEqual(tuple(operation.action for operation in result.operations), ("no-op",))
         self.assertEqual(result.operations[0].change_categories, ())
         self.assertEqual(client.calls, ["list"])
+
+    def test_omitted_advanced_config_preserves_existing_proxy_host_value(self) -> None:
+        client = _FakeNpmplusClient((_proxy_host(advanced_config="# odoo config"),))
+
+        result = apply_npmplus_ingress_route(
+            client=client,
+            request=_request(mode="apply"),
+        )
+
+        self.assertEqual(result.status, "unchanged")
+        self.assertEqual(tuple(operation.action for operation in result.operations), ("no-op",))
+        self.assertEqual(
+            result.proxy_host.advanced_config if result.proxy_host else "",
+            "# odoo config",
+        )
+        self.assertEqual(client.calls, ["list"])
+
+    def test_omitted_advanced_config_preserves_existing_value_during_update(self) -> None:
+        client = _FakeNpmplusClient(
+            (_proxy_host(advanced_config="# odoo config", forward_port=8080),)
+        )
+
+        result = apply_npmplus_ingress_route(
+            client=client,
+            request=_request(mode="apply"),
+        )
+
+        self.assertEqual(tuple(operation.action for operation in result.operations), ("update",))
+        self.assertEqual(result.operations[0].change_categories, ("upstream",))
+        self.assertEqual(
+            result.proxy_host.advanced_config if result.proxy_host else "",
+            "# odoo config",
+        )
+        self.assertEqual(client.calls, ["list", "update:78"])
+
+    def test_explicit_empty_advanced_config_clears_existing_proxy_host_value(self) -> None:
+        client = _FakeNpmplusClient((_proxy_host(advanced_config="# odoo config"),))
+
+        result = apply_npmplus_ingress_route(
+            client=client,
+            request=_request(mode="apply", route=_desired_route(advanced_config="")),
+        )
+
+        self.assertEqual(tuple(operation.action for operation in result.operations), ("update",))
+        self.assertEqual(result.operations[0].change_categories, ("provider_options",))
+        self.assertEqual(result.proxy_host.advanced_config if result.proxy_host else None, "")
+        self.assertEqual(client.calls, ["list", "update:78"])
+
+    def test_explicit_advanced_config_replaces_existing_proxy_host_value(self) -> None:
+        client = _FakeNpmplusClient((_proxy_host(advanced_config="# odoo config"),))
+
+        result = apply_npmplus_ingress_route(
+            client=client,
+            request=_request(
+                mode="apply",
+                route=_desired_route(advanced_config="# replacement config"),
+            ),
+        )
+
+        self.assertEqual(tuple(operation.action for operation in result.operations), ("update",))
+        self.assertEqual(result.operations[0].change_categories, ("provider_options",))
+        self.assertEqual(
+            result.proxy_host.advanced_config if result.proxy_host else "",
+            "# replacement config",
+        )
+        self.assertEqual(client.calls, ["list", "update:78"])
 
     def test_noop_ignores_api_assigned_location_ids(self) -> None:
         route = _desired_route(locations=[_location()])


### PR DESCRIPTION
## Summary

- Preserve existing NPMplus proxy-host advanced nginx config when a route update omits advanced_config, so Odoo routes inherit the current password-gated edge config.
- Keep explicit advanced_config values authoritative, including an explicit empty string to clear the provider value.
- Tighten Dokploy compose-log container selection for web services and document Cloudflare/Auth future driver work.

## Verification

- uv run python -m unittest tests.test_ingress_cli tests.test_npmplus_ingress_workflow tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_name_variants tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_ignores_web_named_sidecar_containers tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_service_name tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_label tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_apply_workflow_requires_operator_guards
- uv run --extra dev ruff check control_plane/cli_ingress.py control_plane/workflows/npmplus_ingress.py control_plane/dokploy.py tests/test_ingress_cli.py tests/test_npmplus_ingress_workflow.py tests/test_dokploy.py
- uv run --extra dev ruff format --check control_plane/cli_ingress.py control_plane/workflows/npmplus_ingress.py control_plane/dokploy.py tests/test_ingress_cli.py tests/test_npmplus_ingress_workflow.py tests/test_dokploy.py
- uv run --extra dev mypy control_plane/cli_ingress.py control_plane/workflows/npmplus_ingress.py control_plane/dokploy.py tests/test_ingress_cli.py tests/test_npmplus_ingress_workflow.py tests/test_dokploy.py

## Review

- Claude/Gemini pre-merge review completed; follow-up fixes added for exact web-container matching, CLI explicit-empty coverage, and Cloudflare doc wording.
