### PR TITLE
Add Dokploy target inspect read path

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -72,6 +72,7 @@
     "Security",
     "CodeQL",
     "Deploy Launchplane",
+    "Dokploy Target Inspect",
     "Dokploy Target Setup",
     "Edge Endpoint Apply",
     "Ingress Route Canary Apply",

--- a/.github/workflows/dokploy-target-inspect.yml
+++ b/.github/workflows/dokploy-target-inspect.yml
@@ -1,0 +1,171 @@
+---
+name: Dokploy Target Inspect
+
+"on":
+  workflow_dispatch:
+    inputs:
+      context:
+        description: Launchplane target context for tracked target inspect.
+        required: false
+        default: ""
+        type: string
+      instance:
+        description: Launchplane target instance for tracked target inspect.
+        required: false
+        default: ""
+        type: string
+      target_type:
+        description: Explicit Dokploy target type when not inspecting a tracked route.
+        required: false
+        default: ""
+        type: string
+      target_id:
+        description: Explicit Dokploy target id when not inspecting a tracked route.
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: dokploy-target-inspect-${{ inputs.context }}-${{ inputs.instance }}-${{ inputs.target_type }}-${{ inputs.target_id }}
+  cancel-in-progress: false
+
+jobs:
+  inspect:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      CONTEXT: ${{ inputs.context }}
+      INSTANCE: ${{ inputs.instance }}
+      TARGET_TYPE: ${{ inputs.target_type }}
+      TARGET_ID: ${{ inputs.target_id }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve service endpoint
+        id: service
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+          origin="${LAUNCHPLANE_URL%/}"
+          without_scheme="${origin#*://}"
+          audience="${without_scheme%%/*}"
+          audience="${audience%%:*}"
+          if [ -z "$audience" ] || [ "$audience" = "$origin" ]; then
+            echo "LAUNCHPLANE_URL must be an absolute URL." >&2
+            exit 1
+          fi
+          {
+            echo "origin=$origin"
+            echo "audience=$audience"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate inspect inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          has_route=false
+          has_target=false
+          if [ -n "$(printf '%s' "$CONTEXT$INSTANCE" | xargs)" ]; then
+            has_route=true
+          fi
+          if [ -n "$(printf '%s' "$TARGET_TYPE$TARGET_ID" | xargs)" ]; then
+            has_target=true
+          fi
+          if [ "$has_route" = true ] && [ "$has_target" = true ]; then
+            echo "Use context/instance or target_type/target_id, not both." >&2
+            exit 1
+          fi
+          if [ "$has_route" = true ]; then
+            if [ -z "$(printf '%s' "$CONTEXT" | xargs)" ] \
+              || [ -z "$(printf '%s' "$INSTANCE" | xargs)" ]; then
+              echo "context and instance are both required for tracked inspect." >&2
+              exit 1
+            fi
+          elif [ "$has_target" = true ]; then
+            if [ -z "$(printf '%s' "$TARGET_TYPE" | xargs)" ] \
+              || [ -z "$(printf '%s' "$TARGET_ID" | xargs)" ]; then
+              echo "target_type and target_id are both required for explicit inspect." >&2
+              exit 1
+            fi
+          else
+            echo "context/instance or target_type/target_id is required." >&2
+            exit 1
+          fi
+
+      - name: Inspect target
+        env:
+          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
+          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          oidc_token="$({
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+            | jq -r '.value'
+          })"
+          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
+            echo "GitHub OIDC token response did not include a token value." >&2
+            exit 1
+          fi
+
+          query="$(jq -rn \
+            --arg context "$CONTEXT" \
+            --arg instance "$INSTANCE" \
+            --arg target_type "$TARGET_TYPE" \
+            --arg target_id "$TARGET_ID" \
+            'def encpair($key; $value):
+              select(($value | length) > 0) | "\($key)=\($value | @uri)";
+            [
+              encpair("context"; $context),
+              encpair("instance"; $instance),
+              encpair("target_type"; $target_type),
+              encpair("target_id"; $target_id)
+            ] | join("&")')"
+          response_file="dokploy-target-inspect-response.json"
+          status_code="$(curl -sS \
+            -o "$response_file" \
+            -w '%{http_code}' \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Accept: application/json' \
+            "${SERVICE_ORIGIN%/}/v1/dokploy-targets/inspect?${query}")"
+          jq . "$response_file"
+          if [ "$status_code" != "200" ]; then
+            echo "Dokploy target inspect failed with HTTP ${status_code}." >&2
+            exit 1
+          fi
+
+      - name: Upload inspect evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: dokploy-target-inspect
+          path: dokploy-target-inspect-response.json
+          if-no-files-found: error
+
+      - name: Summarize inspect
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Dokploy target inspect"
+            echo
+            if [ -f dokploy-target-inspect-response.json ]; then
+              jq '{
+                status,
+                trace_id,
+                target: .inspect.tracked_target,
+                provider_target_record: .inspect.provider_target_record,
+                provider: .inspect.provider
+              }' dokploy-target-inspect-response.json
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/dokploy_target_inspect.py
+++ b/control_plane/dokploy_target_inspect.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Literal, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+
+DokployTargetType = Literal["application", "compose"]
+
+
+class FetchDokployTargetPayload(Protocol):
+    def __call__(
+        self, *, host: str, token: str, target_type: str, target_id: str
+    ) -> control_plane_dokploy.JsonObject: ...
+
+
+class DokployTargetInspectRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str = "launchplane"
+    context: str = ""
+    instance: str = ""
+    target_type: DokployTargetType | str = ""
+    target_id: str = ""
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "DokployTargetInspectRequest":
+        self.product = self.product.strip()
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        self.target_type = self.target_type.strip().lower()
+        self.target_id = self.target_id.strip()
+        if self.product != "launchplane":
+            raise ValueError("Dokploy target inspect requires product 'launchplane'.")
+        has_route = bool(self.context or self.instance)
+        has_explicit_target = bool(self.target_type or self.target_id)
+        if has_route and has_explicit_target:
+            raise ValueError(
+                "Dokploy target inspect accepts either context/instance or target_type/target_id, not both."
+            )
+        if has_route:
+            if not self.context or not self.instance:
+                raise ValueError("Tracked Dokploy target inspect requires context and instance.")
+            return self
+        if not self.target_type or not self.target_id:
+            raise ValueError("Explicit Dokploy target inspect requires target_type and target_id.")
+        if self.target_type not in {"application", "compose"}:
+            raise ValueError("Dokploy target inspect target_type must be application or compose.")
+        return self
+
+
+class DokployTargetInspectStore(Protocol):
+    def read_dokploy_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetRecord: ...
+
+    def read_dokploy_target_id_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetIdRecord: ...
+
+    def read_provider_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> ProviderTargetRecord: ...
+
+
+def inspect_dokploy_target(
+    *,
+    record_store: DokployTargetInspectStore,
+    host: str,
+    token: str,
+    request: DokployTargetInspectRequest,
+    fetch_target_payload: FetchDokployTargetPayload | None = None,
+) -> dict[str, object]:
+    target_record: DokployTargetRecord | None = None
+    target_id_record: DokployTargetIdRecord | None = None
+    provider_target_record: ProviderTargetRecord | None = None
+
+    target_type: DokployTargetType
+    if request.target_type == "application":
+        target_type = "application"
+    else:
+        target_type = "compose"
+    target_id = request.target_id
+    if request.context and request.instance:
+        target_record = record_store.read_dokploy_target_record(
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+        target_id_record = record_store.read_dokploy_target_id_record(
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+        try:
+            provider_target_record = record_store.read_provider_target_record(
+                context_name=request.context,
+                instance_name=request.instance,
+            )
+        except FileNotFoundError:
+            provider_target_record = None
+        target_type = target_record.target_type
+        target_id = target_id_record.target_id
+
+    payload_fetcher = fetch_target_payload or control_plane_dokploy.fetch_dokploy_target_payload
+    provider_payload = payload_fetcher(
+        host=host,
+        token=token,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    provider_summary = summarize_dokploy_target_payload(
+        target_type=target_type,
+        target_id=target_id,
+        payload=provider_payload,
+    )
+    result: dict[str, object] = {
+        "status": "ok",
+        "target_type": target_type,
+        "target_id": target_id,
+        "provider_payload_redacted": True,
+        "provider": provider_summary,
+    }
+    if target_record is not None and target_id_record is not None:
+        result["tracked_target"] = {
+            "context": target_record.context,
+            "instance": target_record.instance,
+            "target_type": target_record.target_type,
+            "target_name": target_record.target_name,
+            "target_id": target_id_record.target_id,
+            "project_name": target_record.project_name,
+            "source_git_ref": target_record.source_git_ref,
+            "source_type": target_record.source_type,
+            "compose_path": target_record.compose_path,
+            "domains": list(target_record.domains),
+            "healthcheck_path": target_record.healthcheck_path,
+            "deploy_timeout_seconds": target_record.deploy_timeout_seconds,
+            "source_label": target_record.source_label,
+            "updated_at": target_record.updated_at,
+        }
+        if provider_target_record is None:
+            result["provider_target_record"] = {"status": "missing"}
+        else:
+            result["provider_target_record"] = {
+                "status": "present",
+                "provider_id": provider_target_record.provider_id,
+                "target_category": provider_target_record.target_category,
+                "target_id": provider_target_record.target_id,
+                "display_name": provider_target_record.display_name,
+                "provider_target_type": provider_target_record.provider_target_type,
+                "source_label": provider_target_record.source_label,
+                "updated_at": provider_target_record.updated_at,
+            }
+    return result
+
+
+def summarize_dokploy_target_payload(
+    *, target_type: str, target_id: str, payload: Mapping[str, object]
+) -> dict[str, object]:
+    summary: dict[str, object] = {
+        "target_type": target_type,
+        "target_id": target_id,
+        "id": _string_field(payload, "id", "uuid", "applicationId", "composeId"),
+        "name": _string_field(payload, "name"),
+        "app_name": _string_field(payload, "appName"),
+        "server_id": _string_field(payload, "serverId"),
+        "source_type": _string_field(payload, "sourceType"),
+        "compose_path": _string_field(payload, "composePath"),
+        "description_present": bool(_string_field(payload, "description")),
+        "domains": _domain_summaries(payload),
+        "environment": _environment_summary(payload),
+        "env": _env_summary(payload),
+    }
+    return {key: value for key, value in summary.items() if _present(value)}
+
+
+def _environment_summary(payload: Mapping[str, object]) -> dict[str, object]:
+    environment = _object_field(payload, "environment")
+    project = _object_field(environment, "project")
+    summary = {
+        "id": _string_field(payload, "environmentId") or _string_field(environment, "id", "uuid"),
+        "name": _string_field(environment, "name"),
+        "project_id": _string_field(payload, "projectId") or _string_field(project, "id", "uuid"),
+        "project_name": _string_field(project, "name"),
+    }
+    return {key: value for key, value in summary.items() if _present(value)}
+
+
+def _env_summary(payload: Mapping[str, object]) -> dict[str, object]:
+    env_object = _object_field(payload, "env") or _object_field(payload, "environmentVariables")
+    if env_object:
+        return {
+            "format": "object",
+            "key_count": len(env_object),
+            "keys": sorted(str(key) for key in env_object),
+            "values_redacted": True,
+        }
+    env_value = _string_field(payload, "env")
+    if not env_value:
+        return {}
+    keys = []
+    for line in env_value.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        keys.append(stripped.split("=", 1)[0].strip())
+    return {
+        "format": "dotenv",
+        "key_count": len(keys),
+        "keys": sorted(key for key in keys if key),
+        "values_redacted": True,
+    }
+
+
+def _domain_summaries(payload: Mapping[str, object]) -> list[dict[str, object]]:
+    raw_domains = payload.get("domains") or payload.get("applicationDomains") or []
+    if not isinstance(raw_domains, list):
+        return []
+    summaries: list[dict[str, object]] = []
+    for raw_domain in raw_domains:
+        if not isinstance(raw_domain, Mapping):
+            continue
+        summary = {
+            "id": _string_field(raw_domain, "id", "uuid", "domainId"),
+            "host": _string_field(raw_domain, "host", "domain", "domainName"),
+            "port": _int_field(raw_domain, "port", "targetPort"),
+            "https": _bool_field(raw_domain, "https", "secure"),
+        }
+        summaries.append({key: value for key, value in summary.items() if _present(value)})
+    return summaries
+
+
+def _present(value: object) -> bool:
+    if value is None:
+        return False
+    if value == "":
+        return False
+    if value == []:
+        return False
+    if value == {}:
+        return False
+    return True
+
+
+def _object_field(payload: Mapping[str, object], key: str) -> dict[str, object]:
+    value = payload.get(key)
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _string_field(payload: Mapping[str, object], *keys: str) -> str:
+    for key in keys:
+        value = payload.get(key)
+        if value is None:
+            continue
+        normalized_value = str(value).strip()
+        if normalized_value:
+            return normalized_value
+    return ""
+
+
+def _int_field(payload: Mapping[str, object], *keys: str) -> int | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return value
+        if isinstance(value, str) and value.strip().isdigit():
+            return int(value.strip())
+    return None
+
+
+def _bool_field(payload: Mapping[str, object], *keys: str) -> bool | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str) and value.strip().lower() in {"true", "false"}:
+            return value.strip().lower() == "true"
+    return None

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -24,6 +24,10 @@ from jwt import InvalidTokenError
 
 from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import dokploy as control_plane_dokploy
+from control_plane.dokploy_target_inspect import (
+    DokployTargetInspectRequest,
+    inspect_dokploy_target,
+)
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
@@ -546,6 +550,7 @@ _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-la
 _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
 _NPMPLUS_INGRESS_APPLY_ROUTE_PATH = "/v1/drivers/ingress/route-apply"
 _EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
+_DOKPLOY_TARGET_INSPECT_ROUTE = "/v1/dokploy-targets/inspect"
 _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE = "/v1/ingress/canary-routes/records/apply"
 _INGRESS_CANARY_ROUTE_APPLY_ROUTE = "/v1/ingress/canary-routes/apply"
 _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/controller/run-once"
@@ -4426,6 +4431,8 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "edge_endpoint.read", {"edge_endpoint_list": "true"}
     if len(segments) == 4 and segments[:3] == ["v1", "edge-endpoints", "records"]:
         return "edge_endpoint.read", {"edge_endpoint_key": segments[3]}
+    if len(segments) == 3 and segments == ["v1", "dokploy-targets", "inspect"]:
+        return "dokploy_target.inspect", {}
     if len(segments) == 4 and segments == ["v1", "ingress", "canary-routes", "records"]:
         return "ingress_canary_route.read", {"ingress_canary_route_list": "true"}
     if len(segments) == 5 and segments[:4] == ["v1", "ingress", "canary-routes", "records"]:
@@ -10171,6 +10178,87 @@ def create_launchplane_service_app(
                             "records": [
                                 record.model_dump(mode="json") for record in endpoint_records
                             ],
+                        },
+                    )
+                if action == "dokploy_target.inspect":
+                    if not authz_policy.allows(
+                        identity=identity,
+                        action=action,
+                        product="launchplane",
+                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
+                    ):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=403,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "authorization_denied",
+                                    "message": "Workflow cannot inspect Launchplane Dokploy targets.",
+                                },
+                            },
+                        )
+                    if not isinstance(record_store, PostgresRecordStore):
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=503,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "database_required",
+                                    "message": "Dokploy target inspect requires Launchplane database storage.",
+                                },
+                            },
+                        )
+                    try:
+                        inspect_request = DokployTargetInspectRequest.model_validate(
+                            {
+                                "schema_version": 1,
+                                "product": "launchplane",
+                                "context": _query_string_value(query, "context"),
+                                "instance": _query_string_value(query, "instance"),
+                                "target_type": _query_string_value(query, "target_type"),
+                                "target_id": _query_string_value(query, "target_id"),
+                            }
+                        )
+                        host, token = control_plane_dokploy.read_dokploy_config(
+                            control_plane_root=resolved_root,
+                            database_url=database_url,
+                        )
+                        inspect_result = inspect_dokploy_target(
+                            record_store=record_store,
+                            host=host,
+                            token=token,
+                            request=inspect_request,
+                        )
+                    except ValueError as error:
+                        return _json_response(
+                            start_response=start_response,
+                            status_code=400,
+                            payload={
+                                "status": "rejected",
+                                "trace_id": request_trace_id,
+                                "error": {
+                                    "code": "invalid_dokploy_target_inspect",
+                                    "message": str(error),
+                                },
+                            },
+                        )
+                    except FileNotFoundError:
+                        return _not_found_response(
+                            start_response=start_response,
+                            trace_id=request_trace_id,
+                            path=path,
+                        )
+                    return _json_response(
+                        start_response=start_response,
+                        status_code=200,
+                        payload={
+                            "status": "ok",
+                            "trace_id": request_trace_id,
+                            "inspect": inspect_result,
                         },
                     )
                 if action == "ingress_canary_route.read":

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -879,6 +879,19 @@ but the service fails before records are written, recover by re-running the
 workflow with `operation=adopt` and the created provider target id, not by
 creating a second target for the same lane.
 
