### PR TITLE
Constrain Odoo readback evidence markers

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -62,6 +62,24 @@ ODOO_UPSTREAM_RESTORE_WORKFLOW_ENV_KEYS = (
 DEFAULT_DATA_WORKFLOW_LOCK_PATH = "/volumes/data/.data_workflow_in_progress"
 DEFAULT_ODOO_BACKUP_ROOT = "/volumes/data/backups/launchplane"
 ODOO_RAW_COMPOSE_REQUIRED_SERVICES = ("web", "database", "script-runner")
+ODOO_POST_DEPLOY_BOOLEAN_READBACK_MARKERS = frozenset(
+    {
+        "odoo_instance_overrides_payload_present",
+        "website_bootstrap_domain_set",
+        "website_bootstrap_domain_matches_canonical",
+        "website_bootstrap_homepage_url_set",
+        "website_bootstrap_homepage_url_matches",
+        "website_bootstrap_homepage_page_found",
+        "website_bootstrap_primary_page_xmlid_found",
+        "website_bootstrap_homepage_matches_page",
+        "website_bootstrap_logo_present",
+        "website_bootstrap_applied",
+    }
+)
+ODOO_POST_DEPLOY_NUMERIC_READBACK_MARKERS = frozenset({"website_bootstrap_website_id"})
+ODOO_POST_DEPLOY_READBACK_MARKERS = (
+    ODOO_POST_DEPLOY_BOOLEAN_READBACK_MARKERS | ODOO_POST_DEPLOY_NUMERIC_READBACK_MARKERS
+)
 _LIKELY_SECRET_LOG_VALUE_PATTERN = re.compile(
     r"(?i)(\b[A-Z0-9_]*(?:PASSWORD|PASS|TOKEN|SECRET|API_KEY|ACCESS_KEY|PRIVATE_KEY|DATABASE_URL)[A-Z0-9_]*\s*[=:]\s*)([^\s,;]+)"
 )
@@ -2157,12 +2175,17 @@ def extract_odoo_post_deploy_readback_markers(deployment: JsonObject | None) -> 
             continue
         normalized_key = key.strip()
         normalized_value = raw_value.strip().lower()
-        if (
-            normalized_key != "odoo_instance_overrides_payload_present"
-            and not normalized_key.startswith("website_bootstrap_")
-        ):
+        if normalized_key not in ODOO_POST_DEPLOY_READBACK_MARKERS:
             continue
-        if normalized_value not in {"true", "false"} and not normalized_value.isdigit():
+        if normalized_key in ODOO_POST_DEPLOY_BOOLEAN_READBACK_MARKERS and normalized_value not in {
+            "true",
+            "false",
+        }:
+            continue
+        if (
+            normalized_key in ODOO_POST_DEPLOY_NUMERIC_READBACK_MARKERS
+            and not normalized_value.isdigit()
+        ):
             continue
         markers[normalized_key] = normalized_value
     return markers
@@ -2315,6 +2338,7 @@ def _build_dokploy_data_workflow_script(
     }
     workflow_arguments = workflow_arguments_by_mode[workflow_mode]
     workflow_label = workflow_label_by_mode[workflow_mode]
+    readback_marker_patterns = "|".join(sorted(ODOO_POST_DEPLOY_READBACK_MARKERS))
     return f"""#!/usr/bin/env bash
 set -euo pipefail
 
@@ -2477,7 +2501,7 @@ workflow_exit_status=${{PIPESTATUS[0]}}
 set -e
 
 echo "Odoo {workflow_label} readback markers:"
-grep -E '^(odoo_instance_overrides_payload_present|website_bootstrap_[a-z0-9_]+)=' "$workflow_output_file" \
+grep -E '^({readback_marker_patterns})=' "$workflow_output_file" \
     | sort -u \
     || true
 rm -f "$workflow_output_file"

--- a/control_plane/workflows/odoo_post_deploy.py
+++ b/control_plane/workflows/odoo_post_deploy.py
@@ -107,6 +107,10 @@ def _write_odoo_instance_override_apply_result(
     return updated_record
 
 
+def _prefix_post_deploy_readback_evidence(markers: dict[str, str]) -> dict[str, str]:
+    return {f"post_deploy_readback_{key}": value for key, value in markers.items()}
+
+
 def _require_record_store(record_store: object) -> OdooPostDeployStore:
     required_methods = (
         "read_odoo_instance_override_record",
@@ -179,7 +183,7 @@ def execute_odoo_post_deploy(
         "restore" if run_destructive_restore else "deploy"
     )
     override_payload: OdooPostDeployPayload | None = None
-    post_deploy_readback_evidence: dict[str, str] = {}
+    post_deploy_readback_markers: dict[str, str] = {}
 
     target_definition = _resolve_compose_target_definition(
         control_plane_root=control_plane_root,
@@ -226,7 +230,7 @@ def execute_odoo_post_deploy(
         host, token = control_plane_dokploy.read_dokploy_config(
             control_plane_root=control_plane_root
         )
-        post_deploy_readback_evidence = (
+        post_deploy_readback_markers = (
             control_plane_dokploy.run_compose_post_deploy_update(
                 host=host,
                 token=token,
@@ -270,7 +274,7 @@ def execute_odoo_post_deploy(
             override_evidence=(
                 {
                     **(override_payload.redacted_evidence() if override_payload else {}),
-                    **post_deploy_readback_evidence,
+                    **_prefix_post_deploy_readback_evidence(post_deploy_readback_markers),
                 }
             ),
             error_message=str(error),
@@ -321,7 +325,7 @@ def execute_odoo_post_deploy(
         required_container_environment_keys=required_workflow_environment_keys,
         override_evidence={
             **(override_payload.redacted_evidence() if override_payload else {}),
-            **post_deploy_readback_evidence,
+            **_prefix_post_deploy_readback_evidence(post_deploy_readback_markers),
         },
         applied_at=applied_at,
     )

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -3233,10 +3233,11 @@ actions = ["launchplane_service_deploy.execute"]
         self.assertIn("workflow_output_file=$(mktemp)", script)
         self.assertIn("workflow_exit_status=${PIPESTATUS[0]}", script)
         self.assertIn("Odoo post-deploy maintenance readback markers:", script)
-        self.assertIn(
-            "grep -E '^(odoo_instance_overrides_payload_present|website_bootstrap_[a-z0-9_]+)='",
-            script,
-        )
+        self.assertIn("grep -E '^(", script)
+        self.assertIn("odoo_instance_overrides_payload_present", script)
+        self.assertIn("website_bootstrap_applied", script)
+        self.assertIn("website_bootstrap_domain_matches_canonical", script)
+        self.assertNotIn("website_bootstrap_[a-z0-9_]+", script)
         self.assertIn('if [ "$workflow_exit_status" -ne 0 ]; then', script)
         self.assertIn("start_web_container\ntrap - EXIT", script)
         self.assertNotIn("restart_web_on_success", script)
@@ -3251,6 +3252,9 @@ actions = ["launchplane_service_deploy.execute"]
                         "website_bootstrap_website_id=1",
                         "odoo_instance_overrides_payload_present=true",
                         "website_bootstrap_secret=token-value",
+                        "website_bootstrap_secret=123456",
+                        "website_bootstrap_included=false",
+                        "website_bootstrap_domain_set=123",
                         "ODOO_DB_PASSWORD=secret",
                         "random_line=true",
                     )

--- a/tests/test_odoo_post_deploy.py
+++ b/tests/test_odoo_post_deploy.py
@@ -107,13 +107,18 @@ class OdooPostDeployWorkflowTests(unittest.TestCase):
             self.assertEqual(result.override_evidence["workflow_intent"], "deploy")
             self.assertEqual(result.override_evidence["config_parameter_count"], "1")
             self.assertEqual(
-                result.override_evidence["odoo_instance_overrides_payload_present"],
+                result.override_evidence[
+                    "post_deploy_readback_odoo_instance_overrides_payload_present"
+                ],
                 "true",
             )
             self.assertEqual(
-                result.override_evidence["website_bootstrap_domain_matches_canonical"],
+                result.override_evidence[
+                    "post_deploy_readback_website_bootstrap_domain_matches_canonical"
+                ],
                 "true",
             )
+            self.assertNotIn("website_bootstrap_domain_matches_canonical", result.override_evidence)
             self.assertEqual(len(captured_runs), 1)
             workflow_environment = cast(
                 "dict[str, str]", captured_runs[0]["workflow_environment_overrides"]


### PR DESCRIPTION
## Summary
- replace broad post-deploy readback marker prefix matching with a closed allowlist
- emit only the same closed marker set from the generated Dokploy schedule script
- namespace log-derived readback evidence under post_deploy_readback_* so it cannot overwrite typed payload evidence

## Validation
- uv run --extra dev ruff format --check control_plane/dokploy.py control_plane/workflows/odoo_post_deploy.py tests/test_dokploy.py tests/test_odoo_post_deploy.py
- uv run --extra dev ruff check control_plane/dokploy.py control_plane/workflows/odoo_post_deploy.py tests/test_dokploy.py tests/test_odoo_post_deploy.py
- uv run --extra dev mypy control_plane tests/test_dokploy.py tests/test_odoo_post_deploy.py
- uv run python -m unittest tests.test_dokploy tests.test_odoo_post_deploy tests.test_odoo_stable_target_replacement tests.test_odoo_generic_web_post_deploy