### PR TITLE
Refresh Launchplane OIDC token on request retries

### DIFF
--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -48,12 +48,15 @@ function describeError(error) {
   return String(error);
 }
 
-async function fetchWithRetry(url, init, options) {
+async function fetchWithRetry(url, initOrFactory, options) {
   const attempts = parsePositiveInteger(options.retryAttempts, "retry-attempts");
   const delayMs = parseNonNegativeInteger(options.retryDelayMs, "retry-delay-ms");
   let lastError = null;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
+      const init = typeof initOrFactory === "function"
+        ? await initOrFactory()
+        : initOrFactory;
       return await fetch(url, init);
     } catch (error) {
       lastError = error;
@@ -352,7 +355,7 @@ async function requestLaunchplaneUntilComplete(requestUrl, requestInit, options)
 
   while (true) {
     attempt += 1;
-    const response = await fetchWithRetry(requestUrl, await requestInit(), {
+    const response = await fetchWithRetry(requestUrl, requestInit, {
       ...options,
       label: "Launchplane request",
     });

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -53,6 +53,13 @@ global.fetch = async (url, init) => {{
     return new Response(JSON.stringify({{value: `oidc-token-${{oidcTokenCount}}`}}), {{status: 200}});
   }}
   launchplaneRequestCount += 1;
+  const failureAttempts = String(process.env.TEST_LAUNCHPLANE_NETWORK_FAILURE_ATTEMPTS || '')
+    .split(',')
+    .filter(Boolean)
+    .map((value) => Number(value));
+  if (failureAttempts.includes(launchplaneRequestCount)) {{
+    throw new TypeError('simulated Launchplane network failure');
+  }}
   const configuredStatuses = String(process.env.TEST_REFRESH_STATUSES || '').split(',').filter(Boolean);
   const refreshStatus = configuredStatuses[launchplaneRequestCount - 1] || process.env.TEST_REFRESH_STATUS || 'pass';
   return new Response(JSON.stringify({{
@@ -108,11 +115,41 @@ process.on('beforeExit', () => {{
             )
             self.assertEqual(calls[1]["headers"]["Authorization"], "Bearer oidc-token-1")
             self.assertEqual(
+                [call for call in calls if call["url"].startswith("https://oidc.example/token")],
+                [calls[0]],
+            )
+            self.assertEqual(
                 calls[1]["headers"]["Idempotency-Key"],
                 "generic-web-preview-refresh:sellyouroutboard:42:sha",
             )
             self.assertEqual(json.loads(calls[1]["body"])["product"], "sellyouroutboard")
             self.assertIn("application_id<<", output_path.read_text(encoding="utf-8"))
+
+    def test_retries_launchplane_request_with_fresh_oidc_token(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/drivers/odoo/prod-promotion-run",
+                "payload": '{"schema_version":1,"product":"odoo-tenant-cm-website","run":{"schema_version":1,"context":"cm_website","request_id":"27489057866-1"}}',
+                "retry-attempts": "2",
+                "retry-delay-ms": "1",
+            },
+            environment={"TEST_LAUNCHPLANE_NETWORK_FAILURE_ATTEMPTS": "1"},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = json.loads(result.stderr.strip().splitlines()[-1])
+        launchplane_calls = [
+            call
+            for call in calls
+            if call["url"]
+            == "https://launchplane.example/v1/drivers/odoo/prod-promotion-run"
+        ]
+        self.assertEqual(len(launchplane_calls), 2)
+        self.assertEqual(
+            [call["headers"]["Authorization"] for call in launchplane_calls],
+            ["Bearer oidc-token-1", "Bearer oidc-token-2"],
+        )
 
     def test_writes_mapped_response_value_to_file(self) -> None:
         with TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- rebuild Launchplane request init for each network retry so retries mint fresh GitHub OIDC tokens
- add regression coverage for prod-promotion-run retrying after a network failure with token-1 then token-2

## Verification
- python3 -m py_compile tests/test_launchplane_request_action.py
- uv run python -m unittest tests.test_launchplane_request_action
- uv run --extra dev ruff check tests/test_launchplane_request_action.py

## Context
CM prod promotion hit HTTP 401 after a long synchronous request retried with a stale OIDC token. This keeps the existing action shape but makes network retries rebuild auth instead of reusing expired headers.