### PR TITLE
Bootstrap runner registration host directory

### DIFF
--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -13,9 +13,9 @@ name: Runner Lane Registration
         required: true
         type: string
       registration_root:
-        description: Approved absolute runner registration root.
+        description: Absolute runner root, or auto for service-user home.
         required: false
-        default: /opt/actions-runners
+        default: auto
         type: string
       labels:
         description: Comma-separated runner labels.
@@ -125,6 +125,13 @@ jobs:
           set -euo pipefail
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "Missing runner registration GitHub token secret." >&2
+            exit 1
+          fi
+          if [ "$REGISTRATION_ROOT" = "auto" ]; then
+            REGISTRATION_ROOT="$HOME/actions-runners"
+          fi
+          if [ "${REGISTRATION_ROOT#/}" = "$REGISTRATION_ROOT" ]; then
+            echo "registration_root must be absolute or auto." >&2
             exit 1
           fi
           label_args=()

--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 import json
 import os
 import pwd
+import shlex
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
@@ -287,19 +288,59 @@ def _audit_route_payload(audit: RunnerLaneRegistrationAuditRecord) -> dict[str, 
 
 def _registration_command(*, request: RunnerLaneRegistrationExecutorRequest) -> tuple[str, ...]:
     runner_directory = f"{request.registration_root}/{request.lane_name}"
+    quoted_runner_directory = shlex.quote(runner_directory)
+    quoted_repository_url = shlex.quote(f"https://github.com/{request.repository}")
+    quoted_lane_name = shlex.quote(request.lane_name)
+    quoted_labels = shlex.quote(",".join(request.labels))
     return (
         "bash",
         "-lc",
         "set -euo pipefail\n"
-        f"mkdir -p {runner_directory!r}\n"
-        f"cd {runner_directory!r}\n"
+        f"mkdir -p {quoted_runner_directory}\n"
+        f"cd {quoted_runner_directory}\n"
+        "if [ ! -x ./config.sh ]; then\n"
+        '  runner_arch="$(uname -m)"\n'
+        '  case "$runner_arch" in\n'
+        "    x86_64|amd64) runner_arch=x64 ;;\n"
+        "    aarch64|arm64) runner_arch=arm64 ;;\n"
+        '    *) echo "unsupported runner architecture: $runner_arch" >&2; exit 1 ;;\n'
+        "  esac\n"
+        '  runner_version="${ACTIONS_RUNNER_VERSION:-}"\n'
+        '  if [ -z "$runner_version" ]; then\n'
+        "    runner_version=\"$(python3 - <<'PY'\n"
+        "import json\n"
+        "import urllib.request\n"
+        "request = urllib.request.Request(\n"
+        "    'https://api.github.com/repos/actions/runner/releases/latest',\n"
+        "    headers={'Accept': 'application/vnd.github+json'},\n"
+        ")\n"
+        "with urllib.request.urlopen(request, timeout=30) as response:\n"
+        "    payload = json.load(response)\n"
+        "print(str(payload['tag_name']).removeprefix('v'))\n"
+        "PY\n"
+        '    )"\n'
+        "  fi\n"
+        '  asset="actions-runner-linux-${runner_arch}-${runner_version}.tar.gz"\n'
+        '  url="https://github.com/actions/runner/releases/download/v${runner_version}/${asset}"\n'
+        '  archive="$(mktemp)"\n'
+        '  curl -fsSL "$url" -o "$archive"\n'
+        '  tar -xzf "$archive"\n'
+        '  rm -f "$archive"\n'
+        "fi\n"
         "test -x ./config.sh\n"
         "./config.sh "
-        f"--url https://github.com/{request.repository} "
+        f"--url {quoted_repository_url} "
         '--token "$RUNNER_REGISTRATION_TOKEN" '
-        f"--name {request.lane_name!r} "
-        f"--labels {','.join(request.labels)!r} "
-        "--unattended --replace",
+        f"--name {quoted_lane_name} "
+        f"--labels {quoted_labels} "
+        "--unattended --replace\n"
+        'if [ -f .runner.pid ] && kill -0 "$(cat .runner.pid)" 2>/dev/null; then\n'
+        "  :\n"
+        "else\n"
+        "  nohup ./run.sh > runner.log 2>&1 &\n"
+        "  echo $! > .runner.pid\n"
+        "fi\n"
+        "sleep 12",
     )
 
 

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -181,24 +181,31 @@ uv run launchplane work-graph runner-lane-registration-executor \
   --execution-lane chris-testing-ops-gate \
   --service-user launchplane-runner-hygiene \
   --lane-name product-runner-1 \
-  --registration-root /opt/actions-runners \
+  --registration-root /home/launchplane-runner-hygiene/actions-runners \
   --label self-hosted \
   --label launchplane \
   --label launchplane-managed \
   --audit-record-key runner-lane-registration/2026-06-08/product/dry-run \
   --allowed-repository owner/name \
   --approved-host chris-testing \
-  --allowed-registration-root /opt/actions-runners \
+  --allowed-registration-root /home/launchplane-runner-hygiene/actions-runners \
   --inventory-file runner-inventory.json
 ```
 
 The command is dry-run by default. A dry-run writes only local JSON evidence and
 does not request a GitHub registration token. `--mutate` requires an environment
 GitHub token, validates the local host/user/execution-lane boundary, requests a
-short-lived GitHub runner registration token, runs the host-local runner
-`config.sh`, then re-reads GitHub inventory and fails closed unless the expected
-lane appears online with the requested labels. The token itself is never written
-to the audit record, command output, or JSON result.
+short-lived GitHub runner registration token, prepares the official GitHub
+Actions runner package under the approved registration root when needed, runs
+the host-local runner `config.sh`, starts the runner process, then re-reads
+GitHub inventory and fails closed unless the expected lane appears online with
+the requested labels. The token itself is never written to the audit record,
+command output, or JSON result.
+
+The manual workflow defaults `registration_root` to `auto`, which resolves to
+`$HOME/actions-runners` for the constrained service user. Operators may pass an
+absolute root explicitly, but the service user must already be able to create
+lane directories below that root.
 
 The manual workflow requires the repository secret
 `LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN` for cross-repository runner

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -197,8 +197,10 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
         self.assertEqual(token_fetcher.calls, ["cbusillo/odoo-tenant-cm-website"])
         self.assertEqual(len(command_runner.commands), 1)
         command_text = " ".join(command_runner.commands[0])
+        self.assertIn("actions-runner-linux-${runner_arch}-${runner_version}.tar.gz", command_text)
         self.assertIn("./config.sh", command_text)
-        self.assertIn("--labels 'launchplane,launchplane-managed,self-hosted'", command_text)
+        self.assertIn("nohup ./run.sh", command_text)
+        self.assertIn("--labels launchplane,launchplane-managed,self-hosted", command_text)
         self.assertIn("RUNNER_REGISTRATION_TOKEN", command_runner.envs[0])
         self.assertEqual(command_runner.envs[0]["RUNNER_REGISTRATION_TOKEN"], "secret-token")
         self.assertNotIn("secret-token", command_text)
@@ -279,7 +281,10 @@ def _policy() -> RunnerLaneRegistrationPolicy:
     return RunnerLaneRegistrationPolicy(
         allowed_repositories=("cbusillo/odoo-tenant-cm-website",),
         approved_hosts=("chris-testing",),
-        allowed_registration_roots=("/opt/actions-runners",),
+        allowed_registration_roots=(
+            "/home/launchplane-runner-hygiene/actions-runners",
+            "/opt/actions-runners",
+        ),
     )
 
 
@@ -306,7 +311,7 @@ def _executor_request(*, mutate: bool) -> RunnerLaneRegistrationExecutorRequest:
         execution_lane="chris-testing-ops-gate",
         service_user="launchplane-runner-hygiene",
         lane_name="cm-website-runner-1",
-        registration_root="/opt/actions-runners",
+        registration_root="/home/launchplane-runner-hygiene/actions-runners",
         labels=("self-hosted", "launchplane", "launchplane-managed"),
         mutate=mutate,
         audit_record_key="runner-lane-registration/2026-06-08/cm-website/test",


### PR DESCRIPTION
## Summary

- Defaults the manual runner registration workflow to a service-user-owned `auto` root (`$HOME/actions-runners`) instead of root-owned `/opt/actions-runners`.
- Bootstraps the official GitHub Actions runner package when `config.sh` is missing in a new lane directory.
- Starts `run.sh` after registration so post-registration inventory can observe the lane online.

## Live Evidence

The first live apply run proved the control-plane path but failed at host prep:

- Run: https://github.com/cbusillo/launchplane/actions/runs/27157039099
- Plan status: `ready`
- GitHub registration token fetched and redacted in audit output
- Terminal audit status: `failed`
- Failure: service user could not create `/opt/actions-runners/cm-website-chris-testing`
- Post-inventory: still zero runners in `cbusillo/odoo-tenant-cm-website`

This PR fixes that root-owned directory assumption and the follow-on missing runner package assumption.

## Verification

- `uv run python -m unittest tests.test_runner_lane_registration`
- `uv run --extra dev ruff format --check control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `uv run --extra dev ruff check control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `uv run --extra dev mypy control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `git diff --check`
