### PR TITLE
Fix ingress dry-run certs and log evidence

### DIFF
--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -31,9 +31,9 @@ name: Ingress Route Dry Run
         required: true
         type: number
       certificate_id:
-        description: Existing provider certificate id.
+        description: Existing provider certificate id, or new for provider-managed issuance.
         required: true
-        type: number
+        type: string
       expected_host_id:
         description: Optional existing provider host id that must own the domain.
         required: false
@@ -105,8 +105,16 @@ jobs:
             --arg route_options_json "$ROUTE_OPTIONS_JSON" \
             --arg expected_host_id "$EXPECTED_HOST_ID" \
             --argjson forward_port "$FORWARD_PORT" \
-            --argjson certificate_id "$CERTIFICATE_ID" \
+            --arg certificate_id "$CERTIFICATE_ID" \
             '($route_options_json | fromjson) as $options |
+            ($certificate_id | gsub("^\\s+|\\s+$"; "")) as $certificate_id_text |
+            (if $certificate_id_text == "new" then
+              "new"
+            else
+              try ($certificate_id_text | tonumber) catch error(
+                "certificate_id must be an integer or new"
+              )
+            end) as $certificate_id_value |
             ($expected_host_id |
               if . == "" then
                 null
@@ -179,7 +187,7 @@ jobs:
               forward_host: $forward_host,
               edge_endpoint_key: $edge_endpoint_key,
               forward_port: $forward_port,
-              certificate_id: $certificate_id,
+              certificate_id: $certificate_id_value,
               enabled: true,
               ssl_forced: true,
               http2_support: true,

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -1851,13 +1851,14 @@ def run_compose_post_deploy_update(
         token=token,
         schedule_id=schedule_id,
     )
-    completed_schedule_deployment_log_id = deployment_log_id(completed_schedule_deployment)
+    if deployment_key(completed_schedule_deployment) != completed_schedule_deployment_key:
+        completed_schedule_deployment = None
     return _read_odoo_post_deploy_log_markers(
         host=host,
         token=token,
         schedule_id=schedule_id,
         schedule_deployment_key=completed_schedule_deployment_key,
-        deployment_id=completed_schedule_deployment_log_id,
+        deployment_id=completed_schedule_deployment_key,
         deployment=completed_schedule_deployment,
     )
 

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -54,9 +54,6 @@ def build_tracked_target_logs_payload(
     normalized_line_count = control_plane_dokploy.normalize_dokploy_log_line_count(line_count)
     normalized_since = control_plane_dokploy.normalize_dokploy_log_since(since)
     normalized_search = control_plane_dokploy.normalize_dokploy_log_search(search)
-    fetch_line_count = normalized_line_count
-    if normalized_search:
-        fetch_line_count = control_plane_dokploy.MAX_DOKPLOY_LOG_LINE_COUNT
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
     target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
         host=host,
@@ -71,9 +68,9 @@ def build_tracked_target_logs_payload(
             host=host,
             token=token,
             application_id=target_id_record.target_id,
-            line_count=fetch_line_count,
+            line_count=normalized_line_count,
             since=normalized_since,
-            search="",
+            search=normalized_search,
         )
     else:
         logs = control_plane_dokploy.fetch_dokploy_compose_logs(
@@ -82,13 +79,10 @@ def build_tracked_target_logs_payload(
             compose_id=target_id_record.target_id,
             app_name=app_name,
             server_id=server_id,
-            line_count=fetch_line_count,
+            line_count=normalized_line_count,
             since=normalized_since,
-            search="",
+            search=normalized_search,
         )
-    if normalized_search:
-        search_text = normalized_search.lower()
-        logs = tuple(line for line in logs if search_text in line.lower())
     logs = tuple(logs[-normalized_line_count:])
     return {
         "context": normalized_context,

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -224,7 +224,8 @@ but mixing it with a conflicting identity/access provider fails closed.
 
 Operators can also use the `Ingress Route Dry Run` GitHub workflow for a
 service-mediated canary plan through GitHub OIDC. The workflow accepts the
-product, context, domain, upstream target, existing certificate id, expected
+product, context, domain, upstream target, existing certificate id or `new` for
+provider-managed issuance, expected
 provider host id, typed identity/access provider, and route toggles as manual
 inputs, then calls the same route with `mode: dry-run`. Its authz grant is
 plan-only; an apply still requires the separate `ingress_route.apply` permission

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2815,6 +2815,80 @@ domains = ["cm-testing.shinycomputers.com"]
             },
         )
 
+    def test_run_compose_post_deploy_update_uses_waited_deployment_for_logs(
+        self,
+    ) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="opw", instance="prod", target_id="compose-123", target_name="opw-prod"
+        )
+
+        with (
+            patch(
+                "control_plane.dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "env": "ODOO_DB_NAME=opw_prod\nODOO_FILESTORE_PATH=/volumes/data/filestore\n",
+                    "appName": "opw-prod-app",
+                    "serverId": "server-123",
+                },
+            ),
+            patch("control_plane.dokploy.update_dokploy_target_env"),
+            patch("control_plane.dokploy.find_matching_dokploy_schedule", return_value=None),
+            patch(
+                "control_plane.dokploy.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-123"},
+            ),
+            patch(
+                "control_plane.dokploy.latest_deployment_for_schedule",
+                side_effect=(
+                    {"deploymentId": "schedule-before"},
+                    {
+                        "deploymentId": "schedule-after-newer",
+                        "status": "running",
+                        "logs": "website_bootstrap_website_id=99\n",
+                    },
+                ),
+            ),
+            patch(
+                "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
+                return_value="deployment=schedule-after-waited status=done",
+            ),
+            patch(
+                "control_plane.dokploy.fetch_dokploy_deployment_logs",
+                return_value=(
+                    "website_bootstrap_domain_matches_canonical=true",
+                    "website_bootstrap_website_id=7",
+                ),
+            ) as fetch_logs_mock,
+            patch(
+                "control_plane.dokploy.dokploy_request",
+                side_effect=lambda **_kwargs: {"ok": True},
+            ),
+        ):
+            markers = control_plane_dokploy.run_compose_post_deploy_update(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_definition=target_definition,
+                env_file=None,
+            )
+
+        fetch_logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            deployment_id="schedule-after-waited",
+            line_count=control_plane_dokploy.MAX_DOKPLOY_LOG_LINE_COUNT,
+        )
+        self.assertEqual(
+            markers,
+            {
+                "schedule_id": "schedule-123",
+                "schedule_deployment_key": "schedule-after-waited",
+                "schedule_deployment_id": "schedule-after-waited",
+                "log_available": "true",
+                "website_bootstrap_domain_matches_canonical": "true",
+                "website_bootstrap_website_id": "7",
+            },
+        )
+
     def test_run_compose_post_deploy_update_does_not_fail_when_schedule_logs_are_unavailable(
         self,
     ) -> None:
