### PR TITLE
Fail fast on preview identity mismatches

### DIFF
--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -729,34 +729,14 @@ def _post_every_code_claim_comment(
     repository = record.repository.strip()
     if not repository or record.issue_number <= 0:
         return ""
-    token_env_key = github_token_env.strip()
-    if not token_env_key:
-        raise RuntimeError("Every Code claim comments require --github-token-env")
-    github_token = os.environ.get(token_env_key, "").strip()
-    if not github_token:
-        raise RuntimeError(f"{token_env_key} is required for Every Code claim comments")
-    github_env = {"GH_TOKEN": github_token, "GITHUB_TOKEN": github_token}
-    expected_actor_env_key = github_actor_env.strip()
-    expected_actor = (
-        os.environ.get(expected_actor_env_key, "").strip()
-        if expected_actor_env_key
-        else ""
-    )
     try:
-        actor_result = runner(("gh", "api", "user", "--jq", ".login"), github_env)
-    except OSError as exc:
-        raise RuntimeError(f"Could not verify GitHub claim-comment actor: {exc}") from exc
-    if actor_result.returncode != 0:
-        detail = actor_result.stderr.strip() or actor_result.stdout.strip() or "gh api user failed"
-        raise RuntimeError(f"Could not verify GitHub claim-comment actor: {detail}")
-    actual_actor = actor_result.stdout.strip()
-    if not actual_actor:
-        raise RuntimeError("Could not verify GitHub claim-comment actor: empty login")
-    if expected_actor and actual_actor.casefold() != expected_actor.casefold():
-        raise RuntimeError(
-            "Every Code claim-comment GitHub actor mismatch: "
-            f"expected {expected_actor!r}, got {actual_actor!r}"
+        github_env = _every_code_github_env(
+            github_token_env=github_token_env,
+            github_actor_env=github_actor_env,
+            runner=runner,
         )
+    except RuntimeError as exc:
+        raise RuntimeError(f"Could not verify GitHub claim-comment actor: {exc}") from exc
     body = every_code_claim_comment_body(
         record,
         host=host,
@@ -781,6 +761,90 @@ def _post_every_code_claim_comment(
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "gh issue comment failed"
         return f"Could not post GitHub working comment: {detail}"
+    return ""
+
+
+def _every_code_github_env(
+    *,
+    github_token_env: str = EVERY_CODE_GITHUB_TOKEN_ENV_KEY,
+    github_actor_env: str = EVERY_CODE_GITHUB_ACTOR_ENV_KEY,
+    runner: Runner,
+) -> dict[str, str]:
+    token_env_key = github_token_env.strip()
+    if not token_env_key:
+        raise RuntimeError("Every Code GitHub operations require a token env key")
+    github_token = os.environ.get(token_env_key, "").strip()
+    if not github_token:
+        raise RuntimeError(f"{token_env_key} is required for Every Code GitHub operations")
+    github_env = {"GH_TOKEN": github_token, "GITHUB_TOKEN": github_token}
+    expected_actor_env_key = github_actor_env.strip()
+    expected_actor = (
+        os.environ.get(expected_actor_env_key, "").strip()
+        if expected_actor_env_key
+        else ""
+    )
+    try:
+        actor_result = runner(("gh", "api", "user", "--jq", ".login"), github_env)
+    except OSError as exc:
+        raise RuntimeError(f"Could not verify GitHub actor: {exc}") from exc
+    if actor_result.returncode != 0:
+        detail = actor_result.stderr.strip() or actor_result.stdout.strip() or "gh api user failed"
+        raise RuntimeError(f"Could not verify GitHub actor: {detail}")
+    actual_actor = actor_result.stdout.strip()
+    if not actual_actor:
+        raise RuntimeError("Could not verify GitHub actor: empty login")
+    if expected_actor and actual_actor.casefold() != expected_actor.casefold():
+        raise RuntimeError(
+            "Every Code GitHub actor mismatch: "
+            f"expected {expected_actor!r}, got {actual_actor!r}"
+        )
+    return github_env
+
+
+def _remove_every_code_source_issue_labels(
+    *,
+    record: EveryCodeWorkRequestRecord,
+    runner: Runner,
+    github_token_env: str = EVERY_CODE_GITHUB_TOKEN_ENV_KEY,
+    github_actor_env: str = EVERY_CODE_GITHUB_ACTOR_ENV_KEY,
+) -> str:
+    repository = record.repository.strip()
+    if not repository or record.issue_number <= 0:
+        return ""
+    try:
+        github_env = _every_code_github_env(
+            github_token_env=github_token_env,
+            github_actor_env=github_actor_env,
+            runner=runner,
+        )
+    except RuntimeError as exc:
+        return str(exc)
+    errors: list[str] = []
+    for label in (record.trigger_label.strip(), "preview-ready"):
+        if not label:
+            continue
+        try:
+            result = runner(
+                (
+                    "gh",
+                    "issue",
+                    "edit",
+                    str(record.issue_number),
+                    "--repo",
+                    repository,
+                    "--remove-label",
+                    label,
+                ),
+                github_env,
+            )
+        except OSError as exc:
+            errors.append(f"{label}: {exc}")
+            continue
+        if result.returncode != 0:
+            detail = result.stderr.strip() or result.stdout.strip() or "gh issue edit failed"
+            errors.append(f"{label}: {detail}")
+    if errors:
+        return "Could not remove Every Code source issue labels: " + "; ".join(errors)
     return ""
 
 
@@ -2596,10 +2660,17 @@ def request_ready_every_code_pr_preview_labels(
     reviewer_backfilled = 0
     for record in records:
         if _every_code_work_request_closed_before_preview(record):
+            label_cleanup_error = _remove_every_code_source_issue_labels(
+                record=record,
+                runner=run,
+            )
+            reason = "Source issue closed before preview was ready."
+            if label_cleanup_error:
+                reason = f"{reason} {label_cleanup_error}"
             cancelled += _cancel_every_code_preview_gates_for_record(
                 record_store=record_store,
                 record=record,
-                reason="Source issue closed before preview was ready.",
+                reason=reason,
             )
             continue
         result_pr_url = _every_code_preview_pr_url_for_record(record, runner=run)

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -953,6 +953,11 @@ def _wait_for_preview_health(
                             )
                             if status == "match":
                                 return
+                            if status == "mismatch":
+                                raise click.ClickException(
+                                    "Preview runtime identity did not match the expected "
+                                    f"deployment identity: {detail}."
+                                )
                             last_detail = detail
         except HTTPError as exc:
             body = exc.read().decode("utf-8", errors="replace")

--- a/docs/records.md
+++ b/docs/records.md
@@ -874,11 +874,12 @@ preflights.
   the service status route.
 - The local worker handoff is `uv run launchplane every-code run` for polling or
   `uv run launchplane every-code run-once` for a single scan. Each pass applies
-  trusted PR feedback, reconciles preview gates and ready preview labels, routes
-  failed checks back to the owning session, then claims at most one queued
-  request. Request handoff opens or reuses deterministic visible tmux sessions
-  for local checkouts, records `running` or immediate `blocked` status, and
-  wraps the visible command so terminal success or failure calls
+  trusted PR feedback, reconciles preview gates and ready preview labels, removes
+  stale source-issue queue labels for closed requests that can no longer reach
+  preview readiness, routes failed checks back to the owning session, then claims
+  at most one queued request. Request handoff opens or reuses deterministic
+  visible tmux sessions for local checkouts, records `running` or immediate
+  `blocked` status, and wraps the visible command so terminal success or failure calls
   `uv run launchplane every-code finish`.
 - A Mac host can leave the poller running with
   `uv run launchplane every-code start`, inspect it with

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -270,6 +270,10 @@ class _Runner:
             if self.fail_issue_comment:
                 return subprocess.CompletedProcess(args, 1, "", "rate limited")
             return subprocess.CompletedProcess(args, 0, "", "")
+        if args[:3] == ("gh", "issue", "edit"):
+            if env is None or env.get("GH_TOKEN") != "bot-token":
+                return subprocess.CompletedProcess(args, 1, "", "missing bot token")
+            return subprocess.CompletedProcess(args, 0, "", "")
         if args[:3] == ("gh", "api", "user"):
             if env is None or env.get("GH_TOKEN") != "bot-token":
                 return subprocess.CompletedProcess(args, 1, "", "missing bot token")
@@ -1241,26 +1245,77 @@ class EveryCodeWorkerTests(unittest.TestCase):
                 ).model_copy(update={"result_summary": "Source issue closed by Mbanks89."})
             )
             store.write_every_code_preview_gate_record(_preview_gate_record())
-            runner = _Runner(
-                pr_view_payload={
-                    "state": "OPEN",
-                    "headRefOid": "abcdef1234567890",
-                    "labels": [],
-                    "statusCheckRollup": [
-                        {"name": "static_checks", "status": "COMPLETED", "conclusion": "SUCCESS"},
-                    ],
-                }
-            )
+            runner = _Runner()
 
-            result = request_ready_every_code_pr_preview_labels(
-                record_store=store,
-                runner=runner,
-            )
-            gate_records = store.list_every_code_preview_gate_records(status="cancelled")
+            with patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN": "bot-token",
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_ACTOR": "shiny-code-bot",
+                },
+            ):
+                result = request_ready_every_code_pr_preview_labels(
+                    record_store=store,
+                    runner=runner,
+                )
+                gate_records = store.list_every_code_preview_gate_records(status="cancelled")
 
         self.assertEqual(result.cancelled, 1)
         self.assertEqual(len(gate_records), 1)
         self.assertIn("Source issue closed", gate_records[0].blocked_reason)
+        self.assertEqual(
+            runner.calls,
+            [
+                ("gh", "api", "user", "--jq", ".login"),
+                (
+                    "gh",
+                    "issue",
+                    "edit",
+                    "123",
+                    "--repo",
+                    "cbusillo/sellyouroutboard",
+                    "--remove-label",
+                    "every-code",
+                ),
+                (
+                    "gh",
+                    "issue",
+                    "edit",
+                    "123",
+                    "--repo",
+                    "cbusillo/sellyouroutboard",
+                    "--remove-label",
+                    "preview-ready",
+                ),
+            ],
+        )
+
+    def test_preview_gate_cancels_when_source_issue_closed_even_without_label_token(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_sellyouroutboard_preview_profile(store)
+            store.write_every_code_work_request_record(
+                _done_record(
+                    repository="cbusillo/sellyouroutboard",
+                    result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/86",
+                ).model_copy(update={"result_summary": "Source issue closed by Mbanks89."})
+            )
+            store.write_every_code_preview_gate_record(_preview_gate_record())
+            runner = _Runner()
+
+            with patch.dict(os.environ, {"LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN": ""}):
+                result = request_ready_every_code_pr_preview_labels(
+                    record_store=store,
+                    runner=runner,
+                )
+                gate_records = store.list_every_code_preview_gate_records(status="cancelled")
+
+        self.assertEqual(result.cancelled, 1)
+        self.assertEqual(len(gate_records), 1)
+        self.assertIn("Source issue closed", gate_records[0].blocked_reason)
+        self.assertIn("LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN", gate_records[0].blocked_reason)
         self.assertFalse(runner.calls)
 
     def test_preview_gate_skips_pull_request_with_preview_label(self) -> None:

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -933,7 +933,7 @@ class GenericWebPreviewTests(unittest.TestCase):
 
         self.assertEqual(sleeps, [5, 5, 2])
 
-    def test_wait_for_preview_health_requires_matching_runtime_identity(self) -> None:
+    def test_wait_for_preview_health_keeps_polling_ok_false_with_identity(self) -> None:
         expected_identity = RuntimeIdentity(
             product="sellyouroutboard",
             context="sellyouroutboard-testing",
@@ -945,12 +945,9 @@ class GenericWebPreviewTests(unittest.TestCase):
             image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
             preview_id="pr-42",
         )
-        stale_identity = expected_identity.model_copy(
-            update={"artifact_id": "ghcr.io/cbusillo/sellyouroutboard:stale"}
-        )
         responses = iter(
             (
-                {"ok": True, "runtime_identity": stale_identity.model_dump(mode="json")},
+                {"ok": False, "runtime_identity": expected_identity.model_dump(mode="json")},
                 {"ok": True, "runtime_identity": expected_identity.model_dump(mode="json")},
             )
         )
@@ -981,6 +978,53 @@ class GenericWebPreviewTests(unittest.TestCase):
             )
 
         self.assertEqual(sleeps, [5])
+
+    def test_wait_for_preview_health_fails_fast_on_mismatched_runtime_identity(self) -> None:
+        expected_identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="pr-42",
+            environment_kind="preview",
+            deployment_record_id="deployment-20260614T200000Z-syo-pr-42",
+            artifact_id="ghcr.io/cbusillo/sellyouroutboard:sha",
+            source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+            image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+            preview_id="pr-42",
+        )
+        stale_identity = expected_identity.model_copy(
+            update={"artifact_id": "ghcr.io/cbusillo/sellyouroutboard:stale"}
+        )
+        responses = iter(
+            ({"ok": True, "runtime_identity": stale_identity.model_dump(mode="json")},)
+        )
+
+        class _Response:
+            status = 200
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(next(responses)).encode("utf-8")
+
+        sleeps: list[float] = []
+
+        with (
+            patch("control_plane.workflows.generic_web_preview.urlopen", return_value=_Response()),
+            patch("control_plane.workflows.generic_web_preview.time.sleep", side_effect=sleeps.append),
+        ):
+            with self.assertRaisesRegex(click.ClickException, "did not match"):
+                _wait_for_preview_health(
+                    preview_url="https://preview-42.example.test",
+                    health_path="/api/health",
+                    timeout_seconds=30,
+                    expected_runtime_identity=expected_identity,
+                )
+
+        self.assertEqual(sleeps, [])
 
     def test_execute_generic_web_preview_refresh_creates_application_from_template(self) -> None:
         store = _GenericWebPreviewStore(_profile())


### PR DESCRIPTION
## Summary

- Fail generic-web preview refresh immediately when health returns a deterministic runtime identity mismatch
- Keep polling transient preview health responses such as empty, non-JSON, missing identity, and ok=false
- Remove stale Every Code source-issue queue labels when the source issue closes before preview readiness, using the configured bot GitHub token and without blocking gate cancellation
- Document the stale-label cleanup in the Every Code record lifecycle

## Verification

- `git diff --check`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py control_plane/every_code_worker.py tests/test_generic_web_preview.py tests/test_every_code_worker.py --diff`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py control_plane/every_code_worker.py tests/test_generic_web_preview.py tests/test_every_code_worker.py`
- `uv run python -m unittest tests.test_generic_web_preview tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_gate_cancels_when_source_issue_closed tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_gate_cancels_when_source_issue_closed_even_without_label_token tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_gate_cancels_closed_pull_request tests.test_every_code_worker.EveryCodeWorkerTests.test_preview_gate_labels_done_pull_request_after_checks_pass`

## Review

Two agent reviews approved the combined diff. Residual noted risk: repeated reconciliation may attempt no-op label removal for already-terminal records, but cancellation remains non-blocking and the labels are already gone after the first successful pass.