### PR TITLE
Harden Odoo website bootstrap deploy evidence

### DIFF
--- a/control_plane/contracts/odoo_post_deploy_payload.py
+++ b/control_plane/contracts/odoo_post_deploy_payload.py
@@ -127,9 +127,7 @@ class OdooPostDeployPayload(BaseModel):
         if not self.instance:
             raise ValueError("Odoo post-deploy payload requires instance")
         if self.workflow_intent == "restore" and self.website_bootstrap is not None:
-            raise ValueError(
-                "restore Odoo post-deploy payloads must not include website_bootstrap"
-            )
+            raise ValueError("restore Odoo post-deploy payloads must not include website_bootstrap")
         return self
 
     @property
@@ -157,9 +155,7 @@ class OdooPostDeployPayload(BaseModel):
             "schema_version": self.schema_version,
             "context": self.context,
             "instance": self.instance,
-            "config_parameters": [
-                override.to_wire_dict() for override in self.config_parameters
-            ],
+            "config_parameters": [override.to_wire_dict() for override in self.config_parameters],
             "addon_settings": [override.to_wire_dict() for override in self.addon_settings],
         }
         if self.website_bootstrap is not None:
@@ -167,16 +163,16 @@ class OdooPostDeployPayload(BaseModel):
         return payload
 
     def to_wire_json_bytes(self) -> bytes:
-        return json.dumps(
-            self.to_wire_dict(), separators=(",", ":"), sort_keys=True
-        ).encode("utf-8")
+        return json.dumps(self.to_wire_dict(), separators=(",", ":"), sort_keys=True).encode(
+            "utf-8"
+        )
 
     @property
     def wire_sha256(self) -> str:
         return hashlib.sha256(self.to_wire_json_bytes()).hexdigest()
 
     def redacted_evidence(self) -> dict[str, str]:
-        return {
+        evidence = {
             "workflow_intent": self.workflow_intent,
             "payload_schema_version": str(self.schema_version),
             "payload_sha256": self.wire_sha256,
@@ -187,3 +183,29 @@ class OdooPostDeployPayload(BaseModel):
                 self.required_container_environment_keys
             ),
         }
+        if self.website_bootstrap is not None:
+            homepage_route_count = sum(
+                1 for route in self.website_bootstrap.routes if route.homepage
+            )
+            evidence.update(
+                {
+                    "website_bootstrap_name_present": str(
+                        bool(self.website_bootstrap.name.strip())
+                    ).lower(),
+                    "website_bootstrap_canonical_url_present": str(
+                        bool(self.website_bootstrap.canonical_url.strip())
+                    ).lower(),
+                    "website_bootstrap_homepage_url_present": str(
+                        bool(self.website_bootstrap.homepage_url.strip())
+                    ).lower(),
+                    "website_bootstrap_logo_path_present": str(
+                        bool(self.website_bootstrap.logo_path.strip())
+                    ).lower(),
+                    "website_bootstrap_logo_alt_present": str(
+                        bool(self.website_bootstrap.logo_alt.strip())
+                    ).lower(),
+                    "website_bootstrap_route_count": str(len(self.website_bootstrap.routes)),
+                    "website_bootstrap_homepage_route_count": str(homepage_route_count),
+                }
+            )
+        return evidence

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -16,6 +16,8 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
+from control_plane.contracts.odoo_instance_override_record import OdooOverrideApplyPhase
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -24,7 +26,6 @@ from control_plane.contracts.promotion_record import HealthcheckEvidence, PostDe
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.runtime_identity import RuntimeIdentity, runtime_identity_env
 from control_plane.contracts.ship_request import ShipRequest
