### PR TITLE
Attach Odoo post-deploy readback evidence

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1598,7 +1598,7 @@ def run_compose_post_deploy_update(
     required_workflow_environment_keys: tuple[str, ...] = (),
     protected_shopify_store_keys: tuple[str, ...] = (),
     run_destructive_restore: bool = False,
-) -> None:
+) -> dict[str, str]:
     compose_id = target_definition.target_id.strip()
     compose_name = (
         target_definition.target_name.strip()
@@ -1764,6 +1764,12 @@ def run_compose_post_deploy_update(
         before_key=deployment_key(latest_schedule_deployment),
         timeout_seconds=schedule_timeout_seconds,
     )
+    completed_schedule_deployment = latest_deployment_for_schedule(
+        host=host,
+        token=token,
+        schedule_id=schedule_id,
+    )
+    return extract_odoo_post_deploy_readback_markers(completed_schedule_deployment)
 
 
 def run_compose_odoo_stable_bootstrap(
@@ -2139,6 +2145,27 @@ def extract_deployments(raw_payload: JsonValue) -> list[JsonObject]:
             if isinstance(nested_items, list):
                 return _collect_object_items(nested_items)
     return []
+
+
+def extract_odoo_post_deploy_readback_markers(deployment: JsonObject | None) -> dict[str, str]:
+    if deployment is None:
+        return {}
+    markers: dict[str, str] = {}
+    for line in normalize_dokploy_log_payload(deployment):
+        key, separator, raw_value = line.partition("=")
+        if not separator:
+            continue
+        normalized_key = key.strip()
+        normalized_value = raw_value.strip().lower()
+        if (
+            normalized_key != "odoo_instance_overrides_payload_present"
+            and not normalized_key.startswith("website_bootstrap_")
+        ):
+            continue
+        if normalized_value not in {"true", "false"} and not normalized_value.isdigit():
+            continue
+        markers[normalized_key] = normalized_value
+    return markers
 
 
 def _collect_object_items(raw_items: list[JsonValue]) -> list[JsonObject]:

--- a/control_plane/workflows/odoo_post_deploy.py
+++ b/control_plane/workflows/odoo_post_deploy.py
@@ -179,6 +179,7 @@ def execute_odoo_post_deploy(
         "restore" if run_destructive_restore else "deploy"
     )
     override_payload: OdooPostDeployPayload | None = None
+    post_deploy_readback_evidence: dict[str, str] = {}
 
     target_definition = _resolve_compose_target_definition(
         control_plane_root=control_plane_root,
@@ -225,15 +226,18 @@ def execute_odoo_post_deploy(
         host, token = control_plane_dokploy.read_dokploy_config(
             control_plane_root=control_plane_root
         )
-        control_plane_dokploy.run_compose_post_deploy_update(
-            host=host,
-            token=token,
-            target_definition=target_definition,
-            env_file=env_file,
-            workflow_environment_overrides=workflow_environment_overrides,
-            required_workflow_environment_keys=required_workflow_environment_keys,
-            protected_shopify_store_keys=protected_shopify_store_keys,
-            run_destructive_restore=run_destructive_restore,
+        post_deploy_readback_evidence = (
+            control_plane_dokploy.run_compose_post_deploy_update(
+                host=host,
+                token=token,
+                target_definition=target_definition,
+                env_file=env_file,
+                workflow_environment_overrides=workflow_environment_overrides,
+                required_workflow_environment_keys=required_workflow_environment_keys,
+                protected_shopify_store_keys=protected_shopify_store_keys,
+                run_destructive_restore=run_destructive_restore,
+            )
+            or {}
         )
     except click.ClickException as error:
         if odoo_override_record is not None and override_should_apply:
@@ -264,7 +268,10 @@ def execute_odoo_post_deploy(
             workflow_intent=workflow_intent,
             required_container_environment_keys=required_workflow_environment_keys,
             override_evidence=(
-                override_payload.redacted_evidence() if override_payload else {}
+                {
+                    **(override_payload.redacted_evidence() if override_payload else {}),
+                    **post_deploy_readback_evidence,
+                }
             ),
             error_message=str(error),
         )
@@ -303,13 +310,18 @@ def execute_odoo_post_deploy(
             workflow_environment_overrides or required_workflow_environment_keys
         ),
         override_payload_sha256=override_payload.wire_sha256 if override_payload else "",
-        override_payload_schema_version=(override_payload.schema_version if override_payload else None),
+        override_payload_schema_version=(
+            override_payload.schema_version if override_payload else None
+        ),
         override_count=override_payload.override_count if override_payload else 0,
         website_bootstrap_included=(
             override_payload.website_bootstrap_included if override_payload else False
         ),
         workflow_intent=workflow_intent,
         required_container_environment_keys=required_workflow_environment_keys,
-        override_evidence=override_payload.redacted_evidence() if override_payload else {},
+        override_evidence={
+            **(override_payload.redacted_evidence() if override_payload else {}),
+            **post_deploy_readback_evidence,
+        },
         applied_at=applied_at,
     )

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -3242,6 +3242,31 @@ actions = ["launchplane_service_deploy.execute"]
         self.assertNotIn("restart_web_on_success", script)
         self.assertIn('"${workflow_environment[@]}"', script)
 
+    def test_extract_odoo_post_deploy_readback_markers_allows_only_safe_marker_values(self) -> None:
+        markers = control_plane_dokploy.extract_odoo_post_deploy_readback_markers(
+            {
+                "logs": "\n".join(
+                    (
+                        "website_bootstrap_domain_matches_canonical=true",
+                        "website_bootstrap_website_id=1",
+                        "odoo_instance_overrides_payload_present=true",
+                        "website_bootstrap_secret=token-value",
+                        "ODOO_DB_PASSWORD=secret",
+                        "random_line=true",
+                    )
+                )
+            }
+        )
+
+        self.assertEqual(
+            markers,
+            {
+                "website_bootstrap_domain_matches_canonical": "true",
+                "website_bootstrap_website_id": "1",
+                "odoo_instance_overrides_payload_present": "true",
+            },
+        )
+
     def test_service_deploy_dokploy_image_rolls_forward_and_verifies_health(self) -> None:
         runner = CliRunner()
         captured_env_updates: list[dict[str, object]] = []

--- a/tests/test_odoo_post_deploy.py
+++ b/tests/test_odoo_post_deploy.py
@@ -61,6 +61,13 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
                 )
             )
 
+            def capture_post_deploy_run(**kwargs: object) -> dict[str, str]:
+                captured_runs.append(kwargs)
+                return {
+                    "odoo_instance_overrides_payload_present": "true",
+                    "website_bootstrap_domain_matches_canonical": "true",
+                }
+
             with (
                 patch(
                     "control_plane.workflows.odoo_post_deploy.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
@@ -72,13 +79,7 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
                 ),
                 patch(
                     "control_plane.workflows.odoo_post_deploy.control_plane_dokploy.run_compose_post_deploy_update",
-                    side_effect=lambda **kwargs: (
-                        captured_runs.append(kwargs)
-                        or {
-                            "odoo_instance_overrides_payload_present": "true",
-                            "website_bootstrap_domain_matches_canonical": "true",
-                        }
-                    ),
+                    side_effect=capture_post_deploy_run,
                 ),
                 patch(
                     "control_plane.workflows.odoo_post_deploy.utc_now_timestamp",

--- a/tests/test_odoo_post_deploy.py
+++ b/tests/test_odoo_post_deploy.py
@@ -72,7 +72,13 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
                 ),
                 patch(
                     "control_plane.workflows.odoo_post_deploy.control_plane_dokploy.run_compose_post_deploy_update",
-                    side_effect=lambda **kwargs: captured_runs.append(kwargs),
+                    side_effect=lambda **kwargs: (
+                        captured_runs.append(kwargs)
+                        or {
+                            "odoo_instance_overrides_payload_present": "true",
+                            "website_bootstrap_domain_matches_canonical": "true",
+                        }
+                    ),
                 ),
                 patch(
                     "control_plane.workflows.odoo_post_deploy.utc_now_timestamp",
@@ -99,6 +105,14 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
             )
             self.assertEqual(result.override_evidence["workflow_intent"], "deploy")
             self.assertEqual(result.override_evidence["config_parameter_count"], "1")
+            self.assertEqual(
+                result.override_evidence["odoo_instance_overrides_payload_present"],
+                "true",
+            )
+            self.assertEqual(
+                result.override_evidence["website_bootstrap_domain_matches_canonical"],
+                "true",
+            )
             self.assertEqual(len(captured_runs), 1)
             workflow_environment = cast(
                 "dict[str, str]", captured_runs[0]["workflow_environment_overrides"]
@@ -240,9 +254,7 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
             self.assertEqual(result.workflow_intent, "restore")
             self.assertEqual(result.override_count, 1)
             self.assertFalse(result.website_bootstrap_included)
-            self.assertEqual(
-                result.override_evidence["website_bootstrap_included"], "false"
-            )
+            self.assertEqual(result.override_evidence["website_bootstrap_included"], "false")
             self.assertEqual(len(captured_runs), 1)
             workflow_environment = cast(
                 "dict[str, str]", captured_runs[0]["workflow_environment_overrides"]


### PR DESCRIPTION
## Summary

- return safe Odoo post-deploy readback markers from the Dokploy schedule deployment
- merge those markers into Odoo post-deploy override evidence
- filter marker values to boolean/numeric evidence only

## Why

The cm_website testing deploy still fails canonical/logo. Launchplane can prove payload render and schedule completion, but not the Odoo shell readback markers emitted by devkit. This patch carries those safe markers into the operation result so the next deploy can identify whether Odoo persisted website/domain/homepage/logo state.

## Validation

- `uv run --extra dev ruff format control_plane/dokploy.py control_plane/workflows/odoo_post_deploy.py tests/test_dokploy.py tests/test_odoo_post_deploy.py`
- `uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/odoo_post_deploy.py tests/test_dokploy.py tests/test_odoo_post_deploy.py`
- `uv run python -m unittest tests.test_dokploy tests.test_odoo_post_deploy tests.test_odoo_stable_target_replacement tests.test_odoo_generic_web_post_deploy`
