### PR TITLE
Harden runner registration boundary

### DIFF
--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -58,6 +58,8 @@ jobs:
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE }}
       RUNNER_REGISTRATION_SERVICE_USER: >-
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SERVICE_USER }}
+      RUNNER_REGISTRATION_ALLOWED_ROOT: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_REGISTRATION_ALLOWED_ROOT }}
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     steps:
       - name: Checkout
@@ -90,11 +92,14 @@ jobs:
             echo "Runner must execute as expected service user." >&2
             exit 1
           fi
-          if [ "${{ inputs.mutate }}" = "true" ] &&
-            [ "${{ inputs.confirmation }}" != "register runner lane" ]; then
+          if [ "${MUTATE_REQUESTED}" = "true" ] &&
+            [ "${CONFIRMATION}" != "register runner lane" ]; then
             echo "mutate=true requires confirmation: register runner lane" >&2
             exit 1
           fi
+        env:
+          MUTATE_REQUESTED: ${{ inputs.mutate }}
+          CONFIRMATION: ${{ inputs.confirmation }}
 
       - name: Read pre-registration inventory
         shell: bash
@@ -122,29 +127,47 @@ jobs:
           RUNNER_LABELS_INPUT: ${{ inputs.labels }}
           AUDIT_RECORD_KEY: ${{ inputs.audit_record_key }}
           GH_TOKEN: ${{ secrets.LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN }}
+          MUTATE_REQUESTED: ${{ inputs.mutate }}
         run: |
           set -euo pipefail
+          approved_root="${RUNNER_REGISTRATION_ALLOWED_ROOT:-$HOME/actions-runners}"
+          jq -n \
+            --arg audit_record_key "$AUDIT_RECORD_KEY" \
+            --arg message \
+              "runner lane registration executor did not produce a result" \
+            '{status:"failed", audit_record_key:$audit_record_key,
+              message:$message}' \
+            > runner-lane-registration-result.json
           if [ -z "${GH_TOKEN:-}" ]; then
             echo "Missing runner registration GitHub token secret." >&2
             exit 1
           fi
           if [ "$REGISTRATION_ROOT" = "auto" ]; then
-            REGISTRATION_ROOT="$HOME/actions-runners"
+            REGISTRATION_ROOT="$approved_root"
           fi
           if [ "${REGISTRATION_ROOT#/}" = "$REGISTRATION_ROOT" ]; then
             echo "registration_root must be absolute or auto." >&2
             exit 1
           fi
-          label_args=()
-          IFS=',' read -r -a labels <<< "$RUNNER_LABELS_INPUT"
-          for label in "${labels[@]}"; do
-            trimmed="$(xargs <<< "$label")"
-            if [ -n "$trimmed" ]; then
-              label_args+=(--label "$trimmed")
-            fi
-          done
+          if [ -n "${RUNNER_REGISTRATION_ALLOWED_ROOT:-}" ] &&
+            [ "$REGISTRATION_ROOT" != "$RUNNER_REGISTRATION_ALLOWED_ROOT" ]; then
+            echo "registration_root must match Launchplane approved root." >&2
+            exit 1
+          fi
+          python - <<'PY' > runner-lane-registration-label-args.bin
+          import os
+          import sys
+
+          labels = os.environ["RUNNER_LABELS_INPUT"].split(",")
+          for label in labels:
+              trimmed = label.strip()
+              if trimmed:
+                  sys.stdout.write("--label\0")
+                  sys.stdout.write(f"{trimmed}\0")
+          PY
+          mapfile -d '' -t label_args < runner-lane-registration-label-args.bin
           mutate_flag=--dry-run
-          if [ "${{ inputs.mutate }}" = "true" ]; then
+          if [ "$MUTATE_REQUESTED" = "true" ]; then
             mutate_flag=--mutate
           fi
           GITHUB_TOKEN="$GH_TOKEN" uv run launchplane work-graph \
@@ -159,23 +182,27 @@ jobs:
             --audit-record-key "$AUDIT_RECORD_KEY" \
             --allowed-repository "$TARGET_REPOSITORY" \
             --approved-host "$RUNNER_REGISTRATION_HOST" \
