### PR TITLE
Harden Dokploy schedule log readback

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1808,10 +1808,19 @@ def run_compose_post_deploy_update(
     )
     if not completed_schedule_deployment_key:
         raise click.ClickException("Dokploy schedule deployment completed without a deployment id.")
+    completed_schedule_deployment = latest_deployment_for_schedule(
+        host=host,
+        token=token,
+        schedule_id=schedule_id,
+    )
+    completed_schedule_deployment_log_id = deployment_log_id(completed_schedule_deployment)
     return _read_odoo_post_deploy_log_markers(
         host=host,
         token=token,
-        deployment_id=completed_schedule_deployment_key,
+        schedule_id=schedule_id,
+        schedule_deployment_key=completed_schedule_deployment_key,
+        deployment_id=completed_schedule_deployment_log_id,
+        deployment=completed_schedule_deployment,
     )
 
 
@@ -2098,6 +2107,16 @@ def deployment_key(deployment: JsonObject | None) -> str:
     return ""
 
 
+def deployment_log_id(deployment: JsonObject | None) -> str:
+    if deployment is None:
+        return ""
+    for key_name in ("deploymentId", "deployment_id"):
+        value = deployment.get(key_name)
+        if value:
+            return str(value)
+    return ""
+
+
 def deployment_key_from_wait_result(wait_result: str) -> str:
     for token in wait_result.split():
         key, separator, value = token.partition("=")
@@ -2225,8 +2244,29 @@ def extract_odoo_post_deploy_readback_markers(deployment: JsonObject | None) -> 
 
 
 def _read_odoo_post_deploy_log_markers(
-    *, host: str, token: str, deployment_id: str
+    *,
+    host: str,
+    token: str,
+    schedule_id: str,
+    schedule_deployment_key: str,
+    deployment_id: str,
+    deployment: JsonObject | None = None,
 ) -> dict[str, str]:
+    evidence = {
+        "schedule_id": schedule_id,
+        "schedule_deployment_key": schedule_deployment_key,
+    }
+    if deployment_id:
+        evidence["schedule_deployment_id"] = deployment_id
+    inline_log_lines = normalize_dokploy_log_payload(deployment) if deployment else ()
+    if inline_log_lines:
+        return {
+            **evidence,
+            "log_available": "true",
+            **extract_odoo_post_deploy_readback_markers({"logs": list(inline_log_lines)}),
+        }
+    if not deployment_id:
+        return {**evidence, "log_available": "false"}
     try:
         deployment_log_lines = fetch_dokploy_deployment_logs(
             host=host,
@@ -2235,9 +2275,9 @@ def _read_odoo_post_deploy_log_markers(
             line_count=MAX_DOKPLOY_LOG_LINE_COUNT,
         )
     except click.ClickException:
-        return {"log_available": "false"}
+        return {**evidence, "log_available": "false"}
     markers = extract_odoo_post_deploy_readback_markers({"logs": list(deployment_log_lines)})
-    return {"log_available": "true", **markers}
+    return {**evidence, "log_available": "true", **markers}
 
 
 def _collect_object_items(raw_items: list[JsonValue]) -> list[JsonObject]:

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2534,7 +2534,10 @@ domains = ["cm-testing.shinycomputers.com"]
             ),
             patch(
                 "control_plane.dokploy.latest_deployment_for_schedule",
-                return_value={"deploymentId": "schedule-before"},
+                side_effect=(
+                    {"deploymentId": "schedule-before"},
+                    {"deploymentId": "schedule-after", "status": "done"},
+                ),
             ),
             patch(
                 "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
@@ -2569,9 +2572,78 @@ domains = ["cm-testing.shinycomputers.com"]
         self.assertEqual(
             markers,
             {
+                "schedule_id": "schedule-123",
+                "schedule_deployment_key": "schedule-after",
+                "schedule_deployment_id": "schedule-after",
                 "log_available": "true",
                 "website_bootstrap_domain_matches_canonical": "true",
                 "website_bootstrap_website_id": "7",
+            },
+        )
+
+    def test_run_compose_post_deploy_update_reads_inline_schedule_log_markers(
+        self,
+    ) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="opw", instance="prod", target_id="compose-123", target_name="opw-prod"
+        )
+
+        with (
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "ODOO_DB_NAME=opw_prod\nODOO_FILESTORE_PATH=/volumes/data/filestore\n",
+                    "appName": "opw-prod-app",
+                    "serverId": "server-123",
+                },
+            ),
+            patch("control_plane.dokploy.update_dokploy_target_env"),
+            patch("control_plane.dokploy.find_matching_dokploy_schedule", return_value=None),
+            patch(
+                "control_plane.dokploy.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-123"},
+            ),
+            patch(
+                "control_plane.dokploy.latest_deployment_for_schedule",
+                side_effect=(
+                    {"deploymentId": "schedule-before"},
+                    {
+                        "deploymentId": "schedule-after",
+                        "status": "done",
+                        "logs": (
+                            "website_bootstrap_domain_matches_canonical=true\n"
+                            "website_bootstrap_website_id=9\n"
+                        ),
+                    },
+                ),
+            ),
+            patch(
+                "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
+                return_value="deployment=schedule-after status=done",
+            ),
+            patch("control_plane.dokploy.fetch_dokploy_deployment_logs") as fetch_logs_mock,
+            patch(
+                "control_plane.dokploy.dokploy_request",
+                side_effect=lambda **_kwargs: {"ok": True},
+            ),
+        ):
+            markers = control_plane_dokploy.run_compose_post_deploy_update(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_definition=target_definition,
+                env_file=None,
+            )
+
+        fetch_logs_mock.assert_not_called()
+        self.assertEqual(
+            markers,
+            {
+                "schedule_id": "schedule-123",
+                "schedule_deployment_key": "schedule-after",
+                "schedule_deployment_id": "schedule-after",
+                "log_available": "true",
+                "website_bootstrap_domain_matches_canonical": "true",
+                "website_bootstrap_website_id": "9",
             },
         )
 
