### PR TITLE
Use Odoo runtime health for stable lanes

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -36,6 +36,7 @@ from control_plane.workflows.odoo_post_deploy import OdooPostDeployRequest, exec
 from control_plane.workflows.odoo_verification import (
     OdooVerificationEvidence,
     default_odoo_health_url,
+    is_legacy_derived_odoo_health_url,
     verify_odoo_stable_readiness,
 )
 from control_plane.runtime_key_safety import RuntimeKeySafetyPolicyReadStore
@@ -561,10 +562,15 @@ def _target_base_url(*, lane: ProductLaneProfile, domains: tuple[str, ...]) -> s
 def _target_health_url(
     *, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile, domains: tuple[str, ...]
 ) -> str:
-    if lane.health_url.strip():
-        return lane.health_url.strip()
     base_url = _target_base_url(lane=lane, domains=domains)
-    return default_odoo_health_url(base_url=base_url, health_path=profile.health_path)
+    lane_health_url = lane.health_url.strip()
+    if lane_health_url and not is_legacy_derived_odoo_health_url(
+        health_url=lane_health_url,
+        base_url=base_url,
+        profile_health_path=profile.health_path,
+    ):
+        return lane_health_url
+    return default_odoo_health_url(base_url=base_url)
 
 
 def _normalize_domain(raw_domain: str) -> str:

--- a/control_plane/workflows/odoo_verification.py
+++ b/control_plane/workflows/odoo_verification.py
@@ -7,7 +7,7 @@ import re
 import time
 from typing import Literal
 from urllib.error import HTTPError, URLError
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urljoin, urlparse, urlunsplit
 from urllib.request import Request, urlopen
 
 import click
