### PR TITLE
Preserve legacy Odoo install modules for older artifacts

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -2148,7 +2148,7 @@ def deployment_key(deployment: JsonObject | None) -> str:
 def deployment_log_id(deployment: JsonObject | None) -> str:
     if deployment is None:
         return ""
-    for key_name in ("deploymentId", "deployment_id"):
+    for key_name in ("deploymentId", "deployment_id", "id", "uuid"):
         value = deployment.get(key_name)
         if value:
             return str(value)

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1296,16 +1296,23 @@ def execute_odoo_stable_target_replacement_apply(
         current_env_map = control_plane_dokploy.parse_dokploy_env_text(
             str(target_payload.get("env") or "")
         )
+        legacy_odoo_install_modules = current_env_map.get(ODOO_INSTALL_MODULES_ENV_KEY, "")
         desired_env_map = dict(current_env_map)
         for key in control_plane_dokploy.ODOO_RUNTIME_OVERRIDE_TARGET_ENV_KEYS:
             desired_env_map.pop(key, None)
         desired_env_map.pop(ODOO_INSTALL_MODULES_ENV_KEY, None)
         desired_env_map.update(runtime_environment_values)
         desired_env_map.update(runtime_override_environment)
+        explicit_odoo_install_modules = desired_env_map.get(ODOO_INSTALL_MODULES_ENV_KEY, "")
+        manifest_odoo_install_modules = artifact_manifest.odoo_install_modules
+        fallback_odoo_install_modules = (
+            "" if manifest_odoo_install_modules else legacy_odoo_install_modules
+        )
         desired_env_map[ODOO_INSTALL_MODULES_ENV_KEY] = _merge_odoo_install_modules(
             LAUNCHPLANE_REQUIRED_ODOO_MODULES,
-            artifact_manifest.odoo_install_modules,
-            desired_env_map.get(ODOO_INSTALL_MODULES_ENV_KEY, ""),
+            manifest_odoo_install_modules,
+            fallback_odoo_install_modules,
+            explicit_odoo_install_modules,
         )
         runtime_source["required_odoo_modules"] = ",".join(LAUNCHPLANE_REQUIRED_ODOO_MODULES)
         runtime_source["artifact_odoo_install_modules"] = ",".join(

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2704,7 +2704,7 @@ domains = ["cm-testing.shinycomputers.com"]
                 "control_plane.dokploy.latest_deployment_for_schedule",
                 side_effect=(
                     {"deploymentId": "schedule-before"},
-                    {"deploymentId": "schedule-after", "status": "done"},
+                    {"id": "schedule-after", "status": "done"},
                 ),
             ),
             patch(
@@ -2899,8 +2899,8 @@ domains = ["cm-testing.shinycomputers.com"]
             patch(
                 "control_plane.dokploy.latest_deployment_for_schedule",
                 side_effect=(
-                    {"id": "schedule-before", "status": "done"},
-                    {"id": "schedule-row-after", "status": "done"},
+                    {"status": "done"},
+                    {"status": "done"},
                 ),
             ),
             patch(

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -1198,6 +1198,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                         "ODOO_DATA_VOLUME=cm_testing_odoo_data",
                         "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
                         "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        "ODOO_INSTALL_MODULES=cm_website,legacy_theme",
                     )
                 ),
             }
@@ -1283,7 +1284,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         persisted_env_map = control_plane_dokploy.parse_dokploy_env_text(persisted_env)
         self.assertEqual(
             persisted_env_map["ODOO_INSTALL_MODULES"],
-            "launchplane_settings,disable_odoo_online",
+            "launchplane_settings,disable_odoo_online,cm_website,legacy_theme",
         )
         final_deployment = store.deployment_records[-1]
         self.assertEqual(final_deployment.source_git_ref, "feed123")


### PR DESCRIPTION
## Summary
- preserve live ODOO_INSTALL_MODULES only when an older artifact manifest has no odoo_install_modules intent
- keep new artifact manifests authoritative so stale live modules do not leak forward
- accept Dokploy schedule deployment log ids from id/uuid as well as deploymentId/deployment_id

## Verification
- python3 -m py_compile control_plane/workflows/odoo_stable_target_replacement.py control_plane/dokploy.py tests/test_odoo_stable_target_replacement.py tests/test_dokploy.py
- uv run python -m unittest tests.test_odoo_stable_target_replacement tests.test_dokploy
- uv run --extra dev ruff check control_plane/workflows/odoo_stable_target_replacement.py control_plane/dokploy.py tests/test_odoo_stable_target_replacement.py tests/test_dokploy

## Context
Follow-up for auto-review findings P1/P2 after adding artifact-published Odoo install module intent.