### PR TITLE
Read wrapped config status in environment evidence

### DIFF
--- a/.github/workflows/product-environment-evidence.yml
+++ b/.github/workflows/product-environment-evidence.yml
@@ -191,13 +191,14 @@ jobs:
             jq \
               --arg product "$product" \
               --arg environment "$environment" \
-              '{
+              '(.config_status // .environment // .) as $config_status
+              | {
                 product: $product,
                 environment: $environment,
-                context,
-                trust_state,
+                context: $config_status.context,
+                trust_state: $config_status.trust_state,
                 runtime_settings: [
-                  .runtime_settings[] | {
+                  $config_status.runtime_settings[] | {
                     key,
                     status,
                     trust_state,
@@ -206,7 +207,7 @@ jobs:
                   }
                 ],
                 managed_secrets: [
-                  .managed_secrets[] | {
+                  $config_status.managed_secrets[] | {
                     binding_key,
                     status,
                     integration,
@@ -214,7 +215,7 @@ jobs:
                     updated_at
                   }
                 ],
-                warnings
+                warnings: $config_status.warnings
               }' \
               "$config_status_file" > "$config_summary_file"
             jq . "$config_summary_file"

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -12,6 +12,7 @@ class DocsContractsTests(TestCase):
             "/v1/products/${product}/environments/${environment}/config-status",
             workflow_text,
         )
+        self.assertIn("(.config_status // .environment // .) as $config_status", workflow_text)
         self.assertIn("config-status-summary.json", workflow_text)
         self.assertIn("product-environment-evidence-results/*-summary.json", workflow_text)
 


### PR DESCRIPTION
## Summary
- unwrap config-status responses from the Launchplane service envelope
- keep compatibility with direct config-status shapes in the diagnostic workflow
- tighten the workflow contract test for the wrapped response shape

## Tests
- uv run python -m unittest tests.test_docs_contracts tests.test_config_authority_audit