### PR TITLE
Do not fail Odoo post-deploy on missing log markers

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -64,6 +64,7 @@ DEFAULT_ODOO_BACKUP_ROOT = "/volumes/data/backups/launchplane"
 ODOO_RAW_COMPOSE_REQUIRED_SERVICES = ("web", "database", "script-runner")
 ODOO_POST_DEPLOY_BOOLEAN_READBACK_MARKERS = frozenset(
     {
+        "log_available",
         "odoo_instance_overrides_payload_present",
         "website_bootstrap_domain_set",
         "website_bootstrap_domain_matches_canonical",
@@ -1807,13 +1808,11 @@ def run_compose_post_deploy_update(
     )
     if not completed_schedule_deployment_key:
         raise click.ClickException("Dokploy schedule deployment completed without a deployment id.")
-    deployment_log_lines = fetch_dokploy_deployment_logs(
+    return _read_odoo_post_deploy_log_markers(
         host=host,
         token=token,
         deployment_id=completed_schedule_deployment_key,
-        line_count=MAX_DOKPLOY_LOG_LINE_COUNT,
     )
-    return extract_odoo_post_deploy_readback_markers({"logs": list(deployment_log_lines)})
 
 
 def run_compose_odoo_stable_bootstrap(
@@ -2223,6 +2222,22 @@ def extract_odoo_post_deploy_readback_markers(deployment: JsonObject | None) -> 
             continue
         markers[normalized_key] = normalized_value
     return markers
+
+
+def _read_odoo_post_deploy_log_markers(
+    *, host: str, token: str, deployment_id: str
+) -> dict[str, str]:
+    try:
+        deployment_log_lines = fetch_dokploy_deployment_logs(
+            host=host,
+            token=token,
+            deployment_id=deployment_id,
+            line_count=MAX_DOKPLOY_LOG_LINE_COUNT,
+        )
+    except click.ClickException:
+        return {"log_available": "false"}
+    markers = extract_odoo_post_deploy_readback_markers({"logs": list(deployment_log_lines)})
+    return {"log_available": "true", **markers}
 
 
 def _collect_object_items(raw_items: list[JsonValue]) -> list[JsonObject]:

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2569,10 +2569,59 @@ domains = ["cm-testing.shinycomputers.com"]
         self.assertEqual(
             markers,
             {
+                "log_available": "true",
                 "website_bootstrap_domain_matches_canonical": "true",
                 "website_bootstrap_website_id": "7",
             },
         )
+
+    def test_run_compose_post_deploy_update_does_not_fail_when_schedule_logs_are_unavailable(
+        self,
+    ) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="opw", instance="prod", target_id="compose-123", target_name="opw-prod"
+        )
+
+        with (
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "ODOO_DB_NAME=opw_prod\nODOO_FILESTORE_PATH=/volumes/data/filestore\n",
+                    "appName": "opw-prod-app",
+                    "serverId": "server-123",
+                },
+            ),
+            patch("control_plane.dokploy.update_dokploy_target_env"),
+            patch("control_plane.dokploy.find_matching_dokploy_schedule", return_value=None),
+            patch(
+                "control_plane.dokploy.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-123"},
+            ),
+            patch(
+                "control_plane.dokploy.latest_deployment_for_schedule",
+                return_value={"deploymentId": "schedule-before"},
+            ),
+            patch(
+                "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
+                return_value="deployment=schedule-after status=done",
+            ),
+            patch(
+                "control_plane.dokploy.fetch_dokploy_deployment_logs",
+                side_effect=click.ClickException("not found"),
+            ),
+            patch(
+                "control_plane.dokploy.dokploy_request",
+                side_effect=lambda **_kwargs: {"ok": True},
+            ),
+        ):
+            markers = control_plane_dokploy.run_compose_post_deploy_update(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_definition=target_definition,
+                env_file=None,
+            )
+
+        self.assertEqual(markers, {"log_available": "false"})
 
     def test_run_compose_post_deploy_update_can_run_destructive_restore_workflow(
         self,


### PR DESCRIPTION
## Summary
- treat Dokploy schedule deployment log readback as optional marker evidence
- return `log_available=false` when `deployment.readLogs` is unavailable instead of failing post-deploy
- keep schedule completion and missing deployment id fail-closed

## Context
The live tenant deploy after #1285 still received 404 from `/api/deployment.readLogs` for the schedule deployment id. That optional marker fetch should not mask the real canonical/logo fixture proof.

## Validation
- uv run --extra dev ruff format --check control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev ruff check control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev mypy control_plane tests/test_dokploy.py
- uv run python -m unittest tests.test_dokploy tests.test_odoo_post_deploy tests.test_odoo_stable_target_replacement tests.test_odoo_generic_web_post_deploy
