### PR TITLE
Guard provider target authority replacement

### DIFF
--- a/.github/workflows/dokploy-target-setup.yml
+++ b/.github/workflows/dokploy-target-setup.yml
@@ -113,6 +113,13 @@ name: Dokploy Target Setup
         description: Optional deploy timeout to store.
         required: false
         type: string
+      expected_current_provider_target_json:
+        description: >-
+          Optional JSON deployed target authority that must match the existing
+          provider-target row before replacing it.
+        required: false
+        default: ""
+        type: string
       confirmation:
         description: Type APPLY DOKPLOY TARGET SETUP when mode=apply.
         required: false
@@ -160,6 +167,8 @@ jobs:
       RUNTIME_PORT: ${{ inputs.runtime_port }}
       HEALTHCHECK_PATH: ${{ inputs.healthcheck_path }}
       DEPLOY_TIMEOUT_SECONDS: ${{ inputs.deploy_timeout_seconds }}
+      EXPECTED_CURRENT_PROVIDER_TARGET_JSON: >-
+        ${{ inputs.expected_current_provider_target_json }}
       CONFIRMATION: ${{ inputs.confirmation }}
       REASON: ${{ inputs.reason }}
     steps:
@@ -308,6 +317,19 @@ jobs:
             payload="$(
               jq --argjson timeout "$DEPLOY_TIMEOUT_SECONDS" \
                 '.deploy_timeout_seconds = $timeout' <<< "$payload"
+            )"
+          fi
+          expected_current_provider_target_text="$(
+            printf '%s' "$EXPECTED_CURRENT_PROVIDER_TARGET_JSON" \
+              | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+          )"
+          if [ -n "$expected_current_provider_target_text" ]; then
+            payload="$(
+              jq \
+                --argjson expected_current_provider_target \
+                  "$expected_current_provider_target_text" \
+                '.expected_current_provider_target = $expected_current_provider_target' \
+                <<< "$payload"
             )"
           fi
           idempotency_key="dokploy-target-setup:${OPERATION}:"

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -53,6 +53,7 @@ from control_plane.contracts.agent_write_intent import (
 )
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
+from control_plane.contracts.deploy_target import DeployedTargetReference
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
@@ -2262,6 +2263,7 @@ class DokployTargetSetupEnvelope(BaseModel):
     domains: tuple[str, ...] = ()
     runtime_port: int | None = Field(default=None, ge=1, le=65535)
     deploy_timeout_seconds: int | None = Field(default=None, ge=1)
+    expected_current_provider_target: DeployedTargetReference | None = None
     confirmation: str = ""
     reason: str = ""
 
