### PR TITLE
Filter tracked target log search inside Launchplane

### DIFF
--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -54,6 +54,9 @@ def build_tracked_target_logs_payload(
     normalized_line_count = control_plane_dokploy.normalize_dokploy_log_line_count(line_count)
     normalized_since = control_plane_dokploy.normalize_dokploy_log_since(since)
     normalized_search = control_plane_dokploy.normalize_dokploy_log_search(search)
+    fetch_line_count = normalized_line_count
+    if normalized_search:
+        fetch_line_count = control_plane_dokploy.MAX_DOKPLOY_LOG_LINE_COUNT
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
     target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
         host=host,
@@ -68,9 +71,9 @@ def build_tracked_target_logs_payload(
             host=host,
             token=token,
             application_id=target_id_record.target_id,
-            line_count=normalized_line_count,
+            line_count=fetch_line_count,
             since=normalized_since,
-            search=normalized_search,
+            search="",
         )
     else:
         logs = control_plane_dokploy.fetch_dokploy_compose_logs(
@@ -79,10 +82,14 @@ def build_tracked_target_logs_payload(
             compose_id=target_id_record.target_id,
             app_name=app_name,
             server_id=server_id,
-            line_count=normalized_line_count,
+            line_count=fetch_line_count,
             since=normalized_since,
-            search=normalized_search,
+            search="",
         )
+    if normalized_search:
+        search_text = normalized_search.lower()
+        logs = tuple(line for line in logs if search_text in line.lower())
+    logs = tuple(logs[-normalized_line_count:])
     return {
         "context": normalized_context,
         "instance": normalized_instance,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13597,7 +13597,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
                 patch(
                     "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
-                    return_value=("ok", "RESEND_API_KEY=[redacted]"),
+                    return_value=("ok", "contact form submitted", "RESEND_API_KEY=[redacted]"),
                 ) as logs_mock,
             ):
                 app = create_launchplane_service_app(
@@ -13619,15 +13619,15 @@ class LaunchplaneServiceTests(unittest.TestCase):
             host="https://dokploy.example.com",
             token="secret-token",
             application_id="app-123",
-            line_count=2,
+            line_count=1000,
             since="5m",
-            search="contact",
+            search="",
         )
         self.assertEqual(payload["status"], "ok")
         self.assertEqual(payload["target"]["target_name"], "syo-testing-app")
         self.assertEqual(payload["target"]["app_name"], "syo-testing-gfbiqh")
         self.assertEqual(payload["request"], {"line_count": 2, "since": "5m", "search": "contact"})
-        self.assertEqual(payload["logs"]["lines"], ["ok", "RESEND_API_KEY=[redacted]"])
+        self.assertEqual(payload["logs"]["lines"], ["contact form submitted"])
         self.assertNotIn("secret-token", json.dumps(payload))
 
     def test_tracked_target_logs_endpoint_returns_redacted_compose_logs(self) -> None:
@@ -13703,6 +13703,85 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["target"]["app_name"], "cm-website-testing-iul0ql")
         self.assertEqual(payload["logs"]["lines"], ["booting", "ODOO_ADMIN_PASSWORD=[redacted]"])
         self.assertNotIn("secret-token", json.dumps(payload))
+
+    def test_tracked_target_logs_endpoint_filters_compose_logs_without_provider_search(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm_website",
+                instance="testing",
+                target_id="compose-123",
+                target_type="compose",
+                target_name="cm-website-testing",
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["launchplane"],
+                            "contexts": ["cm_website"],
+                            "actions": ["target_logs.read"],
+                        }
+                    ]
+                }
+            )
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "cm-website-testing-iul0ql", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_compose_logs",
+                    return_value=(
+                        "booting",
+                        "website_bootstrap_applied name=Cell Mechanic",
+                        "canonical probe served",
+                    ),
+                ) as logs_mock,
+            ):
+                app = create_launchplane_service_app(
+                    state_dir=root / "state",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    control_plane_root_path=root,
+                    database_url=database_url,
+                )
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/contexts/cm_website/instances/testing/logs",
+                    query_string="lines=2&since=2h&search=website_bootstrap_applied",
+                )
+
+        self.assertEqual(status_code, 200)
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            compose_id="compose-123",
+            app_name="cm-website-testing-iul0ql",
+            server_id="server-1",
+            line_count=1000,
+            since="2h",
+            search="",
+        )
+        self.assertEqual(
+            payload["request"],
+            {"line_count": 2, "since": "2h", "search": "website_bootstrap_applied"},
+        )
+        self.assertEqual(payload["logs"]["lines"], ["website_bootstrap_applied name=Cell Mechanic"])
 
     def test_tracked_target_logs_endpoint_requires_authz_action(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- fetch tracked target logs from Dokploy without provider search when a search term is requested
- apply bounded, case-insensitive filtering inside Launchplane before returning redacted lines
- cover searched application and compose log reads so provider search is not required

## Evidence
- Live run 27480057616 succeeded for cm_website/testing with lines=1000 since=2h search empty.
- Prior run 27471834299 failed with HTTP 400 only when search=website_bootstrap_applied was sent to the tracked logs route.

## Tests
- uv run python -m unittest tests.test_service -k tracked_target_logs
- uv run --extra dev ruff format --check control_plane/tracked_target_logs.py tests/test_service.py
- uv run --extra dev ruff check control_plane/tracked_target_logs.py tests/test_service.py