### PR TITLE
Improve Dokploy compose web log selection

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -956,7 +956,10 @@ def fetch_dokploy_compose_logs(
 
 def _select_compose_log_container(containers: list[JsonObject]) -> JsonObject:
     for container in containers:
-        if _compose_log_container_is_web(container):
+        if _compose_log_container_has_web_service(container):
+            return container
+    for container in containers:
+        if _compose_log_container_has_web_name(container):
             return container
     for container in containers:
         if str(container.get("containerId") or "").strip():
@@ -965,18 +968,65 @@ def _select_compose_log_container(containers: list[JsonObject]) -> JsonObject:
 
 
 def _compose_log_container_is_web(container: JsonObject) -> bool:
-    service_name = str(container.get("serviceName") or "").strip().lower()
-    if service_name == "web":
-        return True
-    labels = container.get("labels")
-    if isinstance(labels, dict):
-        label_service = str(labels.get("com.docker.compose.service") or "").strip().lower()
-        if label_service == "web":
+    return _compose_log_container_has_web_service(container) or _compose_log_container_has_web_name(
+        container
+    )
+
+
+def _compose_log_container_has_web_service(container: JsonObject) -> bool:
+    for service_name in _compose_log_container_service_names(container):
+        if service_name == "web":
             return True
-    container_name = str(container.get("name") or "").strip().lower().strip("/")
-    if not container_name:
+    return False
+
+
+def _compose_log_container_has_web_name(container: JsonObject) -> bool:
+    for container_name in _compose_log_container_names(container):
+        if _compose_log_container_name_is_web(container_name):
+            return True
+    return False
+
+
+def _compose_log_container_service_names(container: JsonObject) -> tuple[str, ...]:
+    service_names: list[str] = []
+    for key in ("serviceName", "Service", "composeServiceName"):
+        value = str(container.get(key) or "").strip().lower()
+        if value:
+            service_names.append(value)
+    for labels_key in ("labels", "Labels"):
+        labels = container.get(labels_key)
+        if isinstance(labels, dict):
+            for label_key, label_value in labels.items():
+                if str(label_key).strip().lower() == "com.docker.compose.service":
+                    value = str(label_value or "").strip().lower()
+                    if value:
+                        service_names.append(value)
+    return tuple(service_names)
+
+
+def _compose_log_container_names(container: JsonObject) -> tuple[str, ...]:
+    names: list[str] = []
+    for key in ("name", "Name", "containerName", "container_name"):
+        value = str(container.get(key) or "").strip()
+        if value:
+            names.append(value)
+    for key in ("names", "Names"):
+        values = container.get(key)
+        if isinstance(values, list):
+            for raw_name in values:
+                if raw_name is None:
+                    continue
+                normalized_value = str(raw_name).strip()
+                if normalized_value:
+                    names.append(normalized_value)
+    return tuple(names)
+
+
+def _compose_log_container_name_is_web(container_name: str) -> bool:
+    normalized_name = container_name.strip().lower().strip("/")
+    if not normalized_name:
         return False
-    name_parts = tuple(part for part in re.split(r"[-_.]+", container_name) if part)
+    name_parts = tuple(part for part in re.split(r"[-_.]+", normalized_name) if part)
     if not name_parts:
         return False
     service_part = (

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -448,6 +448,127 @@ class DokployConfigTests(unittest.TestCase):
         query = cast(dict[str, object], requests[1]["query"])
         self.assertEqual(query["containerId"], "web")
 
+    def test_fetch_compose_logs_prefers_web_container_pascal_case_label(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "db", "Name": "/tenant-database-1"},
+                    {
+                        "containerId": "web",
+                        "Name": "/tenant-runtime-1",
+                        "Labels": {"com.docker.compose.service": "web"},
+                    },
+                ]
+            return {"logs": "web log"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("web log",))
+        query = cast(dict[str, object], requests[1]["query"])
+        self.assertEqual(query["containerId"], "web")
+
+    def test_fetch_compose_logs_prefers_service_match_over_name_fallback(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "sidecar", "Name": "/tenant-cron-web-1"},
+                    {"containerId": "web", "serviceName": "web"},
+                ]
+            return {"logs": "web log"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("web log",))
+        query = cast(dict[str, object], requests[1]["query"])
+        self.assertEqual(query["containerId"], "web")
+
+    def test_fetch_compose_logs_prefers_web_container_docker_name_variants(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "db", "Name": "/tenant-database-1"},
+                    {"containerId": "script", "containerName": "tenant_script-runner_1"},
+                    {"containerId": "web", "Names": ["/tenant-web-1"]},
+                ]
+            return {"logs": "web log"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("web log",))
+        query = cast(dict[str, object], requests[1]["query"])
+        self.assertEqual(query["containerId"], "web")
+
+    def test_fetch_compose_logs_prefers_web_container_service_variants(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "db", "Service": "database"},
+                    {
+                        "containerId": "web",
+                        "composeServiceName": "web",
+                        "Name": "/tenant-runtime-1",
+                    },
+                ]
+            return {"logs": "web log"}
+
+        with patch(
+            "control_plane.dokploy.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("web log",))
+        query = cast(dict[str, object], requests[1]["query"])
+        self.assertEqual(query["containerId"], "web")
+
     def test_environments_logs_resolves_tracked_application_and_redacts_output(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- broaden Dokploy compose log web-container selection across Docker/Dokploy payload variants
- prefer exact service/label matches before name-based fallback
- add targeted tests for PascalCase labels, Docker name variants, and sidecar precedence

## Verification
- uv run python -m unittest tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_calls_dokploy_read_logs_endpoint tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_name_variants tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_ignores_web_named_sidecar_containers tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_service_name tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_label tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_pascal_case_label tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_service_match_over_name_fallback tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_docker_name_variants tests.test_dokploy.DokployConfigTests.test_fetch_compose_logs_prefers_web_container_service_variants
- uv run --extra dev ruff format --check control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev ruff check control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev mypy control_plane/dokploy.py tests/test_dokploy.py

Reviewed by Claude and Gemini-family agents before PR; incorporated their sidecar precedence and PascalCase Labels coverage feedback.