@@ -2672,6 +2674,7 @@ def _execute_dokploy_target_setup(
             healthcheck_path=request.healthcheck_path,
             domains=request.domains,
             deploy_timeout_seconds=request.deploy_timeout_seconds,
+            expected_current_provider_target=request.expected_current_provider_target,
             source_label="service:dokploy-targets:setup:adopt",
             apply=apply_changes,
             fetch_target_payload=_fetch_dokploy_target_payload_for_setup,
@@ -2705,6 +2708,7 @@ def _execute_dokploy_target_setup(
             healthcheck_path=request.healthcheck_path,
             domains=request.domains,
             deploy_timeout_seconds=request.deploy_timeout_seconds,
+            expected_current_provider_target=request.expected_current_provider_target,
             source_label="service:dokploy-targets:setup:create-application",
             apply=apply_changes,
             mutate_provider=_mutate_dokploy_payload_for_target_setup,
@@ -2733,6 +2737,7 @@ def _execute_dokploy_target_setup(
             healthcheck_path=request.healthcheck_path,
             domains=request.domains,
             deploy_timeout_seconds=request.deploy_timeout_seconds,
+            expected_current_provider_target=request.expected_current_provider_target,
             source_label="service:dokploy-targets:setup:create-compose",
             apply=apply_changes,
             mutate_provider=_mutate_dokploy_payload_for_target_setup,

--- a/control_plane/workflows/dokploy_target_adoption.py
+++ b/control_plane/workflows/dokploy_target_adoption.py
@@ -3,7 +3,7 @@ from typing import Protocol
 
 from pydantic import BaseModel, ConfigDict
 
-from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.deploy_target import DeployedTargetReference, ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord, DokployTargetType
 from control_plane.dokploy import JsonObject
@@ -99,6 +99,7 @@ def adopt_dokploy_target(
     healthcheck_path: str = "",
     domains: tuple[str, ...] = (),
     deploy_timeout_seconds: int | None = None,
+    expected_current_provider_target: DeployedTargetReference | None = None,
     source_label: str = "cli:dokploy-targets:adopt",
     updated_at: str = "",
     apply: bool = False,
@@ -175,6 +176,7 @@ def adopt_dokploy_target(
             record_store=record_store,
             target_record=target_record,
             target_id_record=target_id_record,
+            expected_current_provider_target=expected_current_provider_target,
         )
         record_store.write_dokploy_target_record(target_record)
         record_store.write_dokploy_target_id_record(target_id_record)
@@ -211,6 +213,7 @@ def create_dokploy_application_target(
     healthcheck_path: str = "",
     domains: tuple[str, ...] = (),
     deploy_timeout_seconds: int | None = None,
+    expected_current_provider_target: DeployedTargetReference | None = None,
     source_label: str = "cli:dokploy-targets:create-application",
     updated_at: str = "",
     apply: bool = False,
@@ -305,6 +308,7 @@ def create_dokploy_application_target(
         record_store=record_store,
         context=normalized_context,
         instance=normalized_instance,
+        expected_current_provider_target=expected_current_provider_target,
     )
 
     created_project_id = normalized_project_id
@@ -359,6 +363,7 @@ def create_dokploy_application_target(
         healthcheck_path=normalized_healthcheck_path,
         domains=domains,
         deploy_timeout_seconds=deploy_timeout_seconds,
+        expected_current_provider_target=expected_current_provider_target,
         source_label=source_label,
         updated_at=updated_at,
         apply=True,
@@ -401,6 +406,7 @@ def create_dokploy_compose_target(
     healthcheck_path: str = "",
     domains: tuple[str, ...] = (),
     deploy_timeout_seconds: int | None = None,
+    expected_current_provider_target: DeployedTargetReference | None = None,
     source_label: str = "cli:dokploy-targets:create-compose",
     updated_at: str = "",
     apply: bool = False,
@@ -505,6 +511,7 @@ def create_dokploy_compose_target(
         record_store=record_store,
         context=normalized_context,
         instance=normalized_instance,
+        expected_current_provider_target=expected_current_provider_target,
     )
 
     created_project_id = normalized_project_id
@@ -556,6 +563,7 @@ def create_dokploy_compose_target(
         healthcheck_path=normalized_healthcheck_path,
         domains=domains,
         deploy_timeout_seconds=deploy_timeout_seconds,
+        expected_current_provider_target=expected_current_provider_target,
         source_label=source_label,
         updated_at=updated_at,
         apply=True,
@@ -601,14 +609,32 @@ def _require_non_empty(value: str, field_name: str) -> str:
 
 
 def _ensure_create_route_has_no_provider_target(
-    *, record_store: DokployTargetAdoptionRecordStore, context: str, instance: str
+    *,
+    record_store: DokployTargetAdoptionRecordStore,
+    context: str,
+    instance: str,
+    expected_current_provider_target: DeployedTargetReference | None = None,
 ) -> None:
+    found_current_provider_target = False
     for record in record_store.list_physical_provider_target_records():
-        if record.context == context and record.instance == instance:
+        if record.context != context or record.instance != instance:
+            continue
+        found_current_provider_target = True
+        if expected_current_provider_target is None:
             raise ValueError(
                 "Provider target dual-write conflict for "
                 f"{context}/{instance}; create would replace an explicit provider target."
             )
+        if record.to_deployed_target_reference() != expected_current_provider_target:
+            raise ValueError(
+                "Provider target replacement expectation did not match current authority for "
+                f"{context}/{instance}."
+            )
+    if expected_current_provider_target is not None and not found_current_provider_target:
+        raise ValueError(
+            "Provider target replacement expected an existing provider target for "
+            f"{context}/{instance}."
+        )
 
 
 def _normalize_route_part(value: str, field_name: str) -> str:

--- a/control_plane/workflows/provider_target_dual_write.py
+++ b/control_plane/workflows/provider_target_dual_write.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.deploy_target import DeployedTargetReference, ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 
@@ -18,6 +18,7 @@ def prepare_provider_target_from_dokploy_records(
     record_store: ProviderTargetDualWriteStore,
     target_record: DokployTargetRecord,
     target_id_record: DokployTargetIdRecord,
+    expected_current_provider_target: DeployedTargetReference | None = None,
 ) -> ProviderTargetRecord:
     provider_target_record = ProviderTargetRecord.from_dokploy_records(
         target_record=target_record,
@@ -28,13 +29,27 @@ def prepare_provider_target_from_dokploy_records(
         context=provider_target_record.context,
         instance=provider_target_record.instance,
     )
-    if current_record is not None and _authority_payload(current_record) != _authority_payload(
-        provider_target_record
-    ):
-        raise ValueError(
-            "Provider target dual-write conflict for "
-            f"{provider_target_record.context}/{provider_target_record.instance}."
-        )
+    if expected_current_provider_target is not None:
+        if current_record is None:
+            raise ValueError(
+                "Provider target replacement expected an existing provider target for "
+                f"{provider_target_record.context}/{provider_target_record.instance}."
+            )
+        expected_authority = _reference_authority_payload(expected_current_provider_target)
+        current_authority = _authority_payload(current_record)
+        if current_authority != expected_authority:
+            raise ValueError(
+                "Provider target replacement expectation did not match current authority for "
+                f"{provider_target_record.context}/{provider_target_record.instance}."
+            )
+    if current_record is not None:
+        current_authority = _authority_payload(current_record)
+        next_authority = _authority_payload(provider_target_record)
+        if current_authority != next_authority and expected_current_provider_target is None:
+            raise ValueError(
+                "Provider target dual-write conflict for "
+                f"{provider_target_record.context}/{provider_target_record.instance}."
+            )
     return provider_target_record
 
 
@@ -43,11 +58,13 @@ def write_provider_target_from_dokploy_records(
     record_store: ProviderTargetDualWriteStore,
     target_record: DokployTargetRecord,
     target_id_record: DokployTargetIdRecord,
+    expected_current_provider_target: DeployedTargetReference | None = None,
 ) -> ProviderTargetRecord:
     provider_target_record = prepare_provider_target_from_dokploy_records(
         record_store=record_store,
         target_record=target_record,
         target_id_record=target_id_record,
+        expected_current_provider_target=expected_current_provider_target,
     )
     record_store.write_provider_target_record(provider_target_record)
     return provider_target_record
@@ -74,4 +91,15 @@ def _authority_payload(record: ProviderTargetRecord) -> dict[str, object]:
         "display_name": record.display_name,
         "provider_target_type": record.provider_target_type,
         "provider_evidence": dict(record.provider_evidence),
+    }
+
+
+def _reference_authority_payload(reference: DeployedTargetReference) -> dict[str, object]:
+    return {
+        "provider_id": reference.provider_id,
+        "target_category": reference.target_category,
+        "target_id": reference.target_id,
+        "display_name": reference.display_name,
+        "provider_target_type": reference.provider_target_type,
+        "provider_evidence": dict(reference.provider_evidence),
     }

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -105,6 +105,12 @@ one domain. If a provider create succeeds but the follow-up Launchplane record
 write fails, note the created Dokploy compose/application id from the workflow
 logs and re-run the workflow with `operation=adopt` for the same
 context/instance instead of creating another target.
+When repairing an accidental target-authority collision, pass
+`expected_current_provider_target_json` from provider-target audit evidence so
+Launchplane replaces the existing provider-target row only if the live DB-backed
+authority still matches the reviewed old target. Without that expectation,
+target setup continues to fail closed instead of replacing explicit provider
+authority.
 
 When the Dokploy application does not exist yet, let Launchplane plan and apply
 the provider mutation so the app id is captured in records immediately:

--- a/tests/test_dokploy_target_adoption.py
+++ b/tests/test_dokploy_target_adoption.py
@@ -10,7 +10,7 @@ from click.testing import CliRunner
 
 from control_plane.cli import main
 from control_plane import secrets as control_plane_secrets
-from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.deploy_target import DeployedTargetReference, ProviderTargetRecord
 from control_plane.dokploy import JsonObject
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.dokploy_target_adoption import (
@@ -178,6 +178,128 @@ class DokployTargetAdoptionTests(unittest.TestCase):
             self.assertEqual(store.list_dokploy_target_records(), ())
             self.assertEqual(store.list_dokploy_target_id_records(), ())
             store.close()
+
+    def test_adopt_target_replaces_provider_target_when_current_authority_matches_expectation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            stale_provider_target = ProviderTargetRecord(
+                context="cm_website",
+                instance="prod",
+                provider_id="dokploy",
+                target_category="compose",
+                target_id="compose-cm-prod",
+                display_name="cm-prod",
+                provider_target_type="compose",
+                provider_evidence={"project_name": "odoo"},
+                updated_at="2026-06-14T03:53:56Z",
+                source_label="test:stale-provider-target",
+            )
+            store.write_provider_target_record(stale_provider_target)
+
+            result = adopt_dokploy_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="cm_website",
+                instance="prod",
+                target_type="compose",
+                target_id="compose-cm-website-prod",
+                project_name="odoo",
+                target_name="odoo-tenant-cm-website-prod",
+                healthcheck_path="/web/health",
+                domains=("cm-website-prod.shinycomputers.com",),
+                updated_at="2026-06-14T12:05:00Z",
+                expected_current_provider_target=(
+                    stale_provider_target.to_deployed_target_reference()
+                ),
+                apply=True,
+                fetch_target_payload=lambda *_args: {
+                    "name": "odoo-tenant-cm-website-prod",
+                    "environment": {"project": {"name": "odoo"}},
+                },
+            )
+            target_record = store.read_dokploy_target_record(
+                context_name="cm_website", instance_name="prod"
+            )
+            target_id_record = store.read_dokploy_target_id_record(
+                context_name="cm_website", instance_name="prod"
+            )
+            provider_target_record = store.read_provider_target_record(
+                context_name="cm_website", instance_name="prod"
+            )
+            store.close()
+
+        self.assertTrue(result.applied)
+        self.assertEqual(target_record.target_name, "odoo-tenant-cm-website-prod")
+        self.assertEqual(target_id_record.target_id, "compose-cm-website-prod")
+        self.assertEqual(provider_target_record.target_id, "compose-cm-website-prod")
+        self.assertEqual(provider_target_record.display_name, "odoo-tenant-cm-website-prod")
+
+    def test_adopt_target_rejects_provider_target_replacement_when_expectation_mismatches(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            store.write_provider_target_record(
+                ProviderTargetRecord(
+                    context="cm_website",
+                    instance="prod",
+                    provider_id="dokploy",
+                    target_category="compose",
+                    target_id="compose-cm-prod",
+                    display_name="cm-prod",
+                    provider_target_type="compose",
+                    provider_evidence={"project_name": "odoo"},
+                    updated_at="2026-06-14T03:53:56Z",
+                    source_label="test:stale-provider-target",
+                )
+            )
+
+            with self.assertRaisesRegex(ValueError, "expectation did not match"):
+                adopt_dokploy_target(
+                    record_store=store,
+                    host="https://dokploy.example.invalid",
+                    token="token",
+                    context="cm_website",
+                    instance="prod",
+                    target_type="compose",
+                    target_id="compose-cm-website-prod",
+                    project_name="odoo",
+                    target_name="odoo-tenant-cm-website-prod",
+                    healthcheck_path="/web/health",
+                    domains=("cm-website-prod.shinycomputers.com",),
+                    updated_at="2026-06-14T12:05:00Z",
+                    expected_current_provider_target=DeployedTargetReference(
+                        provider_id="dokploy",
+                        target_category="compose",
+                        target_id="some-other-compose",
+                        display_name="cm-prod",
+                        provider_target_type="compose",
+                        provider_evidence={"project_name": "odoo"},
+                    ),
+                    apply=True,
+                    fetch_target_payload=lambda *_args: {
+                        "name": "odoo-tenant-cm-website-prod",
+                        "environment": {"project": {"name": "odoo"}},
+                    },
+                )
+
+            self.assertEqual(store.list_dokploy_target_records(), ())
+            self.assertEqual(store.list_dokploy_target_id_records(), ())
+            provider_target_record = store.read_provider_target_record(
+                context_name="cm_website", instance_name="prod"
+            )
+            store.close()
+
+        self.assertEqual(provider_target_record.target_id, "compose-cm-prod")
 
     def test_adopt_target_preserves_live_healthcheck_settings(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -862,6 +984,121 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertEqual(requests, [])
         self.assertEqual(target_records, ())
         self.assertEqual(target_id_records, ())
+
+    def test_create_compose_target_replaces_provider_target_when_current_authority_matches_expectation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            stale_provider_target = ProviderTargetRecord(
+                context="cm_website",
+                instance="prod",
+                provider_id="dokploy",
+                target_category="compose",
+                target_id="compose-cm-prod",
+                display_name="cm-prod",
+                provider_target_type="compose",
+                provider_evidence={"project_name": "odoo"},
+                updated_at="2026-06-14T03:53:56Z",
+                source_label="test:stale-provider-target",
+            )
+            store.write_provider_target_record(stale_provider_target)
+            requests: list[tuple[str, JsonObject]] = []
+
+            def mutate_provider(
+                _host: str, _token: str, path: str, payload: JsonObject
+            ) -> JsonObject:
+                requests.append((path, payload))
+                if path == "/api/compose.create":
+                    return {"composeId": "compose-cm-website-prod"}
+                raise AssertionError(path)
+
+            result = create_dokploy_compose_target(
+                record_store=store,
+                host="https://dokploy.example.invalid",
+                token="token",
+                context="cm_website",
+                instance="prod",
+                target_name="odoo-tenant-cm-website-prod",
+                environment_id="env-prod",
+                server_id="server-prod",
+                app_name="odoo-tenant-cm-website-prod",
+                domains=("cm-website-prod.shinycomputers.com",),
+                deploy_timeout_seconds=900,
+                expected_current_provider_target=(
+                    stale_provider_target.to_deployed_target_reference()
+                ),
+                apply=True,
+                mutate_provider=mutate_provider,
+                fetch_target_payload=lambda *_args: {
+                    "name": "odoo-tenant-cm-website-prod",
+                    "sourceType": "raw",
+                    "composePath": "docker-compose.yml",
+                    "environment": {"project": {"name": "odoo"}},
+                },
+            )
+            target_record = store.read_dokploy_target_record(
+                context_name="cm_website", instance_name="prod"
+            )
+            target_id_record = store.read_dokploy_target_id_record(
+                context_name="cm_website", instance_name="prod"
+            )
+            provider_target_record = store.read_provider_target_record(
+                context_name="cm_website", instance_name="prod"
+            )
+            store.close()
+
+        self.assertTrue(result.applied)
+        self.assertEqual([path for path, _payload in requests], ["/api/compose.create"])
+        self.assertEqual(target_record.target_name, "odoo-tenant-cm-website-prod")
+        self.assertEqual(target_id_record.target_id, "compose-cm-website-prod")
+        self.assertEqual(provider_target_record.target_id, "compose-cm-website-prod")
+        self.assertEqual(provider_target_record.display_name, "odoo-tenant-cm-website-prod")
+
+    def test_create_compose_target_with_replacement_expectation_requires_existing_provider_target(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            requests: list[tuple[str, JsonObject]] = []
+
+            def mutate_provider(
+                _host: str, _token: str, path: str, payload: JsonObject
+            ) -> JsonObject:
+                requests.append((path, payload))
+                return {"composeId": "compose-cm-website-prod"}
+
+            with self.assertRaisesRegex(ValueError, "expected an existing provider target"):
+                create_dokploy_compose_target(
+                    record_store=store,
+                    host="https://dokploy.example.invalid",
+                    token="token",
+                    context="cm_website",
+                    instance="prod",
+                    target_name="odoo-tenant-cm-website-prod",
+                    environment_id="env-prod",
+                    server_id="server-prod",
+                    expected_current_provider_target=DeployedTargetReference(
+                        provider_id="dokploy",
+                        target_category="compose",
+                        target_id="compose-cm-prod",
+                        display_name="cm-prod",
+                        provider_target_type="compose",
+                        provider_evidence={"project_name": "odoo"},
+                    ),
+                    apply=True,
+                    mutate_provider=mutate_provider,
+                    fetch_target_payload=lambda *_args: {"name": "odoo-tenant-cm-website-prod"},
+                )
+            store.close()
+
+        self.assertEqual(requests, [])
 
     def test_create_application_target_rejects_healthcheck_path_before_provider_mutation(
         self,

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -646,6 +646,9 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("Validate reconcile compose domain inputs", workflow_text)
         self.assertIn("domain is required when operation=reconcile-compose-domain", workflow_text)
         self.assertIn("runtime_port is required for reconcile-compose-domain", workflow_text)
+        self.assertIn("expected_current_provider_target_json:", workflow_text)
+        self.assertIn("EXPECTED_CURRENT_PROVIDER_TARGET_JSON", workflow_text)
+        self.assertIn("expected_current_provider_target", workflow_text)
         self.assertIn("APPLY DOKPLOY TARGET SETUP", workflow_text)
 
     def test_reusable_odoo_workflows_accept_configured_service_identity(self) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14603,6 +14603,123 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(target_id_record.target_id, "compose-123")
         self.assertEqual(provider_target.target_id, "compose-123")
 
+    def test_dokploy_target_setup_endpoint_replaces_provider_target_with_expected_authority(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            stale_provider_target = ProviderTargetRecord(
+                context="cm_website",
+                instance="prod",
+                provider_id="dokploy",
+                target_category="compose",
+                target_id="compose-cm-prod",
+                display_name="cm-prod",
+                provider_target_type="compose",
+                provider_evidence={"project_name": "Odoo"},
+                updated_at="2026-06-14T03:53:56Z",
+                source_label="test:stale-provider-target",
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+                store.write_provider_target_record(stale_provider_target)
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service._fetch_dokploy_target_payload_for_setup",
+                    return_value={
+                        "name": "odoo-tenant-cm-website-prod",
+                        "sourceType": "raw",
+                        "composePath": "docker-compose.yml",
+                        "environment": {"project": {"name": "Odoo"}},
+                    },
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "operation": "adopt",
+                        "product": "launchplane",
+                        "context": "cm_website",
+                        "instance": "prod",
+                        "target_type": "compose",
+                        "target_id": "compose-cm-website-prod",
+                        "target_name": "odoo-tenant-cm-website-prod",
+                        "project_name": "Odoo",
+                        "domains": ["cm-website-prod.shinycomputers.com"],
+                        "healthcheck_path": "/web/health",
+                        "expected_current_provider_target": (
+                            stale_provider_target.to_deployed_target_reference().model_dump(
+                                mode="json"
+                            )
+                        ),
+                        "confirmation": "APPLY DOKPLOY TARGET SETUP",
+                        "reason": "Repair cm website prod target authority.",
+                    },
+                    headers={"Idempotency-Key": "dokploy-target-setup-cm-website-prod"},
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                target_record = store.read_dokploy_target_record(
+                    context_name="cm_website", instance_name="prod"
+                )
+                target_id_record = store.read_dokploy_target_id_record(
+                    context_name="cm_website", instance_name="prod"
+                )
+                provider_target = store.read_provider_target_record(
+                    context_name="cm_website", instance_name="prod"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertTrue(payload["result"]["applied"])
+        self.assertEqual(target_record.target_name, "odoo-tenant-cm-website-prod")
+        self.assertEqual(target_id_record.target_id, "compose-cm-website-prod")
+        self.assertEqual(provider_target.target_id, "compose-cm-website-prod")
+
     def test_dokploy_target_setup_reconciles_existing_compose_domain_route(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary
- add an optional expected-current provider target guard for Dokploy target setup replacements
- preserve the default fail-closed provider-target dual-write conflict behavior
- let adoption/create-compose replace explicit provider-target authority only when the supplied old deployed target reference exactly matches the current row
- expose `expected_current_provider_target_json` on the Dokploy Target Setup workflow and document the repair pattern

## Why
`cm_website/prod` was accidentally adopted to the full CM prod compose target. A normal create/adopt repair correctly fails closed because an explicit provider-target row already exists. This adds a guarded replacement path so operators can repair bad authority using provider-target audit evidence without allowing broad overwrites.

## Local verification
- `uv run python -m unittest tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_adopt_target_blocks_conflicting_provider_target_before_writes tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_adopt_target_replaces_provider_target_when_current_authority_matches_expectation tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_adopt_target_rejects_provider_target_replacement_when_expectation_mismatches tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_create_application_target_blocks_existing_provider_target_before_provider_mutation tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_create_compose_target_replaces_provider_target_when_current_authority_matches_expectation tests.test_dokploy_target_adoption.DokployTargetAdoptionTests.test_create_compose_target_with_replacement_expectation_requires_existing_provider_target tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_endpoint_applies_compose_target tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_endpoint_replaces_provider_target_with_expected_authority tests.test_product_onboarding.ProductOnboardingTests.test_dokploy_target_setup_workflow_supports_compose_domain_reconcile tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_dokploy_target_setup_launchplane_product_is_self_management`
- `uv run --extra dev ruff check control_plane/service.py control_plane/workflows/dokploy_target_adoption.py control_plane/workflows/provider_target_dual_write.py tests/test_dokploy_target_adoption.py tests/test_service.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff format --check control_plane/service.py control_plane/workflows/dokploy_target_adoption.py control_plane/workflows/provider_target_dual_write.py tests/test_dokploy_target_adoption.py tests/test_service.py tests/test_product_onboarding.py`
- `git diff --check`