### PR TITLE
Add Launchplane edge endpoint source of truth

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -73,6 +73,7 @@
     "CodeQL",
     "Deploy Launchplane",
     "Dokploy Target Setup",
+    "Edge Endpoint Apply",
     "Ingress Route Canary Apply",
     "Ingress Route Apply",
     "Ingress Route Audit Read",

--- a/.github/workflows/edge-endpoint-apply.yml
+++ b/.github/workflows/edge-endpoint-apply.yml
@@ -1,0 +1,203 @@
+---
+name: Edge Endpoint Apply
+
+"on":
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Plan or apply the edge endpoint record.
+        required: true
+        default: dry-run
+        type: choice
+        options:
+          - dry-run
+          - apply
+      endpoint_key:
+        description: Human-friendly Launchplane edge endpoint key.
+        required: true
+        type: string
+      server_name:
+        description: Human-friendly provider server identity.
+        required: true
+        type: string
+      upstream_host:
+        description: IP address passed to the edge provider.
+        required: true
+        type: string
+      upstream_scheme:
+        description: Upstream scheme passed to the edge provider.
+        required: true
+        default: https
+        type: choice
+        options:
+          - http
+          - https
+      upstream_port:
+        description: Upstream port passed to the edge provider.
+        required: true
+        default: 443
+        type: number
+      status:
+        description: Edge endpoint lifecycle status.
+        required: true
+        default: active
+        type: choice
+        options:
+          - active
+          - disabled
+      source_label:
+        description: Optional source/provenance label.
+        required: false
+        default: ""
+        type: string
+      reason:
+        description: Operator reason recorded with the Launchplane request.
+        required: true
+        type: string
+      idempotency_key:
+        description: Unique idempotency key for apply attempts.
+        required: false
+        default: ""
+        type: string
+      confirmation:
+        description: Type APPLY LAUNCHPLANE EDGE ENDPOINT to confirm mutation.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: launchplane-edge-endpoint-${{ inputs.endpoint_key }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Build edge endpoint payload
+        id: payload
+        shell: bash
+        env:
+          MODE: ${{ inputs.mode }}
+          ENDPOINT_KEY: ${{ inputs.endpoint_key }}
+          SERVER_NAME: ${{ inputs.server_name }}
+          UPSTREAM_HOST: ${{ inputs.upstream_host }}
+          UPSTREAM_SCHEME: ${{ inputs.upstream_scheme }}
+          UPSTREAM_PORT: ${{ inputs.upstream_port }}
+          STATUS: ${{ inputs.status }}
+          SOURCE_LABEL: ${{ inputs.source_label }}
+          REASON: ${{ inputs.reason }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          payload_file="$RUNNER_TEMP/edge-endpoint-apply-request.json"
+          updated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          if ! jq -en --arg host "$UPSTREAM_HOST" '
+            def octet:
+              test("^(0|[1-9][0-9]?|1[0-9][0-9]|2[0-4][0-9]|25[0-5])$");
+            ($host | split(".")) as $parts
+            | ($parts | length) == 4
+              and all($parts[]; octet)
+          ' >/dev/null; then
+            echo "upstream_host must be an IPv4 address." >&2
+            exit 1
+          fi
+          jq -n \
+            --arg mode "$MODE" \
+            --arg endpoint_key "$ENDPOINT_KEY" \
+            --arg server_name "$SERVER_NAME" \
+            --arg upstream_host "$UPSTREAM_HOST" \
+            --arg upstream_scheme "$UPSTREAM_SCHEME" \
+            --arg status "$STATUS" \
+            --arg source_label "$SOURCE_LABEL" \
+            --arg reason "$REASON" \
+            --arg confirmation "$CONFIRMATION" \
+            --arg updated_at "$updated_at" \
+            --argjson upstream_port "$UPSTREAM_PORT" \
+            '{
+              schema_version: 1,
+              mode: $mode,
+              reason: $reason,
+              confirmation: $confirmation,
+              endpoint: {
+                schema_version: 1,
+                endpoint_key: $endpoint_key,
+                provider: "dokploy",
+                server_name: $server_name,
+                upstream_host: $upstream_host,
+                upstream_host_kind: "ip",
+                upstream_scheme: $upstream_scheme,
+                upstream_port: $upstream_port,
+                status: $status,
+                source_label: $source_label,
+                updated_at: $updated_at
+              }
+            }' >"$payload_file"
+          echo "payload_file=$payload_file" >>"$GITHUB_OUTPUT"
+
+      - name: Validate apply guards
+        if: ${{ inputs.mode == 'apply' }}
+        shell: bash
+        env:
+          CONFIRMATION: ${{ inputs.confirmation }}
+          IDEMPOTENCY_KEY: ${{ inputs.idempotency_key }}
+        run: |
+          set -euo pipefail
+          if [ "$CONFIRMATION" != "APPLY LAUNCHPLANE EDGE ENDPOINT" ]; then
+            echo "confirmation must be APPLY LAUNCHPLANE EDGE ENDPOINT" >&2
+            exit 1
+          fi
+          if [ -z "${IDEMPOTENCY_KEY// }" ]; then
+            echo "idempotency_key is required for apply." >&2
+            exit 1
+          fi
+
+      - name: Request edge endpoint apply
+        id: launchplane
+        uses: ./.github/actions/launchplane-request
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          method: POST
+          route-path: /v1/edge-endpoints/apply
+          payload-file: ${{ steps.payload.outputs.payload_file }}
+          idempotency-key: ${{ inputs.idempotency_key }}
+          timeout-ms: "30000"
+          fail-result-paths: records.edge_endpoint_status
+          response-output-file: edge-endpoint-apply.json
+
+      - name: Summarize endpoint
+        shell: bash
+        env:
+          MODE: ${{ inputs.mode }}
+        run: |
+          set -euo pipefail
+          jq . edge-endpoint-apply.json
+          endpoint_key="$(
+            jq -r '.result.endpoint_key' edge-endpoint-apply.json
+          )"
+          status="$(
+            jq -r '.records.edge_endpoint_status' edge-endpoint-apply.json
+          )"
+          {
+            echo '## Edge endpoint apply'
+            echo
+            echo "- Endpoint: $endpoint_key"
+            echo "- Mode: $MODE"
+            echo "- Status: $status"
+          } >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload response
+        uses: actions/upload-artifact@v7
+        with:
+          name: edge-endpoint-apply
+          path: edge-endpoint-apply.json
+          if-no-files-found: error

