### PR TITLE
Propagate Odoo prod promotion product

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2891,6 +2891,7 @@ def _dispatch_odoo_prod_promotion_run(
     start_response: _StartResponse,
     trace_id: str,
 ) -> tuple[dict[str, object], BaseModel | dict[str, object] | None] | list[bytes]:
+    run_request = request.run.model_copy(update={"product": request.product})
     del (
         resolved_context,
         identity,
@@ -2905,7 +2906,7 @@ def _dispatch_odoo_prod_promotion_run(
         state_dir=state_dir,
         database_url=database_url,
         record_store=cast(OdooProdPromotionRunStore, record_store),
-        request=request.run,
+        request=run_request,
     )
     return driver_result.model_dump(mode="json"), driver_result
 

--- a/control_plane/workflows/odoo_prod_promotion_run.py
+++ b/control_plane/workflows/odoo_prod_promotion_run.py
@@ -41,6 +41,7 @@ class OdooProdPromotionRunRequest(BaseModel):
     context: str
     from_instance: str = "testing"
     to_instance: str = "prod"
+    product: str = ""
     request_id: str
     backup_timeout_seconds: int | None = Field(default=None, ge=1)
     promotion_timeout_seconds: int | None = Field(default=None, ge=1)
@@ -54,6 +55,7 @@ class OdooProdPromotionRunRequest(BaseModel):
         self.context = self.context.strip().lower()
         self.from_instance = self.from_instance.strip().lower()
         self.to_instance = self.to_instance.strip().lower()
+        self.product = self.product.strip()
         self.request_id = self.request_id.strip()
         if not self.context:
             raise ValueError("Odoo prod promotion run requires context.")
@@ -144,6 +146,7 @@ def execute_odoo_prod_promotion_run(
             context=request.context,
             from_instance=request.from_instance,
             to_instance=request.to_instance,
+            product=request.product,
             artifact_id=inputs_result.artifact_id,
             backup_record_id=inputs_result.backup_record_id,
             source_git_ref=inputs_result.source_git_ref,

--- a/tests/test_odoo_prod_promotion_run.py
+++ b/tests/test_odoo_prod_promotion_run.py
@@ -54,6 +54,7 @@ class OdooProdPromotionRunTests(unittest.TestCase):
                 record_store=record_store,
                 request=OdooProdPromotionRunRequest(
                     context="CM",
+                    product="odoo-tenant-cm-website",
                     request_id="run-123-attempt-1",
                     backup_timeout_seconds=300,
                     promotion_timeout_seconds=600,
@@ -76,6 +77,7 @@ class OdooProdPromotionRunTests(unittest.TestCase):
         self.assertEqual(backup_mock.call_args.kwargs["request"].timeout_seconds, 300)
         promotion_mock.assert_called_once()
         promotion_request = promotion_mock.call_args.kwargs["request"]
+        self.assertEqual(promotion_request.product, "odoo-tenant-cm-website")
         self.assertEqual(promotion_request.artifact_id, "artifact-cm-new")
         self.assertEqual(promotion_request.timeout_seconds, 600)
         self.assertEqual(promotion_request.health_timeout_seconds, 180)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -34011,6 +34011,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(run_call["state_dir"], root / "state")
             self.assertIsNone(run_call["database_url"])
             self.assertEqual(run_call["request"].context, "cm")
+            self.assertEqual(run_call["request"].product, "odoo")
             self.assertEqual(run_call["request"].request_id, "run-123-attempt-1")
 
     def test_odoo_prod_promotion_run_allows_reusable_launchplane_workflow(self) -> None:


### PR DESCRIPTION
## Summary
- Preserve the product from the prod-promotion driver envelope when dispatching the run workflow
- Forward that product into the inner Odoo promotion request so product-profile lookup does not fall back to context-derived keys
- Add focused tests for service dispatch and workflow product forwarding

## Tests
- uv run python -m unittest tests.test_odoo_prod_promotion_run tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_driver_executes_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_allows_reusable_launchplane_workflow tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_driver_replays_idempotent_response tests.test_service.LaunchplaneServiceTests.test_odoo_prod_promotion_run_driver_rejects_unauthorized_workflow