### PR TITLE
Seed runner registration audit grant

### DIFF
--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -402,6 +402,14 @@ post_grant \
 	runner-host-hygiene-audit
 post_grant \
 	"$GITHUB_REPOSITORY" \
+	runner-lane-registration.yml \
+	launchplane \
+	launchplane \
+	runner_lane_registration_audit.write \
+	deploy:runner-lane-registration-audit-grant \
+	runner-lane-registration-audit
+post_grant \
+	"$GITHUB_REPOSITORY" \
 	work-graph-snapshot-validate.yml \
 	launchplane \
 	launchplane \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -440,6 +440,16 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("merge-train-runner-schedule", script_text)
         self.assertIn("schedule", script_text)
 
+    def test_deploy_authz_grants_include_runner_registration_audit_writer(
+        self,
+    ) -> None:
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
+
+        self.assertIn("runner-lane-registration.yml", script_text)
+        self.assertIn("runner_lane_registration_audit.write", script_text)
+        self.assertIn("deploy:runner-lane-registration-audit-grant", script_text)
+        self.assertIn("runner-lane-registration-audit", script_text)
+
     def test_deploy_authz_grants_accept_configured_github_action_grants(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

- Seed the deploy-time GitHub Actions authz grant for `runner-lane-registration.yml` to write runner lane registration audit evidence.
- Add regression coverage so the deploy grant script keeps `runner_lane_registration_audit.write` wired.

## Context

PR #1237 made the runner-lane registration workflow use service-backed audit writes. The service route requires `runner_lane_registration_audit.write`; without this grant, the workflow would 403 in real use.

## Validation

- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_runner_registration_audit_writer`
- `shellcheck scripts/deploy/ensure-authz-grants.sh`
- `shfmt -d scripts/deploy/ensure-authz-grants.sh`
- `uv run python -m unittest tests.test_product_onboarding tests.test_authz_grant_service tests.test_every_code_reconciliation`
- `uv run --extra dev ruff format --check tests/test_product_onboarding.py`
- `uv run --extra dev ruff check tests/test_product_onboarding.py`
- `uv run --extra dev mypy tests/test_product_onboarding.py`
- `git diff --check`