@@ -2599,7 +2671,10 @@ domains = ["cm-testing.shinycomputers.com"]
             ),
             patch(
                 "control_plane.dokploy.latest_deployment_for_schedule",
-                return_value={"deploymentId": "schedule-before"},
+                side_effect=(
+                    {"deploymentId": "schedule-before"},
+                    {"deploymentId": "schedule-after", "status": "done"},
+                ),
             ),
             patch(
                 "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
@@ -2621,7 +2696,71 @@ domains = ["cm-testing.shinycomputers.com"]
                 env_file=None,
             )
 
-        self.assertEqual(markers, {"log_available": "false"})
+        self.assertEqual(
+            markers,
+            {
+                "schedule_id": "schedule-123",
+                "schedule_deployment_key": "schedule-after",
+                "schedule_deployment_id": "schedule-after",
+                "log_available": "false",
+            },
+        )
+
+    def test_run_compose_post_deploy_update_does_not_read_logs_without_deployment_id(
+        self,
+    ) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="opw", instance="prod", target_id="compose-123", target_name="opw-prod"
+        )
+
+        with (
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "ODOO_DB_NAME=opw_prod\nODOO_FILESTORE_PATH=/volumes/data/filestore\n",
+                    "appName": "opw-prod-app",
+                    "serverId": "server-123",
+                },
+            ),
+            patch("control_plane.dokploy.update_dokploy_target_env"),
+            patch("control_plane.dokploy.find_matching_dokploy_schedule", return_value=None),
+            patch(
+                "control_plane.dokploy.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-123"},
+            ),
+            patch(
+                "control_plane.dokploy.latest_deployment_for_schedule",
+                side_effect=(
+                    {"id": "schedule-before", "status": "done"},
+                    {"id": "schedule-row-after", "status": "done"},
+                ),
+            ),
+            patch(
+                "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
+                return_value="deployment=schedule-row-after status=done",
+            ),
+            patch("control_plane.dokploy.fetch_dokploy_deployment_logs") as fetch_logs_mock,
+            patch(
+                "control_plane.dokploy.dokploy_request",
+                side_effect=lambda **_kwargs: {"ok": True},
+            ),
+        ):
+            markers = control_plane_dokploy.run_compose_post_deploy_update(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_definition=target_definition,
+                env_file=None,
+            )
+
+        fetch_logs_mock.assert_not_called()
+        self.assertEqual(
+            markers,
+            {
+                "schedule_id": "schedule-123",
+                "schedule_deployment_key": "schedule-row-after",
+                "log_available": "false",
+            },
+        )
 
     def test_run_compose_post_deploy_update_can_run_destructive_restore_workflow(
         self,


### PR DESCRIPTION
## Summary
- Re-read the completed Dokploy schedule deployment after post-deploy schedule completion.
- Parse inline log/output fields from the schedule deployment payload before calling deployment.readLogs.
- Persist schedule id and schedule deployment key/id into Odoo post-deploy readback evidence, including unavailable-log cases.
- Avoid using generic deployment object id/uuid fallbacks as deployment.readLogs ids; only real deploymentId fields are used for log tailing.

## Plan alignment
The last Odoo testing deploy after #1288 still failed canonical/logo, but it finally persisted . This slice narrows the next proof: either Launchplane captures the schedule readback markers, or the operation tells us the exact schedule/deployment identifiers needed to inspect Dokploy without SSH/LXC guessing.

## Validation
- uv run python -m unittest tests.test_dokploy tests.test_odoo_post_deploy tests.test_odoo_stable_target_replacement
- uv run --extra dev ruff format --check control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev ruff check control_plane/dokploy.py tests/test_dokploy.py --diff
- uv run --extra dev ruff check control_plane/dokploy.py tests/test_dokploy.py
- uv run --extra dev mypy control_plane/dokploy.py tests/test_dokploy.py
- uv run python -m unittest

## Review
Read-only agents reviewed the schedule log path after tenant deploy run 27478600351. One flagged schedule/readLogs query-shape uncertainty; current Dokploy source shows deployment.readLogs accepts deploymentId/tail, so this PR avoids adding an unsupported type parameter and instead tightens deployment id handling plus inline payload parsing.