### PR TITLE
Require Odoo operational modules in target env

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -82,6 +82,8 @@ class OdooStableTargetReplacementStore(RuntimeKeySafetyPolicyReadStore, Protocol
 DokployRequest = Callable[..., JsonValue]
 DokployConfigReader = Callable[..., tuple[str, str]]
 ODOO_STABLE_TARGET_REPLACEMENT_VERIFY_RETRY_INTERVAL_SECONDS = 5
+ODOO_INSTALL_MODULES_ENV_KEY = "ODOO_INSTALL_MODULES"
+LAUNCHPLANE_REQUIRED_ODOO_MODULES = ("launchplane_settings", "disable_odoo_online")
 
 
 class OdooStableTargetRuntimeSnapshot(BaseModel):
@@ -629,6 +631,16 @@ def _record_with_target_replacement_canonical(
             "source_label": "odoo-stable-target-replacement",
         }
     )
+
+
+def _merge_required_odoo_install_modules(raw_modules: str) -> str:
+    merged_modules: list[str] = []
+    for module_name in (*LAUNCHPLANE_REQUIRED_ODOO_MODULES, *raw_modules.split(",")):
+        normalized_module_name = module_name.strip()
+        if not normalized_module_name or normalized_module_name in merged_modules:
+            continue
+        merged_modules.append(normalized_module_name)
+    return ",".join(merged_modules)
 
 
 def _normalize_domain(raw_domain: str) -> str:
@@ -1280,6 +1292,11 @@ def execute_odoo_stable_target_replacement_apply(
             desired_env_map.pop(key, None)
         desired_env_map.update(runtime_environment_values)
         desired_env_map.update(runtime_override_environment)
+        desired_env_map[ODOO_INSTALL_MODULES_ENV_KEY] = _merge_required_odoo_install_modules(
+            desired_env_map.get(ODOO_INSTALL_MODULES_ENV_KEY, "")
+        )
+        runtime_source["required_odoo_modules"] = ",".join(LAUNCHPLANE_REQUIRED_ODOO_MODULES)
+        runtime_source["odoo_install_modules"] = desired_env_map[ODOO_INSTALL_MODULES_ENV_KEY]
         if runtime_override_payload is not None:
             missing_override_secret_keys = tuple(
                 key

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -844,6 +844,12 @@ context only, and `context_instance` has both context and instance.
   persisted to the Dokploy compose target environment before the web container
   is redeployed, and the same payload is passed to the Odoo data-workflow
   runner for post-deploy maintenance.
+- Odoo stable target replacement also merges the required Launchplane-managed
+  operational modules into `ODOO_INSTALL_MODULES` before redeploying the web
+  container. Artifact inputs or base images make addon files available, but the
+  target env install list is what activates modules such as
+  `launchplane_settings` and `disable_odoo_online` in already-initialized
+  databases.
 - When a deploy-phase payload is expected, Launchplane also persists generic
   runtime assertion flags that tell the Odoo runtime to fail closed if managed
   instance overrides or website bootstrap data are missing. Launchplane re-reads

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -51,6 +51,7 @@ from control_plane.dokploy import JsonObject, JsonValue
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_stable_target_replacement import (
     DokployRequest,
+    _merge_required_odoo_install_modules,
     build_odoo_stable_target_replacement_plan,
     execute_odoo_stable_target_replacement_apply,
     _target_health_url,
@@ -357,6 +358,12 @@ def _request(path: str, query: object | None = None, **_: object) -> JsonValue:
 
 
 class OdooStableTargetReplacementTests(unittest.TestCase):
+    def test_merge_required_odoo_install_modules_prepends_and_dedupes(self) -> None:
+        self.assertEqual(
+            _merge_required_odoo_install_modules("cm_website, disable_odoo_online, website"),
+            "launchplane_settings,disable_odoo_online,cm_website,website",
+        )
+
     def test_build_plan_allows_issue_backed_opw_upstream_restore_policy(self) -> None:
         with (
             patch(
@@ -1024,6 +1031,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertNotIn("ODOO_WEB_COMMAND=/odoo/odoo-bin", persisted_env)
         self.assertIn("ODOO_WORKERS=2", persisted_env)
         persisted_env_map = control_plane_dokploy.parse_dokploy_env_text(persisted_env)
+        self.assertEqual(
+            persisted_env_map["ODOO_INSTALL_MODULES"],
+            "launchplane_settings,disable_odoo_online",
+        )
         self.assertEqual(persisted_env_map[LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY], "true")
         self.assertNotIn(
             LAUNCHPLANE_INSTANCE_OVERRIDES_REQUIRED_ENV_KEY,
@@ -1127,6 +1138,14 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         )
         self.assertEqual(
             final_deployment.runtime_source["runtime_override_instance_required"], "false"
+        )
+        self.assertEqual(
+            final_deployment.runtime_source["required_odoo_modules"],
+            "launchplane_settings,disable_odoo_online",
+        )
+        self.assertEqual(
+            final_deployment.runtime_source["odoo_install_modules"],
+            "launchplane_settings,disable_odoo_online",
         )
         self.assertEqual(result.runtime_source, final_deployment.runtime_source)
         assert final_deployment.runtime_identity is not None


### PR DESCRIPTION
## Summary
- merge launchplane_settings and disable_odoo_online into ODOO_INSTALL_MODULES during stable target replacement
- record the required/final Odoo module list in runtime_source evidence
- document that target env activation is required for already-initialized databases

## Validation
- uv run python -m unittest tests.test_odoo_stable_target_replacement

## Review
- focused read-only agent review over this diff returned no findings