### PR TITLE
Add Dokploy compose domain prune

### DIFF
--- a/.github/workflows/dokploy-target-setup.yml
+++ b/.github/workflows/dokploy-target-setup.yml
@@ -20,6 +20,7 @@ name: Dokploy Target Setup
           - adopt
           - create-application
           - create-compose
+          - prune-compose-domain
           - reconcile-compose-domain
       context:
         description: Launchplane target context.
@@ -95,7 +96,7 @@ name: Dokploy Target Setup
         required: false
         type: string
       domain:
-        description: Optional comma-separated domain hosts to store/reconcile.
+        description: Optional comma-separated domain hosts to store/reconcile/prune.
         required: false
         default: ""
         type: string
@@ -208,14 +209,19 @@ jobs:
           fi
 
       - name: Validate reconcile compose domain inputs
-        if: env.OPERATION == 'reconcile-compose-domain'
+        if: >-
+          env.OPERATION == 'reconcile-compose-domain'
+          || env.OPERATION == 'prune-compose-domain'
         shell: bash
         run: |
           set -euo pipefail
           if [ -z "$(printf '%s' "$DOMAIN" | xargs)" ]; then
-            echo "domain is required when operation=reconcile-compose-domain." \
+            echo "domain is required for compose domain reconcile/prune." \
               >&2
             exit 1
+          fi
+          if [ "$OPERATION" = "prune-compose-domain" ]; then
+            exit 0
           fi
           runtime_port="$(printf '%s' "$RUNTIME_PORT" | xargs)"
           if [ -z "$runtime_port" ]; then

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -2244,6 +2244,7 @@ class DokployTargetSetupEnvelope(BaseModel):
         "adopt",
         "create-application",
         "create-compose",
+        "prune-compose-domain",
         "reconcile-compose-domain",
     ]
     product: str = "launchplane"
@@ -2321,6 +2322,8 @@ class DokployTargetSetupEnvelope(BaseModel):
                 raise ValueError("Dokploy compose domain reconciliation requires domains.")
             if self.runtime_port is None:
                 raise ValueError("Dokploy compose domain reconciliation requires runtime_port.")
+        if self.operation == "prune-compose-domain" and not self.domains:
+            raise ValueError("Dokploy compose domain prune requires domains.")
         if self.healthcheck_path and not self.healthcheck_path.startswith("/"):
             raise ValueError("Dokploy target setup healthcheck_path must start with /.")
         return self
@@ -2335,6 +2338,19 @@ class DokployComposeDomainReconcileResult(BaseModel):
     domains: tuple[str, ...]
     runtime_port: int
     route_domain_ids: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+
+class DokployComposeDomainPruneResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    applied: bool
+    target_record: DokployTargetRecord
+    target_id_record: DokployTargetIdRecord
+    domains: tuple[str, ...]
+    matched_domain_ids: tuple[str, ...] = ()
+    deleted_domain_ids: tuple[str, ...] = ()
+    missing_domains: tuple[str, ...] = ()
     warnings: tuple[str, ...] = ()
 
 
