### PR TITLE
Fix Odoo reusable workflow product scope

### DIFF
--- a/.github/actions/launchplane-request/action.yml
+++ b/.github/actions/launchplane-request/action.yml
@@ -176,6 +176,8 @@ outputs:
     description: Dynamic output exposed by output-paths.
   trace_id:
     description: Dynamic output exposed by output-paths.
+  website_bootstrap_included:
+    description: Dynamic output exposed by output-paths.
 
 runs:
   using: node24

--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -14,7 +14,8 @@ name: Reusable Odoo Artifact Publish
         type: string
       product:
         description: >-
-          Launchplane product profile key. Defaults to odoo-tenant-${context}.
+          Launchplane product profile key. Defaults to odoo-tenant-${context}
+          with underscores normalized to dashes.
         required: false
         default: ""
         type: string
@@ -232,7 +233,8 @@ jobs:
           set -euo pipefail
           product="$INPUT_PRODUCT"
           if [ -z "$product" ]; then
-            product="odoo-tenant-${CONTEXT_NAME}"
+            context_slug="${CONTEXT_NAME//_/-}"
+            product="odoo-tenant-${context_slug}"
           fi
           publish_scope="${product}:${CONTEXT_NAME}:${INSTANCE_NAME}"
           run_scope="run-${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"

--- a/.github/workflows/reusable-odoo-post-deploy.yml
+++ b/.github/workflows/reusable-odoo-post-deploy.yml
@@ -8,6 +8,13 @@ name: Reusable Odoo Post Deploy
         description: Launchplane Odoo context.
         required: true
         type: string
+      product:
+        description: >-
+          Optional Launchplane product key. Defaults to odoo-tenant-${context}
+          with underscores normalized to dashes.
+        required: false
+        default: ""
+        type: string
       instance:
         description: Odoo instance to run post-deploy against.
         required: true
@@ -33,6 +40,28 @@ name: Reusable Odoo Post Deploy
         required: false
         default: ""
         type: string
+    outputs:
+      post_deploy_status:
+        description: Odoo post-deploy status.
+        value: ${{ jobs.post-deploy.outputs.post_deploy_status }}
+      override_status:
+        description: Odoo override apply status.
+        value: ${{ jobs.post-deploy.outputs.override_status }}
+      override_record_found:
+        description: Whether an override record existed.
+        value: ${{ jobs.post-deploy.outputs.override_record_found }}
+      override_payload_rendered:
+        description: Whether an override payload was rendered.
+        value: ${{ jobs.post-deploy.outputs.override_payload_rendered }}
+      website_bootstrap_included:
+        description: Whether the typed website bootstrap payload was included.
+        value: ${{ jobs.post-deploy.outputs.website_bootstrap_included }}
+      applied_at:
+        description: Override apply timestamp.
+        value: ${{ jobs.post-deploy.outputs.applied_at }}
+      error_message:
+        description: Launchplane driver error message, when present.
+        value: ${{ jobs.post-deploy.outputs.error_message }}
 
 permissions:
   contents: read
@@ -40,25 +69,57 @@ permissions:
 
 jobs:
   post-deploy:
+    outputs:
+      post_deploy_status: ${{ steps.lp.outputs.post_deploy_status }}
+      override_status: ${{ steps.lp.outputs.override_status }}
+      override_record_found: ${{ steps.lp.outputs.override_record_found }}
+      override_payload_rendered: >-
+        ${{ steps.lp.outputs.override_payload_rendered }}
+      website_bootstrap_included: >-
+        ${{ steps.lp.outputs.website_bootstrap_included }}
+      applied_at: ${{ steps.lp.outputs.applied_at }}
+      error_message: ${{ steps.lp.outputs.error_message }}
     runs-on:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     steps:
