### PR TITLE
Normalize Odoo stable bootstrap canonical

### DIFF
--- a/control_plane/workflows/odoo_stable_bootstrap.py
+++ b/control_plane/workflows/odoo_stable_bootstrap.py
@@ -60,6 +60,10 @@ class OdooStableBootstrapStore(Protocol):
         self, *, context_name: str, instance_name: str
     ) -> OdooInstanceOverrideRecord: ...
 
+    def write_odoo_instance_override_record(
+        self, record: OdooInstanceOverrideRecord
+    ) -> object: ...
+
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
 
     def read_dokploy_target_record(
@@ -292,6 +296,28 @@ def _read_odoo_instance_override_record(
         return None
 
 
+def _record_with_stable_bootstrap_canonical(
+    *,
+    record: OdooInstanceOverrideRecord | None,
+    canonical_url: str,
+    updated_at: str,
+) -> OdooInstanceOverrideRecord | None:
+    normalized_canonical_url = canonical_url.strip().rstrip("/")
+    if record is None or record.website_bootstrap is None or not normalized_canonical_url:
+        return record
+    if record.website_bootstrap.canonical_url == normalized_canonical_url:
+        return record
+    return record.model_copy(
+        update={
+            "website_bootstrap": record.website_bootstrap.model_copy(
+                update={"canonical_url": normalized_canonical_url}
+            ),
+            "updated_at": updated_at,
+            "source_label": "odoo-stable-bootstrap",
+        }
+    )
+
+
 def execute_odoo_stable_bootstrap(
     *,
     control_plane_root: Path,
@@ -354,11 +380,21 @@ def execute_odoo_stable_bootstrap(
         target_record=target_record,
         domain_hosts=resolved_domains,
     )
+    base_url = _target_base_url(lane=lane, domains=resolved_domains)
 
     deployment_record_id = generate_deployment_record_id(
         context_name=request.context, instance_name=request.instance
     )
     started_at = utc_now_timestamp()
+    normalized_override_record = _record_with_stable_bootstrap_canonical(
+        record=odoo_override_record,
+        canonical_url=base_url,
+        updated_at=started_at,
+    )
+    if normalized_override_record is not None and normalized_override_record is not odoo_override_record:
+        record_store.write_odoo_instance_override_record(normalized_override_record)
+        odoo_override_record = normalized_override_record
+
     ship_request = _build_bootstrap_ship_request(
         context=request.context,
         instance=request.instance,
@@ -544,7 +580,6 @@ def execute_odoo_stable_bootstrap(
             error_message=post_deploy_result.error_message or "Odoo post-deploy failed.",
         )
 
-    base_url = _target_base_url(lane=lane, domains=resolved_domains)
     health_url = _target_health_url(profile=profile, lane=lane, domains=resolved_domains)
     health_timeout_seconds = (
         request.health_timeout_seconds

--- a/docs/records.md
+++ b/docs/records.md
@@ -676,6 +676,10 @@ state/
   including site identity, canonical URL, logo path, source metadata, and route
   definitions. Product repos remain the source of that intent; Launchplane
   persists the typed payload and renders it during Odoo post-deploy.
+- Stable bootstrap normalizes the persisted `website_bootstrap.canonical_url`
+  to the Launchplane-resolved stable target base URL before post-deploy renders
+  the payload, so local tenant bootstrap defaults do not become stable lane URL
+  authority.
 - `apply_on` records the phases where the override is intended to apply, and
   `last_apply` records the latest driver result without making the addon layer
   the durable audit surface.

--- a/tests/test_odoo_stable_bootstrap.py
+++ b/tests/test_odoo_stable_bootstrap.py
@@ -154,6 +154,7 @@ class _Store:
         self.missing_target_record = False
         self.missing_target_id_record = False
         self.missing_inventory = False
+        self.odoo_instance_override_records: list[OdooInstanceOverrideRecord] = []
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
         if product != self.profile.product:
@@ -196,7 +197,14 @@ class _Store:
     def read_odoo_instance_override_record(
         self, *, context_name: str, instance_name: str
     ) -> OdooInstanceOverrideRecord:
+        if self.odoo_instance_override_records:
+            record = self.odoo_instance_override_records[-1]
+            if (context_name, instance_name) == (record.context, record.instance):
+                return record
         raise FileNotFoundError(f"{context_name}/{instance_name}")
+
+    def write_odoo_instance_override_record(self, record: OdooInstanceOverrideRecord) -> None:
+        self.odoo_instance_override_records.append(record)
 
 
 class OdooStableBootstrapTests(unittest.TestCase):
@@ -390,6 +398,111 @@ class OdooStableBootstrapTests(unittest.TestCase):
             store.environment_inventories[0].bootstrap_record_id,
             "deployment-cm-testing-bootstrap",
         )
+
+    def test_execute_overlays_stable_canonical_before_post_deploy(self) -> None:
+        store = _Store()
+        store.odoo_instance_override_records.append(
+            OdooInstanceOverrideRecord(
+                context="cm",
+                instance="testing",
+                apply_on=("deploy",),
+                website_bootstrap=OdooWebsiteBootstrapPayload(
+                    tenant="cm",
+                    name="Cell Mechanic",
+                    homepage_url="/cell-mechanic",
+                    logo_path="addons/cm_website/static/src/img/logo.png",
+                    logo_alt="Cell Mechanic",
+                    routes=(
+                        OdooWebsiteBootstrapRoute(
+                            name="Cell Mechanic",
+                            url="/cell-mechanic",
+                            module="cm_website",
+                            homepage=True,
+                        ),
+                    ),
+                ),
+                updated_at="2026-05-10T00:00:00Z",
+            )
+        )
+        captured_bootstrap_runs: list[dict[str, object]] = []
+
+        def post_deploy_side_effect(**_: object) -> OdooPostDeployResult:
+            record = store.odoo_instance_override_records[-1]
+            self.assertIsNotNone(record.website_bootstrap)
+            assert record.website_bootstrap is not None
+            self.assertEqual(
+                record.website_bootstrap.canonical_url,
+                "https://cm-testing.shinycomputers.com",
+            )
+            return OdooPostDeployResult(
+                context="cm",
+                instance="testing",
+                phase="deploy",
+                post_deploy_status="pass",
+            )
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.com", "token-123"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.control_plane_dokploy.run_compose_odoo_stable_bootstrap",
+                side_effect=lambda **kwargs: captured_bootstrap_runs.append(kwargs),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.execute_odoo_post_deploy",
+                side_effect=post_deploy_side_effect,
+            ) as post_deploy_mock,
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.verify_odoo_stable_readiness",
+                return_value=_verification_result(),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.utc_now_timestamp",
+                side_effect=("2026-05-10T02:00:00Z", "2026-05-10T02:01:00Z"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_bootstrap.generate_deployment_record_id",
+                return_value="deployment-cm-testing-bootstrap",
+            ),
+        ):
+            result = execute_odoo_stable_bootstrap(
+                control_plane_root=Path("/tmp/launchplane"),
+                record_store=store,
+                request=OdooStableBootstrapRequest(
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    instance="testing",
+                    confirmation=_BOOTSTRAP_CONFIRMATION,
+                ),
+                dokploy_request=cast(DokployRequest, _dokploy_request),
+            )
+
+        self.assertEqual(result.bootstrap_status, "pass")
+        self.assertEqual(len(store.odoo_instance_override_records), 2)
+        updated_record = store.odoo_instance_override_records[-1]
+        self.assertIsNotNone(updated_record.website_bootstrap)
+        assert updated_record.website_bootstrap is not None
+        self.assertEqual(
+            updated_record.website_bootstrap.canonical_url,
+            "https://cm-testing.shinycomputers.com",
+        )
+        self.assertEqual(updated_record.updated_at, "2026-05-10T02:00:00Z")
+        self.assertEqual(updated_record.source_label, "odoo-stable-bootstrap")
+        workflow_environment = cast(
+            "dict[str, str]", captured_bootstrap_runs[0]["workflow_environment_overrides"]
+        )
+        decoded_payload = json.loads(
+            base64.b64decode(workflow_environment["ODOO_INSTANCE_OVERRIDES_PAYLOAD_B64"]).decode(
+                "utf-8"
+            )
+        )
+        self.assertEqual(
+            decoded_payload["website_bootstrap"]["canonical_url"],
+            "https://cm-testing.shinycomputers.com",
+        )
+        post_deploy_mock.assert_called_once()
 
     def test_execute_proves_bootstrap_domain_from_live_target(self) -> None:
         store = _Store()


### PR DESCRIPTION
## Summary
- persist the Launchplane-resolved stable target base URL into `website_bootstrap.canonical_url` before Odoo stable bootstrap post-deploy re-reads the override record
- stamp the canonical overlay with `updated_at` and `source_label` evidence
- add regression coverage proving the normalized record exists before post-deploy and is included in the bootstrap runner payload
- document that stable bootstrap, not tenant-local bootstrap defaults, owns stable lane canonical URL authority

## Validation
- `uv run python -m unittest tests.test_odoo_stable_bootstrap tests.test_odoo_instance_override_rendering tests.test_odoo_post_deploy`
- `uv run --extra dev ruff check --exit-zero control_plane/workflows/odoo_stable_bootstrap.py tests/test_odoo_stable_bootstrap.py`
- `uv run --extra dev ruff check control_plane/workflows/odoo_stable_bootstrap.py tests/test_odoo_stable_bootstrap.py`
- `git diff --check`

## Review Notes
- Focused two-agent review found metadata/order-test gaps; both were fixed before this PR.
- JetBrains inspection was attempted via `/Users/cbusillo/Applications/PyCharm.app/Contents/bin/inspect.sh`, but it was blocked because another PyCharm instance is already running.

## #1224 Context
- Wrote cm_website/testing website-bootstrap override via run `27467010953`; accepted with trace `launchplane_req_5a7d917b8fa34d129a329a3305ff9691`.
- Reran Odoo Stable Bootstrap via run `27467022952`; bootstrap/post-deploy/health passed, but canonical still failed because the public root served Odoo DB manager. This PR removes the Launchplane canonical-record ambiguity before the next proof run. If the host still serves DB manager after this deploy, the remaining issue is likely Odoo runtime DB selection / DB-filter binding.