@@ -72,6 +72,29 @@ def default_odoo_health_url(
     if not normalized_health_path.startswith("/"):
         normalized_health_path = f"/{normalized_health_path}"
     return f"{normalized_base_url}{normalized_health_path}"
+
+
+def is_legacy_derived_odoo_health_url(
+    *, health_url: str, base_url: str, profile_health_path: str
+) -> bool:
+    expected = default_odoo_health_url(base_url=base_url, health_path=profile_health_path)
+    return bool(expected) and _normalized_health_url(health_url) == _normalized_health_url(expected)
+
+
+def _normalized_health_url(raw_url: str) -> str:
+    parsed = urlparse(raw_url.strip())
+    path = (parsed.path or "/").rstrip("/") or "/"
+    if parsed.params:
+        path = f"{path};{parsed.params}"
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            parsed.netloc.lower(),
+            path,
+            parsed.query,
+            "",
+        )
+    )
 
 
 def verify_odoo_stable_readiness(

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -8,6 +8,7 @@ from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.product_onboarding_manifest import (
+    ProductOnboardingLaneManifest,
     ProductOnboardingManifest,
     ProductOnboardingSecretBindingManifest,
 )
@@ -94,7 +95,7 @@ def build_product_profile_record(
                 instance=lane.instance,
                 context=lane.context,
                 base_url=lane.base_url,
-                health_url=lane.health_url or _health_url(lane.base_url, manifest.health_path),
+                health_url=_lane_health_url(manifest=manifest, lane=lane),
                 odoo_stable_bootstrap=lane.odoo_stable_bootstrap,
                 odoo_prelaunch_rebuild=lane.odoo_prelaunch_rebuild,
                 odoo_data_policy=lane.odoo_data_policy,
@@ -109,6 +110,15 @@ def build_product_profile_record(
         updated_at=updated_at,
         source=manifest.source_label,
     )
+
+
+def _lane_health_url(*, manifest: ProductOnboardingManifest, lane: ProductOnboardingLaneManifest) -> str:
+    health_url = lane.health_url.strip()
+    if health_url:
+        return health_url
+    if manifest.driver_id == "odoo":
+        return ""
+    return _health_url(lane.base_url, manifest.health_path)
 
 
 def _merged_historical_contexts(

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -44,6 +44,10 @@ from control_plane.contracts.runtime_identity import (
     health_payload_runtime_identity_status,
 )
 from control_plane.drivers.registry import read_driver_descriptor
+from control_plane.workflows.odoo_verification import (
+    default_odoo_health_url,
+    is_legacy_derived_odoo_health_url,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -205,9 +209,7 @@ def discover_public_ingress_monitor_targets(
             if not lane.public_ingress_monitoring.enabled:
                 continue
             base_url = lane.base_url.strip().rstrip("/")
-            health_url = (
-                lane.health_url.strip() or _health_url(base_url, profile.health_path)
-            ).strip()
+            health_url = _monitor_health_url(profile=profile, lane=lane, base_url=base_url)
             if not (base_url or health_url):
                 continue
             targets.append(
@@ -811,7 +813,27 @@ def _failure_summary(code: PublicIngressFailureCode) -> str:
 def _health_url(base_url: str, health_path: str) -> str:
     if not base_url.strip():
         return ""
-    return f"{base_url.rstrip('/')}{health_path}"
+    normalized_health_path = health_path.strip()
+    if not normalized_health_path.startswith("/"):
+        normalized_health_path = f"/{normalized_health_path}"
+    return f"{base_url.rstrip('/')}{normalized_health_path}"
+
+
+def _monitor_health_url(
+    *, profile: LaunchplaneProductProfileRecord, lane: ProductLaneProfile, base_url: str
+) -> str:
+    lane_health_url = lane.health_url.strip()
+    if profile.driver_id == "odoo":
+        if lane_health_url and not is_legacy_derived_odoo_health_url(
+            health_url=lane_health_url,
+            base_url=base_url,
+            profile_health_path=profile.health_path,
+        ):
+            return lane_health_url
+        return default_odoo_health_url(base_url=base_url)
+    if lane_health_url:
+        return lane_health_url
+    return _health_url(base_url, profile.health_path).strip()
 
 
 def _normalized_url(url: str) -> str:

--- a/import-material/launchplane/seed-imports/catalog.json
+++ b/import-material/launchplane/seed-imports/catalog.json
@@ -795,7 +795,7 @@
             "instance": "testing",
             "context": "cm_website",
             "base_url": "https://cm-website-testing.shinycomputers.com",
-            "health_url": "https://cm-website-testing.shinycomputers.com/cm-website/health",
+            "health_url": "https://cm-website-testing.shinycomputers.com/launchplane/health",
             "odoo_data_policy": {
               "data_authority": "resettable",
               "allowed_rebuild_sources": ["empty"],
@@ -808,7 +808,7 @@
             "instance": "prod",
             "context": "cm_website",
             "base_url": "https://www.cellmechanic.com",
-            "health_url": "https://www.cellmechanic.com/cm-website/health",
+            "health_url": "https://www.cellmechanic.com/launchplane/health",
             "odoo_data_policy": {
               "data_authority": "resettable",
               "allowed_rebuild_sources": ["empty"],

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -63,7 +63,7 @@ def _verification_result() -> OdooVerificationResult:
         logo_status="pass",
         evidence=OdooVerificationEvidence(
             base_url="https://cm-testing.shinycomputers.com",
-            health_url="https://cm-testing.shinycomputers.com/web/health",
+            health_url="https://cm-testing.shinycomputers.com/launchplane/health",
             canonical_url="https://cm-testing.shinycomputers.com",
             logo_urls=("https://cm-testing.shinycomputers.com/web/image/website/1/logo",),
         ),
@@ -77,7 +77,7 @@ def _verification_failure_result() -> OdooVerificationResult:
         logo_status="skipped",
         evidence=OdooVerificationEvidence(
             base_url="https://cm-testing.shinycomputers.com",
-            health_url="https://cm-testing.shinycomputers.com/web/health",
+            health_url="https://cm-testing.shinycomputers.com/launchplane/health",
             canonical_url="https://cm-testing.shinycomputers.com",
         ),
         error_message="canonical failed",
@@ -263,14 +263,14 @@ class OdooStableBootstrapTests(unittest.TestCase):
         self.assertEqual(post_deploy_mock.call_args.kwargs["request"].phase, "deploy")
         verify_readiness.assert_called_once_with(
             base_url="https://cm-testing.shinycomputers.com",
-            health_url="https://cm-testing.shinycomputers.com/web/health",
+            health_url="https://cm-testing.shinycomputers.com/launchplane/health",
             verify_health=True,
             verify_canonical=True,
             verify_logo=True,
             timeout_seconds=30,
             retry_interval_seconds=5,
         )
-        self.assertEqual(result.health_url, "https://cm-testing.shinycomputers.com/web/health")
+        self.assertEqual(result.health_url, "https://cm-testing.shinycomputers.com/launchplane/health")
         self.assertEqual(result.canonical_url, "https://cm-testing.shinycomputers.com")
         self.assertEqual(
             result.logo_urls,

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -44,6 +44,7 @@ from control_plane.workflows.odoo_stable_target_replacement import (
     DokployRequest,
     build_odoo_stable_target_replacement_plan,
     execute_odoo_stable_target_replacement_apply,
+    _target_health_url,
 )
 from control_plane.workflows.odoo_verification import (
     OdooVerificationEvidence,
@@ -188,7 +189,7 @@ def _verification_result() -> OdooVerificationResult:
         logo_status="pass",
         evidence=OdooVerificationEvidence(
             base_url="https://cm-testing.shinycomputers.com",
-            health_url="https://cm-testing.shinycomputers.com/web/health",
+            health_url="https://cm-testing.shinycomputers.com/launchplane/health",
             canonical_url="https://cm-testing.shinycomputers.com",
             logo_urls=("https://cm-testing.shinycomputers.com/web/image/website/1/logo",),
         ),
@@ -653,6 +654,55 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 ),
             )
 
+    def test_target_health_url_uses_odoo_runtime_identity_path(self) -> None:
+        profile = _profile().model_copy(update={"health_path": "/cm-website/health"})
+        lane = profile.lanes[0]
+
+        health_url = _target_health_url(
+            profile=profile,
+            lane=lane,
+            domains=("cm-website-testing.shinycomputers.com",),
+        )
+
+        self.assertEqual(
+            health_url,
+            "https://cm-website-testing.shinycomputers.com/launchplane/health",
+        )
+
+    def test_target_health_url_ignores_stale_derived_product_health_url(self) -> None:
+        profile = _profile().model_copy(update={"health_path": "/cm-website/health"})
+        lane = profile.lanes[0].model_copy(
+            update={
+                "base_url": "https://cm-website-testing.shinycomputers.com/",
+                "health_url": "HTTPS://CM-WEBSITE-TESTING.SHINYCOMPUTERS.COM/cm-website/health/",
+            }
+        )
+
+        health_url = _target_health_url(
+            profile=profile,
+            lane=lane,
+            domains=("cm-website-testing.shinycomputers.com",),
+        )
+
+        self.assertEqual(
+            health_url,
+            "https://cm-website-testing.shinycomputers.com/launchplane/health",
+        )
+
+    def test_target_health_url_allows_explicit_lane_override(self) -> None:
+        profile = _profile().model_copy(update={"health_path": "/cm-website/health"})
+        lane = profile.lanes[0].model_copy(
+            update={"health_url": "https://internal.example.test/web/health"}
+        )
+
+        health_url = _target_health_url(
+            profile=profile,
+            lane=lane,
+            domains=("cm-website-testing.shinycomputers.com",),
+        )
+
+        self.assertEqual(health_url, "https://internal.example.test/web/health")
+
     def test_apply_recreates_target_in_place_and_writes_breadcrumb_inventory(self) -> None:
         store = _Store(
             target_record=_target_record(),
@@ -873,14 +923,14 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertFalse(post_deploy.call_args.kwargs["run_destructive_restore"])
         verify_readiness.assert_called_once_with(
             base_url="https://cm-testing.shinycomputers.com",
-            health_url="https://cm-testing.shinycomputers.com/web/health",
+            health_url="https://cm-testing.shinycomputers.com/launchplane/health",
             verify_health=True,
             verify_canonical=True,
             verify_logo=True,
             timeout_seconds=180,
             retry_interval_seconds=5,
         )
-        self.assertEqual(result.health_url, "https://cm-testing.shinycomputers.com/web/health")
+        self.assertEqual(result.health_url, "https://cm-testing.shinycomputers.com/launchplane/health")
         self.assertEqual(result.canonical_url, "https://cm-testing.shinycomputers.com")
         self.assertEqual(
             result.logo_urls,

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1700,13 +1700,13 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                     "testing",
                     "cm_website",
                     "https://cm-website-testing.shinycomputers.com",
-                    "https://cm-website-testing.shinycomputers.com/cm-website/health",
+                    "https://cm-website-testing.shinycomputers.com/launchplane/health",
                 ),
                 (
                     "prod",
                     "cm_website",
                     "https://www.cellmechanic.com",
-                    "https://www.cellmechanic.com/cm-website/health",
+                    "https://www.cellmechanic.com/launchplane/health",
                 ),
             ],
         )
@@ -1727,6 +1727,34 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(
             manifest.source_label,
             "import-material:odoo-cm-website-product-onboarding",
+        )
+
+    def test_apply_odoo_product_onboarding_keeps_runtime_identity_health_urls(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            manifest = ProductOnboardingManifest.model_validate(
+                _seed_import_manifest("odoo-cm-website-product-onboarding")
+            )
+
+            apply_product_onboarding_manifest(record_store=store, manifest=manifest)
+
+            profile = store.read_product_profile_record("odoo-tenant-cm-website")
+            store.close()
+
+        self.assertEqual(profile.driver_id, "odoo")
+        self.assertEqual(profile.health_path, "/cm-website/health")
+        self.assertEqual(
+            [(lane.instance, lane.health_url) for lane in profile.lanes],
+            [
+                (
+                    "testing",
+                    "https://cm-website-testing.shinycomputers.com/launchplane/health",
+                ),
+                ("prod", "https://www.cellmechanic.com/launchplane/health"),
+            ],
         )
 
     def test_seed_import_odoo_cm_onboarding_manifest_requires_prod_target_id(self) -> None:

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -263,12 +263,61 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(targets[0].health_url, "https://example.test/healthz")
 
     def test_discovers_inherited_generic_web_drivers(self) -> None:
-        store = _Store((_profile(driver_id="odoo"),))
+        store = _Store(
+            (
+                _profile(
+                    driver_id="odoo",
+                ).model_copy(update={"health_path": "/cm-website/health"}),
+            )
+        )
 
         targets = discover_public_ingress_monitor_targets(store)
 
         self.assertEqual(len(targets), 1)
         self.assertEqual(targets[0].driver_id, "odoo")
+        self.assertEqual(targets[0].health_url, "https://example.test/launchplane/health")
+
+    def test_discovers_odoo_targets_with_stale_derived_health_url(self) -> None:
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            base_url="https://example.test/",
+            health_url="HTTPS://EXAMPLE.TEST/cm-website/health/",
+            public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=True),
+        )
+        store = _Store(
+            (
+                _profile(driver_id="odoo", lane=lane).model_copy(
+                    update={"health_path": "/cm-website/health"}
+                ),
+            )
+        )
+
+        targets = discover_public_ingress_monitor_targets(store)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].health_url, "https://example.test/launchplane/health")
+
+    def test_discovers_odoo_targets_with_explicit_health_url_override(self) -> None:
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            base_url="https://example.test",
+            health_url="https://internal.example.test/web/health",
+            public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=True),
+        )
+        store = _Store(
+            (
+                _profile(driver_id="odoo", lane=lane).model_copy(
+                    update={"health_path": "/cm-website/health"}
+                ),
+            )
+        )
+
+        targets = discover_public_ingress_monitor_targets(store)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].health_url, "https://internal.example.test/web/health")
 
     def test_disabled_lane_is_not_monitored(self) -> None:
         lane = ProductLaneProfile(


### PR DESCRIPTION
## Summary
- default Odoo stable target replacement, bootstrap, and public ingress monitoring to Launchplane's runtime identity health path
- keep product-specific Odoo health paths out of generated lane health URLs while preserving explicit overrides
- detect stale derived Odoo lane health URLs and fall back to /launchplane/health
- update cm-website seed import health URLs to the Launchplane runtime health endpoint

## Validation
- uv run python -m unittest
- Claude review: no blockers; minor residual risks only
- Gemini review: clean; no blockers

## Notes
- This keeps LP owning Odoo lane verification. Product-specific health_path remains recorded, but stable lane verification uses /launchplane/health per docs/records.md.