-            --allowed-registration-root "$REGISTRATION_ROOT" \
+            --allowed-registration-root "$approved_root" \
             --inventory-file runner-lane-registration-pre-inventory.json \
             --audit-mode service \
             --service-url "$LAUNCHPLANE_SERVICE_URL" \
             "$mutate_flag" \
-            > runner-lane-registration-result.json
+            > runner-lane-registration-result.tmp
+          mv \
+            runner-lane-registration-result.tmp \
+            runner-lane-registration-result.json
           status="$(jq -r '.status // ""' runner-lane-registration-result.json)"
           echo "registration_status=$status" >>"$GITHUB_OUTPUT"
 
       - name: Upload registration result
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: runner-lane-registration-result
           path: |
             runner-lane-registration-pre-inventory.json
             runner-lane-registration-result.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Fail on unexpected registration result
         env:

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -57,6 +57,9 @@ from control_plane.workflows.runner_lane_registration_executor import dry_run_au
 from control_plane.workflows.runner_lane_registration_executor import (
     execute_runner_lane_registration_executor,
 )
+from control_plane.workflows.runner_lane_registration_executor import (
+    validate_local_executor_environment as validate_runner_registration_environment,
+)
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
 from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandRunner
@@ -67,7 +70,9 @@ from control_plane.workflows.runner_host_hygiene_executor import (
 from control_plane.workflows.runner_host_hygiene_executor import (
     execute_runner_host_hygiene_executor,
 )
-from control_plane.workflows.runner_host_hygiene_executor import validate_local_executor_environment
+from control_plane.workflows.runner_host_hygiene_executor import (
+    validate_local_executor_environment as validate_runner_host_hygiene_environment,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -608,8 +613,10 @@ def runner_lane_registration_executor(
         pre_inventory = _load_runner_lane_inventory(inventory_file)
         token_env = github_token_env.strip()
         token = os.environ.get(token_env, "").strip() if token_env else ""
+        if not token:
+            raise click.ClickException(f"Missing GitHub token in environment variable {token_env}.")
         transport = UrllibMergeTrainGitHubTransport(
-            token=token or "dry-run-token",
+            token=token,
             api_base_url=github_api_base_url,
         )
         inventory_reader = GitHubRunnerLaneInventoryReader(transport=transport)
@@ -628,19 +635,21 @@ def runner_lane_registration_executor(
                     label="runner lane registration",
                 ),
             )
+        request = RunnerLaneRegistrationExecutorRequest(
+            repository=repository,
+            host_name=host_name,
+            execution_lane=execution_lane,
+            service_user=service_user,
+            lane_name=lane_name,
+            registration_root=registration_root,
+            labels=labels,
+            mutate=mutate,
+            audit_record_key=audit_record_key,
+            timeout_seconds=timeout_seconds,
+        )
+        validate_runner_registration_environment(request=request)
         result = execute_runner_lane_registration_executor(
-            request=RunnerLaneRegistrationExecutorRequest(
-                repository=repository,
-                host_name=host_name,
-                execution_lane=execution_lane,
-                service_user=service_user,
-                lane_name=lane_name,
-                registration_root=registration_root,
-                labels=labels,
-                mutate=mutate,
-                audit_record_key=audit_record_key,
-                timeout_seconds=timeout_seconds,
-            ),
+            request=request,
             policy=RunnerLaneRegistrationPolicy(
                 allowed_repositories=allowed_repositories,
                 approved_hosts=approved_hosts,
@@ -1225,7 +1234,7 @@ def runner_host_hygiene_executor(
             timeout_seconds=timeout_seconds,
             prune_until=prune_until,
         )
-        validate_local_executor_environment(request=request)
+        validate_runner_host_hygiene_environment(request=request)
         result = execute_runner_host_hygiene_executor(
             request=request,
             remote_runner=build_local_command_runner(),

--- a/control_plane/contracts/runner_lane_registration.py
+++ b/control_plane/contracts/runner_lane_registration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Literal
+import re
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -63,9 +64,17 @@ class RunnerLaneRegistrationRequest(BaseModel):
         self.repository = _normalized_repository(self.repository)
         self.host_name = _required_text(
             self.host_name, "runner lane registration requires host_name"
-        )
+        ).lower()
         self.lane_name = _required_text(
             self.lane_name, "runner lane registration requires lane_name"
+        ).lower()
+        _validate_slug(
+            self.host_name,
+            "runner lane registration host_name must use letters, numbers, dots, underscores, or hyphens",
+        )
+        _validate_slug(
+            self.lane_name,
+            "runner lane registration lane_name must use letters, numbers, dots, underscores, or hyphens",
         )
         self.registration_root = _normalized_path(
             _required_text(
@@ -256,7 +265,9 @@ def plan_runner_lane_registration(
                 f"runner lane inventory repository does not match request: {inventory_repository}",
             )
         )
-    existing_lanes = tuple(lane for lane in inventory.lanes if lane.name == request.lane_name)
+    existing_lanes = tuple(
+        lane for lane in inventory.lanes if lane.name.strip().lower() == request.lane_name
+    )
     if existing_lanes:
         blockers.append(
             _blocker(
@@ -345,7 +356,13 @@ def _normalized_labels(values: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def _normalized_tokens(values: tuple[str, ...]) -> tuple[str, ...]:
-    return tuple(sorted({value.strip().lower() for value in values if value.strip()}))
+    normalized_tokens = tuple(sorted({value.strip().lower() for value in values if value.strip()}))
+    for token in normalized_tokens:
+        _validate_slug(
+            token,
+            "runner lane registration labels must use letters, numbers, dots, underscores, or hyphens",
+        )
+    return normalized_tokens
 
 
 def _normalized_path(value: str) -> str:
@@ -362,6 +379,11 @@ def _normalized_path(value: str) -> str:
             continue
         segments.append(segment)
     return "/" + "/".join(segments)
+
+
+def _validate_slug(value: str, message: str) -> None:
+    if not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,127}", value):
+        raise ValueError(message)
 
 
 def _required_text(value: str, message: str) -> str:

--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 import json
 import os
 import pwd
+import re
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
@@ -46,15 +47,27 @@ class RunnerLaneRegistrationExecutorRequest(BaseModel):
         self.repository = repository_full_name(self.repository)
         self.host_name = _required_text(
             self.host_name, "runner lane registration executor requires host_name"
-        )
+        ).lower()
         self.execution_lane = _required_text(
             self.execution_lane, "runner lane registration executor requires execution_lane"
-        )
+        ).lower()
         self.service_user = _required_text(
             self.service_user, "runner lane registration executor requires service_user"
         )
         self.lane_name = _required_text(
             self.lane_name, "runner lane registration executor requires lane_name"
+        ).lower()
+        _validate_slug(
+            self.host_name,
+            "runner lane registration executor host_name must use letters, numbers, dots, underscores, or hyphens",
+        )
+        _validate_slug(
+            self.execution_lane,
+            "runner lane registration executor execution_lane must use letters, numbers, dots, underscores, or hyphens",
+        )
+        _validate_slug(
+            self.lane_name,
+            "runner lane registration executor lane_name must use letters, numbers, dots, underscores, or hyphens",
         )
         self.registration_root = _required_text(
             self.registration_root,
@@ -156,19 +169,25 @@ def execute_runner_lane_registration_executor(
     )
 
 
-def validate_local_executor_environment(*, request: RunnerLaneRegistrationExecutorRequest) -> None:
-    current_user = pwd.getpwuid(os.getuid()).pw_name
-    if current_user != request.service_user:
+def validate_local_executor_environment(
+    *,
+    request: RunnerLaneRegistrationExecutorRequest,
+    env: Mapping[str, str] | None = None,
+    current_user: str | None = None,
+) -> None:
+    execution_env = os.environ if env is None else env
+    effective_user = current_user or pwd.getpwuid(os.getuid()).pw_name
+    if effective_user != request.service_user:
         raise ValueError(f"runner lane registration executor must run as {request.service_user}.")
-    github_repository = os.environ.get("GITHUB_REPOSITORY", "").strip().lower()
-    if github_repository and github_repository != "cbusillo/launchplane":
+    github_repository = execution_env.get("GITHUB_REPOSITORY", "").strip().lower()
+    if github_repository != "cbusillo/launchplane":
         raise ValueError("runner lane registration executor must run from cbusillo/launchplane.")
     runner_labels = {
         label.strip().lower()
-        for label in os.environ.get("RUNNER_LABELS", "").split(",")
+        for label in execution_env.get("RUNNER_LABELS", "").split(",")
         if label.strip()
     }
-    if runner_labels and request.execution_lane.lower() not in runner_labels:
+    if request.execution_lane.lower() not in runner_labels:
         raise ValueError(
             "runner lane registration executor is not running on the approved execution lane."
         )
@@ -270,3 +289,8 @@ def _required_text(value: str, message: str) -> str:
     if not normalized_value:
         raise ValueError(message)
     return normalized_value
+
+
+def _validate_slug(value: str, message: str) -> None:
+    if not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,127}", value):
+        raise ValueError(message)

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -11,6 +11,7 @@ from typing import cast
 from typing import Any
 from click import Command
 from click.testing import CliRunner
+import getpass
 
 from control_plane.cli import main
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
@@ -28,6 +29,9 @@ from control_plane.workflows.runner_lane_registration_executor import (
 )
 from control_plane.workflows.runner_lane_registration_executor import (
     execute_runner_lane_registration_executor,
+)
+from control_plane.workflows.runner_lane_registration_executor import (
+    validate_local_executor_environment,
 )
 
 
@@ -80,6 +84,22 @@ class _AuditPoster:
 
 
 class RunnerLaneRegistrationPlanTests(unittest.TestCase):
+    def test_request_rejects_unsafe_lane_name(self) -> None:
+        with self.assertRaisesRegex(ValueError, "lane_name must use"):
+            _request(lane_name="cm-website;rm -rf /", mutate=True)
+
+    def test_request_rejects_unsafe_label(self) -> None:
+        with self.assertRaisesRegex(ValueError, "labels must use"):
+            RunnerLaneRegistrationRequest(
+                repository="cbusillo/odoo-tenant-cm-website",
+                host_name="chris-testing",
+                lane_name="cm-website-runner-1",
+                registration_root="/opt/actions-runners",
+                labels=("self-hosted", "launchplane $(touch bad)"),
+                mutate=True,
+                audit_record_key="runner-lane-registration/2026-06-08/cm-website/test",
+            )
+
     def test_plan_blocks_without_mutate_and_without_allowed_repo(self) -> None:
         plan = plan_runner_lane_registration(
             policy=RunnerLaneRegistrationPolicy(
@@ -124,7 +144,7 @@ class RunnerLaneRegistrationPlanTests(unittest.TestCase):
         plan = plan_runner_lane_registration(
             policy=_policy(),
             request=_request(mutate=True),
-            inventory=_inventory(lanes=(_lane(),)),
+            inventory=_inventory(lanes=(_lane(name="CM-Website-Runner-1"),)),
         )
 
         self.assertEqual(plan.status, "blocked")
@@ -153,6 +173,10 @@ class GitHubRunnerLaneRegistrationTokenFetcherTests(unittest.TestCase):
 
 
 class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
+    def test_executor_request_rejects_unsafe_execution_lane(self) -> None:
+        with self.assertRaisesRegex(ValueError, "execution_lane must use"):
+            _executor_request(mutate=True, execution_lane="ops-gate;touch bad")
+
     def test_blocked_plan_posts_planned_audit_without_token_or_command(self) -> None:
         token_fetcher = _TokenFetcher()
         command_runner = _CommandRunner()
@@ -196,9 +220,35 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
         self.assertNotIn("secret-token", result.model_dump_json())
         self.assertEqual([record[0] for record in audit_poster.records], ["planned", "failed"])
 
+    def test_local_environment_fails_closed_without_actions_repository(self) -> None:
+        with self.assertRaisesRegex(ValueError, "must run from cbusillo/launchplane"):
+            validate_local_executor_environment(
+                request=_executor_request(mutate=True),
+                env={},
+                current_user="launchplane-runner-hygiene",
+            )
+
+    def test_local_environment_fails_closed_without_execution_lane_label(self) -> None:
+        with self.assertRaisesRegex(ValueError, "approved execution lane"):
+            validate_local_executor_environment(
+                request=_executor_request(mutate=True),
+                env={"GITHUB_REPOSITORY": "cbusillo/launchplane"},
+                current_user="launchplane-runner-hygiene",
+            )
+
+    def test_local_environment_accepts_expected_actions_scope(self) -> None:
+        validate_local_executor_environment(
+            request=_executor_request(mutate=True),
+            env={
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "RUNNER_LABELS": "self-hosted,launchplane,chris-testing-ops-gate",
+            },
+            current_user="launchplane-runner-hygiene",
+        )
+
 
 class RunnerLaneRegistrationCliTests(unittest.TestCase):
-    def test_cli_dry_run_emits_blocked_result_without_github_token(self) -> None:
+    def test_cli_dry_run_requires_github_token(self) -> None:
         with TemporaryDirectory() as temp_dir:
             inventory_file = Path(temp_dir) / "inventory.json"
             inventory_file.write_text(
@@ -243,12 +293,10 @@ class RunnerLaneRegistrationCliTests(unittest.TestCase):
                 env={},
             )
 
-        self.assertEqual(result.exit_code, 0, result.output)
-        payload = json.loads(result.output)
-        self.assertEqual(payload["status"], "blocked")
-        self.assertIn("planned_response", payload)
+        self.assertEqual(result.exit_code, 1)
+        self.assertIn("Missing GitHub token", result.output)
 
-    def test_cli_mutate_reports_supervisor_required_without_github_token(self) -> None:
+    def test_cli_dry_run_requires_matching_actions_execution_context(self) -> None:
         with TemporaryDirectory() as temp_dir:
             inventory_file = Path(temp_dir) / "inventory.json"
             inventory_file.write_text(
@@ -268,7 +316,7 @@ class RunnerLaneRegistrationCliTests(unittest.TestCase):
                     "--execution-lane",
                     "chris-testing-ops-gate",
                     "--service-user",
-                    "launchplane-runner-hygiene",
+                    getpass.getuser(),
                     "--lane-name",
                     "cm-website-runner-1",
                     "--registration-root",
@@ -289,17 +337,37 @@ class RunnerLaneRegistrationCliTests(unittest.TestCase):
                     "/opt/actions-runners",
                     "--inventory-file",
                     str(inventory_file),
-                    "--mutate",
                 ],
-                env={},
+                env={"GITHUB_TOKEN": "github-token"},
             )
 
-        self.assertEqual(result.exit_code, 0, result.output)
-        payload = json.loads(result.output)
-        self.assertEqual(payload["status"], "failed")
-        self.assertIn("supervised host maintainer", payload["message"])
-        self.assertEqual(payload["token_record"], None)
-        self.assertNotIn("secret-token", result.output)
+        self.assertEqual(result.exit_code, 1)
+        self.assertTrue(
+            "must run from cbusillo/launchplane" in result.output
+            or "approved execution lane" in result.output,
+            result.output,
+        )
+
+
+class RunnerLaneRegistrationWorkflowTests(unittest.TestCase):
+    def test_workflow_uses_env_confirmation_and_preserves_artifacts(self) -> None:
+        workflow_text = Path(".github/workflows/runner-lane-registration.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn('${{ inputs.confirmation }}" !=', workflow_text)
+        self.assertIn("CONFIRMATION: ${{ inputs.confirmation }}", workflow_text)
+        self.assertIn("if: always()", workflow_text)
+        self.assertIn("if-no-files-found: warn", workflow_text)
+        self.assertIn("runner lane registration executor did not produce a result", workflow_text)
+
+    def test_workflow_does_not_allowlist_user_registration_root(self) -> None:
+        workflow_text = Path(".github/workflows/runner-lane-registration.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertNotIn('--allowed-registration-root "$REGISTRATION_ROOT"', workflow_text)
+        self.assertIn('--allowed-registration-root "$approved_root"', workflow_text)
 
 
 def _policy() -> RunnerLaneRegistrationPolicy:
@@ -317,11 +385,12 @@ def _request(
     *,
     registration_root: str = "/opt/actions-runners",
     mutate: bool,
+    lane_name: str = "cm-website-runner-1",
 ) -> RunnerLaneRegistrationRequest:
     return RunnerLaneRegistrationRequest(
         repository="cbusillo/odoo-tenant-cm-website",
         host_name="chris-testing",
-        lane_name="cm-website-runner-1",
+        lane_name=lane_name,
         registration_root=registration_root,
         labels=("self-hosted", "launchplane", "launchplane-managed"),
         mutate=mutate,
@@ -329,11 +398,13 @@ def _request(
     )
 
 
-def _executor_request(*, mutate: bool) -> RunnerLaneRegistrationExecutorRequest:
+def _executor_request(
+    *, mutate: bool, execution_lane: str = "chris-testing-ops-gate"
+) -> RunnerLaneRegistrationExecutorRequest:
     return RunnerLaneRegistrationExecutorRequest(
         repository="cbusillo/odoo-tenant-cm-website",
         host_name="chris-testing",
-        execution_lane="chris-testing-ops-gate",
+        execution_lane=execution_lane,
         service_user="launchplane-runner-hygiene",
         lane_name="cm-website-runner-1",
         registration_root="/home/launchplane-runner-hygiene/actions-runners",
@@ -351,10 +422,10 @@ def _inventory(*, lanes: tuple[RunnerLaneRecord, ...]) -> RunnerLaneInventory:
     )
 
 
-def _lane() -> RunnerLaneRecord:
+def _lane(*, name: str = "cm-website-runner-1") -> RunnerLaneRecord:
     return RunnerLaneRecord(
         github_id=1,
-        name="cm-website-runner-1",
+        name=name,
         repository="cbusillo/odoo-tenant-cm-website",
         status="online",
         busy=False,


### PR DESCRIPTION
## Summary

- Keep runner registration non-mutating while hardening the Launchplane-only boundary for the future durable maintainer.
- Route workflow confirmation/mutate inputs through environment variables, preserve failure artifacts with a fallback result JSON, and stop allowlisting a user-provided registration root.
- Require explicit GitHub token and Launchplane Actions execution context in the registration CLI before executor work.
- Validate host/lane/label identifiers before any future path/systemd derivation can use them.

## Non-goals

- This does not add live runner registration, `run.sh`, `nohup`, systemd mutation, or product-repo workflow adoption.
- `cm-website` remains a proving target only; no product repo files were touched.

## Validation

- `uv run python -m unittest tests.test_runner_lane_registration`
- `uv run --extra dev ruff format --check control_plane/contracts/runner_lane_registration.py control_plane/workflows/runner_lane_registration_executor.py control_plane/cli_runner_lanes.py tests/test_runner_lane_registration.py`
- `uv run --extra dev ruff check control_plane/contracts/runner_lane_registration.py control_plane/workflows/runner_lane_registration_executor.py control_plane/cli_runner_lanes.py tests/test_runner_lane_registration.py`
- `uv run --extra dev mypy control_plane/contracts/runner_lane_registration.py control_plane/workflows/runner_lane_registration_executor.py control_plane/cli_runner_lanes.py tests/test_runner_lane_registration.py`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/runner-lane-registration.yml`
- `git diff --check`
- `uv run python -m unittest tests.test_runner_lane_registration tests.test_runner_lane_inventory tests.test_service tests.test_filesystem_store tests.test_postgres_store` (619 tests OK)