--- a/.github/workflows/ingress-route-apply.yml
+++ b/.github/workflows/ingress-route-apply.yml
@@ -13,7 +13,9 @@ name: Ingress Route Apply
         required: true
         type: string
       route_json:
-        description: JSON object with desired route and apply guard options.
+        description: >-
+          JSON object with desired route and apply guard options. Set
+          route.edge_endpoint_key to use a Launchplane-owned upstream record.
         required: true
         type: string
       reason:

--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -17,8 +17,14 @@ name: Ingress Route Dry Run
         required: true
         type: string
       forward_host:
-        description: Upstream host for the desired provider route.
-        required: true
+        description: Raw upstream host override for the desired provider route.
+        required: false
+        default: ""
+        type: string
+      edge_endpoint_key:
+        description: DB-backed edge endpoint key used to resolve upstream IP.
+        required: false
+        default: ""
         type: string
       forward_port:
         description: Upstream port for the desired provider route.
@@ -83,6 +89,7 @@ jobs:
           EXPECTED_HOST_ID: ${{ inputs.expected_host_id }}
           FORWARD_SCHEME: ${{ inputs.forward_scheme }}
           FORWARD_HOST: ${{ inputs.forward_host }}
+          EDGE_ENDPOINT_KEY: ${{ inputs.edge_endpoint_key }}
           FORWARD_PORT: ${{ inputs.forward_port }}
           CERTIFICATE_ID: ${{ inputs.certificate_id }}
           ROUTE_OPTIONS_JSON: ${{ inputs.route_options_json }}
@@ -96,6 +103,7 @@ jobs:
             --arg reason "$REASON" \
             --arg forward_scheme "$FORWARD_SCHEME" \
             --arg forward_host "$FORWARD_HOST" \
+            --arg edge_endpoint_key "$EDGE_ENDPOINT_KEY" \
             --arg route_options_json "$ROUTE_OPTIONS_JSON" \
             --arg expected_host_id "$EXPECTED_HOST_ID" \
             --argjson forward_port "$FORWARD_PORT" \
@@ -115,6 +123,16 @@ jobs:
               if $options | has($key) then $options[$key] else $default end;
             if ($options | type) != "object" then
               error("route_options_json must be a JSON object")
