### PR TITLE
Use schedule deployment id for log readback

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1796,13 +1796,17 @@ def run_compose_post_deploy_update(
         payload={"scheduleId": schedule_id},
         timeout_seconds=schedule_timeout_seconds,
     )
-    completed_schedule_deployment_key = wait_for_dokploy_schedule_deployment(
-        host=host,
-        token=token,
-        schedule_id=schedule_id,
-        before_key=deployment_key(latest_schedule_deployment),
-        timeout_seconds=schedule_timeout_seconds,
+    completed_schedule_deployment_key = deployment_key_from_wait_result(
+        wait_for_dokploy_schedule_deployment(
+            host=host,
+            token=token,
+            schedule_id=schedule_id,
+            before_key=deployment_key(latest_schedule_deployment),
+            timeout_seconds=schedule_timeout_seconds,
+        )
     )
+    if not completed_schedule_deployment_key:
+        raise click.ClickException("Dokploy schedule deployment completed without a deployment id.")
     deployment_log_lines = fetch_dokploy_deployment_logs(
         host=host,
         token=token,
@@ -2092,6 +2096,14 @@ def deployment_key(deployment: JsonObject | None) -> str:
         value = deployment.get(key_name)
         if value:
             return str(value)
+    return ""
+
+
+def deployment_key_from_wait_result(wait_result: str) -> str:
+    for token in wait_result.split():
+        key, separator, value = token.partition("=")
+        if key == "deployment" and separator and value:
+            return value
     return ""
 
 

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -369,6 +369,14 @@ class DokployConfigTests(unittest.TestCase):
 
         self.assertIn("deployment id", str(error_context.exception))
 
+    def test_deployment_key_from_wait_result_reads_deployment_token(self) -> None:
+        self.assertEqual(
+            control_plane_dokploy.deployment_key_from_wait_result(
+                "deployment=schedule-after status=done"
+            ),
+            "schedule-after",
+        )
+
     def test_fetch_compose_logs_prefers_web_container_name_variants(self) -> None:
         requests: list[dict[str, object]] = []
 
@@ -2470,7 +2478,7 @@ domains = ["cm-testing.shinycomputers.com"]
                 ),
                 patch(
                     "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
-                    return_value="schedule-after",
+                    return_value="deployment=schedule-after status=done",
                 ),
                 patch(
                     "control_plane.dokploy.fetch_dokploy_deployment_logs",
@@ -2530,7 +2538,7 @@ domains = ["cm-testing.shinycomputers.com"]
             ),
             patch(
                 "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
-                return_value="schedule-after",
+                return_value="deployment=schedule-after status=done",
             ),
             patch(
                 "control_plane.dokploy.fetch_dokploy_deployment_logs",
@@ -2611,7 +2619,7 @@ domains = ["cm-testing.shinycomputers.com"]
             ),
             patch(
                 "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
-                return_value="schedule-after",
+                return_value="deployment=schedule-after status=done",
             ),
             patch(
                 "control_plane.dokploy.fetch_dokploy_deployment_logs",


### PR DESCRIPTION
## Summary
- parse the deployment id from the schedule wait result before calling deployment.readLogs
- fail closed if a completed schedule deployment does not expose a deployment id
- update post-deploy schedule log tests to use the real wait-result shape

## Context
The first live tenant deploy after #1284 failed because deployment.readLogs received the full wait result string (`deployment=<id> status=done`) instead of just the deployment id.

## Validation
- uv run --extra dev ruff format --check control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev ruff check control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev mypy control_plane tests/test_dokploy.py
- uv run python -m unittest tests.test_dokploy tests.test_odoo_post_deploy tests.test_odoo_stable_target_replacement tests.test_odoo_generic_web_post_deploy
