### PR TITLE
Allow source-backed worker health surfaces

### DIFF
--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -102,6 +102,15 @@ class ProductOnboardingTargetManifest(BaseModel):
             raise ValueError("product onboarding target healthcheck_path must start with /")
         return self
 
+    def is_source_backed_compose(self) -> bool:
+        return (
+            self.target_type == "compose"
+            and self.source_type.strip().lower() == "git"
+            and bool(self.custom_git_url.strip())
+            and bool(self.custom_git_branch.strip())
+            and bool(self.compose_path.strip())
+        )
+
 
 class ProductOnboardingRuntimeEnvironmentManifest(BaseModel):
     model_config = ConfigDict(extra="forbid")
@@ -255,14 +264,27 @@ class ProductOnboardingManifest(BaseModel):
                 raise ValueError(
                     "image-less product onboarding requires source-backed compose provider target"
                 )
+            source_backed_compose_routes = {
+                (target.context.strip(), target.instance.strip())
+                for target in self.provider_targets
+                if target.is_source_backed_compose()
+            }
             for lane in self.lanes:
-                if (
-                    lane.base_url.strip()
-                    or lane.health_url.strip()
-                    or lane.public_ingress_monitoring.enabled
-                ):
+                if lane.base_url.strip():
                     raise ValueError(
-                        "image-less product onboarding requires disabled HTTP surfaces"
+                        "image-less product onboarding requires empty base_url; "
+                        "use explicit health_url for source-backed worker health checks"
+                    )
+                has_health_surface = bool(
+                    lane.health_url.strip() or lane.public_ingress_monitoring.enabled
+                )
+                if not has_health_surface:
+                    continue
+                route = (lane.context.strip(), lane.instance.strip())
+                if route not in source_backed_compose_routes:
+                    raise ValueError(
+                        "image-less product onboarding health surfaces require "
+                        "source-backed compose provider target"
                     )
             for target in self.provider_targets:
                 if target.target_type != "compose":

--- a/docs/records.md
+++ b/docs/records.md
@@ -329,9 +329,11 @@ Simple service products deployed as Dokploy applications use the same product
 profile shape. For a bot or worker service with an HTTP bridge or health
 endpoint, `runtime_port` is the internal HTTP port, `health_path` names the
 product-level health route, and lane `health_url` can point at an internal URL
-reachable by Launchplane. Source-backed workers without an HTTP surface use
-`runtime_port=0` and empty image/health fields only when preview, public ingress
-monitoring, and provider health checks are disabled. See
+reachable by Launchplane. Source-backed compose workers may use `runtime_port=0`
+and empty product-level image/health fields when any observable health surface is
+an explicit lane `health_url`; source-backed workers without an HTTP surface use
+that shape only when preview, public ingress monitoring, and provider health
+checks are disabled. See
 [dokploy-service-deployments.md](dokploy-service-deployments.md) for the
 service-specific contract.
 

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -2118,10 +2118,10 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             ],
         }
 
-        with self.assertRaisesRegex(ValueError, "requires disabled HTTP surfaces"):
+        with self.assertRaisesRegex(ValueError, "requires empty base_url"):
             ProductOnboardingManifest.model_validate(payload)
 
-    def test_product_onboarding_manifest_rejects_image_less_health_url_surface(
+    def test_product_onboarding_manifest_accepts_image_less_explicit_health_url_surface(
         self,
     ) -> None:
         payload: dict[str, object] = {
@@ -2152,7 +2152,187 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             ],
         }
 
