### PR TITLE
Include config status in product environment evidence

### DIFF
--- a/.github/workflows/product-environment-evidence.yml
+++ b/.github/workflows/product-environment-evidence.yml
@@ -119,6 +119,8 @@ jobs:
             environment="$(jq -r '.environment' <<< "$route")"
             response_file="${raw_response_dir}/${product}-${environment}.json"
             summary_file="product-environment-evidence-results/${product}-${environment}-summary.json"
+            config_status_file="${raw_response_dir}/${product}-${environment}-config-status.json"
+            config_summary_file="product-environment-evidence-results/${product}-${environment}-config-status-summary.json"
             status_code="$(curl -sS \
               -o "$response_file" \
               -w '%{http_code}' \
@@ -174,6 +176,48 @@ jobs:
                 "$product" "$environment" >&2
               exit 1
             fi
+            config_status_code="$(curl -sS \
+              -o "$config_status_file" \
+              -w '%{http_code}' \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H 'Accept: application/json' \
+              "${SERVICE_ORIGIN%/}/v1/products/${product}/environments/${environment}/config-status")"
+            if [ "$config_status_code" != "200" ]; then
+              printf 'Product environment config-status read failed for %s/%s.\n' \
+                "$product" "$environment" >&2
+              echo "HTTP status: ${config_status_code}." >&2
+              exit 1
+            fi
+            jq \
+              --arg product "$product" \
+              --arg environment "$environment" \
+              '{
+                product: $product,
+                environment: $environment,
+                context,
+                trust_state,
+                runtime_settings: [
+                  .runtime_settings[] | {
+                    key,
+                    status,
+                    trust_state,
+                    source_label,
+                    updated_at
+                  }
+                ],
+                managed_secrets: [
+                  .managed_secrets[] | {
+                    binding_key,
+                    status,
+                    integration,
+                    trust_state,
+                    updated_at
+                  }
+                ],
+                warnings
+              }' \
+              "$config_status_file" > "$config_summary_file"
+            jq . "$config_summary_file"
           done
 
       - name: Upload product environment evidence

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -3,6 +3,18 @@ from unittest import TestCase
 
 
 class DocsContractsTests(TestCase):
+    def test_product_environment_evidence_includes_config_status(self) -> None:
+        workflow_text = Path(".github/workflows/product-environment-evidence.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "/v1/products/${product}/environments/${environment}/config-status",
+            workflow_text,
+        )
+        self.assertIn("config-status-summary.json", workflow_text)
+        self.assertIn("product-environment-evidence-results/*-summary.json", workflow_text)
+
     def test_odoo_base_image_promotion_owner_is_documented(self) -> None:
         records_doc = Path("docs/records.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- have Product Environment Evidence read /config-status for each requested environment
- upload redacted config-status summaries with runtime key and managed-secret status/trust metadata
- add a contract test that the workflow includes the config-status evidence path

## Tests
- uv run python -m unittest tests.test_docs_contracts tests.test_config_authority_audit