+Dokploy target inspect uses `GET /v1/dokploy-targets/inspect`. The route is a
+read-only proof surface for provider identity before an adoption, creation, or
+repair: callers may pass either `context` and `instance` to inspect the current
+tracked target, or `target_type` and `target_id` to inspect an explicit provider
+target. It requires `dokploy_target.inspect` authz for product/context
+`launchplane`, reads Dokploy through Launchplane-managed secrets, and returns a
+redacted identity summary only: target ids, names, project/environment/server
+identity, domain summaries, source metadata, and environment key names/counts.
+It must not return raw provider payloads or environment values. The manual
+`Dokploy Target Inspect` workflow is the supported shared and production caller
+when operators need provider evidence without mutating Dokploy or Launchplane
+records.
+
 The manual `Product Environment Evidence` workflow is the supported read-only
 Phase Two caller for product environment read-model evidence. It uses GitHub
 OIDC and `product_environment.read` to call `GET

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -540,6 +540,14 @@ post_grant \
 	provider-target-operations-backfill
 post_grant \
 	"$GITHUB_REPOSITORY" \
+	dokploy-target-inspect.yml \
+	launchplane \
+	launchplane \
+	dokploy_target.inspect \
+	deploy:dokploy-target-inspect-grant \
+	dokploy-target-inspect
+post_grant \
+	"$GITHUB_REPOSITORY" \
 	dokploy-target-setup.yml \
 	launchplane \
 	launchplane \

--- a/tests/test_dokploy_target_inspect.py
+++ b/tests/test_dokploy_target_inspect.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane import dokploy as control_plane_dokploy
+from control_plane.dokploy_target_inspect import (
+    DokployTargetInspectRequest,
+    inspect_dokploy_target,
+    summarize_dokploy_target_payload,
+)
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _sqlite_database_url(path: Path) -> str:
+    return f"sqlite:///{path}"
+
+
+def _require_mapping(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    return value
+
+
+def _fake_target_payload(
+    *, host: str, token: str, target_type: str, target_id: str
+) -> control_plane_dokploy.JsonObject:
+    del host, token, target_type, target_id
+    return {
+        "id": "compose-cm-prod",
+        "name": "cm-prod",
+        "serverId": "server-123",
+        "environment": {
+            "id": "env-prod",
+            "name": "prod",
+            "project": {"id": "project-odoo", "name": "odoo"},
+        },
+        "env": {"ODOO_DB_PASSWORD": "secret"},
+    }
+
+
+class DokployTargetInspectTests(unittest.TestCase):
+    def test_summarize_payload_redacts_env_values_and_keeps_identity_fields(self) -> None:
+        summary = summarize_dokploy_target_payload(
+            target_type="compose",
+            target_id="compose-123",
+            payload={
+                "id": "compose-123",
+                "name": "odoo-tenant-cm-website-prod",
+                "appName": "odoo-tenant-cm-website-prod",
+                "serverId": "server-123",
+                "sourceType": "raw",
+                "composePath": "docker-compose.yml",
+                "environment": {
+                    "id": "env-prod",
+                    "name": "prod",
+                    "project": {"id": "project-odoo", "name": "odoo"},
+                },
+                "env": "ODOO_DB_PASSWORD=secret\nDISABLE_ODOO_ONLINE=true\n",
+                "domains": [
+                    {"id": "domain-1", "host": "cm-website-prod.shinycomputers.com", "port": 8069}
+                ],
+            },
+        )
+
+        self.assertEqual(summary["id"], "compose-123")
+        self.assertEqual(summary["server_id"], "server-123")
+        environment = _require_mapping(summary["environment"])
+        env = _require_mapping(summary["env"])
+        self.assertEqual(environment["id"], "env-prod")
+        self.assertEqual(environment["project_id"], "project-odoo")
+        self.assertEqual(env["key_count"], 2)
+        self.assertEqual(env["keys"], ["DISABLE_ODOO_ONLINE", "ODOO_DB_PASSWORD"])
+        self.assertTrue(env["values_redacted"])
+        self.assertNotIn("secret", str(summary))
+
+    def test_inspect_tracked_target_includes_records_and_redacted_provider_summary(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            try:
+                store.ensure_schema()
+                store.write_dokploy_target_record(
+                    DokployTargetRecord(
+                        context="cm_website",
+                        instance="prod",
+                        target_type="compose",
+                        target_name="cm-prod",
+                        project_name="odoo",
+                        domains=("cm-website-prod.shinycomputers.com",),
+                        updated_at="2026-06-14T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+                store.write_dokploy_target_id_record(
+                    DokployTargetIdRecord(
+                        context="cm_website",
+                        instance="prod",
+                        target_id="compose-cm-prod",
+                        updated_at="2026-06-14T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+                store.write_provider_target_record(
+                    ProviderTargetRecord(
+                        context="cm_website",
+                        instance="prod",
+                        provider_id="dokploy",
+                        target_category="compose",
+                        target_id="compose-cm-prod",
+                        display_name="cm-prod",
+                        provider_target_type="compose",
+                        provider_evidence={"project_name": "odoo"},
+                        updated_at="2026-06-14T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+
+                result = inspect_dokploy_target(
+                    record_store=store,
+                    host="https://dokploy.example.invalid",
+                    token="token",
+                    request=DokployTargetInspectRequest(
+                        context="cm_website",
+                        instance="prod",
+                    ),
+                    fetch_target_payload=_fake_target_payload,
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(result["target_id"], "compose-cm-prod")
+        tracked_target = _require_mapping(result["tracked_target"])
+        provider_target_record = _require_mapping(result["provider_target_record"])
+        provider = _require_mapping(result["provider"])
+        provider_environment = _require_mapping(provider["environment"])
+        provider_env = _require_mapping(provider["env"])
+        self.assertEqual(tracked_target["target_name"], "cm-prod")
+        self.assertEqual(provider_target_record["display_name"], "cm-prod")
+        self.assertEqual(provider_environment["id"], "env-prod")
+        self.assertEqual(provider_env["keys"], ["ODOO_DB_PASSWORD"])
+        self.assertTrue(result["provider_payload_redacted"])
+        self.assertNotIn("secret", str(result))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14454,6 +14454,214 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(target_records, ())
 
+    def test_dokploy_target_inspect_endpoint_reads_redacted_provider_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+                store.write_dokploy_target_record(
+                    DokployTargetRecord(
+                        context="cm_website",
+                        instance="prod",
+                        target_type="compose",
+                        target_name="cm-prod",
+                        project_name="odoo",
+                        updated_at="2026-06-14T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+                store.write_dokploy_target_id_record(
+                    DokployTargetIdRecord(
+                        context="cm_website",
+                        instance="prod",
+                        target_id="compose-cm-prod",
+                        updated_at="2026-06-14T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+                store.write_provider_target_record(
+                    ProviderTargetRecord(
+                        context="cm_website",
+                        instance="prod",
+                        provider_id="dokploy",
+                        target_category="compose",
+                        target_id="compose-cm-prod",
+                        display_name="cm-prod",
+                        provider_target_type="compose",
+                        provider_evidence={"project_name": "odoo"},
+                        updated_at="2026-06-14T00:00:00Z",
+                        source_label="test",
+                    )
+                )
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.inspect"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ) as read_dokploy_config,
+                patch(
+                    "control_plane.dokploy_target_inspect.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "id": "compose-cm-prod",
+                        "name": "cm-prod",
+                        "serverId": "server-123",
+                        "environment": {
+                            "id": "env-prod",
+                            "name": "prod",
+                            "project": {"id": "project-odoo", "name": "odoo"},
+                        },
+                        "env": "ODOO_DB_PASSWORD=secret\nDISABLE_ODOO_ONLINE=true\n",
+                    },
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/dokploy-targets/inspect",
+                    query_string="context=cm_website&instance=prod",
+                )
+
+        self.assertEqual(status_code, 200)
+        self.assertEqual(payload["inspect"]["target_id"], "compose-cm-prod")
+        self.assertEqual(payload["inspect"]["tracked_target"]["target_name"], "cm-prod")
+        self.assertEqual(payload["inspect"]["provider"]["environment"]["id"], "env-prod")
+        self.assertEqual(
+            payload["inspect"]["provider"]["env"]["keys"],
+            ["DISABLE_ODOO_ONLINE", "ODOO_DB_PASSWORD"],
+        )
+        self.assertTrue(payload["inspect"]["provider_payload_redacted"])
+        self.assertNotIn("secret", str(payload))
+        self.assertNotIn("provider_evidence", str(payload))
+        read_dokploy_config.assert_called_once_with(
+            control_plane_root=root,
+            database_url=database_url,
+        )
+
+    def test_dokploy_target_inspect_endpoint_rejects_without_authz(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+            finally:
+                store.close()
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/dokploy-targets/inspect",
+                query_string="target_type=compose&target_id=compose-123",
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_dokploy_target_inspect_endpoint_returns_not_found_for_unknown_route(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.ensure_schema()
+            finally:
+                store.close()
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.inspect"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            with patch(
+                "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.invalid", "token"),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="GET",
+                    path="/v1/dokploy-targets/inspect",
+                    query_string="context=missing&instance=prod",
+                )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
+
     def test_dokploy_target_setup_endpoint_applies_compose_target(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)


### PR DESCRIPTION
## Summary

- add a read-only `GET /v1/dokploy-targets/inspect` service route for Dokploy target identity proof
- add a `Dokploy Target Inspect` workflow with `dokploy_target.inspect` authz grant wiring
- return redacted provider identity evidence only: target ids/names, project/environment/server identity, domain summaries, source metadata, and env key names/counts
- document the sanctioned inspect path and add targeted service/module tests

## Why

We need a service-backed way to prove Dokploy project/environment/server authority before repairing `cm_website/prod`, which is currently recorded against the full CM prod target. This avoids guessing provider IDs or using local provider credentials.

## Validation

- `uv run --extra dev ruff check control_plane/dokploy_target_inspect.py control_plane/service.py tests/test_dokploy_target_inspect.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/dokploy_target_inspect.py control_plane/service.py tests/test_dokploy_target_inspect.py tests/test_service.py`
- `uv run python -m unittest tests.test_dokploy_target_inspect tests.test_service.LaunchplaneServiceTests.test_dokploy_target_inspect_endpoint_reads_redacted_provider_identity tests.test_service.LaunchplaneServiceTests.test_dokploy_target_inspect_endpoint_rejects_without_authz tests.test_service.LaunchplaneServiceTests.test_dokploy_target_inspect_endpoint_returns_not_found_for_unknown_route`
- `actionlint .github/workflows/dokploy-target-inspect.yml`

## Review Notes

The current auto-review ledger points at detached worktree `auto-review-0e0413e4` and findings in `/Users/cbusillo/.code/working/launchplane/branches/auto-review-0e0413e4`. Current `origin/main` already contains the provider-side log-search and waited deployment-id fixes from PR #1300, and this branch is based on that merged head.