-        with self.assertRaisesRegex(ValueError, "requires disabled HTTP surfaces"):
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            manifest = ProductOnboardingManifest.model_validate(payload)
+            result = apply_product_onboarding_manifest(
+                record_store=store,
+                manifest=manifest,
+                updated_at="2026-06-12T20:00:00Z",
+            )
+            profile = store.read_product_profile_record("repairshopr-sync")
+            targets = store.list_dokploy_target_records()
+            store.close()
+
+        self.assertEqual(result.product, "repairshopr-sync")
+        self.assertEqual(profile.image.repository, "")
+        self.assertEqual(profile.runtime_port, 0)
+        self.assertEqual(profile.health_path, "")
+        self.assertEqual(
+            profile.lanes[0].health_url,
+            "https://repairshopr-sync.example.test/health",
+        )
+        self.assertFalse(profile.lanes[0].public_ingress_monitoring.enabled)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].target_type, "compose")
+        self.assertFalse(targets[0].healthcheck_enabled)
+
+    def test_product_onboarding_manifest_accepts_image_less_health_monitoring(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "product": "repairshopr-sync",
+            "display_name": "RepairShopr Sync",
+            "repository": "cbusillo/repairshopr_api",
+            "driver_id": "generic-web",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "repairshopr-sync",
+                    "health_url": "https://repairshopr-sync.example.test/health",
+                    "public_ingress_monitoring": {
+                        "enabled": True,
+                        "alert_issue_url": "https://github.com/example/ops/issues/123",
+                    },
+                }
+            ],
+            "provider_targets": [
+                {
+                    "context": "repairshopr-sync",
+                    "instance": "prod",
+                    "target_id": "compose-123",
+                    "target_type": "compose",
+                    "source_type": "git",
+                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
+                    "custom_git_branch": "main",
+                    "compose_path": "docker/coolify/compose.yml",
+                    "healthcheck_enabled": False,
+                }
+            ],
+        }
+
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
+            )
+            store.ensure_schema()
+            manifest = ProductOnboardingManifest.model_validate(payload)
+            apply_product_onboarding_manifest(
+                record_store=store,
+                manifest=manifest,
+                updated_at="2026-06-12T20:00:00Z",
+            )
+            profile = store.read_product_profile_record("repairshopr-sync")
+            store.close()
+
+        self.assertEqual(
+            profile.lanes[0].health_url,
+            "https://repairshopr-sync.example.test/health",
+        )
+        self.assertTrue(profile.lanes[0].public_ingress_monitoring.enabled)
+        self.assertEqual(
+            profile.lanes[0].public_ingress_monitoring.alert_issue_url,
+            "https://github.com/example/ops/issues/123",
+        )
+
+    def test_product_onboarding_manifest_rejects_image_less_health_monitoring_without_url(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "product": "repairshopr-sync",
+            "display_name": "RepairShopr Sync",
+            "repository": "cbusillo/repairshopr_api",
+            "driver_id": "generic-web",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "repairshopr-sync",
+                    "public_ingress_monitoring": {"enabled": True},
+                }
+            ],
+            "provider_targets": [
+                {
+                    "context": "repairshopr-sync",
+                    "instance": "prod",
+                    "target_id": "compose-123",
+                    "target_type": "compose",
+                    "source_type": "git",
+                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
+                    "custom_git_branch": "main",
+                    "compose_path": "docker/coolify/compose.yml",
+                    "healthcheck_enabled": False,
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "requires base_url or explicit health_url"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_manifest_rejects_image_less_health_url_without_source_route(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "product": "repairshopr-sync",
+            "display_name": "RepairShopr Sync",
+            "repository": "cbusillo/repairshopr_api",
+            "driver_id": "generic-web",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "repairshopr-sync",
+                    "health_url": "https://repairshopr-sync.example.test/health",
+                    "public_ingress_monitoring": {"enabled": False},
+                }
+            ],
+            "provider_targets": [
+                {
+                    "context": "repairshopr-sync",
+                    "instance": "staging",
+                    "target_id": "compose-123",
+                    "target_type": "compose",
+                    "source_type": "git",
+                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
+                    "custom_git_branch": "main",
+                    "compose_path": "docker/coolify/compose.yml",
+                    "healthcheck_enabled": False,
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "target must match a stable lane"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_manifest_rejects_image_less_health_url_without_source_backed_target(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "product": "repairshopr-sync",
+            "display_name": "RepairShopr Sync",
+            "repository": "cbusillo/repairshopr_api",
+            "driver_id": "generic-web",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "repairshopr-sync",
+                    "health_url": "https://repairshopr-sync.example.test/health",
+                    "public_ingress_monitoring": {"enabled": False},
+                }
+            ],
+            "provider_targets": [
+                {
+                    "context": "repairshopr-sync",
+                    "instance": "prod",
+                    "target_id": "compose-123",
+                    "target_type": "compose",
+                    "healthcheck_enabled": False,
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "health surfaces require source-backed compose"):
             ProductOnboardingManifest.model_validate(payload)
 
     def test_product_onboarding_manifest_rejects_image_less_product_health_surface(


### PR DESCRIPTION
## Summary
- allow image-less source-backed compose worker products to carry explicit lane health URLs for Launchplane public-ingress monitoring
- keep base_url, product-level health fields, provider domains, and provider healthchecks fail-closed for image-less workers
- document the generic record shape without adding live product/runtime config

## Verification
- `uv run python -m unittest tests.test_product_onboarding`
- `uv run --extra dev ruff check control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff format --check control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py`
- scoped agent review: no blocking findings

## Notes
- Config-authority changed-files audit currently flags pre-existing schema defaults in `product_onboarding_manifest.py` as unclassified when the file is touched. The new behavior does not add checked-in live runtime values; tests use fixture/example values only.