### PR TITLE
Harden edge endpoint key handling

### DIFF
--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -189,6 +189,17 @@ jobs:
               npmplus_noindex: false,
               access_list_id: 0
             } + $route_options) as $route |
+            if (
+              (($route.forward_host // "") | length) == 0
+              and (($route.edge_endpoint_key // "") | length) == 0
+            ) then
+              error("route.forward_host or route.edge_endpoint_key is required")
+            elif (
+              (($route.forward_host // "") | length) != 0
+              and (($route.edge_endpoint_key // "") | length) != 0
+            ) then
+              error("route.forward_host and route.edge_endpoint_key are mutually exclusive")
+            else
             {
               schema_version: 1,
               product: $product,
@@ -205,6 +216,7 @@ jobs:
                 route: $route
               }
             }
+            end
             end' >"$payload_file"
           echo "payload_file=$payload_file" >>"$GITHUB_OUTPUT"
 

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -570,13 +570,17 @@ class FilesystemRecordStore:
         return self._write_model("launchplane_ingress_route_audits", record.record_id, record)
 
     def write_edge_endpoint_record(self, record: EdgeEndpointRecord) -> Path:
-        return self._write_model("launchplane_edge_endpoints", record.endpoint_key, record)
+        return self._write_model(
+            "launchplane_edge_endpoints",
+            _edge_endpoint_record_id(record.endpoint_key),
+            record,
+        )
 
     def read_edge_endpoint_record(self, endpoint_key: str) -> EdgeEndpointRecord:
         return self._read_model(
             EdgeEndpointRecord,
             "launchplane_edge_endpoints",
-            endpoint_key,
+            _edge_endpoint_record_id(endpoint_key),
         )
 
     def list_edge_endpoint_records(
@@ -1411,3 +1415,7 @@ def _odoo_stable_bootstrap_lane_reservation_id(
 def _runner_host_hygiene_audit_record_id(audit_record_key: str) -> str:
     digest = hashlib.sha256(audit_record_key.encode()).hexdigest()[:16]
     return audit_record_key.strip().replace("/", "-") + f"-{digest}"
+
+
+def _edge_endpoint_record_id(endpoint_key: str) -> str:
+    return endpoint_key.replace("/", "%2F").replace("\\", "%5C")

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -14,6 +14,7 @@ from control_plane.contracts.artifact_identity import (
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deploy_target import DeployedTargetReference
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
@@ -305,6 +306,52 @@ def _merge_train_stack_collapse_plan_record(
 
 
 class FilesystemRecordStoreTests(unittest.TestCase):
+    def test_write_read_and_list_edge_endpoint_records_escape_endpoint_key_paths(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            escaped_record = EdgeEndpointRecord(
+                endpoint_key="../cm-prod/dokploy",
+                provider="dokploy",
+                server_name="docker-cm-prod",
+                upstream_host="100.73.170.113",
+                upstream_host_kind="ip",
+                upstream_scheme="https",
+                upstream_port=443,
+                status="active",
+                updated_at="2026-06-07T00:00:00Z",
+                source_label="test:edge-endpoint",
+            )
+            disabled_record = escaped_record.model_copy(
+                update={
+                    "endpoint_key": "disabled:edge",
+                    "status": "disabled",
+                }
+            )
+
+            written_path = store.write_edge_endpoint_record(escaped_record)
+            store.write_edge_endpoint_record(disabled_record)
+            loaded_record = store.read_edge_endpoint_record("../cm-prod/dokploy")
+            active_records = store.list_edge_endpoint_records(
+                provider="dokploy",
+                status="active",
+            )
+            preserved_safe_key_path_exists = (
+                state_dir / "launchplane_edge_endpoints" / "disabled:edge.json"
+            ).exists()
+
+        self.assertEqual(
+            written_path.parent.relative_to(state_dir).as_posix(),
+            "launchplane_edge_endpoints",
+        )
+        self.assertEqual(written_path.name, "..%2Fcm-prod%2Fdokploy.json")
+        self.assertTrue(preserved_safe_key_path_exists)
+        self.assertFalse((state_dir / "cm-prod" / "dokploy.json").exists())
+        self.assertEqual(loaded_record.endpoint_key, "../cm-prod/dokploy")
+        self.assertEqual([record.endpoint_key for record in active_records], ["../cm-prod/dokploy"])
+
     def test_write_and_list_runner_host_hygiene_audit_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -761,9 +761,21 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             workflow_text,
         )
         self.assertIn(
+            'error("route.forward_host or route.edge_endpoint_key is required")',
+            workflow_text,
+        )
+        self.assertIn(
+            'error("route.forward_host and route.edge_endpoint_key are mutually exclusive")',
+            workflow_text,
+        )
+        self.assertIn(
             'error("route_options_json contains unsupported route option key(s)")',
             workflow_text,
         )
+        self.assertIn("forward_host: $forward_host", workflow_text)
+        self.assertIn("edge_endpoint_key: $edge_endpoint_key", workflow_text)
+        self.assertNotIn('                "forward_host",', workflow_text)
+        self.assertNotIn('                "edge_endpoint_key",', workflow_text)
         inputs_section = workflow_text.split("permissions:", maxsplit=1)[0]
         self.assertEqual(inputs_section.count("        description:"), 11)
         self.assertIn("edge_endpoint_key:", inputs_section)


### PR DESCRIPTION
## Summary
- escape path separators in filesystem-backed edge endpoint keys before using them as filenames
- preserve existing safe endpoint-key filenames by not re-encoding non-path characters
- revalidate ingress dry-run upstream selection after final route construction
- add filesystem and workflow contract tests for the reviewed failure modes

## Validation
- uv run python -m unittest tests.test_filesystem_store tests.test_product_onboarding
- uv run python -m unittest
- Claude review: no high-severity findings; residuals only
- Gemini review: flagged broad percent-encoding compatibility risk; addressed by escaping only / and \\ separators

## Notes
This is a focused follow-up for auto-review findings on edge endpoint path safety and ingress dry-run route validation. It is separate from the Odoo health contract PR.