### PR TITLE
Add Dokploy compose domain reconciliation

### DIFF
--- a/.github/workflows/dokploy-target-setup.yml
+++ b/.github/workflows/dokploy-target-setup.yml
@@ -21,6 +21,7 @@ name: Dokploy Target Setup
           - adopt
           - create-application
           - create-compose
+          - reconcile-compose-domain
       context:
         description: Launchplane target context.
         required: true
@@ -199,6 +200,34 @@ jobs:
           fi
           if [ -z "$(printf '%s' "$REASON" | xargs)" ]; then
             echo "reason is required when mode=apply." >&2
+            exit 1
+          fi
+
+      - name: Validate reconcile compose domain inputs
+        if: env.OPERATION == 'reconcile-compose-domain'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "$(printf '%s' "$DOMAIN" | xargs)" ]; then
+            echo "domain is required when operation=reconcile-compose-domain." \
+              >&2
+            exit 1
+          fi
+          runtime_port="$(printf '%s' "$RUNTIME_PORT" | xargs)"
+          if [ -z "$runtime_port" ]; then
+            echo "runtime_port is required for reconcile-compose-domain." \
+              >&2
+            exit 1
+          fi
+          if ! [[ "$runtime_port" =~ ^[1-9][0-9]*$ ]]; then
+            echo \
+              "runtime_port must be a positive integer for reconcile." \
+              >&2
+            exit 1
+          fi
+          if [ "$runtime_port" -gt 65535 ]; then
+            echo "runtime_port must be <= 65535 for reconcile-compose-domain." \
+              >&2
             exit 1
           fi
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -53,6 +53,8 @@ from control_plane.contracts.agent_write_intent import (
 )
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
@@ -2101,7 +2103,12 @@ class DokployTargetSetupEnvelope(BaseModel):
 
     schema_version: int = Field(default=1, ge=1)
     mode: Literal["dry-run", "apply"] = "dry-run"
-    operation: Literal["adopt", "create-application", "create-compose"]
+    operation: Literal[
+        "adopt",
+        "create-application",
+        "create-compose",
+        "reconcile-compose-domain",
+    ]
     product: str = "launchplane"
     context: str
     instance: str
@@ -2162,15 +2169,35 @@ class DokployTargetSetupEnvelope(BaseModel):
                 raise ValueError("Dokploy compose target creation requires target_name.")
             if not self.server_id:
                 raise ValueError("Dokploy compose target creation requires server_id.")
-        if self.runtime_port is not None and self.operation != "create-compose":
+        if self.runtime_port is not None and self.operation not in {
+            "create-compose",
+            "reconcile-compose-domain",
+        }:
             raise ValueError(
-                "Dokploy target setup runtime_port is only supported for create-compose."
+                "Dokploy target setup runtime_port is only supported for create-compose or reconcile-compose-domain."
             )
         if self.runtime_port is not None and not self.domains:
             raise ValueError("Dokploy target setup runtime_port requires at least one domain.")
+        if self.operation == "reconcile-compose-domain":
+            if not self.domains:
+                raise ValueError("Dokploy compose domain reconciliation requires domains.")
+            if self.runtime_port is None:
+                raise ValueError("Dokploy compose domain reconciliation requires runtime_port.")
         if self.healthcheck_path and not self.healthcheck_path.startswith("/"):
             raise ValueError("Dokploy target setup healthcheck_path must start with /.")
         return self
+
+
+class DokployComposeDomainReconcileResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    applied: bool
+    target_record: DokployTargetRecord
+    target_id_record: DokployTargetIdRecord
+    domains: tuple[str, ...]
+    runtime_port: int
+    route_domain_ids: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
 
 
 class LiveTargetRuntimeApplyEnvelope(BaseModel):
@@ -2450,6 +2477,8 @@ def _dokploy_target_setup_result_payload(
     result: BaseModel,
 ) -> dict[str, object]:
     payload = result.model_dump(mode="json")