+      - name: Resolve Launchplane product
+        id: product
+        env:
+          CONTEXT_NAME: ${{ inputs.context }}
+          PRODUCT_INPUT: ${{ inputs.product }}
+        run: |
+          product="$PRODUCT_INPUT"
+          if [ -z "$product" ]; then
+            context_slug="${CONTEXT_NAME//_/-}"
+            product="odoo-tenant-${context_slug}"
+          fi
+          {
+            echo "product=$product"
+            printf '%s=%s:%s:%s\n' \
+              idempotency_key \
+              odp \
+              "$CONTEXT_NAME" \
+              "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Request Launchplane Odoo post-deploy driver
         id: lp
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/post-deploy
           payload: >-
-            {"schema_version":1,"product":"odoo","post_deploy":{"schema_version":1}}
+            {"schema_version":1,"post_deploy":{"schema_version":1}}
           payload-fields: |-
+            product=${{ steps.product.outputs.product }}
             post_deploy.context=${{ inputs.context }}
             post_deploy.instance=${{ inputs.instance }}
             post_deploy.phase=${{ inputs.phase }}
           idempotency-key: >-
-            odp:${{ inputs.context }}:${{ github.run_id }}:${{ github.run_attempt }}
+            ${{ steps.product.outputs.idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
           fail-result-paths: result.post_deploy_status
           output-paths: >-
@@ -66,6 +127,7 @@ jobs:
             override_status=result.override_status,
             override_record_found=result.override_record_found,
             override_payload_rendered=result.override_payload_rendered,
+            website_bootstrap_included=result.website_bootstrap_included,
             applied_at=result.applied_at,
             error_message=result.error_message
 
@@ -76,8 +138,11 @@ jobs:
           OVERRIDE_RECORD_FOUND: ${{ steps.lp.outputs.override_record_found }}
           OVERRIDE_PAYLOAD_RENDERED: >-
             ${{ steps.lp.outputs.override_payload_rendered }}
+          WEBSITE_BOOTSTRAP_INCLUDED: >-
+            ${{ steps.lp.outputs.website_bootstrap_included }}
         run: |
           echo "post_deploy_status=$POST_DEPLOY_STATUS"
           echo "override_status=$OVERRIDE_STATUS"
           echo "override_record_found=$OVERRIDE_RECORD_FOUND"
           echo "override_payload_rendered=$OVERRIDE_PAYLOAD_RENDERED"
+          echo "website_bootstrap_included=$WEBSITE_BOOTSTRAP_INCLUDED"

--- a/.github/workflows/reusable-odoo-prod-promotion.yml
+++ b/.github/workflows/reusable-odoo-prod-promotion.yml
@@ -8,6 +8,13 @@ name: Reusable Odoo Prod Promotion
         description: Launchplane Odoo context.
         required: true
         type: string
+      product:
+        description: >-
+          Optional Launchplane product key. Defaults to odoo-tenant-${context}
+          with underscores normalized to dashes.
+        required: false
+        default: ""
+        type: string
       timeout-ms:
         description: Launchplane request timeout in milliseconds.
         required: false
@@ -36,22 +43,42 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     steps:
+      - name: Resolve Launchplane product
+        id: product
+        env:
+          CONTEXT_NAME: ${{ inputs.context }}
+          PRODUCT_INPUT: ${{ inputs.product }}
+        run: |
+          product="$PRODUCT_INPUT"
+          if [ -z "$product" ]; then
+            context_slug="${CONTEXT_NAME//_/-}"
+            product="odoo-tenant-${context_slug}"
+          fi
+          {
+            echo "product=$product"
+            printf '%s=%s:%s:%s\n' \
+              idempotency_key \
+              opp \
+              "$CONTEXT_NAME" \
+              "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Request Launchplane Odoo prod promotion
         id: lp
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/prod-promotion-run
           payload: >-
-            {"schema_version":1,"product":"odoo","run":{"schema_version":1}}
+            {"schema_version":1,"run":{"schema_version":1}}
           payload-fields: |-
+            product=${{ steps.product.outputs.product }}
             run.context=${{ inputs.context }}
             run.request_id=${{ github.run_id }}-${{ github.run_attempt }}
           idempotency-key: >-
-            opp:${{ inputs.context }}:${{ github.run_id }}:${{
-              github.run_attempt
-            }}
+            ${{ steps.product.outputs.idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
           fail-result-paths: >-
             result.run_status,result.promotion_status,

--- a/.github/workflows/reusable-odoo-prod-rollback.yml
+++ b/.github/workflows/reusable-odoo-prod-rollback.yml
@@ -8,6 +8,13 @@ name: Reusable Odoo Prod Rollback
         description: Launchplane Odoo context.
         required: true
         type: string
+      product:
+        description: >-
+          Optional Launchplane product key. Defaults to odoo-tenant-${context}
+          with underscores normalized to dashes.
+        required: false
+        default: ""
+        type: string
       artifact_id:
         description: Explicit Launchplane artifact ID to deploy back to prod.
         required: true
@@ -49,24 +56,54 @@ jobs:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     steps:
+      - name: Resolve Launchplane product
+        id: product
+        env:
+          CONTEXT_NAME: ${{ inputs.context }}
+          PRODUCT_INPUT: ${{ inputs.product }}
+        run: |
+          product="$PRODUCT_INPUT"
+          if [ -z "$product" ]; then
+            context_slug="${CONTEXT_NAME//_/-}"
+            product="odoo-tenant-${context_slug}"
+          fi
+          {
+            echo "product=$product"
+            printf '%s=%s:%s:%s\n' \
+              idempotency_key \
+              opr \
+              "$CONTEXT_NAME" \
+              "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          } >>"$GITHUB_OUTPUT"
+
       - name: Request Launchplane Odoo prod rollback
         id: lp
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/prod-rollback
-          payload: >-
-            {"schema_version":1,"product":"odoo","rollback":{"schema_version":1,"instance":"prod","source_channel":"testing"}}
+          payload: |-
+            {
+              "schema_version": 1,
+              "rollback": {
+                "schema_version": 1,
+                "instance": "prod",
+                "source_channel": "testing"
+              }
+            }
           payload-fields: |-
+            product=${{ steps.product.outputs.product }}
             rollback.context=${{ inputs.context }}
             rollback.promotion_record_id=${{ inputs.promotion_record_id }}
             rollback.artifact_id=${{ inputs.artifact_id }}
             rollback.reason=${{ inputs.reason }}
           idempotency-key: >-
-            opr:${{ inputs.context }}:${{ github.run_id }}:${{ github.run_attempt }}
+            ${{ steps.product.outputs.idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
-          fail-result-paths: result.rollback_status,result.rollback_health_status
+          fail-result-paths: >-
+            result.rollback_status,result.rollback_health_status
           output-paths: >-
             promotion_record_id=result.promotion_record_id,
             deployment_record_id=result.deployment_record_id,

--- a/.github/workflows/reusable-odoo-testing-deploy.yml
+++ b/.github/workflows/reusable-odoo-testing-deploy.yml
@@ -10,7 +10,8 @@ name: Reusable Odoo Testing Deploy
         type: string
       product:
         description: >-
-          Optional Launchplane product key. Defaults to odoo-tenant-${context}.
+          Optional Launchplane product key. Defaults to odoo-tenant-${context}
+          with underscores normalized to dashes.
         required: false
         default: ""
         type: string
@@ -94,29 +95,56 @@ jobs:
         env:
           CONTEXT_NAME: ${{ inputs.context }}
           PRODUCT_INPUT: ${{ inputs.product }}
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
         run: |
           product="$PRODUCT_INPUT"
           if [ -z "$product" ]; then
-            product="odoo-tenant-${CONTEXT_NAME}"
+            context_slug="${CONTEXT_NAME//_/-}"
+            product="odoo-tenant-${context_slug}"
           fi
-          echo "product=$product" >> "$GITHUB_OUTPUT"
+          run_scope="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          {
+            echo "product=$product"
+            printf '%s=%s:%s:%s:%s:%s:%s\n' \
+              idempotency_key \
+              odoo-target-replacement-apply \
+              "$product" \
+              testing \
+              reusable-testing \
+              "$ARTIFACT_ID" \
+              "$run_scope"
+          } >>"$GITHUB_OUTPUT"
 
       - name: Request Launchplane Odoo target replacement apply
         id: lp
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
-          launchplane-url: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ inputs.launchplane_audience }}
           route-path: /v1/drivers/odoo/target-replacement-apply
-          payload: >-
-            {"schema_version":1,"replacement":{"schema_version":1,"instance":"testing","strategy":"recreate-in-place","allow_empty_data":true,"data_source_mode":"existing","verify_health":true,"verify_canonical":true,"verify_logo":true,"no_cache":false}}
+          payload: |-
+            {
+              "schema_version": 1,
+              "replacement": {
+                "schema_version": 1,
+                "instance": "testing",
+                "strategy": "recreate-in-place",
+                "allow_empty_data": true,
+                "data_source_mode": "existing",
+                "verify_health": true,
+                "verify_canonical": true,
+                "verify_logo": true,
+                "no_cache": false
+              }
+            }
           payload-fields: |-
             product=${{ steps.product.outputs.product }}
             replacement.product=${{ steps.product.outputs.product }}
             replacement.artifact_id=${{ inputs.artifact_id }}
             replacement.source_git_ref=${{ inputs.source_git_ref }}
           idempotency-key: >-
-            odoo-target-replacement-apply:${{ steps.product.outputs.product }}:testing:reusable-testing:${{ inputs.artifact_id }}:${{ github.run_id }}:${{ github.run_attempt }}
+            ${{ steps.product.outputs.idempotency_key }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
           fail-result-paths: result.status
           output-paths: >-
@@ -127,7 +155,8 @@ jobs:
       - name: Poll target replacement operation
         id: poll
         env:
-          LAUNCHPLANE_URL: ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          LAUNCHPLANE_URL: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
           AUDIENCE: ${{ inputs.launchplane_audience }}
           OPERATION_ID: ${{ steps.lp.outputs.operation_id }}
           POLL_URL: ${{ steps.lp.outputs.poll_url }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -781,6 +781,13 @@ context only, and `context_instance` has both context and instance.
   and re-provision derived Odoo service-user API keys. Full database
   sanitization such as disabling mail servers and cron remains tied to explicit
   restore/bootstrap workflows, not ordinary prod image deploys.
+- Reusable Odoo GitHub workflows resolve the Launchplane product before calling
+  driver routes. Callers may pass `product` explicitly; otherwise the default is
+  `odoo-tenant-${context}` after normalizing underscores to dashes, so context
+  `cm_website` resolves to product `odoo-tenant-cm-website`. Post-deploy
+  workflow outputs include `website_bootstrap_included` so callers can prove
+  whether the typed website bootstrap payload was rendered into the remote data
+  workflow request.
 - `POST /v1/drivers/odoo/prod-rollback` rolls a prod-named Odoo lane back to
   the DB-backed `testing` release tuple for the same context. The driver owns
   rollback intent and promotion-record annotation, but the provider mutation runs

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -558,7 +558,8 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("product_repository:", workflow_text)
         self.assertIn("source_git_ref:", workflow_text)
         self.assertIn("PUBLISH LAUNCHPLANE ODOO ARTIFACT", workflow_text)
-        self.assertIn('product="odoo-tenant-${CONTEXT_NAME}"', workflow_text)
+        self.assertIn('context_slug="${CONTEXT_NAME//_/-}"', workflow_text)
+        self.assertIn('product="odoo-tenant-${context_slug}"', workflow_text)
         self.assertIn("/v1/drivers/odoo/artifact-publish-inputs", workflow_text)
         self.assertIn("/v1/drivers/odoo/artifact-publish", workflow_text)
         self.assertIn("product=${{ steps.product.outputs.product }}", workflow_text)
@@ -606,10 +607,40 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         )
 
         self.assertIn("/v1/drivers/odoo/target-replacement-apply", workflow_text)
-        self.assertIn('product="odoo-tenant-${CONTEXT_NAME}"', workflow_text)
+        self.assertIn('context_slug="${CONTEXT_NAME//_/-}"', workflow_text)
+        self.assertIn('product="odoo-tenant-${context_slug}"', workflow_text)
         self.assertIn("product=${{ steps.product.outputs.product }}", workflow_text)
-        self.assertIn('"instance":"testing"', workflow_text)
+        self.assertIn('"instance": "testing"', workflow_text)
         self.assertIn("replacement.artifact_id=${{ inputs.artifact_id }}", workflow_text)
+        self.assertIn("${{ steps.product.outputs.idempotency_key }}", workflow_text)
+
+    def test_reusable_odoo_post_deploy_uses_tenant_product_scope(self) -> None:
+        workflow_text = Path(".github/workflows/reusable-odoo-post-deploy.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("/v1/drivers/odoo/post-deploy", workflow_text)
+        self.assertIn('product="odoo-tenant-${context_slug}"', workflow_text)
+        self.assertIn('context_slug="${CONTEXT_NAME//_/-}"', workflow_text)
+        self.assertIn("product=${{ steps.product.outputs.product }}", workflow_text)
+        self.assertIn("${{ steps.product.outputs.idempotency_key }}", workflow_text)
+        self.assertIn("website_bootstrap_included=result.website_bootstrap_included", workflow_text)
+        self.assertNotIn('"product":"odoo"', workflow_text)
+
+    def test_reusable_odoo_prod_workflows_use_tenant_product_scope(self) -> None:
+        workflow_paths = (
+            Path(".github/workflows/reusable-odoo-prod-promotion.yml"),
+            Path(".github/workflows/reusable-odoo-prod-rollback.yml"),
+        )
+
+        for workflow_path in workflow_paths:
+            with self.subTest(workflow=workflow_path.name):
+                workflow_text = workflow_path.read_text(encoding="utf-8")
+                self.assertIn('context_slug="${CONTEXT_NAME//_/-}"', workflow_text)
+                self.assertIn('product="odoo-tenant-${context_slug}"', workflow_text)
+                self.assertIn("product=${{ steps.product.outputs.product }}", workflow_text)
+                self.assertIn("${{ steps.product.outputs.idempotency_key }}", workflow_text)
+                self.assertNotIn('"product":"odoo"', workflow_text)
 
     def test_odoo_website_bootstrap_override_requires_explicit_target_inputs(self) -> None:
         workflow_text = Path(".github/workflows/odoo-website-bootstrap-override.yml").read_text(


### PR DESCRIPTION
## Summary
- Resolve Odoo reusable workflow product scope from context with underscore-to-dash normalization, so `cm_website` maps to `odoo-tenant-cm-website`.
- Pass resolved product through Odoo artifact publish, testing deploy, post-deploy, prod promotion, and prod rollback driver payloads instead of hardcoded/global product values.
- Expose `website_bootstrap_included` from reusable post-deploy and document the product resolution contract.

## Verification
- `uv run python -m unittest tests.test_product_onboarding`
- `uv run python -m unittest`
- Claude/Gemini review completed; final blocker fixed: post-deploy/promotion/rollback idempotency keys preserve old `prefix:context:run:attempt` shape.

## Remaining live proof
- After merge/deploy, run cm-website post-deploy/target proof and confirm Launchplane accepts `product=odoo-tenant-cm-website` and reports `website_bootstrap_included`.
