### PR TITLE
Allow paired preview scopes in runtime key safety

### DIFF
--- a/control_plane/contracts/runtime_key_safety_policy.py
+++ b/control_plane/contracts/runtime_key_safety_policy.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import string
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -39,6 +40,32 @@ class RuntimeKeySafetyTarget(BaseModel):
         return self
 
 
+class RuntimeSecretSafetyTargetScope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    context: str
+    instances: tuple[str, ...] = ()
+    instance_patterns: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_target_scope(self) -> "RuntimeSecretSafetyTargetScope":
+        context = self.context.strip()
+        if not context:
+            raise ValueError("runtime secret safety target scope requires context")
+        self.context = context
+        self.instances = _normalize_unique_values(
+            self.instances,
+            "runtime secret safety target scope instances values must be non-empty",
+        )
+        self.instance_patterns = _normalize_unique_values(
+            self.instance_patterns,
+            "runtime secret safety target scope instance_patterns values must be non-empty",
+        )
+        for pattern in self.instance_patterns:
+            _validate_instance_pattern(pattern, "target scope instance_patterns")
+        return self
+
+
 class RuntimeSecretSafetyRule(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -46,6 +73,8 @@ class RuntimeSecretSafetyRule(BaseModel):
     secret_class: RuntimeSecretClass
     allowed_contexts: tuple[str, ...] = ()
     allowed_instances: tuple[str, ...] = ()
+    allowed_instance_patterns: tuple[str, ...] = ()
+    allowed_targets: tuple[RuntimeSecretSafetyTargetScope, ...] = ()
     description: str = ""
 
     @model_validator(mode="after")
@@ -62,6 +91,12 @@ class RuntimeSecretSafetyRule(BaseModel):
             self.allowed_instances,
             "runtime secret safety allowed_instances values must be non-empty",
         )
+        self.allowed_instance_patterns = _normalize_unique_values(
+            self.allowed_instance_patterns,
+            "runtime secret safety allowed_instance_patterns values must be non-empty",
+        )
+        for pattern in self.allowed_instance_patterns:
+            _validate_instance_pattern(pattern, "allowed_instance_patterns")
         self.description = self.description.strip()
         return self
 
@@ -160,3 +195,16 @@ def _normalize_unique_values(values: tuple[str, ...], empty_message: str) -> tup
         if value not in normalized:
             normalized.append(value)
     return tuple(normalized)
+
+
+def _validate_instance_pattern(pattern: str, field_name: str) -> None:
+    if any(character in pattern for character in ("/", "\\")):
+        raise ValueError(
+            f"runtime secret safety {field_name} cannot contain path separators"
+        )
+    if not any(character not in "*?[]!" for character in pattern):
+        raise ValueError(
+            f"runtime secret safety {field_name} must contain a literal character"
+        )
+    if any(character in string.whitespace for character in pattern):
+        raise ValueError(f"runtime secret safety {field_name} cannot contain whitespace")

--- a/control_plane/runtime_key_safety.py
+++ b/control_plane/runtime_key_safety.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from fnmatch import fnmatchcase
 from typing import Protocol
 
 from control_plane.contracts.runtime_key_safety_policy import (
@@ -11,6 +12,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyTarget,
     RuntimeSecretClass,
     RuntimeSecretSafetyRule,
+    RuntimeSecretSafetyTargetScope,
 )
 from control_plane.contracts.secret_record import SecretBinding
 
@@ -250,7 +252,9 @@ def _evaluate_binding_rule(
                 ),
             )
         )
-    if rule.allowed_contexts and target.context not in rule.allowed_contexts:
+    target_allowed = _target_allowed(target=target, rule=rule)
+    context_allowed = _context_allowed(target=target, rule=rule)
+    if not target_allowed and not context_allowed:
         findings.append(
             RuntimeKeySafetyFinding(
                 code="context_not_allowed",
@@ -264,7 +268,9 @@ def _evaluate_binding_rule(
                 ),
             )
         )