+    if isinstance(result, DokployComposeDomainReconcileResult):
+        payload.pop("route_domain_ids", None)
     record = payload.get("target_record")
     if isinstance(record, dict):
         env_payload = record.pop("env", None)
@@ -2470,7 +2499,10 @@ def _execute_dokploy_target_setup(
         control_plane_root=control_plane_root_path
     )
     result: (
-        DokployTargetAdoptionResult | DokployTargetCreateResult | DokployComposeTargetCreateResult
+        DokployTargetAdoptionResult
+        | DokployTargetCreateResult
+        | DokployComposeTargetCreateResult
+        | DokployComposeDomainReconcileResult
     )
     if request.operation == "adopt":
         result = adopt_dokploy_target(
@@ -2490,6 +2522,14 @@ def _execute_dokploy_target_setup(
             source_label="service:dokploy-targets:setup:adopt",
             apply=apply_changes,
             fetch_target_payload=_fetch_dokploy_target_payload_for_setup,
+        )
+    elif request.operation == "reconcile-compose-domain":
+        result = _execute_dokploy_compose_domain_reconcile(
+            record_store=record_store,
+            request=request,
+            host=host,
+            token=token,
+            apply_changes=apply_changes,
         )
     elif request.operation == "create-application":
         result = create_dokploy_application_target(
@@ -2545,7 +2585,11 @@ def _execute_dokploy_target_setup(
             mutate_provider=_mutate_dokploy_payload_for_target_setup,
             fetch_target_payload=_fetch_dokploy_target_payload_for_setup,
         )
-    route_domain_ids: list[str] = []
+    route_domain_ids = (
+        list(result.route_domain_ids)
+        if isinstance(result, DokployComposeDomainReconcileResult)
+        else []
+    )
     if apply_changes and request.operation == "create-compose" and request.runtime_port:
         for domain in request.domains:
             route_domain_ids.append(
@@ -2566,6 +2610,68 @@ def _execute_dokploy_target_setup(
         "route_domain_ids": route_domain_ids,
         "setup": _dokploy_target_setup_result_payload(result),
     }
+
+
+def _execute_dokploy_compose_domain_reconcile(
+    *,
+    record_store: PostgresRecordStore,
+    request: DokployTargetSetupEnvelope,
+    host: str,
+    token: str,
+    apply_changes: bool,
+) -> DokployComposeDomainReconcileResult:
+    try:
+        target_record = record_store.read_dokploy_target_record(
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+        target_id_record = record_store.read_dokploy_target_id_record(
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+    except FileNotFoundError as error:
+        raise ValueError(
+            "Dokploy compose domain reconciliation requires tracked target records."
+        ) from error
+    if target_record.target_type != "compose":
+        raise ValueError("Dokploy compose domain reconciliation requires a compose target.")
+    runtime_port = request.runtime_port
+    if runtime_port is None:
+        raise ValueError("Dokploy compose domain reconciliation requires runtime_port.")
+    requested_domains = tuple(dict.fromkeys(request.domains))
+    route_domain_ids: list[str] = []
+    if apply_changes:
+        for domain in requested_domains:
+            route_domain_ids.append(
+                control_plane_dokploy.ensure_compose_web_domain_route(
+                    host=host,
+                    token=token,
+                    compose_id=target_id_record.target_id,
+                    domain_host=domain,
+                    runtime_port=runtime_port,
+                )
+            )
+        merged_domains = tuple(dict.fromkeys((*target_record.domains, *requested_domains)))
+        if merged_domains != target_record.domains:
+            target_record = target_record.model_copy(
+                update={
+                    "domains": merged_domains,
+                    "updated_at": _utc_now_timestamp(),
+                    "source_label": ("service:dokploy-targets:setup:reconcile-compose-domain"),
+                }
+            )
+            record_store.write_dokploy_target_record(target_record)
+    return DokployComposeDomainReconcileResult(
+        applied=apply_changes,
+        target_record=target_record,
+        target_id_record=target_id_record,
+        domains=requested_domains,
+        runtime_port=runtime_port,
+        route_domain_ids=tuple(route_domain_ids),
+        warnings=()
+        if apply_changes
+        else ("dry run only; Dokploy compose domain routes were not reconciled",),
+    )
 
 
 def _handle_odoo_prod_promotion_inputs(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -972,6 +972,14 @@ current inventory, live Dokploy target payload, domains, volume env keys, latest
 deployment, and expected runtime identity. It does not create, delete, deploy,
 or change routes.
 
+For an already-tracked Dokploy compose target, use `Dokploy Target Setup` with
+`operation=reconcile-compose-domain` to reconcile the provider domain route
+without creating or adopting the target again. The service reads the
+Launchplane-owned Dokploy target/id records, requires the target to be a compose
+target, and applies each requested domain to Dokploy's `web` service on the
+requested runtime port. Dry-run mode reads the tracked records and reports the
+planned domain/port tuple without calling Dokploy.
+
 When a plan is `ready`, the trusted `Odoo Target Replacement Apply` workflow can
 call `POST /v1/drivers/odoo/target-replacement-apply` for the guarded
 `recreate-in-place` path. The service creates a durable operation record and

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -670,6 +670,19 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 for literal in forbidden_literals:
                     self.assertNotIn(literal, workflow_text)
 
+    def test_dokploy_target_setup_workflow_supports_compose_domain_reconcile(self) -> None:
+        workflow_text = Path(".github/workflows/dokploy-target-setup.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("- reconcile-compose-domain", workflow_text)
+        self.assertIn("DOMAIN: ${{ inputs.domain }}", workflow_text)
+        self.assertIn("RUNTIME_PORT: ${{ inputs.runtime_port }}", workflow_text)
+        self.assertIn("Validate reconcile compose domain inputs", workflow_text)
+        self.assertIn("domain is required when operation=reconcile-compose-domain", workflow_text)
+        self.assertIn("runtime_port is required for reconcile-compose-domain", workflow_text)
+        self.assertIn("APPLY DOKPLOY TARGET SETUP", workflow_text)
+
     def test_reusable_odoo_workflows_accept_configured_service_identity(self) -> None:
         workflow_paths = (
             Path(".github/workflows/reusable-odoo-artifact-publish.yml"),

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13756,6 +13756,356 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(target_id_record.target_id, "compose-123")
         self.assertEqual(provider_target.target_id, "compose-123")
 
+    def test_dokploy_target_setup_reconciles_existing_compose_domain_route(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm_website",
+                instance="testing",
+                target_id="compose-cm-website-testing",
+                target_type="compose",
+                target_name="cm-website-testing",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            domain_routes: list[tuple[str, str, int]] = []
+
+            def _ensure_domain(
+                *,
+                host: str,
+                token: str,
+                compose_id: str,
+                domain_host: str,
+                runtime_port: int,
+                certificate_type: str = "none",
+            ) -> str:
+                del host, token, certificate_type
+                domain_routes.append((compose_id, domain_host, runtime_port))
+                return "domain-cm-website-testing"
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service.control_plane_dokploy.ensure_compose_web_domain_route",
+                    side_effect=_ensure_domain,
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "operation": "reconcile-compose-domain",
+                        "product": "launchplane",
+                        "context": "cm_website",
+                        "instance": "testing",
+                        "domains": [
+                            "cm-website-testing.shinycomputers.com",
+                            "cm-website-alt.shinycomputers.com",
+                            "cm-website-testing.shinycomputers.com",
+                        ],
+                        "runtime_port": 8069,
+                        "confirmation": "APPLY DOKPLOY TARGET SETUP",
+                        "reason": "Reconcile cm website testing compose domain route.",
+                    },
+                    headers={"Idempotency-Key": "dokploy-compose-domain-cm-website"},
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                target_record = store.read_dokploy_target_record(
+                    context_name="cm_website",
+                    instance_name="testing",
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertTrue(payload["result"]["applied"])
+        self.assertEqual(payload["result"]["operation"], "reconcile-compose-domain")
+        self.assertEqual(
+            payload["result"]["route_domain_ids"],
+            ["domain-cm-website-testing", "domain-cm-website-testing"],
+        )
+        self.assertNotIn("route_domain_ids", payload["result"]["setup"])
+        self.assertEqual(
+            domain_routes,
+            [
+                (
+                    "compose-cm-website-testing",
+                    "cm-website-testing.shinycomputers.com",
+                    8069,
+                ),
+                (
+                    "compose-cm-website-testing",
+                    "cm-website-alt.shinycomputers.com",
+                    8069,
+                ),
+            ],
+        )
+        self.assertEqual(
+            target_record.domains,
+            (
+                "cm-website-testing.shinycomputers.com",
+                "cm-website-alt.shinycomputers.com",
+            ),
+        )
+        self.assertEqual(
+            target_record.source_label,
+            "service:dokploy-targets:setup:reconcile-compose-domain",
+        )
+
+    def test_dokploy_target_setup_reconcile_compose_domain_dry_run_does_not_mutate(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm_website",
+                instance="testing",
+                target_id="compose-cm-website-testing",
+                target_type="compose",
+                target_name="cm-website-testing",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service.control_plane_dokploy.ensure_compose_web_domain_route"
+                ) as ensure_domain,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "dry-run",
+                        "operation": "reconcile-compose-domain",
+                        "product": "launchplane",
+                        "context": "cm_website",
+                        "instance": "testing",
+                        "domains": ["cm-website-testing.shinycomputers.com"],
+                        "runtime_port": 8069,
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertFalse(payload["result"]["applied"])
+        self.assertEqual(payload["result"]["route_domain_ids"], [])
+        self.assertNotIn("route_domain_ids", payload["result"]["setup"])
+        self.assertEqual(
+            payload["result"]["setup"]["warnings"],
+            ["dry run only; Dokploy compose domain routes were not reconciled"],
+        )
+        ensure_domain.assert_not_called()
+
+    def test_dokploy_target_setup_reconcile_compose_domain_rejects_missing_records(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch(
+                "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.invalid", "token"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "dry-run",
+                        "operation": "reconcile-compose-domain",
+                        "product": "launchplane",
+                        "context": "cm_website",
+                        "instance": "testing",
+                        "domains": ["cm-website-testing.shinycomputers.com"],
+                        "runtime_port": 8069,
+                    },
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_dokploy_target_setup")
+        self.assertIn("requires tracked target records", payload["error"]["message"])
+
+    def test_dokploy_target_setup_reconcile_compose_domain_rejects_application_target(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm_website",
+                instance="testing",
+                target_id="app-cm-website-testing",
+                target_type="application",
+                target_name="cm-website-testing",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with patch(
+                "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.invalid", "token"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "dry-run",
+                        "operation": "reconcile-compose-domain",
+                        "product": "launchplane",
+                        "context": "cm_website",
+                        "instance": "testing",
+                        "domains": ["cm-website-testing.shinycomputers.com"],
+                        "runtime_port": 8069,
+                    },
+                )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_dokploy_target_setup")
+        self.assertIn("requires a compose target", payload["error"]["message"])
+
     def test_dokploy_target_setup_endpoint_applies_adopt(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add a Launchplane-owned Dokploy Target Setup operation for reconciling domains on already tracked compose targets
- update the target record domains after successful apply and keep dry-run/provider mutation behavior fail-closed
- expose workflow input validation and document the operational path

## Verification
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_reconciles_existing_compose_domain_route tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_reconcile_compose_domain_dry_run_does_not_mutate tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_reconcile_compose_domain_rejects_missing_records tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_reconcile_compose_domain_rejects_application_target tests.test_product_onboarding.ProductOnboardingTests.test_dokploy_target_setup_workflow_supports_compose_domain_reconcile
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py tests/test_product_onboarding.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py tests/test_product_onboarding.py
- uv run --extra dev mypy control_plane/service.py tests/test_service.py tests/test_product_onboarding.py
- uv run python -m unittest

## Review
- Claude and Gemini reviewed the pre-merge diff; Claude's workflow port-validation finding was fixed before this PR.
