### PR TITLE
Add runner registration driver audit path

### DIFF
--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -1,0 +1,168 @@
+---
+name: Runner Lane Registration
+
+"on":
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: owner/name repository to receive the runner lane.
+        required: true
+        type: string
+      lane_name:
+        description: Runner lane name to register.
+        required: true
+        type: string
+      registration_root:
+        description: Approved absolute runner registration root.
+        required: false
+        default: /opt/actions-runners
+        type: string
+      labels:
+        description: Comma-separated runner labels.
+        required: false
+        default: self-hosted,launchplane,launchplane-managed
+        type: string
+      audit_record_key:
+        description: Launchplane audit record key.
+        required: true
+        type: string
+      mutate:
+        description: Register the runner lane.
+        required: true
+        default: false
+        type: boolean
+      confirmation:
+        description: Required text when mutate=true.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: >-
+    runner-lane-registration-${{ inputs.repository }}-${{ inputs.lane_name }}
+  cancel-in-progress: false
+
+jobs:
+  runner-lane-registration:
+    runs-on:
+      - self-hosted
+      - launchplane
+      - chris-testing-ops-gate
+    env:
+      RUNNER_REGISTRATION_HOST: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_HOST }}
+      RUNNER_REGISTRATION_EXECUTION_LANE: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE }}
+      RUNNER_REGISTRATION_SERVICE_USER: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SERVICE_USER }}
+      LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Validate workflow configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${RUNNER_REGISTRATION_HOST:-}" ]; then
+            echo "Missing runner registration host variable." >&2
+            exit 1
+          fi
+          if [ -z "${RUNNER_REGISTRATION_EXECUTION_LANE:-}" ]; then
+            echo "Missing runner registration execution lane variable." >&2
+            exit 1
+          fi
+          if [ -z "${RUNNER_REGISTRATION_SERVICE_USER:-}" ]; then
+            echo "Missing runner registration service user variable." >&2
+            exit 1
+          fi
+          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
+            echo "Missing Launchplane public URL variable." >&2
+            exit 1
+          fi
+          if [ "$(id -un)" != "$RUNNER_REGISTRATION_SERVICE_USER" ]; then
+            echo "Runner must execute as expected service user." >&2
+            exit 1
+          fi
+          if [ "${{ inputs.mutate }}" = "true" ] &&
+            [ "${{ inputs.confirmation }}" != "register runner lane" ]; then
+            echo "mutate=true requires confirmation: register runner lane" >&2
+            exit 1
+          fi
+
+      - name: Read pre-registration inventory
+        shell: bash
+        env:
+          TARGET_REPOSITORY: ${{ inputs.repository }}
+          GH_TOKEN: ${{ secrets.LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Missing runner registration GitHub token secret." >&2
+            exit 1
+          fi
+          GITHUB_TOKEN="$GH_TOKEN" uv run launchplane work-graph \
+            runner-inventory \
+            --repository "$TARGET_REPOSITORY" \
+            > runner-lane-registration-pre-inventory.json
+
+      - name: Run runner lane registration executor
+        shell: bash
+        env:
+          TARGET_REPOSITORY: ${{ inputs.repository }}
+          LANE_NAME: ${{ inputs.lane_name }}
+          REGISTRATION_ROOT: ${{ inputs.registration_root }}
+          LABELS: ${{ inputs.labels }}
+          AUDIT_RECORD_KEY: ${{ inputs.audit_record_key }}
+          GH_TOKEN: ${{ secrets.LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "Missing runner registration GitHub token secret." >&2
+            exit 1
+          fi
+          label_args=()
+          IFS=',' read -r -a labels <<< "$LABELS"
+          for label in "${labels[@]}"; do
+            trimmed="$(xargs <<< "$label")"
+            if [ -n "$trimmed" ]; then
+              label_args+=(--label "$trimmed")
+            fi
+          done
+          mutate_flag=--dry-run
+          if [ "${{ inputs.mutate }}" = "true" ]; then
+            mutate_flag=--mutate
+          fi
+          GITHUB_TOKEN="$GH_TOKEN" uv run launchplane work-graph \
+            runner-lane-registration-executor \
+            --repository "$TARGET_REPOSITORY" \
+            --host-name "$RUNNER_REGISTRATION_HOST" \
+            --execution-lane "$RUNNER_REGISTRATION_EXECUTION_LANE" \
+            --service-user "$RUNNER_REGISTRATION_SERVICE_USER" \
+            --lane-name "$LANE_NAME" \
+            --registration-root "$REGISTRATION_ROOT" \
+            "${label_args[@]}" \
+            --audit-record-key "$AUDIT_RECORD_KEY" \
+            --allowed-repository "$TARGET_REPOSITORY" \
+            --approved-host "$RUNNER_REGISTRATION_HOST" \
+            --allowed-registration-root "$REGISTRATION_ROOT" \
+            --inventory-file runner-lane-registration-pre-inventory.json \
+            --audit-mode service \
+            --service-url "$LAUNCHPLANE_SERVICE_URL" \
+            "$mutate_flag" \
+            > runner-lane-registration-result.json
+
+      - name: Upload registration result
+        uses: actions/upload-artifact@v7
+        with:
+          name: runner-lane-registration-result
+          path: |
+            runner-lane-registration-pre-inventory.json
+            runner-lane-registration-result.json
+          if-no-files-found: error

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -20,6 +20,7 @@ from control_plane.contracts.runner_lane_control import RunnerLaneControlPolicy
 from control_plane.contracts.runner_lane_control import RunnerLaneControlRequest
 from control_plane.contracts.runner_lane_control import plan_runner_lane_control
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationPolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAction
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
@@ -38,7 +39,24 @@ from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene
 from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import UrllibMergeTrainGitHubTransport
 from control_plane.runner_lane_github import GitHubRunnerLaneInventoryReader
+from control_plane.runner_lane_github import GitHubRunnerLaneRegistrationTokenFetcher
 from control_plane.runner_queue_wait_github import GitHubRunnerQueueWaitReader
+from control_plane.workflows.runner_lane_registration_executor import (
+    RunnerLaneRegistrationExecutorRequest,
+)
+from control_plane.workflows.runner_lane_registration_executor import (
+    build_local_command_runner as build_runner_registration_command_runner,
+)
+from control_plane.workflows.runner_lane_registration_executor import (
+    build_refreshing_service_audit_poster as build_runner_registration_service_audit_poster,
+)
+from control_plane.workflows.runner_lane_registration_executor import (
+    AuditPoster as RunnerRegistrationAuditPoster,
+)
+from control_plane.workflows.runner_lane_registration_executor import dry_run_audit_poster
+from control_plane.workflows.runner_lane_registration_executor import (
+    execute_runner_lane_registration_executor,
+)
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
 from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandRunner
@@ -58,6 +76,10 @@ def register_runner_lane_commands(work_graph: click.Group) -> None:
     work_graph.add_command(runner_queue_wait, name="runner-queue-wait")
     work_graph.add_command(runner_baseline_observe, name="runner-baseline-observe")
     work_graph.add_command(runner_control_plan, name="runner-control-plan")
+    work_graph.add_command(
+        runner_lane_registration_executor,
+        name="runner-lane-registration-executor",
+    )
     work_graph.add_command(runner_host_hygiene_report, name="runner-host-hygiene-report")
     work_graph.add_command(runner_host_hygiene_apply_plan, name="runner-host-hygiene-apply-plan")
     work_graph.add_command(
@@ -464,6 +486,182 @@ def runner_control_plan(
             sort_keys=True,
         )
     )
+
+
+@click.command("runner-lane-registration-executor")
+@click.option("--repository", required=True, help="owner/name repository for the runner lane.")
+@click.option("--host-name", required=True, help="Approved runner host name.")
+@click.option(
+    "--execution-lane",
+    required=True,
+    help="Approved self-hosted ops lane label executing this registration.",
+)
+@click.option("--service-user", required=True, help="Constrained host service user.")
+@click.option("--lane-name", required=True, help="Runner lane name to register.")
+@click.option(
+    "--registration-root",
+    required=True,
+    help="Absolute root directory where runner lanes may be registered.",
+)
+@click.option("--label", "labels", multiple=True, required=True, help="Runner label.")
+@click.option(
+    "--mutate/--dry-run",
+    default=False,
+    show_default=True,
+    help="Create the runner registration token and run config.sh. Defaults to dry-run.",
+)
+@click.option(
+    "--audit-record-key",
+    required=True,
+    help="Launchplane-owned audit record key for this registration attempt.",
+)
+@click.option(
+    "--allowed-repository",
+    "allowed_repositories",
+    multiple=True,
+    help="Repository opted into runner lane registration. Repeat as needed.",
+)
+@click.option(
+    "--approved-host",
+    "approved_hosts",
+    multiple=True,
+    help="Host approved for runner lane registration. Repeat as needed.",
+)
+@click.option(
+    "--allowed-registration-root",
+    "allowed_registration_roots",
+    multiple=True,
+    help="Absolute root allowed for runner registration. Repeat as needed.",
+)
+@click.option(
+    "--required-label",
+    "required_labels",
+    multiple=True,
+    help="Label required by policy. Defaults to self-hosted, launchplane, launchplane-managed.",
+)
+@click.option(
+    "--inventory-file",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    required=True,
+    help="Pre-mutation RunnerLaneInventory JSON from runner-inventory.",
+)
+@click.option(
+    "--github-token-env",
+    default="GITHUB_TOKEN",
+    show_default=True,
+    help="Environment variable containing the GitHub token for mutate mode.",
+)
+@click.option(
+    "--github-api-base-url",
+    default="https://api.github.com",
+    show_default=True,
+    help="GitHub API base URL.",
+)
+@click.option(
+    "--timeout-seconds",
+    default=120,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Timeout for the local runner config command.",
+)
+@click.option(
+    "--audit-mode",
+    type=click.Choice(("local", "service")),
+    default="local",
+    show_default=True,
+    help="Where runner registration audit records should be written.",
+)
+@click.option(
+    "--service-url",
+    default="",
+    help="Launchplane service origin for --audit-mode service.",
+)
+@click.option(
+    "--bearer-token-env",
+    default="LAUNCHPLANE_SERVICE_TOKEN",
+    show_default=True,
+    help="Environment variable containing a Launchplane bearer token.",
+)
+def runner_lane_registration_executor(
+    repository: str,
+    host_name: str,
+    execution_lane: str,
+    service_user: str,
+    lane_name: str,
+    registration_root: str,
+    labels: tuple[str, ...],
+    mutate: bool,
+    audit_record_key: str,
+    allowed_repositories: tuple[str, ...],
+    approved_hosts: tuple[str, ...],
+    allowed_registration_roots: tuple[str, ...],
+    required_labels: tuple[str, ...],
+    inventory_file: Path,
+    github_token_env: str,
+    github_api_base_url: str,
+    timeout_seconds: int,
+    audit_mode: str,
+    service_url: str,
+    bearer_token_env: str,
+) -> None:
+    try:
+        pre_inventory = _load_runner_lane_inventory(inventory_file)
+        token_env = github_token_env.strip()
+        token = os.environ.get(token_env, "").strip() if token_env else ""
+        if mutate and not token:
+            raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
+        transport = UrllibMergeTrainGitHubTransport(
+            token=token or "dry-run-token",
+            api_base_url=github_api_base_url,
+        )
+        inventory_reader = GitHubRunnerLaneInventoryReader(transport=transport)
+        audit_poster: RunnerRegistrationAuditPoster = dry_run_audit_poster
+        if audit_mode == "service":
+            token_env = bearer_token_env.strip()
+            if not token_env:
+                raise click.ClickException(
+                    "runner lane registration executor requires --bearer-token-env."
+                )
+            audit_poster = build_runner_registration_service_audit_poster(
+                service_url=service_url,
+                bearer_token_provider=lambda: _launchplane_service_bearer_token(
+                    service_url=service_url,
+                    token_env=token_env,
+                    label="runner lane registration",
+                ),
+            )
+        result = execute_runner_lane_registration_executor(
+            request=RunnerLaneRegistrationExecutorRequest(
+                repository=repository,
+                host_name=host_name,
+                execution_lane=execution_lane,
+                service_user=service_user,
+                lane_name=lane_name,
+                registration_root=registration_root,
+                labels=labels,
+                mutate=mutate,
+                audit_record_key=audit_record_key,
+                timeout_seconds=timeout_seconds,
+            ),
+            policy=RunnerLaneRegistrationPolicy(
+                allowed_repositories=allowed_repositories,
+                approved_hosts=approved_hosts,
+                allowed_registration_roots=allowed_registration_roots,
+                required_labels=(
+                    required_labels or ("self-hosted", "launchplane", "launchplane-managed")
+                ),
+            ),
+            pre_inventory=pre_inventory,
+            inventory_reader=lambda repo: inventory_reader.read_runner_lane_inventory(
+                repository=repo
+            ),
+            token_fetcher=GitHubRunnerLaneRegistrationTokenFetcher(transport=transport),
+            remote_runner=build_runner_registration_command_runner(),
+            audit_poster=audit_poster,
+        )
+    except (OSError, JSONDecodeError, ValidationError, ValueError) as error:
+        raise click.ClickException(str(error)) from error
+    click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
 
 
 @click.command("runner-host-hygiene-report")
@@ -1090,6 +1288,14 @@ def _load_runner_host_hygiene_apply_plan(apply_plan_file: Path) -> RunnerHostHyg
 
 
 def _runner_host_hygiene_bearer_token(*, service_url: str, token_env: str) -> str:
+    return _launchplane_service_bearer_token(
+        service_url=service_url,
+        token_env=token_env,
+        label="runner host hygiene",
+    )
+
+
+def _launchplane_service_bearer_token(*, service_url: str, token_env: str, label: str) -> str:
     env_token = os.environ.get(token_env, "").strip()
     if env_token:
         return env_token
@@ -1101,7 +1307,7 @@ def _runner_host_hygiene_bearer_token(*, service_url: str, token_env: str) -> st
 
     parsed_service_url = urlsplit(service_url.strip())
     if not parsed_service_url.hostname:
-        raise click.ClickException("runner host hygiene service URL must include a hostname.")
+        raise click.ClickException(f"{label} service URL must include a hostname.")
     separator = "&" if "?" in request_url else "?"
     oidc_request = Request(
         request_url + separator + urlencode({"audience": parsed_service_url.hostname}),

--- a/control_plane/contracts/runner_lane_registration.py
+++ b/control_plane/contracts/runner_lane_registration.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+
+
+RunnerLaneRegistrationPlanStatus = Literal["ready", "blocked"]
+RunnerLaneRegistrationAuditStatus = Literal["planned", "completed", "failed"]
+RunnerLaneRegistrationBlockerCode = Literal[
+    "audit_record_key_missing",
+    "host_not_allowed",
+    "inventory_repository_mismatch",
+    "label_missing",
+    "lane_already_exists",
+    "mutate_not_requested",
+    "registration_root_not_allowed",
+    "repository_not_allowed",
+]
+
+
+class RunnerLaneRegistrationPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    allowed_repositories: tuple[str, ...] = ()
+    approved_hosts: tuple[str, ...] = ()
+    allowed_registration_roots: tuple[str, ...] = ()
+    required_labels: tuple[str, ...] = ("self-hosted", "launchplane", "launchplane-managed")
+    require_audit_record: bool = True
+
+    @model_validator(mode="after")
+    def _normalize_policy(self) -> "RunnerLaneRegistrationPolicy":
+        self.allowed_repositories = _normalized_repositories(self.allowed_repositories)
+        self.approved_hosts = _normalized_tokens(self.approved_hosts)
+        self.allowed_registration_roots = tuple(
+            sorted(
+                {_normalized_path(root) for root in self.allowed_registration_roots if root.strip()}
+            )
+        )
+        self.required_labels = _normalized_labels(self.required_labels)
+        if not self.required_labels:
+            raise ValueError("runner lane registration policy requires at least one label")
+        return self
+
+
+class RunnerLaneRegistrationRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    host_name: str
+    lane_name: str
+    registration_root: str
+    labels: tuple[str, ...]
+    mutate: bool = False
+    audit_record_key: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "RunnerLaneRegistrationRequest":
+        self.repository = _normalized_repository(self.repository)
+        self.host_name = _required_text(
+            self.host_name, "runner lane registration requires host_name"
+        )
+        self.lane_name = _required_text(
+            self.lane_name, "runner lane registration requires lane_name"
+        )
+        self.registration_root = _normalized_path(
+            _required_text(
+                self.registration_root,
+                "runner lane registration requires registration_root",
+            )
+        )
+        self.labels = _normalized_labels(self.labels)
+        self.audit_record_key = self.audit_record_key.strip()
+        if not self.repository:
+            raise ValueError("runner lane registration requires repository")
+        if not self.labels:
+            raise ValueError("runner lane registration requires labels")
+        return self
+
+
+class RunnerLaneRegistrationBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: RunnerLaneRegistrationBlockerCode
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_blocker(self) -> "RunnerLaneRegistrationBlocker":
+        self.message = _required_text(
+            self.message, "runner lane registration blocker requires message"
+        )
+        return self
+
+
+class RunnerLaneRegistrationPlan(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: RunnerLaneRegistrationPlanStatus
+    repository: str
+    host_name: str
+    lane_name: str
+    registration_root: str
+    labels: tuple[str, ...]
+    mutate: bool
+    audit_record_key: str
+    blockers: tuple[RunnerLaneRegistrationBlocker, ...] = ()
+    next_steps: tuple[str, ...] = ()
+    summary: str
+
+    @model_validator(mode="after")
+    def _normalize_plan(self) -> "RunnerLaneRegistrationPlan":
+        self.repository = _required_text(
+            self.repository, "runner lane registration plan requires repository"
+        )
+        self.host_name = _required_text(
+            self.host_name, "runner lane registration plan requires host_name"
+        )
+        self.lane_name = _required_text(
+            self.lane_name, "runner lane registration plan requires lane_name"
+        )
+        self.registration_root = _required_text(
+            self.registration_root,
+            "runner lane registration plan requires registration_root",
+        )
+        self.labels = _normalized_labels(self.labels)
+        self.audit_record_key = self.audit_record_key.strip()
+        self.blockers = tuple(sorted(self.blockers, key=lambda blocker: blocker.code))
+        self.next_steps = tuple(step.strip() for step in self.next_steps if step.strip())
+        self.summary = _required_text(
+            self.summary, "runner lane registration plan requires summary"
+        )
+        if self.status == "ready" and self.blockers:
+            raise ValueError("ready runner lane registration plan cannot include blockers")
+        if self.status == "blocked" and not self.blockers:
+            raise ValueError("blocked runner lane registration plan requires blockers")
+        return self
+
+
+class RunnerLaneRegistrationAuditRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    audit_record_key: str
+    status: RunnerLaneRegistrationAuditStatus
+    request: RunnerLaneRegistrationRequest
+    plan: RunnerLaneRegistrationPlan
+    pre_inventory: RunnerLaneInventory
+    post_inventory: RunnerLaneInventory | None = None
+    message: str
+
+    @model_validator(mode="after")
+    def _normalize_record(self) -> "RunnerLaneRegistrationAuditRecord":
+        self.audit_record_key = _required_text(
+            self.audit_record_key,
+            "runner lane registration audit record requires key",
+        )
+        if self.audit_record_key != self.request.audit_record_key:
+            raise ValueError("runner lane registration audit key must match request")
+        if self.audit_record_key != self.plan.audit_record_key:
+            raise ValueError("runner lane registration audit key must match plan")
+        if self.request.repository != self.plan.repository:
+            raise ValueError("runner lane registration audit request must match plan repository")
+        if self.request.lane_name != self.plan.lane_name:
+            raise ValueError("runner lane registration audit request must match plan lane")
+        if self.pre_inventory.repository != self.request.repository:
+            raise ValueError("runner lane registration pre-inventory must match request repository")
+        if (
+            self.post_inventory is not None
+            and self.post_inventory.repository != self.request.repository
+        ):
+            raise ValueError(
+                "runner lane registration post-inventory must match request repository"
+            )
+        self.message = _required_text(
+            self.message, "runner lane registration audit record requires message"
+        )
+        return self
+
+
+class RunnerLaneRegistrationTokenRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    expires_at: str
+    fetched_at: str
+
+    @model_validator(mode="after")
+    def _normalize_record(self) -> "RunnerLaneRegistrationTokenRecord":
+        self.repository = _normalized_repository(self.repository)
+        self.expires_at = _required_text(
+            self.expires_at, "runner lane registration token record requires expires_at"
+        )
+        self.fetched_at = _required_text(
+            self.fetched_at, "runner lane registration token record requires fetched_at"
+        )
+        return self
+
+
+def plan_runner_lane_registration(
+    *,
+    policy: RunnerLaneRegistrationPolicy,
+    request: RunnerLaneRegistrationRequest,
+    inventory: RunnerLaneInventory,
+) -> RunnerLaneRegistrationPlan:
+    blockers: list[RunnerLaneRegistrationBlocker] = []
+    inventory_repository = _normalized_repository(inventory.repository)
+    if not policy.allowed_repositories or request.repository not in policy.allowed_repositories:
+        blockers.append(
+            _blocker(
+                "repository_not_allowed",
+                f"repository is not opted into runner lane registration: {request.repository}",
+            )
+        )
+    if not policy.approved_hosts or request.host_name.lower() not in policy.approved_hosts:
+        blockers.append(
+            _blocker(
+                "host_not_allowed",
+                f"runner host is not approved for lane registration: {request.host_name}",
+            )
+        )
+    if not _path_under_allowed_roots(
+        path=request.registration_root,
+        allowed_roots=policy.allowed_registration_roots,
+    ):
+        blockers.append(
+            _blocker(
+                "registration_root_not_allowed",
+                "runner registration root is not under an allowed root: "
+                f"{request.registration_root}",
+            )
+        )
+    if policy.require_audit_record and not request.audit_record_key:
+        blockers.append(
+            _blocker(
+                "audit_record_key_missing",
+                "runner lane registration requires an audit record key",
+            )
+        )
+    if not request.mutate:
+        blockers.append(
+            _blocker(
+                "mutate_not_requested",
+                "runner lane registration is dry-run only until mutate is explicitly requested",
+            )
+        )
+    if inventory_repository != request.repository:
+        blockers.append(
+            _blocker(
+                "inventory_repository_mismatch",
+                f"runner lane inventory repository does not match request: {inventory_repository}",
+            )
+        )
+    existing_lanes = tuple(lane for lane in inventory.lanes if lane.name == request.lane_name)
+    if existing_lanes:
+        blockers.append(
+            _blocker(
+                "lane_already_exists",
+                f"runner lane already exists: {request.lane_name}",
+            )
+        )
+    request_labels = set(request.labels)
+    for label in policy.required_labels:
+        if label not in request_labels:
+            blockers.append(
+                _blocker(
+                    "label_missing",
+                    f"runner lane registration is missing required label: {label}",
+                )
+            )
+
+    status: RunnerLaneRegistrationPlanStatus = "blocked" if blockers else "ready"
+    return RunnerLaneRegistrationPlan(
+        status=status,
+        repository=request.repository,
+        host_name=request.host_name,
+        lane_name=request.lane_name,
+        registration_root=request.registration_root,
+        labels=request.labels,
+        mutate=request.mutate,
+        audit_record_key=request.audit_record_key,
+        blockers=tuple(blockers),
+        next_steps=_next_steps(status=status),
+        summary=(
+            "runner lane registration plan is ready"
+            if status == "ready"
+            else "runner lane registration plan is blocked"
+        ),
+    )
+
+
+def _next_steps(*, status: RunnerLaneRegistrationPlanStatus) -> tuple[str, ...]:
+    if status == "blocked":
+        return ("resolve blockers before registering any GitHub runner lane",)
+    return (
+        "request a short-lived GitHub runner registration token",
+        "configure the runner under the approved registration root",
+        "verify GitHub sees the lane online",
+    )
+
+
+def _blocker(
+    code: RunnerLaneRegistrationBlockerCode, message: str
+) -> RunnerLaneRegistrationBlocker:
+    return RunnerLaneRegistrationBlocker(code=code, message=message)
+
+
+def _path_under_allowed_roots(*, path: str, allowed_roots: tuple[str, ...]) -> bool:
+    if not allowed_roots:
+        return False
+    normalized_path = _normalized_path(path)
+    for root in allowed_roots:
+        normalized_root = _normalized_path(root)
+        if normalized_path == normalized_root or normalized_path.startswith(f"{normalized_root}/"):
+            return True
+    return False
+
+
+def _normalized_repositories(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(
+        sorted({normalized for value in values if (normalized := _normalized_repository(value))})
+    )
+
+
+def _normalized_repository(value: str) -> str:
+    normalized_value = value.strip().lower()
+    if not normalized_value:
+        return ""
+    normalized_repository = "/".join(part.strip() for part in normalized_value.split("/"))
+    if normalized_repository.count("/") != 1:
+        raise ValueError("runner lane registration requires repository formatted as owner/name")
+    owner, name = normalized_repository.split("/", 1)
+    if not owner or not name:
+        raise ValueError("runner lane registration requires repository formatted as owner/name")
+    return normalized_repository
+
+
+def _normalized_labels(values: tuple[str, ...]) -> tuple[str, ...]:
+    return _normalized_tokens(values)
+
+
+def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
+    return tuple(sorted({value.strip().lower() for value in values if value.strip()}))
+
+
+def _normalized_path(value: str) -> str:
+    normalized = value.strip().rstrip("/")
+    if not normalized.startswith("/"):
+        raise ValueError("runner lane registration paths must be absolute")
+    segments: list[str] = []
+    for segment in normalized.split("/"):
+        if segment in {"", "."}:
+            continue
+        if segment == "..":
+            if segments:
+                segments.pop()
+            continue
+        segments.append(segment)
+    return "/" + "/".join(segments)
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/control_plane/runner_lane_github.py
+++ b/control_plane/runner_lane_github.py
@@ -7,6 +7,7 @@ from urllib.parse import urlencode
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
 from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationTokenRecord
 from control_plane.github_payload import json_object
 from control_plane.github_payload import repository_full_name
 from control_plane.github_payload import required_int
@@ -47,9 +48,7 @@ class GitHubRunnerLaneInventoryReader:
             payload_object = _json_object(payload, "GitHub runner list response")
             runners_payload = payload_object.get("runners")
             if not isinstance(runners_payload, list):
-                raise MergeTrainGitHubError(
-                    "GitHub runner list response must include runners."
-                )
+                raise MergeTrainGitHubError("GitHub runner list response must include runners.")
             page_lanes = tuple(
                 _runner_lane_record(
                     repository=repository_path,
@@ -66,6 +65,41 @@ class GitHubRunnerLaneInventoryReader:
                     lanes=tuple(lanes),
                 )
             page += 1
+
+
+class GitHubRunnerLaneRegistrationTokenFetcher:
+    def __init__(
+        self,
+        *,
+        transport: MergeTrainGitHubTransport,
+        clock: RunnerLaneClock | None = None,
+    ) -> None:
+        self.transport = transport
+        self.clock = clock or SystemRunnerLaneClock()
+
+    def fetch_registration_token(
+        self, *, repository: str
+    ) -> tuple[str, RunnerLaneRegistrationTokenRecord]:
+        repository_path = _repository_path(repository)
+        payload = self.transport.request(
+            method="POST",
+            path=f"/repos/{repository_path}/actions/runners/registration-token",
+        )
+        payload_object = _json_object(payload, "GitHub runner registration token response")
+        token = _required_text(
+            payload_object.get("token"),
+            "GitHub runner registration token response requires token.",
+        )
+        expires_at = _required_text(
+            payload_object.get("expires_at"),
+            "GitHub runner registration token response requires expires_at.",
+        )
+        fetched_at = self.clock.now().isoformat().replace("+00:00", "Z")
+        return token, RunnerLaneRegistrationTokenRecord(
+            repository=repository_path,
+            expires_at=expires_at,
+            fetched_at=fetched_at,
+        )
 
 
 def _runner_lane_record(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -176,6 +176,7 @@ from control_plane.contracts.public_ingress_monitoring import (
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
 from control_plane.runtime_key_safety import (
     evaluate_runtime_key_safety_from_store,
     latest_active_runtime_key_safety_policy,
@@ -922,6 +923,23 @@ class RunnerHostHygieneAuditEvidenceEnvelope(BaseModel):
     def _validate_alignment(self) -> "RunnerHostHygieneAuditEvidenceEnvelope":
         if self.product.strip() != "launchplane":
             raise ValueError("runner host hygiene audit evidence requires product 'launchplane'")
+        self.product = "launchplane"
+        return self
+
+
+class RunnerLaneRegistrationAuditEvidenceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    audit: RunnerLaneRegistrationAuditRecord
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "RunnerLaneRegistrationAuditEvidenceEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError(
+                "runner lane registration audit evidence requires product 'launchplane'"
+            )
         self.product = "launchplane"
         return self
 
@@ -4500,6 +4518,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/evidence/deployments",
         "/v1/evidence/backup-gates",
         "/v1/evidence/runner-host-hygiene/audits",
+        "/v1/evidence/runner-lane-registration/audits",
         "/v1/evidence/previews/generations",
         "/v1/evidence/previews/destroyed",
         "/v1/authz-policies/github-actions/grants",
@@ -6539,6 +6558,7 @@ def _accepted_payload(
         "odoo_stable_bootstrap_operation_id",
         "odoo_stable_target_replacement_operation_id",
         "runner_host_hygiene_audit_record_key",
+        "runner_lane_registration_audit_record_key",
         "generic_web_rollback_plan_id",
         "public_ingress_notification_policy_id",
         "ingress_route_audit_record_id",
@@ -12704,6 +12724,60 @@ def create_launchplane_service_app(
                     "audit_status": runner_host_hygiene_request.audit.status,
                     "mutate": runner_host_hygiene_request.audit.request.mutate,
                     "audit": runner_host_hygiene_request.audit.model_dump(mode="json"),
+                }
+            elif path == "/v1/evidence/runner-lane-registration/audits":
+                runner_lane_registration_request = (
+                    RunnerLaneRegistrationAuditEvidenceEnvelope.model_validate(payload)
+                )
+                if not authz_policy.allows(
+                    identity=identity,
+                    action="runner_lane_registration_audit.write",
+                    product=runner_lane_registration_request.product,
+                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                ):
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=403,
+                        payload={
+                            "status": "rejected",
+                            "trace_id": request_trace_id,
+                            "error": {
+                                "code": "authorization_denied",
+                                "message": (
+                                    "Workflow cannot write runner lane registration audit evidence."
+                                ),
+                            },
+                        },
+                    )
+                idempotent_response = _check_idempotent_request(
+                    record_store=record_store,
+                    scope=request_scope,
+                    route_path=path,
+                    idempotency_key=request_idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    start_response=start_response,
+                    trace_id=request_trace_id,
+                )
+                if idempotent_response is not None:
+                    return idempotent_response
+                record_store.write_runner_lane_registration_audit_record(
+                    runner_lane_registration_request.audit
+                )
+                result = {
+                    "runner_lane_registration_audit_record_key": (
+                        runner_lane_registration_request.audit.audit_record_key
+                    ),
+                }
+                driver_result = {
+                    "runner_lane_registration_audit_record_key": (
+                        runner_lane_registration_request.audit.audit_record_key
+                    ),
+                    "repository": runner_lane_registration_request.audit.request.repository,
+                    "host_name": runner_lane_registration_request.audit.request.host_name,
+                    "lane_name": runner_lane_registration_request.audit.request.lane_name,
+                    "audit_status": runner_lane_registration_request.audit.status,
+                    "mutate": runner_lane_registration_request.audit.request.mutate,
+                    "audit": runner_lane_registration_request.audit.model_dump(mode="json"),
                 }
             elif path == "/v1/product-config/apply":
                 product_config_request, product_config_response = (

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -62,6 +62,7 @@ from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
 
@@ -162,6 +163,15 @@ class FilesystemRecordStore:
         return self._write_model(
             "launchplane_runner_host_hygiene_audits",
             _runner_host_hygiene_audit_record_id(record.audit_record_key),
+            record,
+        )
+
+    def write_runner_lane_registration_audit_record(
+        self, record: RunnerLaneRegistrationAuditRecord
+    ) -> Path:
+        return self._write_model(
+            "launchplane_runner_lane_registration_audits",
+            _runner_lane_registration_audit_record_id(record.audit_record_key),
             record,
         )
 
@@ -425,6 +435,31 @@ class FilesystemRecordStore:
                 "launchplane_runner_host_hygiene_audits",
             )
             if (not normalized_host_name or record.request.host_name == normalized_host_name)
+            and (not status or record.status == status)
+        ]
+        records.sort(key=lambda record: record.audit_record_key, reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def list_runner_lane_registration_audit_records(
+        self,
+        *,
+        repository: str = "",
+        host_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RunnerLaneRegistrationAuditRecord, ...]:
+        normalized_repository = repository.strip().lower()
+        normalized_host_name = host_name.strip().lower()
+        records = [
+            record
+            for record in self._list_models(
+                RunnerLaneRegistrationAuditRecord,
+                "launchplane_runner_lane_registration_audits",
+            )
+            if (not normalized_repository or record.request.repository == normalized_repository)
+            and (not normalized_host_name or record.request.host_name == normalized_host_name)
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: record.audit_record_key, reverse=True)
@@ -1413,6 +1448,11 @@ def _odoo_stable_bootstrap_lane_reservation_id(
 
 
 def _runner_host_hygiene_audit_record_id(audit_record_key: str) -> str:
+    digest = hashlib.sha256(audit_record_key.encode()).hexdigest()[:16]
+    return audit_record_key.strip().replace("/", "-") + f"-{digest}"
+
+
+def _runner_lane_registration_audit_record_id(audit_record_key: str) -> str:
     digest = hashlib.sha256(audit_record_key.encode()).hexdigest()[:16]
     return audit_record_key.strip().replace("/", "-") + f"-{digest}"
 

--- a/control_plane/storage/migrations/versions/c7f9a1b3d5e7_add_runner_lane_registration_audits.py
+++ b/control_plane/storage/migrations/versions/c7f9a1b3d5e7_add_runner_lane_registration_audits.py
@@ -1,0 +1,85 @@
+"""add runner lane registration audits
+
+Revision ID: c7f9a1b3d5e7
+Revises: c6e8f0a2b4d6
+Create Date: 2026-06-08 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "c7f9a1b3d5e7"
+down_revision: str | None = "c6e8f0a2b4d6"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_runner_lane_registration_audits"
+_REPOSITORY_INDEX = "launchplane_runner_lane_registration_audits_repo_idx"
+_HOST_INDEX = "launchplane_runner_lane_registration_audits_host_idx"
+_STATUS_INDEX = "launchplane_runner_lane_registration_audits_status_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("audit_record_key", sa.String(), nullable=False),
+            sa.Column("repository", sa.String(), nullable=False),
+            sa.Column("host_name", sa.String(), nullable=False),
+            sa.Column("lane_name", sa.String(), nullable=False),
+            sa.Column("status", sa.String(), nullable=False),
+            sa.Column("mutate", sa.Integer(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("audit_record_key"),
+        )
+    if not _index_exists(_TABLE, _REPOSITORY_INDEX):
+        op.create_index(
+            _REPOSITORY_INDEX,
+            _TABLE,
+            ["repository", sa.text("audit_record_key DESC")],
+        )
+    if not _index_exists(_TABLE, _HOST_INDEX):
+        op.create_index(
+            _HOST_INDEX,
+            _TABLE,
+            ["host_name", sa.text("audit_record_key DESC")],
+        )
+    if not _index_exists(_TABLE, _STATUS_INDEX):
+        op.create_index(
+            _STATUS_INDEX,
+            _TABLE,
+            ["status", sa.text("audit_record_key DESC")],
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists(_TABLE):
+        return
+    if _index_exists(_TABLE, _STATUS_INDEX):
+        op.drop_index(_STATUS_INDEX, table_name=_TABLE)
+    if _index_exists(_TABLE, _HOST_INDEX):
+        op.drop_index(_HOST_INDEX, table_name=_TABLE)
+    if _index_exists(_TABLE, _REPOSITORY_INDEX):
+        op.drop_index(_REPOSITORY_INDEX, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -87,6 +87,7 @@ from control_plane.contracts.runtime_environment_record import (
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -420,6 +421,35 @@ class LaunchplaneRunnerHostHygieneAuditRow(Base):
     audit_record_key: Mapped[str] = mapped_column(String, primary_key=True)
     host_name: Mapped[str] = mapped_column(String, nullable=False)
     action: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(String, nullable=False)
+    mutate: Mapped[int] = mapped_column(Integer, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneRunnerLaneRegistrationAuditRow(Base):
+    __tablename__ = "launchplane_runner_lane_registration_audits"
+    __table_args__ = (
+        Index(
+            "launchplane_runner_lane_registration_audits_repo_idx",
+            "repository",
+            desc("audit_record_key"),
+        ),
+        Index(
+            "launchplane_runner_lane_registration_audits_host_idx",
+            "host_name",
+            desc("audit_record_key"),
+        ),
+        Index(
+            "launchplane_runner_lane_registration_audits_status_idx",
+            "status",
+            desc("audit_record_key"),
+        ),
+    )
+
+    audit_record_key: Mapped[str] = mapped_column(String, primary_key=True)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    host_name: Mapped[str] = mapped_column(String, nullable=False)
+    lane_name: Mapped[str] = mapped_column(String, nullable=False)
     status: Mapped[str] = mapped_column(String, nullable=False)
     mutate: Mapped[int] = mapped_column(Integer, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
@@ -2750,6 +2780,50 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_runner_lane_registration_audit_record(
+        self, record: RunnerLaneRegistrationAuditRecord
+    ) -> None:
+        self._write_row(
+            LaunchplaneRunnerLaneRegistrationAuditRow(
+                audit_record_key=record.audit_record_key,
+                repository=record.request.repository,
+                host_name=record.request.host_name,
+                lane_name=record.request.lane_name,
+                status=record.status,
+                mutate=int(record.request.mutate),
+                payload=self._payload_dict(record),
+            )
+        )
+
+    def list_runner_lane_registration_audit_records(
+        self,
+        *,
+        repository: str = "",
+        host_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RunnerLaneRegistrationAuditRecord, ...]:
+        filters: list[object] = []
+        normalized_repository = repository.strip().lower()
+        normalized_host_name = host_name.strip().lower()
+        if normalized_repository:
+            filters.append(
+                LaunchplaneRunnerLaneRegistrationAuditRow.repository == normalized_repository
+            )
+        if normalized_host_name:
+            filters.append(
+                LaunchplaneRunnerLaneRegistrationAuditRow.host_name == normalized_host_name
+            )
+        if status:
+            filters.append(LaunchplaneRunnerLaneRegistrationAuditRow.status == status)
+        return self._list_models(
+            model_type=RunnerLaneRegistrationAuditRecord,
+            orm_model=LaunchplaneRunnerLaneRegistrationAuditRow,
+            filters=filters,
+            order_by=(LaunchplaneRunnerLaneRegistrationAuditRow.audit_record_key.desc(),),
+            limit=limit,
+        )
+
     def read_preview_summary(
         self,
         *,
@@ -3878,6 +3952,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_lifecycle_plans": 0,
             "preview_pr_feedback": 0,
             "runner_host_hygiene_audits": 0,
+            "runner_lane_registration_audits": 0,
             "every_code_preview_gates": 0,
             "agent_write_intents": 0,
             "merge_train_pr_feedback": 0,
@@ -3949,9 +4024,15 @@ class PostgresRecordStore(HumanSessionStore):
                 self.write_preview_pr_feedback_record(pr_feedback_record)
                 counts["preview_pr_feedback"] += 1
         if hasattr(filesystem_store, "list_runner_host_hygiene_audit_records"):
-            for audit_record in filesystem_store.list_runner_host_hygiene_audit_records():
-                self.write_runner_host_hygiene_audit_record(audit_record)
+            for hygiene_audit_record in filesystem_store.list_runner_host_hygiene_audit_records():
+                self.write_runner_host_hygiene_audit_record(hygiene_audit_record)
                 counts["runner_host_hygiene_audits"] += 1
+        if hasattr(filesystem_store, "list_runner_lane_registration_audit_records"):
+            for (
+                registration_audit_record
+            ) in filesystem_store.list_runner_lane_registration_audit_records():
+                self.write_runner_lane_registration_audit_record(registration_audit_record)
+                counts["runner_lane_registration_audits"] += 1
         if hasattr(filesystem_store, "list_every_code_preview_gate_records"):
             for gate_record in filesystem_store.list_every_code_preview_gate_records():
                 self.write_every_code_preview_gate_record(gate_record)

--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -1,0 +1,322 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+import json
+import os
+import pwd
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditStatus
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationPolicy
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationRequest
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationTokenRecord
+from control_plane.contracts.runner_lane_registration import plan_runner_lane_registration
+from control_plane.github_payload import repository_full_name
+from control_plane.runner_lane_github import GitHubRunnerLaneRegistrationTokenFetcher
+from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
+
+
+RemoteCommandRunner = Callable[[Sequence[str], int, Mapping[str, str]], RemoteCommandResult]
+AuditPoster = Callable[[RunnerLaneRegistrationAuditRecord, str], dict[str, object]]
+InventoryReader = Callable[[str], RunnerLaneInventory]
+BearerTokenProvider = Callable[[], str]
+AUDIT_ROUTE_PATH = "/v1/evidence/runner-lane-registration/audits"
+
+
+class RunnerLaneRegistrationExecutorRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    host_name: str
+    execution_lane: str
+    service_user: str
+    lane_name: str
+    registration_root: str
+    labels: tuple[str, ...]
+    mutate: bool = False
+    audit_record_key: str
+    timeout_seconds: int = Field(default=120, ge=1)
+
+    @model_validator(mode="after")
+    def _normalize_request(self) -> "RunnerLaneRegistrationExecutorRequest":
+        self.repository = repository_full_name(self.repository)
+        self.host_name = _required_text(
+            self.host_name, "runner lane registration executor requires host_name"
+        )
+        self.execution_lane = _required_text(
+            self.execution_lane, "runner lane registration executor requires execution_lane"
+        )
+        self.service_user = _required_text(
+            self.service_user, "runner lane registration executor requires service_user"
+        )
+        self.lane_name = _required_text(
+            self.lane_name, "runner lane registration executor requires lane_name"
+        )
+        self.registration_root = _required_text(
+            self.registration_root,
+            "runner lane registration executor requires registration_root",
+        ).rstrip("/")
+        if not self.registration_root.startswith("/"):
+            raise ValueError(
+                "runner lane registration executor requires absolute registration_root"
+            )
+        self.labels = tuple(
+            sorted({label.strip().lower() for label in self.labels if label.strip()})
+        )
+        if not self.labels:
+            raise ValueError("runner lane registration executor requires labels")
+        self.audit_record_key = _required_text(
+            self.audit_record_key,
+            "runner lane registration executor requires audit_record_key",
+        )
+        return self
+
+
+class RunnerLaneRegistrationExecutorResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    audit_record_key: str
+    planned_response: dict[str, object]
+    terminal_response: dict[str, object] | None = None
+    token_record: RunnerLaneRegistrationTokenRecord | None = None
+    message: str
+
+
+def execute_runner_lane_registration_executor(
+    *,
+    request: RunnerLaneRegistrationExecutorRequest,
+    policy: RunnerLaneRegistrationPolicy,
+    pre_inventory: RunnerLaneInventory,
+    inventory_reader: InventoryReader,
+    token_fetcher: GitHubRunnerLaneRegistrationTokenFetcher,
+    remote_runner: RemoteCommandRunner,
+    audit_poster: AuditPoster,
+) -> RunnerLaneRegistrationExecutorResult:
+    registration_request = RunnerLaneRegistrationRequest(
+        repository=request.repository,
+        host_name=request.host_name,
+        lane_name=request.lane_name,
+        registration_root=request.registration_root,
+        labels=request.labels,
+        mutate=request.mutate,
+        audit_record_key=request.audit_record_key,
+    )
+    plan = plan_runner_lane_registration(
+        policy=policy,
+        request=registration_request,
+        inventory=pre_inventory,
+    )
+    planned_audit = RunnerLaneRegistrationAuditRecord(
+        audit_record_key=request.audit_record_key,
+        status="planned",
+        request=registration_request,
+        plan=plan,
+        pre_inventory=pre_inventory,
+        message="planned runner lane registration; no runner mutation was executed yet",
+    )
+    planned_response = audit_poster(
+        planned_audit,
+        f"runner-lane-registration:{request.audit_record_key}:planned",
+    )
+    if plan.status != "ready":
+        return RunnerLaneRegistrationExecutorResult(
+            status="blocked",
+            audit_record_key=request.audit_record_key,
+            planned_response=planned_response,
+            message=plan.summary,
+        )
+
+    validate_local_executor_environment(request=request)
+    token, token_record = token_fetcher.fetch_registration_token(repository=request.repository)
+    register_result = remote_runner(
+        _registration_command(request=request),
+        request.timeout_seconds,
+        {"RUNNER_REGISTRATION_TOKEN": token},
+    )
+    post_inventory = inventory_reader(request.repository)
+    if register_result.returncode == 0 and _post_inventory_has_lane(
+        inventory=post_inventory,
+        lane_name=request.lane_name,
+        labels=request.labels,
+    ):
+        status: RunnerLaneRegistrationAuditStatus = "completed"
+        message = "runner lane registration completed and GitHub inventory verified"
+    else:
+        status = "failed"
+        detail = register_result.stderr.strip() or register_result.stdout.strip() or plan.summary
+        if register_result.returncode == 0:
+            detail = "registered command completed but GitHub inventory did not show expected lane"
+        message = f"runner lane registration failed: {detail}"
+    terminal_audit = RunnerLaneRegistrationAuditRecord(
+        audit_record_key=request.audit_record_key,
+        status=status,
+        request=registration_request,
+        plan=plan,
+        pre_inventory=pre_inventory,
+        post_inventory=post_inventory,
+        message=message,
+    )
+    terminal_response = audit_poster(
+        terminal_audit,
+        f"runner-lane-registration:{request.audit_record_key}:{status}",
+    )
+    return RunnerLaneRegistrationExecutorResult(
+        status=status,
+        audit_record_key=request.audit_record_key,
+        planned_response=planned_response,
+        terminal_response=terminal_response,
+        token_record=token_record,
+        message=message,
+    )
+
+
+def validate_local_executor_environment(*, request: RunnerLaneRegistrationExecutorRequest) -> None:
+    current_user = pwd.getpwuid(os.getuid()).pw_name
+    if current_user != request.service_user:
+        raise ValueError(f"runner lane registration executor must run as {request.service_user}.")
+    github_repository = os.environ.get("GITHUB_REPOSITORY", "").strip().lower()
+    if github_repository and github_repository != "cbusillo/launchplane":
+        raise ValueError("runner lane registration executor must run from cbusillo/launchplane.")
+    runner_labels = {
+        label.strip().lower()
+        for label in os.environ.get("RUNNER_LABELS", "").split(",")
+        if label.strip()
+    }
+    if runner_labels and request.execution_lane.lower() not in runner_labels:
+        raise ValueError(
+            "runner lane registration executor is not running on the approved execution lane."
+        )
+
+
+def build_local_command_runner() -> RemoteCommandRunner:
+    from subprocess import run
+
+    def _run(
+        command: Sequence[str], timeout_seconds: int, env: Mapping[str, str]
+    ) -> RemoteCommandResult:
+        command_env = {**os.environ, **env}
+        completed = run(
+            tuple(command),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            env=command_env,
+        )
+        return RemoteCommandResult(
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+    return _run
+
+
+def dry_run_audit_poster(
+    audit: RunnerLaneRegistrationAuditRecord, idempotency_key: str
+) -> dict[str, object]:
+    return {
+        "status": "accepted-local-dry-run",
+        "idempotency_key": idempotency_key,
+        "audit_record_key": audit.audit_record_key,
+        "audit_status": audit.status,
+    }
+
+
+def build_service_audit_poster(*, service_url: str, bearer_token: str) -> AuditPoster:
+    normalized_bearer_token = bearer_token.strip()
+    if not normalized_bearer_token:
+        raise ValueError("runner lane registration executor requires bearer token")
+    return build_refreshing_service_audit_poster(
+        service_url=service_url,
+        bearer_token_provider=lambda: normalized_bearer_token,
+    )
+
+
+def build_refreshing_service_audit_poster(
+    *, service_url: str, bearer_token_provider: BearerTokenProvider
+) -> AuditPoster:
+    normalized_service_url = service_url.strip().rstrip("/")
+    if not normalized_service_url:
+        raise ValueError("runner lane registration executor requires service_url")
+
+    def post(audit: RunnerLaneRegistrationAuditRecord, idempotency_key: str) -> dict[str, object]:
+        bearer_token = bearer_token_provider().strip()
+        if not bearer_token:
+            raise ValueError("runner lane registration executor requires bearer token")
+        body = json.dumps(_audit_route_payload(audit)).encode()
+        request = Request(
+            f"{normalized_service_url}{AUDIT_ROUTE_PATH}",
+            data=body,
+            headers={
+                "Accept": "application/json",
+                "Authorization": f"Bearer {bearer_token}",
+                "Content-Type": "application/json",
+                "Idempotency-Key": idempotency_key,
+            },
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=30) as response:
+                response_payload = json.loads(response.read().decode("utf-8"))
+        except HTTPError as error:
+            response_text = error.read().decode(errors="replace")
+            raise ValueError(
+                response_text.strip() or f"Launchplane service returned HTTP {error.code}."
+            ) from error
+        if not isinstance(response_payload, dict):
+            raise ValueError("Launchplane service returned a non-object response.")
+        return response_payload
+
+    return post
+
+
+def _audit_route_payload(audit: RunnerLaneRegistrationAuditRecord) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": "launchplane",
+        "audit": audit.model_dump(mode="json"),
+    }
+
+
+def _registration_command(*, request: RunnerLaneRegistrationExecutorRequest) -> tuple[str, ...]:
+    runner_directory = f"{request.registration_root}/{request.lane_name}"
+    return (
+        "bash",
+        "-lc",
+        "set -euo pipefail\n"
+        f"mkdir -p {runner_directory!r}\n"
+        f"cd {runner_directory!r}\n"
+        "test -x ./config.sh\n"
+        "./config.sh "
+        f"--url https://github.com/{request.repository} "
+        '--token "$RUNNER_REGISTRATION_TOKEN" '
+        f"--name {request.lane_name!r} "
+        f"--labels {','.join(request.labels)!r} "
+        "--unattended --replace",
+    )
+
+
+def _post_inventory_has_lane(
+    *, inventory: RunnerLaneInventory, lane_name: str, labels: tuple[str, ...]
+) -> bool:
+    expected_labels = set(labels)
+    for lane in inventory.lanes:
+        if lane.name != lane_name or lane.status != "online":
+            continue
+        if expected_labels.issubset({label.strip().lower() for label in lane.labels}):
+            return True
+    return False
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized_value = value.strip()
+    if not normalized_value:
+        raise ValueError(message)
+    return normalized_value

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -379,6 +379,15 @@ Dokploy-hosted.
   fails closed without positive per-job Docker credential isolation evidence, so
   product repositories should not carry local `DOCKER_CONFIG` workaround retries
   as the long-term safety mechanism.
+- To prove repo-scoped runner registration, start with
+  `.github/workflows/runner-lane-registration.yml` in `mutate=false` mode. For
+  the cm-website pilot, capture `runner-inventory` evidence for
+  `cbusillo/odoo-tenant-cm-website`, run the registration workflow with an audit
+  key under `runner-lane-registration/<date>/...`, inspect the uploaded JSON
+  artifact, and only rerun with `mutate=true` after the dry-run evidence and
+  confirmation text have been reviewed. The workflow writes service-backed
+  runner-registration audit evidence and also uploads the local JSON artifact
+  for operator review.
 - Deploy verification should probe Launchplane's live health endpoint, currently
   `GET /v1/health`, after the Dokploy update.
 - When rollout health fails, deploy automation should restore the previous

--- a/docs/records.md
+++ b/docs/records.md
@@ -204,6 +204,12 @@ an ORM column/table or remains only in the evidence payload.
   operator message. Docker toolchain evidence, host-command output, Docker
   summaries, and rollout notes stay payload-only until they need queryable
   operational views.
+- Runner lane registration audit: modeled fields are `audit_record_key`,
+  `repository`, `host_name`, `lane_name`, `status`, and `mutate`. The payload
+  carries the typed request, registration plan, pre/post runner inventory, and
+  operator message. GitHub registration token values are never persisted; token
+  metadata and host command evidence stay payload-only until operator views need
+  them.
 - Ingress route audit: modeled fields are `record_id`, `product`, `context`,
   `mode`, `status`, `provider_host_id`, and `recorded_at`. The payload carries
   the typed requested domains, expected provider host id, dry-run/apply mode,
@@ -970,6 +976,11 @@ preflights.
   including Docker credential isolation and Docker toolchain/version policy;
   they are not product deploy authority and they do not replace route-specific
   authorization, promotion, backup-gate, or provider safety checks.
+- Runner lane registration audit records are the durable record for the first
+  Launchplane-controlled repository-runner registration host adapter. They live
+  in `launchplane_runner_lane_registration_audits`, are written through
+  `POST /v1/evidence/runner-lane-registration/audits`, and preserve dry-run or
+  apply evidence without storing GitHub runner registration tokens.
 - Scoped agent write-intent evaluation is exposed at
   `POST /v1/agent/write-intents/evaluate`. It validates intent shape, maps the
   intent to an exact existing policy action, evaluates authorization, and returns

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -183,6 +183,14 @@ generic `docker volume prune`, runner work-directory deletion, runner service
 restart, builder deletion, or automatic rollback. Operators should use the
 captured image and volume inventory to decide any later phase-two cleanup lane.
 
+Runner lane registration uses a separate manual ops-lane workflow,
+`.github/workflows/runner-lane-registration.yml`. It shares the same approved
+host, execution-lane, and service-user variables, but it does not prune Docker
+state or restart existing services. Its first slice registers a repo-scoped
+Actions runner lane under an allowlisted registration root and verifies the lane
+through GitHub inventory. Treat the registration artifact as evidence until the
+service-backed runner-registration audit record is accepted.
+
 ## Host Replacement Runbook
 
 `chris-testing` is no longer just a basic self-hosted runner. It also carries the

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -167,3 +167,49 @@ the typed runner-control policy and request against the supplied inventory and
 baseline readiness JSON. `--mutate` records the operator's explicit mutation
 intent in the request so the planner can tell whether a future host adapter would
 be allowed to proceed, but this CLI command itself remains a dry-run surface.
+
+## Registration Executor
+
+The first narrow host adapter for creating a repo-scoped runner lane is the
+manual ops-lane workflow `.github/workflows/runner-lane-registration.yml` and its
+CLI entrypoint:
+
+```bash
+uv run launchplane work-graph runner-lane-registration-executor \
+  --repository owner/name \
+  --host-name chris-testing \
+  --execution-lane chris-testing-ops-gate \
+  --service-user launchplane-runner-hygiene \
+  --lane-name product-runner-1 \
+  --registration-root /opt/actions-runners \
+  --label self-hosted \
+  --label launchplane \
+  --label launchplane-managed \
+  --audit-record-key runner-lane-registration/2026-06-08/product/dry-run \
+  --allowed-repository owner/name \
+  --approved-host chris-testing \
+  --allowed-registration-root /opt/actions-runners \
+  --inventory-file runner-inventory.json
+```
+
+The command is dry-run by default. A dry-run writes only local JSON evidence and
+does not request a GitHub registration token. `--mutate` requires an environment
+GitHub token, validates the local host/user/execution-lane boundary, requests a
+short-lived GitHub runner registration token, runs the host-local runner
+`config.sh`, then re-reads GitHub inventory and fails closed unless the expected
+lane appears online with the requested labels. The token itself is never written
+to the audit record, command output, or JSON result.
+
+The manual workflow requires the repository secret
+`LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN` for cross-repository runner
+inventory and registration-token requests. The default `GITHUB_TOKEN` from the
+Launchplane workflow is not sufficient authority for product repository runner
+administration.
+
+This executor is the proving-ground adapter for #1231. Durable service-backed
+audit persistence is available through
+`POST /v1/evidence/runner-lane-registration/audits` under
+`runner_lane_registration_audit.write`; descriptor-backed operator routing for
+registration planning remains a later slice. The workflow still uploads the JSON
+artifact so operators can inspect the exact plan/result packet for cm-website or
+any other product proof.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1472,6 +1472,35 @@ storage, and returns the `runner_host_hygiene_audit_record_key`. It is evidence
 ingress only: it records planned, completed, or failed audit facts supplied by a
 future approved executor, but it does not mutate runner hosts itself.
 
+### Runner lane registration audit evidence
+
+`POST /v1/evidence/runner-lane-registration/audits`
+
+Request payload:
+
+```json
+{
+  "schema_version": 1,
+  "product": "launchplane",
+  "audit": {
+    "schema_version": 1,
+    "audit_record_key": "runner-lane-registration/2026-06-08/cm-website/dry-run",
+    "status": "planned",
+    "request": "RunnerLaneRegistrationRequest",
+    "plan": "RunnerLaneRegistrationPlan",
+    "pre_inventory": "RunnerLaneInventory",
+    "post_inventory": null,
+    "message": "planned runner lane registration; no host mutation was executed"
+  }
+}
+```
+
+The route requires `runner_lane_registration_audit.write` for product/context
+`launchplane/launchplane`, writes the typed audit record to Launchplane-owned
+storage, and returns the `runner_lane_registration_audit_record_key`. It is
+evidence ingress only; the host-side registration executor owns any GitHub
+registration token request and runner `config.sh` execution.
+
 For VeriReel's first stable-lane Launchplane slice, use context `verireel` for the
 long-lived `testing` and `prod` instances. Preview evidence remains separate
 under `verireel-testing` because previews are not another durable promotion

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -89,6 +89,12 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObserva
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
+from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditStatus
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationPolicy
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationRequest
+from control_plane.contracts.runner_lane_registration import plan_runner_lane_registration
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
@@ -219,6 +225,46 @@ def _runner_host_hygiene_audit_record(
         plan=plan,
         pre_apply_report=report,
         post_apply_report=report if status != "planned" else None,
+        message=message,
+    )
+
+
+def _runner_lane_registration_audit_record(
+    *,
+    audit_record_key: str,
+    status: RunnerLaneRegistrationAuditStatus = "planned",
+    message: str = "planned runner lane registration; no host mutation was executed",
+) -> RunnerLaneRegistrationAuditRecord:
+    inventory = build_runner_lane_inventory(
+        repository="cbusillo/odoo-tenant-cm-website",
+        observed_at="2026-06-08T17:30:00Z",
+        lanes=(),
+    )
+    request = RunnerLaneRegistrationRequest(
+        repository="cbusillo/odoo-tenant-cm-website",
+        host_name="chris-testing",
+        lane_name="cm-website-runner-1",
+        registration_root="/opt/actions-runners",
+        labels=("self-hosted", "launchplane", "launchplane-managed"),
+        mutate=True,
+        audit_record_key=audit_record_key,
+    )
+    plan = plan_runner_lane_registration(
+        policy=RunnerLaneRegistrationPolicy(
+            allowed_repositories=("cbusillo/odoo-tenant-cm-website",),
+            approved_hosts=("chris-testing",),
+            allowed_registration_roots=("/opt/actions-runners",),
+        ),
+        request=request,
+        inventory=inventory,
+    )
+    return RunnerLaneRegistrationAuditRecord(
+        audit_record_key=audit_record_key,
+        status=status,
+        request=request,
+        plan=plan,
+        pre_inventory=inventory,
+        post_inventory=inventory if status != "planned" else None,
         message=message,
     )
 
@@ -382,6 +428,46 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             "launchplane_runner_host_hygiene_audits",
         )
         self.assertTrue(written_path.name.startswith("runner-host-hygiene-2026-05-23-"))
+        self.assertEqual(
+            [record.audit_record_key for record in planned_records],
+            [newer_record.audit_record_key, older_record.audit_record_key],
+        )
+        self.assertEqual(
+            [record.audit_record_key for record in limited_records],
+            [failed_record.audit_record_key],
+        )
+
+    def test_write_and_list_runner_lane_registration_audit_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            older_record = _runner_lane_registration_audit_record(
+                audit_record_key="runner-lane-registration/2026-06-08/cm-website/old"
+            )
+            newer_record = _runner_lane_registration_audit_record(
+                audit_record_key="runner-lane-registration/2026-06-09/cm-website/new"
+            )
+            failed_record = _runner_lane_registration_audit_record(
+                audit_record_key="runner-lane-registration/2026-06-10/cm-website/failed",
+                status="failed",
+                message="post-registration inventory did not show the lane",
+            )
+
+            written_path = store.write_runner_lane_registration_audit_record(older_record)
+            store.write_runner_lane_registration_audit_record(newer_record)
+            store.write_runner_lane_registration_audit_record(failed_record)
+            planned_records = store.list_runner_lane_registration_audit_records(
+                repository="CBUSILLO/ODOO-TENANT-CM-WEBSITE",
+                host_name="Chris-Testing",
+                status="planned",
+            )
+            limited_records = store.list_runner_lane_registration_audit_records(limit=1)
+
+        self.assertEqual(
+            written_path.parent.relative_to(state_dir).as_posix(),
+            "launchplane_runner_lane_registration_audits",
+        )
+        self.assertTrue(written_path.name.startswith("runner-lane-registration-2026-06-08-"))
         self.assertEqual(
             [record.audit_record_key for record in planned_records],
             [newer_record.audit_record_key, older_record.audit_record_key],

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -133,6 +133,12 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObserva
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
+from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditStatus
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationPolicy
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationRequest
+from control_plane.contracts.runner_lane_registration import plan_runner_lane_registration
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -309,6 +315,46 @@ def _runner_host_hygiene_audit_record(
         plan=plan,
         pre_apply_report=report,
         post_apply_report=report if status != "planned" else None,
+        message=message,
+    )
+
+
+def _runner_lane_registration_audit_record(
+    *,
+    audit_record_key: str,
+    status: RunnerLaneRegistrationAuditStatus = "planned",
+    message: str = "planned runner lane registration; no host mutation was executed",
+) -> RunnerLaneRegistrationAuditRecord:
+    inventory = build_runner_lane_inventory(
+        repository="cbusillo/odoo-tenant-cm-website",
+        observed_at="2026-06-08T17:30:00Z",
+        lanes=(),
+    )
+    request = RunnerLaneRegistrationRequest(
+        repository="cbusillo/odoo-tenant-cm-website",
+        host_name="chris-testing",
+        lane_name="cm-website-runner-1",
+        registration_root="/opt/actions-runners",
+        labels=("self-hosted", "launchplane", "launchplane-managed"),
+        mutate=True,
+        audit_record_key=audit_record_key,
+    )
+    plan = plan_runner_lane_registration(
+        policy=RunnerLaneRegistrationPolicy(
+            allowed_repositories=("cbusillo/odoo-tenant-cm-website",),
+            approved_hosts=("chris-testing",),
+            allowed_registration_roots=("/opt/actions-runners",),
+        ),
+        request=request,
+        inventory=inventory,
+    )
+    return RunnerLaneRegistrationAuditRecord(
+        audit_record_key=audit_record_key,
+        status=status,
+        request=request,
+        plan=plan,
+        pre_inventory=inventory,
+        post_inventory=inventory if status != "planned" else None,
         message=message,
     )
 
@@ -2550,6 +2596,50 @@ env_var = "GH_TOKEN"
         )
         self.assertEqual(limited_records[0].message, "post-apply evidence reported low disk")
 
+    def test_runner_lane_registration_audit_records_round_trip(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            older_record = _runner_lane_registration_audit_record(
+                audit_record_key="runner-lane-registration/2026-06-08/cm-website/old"
+            )
+            newer_record = _runner_lane_registration_audit_record(
+                audit_record_key="runner-lane-registration/2026-06-09/cm-website/new"
+            )
+            failed_record = _runner_lane_registration_audit_record(
+                audit_record_key="runner-lane-registration/2026-06-10/cm-website/failed",
+                status="failed",
+                message="post-registration inventory did not show the lane",
+            )
+
+            store.write_runner_lane_registration_audit_record(older_record)
+            store.write_runner_lane_registration_audit_record(newer_record)
+            store.write_runner_lane_registration_audit_record(failed_record)
+            planned_records = store.list_runner_lane_registration_audit_records(
+                repository="CBUSILLO/ODOO-TENANT-CM-WEBSITE",
+                host_name="Chris-Testing",
+                status="planned",
+            )
+            limited_records = store.list_runner_lane_registration_audit_records(limit=1)
+            store.close()
+
+        self.assertEqual(
+            [record.audit_record_key for record in planned_records],
+            [newer_record.audit_record_key, older_record.audit_record_key],
+        )
+        self.assertEqual(
+            [record.audit_record_key for record in limited_records],
+            [failed_record.audit_record_key],
+        )
+        self.assertEqual(
+            limited_records[0].message,
+            "post-registration inventory did not show the lane",
+        )
+
     def test_preview_pr_feedback_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -3246,6 +3336,11 @@ env_var = "GH_TOKEN"
                     audit_record_key="runner-host-hygiene/2026-05-23/chris-testing"
                 )
             )
+            filesystem_store.write_runner_lane_registration_audit_record(
+                _runner_lane_registration_audit_record(
+                    audit_record_key="runner-lane-registration/2026-06-08/cm-website/import"
+                )
+            )
             filesystem_store.write_release_tuple_record(_release_tuple_record())
             filesystem_store.write_product_profile_record(_product_profile_record())
             filesystem_store.write_runtime_key_safety_policy_record(
@@ -3348,6 +3443,7 @@ env_var = "GH_TOKEN"
                     "preview_lifecycle_plans": 1,
                     "preview_pr_feedback": 1,
                     "runner_host_hygiene_audits": 1,
+                    "runner_lane_registration_audits": 1,
                     "every_code_preview_gates": 0,
                     "agent_write_intents": 0,
                     "merge_train_pr_feedback": 0,
@@ -3439,6 +3535,13 @@ env_var = "GH_TOKEN"
                     limit=1,
                 )[0].audit_record_key,
                 "runner-host-hygiene/2026-05-23/chris-testing",
+            )
+            self.assertEqual(
+                store.list_runner_lane_registration_audit_records(
+                    repository="cbusillo/odoo-tenant-cm-website",
+                    limit=1,
+                )[0].audit_record_key,
+                "runner-lane-registration/2026-06-08/cm-website/import",
             )
             self.assertEqual(
                 store.list_runtime_key_safety_policy_records(status="active", limit=1)[0]

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from collections.abc import Sequence
+from collections.abc import Mapping
+import json
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import cast
+from typing import Any
+from unittest.mock import patch
+
+from click import Command
+from click.testing import CliRunner
+
+from control_plane.cli import main
+from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
+from control_plane.contracts.runner_lane_inventory import RunnerLaneRecord
+from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationPolicy
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationRequest
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationTokenRecord
+from control_plane.contracts.runner_lane_registration import plan_runner_lane_registration
+from control_plane.merge_train_github import RecordingMergeTrainGitHubTransport
+from control_plane.runner_lane_github import GitHubRunnerLaneRegistrationTokenFetcher
+from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
+from control_plane.workflows.runner_lane_registration_executor import (
+    RunnerLaneRegistrationExecutorRequest,
+)
+from control_plane.workflows.runner_lane_registration_executor import (
+    execute_runner_lane_registration_executor,
+)
+
+
+CLI_MAIN = cast(Command, main)
+
+
+class _Clock:
+    def now(self) -> datetime:
+        return datetime(2026, 6, 8, 17, 30, tzinfo=timezone.utc)
+
+
+class _TokenFetcher:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def fetch_registration_token(
+        self, *, repository: str
+    ) -> tuple[str, RunnerLaneRegistrationTokenRecord]:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=({"token": "secret-token", "expires_at": "2026-06-08T18:30:00Z"},)
+        )
+        self.calls.append(repository)
+        return GitHubRunnerLaneRegistrationTokenFetcher(
+            transport=transport,
+            clock=_Clock(),
+        ).fetch_registration_token(repository=repository)
+
+
+class _CommandRunner:
+    def __init__(self, *, returncode: int = 0) -> None:
+        self.returncode = returncode
+        self.commands: list[tuple[str, ...]] = []
+        self.envs: list[dict[str, str]] = []
+
+    def __call__(
+        self, command: Sequence[str], _timeout_seconds: int, env: Mapping[str, str]
+    ) -> RemoteCommandResult:
+        self.commands.append(tuple(command))
+        self.envs.append(dict(env))
+        return RemoteCommandResult(returncode=self.returncode, stderr="registration failed")
+
+
+class _AuditPoster:
+    def __init__(self) -> None:
+        self.records: list[tuple[str, str]] = []
+
+    def __call__(self, audit: Any, idempotency_key: str) -> dict[str, object]:
+        self.records.append((audit.status, idempotency_key))
+        return {"status": "accepted", "audit_record_key": audit.audit_record_key}
+
+
+class RunnerLaneRegistrationPlanTests(unittest.TestCase):
+    def test_plan_blocks_without_mutate_and_without_allowed_repo(self) -> None:
+        plan = plan_runner_lane_registration(
+            policy=RunnerLaneRegistrationPolicy(
+                approved_hosts=("chris-testing",),
+                allowed_registration_roots=("/opt/actions-runners",),
+            ),
+            request=_request(mutate=False),
+            inventory=_inventory(lanes=()),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["mutate_not_requested", "repository_not_allowed"],
+        )
+
+    def test_plan_blocks_path_traversal_outside_allowed_root(self) -> None:
+        plan = plan_runner_lane_registration(
+            policy=_policy(),
+            request=_request(registration_root="/opt/actions-runners/../tmp", mutate=True),
+            inventory=_inventory(lanes=()),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["registration_root_not_allowed"],
+        )
+
+    def test_plan_is_ready_for_empty_inventory_and_required_labels(self) -> None:
+        plan = plan_runner_lane_registration(
+            policy=_policy(),
+            request=_request(mutate=True),
+            inventory=_inventory(lanes=()),
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.blockers, ())
+        self.assertIn("request a short-lived", plan.next_steps[0])
+
+    def test_plan_blocks_when_lane_already_exists(self) -> None:
+        plan = plan_runner_lane_registration(
+            policy=_policy(),
+            request=_request(mutate=True),
+            inventory=_inventory(lanes=(_lane(),)),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual([blocker.code for blocker in plan.blockers], ["lane_already_exists"])
+
+
+class GitHubRunnerLaneRegistrationTokenFetcherTests(unittest.TestCase):
+    def test_fetch_registration_token_returns_token_and_safe_record(self) -> None:
+        transport = RecordingMergeTrainGitHubTransport(
+            responses=({"token": "secret-token", "expires_at": "2026-06-08T18:30:00Z"},)
+        )
+
+        token, record = GitHubRunnerLaneRegistrationTokenFetcher(
+            transport=transport,
+            clock=_Clock(),
+        ).fetch_registration_token(repository="cbusillo/odoo-tenant-cm-website")
+
+        self.assertEqual(token, "secret-token")
+        self.assertEqual(record.repository, "cbusillo/odoo-tenant-cm-website")
+        self.assertEqual(record.fetched_at, "2026-06-08T17:30:00Z")
+        self.assertNotIn("secret-token", json.dumps(record.model_dump(mode="json")))
+        self.assertEqual(
+            transport.requests[0].path,
+            "/repos/cbusillo/odoo-tenant-cm-website/actions/runners/registration-token",
+        )
+
+
+class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
+    def test_blocked_plan_posts_planned_audit_without_token_or_command(self) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner()
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_lane_registration_executor(
+            request=_executor_request(mutate=False),
+            policy=_policy(),
+            pre_inventory=_inventory(lanes=()),
+            inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
+            token_fetcher=token_fetcher,  # type: ignore[arg-type]
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(token_fetcher.calls, [])
+        self.assertEqual(command_runner.commands, [])
+        self.assertEqual(audit_poster.records[0][0], "planned")
+
+    def test_ready_executor_registers_and_verifies_inventory(self) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner()
+        audit_poster = _AuditPoster()
+
+        with patch(
+            "control_plane.workflows.runner_lane_registration_executor.validate_local_executor_environment"
+        ):
+            result = execute_runner_lane_registration_executor(
+                request=_executor_request(mutate=True),
+                policy=_policy(),
+                pre_inventory=_inventory(lanes=()),
+                inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
+                token_fetcher=token_fetcher,  # type: ignore[arg-type]
+                remote_runner=command_runner,
+                audit_poster=audit_poster,
+            )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(token_fetcher.calls, ["cbusillo/odoo-tenant-cm-website"])
+        self.assertEqual(len(command_runner.commands), 1)
+        command_text = " ".join(command_runner.commands[0])
+        self.assertIn("./config.sh", command_text)
+        self.assertIn("--labels 'launchplane,launchplane-managed,self-hosted'", command_text)
+        self.assertIn("RUNNER_REGISTRATION_TOKEN", command_runner.envs[0])
+        self.assertEqual(command_runner.envs[0]["RUNNER_REGISTRATION_TOKEN"], "secret-token")
+        self.assertNotIn("secret-token", command_text)
+        self.assertNotIn("secret-token", result.model_dump_json())
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned", "completed"])
+
+    def test_executor_fails_when_post_inventory_does_not_show_lane(self) -> None:
+        with patch(
+            "control_plane.workflows.runner_lane_registration_executor.validate_local_executor_environment"
+        ):
+            result = execute_runner_lane_registration_executor(
+                request=_executor_request(mutate=True),
+                policy=_policy(),
+                pre_inventory=_inventory(lanes=()),
+                inventory_reader=lambda _repo: _inventory(lanes=()),
+                token_fetcher=_TokenFetcher(),  # type: ignore[arg-type]
+                remote_runner=_CommandRunner(),
+                audit_poster=_AuditPoster(),
+            )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("inventory", result.message)
+
+
+class RunnerLaneRegistrationCliTests(unittest.TestCase):
+    def test_cli_dry_run_emits_blocked_result_without_github_token(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            inventory_file = Path(temp_dir) / "inventory.json"
+            inventory_file.write_text(
+                json.dumps(_inventory(lanes=()).model_dump(mode="json")),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-lane-registration-executor",
+                    "--repository",
+                    "cbusillo/odoo-tenant-cm-website",
+                    "--host-name",
+                    "chris-testing",
+                    "--execution-lane",
+                    "chris-testing-ops-gate",
+                    "--service-user",
+                    "launchplane-runner-hygiene",
+                    "--lane-name",
+                    "cm-website-runner-1",
+                    "--registration-root",
+                    "/opt/actions-runners",
+                    "--label",
+                    "self-hosted",
+                    "--label",
+                    "launchplane",
+                    "--label",
+                    "launchplane-managed",
+                    "--audit-record-key",
+                    "runner-lane-registration/2026-06-08/cm-website/dry-run",
+                    "--allowed-repository",
+                    "cbusillo/odoo-tenant-cm-website",
+                    "--approved-host",
+                    "chris-testing",
+                    "--allowed-registration-root",
+                    "/opt/actions-runners",
+                    "--inventory-file",
+                    str(inventory_file),
+                ],
+                env={},
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "blocked")
+        self.assertIn("planned_response", payload)
+
+
+def _policy() -> RunnerLaneRegistrationPolicy:
+    return RunnerLaneRegistrationPolicy(
+        allowed_repositories=("cbusillo/odoo-tenant-cm-website",),
+        approved_hosts=("chris-testing",),
+        allowed_registration_roots=("/opt/actions-runners",),
+    )
+
+
+def _request(
+    *,
+    registration_root: str = "/opt/actions-runners",
+    mutate: bool,
+) -> RunnerLaneRegistrationRequest:
+    return RunnerLaneRegistrationRequest(
+        repository="cbusillo/odoo-tenant-cm-website",
+        host_name="chris-testing",
+        lane_name="cm-website-runner-1",
+        registration_root=registration_root,
+        labels=("self-hosted", "launchplane", "launchplane-managed"),
+        mutate=mutate,
+        audit_record_key="runner-lane-registration/2026-06-08/cm-website/test",
+    )
+
+
+def _executor_request(*, mutate: bool) -> RunnerLaneRegistrationExecutorRequest:
+    return RunnerLaneRegistrationExecutorRequest(
+        repository="cbusillo/odoo-tenant-cm-website",
+        host_name="chris-testing",
+        execution_lane="chris-testing-ops-gate",
+        service_user="launchplane-runner-hygiene",
+        lane_name="cm-website-runner-1",
+        registration_root="/opt/actions-runners",
+        labels=("self-hosted", "launchplane", "launchplane-managed"),
+        mutate=mutate,
+        audit_record_key="runner-lane-registration/2026-06-08/cm-website/test",
+    )
+
+
+def _inventory(*, lanes: tuple[RunnerLaneRecord, ...]) -> RunnerLaneInventory:
+    return build_runner_lane_inventory(
+        repository="cbusillo/odoo-tenant-cm-website",
+        observed_at="2026-06-08T17:30:00Z",
+        lanes=lanes,
+    )
+
+
+def _lane() -> RunnerLaneRecord:
+    return RunnerLaneRecord(
+        github_id=1,
+        name="cm-website-runner-1",
+        repository="cbusillo/odoo-tenant-cm-website",
+        status="online",
+        busy=False,
+        labels=("self-hosted", "launchplane", "launchplane-managed"),
+        observed_at="2026-06-08T17:31:00Z",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -106,6 +106,13 @@ from control_plane.contracts.runner_host_hygiene import (
     evaluate_runner_host_hygiene,
     plan_runner_host_hygiene_apply,
 )
+from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.contracts.runner_lane_registration import (
+    RunnerLaneRegistrationAuditRecord,
+    RunnerLaneRegistrationPolicy,
+    RunnerLaneRegistrationRequest,
+    plan_runner_lane_registration,
+)
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
@@ -1346,6 +1353,45 @@ def _runner_host_hygiene_audit_payload(
         plan=plan,
         pre_apply_report=report,
         message="planned runner host hygiene apply; no host mutation was executed",
+    )
+    return {"schema_version": 1, "product": product, "audit": audit_record.model_dump(mode="json")}
+
+
+def _runner_lane_registration_audit_payload(
+    *,
+    audit_record_key: str = "runner-lane-registration/2026-06-08/cm-website/dry-run",
+    product: str = "launchplane",
+) -> dict[str, object]:
+    inventory = build_runner_lane_inventory(
+        repository="cbusillo/odoo-tenant-cm-website",
+        observed_at="2026-06-08T17:30:00Z",
+        lanes=(),
+    )
+    request = RunnerLaneRegistrationRequest(
+        repository="cbusillo/odoo-tenant-cm-website",
+        host_name="chris-testing",
+        lane_name="cm-website-runner-1",
+        registration_root="/opt/actions-runners",
+        labels=("self-hosted", "launchplane", "launchplane-managed"),
+        mutate=False,
+        audit_record_key=audit_record_key,
+    )
+    plan = plan_runner_lane_registration(
+        policy=RunnerLaneRegistrationPolicy(
+            allowed_repositories=("cbusillo/odoo-tenant-cm-website",),
+            approved_hosts=("chris-testing",),
+            allowed_registration_roots=("/opt/actions-runners",),
+        ),
+        request=request,
+        inventory=inventory,
+    )
+    audit_record = RunnerLaneRegistrationAuditRecord(
+        audit_record_key=audit_record_key,
+        status="planned",
+        request=request,
+        plan=plan,
+        pre_inventory=inventory,
+        message="planned runner lane registration; no host mutation was executed",
     )
     return {"schema_version": 1, "product": product, "audit": audit_record.model_dump(mode="json")}
 
@@ -26537,6 +26583,204 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 method="POST",
                 path="/v1/evidence/runner-host-hygiene/audits",
                 payload=_runner_host_hygiene_audit_payload(product="odoo"),
+            )
+
+            self.assertEqual(status_code, 400)
+            self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_runner_lane_registration_audit_endpoint_writes_record_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/runner-lane-registration.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["runner_lane_registration_audit.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/runner-lane-registration.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-lane-registration/audits",
+                payload=_runner_lane_registration_audit_payload(),
+            )
+
+            self.assertEqual(status_code, 202, msg=json.dumps(payload, indent=2))
+            self.assertEqual(payload["status"], "accepted")
+            self.assertEqual(
+                payload["records"],
+                {
+                    "runner_lane_registration_audit_record_key": (
+                        "runner-lane-registration/2026-06-08/cm-website/dry-run"
+                    ),
+                },
+            )
+            self.assertEqual(
+                payload["result"]["runner_lane_registration_audit_record_key"],
+                "runner-lane-registration/2026-06-08/cm-website/dry-run",
+            )
+            self.assertEqual(payload["result"]["repository"], "cbusillo/odoo-tenant-cm-website")
+            self.assertEqual(payload["result"]["host_name"], "chris-testing")
+            self.assertEqual(payload["result"]["lane_name"], "cm-website-runner-1")
+            self.assertEqual(payload["result"]["audit_status"], "planned")
+            self.assertFalse(payload["result"]["mutate"])
+            self.assertEqual(payload["result"]["audit"]["status"], "planned")
+            store = FilesystemRecordStore(state_dir=state_dir)
+            records = store.list_runner_lane_registration_audit_records(
+                repository="cbusillo/odoo-tenant-cm-website",
+                host_name="chris-testing",
+                status="planned",
+            )
+            self.assertEqual(len(records), 1)
+            self.assertEqual(
+                records[0].audit_record_key,
+                "runner-lane-registration/2026-06-08/cm-website/dry-run",
+            )
+            self.assertFalse(records[0].request.mutate)
+
+    def test_runner_lane_registration_audit_endpoint_replays_idempotent_write(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/runner-lane-registration.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["runner_lane_registration_audit.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/runner-lane-registration.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = _runner_lane_registration_audit_payload()
+
+            first_status_code, first_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-lane-registration/audits",
+                payload=request_payload,
+                headers={"Idempotency-Key": "runner-lane-registration:cm-website:planned"},
+            )
+            second_status_code, second_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-lane-registration/audits",
+                payload=request_payload,
+                headers={"Idempotency-Key": "runner-lane-registration:cm-website:planned"},
+            )
+
+            self.assertEqual(first_status_code, 202, msg=json.dumps(first_payload, indent=2))
+            self.assertEqual(second_status_code, 202, msg=json.dumps(second_payload, indent=2))
+            self.assertEqual(first_payload["records"], second_payload["records"])
+            self.assertTrue(second_payload["replayed"])
+            self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+
+    def test_runner_lane_registration_audit_endpoint_rejects_unauthorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-lane-registration/audits",
+                payload=_runner_lane_registration_audit_payload(),
+            )
+
+            self.assertEqual(status_code, 403)
+            self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_runner_lane_registration_audit_endpoint_rejects_non_launchplane_product(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": ["*"],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["runner_lane_registration_audit.write"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/evidence/runner-lane-registration/audits",
+                payload=_runner_lane_registration_audit_payload(product="odoo"),
             )
 
             self.assertEqual(status_code, 400)


### PR DESCRIPTION
## Summary

- Adds typed runner lane registration policy/request/plan/audit contracts with fail-closed blockers.
- Adds a GitHub registration-token adapter and a dry-run-first host executor that never persists token values.
- Adds a Launchplane service audit route, filesystem/Postgres persistence, migration, manual workflow, and docs for the runner-registration proof path.

Closes #1231.

## Verification

- `uv run python -m unittest tests.test_runner_lane_registration tests.test_filesystem_store tests.test_postgres_store tests.test_service` (`602` tests)
- `uv run --extra dev ruff format --check ...changed Python files...`
- `uv run --extra dev ruff check ...changed Python files...`
- `uv run --extra dev mypy ...changed Python files...`
- `git diff --check`
- `uv run python -m unittest` (`2199` tests)

## Live Proof Notes

This PR does not perform a live GitHub runner mutation. After merge/deploy, the cm-website proof should run in this order:

1. Add the scoped workflow authz grant for `runner_lane_registration_audit.write` on `.github/workflows/runner-lane-registration.yml`.
2. Configure the runner registration GitHub token secret for the workflow.
3. Dispatch `runner-lane-registration.yml` with `mutate=false` and inspect the service-backed audit record.
4. Dispatch with `mutate=true` only after the dry-run audit is reviewed and approved.
