### PR TITLE
Fix Odoo stable target DB binding

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -175,6 +175,8 @@ def render_odoo_raw_compose_file(
 x-odoo-env: &odoo-env
   ODOO_STACK_NAME: ${{ODOO_STACK_NAME:-}}
   ODOO_PROJECT_NAME: ${{ODOO_PROJECT_NAME:-}}
+  PLATFORM_CONTEXT: ${{PLATFORM_CONTEXT:-}}
+  PLATFORM_INSTANCE: ${{PLATFORM_INSTANCE:-}}
   ODOO_DB_HOST: database
   ODOO_DB_PORT: "5432"
   ODOO_DB_NAME: ${{ODOO_DB_NAME:?missing}}
@@ -211,7 +213,7 @@ services:
     command:
       - /bin/sh
       - -lc
-      - ${{ODOO_WEB_COMMAND:-/odoo/odoo-bin}}
+      - ${{ODOO_WEB_COMMAND:-python3 /volumes/scripts/run_odoo_startup.py -c /tmp/platform.odoo.conf}}
     volumes:
       - odoo_data:/volumes/data
       - odoo_logs:/volumes/logs

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1173,6 +1173,10 @@ def execute_odoo_stable_target_replacement_apply(
         )
         desired_env_map = dict(current_env_map)
         desired_env_map.update(runtime_environment_values)
+        if desired_env_map.get("ODOO_WEB_COMMAND", "").strip() == "/odoo/odoo-bin":
+            desired_env_map.pop("ODOO_WEB_COMMAND", None)
+        desired_env_map["PLATFORM_CONTEXT"] = plan.context
+        desired_env_map["PLATFORM_INSTANCE"] = plan.instance
         desired_env_map["DOCKER_IMAGE_REFERENCE"] = image_reference
         desired_env_map.update(runtime_identity_env(runtime_identity))
         control_plane_dokploy.update_dokploy_target_env(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1018,12 +1018,16 @@ target, explicit Odoo volume env keys, and expected hostnames; the operation
 worker re-syncs the Launchplane-rendered compose source, reconciles each expected
 Dokploy compose domain route to the `web` service on the product runtime port,
 renders the matching HTTP and HTTPS Traefik router labels into the raw compose,
-injects the runtime identity breadcrumb, triggers Dokploy deploy, runs Odoo
-post-deploy, verifies health/canonical/logo, and writes deployment plus
-inventory records. The explicit raw-compose routers keep the runtime reachable
-even when Dokploy stores the compose domain record separately from the raw source
-update. By default it deploys the artifact already recorded in current
-inventory. Operators may supply both `artifact_id` and `source_git_ref` to deploy
+defaults the web process to the devkit startup wrapper so public runtimes write
+their generated config, initialize the selected database, and pin HTTP DB
+selection to `ODOO_DB_NAME`, injects the platform context/instance and runtime
+identity breadcrumb, triggers Dokploy deploy, runs Odoo post-deploy, verifies
+health/canonical/logo, and
+writes deployment plus inventory records. The explicit raw-compose routers keep
+the runtime reachable even when Dokploy stores the compose domain record
+separately from the raw source update. By default it deploys the artifact
+already recorded in current inventory. Operators may supply both `artifact_id`
+and `source_git_ref` to deploy
 a newly published stored artifact before it has become inventory; the service
 refuses mismatches against the stored artifact manifest. Do not manually delete
 canonical stable targets as a replacement shortcut; add the missing Launchplane

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2828,6 +2828,12 @@ class LaunchplaneServiceDeployTests(unittest.TestCase):
 
         self.assertIn("image: ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123", compose_file)
         self.assertIn("\n  web:", compose_file)
+        self.assertIn(
+            "${ODOO_WEB_COMMAND:-python3 /volumes/scripts/run_odoo_startup.py -c /tmp/platform.odoo.conf}",
+            compose_file,
+        )
+        self.assertIn("PLATFORM_CONTEXT: ${PLATFORM_CONTEXT:-}", compose_file)
+        self.assertIn("PLATFORM_INSTANCE: ${PLATFORM_INSTANCE:-}", compose_file)
         self.assertIn('- "${ODOO_WEB_HOST_PORT:-8069}:8069"', compose_file)
         self.assertIn('- "${ODOO_LONGPOLL_HOST_PORT:-8072}:8072"', compose_file)
         self.assertIn("\n  database:", compose_file)

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -355,6 +355,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                             "ODOO_DATA_VOLUME=cm_testing_odoo_data",
                             "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
                             "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                            "ODOO_WEB_COMMAND=/odoo/odoo-bin",
                         )
                     ),
                 },
@@ -950,6 +951,9 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertIn("LAUNCHPLANE_RUNTIME_IDENTITY_JSON=", persisted_env)
         self.assertIn("LAUNCHPLANE_DEPLOYMENT_RECORD_ID=", persisted_env)
         self.assertIn("LAUNCHPLANE_ARTIFACT_ID=artifact-cm-testing", persisted_env)
+        self.assertIn("PLATFORM_CONTEXT=cm", persisted_env)
+        self.assertIn("PLATFORM_INSTANCE=testing", persisted_env)
+        self.assertNotIn("ODOO_WEB_COMMAND=/odoo/odoo-bin", persisted_env)
         self.assertIn("ODOO_WORKERS=2", persisted_env)
         self.assertGreaterEqual(len(store.deployment_records), 2)
         final_deployment = store.deployment_records[-1]


### PR DESCRIPTION
## Summary
- default raw Odoo compose web startup to the devkit startup wrapper
- inject PLATFORM_CONTEXT and PLATFORM_INSTANCE during stable target replacement
- remove stale legacy ODOO_WEB_COMMAND=/odoo/odoo-bin so existing targets use the wrapper fallback
- document the stable replacement runtime binding behavior

## Validation
- uv run python -m unittest tests.test_dokploy.LaunchplaneServiceDeployTests tests.test_odoo_stable_target_replacement.OdooStableTargetReplacementTests
- git diff --check
- uv run --extra dev ruff check --diff control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_dokploy.py tests/test_odoo_stable_target_replacement.py

Part of #1224.