-    if rule.allowed_instances and target.instance not in rule.allowed_instances:
+    if not target_allowed and not _instance_allowed_for_diagnostics(
+        target=target, rule=rule
+    ):
         findings.append(
             RuntimeKeySafetyFinding(
                 code="instance_not_allowed",
@@ -279,3 +285,109 @@ def _evaluate_binding_rule(
             )
         )
     return tuple(findings)
+
+
+def _target_allowed(*, target: RuntimeKeySafetyTarget, rule: RuntimeSecretSafetyRule) -> bool:
+    legacy_restricted = bool(
+        rule.allowed_contexts or rule.allowed_instances or rule.allowed_instance_patterns
+    )
+    paired_restricted = bool(rule.allowed_targets)
+    if not legacy_restricted and not paired_restricted:
+        return True
+    if legacy_restricted and _legacy_scope_allowed(target=target, rule=rule):
+        return True
+    return any(
+        _target_scope_allowed(target=target, scope=scope)
+        for scope in rule.allowed_targets
+    )
+
+
+def _context_allowed(*, target: RuntimeKeySafetyTarget, rule: RuntimeSecretSafetyRule) -> bool:
+    legacy_restricted = bool(
+        rule.allowed_contexts or rule.allowed_instances or rule.allowed_instance_patterns
+    )
+    if legacy_restricted and (
+        not rule.allowed_contexts or target.context in rule.allowed_contexts
+    ):
+        return True
+    return any(scope.context == target.context for scope in rule.allowed_targets)
+
+
+def _instance_allowed_for_diagnostics(
+    *, target: RuntimeKeySafetyTarget, rule: RuntimeSecretSafetyRule
+) -> bool:
+    matching_target_scopes = tuple(
+        scope for scope in rule.allowed_targets if scope.context == target.context
+    )
+    if matching_target_scopes:
+        return any(
+            not scope.instances
+            and not scope.instance_patterns
+            or _instance_allowed(
+                instance=target.instance,
+                instances=scope.instances,
+                instance_patterns=scope.instance_patterns,
+            )
+            for scope in matching_target_scopes
+        )
+    if rule.allowed_instances or rule.allowed_instance_patterns:
+        return _legacy_instance_allowed(target=target, rule=rule)
+    return True
+
+
+def _legacy_scope_allowed(
+    *, target: RuntimeKeySafetyTarget, rule: RuntimeSecretSafetyRule
+) -> bool:
+    return _legacy_context_allowed(target=target, rule=rule) and _legacy_instance_allowed(
+        target=target, rule=rule
+    )
+
+
+def _legacy_context_allowed(
+    *, target: RuntimeKeySafetyTarget, rule: RuntimeSecretSafetyRule
+) -> bool:
+    return not rule.allowed_contexts or target.context in rule.allowed_contexts
+
+
+def _legacy_instance_allowed(
+    *, target: RuntimeKeySafetyTarget, rule: RuntimeSecretSafetyRule
+) -> bool:
+    if not rule.allowed_instances and not rule.allowed_instance_patterns:
+        return True
+    return _instance_allowed(
+        instance=target.instance,
+        instances=rule.allowed_instances,
+        instance_patterns=rule.allowed_instance_patterns,
+    )
+
+
+def _target_scope_allowed(
+    *,
+    target: RuntimeKeySafetyTarget,
+    scope: RuntimeSecretSafetyTargetScope,
+) -> bool:
+    if scope.context != target.context:
+        return False
+    if not scope.instances and not scope.instance_patterns:
+        return True
+    return _instance_allowed(
+        instance=target.instance,
+        instances=scope.instances,
+        instance_patterns=scope.instance_patterns,
+    )
+
+
+def _instance_allowed(
+    *,
+    instance: str,
+    instances: tuple[str, ...],
+    instance_patterns: tuple[str, ...],
+) -> bool:
+    if instance in instances:
+        return True
+    if any(character in instance for character in ("/", "\\")):
+        return False
+    return any(
+        fnmatchcase(instance, pattern)
+        for pattern in instance_patterns
+    )

--- a/control_plane/runtime_key_safety_service.py
+++ b/control_plane/runtime_key_safety_service.py
@@ -6,6 +6,7 @@ from typing import Protocol
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
+    RuntimeSecretSafetyTargetScope,
 )
 
 
@@ -81,23 +82,66 @@ def merge_runtime_key_safety_rules(
     requested_rules: tuple[RuntimeSecretSafetyRule, ...],
 ) -> tuple[RuntimeSecretSafetyRule, ...]:
     rules_by_binding_key = {rule.binding_key: rule for rule in existing_rules}
