### PR TITLE
Allow artifact publish reusable wrapper calls

### DIFF
--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -143,7 +143,7 @@ jobs:
           if [ -z "$source_git_ref" ]; then
             source_git_ref="$DEFAULT_SOURCE_GIT_REF"
           fi
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ -n "$CONFIRMATION" ]; then
             if [ "$CONFIRMATION" != "PUBLISH LAUNCHPLANE ODOO ARTIFACT" ]; then
               echo "confirmation must be PUBLISH LAUNCHPLANE ODOO ARTIFACT" >&2
               exit 1


### PR DESCRIPTION
## Summary

- Let reusable Odoo artifact publish wrapper calls use caller repo/ref defaults without requiring the direct-dispatch confirmation phrase.
- Keep direct reusable dispatch protected: when a confirmation input is supplied, it must still equal `PUBLISH LAUNCHPLANE ODOO ARTIFACT` and explicit repository/ref are still required.

## Why

`odoo-tenant-cm-website` now passes the required product input, but its `Odoo Artifact Publish` wrapper still failed in the reusable workflow's source resolution step. The reusable workflow saw the caller event as `workflow_dispatch` and demanded its own direct-dispatch confirmation even though the tenant wrapper had already confirmed the operation.

Failed evidence: `cbusillo/odoo-tenant-cm-website` run `27468248183`, step `Resolve artifact source`.

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/reusable-odoo-artifact-publish.yml`
- `git diff --check`

Note: I accidentally ran ruff against the YAML workflow first; that produced expected YAML-as-Python syntax noise and was not used as validation.
