### PR TITLE
Authorize edge endpoint workflow

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -488,6 +488,16 @@ post_grant \
 	dokploy_target.setup \
 	deploy:dokploy-target-setup-grant \
 	dokploy-target-setup
+post_launchplane_service_grant \
+	edge-endpoint-apply.yml \
+	edge_endpoint.apply \
+	deploy:edge-endpoint-apply-workflow-grant \
+	edge-endpoint-apply-workflow
+post_launchplane_service_grant \
+	edge-endpoint-apply.yml \
+	edge_endpoint.read \
+	deploy:edge-endpoint-read-workflow-grant \
+	edge-endpoint-read-workflow
 post_terminal_agent_grant \
 	launchplane \
 	launchplane \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1234,13 +1234,16 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             script_text,
         )
 
-    def test_deploy_authz_grants_include_local_operator_edge_endpoint_authority(
+    def test_deploy_authz_grants_include_edge_endpoint_authority(
         self,
     ) -> None:
         script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
 
+        self.assertIn("edge-endpoint-apply.yml", script_text)
         self.assertIn("edge_endpoint.apply", script_text)
         self.assertIn("edge_endpoint.read", script_text)
+        self.assertIn("deploy:edge-endpoint-apply-workflow-grant", script_text)
+        self.assertIn("deploy:edge-endpoint-read-workflow-grant", script_text)
         self.assertIn("deploy:local-operator-edge-endpoint-apply-grant", script_text)
         self.assertIn("deploy:local-operator-edge-endpoint-read-grant", script_text)
 


### PR DESCRIPTION
## Summary
- grant the new Edge Endpoint Apply workflow GitHub OIDC authority for edge_endpoint.apply/read on launchplane/launchplane
- keep the existing local-operator bearer grants for operator/API use
- update the authz grant coverage test

## Why
The deployed /v1/edge-endpoints/apply route is reachable, but the workflow dry-run failed with 403 authorization_denied because only local-operator grants were seeded. Trace: launchplane_req_89fb7fcb963e47fe8379feab33abf12b.

## Tests
- bash -n scripts/deploy/ensure-authz-grants.sh
- shfmt -d scripts/deploy/ensure-authz-grants.sh
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_edge_endpoint_authority
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev mypy tests/test_product_onboarding.py