+            elif (
+              ($forward_host | length) == 0
+              and ($edge_endpoint_key | length) == 0
+            ) then
+              error("forward_host or edge_endpoint_key is required")
+            elif (
+              ($forward_host | length) != 0
+              and ($edge_endpoint_key | length) != 0
+            ) then
+              error("forward_host and edge_endpoint_key are mutually exclusive")
             elif (
               $expected_host_id_value != null
               and ($expected_host_id_value | type) != "number"
@@ -161,6 +179,7 @@ jobs:
               domain_names: [$domain],
               forward_scheme: $forward_scheme,
               forward_host: $forward_host,
+              edge_endpoint_key: $edge_endpoint_key,
               forward_port: $forward_port,
               certificate_id: $certificate_id,
               enabled: true,

--- a/control_plane/contracts/edge_endpoint_record.py
+++ b/control_plane/contracts/edge_endpoint_record.py
@@ -1,0 +1,68 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+EdgeEndpointProvider = Literal["dokploy"]
+EdgeEndpointStatus = Literal["active", "disabled"]
+EdgeEndpointUpstreamHostKind = Literal["ip"]
+EdgeEndpointUpstreamScheme = Literal["http", "https"]
+
+
+class EdgeEndpointRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    endpoint_key: str
+    provider: EdgeEndpointProvider = "dokploy"
+    server_name: str
+    upstream_host: str
+    upstream_host_kind: EdgeEndpointUpstreamHostKind = "ip"
+    upstream_scheme: EdgeEndpointUpstreamScheme = "https"
+    upstream_port: int = Field(ge=1, le=65535)
+    status: EdgeEndpointStatus = "active"
+    source_label: str = ""
+    updated_at: str
+
+    @field_validator(
+        "endpoint_key",
+        "server_name",
+        "upstream_host",
+        "updated_at",
+        mode="after",
+    )
+    @classmethod
+    def _validate_required_text(cls, value: str) -> str:
+        normalized_value = value.strip()
+        if not normalized_value:
+            raise ValueError("edge endpoint record requires non-empty text fields")
+        return normalized_value
+
+    @field_validator("source_label", mode="after")
+    @classmethod
+    def _normalize_optional_text(cls, value: str) -> str:
+        return value.strip()
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "EdgeEndpointRecord":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported edge endpoint record schema version")
+        if self.upstream_host_kind != "ip":
+            raise ValueError("edge endpoint upstream_host_kind must be ip")
+        if not _is_ipv4_address(self.upstream_host):
+            raise ValueError("edge endpoint upstream_host must be an IPv4 address")
+        return self
+
+
+def _is_ipv4_address(value: str) -> bool:
+    parts = value.split(".")
+    if len(parts) != 4:
+        return False
+    for part in parts:
+        if not part.isdecimal():
+            return False
+        if len(part) > 1 and part.startswith("0"):
+            return False
+        octet = int(part)
+        if octet < 0 or octet > 255:
+            return False
+    return True

--- a/control_plane/contracts/ingress_route_audit_record.py
+++ b/control_plane/contracts/ingress_route_audit_record.py
@@ -41,6 +41,7 @@ class IngressRouteAuditRecord(BaseModel):
     status: IngressRouteAuditStatus
     dry_run: bool
     requested_domains: tuple[str, ...]
+    edge_endpoint_key: str = ""
     expected_host_id: int | None = Field(default=None, ge=1)
     provider_host_id: int | None = Field(default=None, ge=1)
     operations: tuple[IngressRouteAuditOperation, ...]
@@ -60,6 +61,7 @@ class IngressRouteAuditRecord(BaseModel):
         self.recorded_at = _required_text(
             self.recorded_at, "ingress route audit requires recorded_at"
         )
+        self.edge_endpoint_key = self.edge_endpoint_key.strip()
         self.idempotency_key = self.idempotency_key.strip()
         normalized_domains = tuple(
             dict.fromkeys(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -55,6 +55,7 @@ from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
@@ -536,6 +537,7 @@ _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
 _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
 _NPMPLUS_INGRESS_APPLY_ROUTE_PATH = "/v1/drivers/ingress/route-apply"
+_EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
 _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/controller/run-once"
 _MERGE_TRAIN_PR_FEEDBACK_ROUTE = "/v1/work-graph/merge-train/pr-feedback"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
@@ -835,6 +837,20 @@ class _IngressRouteAuditRecordStore(Protocol):
         context_name: str = "",
         limit: int | None = None,
     ) -> tuple[IngressRouteAuditRecord, ...]: ...
+
+
+class _EdgeEndpointRecordStore(Protocol):
+    def write_edge_endpoint_record(self, record: EdgeEndpointRecord) -> object: ...
+
+    def read_edge_endpoint_record(self, endpoint_key: str) -> EdgeEndpointRecord: ...
+
+    def list_edge_endpoint_records(
+        self,
+        *,
+        provider: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EdgeEndpointRecord, ...]: ...
 
 
 _StartResponse = Callable[[str, list[tuple[str, str]]], None]
@@ -1289,6 +1305,29 @@ _NPMPLUS_INGRESS_APPLY_ROUTE = _DriverRouteExecutionMetadata(
         "Workflow cannot plan or apply the ingress route for the requested product/context."
     ),
 )
+
+
+class EdgeEndpointApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: Literal["dry-run", "apply"] = "dry-run"
+    endpoint: EdgeEndpointRecord
+    reason: str = ""
+    confirmation: str = ""
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "EdgeEndpointApplyEnvelope":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported edge endpoint apply schema version")
+        self.reason = self.reason.strip()
+        self.confirmation = self.confirmation.strip()
+        if self.mode == "apply":
+            if not self.reason:
+                raise ValueError("Edge endpoint apply requires a reason")
+            if self.confirmation != "APPLY LAUNCHPLANE EDGE ENDPOINT":
+                raise ValueError("Edge endpoint apply requires exact confirmation text")
+        return self
 
 
 class MergeTrainPolicyImportEnvelope(BaseModel):
@@ -2362,6 +2401,24 @@ def _handle_npmplus_ingress_apply(
         )
 
     ingress_provider = ingress_provider_factory()
+    try:
+        resolved_ingress_request = _resolve_ingress_edge_endpoint(
+            record_store=record_store,
+            request=request.ingress,
+        )
+    except click.ClickException as error:
+        return _json_response(
+            start_response=start_response,
+            status_code=400,
+            payload={
+                "status": "rejected",
+                "trace_id": trace_id,
+                "error": {
+                    "code": "invalid_edge_endpoint",
+                    "message": str(error),
+                },
+            },
+        )
     if request.ingress.mode == "apply":
         idempotent_response = _check_idempotent_request(
             record_store=record_store,
@@ -2380,17 +2437,17 @@ def _handle_npmplus_ingress_apply(
             product=request.product,
             context=request.context,
             provider=ingress_provider.provider_id,
-            request=request.ingress,
+            request=resolved_ingress_request,
             idempotency_key=request_idempotency_key,
         )
-    ingress_result = ingress_provider.apply_route(request=request.ingress)
+    ingress_result = ingress_provider.apply_route(request=resolved_ingress_request)
     ingress_audit_record = _write_ingress_route_audit_record(
         record_store=record_store,
         trace_id=trace_id,
         product=request.product,
         context=request.context,
         provider=ingress_provider.provider_id,
-        request=request.ingress,
+        request=resolved_ingress_request,
         result=ingress_result,
         idempotency_key=request_idempotency_key,
     )
@@ -4251,6 +4308,10 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "ingress_route.plan", {"ingress_route_audit_list": "true"}
     if len(segments) == 5 and segments[:4] == ["v1", "ingress", "route-audits", "records"]:
         return "ingress_route.plan", {"ingress_route_audit_record_id": segments[4]}
+    if len(segments) == 3 and segments == ["v1", "edge-endpoints", "records"]:
+        return "edge_endpoint.read", {"edge_endpoint_list": "true"}
+    if len(segments) == 4 and segments[:3] == ["v1", "edge-endpoints", "records"]:
+        return "edge_endpoint.read", {"edge_endpoint_key": segments[3]}
     if path == _MERGE_TRAIN_ADMISSION_ROUTE:
         return "merge_train.admission", {}
     if path == _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE:
@@ -4453,6 +4514,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/product-onboarding/apply",
         "/v1/dokploy-targets/setup",
         PROVIDER_TARGET_OPERATIONS_ROUTE,
+        _EDGE_ENDPOINT_APPLY_ROUTE,
         "/v1/product-config/apply",
         "/v1/product-profiles/context-cutover/apply",
         "/v1/product-profiles/legacy-context-cleanup/apply",
@@ -6480,6 +6542,7 @@ def _accepted_payload(
         "generic_web_rollback_plan_id",
         "public_ingress_notification_policy_id",
         "ingress_route_audit_record_id",
+        "edge_endpoint_key",
     }
     accepted_record_keys = record_keys | extra_record_keys
     records: dict[str, object] = {}
@@ -6511,6 +6574,8 @@ def _accepted_payload_extra_record_keys(*, route_path: str) -> frozenset[str]:
         return frozenset({"rollback_status", "deploy_status", "post_deploy_status"})
     if route_path == _NPMPLUS_INGRESS_APPLY_ROUTE.route_path:
         return frozenset({"ingress_provider"})
+    if route_path == _EDGE_ENDPOINT_APPLY_ROUTE:
+        return frozenset({"edge_endpoint_status"})
     return frozenset()
 
 
@@ -6597,6 +6662,46 @@ def _ingress_route_audit_record_store(record_store: object) -> _IngressRouteAudi
     raise click.ClickException(
         "Ingress route audit reads require Launchplane ingress-audit record storage."
     )
+
+
+def _edge_endpoint_record_store(record_store: object) -> _EdgeEndpointRecordStore:
+    required_methods = (
+        "write_edge_endpoint_record",
+        "read_edge_endpoint_record",
+        "list_edge_endpoint_records",
+    )
+    if all(hasattr(record_store, method_name) for method_name in required_methods):
+        return cast(_EdgeEndpointRecordStore, record_store)
+    raise click.ClickException("Edge endpoint operations require Launchplane record storage.")
+
+
+def _resolve_ingress_edge_endpoint(
+    *,
+    record_store: object,
+    request: NpmplusIngressApplyRequest,
+) -> NpmplusIngressApplyRequest:
+    endpoint_key = request.route.edge_endpoint_key.strip()
+    if not endpoint_key:
+        return request
+    endpoint_store = _edge_endpoint_record_store(record_store)
+    try:
+        endpoint = endpoint_store.read_edge_endpoint_record(endpoint_key)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"Ingress edge endpoint {endpoint_key!r} was not found."
+        ) from exc
+    if endpoint.status != "active":
+        raise click.ClickException(
+            f"Ingress edge endpoint {endpoint_key!r} is {endpoint.status}, not active."
+        )
+    resolved_route = request.route.model_copy(
+        update={
+            "forward_scheme": endpoint.upstream_scheme,
+            "forward_host": endpoint.upstream_host,
+            "forward_port": endpoint.upstream_port,
+        }
+    )
+    return request.model_copy(update={"route": resolved_route})
 
 
 def _query_string_value(query: dict[str, list[str]], key: str) -> str:
@@ -7289,6 +7394,7 @@ def _write_ingress_route_audit_record(
         status=result.status,
         dry_run=result.dry_run,
         requested_domains=request.route.domain_names,
+        edge_endpoint_key=request.route.edge_endpoint_key,
         expected_host_id=request.expected_host_id,
         provider_host_id=provider_host_id,
         operations=tuple(
@@ -7302,6 +7408,30 @@ def _write_ingress_route_audit_record(
     )
     write_record(record)
     return record
+
+
+def _edge_endpoint_apply_result(
+    *,
+    record_store: object,
+    request: EdgeEndpointApplyEnvelope,
+) -> tuple[dict[str, object], dict[str, object]]:
+    endpoint_store = _edge_endpoint_record_store(record_store)
+    if request.mode == "apply":
+        endpoint_store.write_edge_endpoint_record(request.endpoint)
+        status = "applied"
+    else:
+        status = "planned"
+    return {
+        "edge_endpoint_key": request.endpoint.endpoint_key,
+        "edge_endpoint_status": status,
+        "mode": request.mode,
+        "reason": request.reason,
+    }, {
+        "mode": request.mode,
+        "endpoint_key": request.endpoint.endpoint_key,
+        "endpoint_status": status,
+        "record": request.endpoint.model_dump(mode="json"),
+    }
 
 
 def _write_ingress_route_pending_audit_record(
@@ -7331,6 +7461,7 @@ def _write_ingress_route_pending_audit_record(
         status="pending",
         dry_run=request.mode == "dry-run",
         requested_domains=request.route.domain_names,
+        edge_endpoint_key=request.route.edge_endpoint_key,
         expected_host_id=request.expected_host_id,
         provider_host_id=None,
         operations=(
@@ -9719,6 +9850,83 @@ def create_launchplane_service_app(
                             "count": len(limited_records),
                             "records": [
                                 record.model_dump(mode="json") for record in limited_records
+                            ],
+                        },
+                    )
+                if action == "edge_endpoint.read":
+                    endpoint_store = _edge_endpoint_record_store(record_store)
+                    if "edge_endpoint_key" in params:
+                        if not authz_policy.allows(
+                            identity=identity,
+                            action=action,
+                            product="launchplane",
+                            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                        ):
+                            return _json_response(
+                                start_response=start_response,
+                                status_code=403,
+                                payload={
+                                    "status": "rejected",
+                                    "trace_id": request_trace_id,
+                                    "error": {
+                                        "code": "authorization_denied",
+                                        "message": "Workflow cannot read Launchplane edge endpoint records.",
+                                    },
+                                },
+                            )
+                        try:
+                            endpoint_record = endpoint_store.read_edge_endpoint_record(
+                                params["edge_endpoint_key"]
+                            )
+                        except FileNotFoundError:
+                            return _not_found_response(
+                                start_response=start_response,
+                                trace_id=request_trace_id,
+                                path=path,
+                            )
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=200,
+                            payload={
+                                "status": "ok",
+                                "trace_id": request_trace_id,
+                                "record": endpoint_record.model_dump(mode="json"),
+                            },
+                        )
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot read Launchplane edge endpoint records.",
+                                },
+                            },
+                        )
+                    limit = _query_int_value(query, "limit", default=25, minimum=1, maximum=100)
+                    endpoint_records = endpoint_store.list_edge_endpoint_records(
+                        provider=_query_string_value(query, "provider"),
+                        status=_query_string_value(query, "status"),
+                        limit=limit,
+                    )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "limit": limit,
+                            "count": len(endpoint_records),
+                            "records": [
+                                record.model_dump(mode="json") for record in endpoint_records
                             ],
                         },
                     )