@@ -2874,7 +2948,7 @@ domains = ["cm-testing.shinycomputers.com"]
             },
         )
 
-    def test_run_compose_post_deploy_update_does_not_read_logs_without_deployment_id(
+    def test_run_compose_post_deploy_update_uses_waited_id_when_refetch_has_none(
         self,
     ) -> None:
         target_definition = control_plane_dokploy.DokployTargetDefinition(
@@ -2907,7 +2981,10 @@ domains = ["cm-testing.shinycomputers.com"]
                 "control_plane.dokploy.wait_for_dokploy_schedule_deployment",
                 return_value="deployment=schedule-row-after status=done",
             ),
-            patch("control_plane.dokploy.fetch_dokploy_deployment_logs") as fetch_logs_mock,
+            patch(
+                "control_plane.dokploy.fetch_dokploy_deployment_logs",
+                side_effect=click.ClickException("not found"),
+            ) as fetch_logs_mock,
             patch(
                 "control_plane.dokploy.dokploy_request",
                 side_effect=lambda **_kwargs: {"ok": True},
@@ -2920,12 +2997,18 @@ domains = ["cm-testing.shinycomputers.com"]
                 env_file=None,
             )
 
-        fetch_logs_mock.assert_not_called()
+        fetch_logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            deployment_id="schedule-row-after",
+            line_count=control_plane_dokploy.MAX_DOKPLOY_LOG_LINE_COUNT,
+        )
         self.assertEqual(
             markers,
             {
                 "schedule_id": "schedule-123",
                 "schedule_deployment_key": "schedule-row-after",
+                "schedule_deployment_id": "schedule-row-after",
                 "log_available": "false",
             },
         )

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -702,8 +702,10 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("'.result.preview_pr_feedback // \"\"'", workflow_text)
         self.assertIn("authorized", workflow_text)
         self.assertIn("accepted a non-dry-run feedback probe", workflow_text)
-        self.assertIn("--data-urlencode \"audience=${service_audience}\"", workflow_text)
-        self.assertIn("Artifact publish inputs did not include the product repository", workflow_text)
+        self.assertIn('--data-urlencode "audience=${service_audience}"', workflow_text)
+        self.assertIn(
+            "Artifact publish inputs did not include the product repository", workflow_text
+        )
         self.assertIn("PRODUCT_REPOSITORY", workflow_text)
         self.assertIn("source_repository=result.repository", workflow_text)
         self.assertIn('"operation": "destroy"', workflow_text)
