### PR TITLE
Surface Odoo post-deploy readback markers

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -2437,12 +2437,26 @@ workflow_identity_key=$(docker exec -u root \
     ')
 
 echo "Running Odoo {workflow_label} in container ${{script_runner_container_id}}"
+workflow_output_file=$(mktemp)
+set +e
 docker exec \
     -e DATA_WORKFLOW_SSH_DIR="${{workflow_ssh_dir}}" \
     -e DATA_WORKFLOW_SSH_KEY="$workflow_identity_key" \
     "${{workflow_environment[@]}}" \
     "${{script_runner_container_id}}" \
-    python3 -u /volumes/scripts/run_odoo_data_workflows.py "${{workflow_arguments[@]}}"
+    python3 -u /volumes/scripts/run_odoo_data_workflows.py "${{workflow_arguments[@]}}" \
+    2>&1 | tee "$workflow_output_file"
+workflow_exit_status=${{PIPESTATUS[0]}}
+set -e
+
+echo "Odoo {workflow_label} readback markers:"
+grep -E '^(odoo_instance_overrides_payload_present|website_bootstrap_[a-z0-9_]+)=' "$workflow_output_file" \
+    | sort -u \
+    || true
+rm -f "$workflow_output_file"
+if [ "$workflow_exit_status" -ne 0 ]; then
+    exit "$workflow_exit_status"
+fi
 
 if [ "${{#protected_shopify_store_keys[@]}}" -gt 0 ]; then
     echo "Checking protected Shopify store keys for ${{database_name}}"

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -3230,6 +3230,14 @@ actions = ["launchplane_service_deploy.execute"]
         self.assertIn('local exit_status="$?"', script)
         self.assertIn('if [ "${web_was_running}" != "1" ]; then', script)
         self.assertIn('docker start "${web_container_id}" >/dev/null || true', script)
+        self.assertIn("workflow_output_file=$(mktemp)", script)
+        self.assertIn("workflow_exit_status=${PIPESTATUS[0]}", script)
+        self.assertIn("Odoo post-deploy maintenance readback markers:", script)
+        self.assertIn(
+            "grep -E '^(odoo_instance_overrides_payload_present|website_bootstrap_[a-z0-9_]+)='",
+            script,
+        )
+        self.assertIn('if [ "$workflow_exit_status" -ne 0 ]; then', script)
         self.assertIn("start_web_container\ntrap - EXIT", script)
         self.assertNotIn("restart_web_on_success", script)
         self.assertIn('"${workflow_environment[@]}"', script)


### PR DESCRIPTION
## Summary

- capture the Odoo data-workflow stdout during Dokploy post-deploy schedules
- re-emit only safe `website_bootstrap_*` and override-presence markers
- preserve the underlying workflow exit status so failures still fail closed

## Why

The latest cm_website testing deploy proves Launchplane renders and hands off the override payload, but the public page still fails canonical/logo. This patch exposes the devkit bootstrap readback markers in schedule output so the next deploy can show whether Odoo persisted website/domain/homepage/logo state.

## Validation

- `uv run --extra dev ruff format --check control_plane/dokploy.py tests/test_dokploy.py`
- `uv run --extra dev ruff check control_plane/dokploy.py tests/test_dokploy.py`
- `uv run python -m unittest tests.test_dokploy`
- `uv run python -m unittest tests.test_odoo_stable_target_replacement tests.test_odoo_generic_web_post_deploy`