@@ -13704,6 +13912,55 @@ def create_launchplane_service_app(
                 assert isinstance(provider_target_result, ProviderTargetOperationRouteResult)
                 result = provider_target_result.result
                 driver_result = provider_target_result.driver_result
+            elif path == _EDGE_ENDPOINT_APPLY_ROUTE:
+                edge_endpoint_request = EdgeEndpointApplyEnvelope.model_validate(payload)
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="edge_endpoint.apply",
+                    product="launchplane",
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": "Workflow cannot apply Launchplane edge endpoint records.",
+                            },
+                        },
+                    )
+                if edge_endpoint_request.mode == "apply":
+                    if not request_idempotency_key:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=400,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "idempotency_key_required",
+                                    "message": "Edge endpoint apply requests require an Idempotency-Key header.",
+                                },
+                            },
+                        )
+                    idempotent_response = _check_idempotent_request(
+                        record_store=record_store,
+                        scope=request_scope,
+                        route_path=path,
+                        idempotency_key=request_idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        start_response=start_response,
+                        trace_id=request_trace_id,
+                    )
+                    if idempotent_response is not None:
+                        return idempotent_response
+                result, driver_result = _edge_endpoint_apply_result(
+                    record_store=record_store,
+                    request=edge_endpoint_request,
+                )
             elif path in descriptor_driver_dispatch_routes:
                 try:
                     dispatch_response = _dispatch_descriptor_driver_route(

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -13,6 +13,7 @@ from control_plane.contracts.agent_write_intent import AgentWriteIntentRecord
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_work_request import (
@@ -567,6 +568,37 @@ class FilesystemRecordStore:
 
     def write_ingress_route_audit_record(self, record: IngressRouteAuditRecord) -> Path:
         return self._write_model("launchplane_ingress_route_audits", record.record_id, record)
+
+    def write_edge_endpoint_record(self, record: EdgeEndpointRecord) -> Path:
+        return self._write_model("launchplane_edge_endpoints", record.endpoint_key, record)
+
+    def read_edge_endpoint_record(self, endpoint_key: str) -> EdgeEndpointRecord:
+        return self._read_model(
+            EdgeEndpointRecord,
+            "launchplane_edge_endpoints",
+            endpoint_key,
+        )
+
+    def list_edge_endpoint_records(
+        self,
+        *,
+        provider: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EdgeEndpointRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                EdgeEndpointRecord,
+                "launchplane_edge_endpoints",
+            )
+            if (not provider or record.provider == provider)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: (record.provider, record.endpoint_key))
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
 
     def read_ingress_route_audit_record(self, record_id: str) -> IngressRouteAuditRecord:
         return self._read_model(

--- a/control_plane/storage/migrations/versions/c6e8f0a2b4d6_add_edge_endpoints.py
+++ b/control_plane/storage/migrations/versions/c6e8f0a2b4d6_add_edge_endpoints.py
@@ -1,0 +1,72 @@
+"""add edge endpoint records
+
+Revision ID: c6e8f0a2b4d6
+Revises: c5e7f9a1b3d5
+Create Date: 2026-06-07 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c6e8f0a2b4d6"
+down_revision: str | None = "c5e7f9a1b3d5"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_edge_endpoints"
+_PROVIDER_STATUS_INDEX = "launchplane_edge_endpoints_provider_status_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def _payload_column() -> sa.Column[object]:
+    return sa.Column(
+        "payload",
+        sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+        nullable=False,
+    )
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("endpoint_key", sa.String(), nullable=False),
+            sa.Column("provider", sa.String(), nullable=False),
+            sa.Column("server_name", sa.String(), nullable=False),
+            sa.Column("upstream_host", sa.String(), nullable=False),
+            sa.Column("upstream_scheme", sa.String(), nullable=False),
+            sa.Column("upstream_port", sa.Integer(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("updated_at", sa.String(), nullable=False),
+            _payload_column(),
+            sa.PrimaryKeyConstraint("endpoint_key"),
+        )
+    if not _index_exists(_TABLE, _PROVIDER_STATUS_INDEX):
+        op.create_index(
+            _PROVIDER_STATUS_INDEX,
+            _TABLE,
+            ["provider", "status", "endpoint_key"],
+        )
+
+
+def downgrade() -> None:
+    if _table_exists(_TABLE):
+        if _index_exists(_TABLE, _PROVIDER_STATUS_INDEX):
+            op.drop_index(_PROVIDER_STATUS_INDEX, table_name=_TABLE)
+        op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -30,6 +30,7 @@ from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_work_request import (
@@ -525,6 +526,28 @@ class LaunchplaneIngressRouteAuditRow(Base):
     status: Mapped[str] = mapped_column(String, nullable=False)
     provider_host_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
     recorded_at: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneEdgeEndpointRow(Base):
+    __tablename__ = "launchplane_edge_endpoints"
+    __table_args__ = (
+        Index(
+            "launchplane_edge_endpoints_provider_status_idx",
+            "provider",
+            "status",
+            "endpoint_key",
+        ),
+    )
+
+    endpoint_key: Mapped[str] = mapped_column(String, primary_key=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    server_name: Mapped[str] = mapped_column(String, nullable=False)
+    upstream_host: Mapped[str] = mapped_column(String, nullable=False)
+    upstream_scheme: Mapped[str] = mapped_column(String, nullable=False)
+    upstream_port: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -2897,6 +2920,51 @@ class PostgresRecordStore(HumanSessionStore):
                 recorded_at=record.recorded_at,
                 payload=self._payload_dict(record),
             )
+        )
+
+    def write_edge_endpoint_record(self, record: EdgeEndpointRecord) -> None:
+        self._write_row(
+            LaunchplaneEdgeEndpointRow(
+                endpoint_key=record.endpoint_key,
+                provider=record.provider,
+                server_name=record.server_name,
+                upstream_host=record.upstream_host,
+                upstream_scheme=record.upstream_scheme,
+                upstream_port=record.upstream_port,
+                status=record.status,
+                updated_at=record.updated_at,
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def read_edge_endpoint_record(self, endpoint_key: str) -> EdgeEndpointRecord:
+        return self._read_model(
+            model_type=EdgeEndpointRecord,
+            orm_model=LaunchplaneEdgeEndpointRow,
+            filters=(LaunchplaneEdgeEndpointRow.endpoint_key == endpoint_key,),
+        )
+
+    def list_edge_endpoint_records(
+        self,
+        *,
+        provider: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EdgeEndpointRecord, ...]:
+        filters: list[object] = []
+        if provider:
+            filters.append(LaunchplaneEdgeEndpointRow.provider == provider)
+        if status:
+            filters.append(LaunchplaneEdgeEndpointRow.status == status)
+        return self._list_models(
+            model_type=EdgeEndpointRecord,
+            orm_model=LaunchplaneEdgeEndpointRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneEdgeEndpointRow.provider.asc(),
+                LaunchplaneEdgeEndpointRow.endpoint_key.asc(),
+            ),
+            limit=limit,
         )
 
     def read_ingress_route_audit_record(self, record_id: str) -> IngressRouteAuditRecord:

--- a/control_plane/workflows/npmplus_ingress.py
+++ b/control_plane/workflows/npmplus_ingress.py
@@ -133,8 +133,9 @@ class NpmplusIngressRouteDesiredState(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     domain_names: tuple[str, ...]
-    forward_scheme: NpmplusForwardScheme
-    forward_host: str
+    edge_endpoint_key: str = ""
+    forward_scheme: NpmplusForwardScheme = "https"
+    forward_host: str = ""
     forward_port: int | None = Field(default=None, ge=1, le=65535)
     certificate_id: int | Literal["new"] = 0
     ssl_forced: bool = True
@@ -158,6 +159,18 @@ class NpmplusIngressRouteDesiredState(BaseModel):
     locations: tuple[NpmplusLocationPayload, ...] = ()
 
     @model_validator(mode="after")
+    def _validate_upstream_source(self) -> "NpmplusIngressRouteDesiredState":
+        self.edge_endpoint_key = self.edge_endpoint_key.strip()
+        self.forward_host = self.forward_host.strip()
+        if self.edge_endpoint_key and self.forward_host:
+            raise ValueError(
+                "NPMplus ingress route cannot set both forward_host and edge_endpoint_key"
+            )
+        if not self.edge_endpoint_key and not self.forward_host:
+            raise ValueError("NPMplus ingress route requires forward_host or edge_endpoint_key")
+        return self
+
+    @model_validator(mode="after")
     def _validate_identity_access(self) -> "NpmplusIngressRouteDesiredState":
         if self.identity_access is None:
             return self
@@ -172,7 +185,7 @@ class NpmplusIngressRouteDesiredState(BaseModel):
 
     def to_proxy_host_payload(self) -> NpmplusProxyHostPayload:
         return NpmplusProxyHostPayload.model_validate(
-            self.model_dump(mode="json", exclude={"identity_access"})
+            self.model_dump(mode="json", exclude={"edge_endpoint_key", "identity_access"})
         )
 
 

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -83,6 +83,7 @@ Launchplane records/secrets instead of repo files or operator-local env.
 | Class | Current surface(s) | Final authority | Notes |
 | --- | --- | --- | --- |
 | Dokploy credentials | Launchplane managed secrets (`DOKPLOY_HOST`, `DOKPLOY_TOKEN`) | Launchplane managed secrets | Fail closed when the shared store does not have both bindings. |
+| Dokploy edge upstream endpoints | `launchplane_edge_endpoints` | DB-backed Launchplane edge endpoint records | Server identity is human-readable, but provider upstreams passed to NPMplus must be stored IP addresses. Product repos and ad hoc workflow inputs are not durable topology authority. |
 | Runtime environment values | Runtime-environment records | Launchplane runtime-environment records | Includes shared, context, and instance-scoped values. |
 | Secret-shaped runtime keys | Managed runtime secrets overlay | Launchplane managed secrets | Includes `*_PASSWORD`, `*_TOKEN`, `*_SECRET`, `*_KEY`. |
 | Runtime key-safety policy | `launchplane_runtime_key_safety_policies`, seed-import reconciliation endpoint | Launchplane runtime key-safety policy records | Classifies managed secret binding keys by runtime class and scope. Seed-import reconciliation carries metadata only and cannot replace secret values. |

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -177,6 +177,15 @@ overrides.
 Ingress audit records must persist the adapter's provider identity explicitly;
 do not rely on a provider-specific model default for operator evidence.
 
+Dokploy-backed ingress routes should use a DB-backed edge endpoint record instead
+of passing raw upstream topology through product workflows. The endpoint record
+uses a human-friendly `endpoint_key` and `server_name` for operator review, but
+the `upstream_host` stored for NPMplus must be an IP address. The service
+resolves `route.edge_endpoint_key` into `forward_scheme`, `forward_host`, and
+`forward_port` before calling NPMplus, and fails closed when the endpoint is
+missing or disabled. Raw `forward_host` remains an explicit operator override;
+it is not product-repo-owned topology authority.
+
 The matching CLI entrypoint is service-mediated:
 
 ```bash

--- a/docs/records.md
+++ b/docs/records.md
@@ -212,6 +212,13 @@ an ORM column/table or remains only in the evidence payload.
   payload-only until route ownership gets a broader operator UI. Apply requests
   first write a `pending` audit intent before provider mutation and then replace
   it with the final `applied` or `unchanged` outcome.
+- Edge endpoint: modeled fields are `endpoint_key`, `provider`, `server_name`,
+  `upstream_host`, `upstream_scheme`, `upstream_port`, `status`, and
+  `updated_at`. `endpoint_key` and `server_name` are human-facing operator
+  identity. `upstream_host` is the provider data-plane value and must be an IP
+  address for NPMplus-backed routes so a bad hostname cannot become a runtime
+  Nginx startup dependency. Product repositories must not own provider topology,
+  edge IPs, NPMplus host ids, or Dokploy server routing facts.
 
 Promote a payload field into ORM structure when Launchplane needs to filter,
 order, join, authorize, constrain, display it regularly, or drive an action from

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -546,6 +546,20 @@ post_local_owner_grant \
 	public_ingress_notification_policy.apply \
 	deploy:local-operator-public-ingress-notification-policy-grant \
 	local-operator-public-ingress-notification-policy
+post_local_owner_grant \
+	local-operator \
+	launchplane \
+	launchplane \
+	edge_endpoint.apply \
+	deploy:local-operator-edge-endpoint-apply-grant \
+	local-operator-edge-endpoint-apply
+post_local_owner_grant \
+	local-operator \
+	launchplane \
+	launchplane \
+	edge_endpoint.read \
+	deploy:local-operator-edge-endpoint-read-grant \
+	local-operator-edge-endpoint-read
 post_local_operator_product_config_grants \
 	product_config.plan \
 	deploy:local-operator-product-config-plan-grant \

--- a/tests/test_npmplus_ingress_workflow.py
+++ b/tests/test_npmplus_ingress_workflow.py
@@ -302,6 +302,10 @@ class NpmplusIngressWorkflowTests(unittest.TestCase):
             route.identity_access.provider if route.identity_access else "", "authentik"
         )
 
+    def test_edge_endpoint_key_rejects_raw_forward_host_conflict(self) -> None:
+        with self.assertRaises(ValueError):
+            _desired_route(edge_endpoint_key="cm-prod-dokploy")
+
     def test_identity_access_binding_maps_authentik_basic_auth_forwarding(self) -> None:
         route = _desired_route(
             identity_access={

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -33,6 +33,8 @@ from control_plane.contracts.deploy_target import (
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointStatus
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
@@ -393,6 +395,26 @@ def _dokploy_target_record(
         domains=(f"https://{instance}.example.com",),
         updated_at="2026-04-21T18:30:00Z",
         source_label="import:test",
+    )
+
+
+def _edge_endpoint_record(
+    *,
+    endpoint_key: str = "cm-prod-dokploy",
+    upstream_host: str = "100.73.170.113",
+    status: EdgeEndpointStatus = "active",
+) -> EdgeEndpointRecord:
+    return EdgeEndpointRecord(
+        endpoint_key=endpoint_key,
+        provider="dokploy",
+        server_name="docker-cm-prod",
+        upstream_host=upstream_host,
+        upstream_host_kind="ip",
+        upstream_scheme="https",
+        upstream_port=443,
+        status=status,
+        updated_at="2026-06-07T00:00:00Z",
+        source_label="test:edge-endpoint",
     )
 
 
@@ -924,9 +946,14 @@ class PostgresRecordStoreTests(unittest.TestCase):
             store.write_ingress_route_audit_record(ingress_route_audit)
             provider_target = _provider_target_record(context="reon", instance="prod")
             store.write_provider_target_record(provider_target)
+            edge_endpoint = _edge_endpoint_record()
+            store.write_edge_endpoint_record(edge_endpoint)
             inspect_engine = create_engine(database_url)
             inspector = inspect(inspect_engine)
             table_names = set(inspector.get_table_names())
+            edge_endpoint_columns = {
+                column["name"] for column in inspector.get_columns("launchplane_edge_endpoints")
+            }
             provider_target_columns = {
                 column["name"] for column in inspector.get_columns("launchplane_provider_targets")
             }
@@ -938,6 +965,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                 context_name="reon",
                 instance_name="prod",
             )
+            loaded_edge_endpoint = store.read_edge_endpoint_record(edge_endpoint.endpoint_key)
             audit_records = store.list_ingress_route_audit_records(
                 product="launchplane", context_name="reon-prod"
             )
@@ -947,6 +975,22 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(loaded.artifact_id, manifest.artifact_id)
         self.assertEqual(loaded.image.digest, "sha256:image123")
         self.assertEqual(loaded_provider_target.target_id, provider_target.target_id)
+        self.assertEqual(loaded_edge_endpoint.upstream_host, edge_endpoint.upstream_host)
+        self.assertIn("launchplane_edge_endpoints", table_names)
+        self.assertGreaterEqual(
+            edge_endpoint_columns,
+            {
+                "endpoint_key",
+                "provider",
+                "server_name",
+                "upstream_host",
+                "upstream_scheme",
+                "upstream_port",
+                "status",
+                "updated_at",
+                "payload",
+            },
+        )
         self.assertIn("launchplane_provider_targets", table_names)
         self.assertGreaterEqual(
             provider_target_columns,
@@ -2794,6 +2838,32 @@ env_var = "GH_TOKEN"
             [(record.context, record.instance) for record in listed_records],
             [("cm", "testing"), ("opw", "prod")],
         )
+
+    def test_write_read_and_list_edge_endpoint_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            store.write_edge_endpoint_record(_edge_endpoint_record())
+            store.write_edge_endpoint_record(
+                _edge_endpoint_record(endpoint_key="disabled-edge", status="disabled")
+            )
+            loaded_record = store.read_edge_endpoint_record("cm-prod-dokploy")
+            active_records = store.list_edge_endpoint_records(provider="dokploy", status="active")
+            store.close()
+
+        self.assertEqual(loaded_record.server_name, "docker-cm-prod")
+        self.assertEqual(loaded_record.upstream_host, "100.73.170.113")
+        self.assertEqual(loaded_record.upstream_scheme, "https")
+        self.assertEqual(loaded_record.upstream_port, 443)
+        self.assertEqual([record.endpoint_key for record in active_records], ["cm-prod-dokploy"])
+
+    def test_edge_endpoint_record_rejects_hostname_upstream(self) -> None:
+        with self.assertRaises(ValueError):
+            _edge_endpoint_record(upstream_host="dokploy.shiny")
 
     def test_write_and_list_runtime_environment_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -757,11 +757,16 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             workflow_text,
         )
         self.assertIn(
+            'error("forward_host and edge_endpoint_key are mutually exclusive")',
+            workflow_text,
+        )
+        self.assertIn(
             'error("route_options_json contains unsupported route option key(s)")',
             workflow_text,
         )
         inputs_section = workflow_text.split("permissions:", maxsplit=1)[0]
-        self.assertEqual(inputs_section.count("        description:"), 10)
+        self.assertEqual(inputs_section.count("        description:"), 11)
+        self.assertIn("edge_endpoint_key:", inputs_section)
         self.assertIn('default: ""', inputs_section)
         self.assertNotIn("identity_access_provider:", inputs_section)
         self.assertNotIn("identity_access_send_basic_auth:", inputs_section)
@@ -866,6 +871,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("CONFIRMATION: ${{ inputs.confirmation }}", workflow_text)
         self.assertIn("APPLY LAUNCHPLANE INGRESS ROUTE", workflow_text)
         self.assertIn("route_json:", workflow_text)
+        self.assertIn("route.edge_endpoint_key", workflow_text)
         self.assertIn("route_json.route.domain_names must be non-empty", workflow_text)
         self.assertIn('option("allow_create"; false) as $allow_create', workflow_text)
         self.assertIn("($input.expected_host_id // null) as $expected_host_id", workflow_text)
@@ -1227,6 +1233,16 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             "deploy:local-operator-public-ingress-notification-policy-grant",
             script_text,
         )
+
+    def test_deploy_authz_grants_include_local_operator_edge_endpoint_authority(
+        self,
+    ) -> None:
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
+
+        self.assertIn("edge_endpoint.apply", script_text)
+        self.assertIn("edge_endpoint.read", script_text)
+        self.assertIn("deploy:local-operator-edge-endpoint-apply-grant", script_text)
+        self.assertIn("deploy:local-operator-edge-endpoint-read-grant", script_text)
 
     def test_deploy_authz_grants_skip_local_operator_product_config_without_scopes(
         self,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -37,6 +37,8 @@ from control_plane.contracts.driver_descriptor import DriverActionDescriptor, Dr
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointStatus
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.merge_train_policy import MergeTrainPolicy
 from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
@@ -194,6 +196,7 @@ from control_plane.workflows.ingress_provider import NpmplusIngressProvider
 from control_plane.workflows.npmplus_ingress import (
     NpmplusIngressApplyRequest,
     NpmplusIngressApplyResult,
+    NpmplusIngressRouteDesiredState,
 )
 
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
@@ -1453,6 +1456,44 @@ def _npmplus_ingress_route_payload(
     }
 
 
+def _npmplus_proxy_host(**overrides: object) -> NpmplusProxyHost:
+    payload = NpmplusIngressRouteDesiredState(
+        domain_names=("ingress-canary.example.test",),
+        forward_scheme="https",
+        forward_host="100.73.170.113",
+        forward_port=443,
+        certificate_id=47,
+    ).to_proxy_host_payload()
+    return NpmplusProxyHost.model_validate(
+        {"id": 79, **payload.model_dump(mode="json"), "enabled": True, **overrides}
+    )
+
+
+def _edge_endpoint_record(*, status: EdgeEndpointStatus = "active") -> EdgeEndpointRecord:
+    return EdgeEndpointRecord(
+        endpoint_key="cm-prod-dokploy",
+        provider="dokploy",
+        server_name="docker-cm-prod",
+        upstream_host="100.73.170.113",
+        upstream_host_kind="ip",
+        upstream_scheme="https",
+        upstream_port=443,
+        status=status,
+        updated_at="2026-06-07T00:00:00Z",
+        source_label="test:edge-endpoint",
+    )
+
+
+def _edge_endpoint_apply_payload(*, mode: str = "dry-run") -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "mode": mode,
+        "endpoint": _edge_endpoint_record().model_dump(mode="json"),
+        "reason": "test edge endpoint apply",
+        "confirmation": "APPLY LAUNCHPLANE EDGE ENDPOINT" if mode == "apply" else "",
+    }
+
+
 def _meta_product_config_payload(
     *, mode: str = "dry-run", reason: str | None = None
 ) -> dict[str, object]:
@@ -2512,6 +2553,251 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ("route", "upstream", "certificate", "tls", "provider_options"),
         )
         self.assertEqual(records[0].trace_id, payload["trace_id"])
+
+    def test_edge_endpoint_apply_and_read_routes_store_db_backed_upstream(self) -> None:
+        policy = _local_operator_policy(
+            actions=("edge_endpoint.apply", "edge_endpoint.read"),
+            products=("launchplane",),
+            contexts=("launchplane",),
+        )
+        endpoint_payload = _edge_endpoint_apply_payload(mode="apply")
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = FilesystemRecordStore(root / "state")
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=root / "state",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                apply_status_code, apply_payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/edge-endpoints/apply",
+                    payload=endpoint_payload,
+                    authorization="Bearer local-operator-token",
+                    headers={"Idempotency-Key": "edge-endpoint-apply"},
+                )
+                read_status_code, read_payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/edge-endpoints/records/cm-prod-dokploy",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(apply_status_code, 202)
+        self.assertEqual(apply_payload["records"]["edge_endpoint_key"], "cm-prod-dokploy")
+        self.assertEqual(apply_payload["records"]["edge_endpoint_status"], "applied")
+        self.assertEqual(read_status_code, 200)
+        self.assertEqual(read_payload["record"]["server_name"], "docker-cm-prod")
+        self.assertEqual(read_payload["record"]["upstream_host"], "100.73.170.113")
+
+    def test_edge_endpoint_dry_run_does_not_store_upstream(self) -> None:
+        policy = _local_operator_policy(
+            actions=("edge_endpoint.apply", "edge_endpoint.read"),
+            products=("launchplane",),
+            contexts=("launchplane",),
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = FilesystemRecordStore(root / "state")
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
+                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
+                },
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=root / "state",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    local_record_store_for_tests=record_store,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/edge-endpoints/apply",
+                    payload=_edge_endpoint_apply_payload(mode="dry-run"),
+                    authorization="Bearer local-operator-token",
+                )
+                read_status_code, read_payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/edge-endpoints/records/cm-prod-dokploy",
+                    authorization="Bearer local-operator-token",
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["records"]["edge_endpoint_status"], "planned")
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertEqual(payload["result"]["endpoint_key"], "cm-prod-dokploy")
+        self.assertEqual(read_status_code, 404)
+        self.assertEqual(read_payload["status"], "rejected")
+        self.assertEqual(read_payload["error"]["code"], "not_found")
+
+    def test_npmplus_ingress_route_resolves_edge_endpoint_key_to_ip(self) -> None:
+        client = _FakeNpmplusIngressClient((_npmplus_proxy_host(),))
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = FilesystemRecordStore(root / "state")
+            record_store.write_edge_endpoint_record(_edge_endpoint_record())
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=record_store,
+                npmplus_ingress_client_factory=lambda: client,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/ingress/route-apply",
+                payload=_npmplus_ingress_route_payload(
+                    edge_endpoint_key="cm-prod-dokploy",
+                    forward_host="",
+                    forward_scheme="http",
+                    forward_port=80,
+                ),
+                headers={"Idempotency-Key": "npmplus-ingress-edge-dry-run"},
+            )
+            records = record_store.list_ingress_route_audit_records(
+                product="launchplane", context_name="reon-prod"
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["status"], "unchanged")
+        self.assertEqual(
+            payload["result"]["operations"][0]["change_categories"],
+            [],
+        )
+        self.assertEqual(client.calls, ["list"])
+        self.assertEqual(records[0].edge_endpoint_key, "cm-prod-dokploy")
+
+    def test_npmplus_ingress_route_rejects_missing_edge_endpoint_key(self) -> None:
+        client = _FakeNpmplusIngressClient()
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = FilesystemRecordStore(root / "state")
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=record_store,
+                npmplus_ingress_client_factory=lambda: client,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/ingress/route-apply",
+                payload=_npmplus_ingress_route_payload(
+                    edge_endpoint_key="cm-prod-dokploy",
+                    forward_host="",
+                ),
+                headers={"Idempotency-Key": "npmplus-ingress-edge-missing"},
+            )
+            records = record_store.list_ingress_route_audit_records(
+                product="launchplane", context_name="reon-prod"
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_edge_endpoint")
+        self.assertIn("was not found", payload["error"]["message"])
+        self.assertEqual(client.calls, [])
+        self.assertEqual(records, ())
+
+    def test_npmplus_ingress_route_rejects_disabled_edge_endpoint_key(self) -> None:
+        client = _FakeNpmplusIngressClient()
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["launchplane"],
+                        "contexts": ["reon-prod"],
+                        "actions": ["ingress_route.plan"],
+                    }
+                ]
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = FilesystemRecordStore(root / "state")
+            record_store.write_edge_endpoint_record(_edge_endpoint_record(status="disabled"))
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                local_record_store_for_tests=record_store,
+                npmplus_ingress_client_factory=lambda: client,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/ingress/route-apply",
+                payload=_npmplus_ingress_route_payload(
+                    edge_endpoint_key="cm-prod-dokploy",
+                    forward_host="",
+                ),
+                headers={"Idempotency-Key": "npmplus-ingress-edge-disabled"},
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["error"]["code"], "invalid_edge_endpoint")
+        self.assertEqual(client.calls, [])
 
     def test_ingress_route_audit_record_api_lists_and_reads_records(self) -> None:
         client = _FakeNpmplusIngressClient()


### PR DESCRIPTION
## Summary
- add DB-backed Launchplane edge endpoint records for Dokploy/NPM+ upstream source of truth
- add edge endpoint apply/read service routes and operator workflow
- resolve NPM+ ingress route edge_endpoint_key to stored IP/scheme/port and fail closed on missing/disabled endpoints
- document NPM+ IP-only upstream ownership plus future Cloudflare/AuthentiK driver issues

## Review
- Claude + Antigravity reviewed before fixes: no blockers, polish applied
- Claude + Antigravity reviewed after fixes: no blockers

## Tests
- uv run python -m unittest
- uv run --extra dev ruff check .
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff format --check <changed Python files>

Note: full repo ruff format --check still has unrelated pre-existing formatting debt outside this branch; touched Python files pass format check.