-from control_plane.contracts.odoo_instance_override_record import OdooOverrideApplyPhase
 from control_plane.contracts.odoo_stable_target_replacement import (
     OdooStableTargetReplacementApplyRequest,
     OdooStableTargetReplacementApplyResult,
@@ -64,9 +65,15 @@ class OdooStableTargetReplacementStore(RuntimeKeySafetyPolicyReadStore, Protocol
 
     def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest: ...
 
+    def read_odoo_instance_override_record(
+        self, *, context_name: str, instance_name: str
+    ) -> OdooInstanceOverrideRecord: ...
+
     def write_deployment_record(self, record: DeploymentRecord) -> object: ...
 
     def write_environment_inventory(self, record: EnvironmentInventory) -> object: ...
+
+    def write_odoo_instance_override_record(self, record: OdooInstanceOverrideRecord) -> object: ...
 
     def write_release_tuple_record(self, record: ReleaseTupleRecord) -> object: ...
 
@@ -168,18 +175,14 @@ class _ApplyResultBase(BaseModel):
             release_tuple_id=release_tuple_id,
             deploy_status=deploy_status,
             post_deploy_status=post_deploy_status,
-            post_deploy_override_status=getattr(
-                post_deploy_payload, "override_status", "skipped"
-            ),
+            post_deploy_override_status=getattr(post_deploy_payload, "override_status", "skipped"),
             post_deploy_override_record_found=bool(
                 getattr(post_deploy_payload, "override_record_found", False)
             ),
             post_deploy_override_payload_rendered=bool(
                 getattr(post_deploy_payload, "override_payload_rendered", False)
             ),
-            post_deploy_override_count=int(
-                getattr(post_deploy_payload, "override_count", 0) or 0
-            ),
+            post_deploy_override_count=int(getattr(post_deploy_payload, "override_count", 0) or 0),
             post_deploy_website_bootstrap_included=bool(
                 getattr(post_deploy_payload, "website_bootstrap_included", False)
             ),
@@ -591,6 +594,40 @@ def _target_health_url(
     ):
         return lane_health_url
     return default_odoo_health_url(base_url=base_url)
+
+
+def _read_odoo_instance_override_record(
+    *, record_store: OdooStableTargetReplacementStore, context: str, instance: str
+) -> OdooInstanceOverrideRecord | None:
+    try:
+        return record_store.read_odoo_instance_override_record(
+            context_name=context,
+            instance_name=instance,
+        )
+    except FileNotFoundError:
+        return None
+
+
+def _record_with_target_replacement_canonical(
+    *,
+    record: OdooInstanceOverrideRecord | None,
+    canonical_url: str,
+    updated_at: str,
+) -> OdooInstanceOverrideRecord | None:
+    normalized_canonical_url = canonical_url.strip().rstrip("/")
+    if record is None or record.website_bootstrap is None or not normalized_canonical_url:
+        return record
+    if record.website_bootstrap.canonical_url == normalized_canonical_url:
+        return record
+    return record.model_copy(
+        update={
+            "website_bootstrap": record.website_bootstrap.model_copy(
+                update={"canonical_url": normalized_canonical_url}
+            ),
+            "updated_at": updated_at,
+            "source_label": "odoo-stable-target-replacement",
+        }
+    )
 
 
 def _normalize_domain(raw_domain: str) -> str:
@@ -1079,6 +1116,22 @@ def execute_odoo_stable_target_replacement_apply(
         image_reference=image_reference,
     )
     runtime_source: dict[str, str] = {}
+    base_url = _target_base_url(lane=lane, domains=plan.expected_domain_hosts)
+    odoo_override_record = _read_odoo_instance_override_record(
+        record_store=record_store,
+        context=plan.context,
+        instance=plan.instance,
+    )
+    normalized_override_record = _record_with_target_replacement_canonical(
+        record=odoo_override_record,
+        canonical_url=base_url,
+        updated_at=started_at,
+    )
+    if (
+        normalized_override_record is not None
+        and normalized_override_record is not odoo_override_record
+    ):
+        record_store.write_odoo_instance_override_record(normalized_override_record)
 
     try:
         host, token = control_plane_dokploy.read_dokploy_config(
@@ -1387,7 +1440,6 @@ def execute_odoo_stable_target_replacement_apply(
             error_message=post_deploy_result.error_message or "Odoo post-deploy failed.",
         )
 
-    base_url = _target_base_url(lane=lane, domains=plan.expected_domain_hosts)
     health_url = _target_health_url(profile=profile, lane=lane, domains=plan.expected_domain_hosts)
     verification = verify_odoo_stable_readiness(
         base_url=base_url,

--- a/tests/test_odoo_instance_override_rendering.py
+++ b/tests/test_odoo_instance_override_rendering.py
@@ -147,11 +147,39 @@ class OdooInstanceOverrideRenderingTests(unittest.TestCase):
         website_bootstrap = cast("dict[str, object]", wire_payload["website_bootstrap"])
         routes = cast("list[dict[str, object]]", website_bootstrap["routes"])
         self.assertEqual(website_bootstrap["name"], "Example Site")
-        self.assertEqual(
-            website_bootstrap["canonical_url"], "https://example-testing.example.com"
-        )
+        self.assertEqual(website_bootstrap["canonical_url"], "https://example-testing.example.com")
         self.assertEqual(routes[0]["url"], "/home")
+        evidence = payload.redacted_evidence()
+        self.assertEqual(evidence["website_bootstrap_name_present"], "true")
+        self.assertEqual(evidence["website_bootstrap_canonical_url_present"], "true")
+        self.assertEqual(evidence["website_bootstrap_homepage_url_present"], "true")
+        self.assertEqual(evidence["website_bootstrap_logo_path_present"], "true")
+        self.assertEqual(evidence["website_bootstrap_logo_alt_present"], "true")
+        self.assertEqual(evidence["website_bootstrap_route_count"], "1")
+        self.assertEqual(evidence["website_bootstrap_homepage_route_count"], "1")
         self.assertEqual(decoded_payload, wire_payload)
+
+    def test_website_bootstrap_evidence_reports_incomplete_public_identity(self) -> None:
+        record = OdooInstanceOverrideRecord(
+            context="example",
+            instance="testing",
+            website_bootstrap=OdooWebsiteBootstrapPayload(
+                tenant="example",
+                name="Example Site",
+            ),
+            updated_at="2026-05-16T00:00:00Z",
+        )
+
+        evidence = render_post_deploy_payload(record).redacted_evidence()
+
+        self.assertEqual(evidence["website_bootstrap_included"], "true")
+        self.assertEqual(evidence["website_bootstrap_name_present"], "true")
+        self.assertEqual(evidence["website_bootstrap_canonical_url_present"], "false")
+        self.assertEqual(evidence["website_bootstrap_homepage_url_present"], "false")
+        self.assertEqual(evidence["website_bootstrap_logo_path_present"], "false")
+        self.assertEqual(evidence["website_bootstrap_logo_alt_present"], "false")
+        self.assertEqual(evidence["website_bootstrap_route_count"], "0")
+        self.assertEqual(evidence["website_bootstrap_homepage_route_count"], "0")
 
     def test_restore_intent_suppresses_website_bootstrap(self) -> None:
         record = OdooInstanceOverrideRecord(

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -15,6 +15,8 @@ from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
+from control_plane.contracts.odoo_instance_override_record import OdooWebsiteBootstrapPayload
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductExpectedConfigProfile,
@@ -63,6 +65,7 @@ class _Store:
         inventory: EnvironmentInventory | None = None,
         artifact_manifest: ArtifactIdentityManifest | None = None,
         artifact_manifests: tuple[ArtifactIdentityManifest, ...] = (),
+        odoo_instance_override_record: OdooInstanceOverrideRecord | None = None,
     ) -> None:
         self.profile = profile or _profile()
         self.target_record = target_record
@@ -77,6 +80,7 @@ class _Store:
         self.release_tuples: list[object] = []
         self.secret_bindings: tuple[SecretBinding, ...] = ()
         self.runtime_key_safety_policy_records: tuple[RuntimeKeySafetyPolicyRecord, ...] = ()
+        self.odoo_instance_override_record = odoo_instance_override_record
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
         if product != self.profile.product:
@@ -109,11 +113,21 @@ class _Store:
             raise FileNotFoundError(artifact_id)
         return self.artifact_manifests[artifact_id]
 
+    def read_odoo_instance_override_record(
+        self, *, context_name: str, instance_name: str
+    ) -> OdooInstanceOverrideRecord:
+        if self.odoo_instance_override_record is None:
+            raise FileNotFoundError(f"{context_name}/{instance_name}")
+        return self.odoo_instance_override_record
+
     def write_deployment_record(self, record: DeploymentRecord) -> None:
         self.deployment_records.append(record)
 
     def write_environment_inventory(self, record: EnvironmentInventory) -> None:
         self.environment_inventories.append(record)
+
+    def write_odoo_instance_override_record(self, record: OdooInstanceOverrideRecord) -> None:
+        self.odoo_instance_override_record = record
 
     def write_release_tuple_record(self, record: object) -> None:
         self.release_tuples.append(record)
@@ -717,6 +731,20 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             target_record=_target_record(),
             target_id_record=_target_id_record(),
             inventory=_inventory(),
+            odoo_instance_override_record=OdooInstanceOverrideRecord(
+                context="cm",
+                instance="testing",
+                website_bootstrap=OdooWebsiteBootstrapPayload(
+                    tenant="cm",
+                    name="Cell Mechanic",
+                    canonical_url="https://cm-website-local.shinycomputers.com",
+                    homepage_url="/cell-mechanic",
+                    primary_page_xmlid="cm_website.website_page_cell_mechanic",
+                    logo_path="addons/cm_website/static/src/img/cell_mechanic_logo_hi_res_v2.png",
+                    logo_alt="Cell Mechanic",
+                ),
+                updated_at="2026-06-13T18:00:00Z",
+            ),
         )
         persisted_env = ""
         persisted_compose_file = "services: {}"
@@ -912,9 +940,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertTrue(result.post_deploy_override_payload_rendered)
         self.assertEqual(result.post_deploy_override_count, 2)
         self.assertTrue(result.post_deploy_website_bootstrap_included)
-        self.assertEqual(
-            result.post_deploy_override_evidence["config_parameter_count"], "1"
-        )
+        self.assertEqual(result.post_deploy_override_evidence["config_parameter_count"], "1")
         self.assertEqual(result.health_status, "pass")
         self.assertEqual(result.canonical_status, "pass")
         self.assertEqual(result.logo_status, "pass")
@@ -944,6 +970,14 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         wait_deploy.assert_called_once()
         post_deploy.assert_called_once()
         self.assertFalse(post_deploy.call_args.kwargs["run_destructive_restore"])
+        self.assertIsNotNone(store.odoo_instance_override_record)
+        assert store.odoo_instance_override_record is not None
+        self.assertIsNotNone(store.odoo_instance_override_record.website_bootstrap)
+        assert store.odoo_instance_override_record.website_bootstrap is not None
+        self.assertEqual(
+            store.odoo_instance_override_record.website_bootstrap.canonical_url,
+            "https://cm-testing.shinycomputers.com",
+        )
         verify_readiness.assert_called_once_with(
             base_url="https://cm-testing.shinycomputers.com",
             health_url="https://cm-testing.shinycomputers.com/launchplane/health",


### PR DESCRIPTION
## Summary
- normalize Odoo website bootstrap canonical URLs to the stable target base URL before target-replacement post-deploy runs
- add redacted website bootstrap completeness evidence for canonical/homepage/logo/route presence
- cover target replacement normalization and incomplete bootstrap evidence with focused tests

## Plan Alignment
This advances the Odoo fixture-readiness phase after config cleanup. The last cm website deploy proved content and post-deploy execution, but public Odoo still advertised My Website/localhost. This change makes Launchplane stop treating website_bootstrap_included=true as enough evidence and ensures stable target replacement uses the live target URL in the bootstrap payload.

## Validation
- uv run python -m unittest tests.test_odoo_instance_override_rendering tests.test_odoo_stable_target_replacement
- uv run python -m unittest tests.test_odoo_instance_override_rendering tests.test_odoo_post_deploy tests.test_odoo_stable_bootstrap tests.test_odoo_stable_target_replacement tests.test_odoo_generic_web_post_deploy
- uv run --extra dev ruff format --check control_plane/contracts/odoo_post_deploy_payload.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_instance_override_rendering.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev ruff check control_plane/contracts/odoo_post_deploy_payload.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_instance_override_rendering.py tests/test_odoo_stable_target_replacement.py
- uv run --extra dev mypy control_plane/contracts/odoo_post_deploy_payload.py control_plane/workflows/odoo_stable_target_replacement.py tests/test_odoo_instance_override_rendering.py tests/test_odoo_stable_target_replacement.py

## Review
- read-only review agent found no findings; residual risk matches existing stable-bootstrap ordering: canonical normalization is persisted before later deploy phases complete, but is idempotent on retry.