-    for requested_rule in requested_rules:
+    for raw_requested_rule in requested_rules:
+        requested_rule = normalize_runtime_key_safety_requested_rule(raw_requested_rule)
         existing_rule = rules_by_binding_key.get(requested_rule.binding_key)
         if existing_rule is None or existing_rule.secret_class != requested_rule.secret_class:
             rules_by_binding_key[requested_rule.binding_key] = requested_rule
             continue
         rules_by_binding_key[requested_rule.binding_key] = requested_rule.model_copy(
             update={
-                "allowed_contexts": merge_runtime_key_safety_scope_values(
-                    existing_rule.allowed_contexts, requested_rule.allowed_contexts
+                "allowed_contexts": merge_runtime_key_safety_legacy_context_scope(
+                    existing_rule, requested_rule
                 ),
-                "allowed_instances": merge_runtime_key_safety_scope_values(
-                    existing_rule.allowed_instances, requested_rule.allowed_instances
+                **(
+                    merge_runtime_key_safety_instance_scope(existing_rule, requested_rule)
+                    if _has_legacy_scope(requested_rule)
+                    else {
+                        "allowed_instances": existing_rule.allowed_instances,
+                        "allowed_instance_patterns": existing_rule.allowed_instance_patterns,
+                    }
+                ),
+                "allowed_targets": merge_runtime_key_safety_target_scopes(
+                    existing_rule.allowed_targets, requested_rule.allowed_targets
                 ),
                 "description": requested_rule.description or existing_rule.description,
             }
         )
     return tuple(rules_by_binding_key[key] for key in sorted(rules_by_binding_key))
+
+
+def normalize_runtime_key_safety_requested_rule(
+    rule: RuntimeSecretSafetyRule,
+) -> RuntimeSecretSafetyRule:
+    if not rule.allowed_instance_patterns:
+        return rule
+    if rule.allowed_targets:
+        raise ValueError(
+            "runtime key-safety policy requests cannot mix legacy "
+            "allowed_instance_patterns with paired allowed_targets"
+        )
+    if not rule.allowed_contexts:
+        raise ValueError(
+            "runtime key-safety policy requests with allowed_instance_patterns "
+            "must use paired allowed_targets or exact allowed_contexts"
+        )
+    # New writes must not persist preview patterns on legacy axes; paired target
+    # scopes keep context and dynamic instance grants from forming a cross-product.
+    return rule.model_copy(
+        update={
+            "allowed_contexts": (),
+            "allowed_instances": (),
+            "allowed_instance_patterns": (),
+            "allowed_targets": tuple(
+                RuntimeSecretSafetyTargetScope(
+                    context=context,
+                    instances=rule.allowed_instances,
+                    instance_patterns=rule.allowed_instance_patterns,
+                )
+                for context in rule.allowed_contexts
+            ),
+        }
+    )
 
 
 def merge_runtime_key_safety_scope_values(
@@ -106,3 +150,93 @@ def merge_runtime_key_safety_scope_values(
     if not existing_values or not requested_values:
         return ()
     return tuple(sorted({*existing_values, *requested_values}))
+
+
+def merge_runtime_key_safety_legacy_context_scope(
+    existing_rule: RuntimeSecretSafetyRule,
+    requested_rule: RuntimeSecretSafetyRule,
+) -> tuple[str, ...]:
+    if not _has_legacy_scope(requested_rule):
+        return existing_rule.allowed_contexts
+    if not _has_legacy_scope(existing_rule):
+        return requested_rule.allowed_contexts
+    return merge_runtime_key_safety_scope_values(
+        existing_rule.allowed_contexts, requested_rule.allowed_contexts
+    )
+
+
+def merge_runtime_key_safety_target_scopes(
+    existing_scopes: tuple[RuntimeSecretSafetyTargetScope, ...],
+    requested_scopes: tuple[RuntimeSecretSafetyTargetScope, ...],
+) -> tuple[RuntimeSecretSafetyTargetScope, ...]:
+    scopes_by_context = {scope.context: scope for scope in existing_scopes}
+    for requested_scope in requested_scopes:
+        existing_scope = scopes_by_context.get(requested_scope.context)
+        if existing_scope is None:
+            scopes_by_context[requested_scope.context] = requested_scope
+            continue
+        existing_restricted = bool(
+            existing_scope.instances or existing_scope.instance_patterns
+        )
+        requested_restricted = bool(
+            requested_scope.instances or requested_scope.instance_patterns
+        )
+        if not existing_restricted or not requested_restricted:
+            scopes_by_context[requested_scope.context] = requested_scope.model_copy(
+                update={"instances": (), "instance_patterns": ()}
+            )
+            continue
+        scopes_by_context[requested_scope.context] = requested_scope.model_copy(
+            update={
+                "instances": tuple(
+                    sorted({*existing_scope.instances, *requested_scope.instances})
+                ),
+                "instance_patterns": tuple(
+                    sorted(
+                        {
+                            *existing_scope.instance_patterns,
+                            *requested_scope.instance_patterns,
+                        }
+                    )
+                ),
+            }
+        )
+    return tuple(scopes_by_context[key] for key in sorted(scopes_by_context))
+
+
+def _has_legacy_scope(rule: RuntimeSecretSafetyRule) -> bool:
+    return bool(
+        rule.allowed_contexts or rule.allowed_instances or rule.allowed_instance_patterns
+    )
+
+
+def merge_runtime_key_safety_instance_scope(
+    existing_rule: RuntimeSecretSafetyRule,
+    requested_rule: RuntimeSecretSafetyRule,
+) -> dict[str, tuple[str, ...]]:
+    if not _has_legacy_scope(existing_rule):
+        return {
+            "allowed_instances": requested_rule.allowed_instances,
+            "allowed_instance_patterns": requested_rule.allowed_instance_patterns,
+        }
+    existing_restricted = bool(
+        existing_rule.allowed_instances or existing_rule.allowed_instance_patterns
+    )
+    requested_restricted = bool(
+        requested_rule.allowed_instances or requested_rule.allowed_instance_patterns
+    )
+    if not existing_restricted or not requested_restricted:
+        return {"allowed_instances": (), "allowed_instance_patterns": ()}
+    return {
+        "allowed_instances": tuple(
+            sorted({*existing_rule.allowed_instances, *requested_rule.allowed_instances})
+        ),
+        "allowed_instance_patterns": tuple(
+            sorted(
+                {
+                    *existing_rule.allowed_instance_patterns,
+                    *requested_rule.allowed_instance_patterns,
+                }
+            )
+        ),
+    }

--- a/docs/records.md
+++ b/docs/records.md
@@ -737,6 +737,11 @@ state/
   fails closed when no active policy record exists or when a required binding is
   missing, disabled, ambiguous, unclassified, or outside the allowed
   context/instance.
+- Rules may restrict stable scope with exact `allowed_contexts` and
+  `allowed_instances` values. Dynamic preview lanes should use paired
+  `allowed_targets` entries with an exact context and explicit
+  `instance_patterns` such as `pr-*`, so a preview pattern never broadens a rule
+  to a different product or stable context.
 
 ## Launchplane Preview Record
 

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -100,6 +100,10 @@ title: Secrets
 - Evaluation reads only Launchplane managed secret bindings for the requested
   context and instance. If no active policy record exists, the gate fails closed
   instead of falling back to service-host env or product-local scripts.
+- Policy rules can allow dynamic preview instances with paired `allowed_targets`
+  entries that combine an exact preview context with `instance_patterns`, for
+  example `pr-*`. Use paired patterns for reusable preview lanes instead of
+  adding one-off PR instance names to policy records or broadening stable scope.
 - Product-specific preview drivers that derive runtime secrets from a template,
   such as VeriReel's preview database bootstrap, must run the same metadata-only
   gate before creating databases, rendering preview env, or starting preview

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -841,7 +841,10 @@ Common failure classes are stable enough for helper summaries:
 - `secret_configuration_required`: trusted Launchplane runtime cannot write
   managed secrets.
 - `runtime_key_safety_unavailable` or `runtime_key_safety_failed`: the active
-  runtime key-safety policy is missing or rejects the requested binding.
+  runtime key-safety policy is missing or rejects the requested binding. Policy
+  payloads may include paired `allowed_targets` metadata for exact context plus
+  dynamic preview instance patterns; they must not include secret plaintext or
+  checked-in runtime authority.
 - `invalid_request`: malformed payload, secret-shaped runtime key, or nested
   runtime/secret target override.
 
@@ -856,7 +859,9 @@ requires DB-backed storage, and writes metadata-only policy records for managed
 runtime secret binding keys. It merges requested rules into the latest active
 policy by binding key so deploy-time bootstrap can add required classifications
 without dropping existing policy coverage. Request and response payloads must
-not include secret plaintext.
+not include secret plaintext. Rules can carry exact context/instance scope and
+explicit preview instance patterns for dynamic PR lanes; policy apply merges
+those scopes additively without making checked-in files runtime authority.
 
 Product onboarding uses `POST /v1/product-onboarding/apply`. The route accepts
 the same operator-approved manifest as `launchplane product-onboarding apply`

--- a/tests/test_runtime_key_safety.py
+++ b/tests/test_runtime_key_safety.py
@@ -4,6 +4,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeKeySafetyTarget,
     RuntimeSecretSafetyRule,
+    RuntimeSecretSafetyTargetScope,
 )
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.secret_record import SecretStatus
@@ -60,6 +61,8 @@ def _binding(
     binding_key: str,
     binding_id: str = "binding-shopify-token",
     secret_id: str = "secret-shopify-token",
+    context: str = "opw",
+    instance: str = "testing",
     status: SecretStatus = "configured",
 ) -> SecretBinding:
     return SecretBinding(
@@ -67,8 +70,8 @@ def _binding(
         secret_id=secret_id,
         integration="runtime_environment",
         binding_key=binding_key,
-        context="opw",
-        instance="testing",
+        context=context,
+        instance=instance,
         status=status,
         created_at="2026-05-05T20:00:00Z",
         updated_at="2026-05-05T20:00:00Z",
@@ -122,6 +125,280 @@ class RuntimeKeySafetyTests(unittest.TestCase):
         self.assertEqual(evaluation.status, "pass")
         self.assertEqual(evaluation.findings, ())
         self.assertEqual(evaluation.checked_binding_keys, ("SHOPIFY_ACCESS_TOKEN",))
+
+    def test_preview_instance_pattern_accepts_matching_preview_instance(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="verireel-testing",
+                instance="pr-217",
+                environment_class="preview",
+            ),
+            required_binding_keys=("POSTGRES_PASSWORD",),
+            secret_bindings=(
+                _binding(
+                    binding_key="POSTGRES_PASSWORD",
+                    binding_id="binding-postgres-password",
+                    secret_id="secret-postgres-password",
+                    context="verireel-testing",
+                    instance="pr-217",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("verireel-testing",),
+                    allowed_instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "pass")
+        self.assertEqual(evaluation.findings, ())
+
+    def test_paired_target_scope_accepts_matching_preview_instance(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="verireel-testing",
+                instance="pr-217",
+                environment_class="preview",
+            ),
+            required_binding_keys=("POSTGRES_PASSWORD",),
+            secret_bindings=(
+                _binding(
+                    binding_key="POSTGRES_PASSWORD",
+                    binding_id="binding-postgres-password",
+                    secret_id="secret-postgres-password",
+                    context="verireel-testing",
+                    instance="pr-217",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("verireel",),
+                    allowed_instances=("testing",),
+                    allowed_targets=(
+                        RuntimeSecretSafetyTargetScope(
+                            context="verireel-testing",
+                            instance_patterns=("pr-*",),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "pass")
+        self.assertEqual(evaluation.findings, ())
+
+    def test_paired_target_scope_rejects_cross_product_preview_instance(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="verireel",
+                instance="pr-217",
+                environment_class="preview",
+            ),
+            required_binding_keys=("POSTGRES_PASSWORD",),
+            secret_bindings=(
+                _binding(
+                    binding_key="POSTGRES_PASSWORD",
+                    binding_id="binding-postgres-password",
+                    secret_id="secret-postgres-password",
+                    context="verireel",
+                    instance="pr-217",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("verireel",),
+                    allowed_instances=("testing",),
+                    allowed_targets=(
+                        RuntimeSecretSafetyTargetScope(
+                            context="verireel-testing",
+                            instance_patterns=("pr-*",),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(
+            [finding.code for finding in evaluation.findings],
+            ["instance_not_allowed"],
+        )
+
+    def test_paired_target_scope_rejects_cross_product_stable_instance(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="verireel-testing",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("POSTGRES_PASSWORD",),
+            secret_bindings=(
+                _binding(
+                    binding_key="POSTGRES_PASSWORD",
+                    binding_id="binding-postgres-password",
+                    secret_id="secret-postgres-password",
+                    context="verireel-testing",
+                    instance="testing",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("verireel",),
+                    allowed_instances=("testing",),
+                    allowed_targets=(
+                        RuntimeSecretSafetyTargetScope(
+                            context="verireel-testing",
+                            instance_patterns=("pr-*",),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(
+            [finding.code for finding in evaluation.findings],
+            ["instance_not_allowed"],
+        )
+
+    def test_preview_instance_pattern_still_rejects_wrong_context(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="opw-testing",
+                instance="pr-217",
+                environment_class="preview",
+            ),
+            required_binding_keys=("POSTGRES_PASSWORD",),
+            secret_bindings=(
+                _binding(
+                    binding_key="POSTGRES_PASSWORD",
+                    binding_id="binding-postgres-password",
+                    secret_id="secret-postgres-password",
+                    context="opw-testing",
+                    instance="pr-217",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("verireel-testing",),
+                    allowed_instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(
+            [finding.code for finding in evaluation.findings],
+            ["context_not_allowed"],
+        )
+
+    def test_preview_instance_pattern_still_rejects_non_matching_instance(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="verireel-testing",
+                instance="testing",
+                environment_class="testing",
+            ),
+            required_binding_keys=("POSTGRES_PASSWORD",),
+            secret_bindings=(
+                _binding(
+                    binding_key="POSTGRES_PASSWORD",
+                    binding_id="binding-postgres-password",
+                    secret_id="secret-postgres-password",
+                    context="verireel-testing",
+                    instance="testing",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("verireel-testing",),
+                    allowed_instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(
+            [finding.code for finding in evaluation.findings],
+            ["instance_not_allowed"],
+        )
+
+    def test_preview_instance_pattern_does_not_match_separator_bearing_target(self) -> None:
+        evaluation = evaluate_runtime_key_safety(
+            target=RuntimeKeySafetyTarget(
+                context="verireel-testing",
+                instance="pr-217/other",
+                environment_class="preview",
+            ),
+            required_binding_keys=("POSTGRES_PASSWORD",),
+            secret_bindings=(
+                _binding(
+                    binding_key="POSTGRES_PASSWORD",
+                    binding_id="binding-postgres-password",
+                    secret_id="secret-postgres-password",
+                    context="verireel-testing",
+                    instance="pr-217/other",
+                ),
+            ),
+            secret_rules=(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("verireel-testing",),
+                    allowed_instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+        self.assertEqual(evaluation.status, "fail")
+        self.assertEqual(
+            [finding.code for finding in evaluation.findings],
+            ["instance_not_allowed"],
+        )
+
+    def test_preview_instance_pattern_rejects_path_separator(self) -> None:
+        with self.assertRaisesRegex(ValueError, "path separators"):
+            RuntimeSecretSafetyRule(
+                binding_key="POSTGRES_PASSWORD",
+                secret_class="shared_safe",
+                allowed_instance_patterns=("pr-*/*",),
+            )
+
+    def test_preview_instance_pattern_rejects_universal_pattern(self) -> None:
+        with self.assertRaisesRegex(ValueError, "literal character"):
+            RuntimeSecretSafetyRule(
+                binding_key="POSTGRES_PASSWORD",
+                secret_class="shared_safe",
+                allowed_instance_patterns=("*",),
+            )
+
+    def test_preview_instance_pattern_rejects_whitespace(self) -> None:
+        with self.assertRaisesRegex(ValueError, "whitespace"):
+            RuntimeSecretSafetyRule(
+                binding_key="POSTGRES_PASSWORD",
+                secret_class="shared_safe",
+                allowed_instance_patterns=("pr-* preview",),
+            )
+
+    def test_paired_target_scope_rejects_universal_pattern(self) -> None:
+        with self.assertRaisesRegex(ValueError, "literal character"):
+            RuntimeSecretSafetyTargetScope(
+                context="verireel-testing",
+                instance_patterns=("*",),
+            )
 
     def test_unclassified_secret_fails_closed(self) -> None:
         evaluation = evaluate_runtime_key_safety(

--- a/tests/test_runtime_key_safety_service.py
+++ b/tests/test_runtime_key_safety_service.py
@@ -5,10 +5,12 @@ import unittest
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
+    RuntimeSecretSafetyTargetScope,
 )
 from control_plane.runtime_key_safety_service import (
     merge_runtime_key_safety_scope_values,
     merge_runtime_key_safety_rules,
+    normalize_runtime_key_safety_requested_rule,
     summarize_runtime_key_safety_policy_record,
     write_runtime_key_safety_policy,
 )
@@ -41,6 +43,7 @@ def _rule(
     secret_class: str = "prod_only",
     contexts: tuple[str, ...] = (),
     instances: tuple[str, ...] = (),
+    instance_patterns: tuple[str, ...] = (),
     description: str = "",
 ) -> RuntimeSecretSafetyRule:
     return RuntimeSecretSafetyRule.model_validate(
@@ -49,8 +52,22 @@ def _rule(
             "secret_class": secret_class,
             "allowed_contexts": contexts,
             "allowed_instances": instances,
+            "allowed_instance_patterns": instance_patterns,
             "description": description,
         }
+    )
+
+
+def _target_scope(
+    context: str,
+    *,
+    instances: tuple[str, ...] = (),
+    instance_patterns: tuple[str, ...] = (),
+) -> RuntimeSecretSafetyTargetScope:
+    return RuntimeSecretSafetyTargetScope(
+        context=context,
+        instances=instances,
+        instance_patterns=instance_patterns,
     )
 
 
@@ -91,6 +108,221 @@ class RuntimeKeySafetyServiceTests(unittest.TestCase):
         self.assertEqual(smtp_rule.allowed_contexts, ("sellyouroutboard", "verireel"))
         self.assertEqual(smtp_rule.allowed_instances, ("prod",))
         self.assertEqual(smtp_rule.description, "existing")
+
+    def test_rule_merge_converts_requested_legacy_instance_patterns_to_paired_targets(
+        self,
+    ) -> None:
+        merged_rules = merge_runtime_key_safety_rules(
+            (
+                _rule(
+                    "POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    contexts=("verireel",),
+                    instances=("testing",),
+                ),
+            ),
+            (
+                _rule(
+                    "POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    contexts=("verireel-testing",),
+                    instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+        self.assertEqual(len(merged_rules), 1)
+        merged_rule = merged_rules[0]
+        self.assertEqual(merged_rule.allowed_contexts, ("verireel",))
+        self.assertEqual(merged_rule.allowed_instances, ("testing",))
+        self.assertEqual(merged_rule.allowed_instance_patterns, ())
+        self.assertEqual(
+            merged_rule.allowed_targets,
+            (
+                _target_scope(
+                    "verireel-testing",
+                    instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+    def test_requested_legacy_pattern_rule_normalizes_each_context_to_paired_target(
+        self,
+    ) -> None:
+        normalized_rule = normalize_runtime_key_safety_requested_rule(
+            RuntimeSecretSafetyRule(
+                binding_key="POSTGRES_PASSWORD",
+                secret_class="shared_safe",
+                allowed_contexts=("verireel-testing", "opw-testing"),
+                allowed_instances=("pr-216",),
+                allowed_instance_patterns=("pr-*",),
+            )
+        )
+
+        self.assertEqual(normalized_rule.allowed_contexts, ())
+        self.assertEqual(normalized_rule.allowed_instances, ())
+        self.assertEqual(normalized_rule.allowed_instance_patterns, ())
+        self.assertEqual(
+            normalized_rule.allowed_targets,
+            (
+                _target_scope(
+                    "verireel-testing",
+                    instances=("pr-216",),
+                    instance_patterns=("pr-*",),
+                ),
+                _target_scope(
+                    "opw-testing",
+                    instances=("pr-216",),
+                    instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+    def test_requested_legacy_pattern_rule_requires_context(self) -> None:
+        with self.assertRaisesRegex(ValueError, "paired allowed_targets"):
+            normalize_runtime_key_safety_requested_rule(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_instance_patterns=("pr-*",),
+                )
+            )
+
+    def test_requested_rule_rejects_mixed_legacy_patterns_and_paired_targets(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cannot mix"):
+            normalize_runtime_key_safety_requested_rule(
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_contexts=("verireel-testing",),
+                    allowed_instance_patterns=("pr-*",),
+                    allowed_targets=(
+                        _target_scope(
+                            "verireel-testing",
+                            instance_patterns=("pr-*",),
+                        ),
+                    ),
+                )
+            )
+
+    def test_rule_merge_adds_paired_preview_target_without_broadening_legacy_scope(
+        self,
+    ) -> None:
+        merged_rules = merge_runtime_key_safety_rules(
+            (
+                _rule(
+                    "POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    contexts=("verireel",),
+                    instances=("testing",),
+                ),
+            ),
+            (
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_targets=(
+                        _target_scope(
+                            "verireel-testing",
+                            instance_patterns=("pr-*",),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(len(merged_rules), 1)
+        merged_rule = merged_rules[0]
+        self.assertEqual(merged_rule.allowed_contexts, ("verireel",))
+        self.assertEqual(merged_rule.allowed_instances, ("testing",))
+        self.assertEqual(merged_rule.allowed_instance_patterns, ())
+        self.assertEqual(
+            merged_rule.allowed_targets,
+            (
+                _target_scope(
+                    "verireel-testing",
+                    instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+    def test_rule_merge_combines_paired_target_scopes_by_context(self) -> None:
+        merged_rules = merge_runtime_key_safety_rules(
+            (
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_targets=(
+                        _target_scope("verireel-testing", instances=("pr-216",)),
+                    ),
+                ),
+            ),
+            (
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_targets=(
+                        _target_scope(
+                            "verireel-testing",
+                            instance_patterns=("pr-*",),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(len(merged_rules), 1)
+        self.assertEqual(
+            merged_rules[0].allowed_targets,
+            (
+                _target_scope(
+                    "verireel-testing",
+                    instances=("pr-216",),
+                    instance_patterns=("pr-*",),
+                ),
+            ),
+        )
+
+    def test_rule_merge_adds_legacy_scope_to_paired_only_rule_without_opening_it(
+        self,
+    ) -> None:
+        merged_rules = merge_runtime_key_safety_rules(
+            (
+                RuntimeSecretSafetyRule(
+                    binding_key="POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    allowed_targets=(
+                        _target_scope(
+                            "verireel-testing",
+                            instance_patterns=("pr-*",),
+                        ),
+                    ),
+                ),
+            ),
+            (
+                _rule(
+                    "POSTGRES_PASSWORD",
+                    secret_class="shared_safe",
+                    contexts=("verireel",),
+                    instances=("testing",),
+                ),
+            ),
+        )
+
+        self.assertEqual(len(merged_rules), 1)
+        merged_rule = merged_rules[0]
+        self.assertEqual(merged_rule.allowed_contexts, ("verireel",))
+        self.assertEqual(merged_rule.allowed_instances, ("testing",))
+        self.assertEqual(merged_rule.allowed_instance_patterns, ())
+        self.assertEqual(
+            merged_rule.allowed_targets,
+            (
+                _target_scope(
+                    "verireel-testing",
+                    instance_patterns=("pr-*",),
+                ),
+            ),
+        )
 
     def test_write_runtime_key_safety_policy_records_only_changed_policy(self) -> None:
         store = _RuntimeKeySafetyPolicyStore()

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -12,6 +12,7 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretClass,
     RuntimeSecretSafetyRule,
+    RuntimeSecretSafetyTargetScope,
 )
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.dokploy import DokployTargetDefinition
@@ -88,6 +89,57 @@ def _runtime_policy(
                 binding_key="BETTER_AUTH_SECRET",
                 secret_class=secret_class,
                 allowed_contexts=("verireel-testing",),
+            ),
+        ),
+    )
+
+
+def _verireel_preview_runtime_policy() -> RuntimeKeySafetyPolicyRecord:
+    return RuntimeKeySafetyPolicyRecord(
+        record_id="runtime-key-safety-policy-verireel-preview-test",
+        status="active",
+        source="test",
+        updated_at="2026-05-05T22:15:00Z",
+        rules=(
+            RuntimeSecretSafetyRule(
+                binding_key="POSTGRES_PASSWORD",
+                secret_class="shared_safe",
+                allowed_targets=(
+                    RuntimeSecretSafetyTargetScope(
+                        context="verireel-testing",
+                        instance_patterns=("pr-*",),
+                    ),
+                ),
+            ),
+            RuntimeSecretSafetyRule(
+                binding_key="BETTER_AUTH_SECRET",
+                secret_class="shared_safe",
+                allowed_targets=(
+                    RuntimeSecretSafetyTargetScope(
+                        context="verireel-testing",
+                        instance_patterns=("pr-*",),
+                    ),
+                ),
+            ),
+            RuntimeSecretSafetyRule(
+                binding_key="VERIREEL_SECRETS_MASTER_KEY",
+                secret_class="shared_safe",
+                allowed_targets=(
+                    RuntimeSecretSafetyTargetScope(
+                        context="verireel-testing",
+                        instance_patterns=("pr-*",),
+                    ),
+                ),
+            ),
+            RuntimeSecretSafetyRule(
+                binding_key="VERIREEL_CRON_SECRET",
+                secret_class="shared_safe",
+                allowed_targets=(
+                    RuntimeSecretSafetyTargetScope(
+                        context="verireel-testing",
+                        instance_patterns=("pr-*",),
+                    ),
+                ),
             ),
         ),
     )
@@ -307,6 +359,31 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                 "DATABASE_URL": "postgresql://user:pass@db.example/verireel_testing",
                 "BETTER_AUTH_SECRET": "auth-secret",
                 "NEXT_PUBLIC_SITE_URL": "https://testing.example",
+            },
+            request=_refresh_request(),
+        )
+
+    def test_verireel_preview_runtime_key_safety_allows_pr_pattern_for_shared_template_secrets(
+        self,
+    ) -> None:
+        store = _RuntimeKeySafetyStore(
+            policies=(_verireel_preview_runtime_policy(),),
+            bindings=(
+                _runtime_binding("POSTGRES_PASSWORD"),
+                _runtime_binding("BETTER_AUTH_SECRET"),
+                _runtime_binding("VERIREEL_SECRETS_MASTER_KEY"),
+                _runtime_binding("VERIREEL_CRON_SECRET"),
+            ),
+        )
+
+        _enforce_verireel_preview_runtime_key_safety(
+            record_store=store,
+            template_target=_template_target(),
+            template_env_map={
+                "POSTGRES_PASSWORD": "database-password",
+                "BETTER_AUTH_SECRET": "auth-secret",
+                "VERIREEL_SECRETS_MASTER_KEY": "master-key",
+                "VERIREEL_CRON_SECRET": "cron-secret",
             },
             request=_refresh_request(),
         )


### PR DESCRIPTION
## Summary
- add paired runtime key-safety target scopes for exact context plus dynamic preview instances
- normalize new legacy preview-pattern policy requests into paired targets before merge so service writes cannot create cartesian context/instance grants
- add VeriReel preview and policy merge regressions plus docs for DB-backed preview policy scope

## Verification
- `uv run python -m unittest tests.test_runtime_key_safety tests.test_verireel_preview_driver tests.test_runtime_key_safety_service`
- `uv run --extra dev ruff check control_plane/contracts/runtime_key_safety_policy.py control_plane/runtime_key_safety.py control_plane/runtime_key_safety_service.py tests/test_runtime_key_safety.py tests/test_verireel_preview_driver.py tests/test_runtime_key_safety_service.py`

## Deploy note
Deploy this code before writing live runtime key-safety policy records that use `allowed_targets`. Old records remain readable; new service writes normalize preview patterns into paired targets.