@@ -775,6 +777,11 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("PRODUCT: ${{ inputs.product }}", workflow_text)
         self.assertIn("CONTEXT: ${{ inputs.context }}", workflow_text)
         self.assertIn("DOMAIN: ${{ inputs.domain }}", workflow_text)
+        self.assertIn("Existing provider certificate id, or new", workflow_text)
+        self.assertIn('--arg certificate_id "$CERTIFICATE_ID"', workflow_text)
+        self.assertIn('if $certificate_id_text == "new" then', workflow_text)
+        self.assertIn('"certificate_id must be an integer or new"', workflow_text)
+        self.assertIn("certificate_id: $certificate_id_value", workflow_text)
         self.assertIn('echo "- Product: $PRODUCT"', workflow_text)
         self.assertIn('echo "- Context: $CONTEXT"', workflow_text)
         self.assertIn('echo "- Domain: $DOMAIN"', workflow_text)
@@ -1084,9 +1091,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("workflow_run", script_text)
 
     def test_product_onboarding_workflow_calls_service_route_with_apply_guard(self) -> None:
-        workflow_text = Path(".github/workflows/product-onboarding.yml").read_text(
-            encoding="utf-8"
-        )
+        workflow_text = Path(".github/workflows/product-onboarding.yml").read_text(encoding="utf-8")
 
         self.assertIn("/v1/product-onboarding/apply", workflow_text)
         self.assertIn("APPLY PRODUCT ONBOARDING", workflow_text)
@@ -1095,9 +1100,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("product-onboarding-result", workflow_text)
 
     def test_deploy_authz_grants_include_product_onboarding_apply(self) -> None:
-        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(
-            encoding="utf-8"
-        )
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
 
         self.assertIn("product-onboarding.yml", script_text)
         self.assertIn("product_onboarding.apply", script_text)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13597,7 +13597,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
                 patch(
                     "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
-                    return_value=("ok", "contact form submitted", "RESEND_API_KEY=[redacted]"),
+                    return_value=("contact form submitted",),
                 ) as logs_mock,
             ):
                 app = create_launchplane_service_app(
@@ -13619,9 +13619,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
             host="https://dokploy.example.com",
             token="secret-token",
             application_id="app-123",
-            line_count=1000,
+            line_count=2,
             since="5m",
-            search="",
+            search="contact",
         )
         self.assertEqual(payload["status"], "ok")
         self.assertEqual(payload["target"]["target_name"], "syo-testing-app")
@@ -13704,7 +13704,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["logs"]["lines"], ["booting", "ODOO_ADMIN_PASSWORD=[redacted]"])
         self.assertNotIn("secret-token", json.dumps(payload))
 
-    def test_tracked_target_logs_endpoint_filters_compose_logs_without_provider_search(
+    def test_tracked_target_logs_endpoint_delegates_compose_log_search_to_provider(
         self,
     ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -13745,11 +13745,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
                 patch(
                     "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_compose_logs",
-                    return_value=(
-                        "booting",
-                        "website_bootstrap_applied name=Cell Mechanic",
-                        "canonical probe served",
-                    ),
+                    return_value=("website_bootstrap_applied name=Cell Mechanic",),
                 ) as logs_mock,
             ):
                 app = create_launchplane_service_app(
@@ -13773,9 +13769,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
             compose_id="compose-123",
             app_name="cm-website-testing-iul0ql",
             server_id="server-1",
-            line_count=1000,
+            line_count=2,
             since="2h",
-            search="",
+            search="website_bootstrap_applied",
         )
         self.assertEqual(
             payload["request"],


### PR DESCRIPTION
## Summary
- allow Ingress Route Dry Run to accept `certificate_id=new` so dry-run can match the sanctioned apply path for provider-managed cert issuance
- delegate tracked-target log search to Dokploy instead of filtering a bounded local tail
- read Odoo post-deploy log evidence from the waited schedule deployment id and ignore mismatched refetch payloads
- update ingress driver docs and regression tests

## Local verification
- `git diff --check`
- `uv run --extra dev ruff check control_plane/tracked_target_logs.py control_plane/dokploy.py tests/test_service.py tests/test_dokploy.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff format --check control_plane/tracked_target_logs.py control_plane/dokploy.py tests/test_service.py tests/test_dokploy.py tests/test_product_onboarding.py`
- focused unittest set for ingress dry-run, authz catalog guard, tracked logs, and Dokploy post-deploy evidence
- `uv run python -m unittest`

## Operational note
This does not check in CM route authority. The CM/CM website product profile records were corrected through Product Onboarding. After this lands and deploys, the remaining sanctioned operation is the `cm-website-prod.shinycomputers.com` ingress dry-run/apply using the existing `cm-prod-dokploy` edge endpoint record and `certificate_id=new`.