@@ -2619,6 +2635,64 @@ def _mutate_dokploy_payload_for_target_setup(
     return response_object
 
 
+def _fetch_dokploy_compose_domains_for_target_setup(
+    *,
+    host: str,
+    token: str,
+    compose_id: str,
+) -> tuple[dict[str, control_plane_dokploy.JsonValue], ...]:
+    response = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.byComposeId",
+        query={"composeId": compose_id},
+    )
+    if not isinstance(response, list):
+        raise click.ClickException(
+            f"Dokploy domain lookup for compose {compose_id} returned an invalid response."
+        )
+    domains: list[dict[str, control_plane_dokploy.JsonValue]] = []
+    for raw_domain in response:
+        domain = control_plane_dokploy.as_json_object(raw_domain)
+        if domain is not None:
+            domains.append(domain)
+    return tuple(domains)
+
+
+def _delete_dokploy_domain_for_target_setup(*, host: str, token: str, domain_id: str) -> None:
+    control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.delete",
+        method="POST",
+        payload={"domainId": domain_id},
+    )
+
+
+def _dokploy_domain_matches_tracked_compose_web_route(
+    *,
+    provider_domain: dict[str, control_plane_dokploy.JsonValue],
+    compose_id: str,
+    domain_host: str,
+) -> bool:
+    if str(provider_domain.get("host") or "").strip() != domain_host:
+        return False
+    provider_compose_id = str(provider_domain.get("composeId") or "").strip()
+    if provider_compose_id and provider_compose_id != compose_id:
+        return False
+    domain_type = str(provider_domain.get("domainType") or "").strip()
+    if domain_type and domain_type != "compose":
+        return False
+    service_name = str(provider_domain.get("serviceName") or "").strip()
+    if service_name and service_name != "web":
+        return False
+    route_path = str(provider_domain.get("path") or "/").strip() or "/"
+    if route_path != "/":
+        return False
+    internal_path = str(provider_domain.get("internalPath") or "/").strip() or "/"
+    return internal_path == "/"
+
+
 def _fetch_dokploy_target_payload_for_setup(
     host: str,
     token: str,
@@ -2663,6 +2737,7 @@ def _execute_dokploy_target_setup(
         | DokployTargetCreateResult
         | DokployComposeTargetCreateResult
         | DokployComposeDomainReconcileResult
+        | DokployComposeDomainPruneResult
     )
     if request.operation == "adopt":
         result = adopt_dokploy_target(
@@ -2686,6 +2761,14 @@ def _execute_dokploy_target_setup(
         )
     elif request.operation == "reconcile-compose-domain":
         result = _execute_dokploy_compose_domain_reconcile(
+            record_store=record_store,
+            request=request,
+            host=host,
+            token=token,
+            apply_changes=apply_changes,
+        )
+    elif request.operation == "prune-compose-domain":
+        result = _execute_dokploy_compose_domain_prune(
             record_store=record_store,
             request=request,
             host=host,
@@ -2834,6 +2917,99 @@ def _execute_dokploy_compose_domain_reconcile(
         warnings=()
         if apply_changes
         else ("dry run only; Dokploy compose domain routes were not reconciled",),
+    )
+
+
+def _execute_dokploy_compose_domain_prune(
+    *,
+    record_store: PostgresRecordStore,
+    request: DokployTargetSetupEnvelope,
+    host: str,
+    token: str,
+    apply_changes: bool,
+) -> DokployComposeDomainPruneResult:
+    try:
+        target_record = record_store.read_dokploy_target_record(
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+        target_id_record = record_store.read_dokploy_target_id_record(
+            context_name=request.context,
+            instance_name=request.instance,
+        )
+    except FileNotFoundError as error:
+        raise ValueError("Dokploy compose domain prune requires tracked target records.") from error
+    if target_record.target_type != "compose":
+        raise ValueError("Dokploy compose domain prune requires a compose target.")
+
+    requested_domains = tuple(dict.fromkeys(request.domains))
+    provider_domains = _fetch_dokploy_compose_domains_for_target_setup(
+        host=host,
+        token=token,
+        compose_id=target_id_record.target_id,
+    )
+    domains_by_host: dict[str, list[str]] = {domain: [] for domain in requested_domains}
+    for provider_domain in provider_domains:
+        matching_host = next(
+            (
+                domain
+                for domain in requested_domains
+                if _dokploy_domain_matches_tracked_compose_web_route(
+                    provider_domain=provider_domain,
+                    compose_id=target_id_record.target_id,
+                    domain_host=domain,
+                )
+            ),
+            "",
+        )
+        if not matching_host:
+            continue
+        domain_id = str(provider_domain.get("domainId") or "").strip()
+        if not domain_id:
+            raise ValueError(f"Dokploy domain {matching_host} is missing domainId.")
+        domains_by_host[matching_host].append(domain_id)
+
+    matched_domain_ids = tuple(
+        domain_id for domain in requested_domains for domain_id in domains_by_host.get(domain, ())
+    )
+    missing_domains = tuple(
+        domain for domain in requested_domains if not domains_by_host.get(domain)
+    )
+    deleted_domain_ids: list[str] = []
+    if apply_changes:
+        for domain_id in matched_domain_ids:
+            _delete_dokploy_domain_for_target_setup(host=host, token=token, domain_id=domain_id)
+            deleted_domain_ids.append(domain_id)
+        remaining_domains = tuple(
+            domain for domain in target_record.domains if domain not in requested_domains
+        )
+        if remaining_domains != target_record.domains:
+            target_record = target_record.model_copy(
+                update={
+                    "domains": remaining_domains,
+                    "updated_at": _utc_now_timestamp(),
+                    "source_label": "service:dokploy-targets:setup:prune-compose-domain",
+                }
+            )
+            record_store.write_dokploy_target_record(target_record)
+
+    warnings: list[str] = []
+    if not apply_changes:
+        warnings.append("dry run only; Dokploy compose domain routes were not pruned")
+    if missing_domains:
+        warnings.append(
+            "requested domains were not present on the tracked compose target: "
+            + ", ".join(missing_domains)
+        )
+    return DokployComposeDomainPruneResult(
+        applied=apply_changes,
+        target_record=target_record,
+        target_id_record=target_id_record,
+        domains=requested_domains,
+        matched_domain_ids=matched_domain_ids,
+        deleted_domain_ids=tuple(deleted_domain_ids),
+        missing_domains=missing_domains,
+        warnings=tuple(warnings),
     )
 
 
@@ -9675,7 +9851,7 @@ def create_launchplane_service_app(
                         path=path,
                         query=query,
                     )
-                except ValueError as error:
+                except (ValueError, click.ClickException) as error:
                     return _json_response(
                         start_response=start_response,
                         status_code=400,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1017,6 +1017,13 @@ target, and applies each requested domain to Dokploy's `web` service on the
 requested runtime port. Dry-run mode reads the tracked records and reports the
 planned domain/port tuple without calling Dokploy.
 
+Use `operation=prune-compose-domain` only to remove stale provider domain routes
+from an already-tracked Dokploy compose target. The service reads the tracked
+target/id records, requires a compose target, looks up matching Dokploy domain
+records by compose id, reports matched domain ids in dry-run mode, and deletes
+only the explicitly requested matching domain ids in apply mode. Apply also
+removes those hosts from the tracked target record when present.
+
 When a plan is `ready`, the trusted `Odoo Target Replacement Apply` workflow can
 call `POST /v1/drivers/odoo/target-replacement-apply` for the guarded
 `recreate-in-place` path. The service creates a durable operation record and

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -874,10 +874,13 @@ and requires exact confirmation, an operator reason, and an idempotency key for
 apply. The manual `Dokploy Target Setup` workflow is the supported shared and
 production caller; product repos must not store live target IDs or provider
 fixtures as setup authority. Runtime port is accepted only for `create-compose`
-domain reconciliation with at least one domain. If a provider create succeeds
-but the service fails before records are written, recover by re-running the
-workflow with `operation=adopt` and the created provider target id, not by
-creating a second target for the same lane.
+domain reconciliation with at least one domain. Domain pruning is restricted to
+tracked compose targets and explicit domain hosts; dry-run reports matched
+provider domain ids, while apply deletes only those matching ids and updates the
+tracked target domain list. If a provider create succeeds but the service fails
+before records are written, recover by re-running the workflow with
+`operation=adopt` and the created provider target id, not by creating a second
+target for the same lane.
 
 Dokploy target inspect uses `GET /v1/dokploy-targets/inspect`. The route is a
 read-only proof surface for provider identity before an adoption, creation, or

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -644,7 +644,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("DOMAIN: ${{ inputs.domain }}", workflow_text)
         self.assertIn("RUNTIME_PORT: ${{ inputs.runtime_port }}", workflow_text)
         self.assertIn("Validate reconcile compose domain inputs", workflow_text)
-        self.assertIn("domain is required when operation=reconcile-compose-domain", workflow_text)
+        self.assertIn("domain is required for compose domain reconcile/prune", workflow_text)
         self.assertIn("runtime_port is required for reconcile-compose-domain", workflow_text)
         self.assertIn("expected_current_provider_target_json:", workflow_text)
         self.assertIn("EXPECTED_CURRENT_PROVIDER_TARGET_JSON", workflow_text)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1453,6 +1453,7 @@ def _seed_tracked_target_records(
     target_id: str,
     target_type: Literal["compose", "application"],
     target_name: str,
+    domains: tuple[str, ...] = (),
 ) -> None:
     store = PostgresRecordStore(database_url=database_url)
     store.ensure_schema()
@@ -1463,6 +1464,7 @@ def _seed_tracked_target_records(
                 instance=instance,
                 target_type=target_type,
                 target_name=target_name,
+                domains=domains,
                 updated_at="2026-05-01T00:00:00Z",
                 source_label="test",
             )
@@ -15142,6 +15144,351 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ["dry run only; Dokploy compose domain routes were not reconciled"],
         )
         ensure_domain.assert_not_called()
+
+    def test_dokploy_target_setup_prune_compose_domain_dry_run_reports_matches(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm",
+                instance="prod",
+                target_id="compose-cm-prod",
+                target_type="compose",
+                target_name="cm-prod",
+                domains=(
+                    "cm-prod.shinycomputers.com",
+                    "cm-website-prod.shinycomputers.com",
+                ),
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service._fetch_dokploy_compose_domains_for_target_setup",
+                    return_value=(
+                        {
+                            "host": "cm-prod.shinycomputers.com",
+                            "domainId": "domain-cm-prod",
+                            "composeId": "compose-cm-prod",
+                            "domainType": "compose",
+                            "serviceName": "web",
+                            "path": "/",
+                            "internalPath": "/",
+                        },
+                        {
+                            "host": "cm-website-prod.shinycomputers.com",
+                            "domainId": "domain-cm-website-prod-on-cm",
+                            "composeId": "compose-cm-prod",
+                            "domainType": "compose",
+                            "serviceName": "web",
+                            "path": "/",
+                            "internalPath": "/",
+                        },
+                    ),
+                ),
+                patch(
+                    "control_plane.service._delete_dokploy_domain_for_target_setup"
+                ) as delete_domain,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "dry-run",
+                        "operation": "prune-compose-domain",
+                        "product": "launchplane",
+                        "context": "cm",
+                        "instance": "prod",
+                        "domains": ["cm-website-prod.shinycomputers.com"],
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertFalse(payload["result"]["applied"])
+        self.assertEqual(payload["result"]["route_domain_ids"], [])
+        self.assertEqual(
+            payload["result"]["setup"]["matched_domain_ids"],
+            ["domain-cm-website-prod-on-cm"],
+        )
+        self.assertEqual(payload["result"]["setup"]["deleted_domain_ids"], [])
+        self.assertEqual(payload["result"]["setup"]["missing_domains"], [])
+        self.assertIn(
+            "dry run only; Dokploy compose domain routes were not pruned",
+            payload["result"]["setup"]["warnings"],
+        )
+        delete_domain.assert_not_called()
+
+    def test_dokploy_target_setup_prune_compose_domain_deletes_matching_domains(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm",
+                instance="prod",
+                target_id="compose-cm-prod",
+                target_type="compose",
+                target_name="cm-prod",
+                domains=(
+                    "cm-prod.shinycomputers.com",
+                    "cm-website-prod.shinycomputers.com",
+                ),
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+            deleted_domains: list[str] = []
+
+            def _delete_domain(*, host: str, token: str, domain_id: str) -> None:
+                del host, token
+                deleted_domains.append(domain_id)
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service._fetch_dokploy_compose_domains_for_target_setup",
+                    return_value=(
+                        {
+                            "host": "cm-prod.shinycomputers.com",
+                            "domainId": "domain-cm-prod",
+                            "composeId": "compose-cm-prod",
+                            "domainType": "compose",
+                            "serviceName": "web",
+                            "path": "/",
+                            "internalPath": "/",
+                        },
+                        {
+                            "host": "cm-website-prod.shinycomputers.com",
+                            "domainId": "domain-cm-website-prod-on-cm",
+                            "composeId": "compose-cm-prod",
+                            "domainType": "compose",
+                            "serviceName": "web",
+                            "path": "/",
+                            "internalPath": "/",
+                        },
+                    ),
+                ),
+                patch(
+                    "control_plane.service._delete_dokploy_domain_for_target_setup",
+                    side_effect=_delete_domain,
+                ),
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "operation": "prune-compose-domain",
+                        "product": "launchplane",
+                        "context": "cm",
+                        "instance": "prod",
+                        "domains": ["cm-website-prod.shinycomputers.com"],
+                        "confirmation": "APPLY DOKPLOY TARGET SETUP",
+                        "reason": "Remove stale cm website domain from full CM prod target.",
+                    },
+                    headers={"Idempotency-Key": "dokploy-prune-cm-prod-website-domain"},
+                )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                target_record = store.read_dokploy_target_record(
+                    context_name="cm", instance_name="prod"
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertTrue(payload["result"]["applied"])
+        self.assertEqual(payload["result"]["operation"], "prune-compose-domain")
+        self.assertEqual(
+            payload["result"]["setup"]["matched_domain_ids"],
+            ["domain-cm-website-prod-on-cm"],
+        )
+        self.assertEqual(
+            payload["result"]["setup"]["deleted_domain_ids"],
+            ["domain-cm-website-prod-on-cm"],
+        )
+        self.assertEqual(deleted_domains, ["domain-cm-website-prod-on-cm"])
+        self.assertEqual(target_record.domains, ("cm-prod.shinycomputers.com",))
+        self.assertEqual(
+            target_record.source_label,
+            "service:dokploy-targets:setup:prune-compose-domain",
+        )
+
+    def test_dokploy_target_setup_prune_compose_domain_skips_unrelated_routes(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm",
+                instance="prod",
+                target_id="compose-cm-prod",
+                target_type="compose",
+                target_name="cm-prod",
+                domains=("cm-website-prod.shinycomputers.com",),
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["dokploy_target.setup"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/dokploy-target-setup.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+            )
+
+            with (
+                patch(
+                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.service._fetch_dokploy_compose_domains_for_target_setup",
+                    return_value=(
+                        {
+                            "host": "cm-website-prod.shinycomputers.com",
+                            "domainId": "domain-other-service",
+                            "composeId": "compose-cm-prod",
+                            "domainType": "compose",
+                            "serviceName": "longpolling",
+                            "path": "/",
+                            "internalPath": "/",
+                        },
+                        {
+                            "host": "cm-website-prod.shinycomputers.com",
+                            "domainId": "domain-other-path",
+                            "composeId": "compose-cm-prod",
+                            "domainType": "compose",
+                            "serviceName": "web",
+                            "path": "/shop",
+                            "internalPath": "/",
+                        },
+                    ),
+                ),
+                patch(
+                    "control_plane.service._delete_dokploy_domain_for_target_setup"
+                ) as delete_domain,
+            ):
+                status_code, payload = _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/dokploy-targets/setup",
+                    payload={
+                        "schema_version": 1,
+                        "mode": "dry-run",
+                        "operation": "prune-compose-domain",
+                        "product": "launchplane",
+                        "context": "cm",
+                        "instance": "prod",
+                        "domains": ["cm-website-prod.shinycomputers.com"],
+                    },
+                )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["setup"]["matched_domain_ids"], [])
+        self.assertEqual(
+            payload["result"]["setup"]["missing_domains"],
+            ["cm-website-prod.shinycomputers.com"],
+        )
+        delete_domain.assert_not_called()
 
     def test_dokploy_target_setup_reconcile_compose_domain_rejects_missing_records(
         self,


### PR DESCRIPTION
## Summary
- add a dry-run/apply Dokploy Target Setup operation to prune stale compose domain routes
- restrict pruning to tracked compose web/root domain routes and explicit requested hosts
- document the sanctioned prune path and add focused service/workflow tests

## Verification
- uv run --extra dev ruff check control_plane/service.py tests/test_service.py tests/test_product_onboarding.py
- uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py tests/test_product_onboarding.py
- actionlint .github/workflows/dokploy-target-setup.yml
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_reconciles_existing_compose_domain_route tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_reconcile_compose_domain_dry_run_does_not_mutate tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_prune_compose_domain_dry_run_reports_matches tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_prune_compose_domain_deletes_matching_domains tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_prune_compose_domain_skips_unrelated_routes tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_reconcile_compose_domain_rejects_missing_records tests.test_service.LaunchplaneServiceTests.test_dokploy_target_setup_reconcile_compose_domain_rejects_application_target tests.test_product_onboarding.ProductOnboardingTests.test_dokploy_target_setup_workflow_supports_compose_domain_reconcile