### PR TITLE
Disable transient runner registration apply

### DIFF
--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -164,6 +164,11 @@ jobs:
             --service-url "$LAUNCHPLANE_SERVICE_URL" \
             "$mutate_flag" \
             > runner-lane-registration-result.json
+          status="$(jq -r '.status // ""' runner-lane-registration-result.json)"
+          if [ "$status" != "blocked" ] && [ "$status" != "completed" ]; then
+            jq . runner-lane-registration-result.json >&2
+            exit 1
+          fi
 
       - name: Upload registration result
         uses: actions/upload-artifact@v7

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -508,7 +508,7 @@ def runner_control_plan(
     "--mutate/--dry-run",
     default=False,
     show_default=True,
-    help="Create the runner registration token and run config.sh. Defaults to dry-run.",
+    help="Record apply intent. Live registration is disabled until a supervised maintainer exists.",
 )
 @click.option(
     "--audit-record-key",
@@ -549,7 +549,7 @@ def runner_control_plan(
     "--github-token-env",
     default="GITHUB_TOKEN",
     show_default=True,
-    help="Environment variable containing the GitHub token for mutate mode.",
+    help="Environment variable reserved for future supervised registration token fetches.",
 )
 @click.option(
     "--github-api-base-url",
@@ -608,8 +608,6 @@ def runner_lane_registration_executor(
         pre_inventory = _load_runner_lane_inventory(inventory_file)
         token_env = github_token_env.strip()
         token = os.environ.get(token_env, "").strip() if token_env else ""
-        if mutate and not token:
-            raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
         transport = UrllibMergeTrainGitHubTransport(
             token=token or "dry-run-token",
             api_base_url=github_api_base_url,

--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -5,13 +5,11 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 import json
 import os
 import pwd
-import shlex
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
-from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditStatus
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationPolicy
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationRequest
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationTokenRecord
@@ -99,6 +97,7 @@ def execute_runner_lane_registration_executor(
     remote_runner: RemoteCommandRunner,
     audit_poster: AuditPoster,
 ) -> RunnerLaneRegistrationExecutorResult:
+    del inventory_reader, token_fetcher, remote_runner
     registration_request = RunnerLaneRegistrationRequest(
         repository=request.repository,
         host_name=request.host_name,
@@ -133,47 +132,27 @@ def execute_runner_lane_registration_executor(
             message=plan.summary,
         )
 
-    validate_local_executor_environment(request=request)
-    token, token_record = token_fetcher.fetch_registration_token(repository=request.repository)
-    register_result = remote_runner(
-        _registration_command(request=request),
-        request.timeout_seconds,
-        {"RUNNER_REGISTRATION_TOKEN": token},
-    )
-    post_inventory = inventory_reader(request.repository)
-    if register_result.returncode == 0 and _post_inventory_has_lane(
-        inventory=post_inventory,
-        lane_name=request.lane_name,
-        labels=request.labels,
-    ):
-        status: RunnerLaneRegistrationAuditStatus = "completed"
-        message = "runner lane registration completed and GitHub inventory verified"
-    else:
-        status = "failed"
-        detail = register_result.stderr.strip() or register_result.stdout.strip() or plan.summary
-        if register_result.returncode == 0:
-            detail = "registered command completed but GitHub inventory did not show expected lane"
-        message = f"runner lane registration failed: {detail}"
     terminal_audit = RunnerLaneRegistrationAuditRecord(
         audit_record_key=request.audit_record_key,
-        status=status,
+        status="failed",
         request=registration_request,
         plan=plan,
         pre_inventory=pre_inventory,
-        post_inventory=post_inventory,
-        message=message,
+        message=(
+            "runner lane registration requires a supervised host maintainer; "
+            "starting run.sh from an Actions job is disabled"
+        ),
     )
     terminal_response = audit_poster(
         terminal_audit,
-        f"runner-lane-registration:{request.audit_record_key}:{status}",
+        f"runner-lane-registration:{request.audit_record_key}:supervisor-required",
     )
     return RunnerLaneRegistrationExecutorResult(
-        status=status,
+        status="failed",
         audit_record_key=request.audit_record_key,
         planned_response=planned_response,
         terminal_response=terminal_response,
-        token_record=token_record,
-        message=message,
+        message=terminal_audit.message,
     )
 
 
@@ -284,76 +263,6 @@ def _audit_route_payload(audit: RunnerLaneRegistrationAuditRecord) -> dict[str, 
         "product": "launchplane",
         "audit": audit.model_dump(mode="json"),
     }
-
-
-def _registration_command(*, request: RunnerLaneRegistrationExecutorRequest) -> tuple[str, ...]:
-    runner_directory = f"{request.registration_root}/{request.lane_name}"
-    quoted_runner_directory = shlex.quote(runner_directory)
-    quoted_repository_url = shlex.quote(f"https://github.com/{request.repository}")
-    quoted_lane_name = shlex.quote(request.lane_name)
-    quoted_labels = shlex.quote(",".join(request.labels))
-    return (
-        "bash",
-        "-lc",
-        "set -euo pipefail\n"
-        f"mkdir -p {quoted_runner_directory}\n"
-        f"cd {quoted_runner_directory}\n"
-        "if [ ! -x ./config.sh ]; then\n"
-        '  runner_arch="$(uname -m)"\n'
-        '  case "$runner_arch" in\n'
-        "    x86_64|amd64) runner_arch=x64 ;;\n"
-        "    aarch64|arm64) runner_arch=arm64 ;;\n"
-        '    *) echo "unsupported runner architecture: $runner_arch" >&2; exit 1 ;;\n'
-        "  esac\n"
-        '  runner_version="${ACTIONS_RUNNER_VERSION:-}"\n'
-        '  if [ -z "$runner_version" ]; then\n'
-        "    runner_version=\"$(python3 - <<'PY'\n"
-        "import json\n"
-        "import urllib.request\n"
-        "request = urllib.request.Request(\n"
-        "    'https://api.github.com/repos/actions/runner/releases/latest',\n"
-        "    headers={'Accept': 'application/vnd.github+json'},\n"
-        ")\n"
-        "with urllib.request.urlopen(request, timeout=30) as response:\n"
-        "    payload = json.load(response)\n"
-        "print(str(payload['tag_name']).removeprefix('v'))\n"
-        "PY\n"
-        '    )"\n'
-        "  fi\n"
-        '  asset="actions-runner-linux-${runner_arch}-${runner_version}.tar.gz"\n'
-        '  url="https://github.com/actions/runner/releases/download/v${runner_version}/${asset}"\n'
-        '  archive="$(mktemp)"\n'
-        '  curl -fsSL "$url" -o "$archive"\n'
-        '  tar -xzf "$archive"\n'
-        '  rm -f "$archive"\n'
-        "fi\n"
-        "test -x ./config.sh\n"
-        "./config.sh "
-        f"--url {quoted_repository_url} "
-        '--token "$RUNNER_REGISTRATION_TOKEN" '
-        f"--name {quoted_lane_name} "
-        f"--labels {quoted_labels} "
-        "--unattended --replace\n"
-        'if [ -f .runner.pid ] && kill -0 "$(cat .runner.pid)" 2>/dev/null; then\n'
-        "  :\n"
-        "else\n"
-        "  nohup ./run.sh > runner.log 2>&1 &\n"
-        "  echo $! > .runner.pid\n"
-        "fi\n"
-        "sleep 12",
-    )
-
-
-def _post_inventory_has_lane(
-    *, inventory: RunnerLaneInventory, lane_name: str, labels: tuple[str, ...]
-) -> bool:
-    expected_labels = set(labels)
-    for lane in inventory.lanes:
-        if lane.name != lane_name or lane.status != "online":
-            continue
-        if expected_labels.issubset({label.strip().lower() for label in lane.labels}):
-            return True
-    return False
 
 
 def _required_text(value: str, message: str) -> str:

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -193,13 +193,13 @@ uv run launchplane work-graph runner-lane-registration-executor \
 ```
 
 The command is dry-run by default. A dry-run writes only local JSON evidence and
-does not request a GitHub registration token. `--mutate` requires an environment
-GitHub token, validates the local host/user/execution-lane boundary, requests a
-short-lived GitHub runner registration token, prepares the official GitHub
-Actions runner package under the approved registration root when needed, runs
-the host-local runner `config.sh`, starts the runner process, then re-reads
-GitHub inventory and fails closed unless the expected lane appears online with
-the requested labels. The token itself is never written to the audit record,
+does not request a GitHub registration token. `--mutate` records apply intent
+and writes a failed audit explaining that runner registration requires a
+supervised host maintainer. The earlier proof path briefly started `run.sh` from
+inside the GitHub Actions job, but that can produce transient online evidence
+and leave the runner offline after job cleanup. That shortcut is disabled. Until
+the supervised maintainer exists, mutate runs do not request a GitHub
+registration token. The token itself must never be written to the audit record,
 command output, or JSON result.
 
 The manual workflow defaults `registration_root` to `auto`, which resolves to
@@ -220,3 +220,29 @@ audit persistence is available through
 registration planning remains a later slice. The workflow still uploads the JSON
 artifact so operators can inspect the exact plan/result packet for cm-website or
 any other product proof.
+
+## Supervised Runner Maintainer Plan
+
+The durable runner maintainer must replace the disabled apply shortcut before a
+product repository can rely on a Launchplane-managed runner lane. The maintainer
+should reconcile desired runner state rather than simply start `run.sh`:
+
+1. Read GitHub runner inventory and local service state for the requested lane.
+2. If registration is required, request a short-lived GitHub registration token
+   and run `config.sh` under an approved registration root.
+3. Install or update a persistent supervisor outside the GitHub Actions job
+   process tree. Prefer a root-owned systemd unit such as
+   `launchplane-runner@<lane>.service` with `User=<service_user>`, an approved
+   `WorkingDirectory`, `ExecStart=<runner-dir>/run.sh`, and `Restart=always`.
+4. Use a small validated root helper or narrow sudo rule for the privileged
+   systemd verbs. Do not grant arbitrary `systemctl`, file-write, or shell
+   authority.
+5. Mark the audit completed only after the service is enabled and active, the
+   process runs as the expected service user, GitHub inventory shows the lane
+   online with expected labels, and baseline readiness passes.
+
+The offline `cm-website-chris-testing` proof runner was removed from GitHub
+inventory after demonstrating why transient process supervision is not
+acceptable. Future cm-website proof runs should first produce a maintainer
+dry-run that decides whether to adopt, remove, or recreate any existing runner
+record, then apply only through the supervised maintainer path.

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 from typing import Any
-from unittest.mock import patch
-
 from click import Command
 from click.testing import CliRunner
 
@@ -175,54 +173,28 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
         self.assertEqual(command_runner.commands, [])
         self.assertEqual(audit_poster.records[0][0], "planned")
 
-    def test_ready_executor_registers_and_verifies_inventory(self) -> None:
+    def test_ready_executor_requires_supervised_host_maintainer(self) -> None:
         token_fetcher = _TokenFetcher()
         command_runner = _CommandRunner()
         audit_poster = _AuditPoster()
 
-        with patch(
-            "control_plane.workflows.runner_lane_registration_executor.validate_local_executor_environment"
-        ):
-            result = execute_runner_lane_registration_executor(
-                request=_executor_request(mutate=True),
-                policy=_policy(),
-                pre_inventory=_inventory(lanes=()),
-                inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
-                token_fetcher=token_fetcher,  # type: ignore[arg-type]
-                remote_runner=command_runner,
-                audit_poster=audit_poster,
-            )
-
-        self.assertEqual(result.status, "completed")
-        self.assertEqual(token_fetcher.calls, ["cbusillo/odoo-tenant-cm-website"])
-        self.assertEqual(len(command_runner.commands), 1)
-        command_text = " ".join(command_runner.commands[0])
-        self.assertIn("actions-runner-linux-${runner_arch}-${runner_version}.tar.gz", command_text)
-        self.assertIn("./config.sh", command_text)
-        self.assertIn("nohup ./run.sh", command_text)
-        self.assertIn("--labels launchplane,launchplane-managed,self-hosted", command_text)
-        self.assertIn("RUNNER_REGISTRATION_TOKEN", command_runner.envs[0])
-        self.assertEqual(command_runner.envs[0]["RUNNER_REGISTRATION_TOKEN"], "secret-token")
-        self.assertNotIn("secret-token", command_text)
-        self.assertNotIn("secret-token", result.model_dump_json())
-        self.assertEqual([record[0] for record in audit_poster.records], ["planned", "completed"])
-
-    def test_executor_fails_when_post_inventory_does_not_show_lane(self) -> None:
-        with patch(
-            "control_plane.workflows.runner_lane_registration_executor.validate_local_executor_environment"
-        ):
-            result = execute_runner_lane_registration_executor(
-                request=_executor_request(mutate=True),
-                policy=_policy(),
-                pre_inventory=_inventory(lanes=()),
-                inventory_reader=lambda _repo: _inventory(lanes=()),
-                token_fetcher=_TokenFetcher(),  # type: ignore[arg-type]
-                remote_runner=_CommandRunner(),
-                audit_poster=_AuditPoster(),
-            )
+        result = execute_runner_lane_registration_executor(
+            request=_executor_request(mutate=True),
+            policy=_policy(),
+            pre_inventory=_inventory(lanes=()),
+            inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
+            token_fetcher=token_fetcher,  # type: ignore[arg-type]
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
 
         self.assertEqual(result.status, "failed")
-        self.assertIn("inventory", result.message)
+        self.assertIn("supervised host maintainer", result.message)
+        self.assertEqual(token_fetcher.calls, [])
+        self.assertEqual(command_runner.commands, [])
+        self.assertEqual(result.token_record, None)
+        self.assertNotIn("secret-token", result.model_dump_json())
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned", "failed"])
 
 
 class RunnerLaneRegistrationCliTests(unittest.TestCase):
@@ -275,6 +247,59 @@ class RunnerLaneRegistrationCliTests(unittest.TestCase):
         payload = json.loads(result.output)
         self.assertEqual(payload["status"], "blocked")
         self.assertIn("planned_response", payload)
+
+    def test_cli_mutate_reports_supervisor_required_without_github_token(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            inventory_file = Path(temp_dir) / "inventory.json"
+            inventory_file.write_text(
+                json.dumps(_inventory(lanes=()).model_dump(mode="json")),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-lane-registration-executor",
+                    "--repository",
+                    "cbusillo/odoo-tenant-cm-website",
+                    "--host-name",
+                    "chris-testing",
+                    "--execution-lane",
+                    "chris-testing-ops-gate",
+                    "--service-user",
+                    "launchplane-runner-hygiene",
+                    "--lane-name",
+                    "cm-website-runner-1",
+                    "--registration-root",
+                    "/opt/actions-runners",
+                    "--label",
+                    "self-hosted",
+                    "--label",
+                    "launchplane",
+                    "--label",
+                    "launchplane-managed",
+                    "--audit-record-key",
+                    "runner-lane-registration/2026-06-08/cm-website/mutate",
+                    "--allowed-repository",
+                    "cbusillo/odoo-tenant-cm-website",
+                    "--approved-host",
+                    "chris-testing",
+                    "--allowed-registration-root",
+                    "/opt/actions-runners",
+                    "--inventory-file",
+                    str(inventory_file),
+                    "--mutate",
+                ],
+                env={},
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "failed")
+        self.assertIn("supervised host maintainer", payload["message"])
+        self.assertEqual(payload["token_record"], None)
+        self.assertNotIn("secret-token", result.output)
 
 
 def _policy() -> RunnerLaneRegistrationPolicy:


### PR DESCRIPTION
## Summary

- disables the live runner registration apply shortcut that started `run.sh` from inside a GitHub Actions job
- makes ready runner registration plans write a terminal failed audit requiring a supervised host maintainer before any token fetch or host command
- makes the manual registration workflow fail when the executor returns an unexpected failed status instead of uploading a green artifact
- documents the systemd/supervised maintainer plan and notes the offline cm-website proof runner was removed from GitHub inventory

## Live cleanup

The offline `cm-website-chris-testing` proof runner was removed from `cbusillo/odoo-tenant-cm-website` with the GitHub API. Post-delete inventory showed zero runners for that repository.

## Verification

- `uv run --extra dev ruff format --check control_plane/cli_runner_lanes.py control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `git diff --check`
- `uv run --extra dev ruff check control_plane/cli_runner_lanes.py control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `uv run --extra dev mypy control_plane/cli_runner_lanes.py control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `uv run python -m unittest tests.test_runner_lane_registration` (9 tests)
- `uv run python -m unittest tests.test_runner_lane_registration tests.test_service tests.test_filesystem_store tests.test_postgres_store` (602 tests)

## Follow-up

Next work should implement a supervised runner maintainer: systemd-owned service, narrow root helper/sudo boundary, active service + GitHub online + baseline evidence before completed audit.
