### PR TITLE
Preserve runner registration evidence

### DIFF
--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -113,12 +113,13 @@ jobs:
             > runner-lane-registration-pre-inventory.json
 
       - name: Run runner lane registration executor
+        id: registration
         shell: bash
         env:
           TARGET_REPOSITORY: ${{ inputs.repository }}
           LANE_NAME: ${{ inputs.lane_name }}
           REGISTRATION_ROOT: ${{ inputs.registration_root }}
-          LABELS: ${{ inputs.labels }}
+          RUNNER_LABELS_INPUT: ${{ inputs.labels }}
           AUDIT_RECORD_KEY: ${{ inputs.audit_record_key }}
           GH_TOKEN: ${{ secrets.LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN }}
         run: |
@@ -135,7 +136,7 @@ jobs:
             exit 1
           fi
           label_args=()
-          IFS=',' read -r -a labels <<< "$LABELS"
+          IFS=',' read -r -a labels <<< "$RUNNER_LABELS_INPUT"
           for label in "${labels[@]}"; do
             trimmed="$(xargs <<< "$label")"
             if [ -n "$trimmed" ]; then
@@ -165,10 +166,7 @@ jobs:
             "$mutate_flag" \
             > runner-lane-registration-result.json
           status="$(jq -r '.status // ""' runner-lane-registration-result.json)"
-          if [ "$status" != "blocked" ] && [ "$status" != "completed" ]; then
-            jq . runner-lane-registration-result.json >&2
-            exit 1
-          fi
+          echo "registration_status=$status" >>"$GITHUB_OUTPUT"
 
       - name: Upload registration result
         uses: actions/upload-artifact@v7
@@ -178,3 +176,14 @@ jobs:
             runner-lane-registration-pre-inventory.json
             runner-lane-registration-result.json
           if-no-files-found: error
+
+      - name: Fail on unexpected registration result
+        env:
+          REGISTRATION_STATUS: >-
+            ${{ steps.registration.outputs.registration_status }}
+        run: |
+          if [ "$REGISTRATION_STATUS" != "blocked" ] &&
+            [ "$REGISTRATION_STATUS" != "completed" ]; then
+            jq . runner-lane-registration-result.json >&2
+            exit 1
+          fi

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -434,7 +434,10 @@ class FilesystemRecordStore:
                 RunnerHostHygieneApplyAuditRecord,
                 "launchplane_runner_host_hygiene_audits",
             )
-            if (not normalized_host_name or record.request.host_name == normalized_host_name)
+            if (
+                not normalized_host_name
+                or record.request.host_name.strip().lower() == normalized_host_name
+            )
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: record.audit_record_key, reverse=True)
@@ -458,8 +461,14 @@ class FilesystemRecordStore:
                 RunnerLaneRegistrationAuditRecord,
                 "launchplane_runner_lane_registration_audits",
             )
-            if (not normalized_repository or record.request.repository == normalized_repository)
-            and (not normalized_host_name or record.request.host_name == normalized_host_name)
+            if (
+                not normalized_repository
+                or record.request.repository.strip().lower() == normalized_repository
+            )
+            and (
+                not normalized_host_name
+                or record.request.host_name.strip().lower() == normalized_host_name
+            )
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: record.audit_record_key, reverse=True)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -2786,9 +2786,9 @@ class PostgresRecordStore(HumanSessionStore):
         self._write_row(
             LaunchplaneRunnerLaneRegistrationAuditRow(
                 audit_record_key=record.audit_record_key,
-                repository=record.request.repository,
-                host_name=record.request.host_name,
-                lane_name=record.request.lane_name,
+                repository=record.request.repository.strip().lower(),
+                host_name=record.request.host_name.strip().lower(),
+                lane_name=record.request.lane_name.strip().lower(),
                 status=record.status,
                 mutate=int(record.request.mutate),
                 payload=self._payload_dict(record),

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -234,15 +234,17 @@ def _runner_lane_registration_audit_record(
     audit_record_key: str,
     status: RunnerLaneRegistrationAuditStatus = "planned",
     message: str = "planned runner lane registration; no host mutation was executed",
+    repository: str = "cbusillo/odoo-tenant-cm-website",
+    host_name: str = "chris-testing",
 ) -> RunnerLaneRegistrationAuditRecord:
     inventory = build_runner_lane_inventory(
-        repository="cbusillo/odoo-tenant-cm-website",
+        repository=repository,
         observed_at="2026-06-08T17:30:00Z",
         lanes=(),
     )
     request = RunnerLaneRegistrationRequest(
-        repository="cbusillo/odoo-tenant-cm-website",
-        host_name="chris-testing",
+        repository=repository,
+        host_name=host_name,
         lane_name="cm-website-runner-1",
         registration_root="/opt/actions-runners",
         labels=("self-hosted", "launchplane", "launchplane-managed"),
@@ -442,7 +444,8 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             state_dir = Path(temporary_directory_name)
             store = FilesystemRecordStore(state_dir=state_dir)
             older_record = _runner_lane_registration_audit_record(
-                audit_record_key="runner-lane-registration/2026-06-08/cm-website/old"
+                audit_record_key="runner-lane-registration/2026-06-08/cm-website/old",
+                host_name="Chris-Testing",
             )
             newer_record = _runner_lane_registration_audit_record(
                 audit_record_key="runner-lane-registration/2026-06-09/cm-website/new"

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -324,15 +324,17 @@ def _runner_lane_registration_audit_record(
     audit_record_key: str,
     status: RunnerLaneRegistrationAuditStatus = "planned",
     message: str = "planned runner lane registration; no host mutation was executed",
+    repository: str = "cbusillo/odoo-tenant-cm-website",
+    host_name: str = "chris-testing",
 ) -> RunnerLaneRegistrationAuditRecord:
     inventory = build_runner_lane_inventory(
-        repository="cbusillo/odoo-tenant-cm-website",
+        repository=repository,
         observed_at="2026-06-08T17:30:00Z",
         lanes=(),
     )
     request = RunnerLaneRegistrationRequest(
-        repository="cbusillo/odoo-tenant-cm-website",
-        host_name="chris-testing",
+        repository=repository,
+        host_name=host_name,
         lane_name="cm-website-runner-1",
         registration_root="/opt/actions-runners",
         labels=("self-hosted", "launchplane", "launchplane-managed"),
@@ -2605,7 +2607,8 @@ env_var = "GH_TOKEN"
             )
             store.ensure_schema()
             older_record = _runner_lane_registration_audit_record(
-                audit_record_key="runner-lane-registration/2026-06-08/cm-website/old"
+                audit_record_key="runner-lane-registration/2026-06-08/cm-website/old",
+                host_name="Chris-Testing",
             )
             newer_record = _runner_lane_registration_audit_record(
                 audit_record_key="runner-lane-registration/2026-06-09/cm-website/new"


### PR DESCRIPTION
## Summary

- Preserve runner lane registration workflow artifacts before failing on unexpected executor results.
- Normalize runner host/repository indexed values consistently when storing and filtering registration audit evidence.
- Add store coverage for mixed-case host names so host-scoped audit listings continue to find existing records.

## Validation

- `uv run python -m unittest tests.test_filesystem_store tests.test_postgres_store`
- `uv run --extra dev ruff format --check control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev ruff check control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev mypy control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/runner-lane-registration.yml`
- `git diff --check`
- `uv run python -m unittest tests.test_runner_lane_registration tests.test_service tests.test_filesystem_store tests.test_postgres_store` (602 tests OK)
