### PR TITLE
Add lane health monitoring checks

### DIFF
--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -122,6 +122,8 @@ class ProductEnvironmentReadModelStore(ProductReadModelStore, Protocol):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]: ...
 
@@ -131,6 +133,8 @@ class ProductEnvironmentReadModelStore(ProductReadModelStore, Protocol):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressIncidentRecord, ...]: ...

--- a/control_plane/contracts/product_health_monitoring_migration.py
+++ b/control_plane/contracts/product_health_monitoring_migration.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+
+def migrate_product_profile_health_monitoring_payload(payload: object) -> object:
+    """Return a profile payload using lane health_monitoring checks.
+
+    This is used by both the database migration and the file-backed store so
+    persisted legacy records receive the same one-time shape conversion.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    migrated_payload = deepcopy(payload)
+    lanes = migrated_payload.get("lanes")
+    if not isinstance(lanes, list):
+        return migrated_payload
+    for lane in lanes:
+        if not isinstance(lane, dict):
+            continue
+        if "health_monitoring" in lane:
+            lane.pop("public_ingress_monitoring", None)
+            continue
+        old_policy = lane.pop("public_ingress_monitoring", None)
+        if isinstance(old_policy, dict):
+            enabled = bool(old_policy.get("enabled", True))
+            lane["health_monitoring"] = {
+                "checks": [
+                    _public_http_check(
+                        enabled=enabled,
+                        require_runtime_identity=bool(
+                            old_policy.get("require_runtime_identity", False)
+                        ),
+                        alert_issue_url=str(old_policy.get("alert_issue_url") or ""),
+                    )
+                ]
+            }
+        elif _lane_has_public_http_surface(lane=lane, profile=migrated_payload):
+            lane["health_monitoring"] = {"checks": [_public_http_check()]}
+        else:
+            lane["health_monitoring"] = {"checks": []}
+    return migrated_payload
+
+
+def downgrade_product_profile_health_monitoring_payload(payload: object) -> object:
+    if not isinstance(payload, dict):
+        return payload
+    downgraded_payload = deepcopy(payload)
+    lanes = downgraded_payload.get("lanes")
+    if not isinstance(lanes, list):
+        return downgraded_payload
+    for lane in lanes:
+        if not isinstance(lane, dict):
+            continue
+        if "public_ingress_monitoring" in lane:
+            lane.pop("health_monitoring", None)
+            continue
+        health_monitoring = lane.pop("health_monitoring", None)
+        public_check = None
+        if isinstance(health_monitoring, dict):
+            checks = health_monitoring.get("checks")
+            if isinstance(checks, list):
+                public_check = next(
+                    (
+                        check
+                        for check in checks
+                        if isinstance(check, dict) and check.get("kind") == "public_http"
+                    ),
+                    None,
+                )
+        if isinstance(public_check, dict):
+            lane["public_ingress_monitoring"] = {
+                "enabled": bool(public_check.get("enabled", True)),
+                "require_runtime_identity": bool(
+                    public_check.get("require_runtime_identity", False)
+                ),
+                "alert_issue_url": str(public_check.get("alert_issue_url") or ""),
+            }
+        else:
+            lane["public_ingress_monitoring"] = {"enabled": False}
+    return downgraded_payload
+
+
+def canonical_health_check_record_token(check_name: str) -> str:
+    normalized_name = health_check_record_token(check_name)
+    if normalized_name in {"", "public-ingress"}:
+        return ""
+    return normalized_name
+
+
+def health_check_record_token(check_name: str) -> str:
+    return "".join(
+        character if character.isalnum() else "-" for character in check_name.strip().lower()
+    ).strip("-")
+
+
+def _public_http_check(
+    *,
+    enabled: bool = True,
+    require_runtime_identity: bool = False,
+    alert_issue_url: str = "",
+) -> dict[str, object]:
+    return {
+        "name": "public-ingress",
+        "kind": "public_http",
+        "enabled": enabled,
+        "url": "",
+        "require_runtime_identity": require_runtime_identity,
+        "alert_issue_url": alert_issue_url,
+        "provider": "",
+        "provider_check": "",
+    }
+
+
+def _lane_has_public_http_surface(*, lane: dict[str, object], profile: dict[str, object]) -> bool:
+    if str(lane.get("health_url") or "").strip():
+        return True
+    if str(lane.get("base_url") or "").strip() and str(profile.get("health_path") or "").strip():
+        return True
+    return False

--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -9,8 +9,8 @@ from control_plane.contracts.product_profile_record import (
     ProductOdooPrelaunchRebuildPolicy,
     ProductOdooStableBootstrapPolicy,
     ProductExpectedConfigProfile,
+    ProductLaneHealthMonitoringPolicy,
     ProductPreviewProfile,
-    ProductPublicIngressMonitoringPolicy,
     ProductPromotionWorkflowProfile,
 )
 from control_plane.contracts.runtime_environment_record import ScalarValue
@@ -31,8 +31,8 @@ class ProductOnboardingLaneManifest(BaseModel):
         default_factory=ProductOdooPrelaunchRebuildPolicy
     )
     odoo_data_policy: ProductOdooLaneDataPolicy = Field(default_factory=ProductOdooLaneDataPolicy)
-    public_ingress_monitoring: ProductPublicIngressMonitoringPolicy = Field(
-        default_factory=ProductPublicIngressMonitoringPolicy
+    health_monitoring: ProductLaneHealthMonitoringPolicy = Field(
+        default_factory=ProductLaneHealthMonitoringPolicy
     )
 
     @model_validator(mode="after")
@@ -228,18 +228,23 @@ class ProductOnboardingManifest(BaseModel):
             raise ValueError("product onboarding lanes must be unique by instance")
         ProductPreviewProfile.model_validate(self.preview.model_dump(mode="json"))
         for lane in self.lanes:
-            if not lane.public_ingress_monitoring.enabled:
-                continue
-            if lane.health_url.strip():
-                continue
-            if not lane.base_url.strip():
-                raise ValueError(
-                    "public ingress monitoring requires base_url or explicit health_url"
-                )
-            if not self.health_path:
-                raise ValueError(
-                    "public ingress monitoring for lane with base_url requires health_path"
-                )
+            for check in lane.health_monitoring.checks:
+                if not check.enabled:
+                    continue
+                if check.kind == "provider":
+                    continue
+                if check.url:
+                    continue
+                if check.kind == "private_http":
+                    raise ValueError("private HTTP health check requires url")
+                if lane.health_url.strip():
+                    continue
+                if not lane.base_url.strip():
+                    raise ValueError(
+                        "public HTTP health check requires base_url or explicit health_url"
+                    )
+                if not self.health_path:
+                    raise ValueError("public HTTP health check with base_url requires health_path")
 
         for target in self.provider_targets:
             route = (target.context.strip(), target.instance.strip())
@@ -276,7 +281,8 @@ class ProductOnboardingManifest(BaseModel):
                         "use explicit health_url for source-backed worker health checks"
                     )
                 has_health_surface = bool(
-                    lane.health_url.strip() or lane.public_ingress_monitoring.enabled
+                    lane.health_url.strip()
+                    or any(check.enabled for check in lane.health_monitoring.checks)
                 )
                 if not has_health_surface:
                     continue

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -2,6 +2,11 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.product_health_monitoring_migration import (
+    canonical_health_check_record_token,
+)
+from control_plane.contracts.product_health_monitoring_migration import health_check_record_token
+
 
 PRODUCT_PREVIEW_DEFAULT_ENABLE_LABEL = "launchplane-preview"
 OdooDataAuthority = Literal["unknown", "resettable", "restorable", "authoritative"]
@@ -146,16 +151,62 @@ class ProductOdooLaneDataPolicy(BaseModel):
         return source in self.allowed_rebuild_sources
 
 
-class ProductPublicIngressMonitoringPolicy(BaseModel):
+ProductLaneHealthCheckKind = Literal["public_http", "private_http", "provider"]
+
+
+class ProductLaneHealthCheck(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    name: str
+    kind: ProductLaneHealthCheckKind = "public_http"
     enabled: bool = True
+    url: str = ""
     require_runtime_identity: bool = False
     alert_issue_url: str = ""
+    provider: str = ""
+    provider_check: str = ""
 
     @model_validator(mode="after")
-    def _validate_policy(self) -> "ProductPublicIngressMonitoringPolicy":
+    def _validate_check(self) -> "ProductLaneHealthCheck":
+        self.name = self.name.strip()
+        self.url = self.url.strip()
         self.alert_issue_url = self.alert_issue_url.strip()
+        self.provider = self.provider.strip()
+        self.provider_check = self.provider_check.strip()
+        if not self.name:
+            raise ValueError("product lane health check requires name")
+        if not health_check_record_token(self.name):
+            raise ValueError(
+                "product lane health check name must contain at least one alphanumeric character"
+            )
+        if self.kind != "public_http" and canonical_health_check_record_token(self.name) == "":
+            raise ValueError("non-public health checks cannot use the reserved public-ingress name")
+        if self.kind in {"public_http", "private_http"}:
+            if self.provider or self.provider_check:
+                raise ValueError("HTTP health checks cannot set provider fields")
+        elif self.kind == "provider":
+            if self.url:
+                raise ValueError("provider health checks cannot set url")
+            if not self.provider:
+                raise ValueError("provider health check requires provider")
+            if not self.provider_check:
+                raise ValueError("provider health check requires provider_check")
+        return self
+
+
+class ProductLaneHealthMonitoringPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    checks: tuple[ProductLaneHealthCheck, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_policy(self) -> "ProductLaneHealthMonitoringPolicy":
+        tokens: list[str] = []
+        for check in self.checks:
+            token = canonical_health_check_record_token(check.name)
+            if token in tokens:
+                raise ValueError("product lane health check names must be unique")
+            tokens.append(token)
         return self
 
 
@@ -173,8 +224,8 @@ class ProductLaneProfile(BaseModel):
         default_factory=ProductOdooPrelaunchRebuildPolicy
     )
     odoo_data_policy: ProductOdooLaneDataPolicy = Field(default_factory=ProductOdooLaneDataPolicy)
-    public_ingress_monitoring: ProductPublicIngressMonitoringPolicy = Field(
-        default_factory=ProductPublicIngressMonitoringPolicy
+    health_monitoring: ProductLaneHealthMonitoringPolicy = Field(
+        default_factory=ProductLaneHealthMonitoringPolicy
     )
 
     @model_validator(mode="after")
@@ -418,16 +469,21 @@ class LaunchplaneProductProfileRecord(BaseModel):
 
     def validate_write_contract(self) -> "LaunchplaneProductProfileRecord":
         for lane in self.lanes:
-            if not lane.public_ingress_monitoring.enabled:
-                continue
-            if lane.health_url.strip():
-                continue
-            if not lane.base_url.strip():
-                raise ValueError(
-                    "public ingress monitoring requires base_url or explicit health_url"
-                )
-            if not self.health_path:
-                raise ValueError(
-                    "public ingress monitoring for lane with base_url requires health_path"
-                )
+            for check in lane.health_monitoring.checks:
+                if not check.enabled:
+                    continue
+                if check.kind == "provider":
+                    continue
+                if check.url:
+                    continue
+                if check.kind == "private_http":
+                    raise ValueError("private HTTP health check requires url")
+                if lane.health_url.strip():
+                    continue
+                if not lane.base_url.strip():
+                    raise ValueError(
+                        "public HTTP health check requires base_url or explicit health_url"
+                    )
+                if not self.health_path:
+                    raise ValueError("public HTTP health check with base_url requires health_path")
         return self

--- a/control_plane/contracts/public_ingress_monitoring.py
+++ b/control_plane/contracts/public_ingress_monitoring.py
@@ -6,6 +6,10 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from control_plane.contracts.product_health_monitoring_migration import (
+    canonical_health_check_record_token,
+)
+from control_plane.contracts.product_health_monitoring_migration import health_check_record_token
 from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
 
 
@@ -15,7 +19,8 @@ PublicIngressIncidentEvent = Literal["opened", "updated", "resolved"]
 PublicIngressNotificationDestinationKind = Literal["github_issue", "email", "discord"]
 PublicIngressNotificationStatus = Literal["enabled", "disabled"]
 PublicIngressNotificationDeliveryStatus = Literal["delivered", "skipped", "failed"]
-PublicIngressTargetKind = Literal["base_url", "health_url"]
+PublicIngressHealthCheckKind = Literal["public_http", "private_http", "provider"]
+PublicIngressTargetKind = Literal["base_url", "health_url", "private_health_url", "provider"]
 PublicIngressFailureCode = Literal[
     "connection_timeout",
     "dns_failure",
@@ -23,6 +28,7 @@ PublicIngressFailureCode = Literal[
     "http_error",
     "invalid_url",
     "private_url",
+    "provider_check_unavailable",
     "redirect_loop",
     "self_redirect",
     "tls_failure",
@@ -72,6 +78,8 @@ class PublicIngressObservationRecord(BaseModel):
     driver_id: str = ""
     context: str
     instance: str
+    check_name: str = "public-ingress"
+    check_kind: PublicIngressHealthCheckKind = "public_http"
     observed_at: str
     status: PublicIngressObservationStatus
     failure_code: PublicIngressFailureCode | None = None
@@ -98,6 +106,9 @@ class PublicIngressObservationRecord(BaseModel):
         )
         self.repository = self.repository.strip()
         self.driver_id = self.driver_id.strip()
+        self.check_name = _required_text(
+            self.check_name, "public ingress observation requires check_name"
+        )
         self.base_url = self.base_url.strip()
         self.health_url = self.health_url.strip()
         self.notification_key = self.notification_key.strip()
@@ -129,6 +140,8 @@ class PublicIngressIncidentRecord(BaseModel):
     driver_id: str = ""
     context: str
     instance: str
+    check_name: str = "public-ingress"
+    check_kind: PublicIngressHealthCheckKind = "public_http"
     status: PublicIngressIncidentStatus
     opened_at: str
     opened_observation_id: str
@@ -164,6 +177,9 @@ class PublicIngressIncidentRecord(BaseModel):
         )
         self.repository = self.repository.strip()
         self.driver_id = self.driver_id.strip()
+        self.check_name = _required_text(
+            self.check_name, "public ingress incident requires check_name"
+        )
         self.resolved_at = self.resolved_at.strip()
         self.resolved_observation_id = self.resolved_observation_id.strip()
         self.summary = _required_text(self.summary, "public ingress incident requires summary")
@@ -253,6 +269,8 @@ class PublicIngressNotificationPolicyRecord(BaseModel):
     product: str = ""
     context: str = ""
     instance: str = ""
+    check_name: str = ""
+    check_kind: PublicIngressHealthCheckKind | Literal[""] = ""
     status: PublicIngressNotificationStatus = "enabled"
     destinations: tuple[PublicIngressNotificationDestination, ...] = ()
     created_at: str
@@ -267,6 +285,7 @@ class PublicIngressNotificationPolicyRecord(BaseModel):
         self.product = self.product.strip()
         self.context = self.context.strip()
         self.instance = self.instance.strip()
+        self.check_name = self.check_name.strip()
         self.created_at = _required_text(
             self.created_at, "public ingress notification policy requires created_at"
         )
@@ -283,6 +302,14 @@ class PublicIngressNotificationPolicyRecord(BaseModel):
             raise ValueError(
                 "public ingress notification policy with instance scope requires context"
             )
+        if self.check_name and not self.instance:
+            raise ValueError(
+                "public ingress notification policy with check_name scope requires instance"
+            )
+        if self.check_kind and not (self.context and self.instance):
+            raise ValueError(
+                "public ingress notification policy with check_kind scope requires lane scope"
+            )
         return self
 
     def matches(self, incident: PublicIngressIncidentRecord) -> bool:
@@ -290,6 +317,12 @@ class PublicIngressNotificationPolicyRecord(BaseModel):
             (not self.product or self.product == incident.product)
             and (not self.context or self.context == incident.context)
             and (not self.instance or self.instance == incident.instance)
+            and (
+                not self.check_name
+                or canonical_health_check_record_token(self.check_name)
+                == canonical_health_check_record_token(incident.check_name)
+            )
+            and (not self.check_kind or self.check_kind == incident.check_kind)
         )
 
 
@@ -344,11 +377,12 @@ class PublicIngressNotificationAttemptRecord(BaseModel):
 
 
 def build_public_ingress_observation_id(
-    *, product: str, context: str, instance: str, observed_at: str
+    *, product: str, context: str, instance: str, observed_at: str, check_name: str = ""
 ) -> str:
+    check_token = _check_record_token(check_name)
     return "-".join(
         _record_token(value)
-        for value in ("public-ingress", product, context, instance, observed_at)
+        for value in ("public-ingress", product, context, instance, check_token, observed_at)
         if _record_token(value)
     )
 
@@ -363,10 +397,13 @@ def build_public_ingress_incident_id(
     )
 
 
-def build_public_ingress_lane_incident_id(*, product: str, context: str, instance: str) -> str:
+def build_public_ingress_lane_incident_id(
+    *, product: str, context: str, instance: str, check_name: str = ""
+) -> str:
+    check_token = _check_record_token(check_name)
     return "-".join(
         _record_token(value)
-        for value in ("public-ingress-incident", product, context, instance)
+        for value in ("public-ingress-incident", product, context, instance, check_token)
         if _record_token(value)
     )
 
@@ -402,9 +439,13 @@ def build_public_ingress_notification_attempt_id(
 
 
 def _record_token(value: str) -> str:
-    return "".join(
-        character if character.isalnum() else "-" for character in value.strip().lower()
-    ).strip("-")
+    return health_check_record_token(value)
+
+
+def _check_record_token(check_name: str) -> str:
+    # Preserve legacy public-ingress observation and incident ids for the default
+    # public HTTP check while still separating every explicitly named non-default check.
+    return canonical_health_check_record_token(check_name)
 
 
 def _required_text(value: str, message: str) -> str:

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -54,6 +54,12 @@ from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLife
 from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_health_monitoring_migration import (
+    canonical_health_check_record_token,
+)
+from control_plane.contracts.product_health_monitoring_migration import (
+    migrate_product_profile_health_monitoring_payload,
+)
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressNotificationAttemptRecord,
@@ -782,6 +788,8 @@ class FilesystemRecordStore:
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]:
         records = [
@@ -793,6 +801,12 @@ class FilesystemRecordStore:
             if (not product or record.product == product)
             and (not context_name or record.context == context_name)
             and (not instance_name or record.instance == instance_name)
+            and (
+                not check_name
+                or canonical_health_check_record_token(record.check_name)
+                == canonical_health_check_record_token(check_name)
+            )
+            and (not check_kind or record.check_kind == check_kind)
         ]
         records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
         if limit is not None:
@@ -808,6 +822,8 @@ class FilesystemRecordStore:
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressIncidentRecord, ...]:
@@ -820,6 +836,12 @@ class FilesystemRecordStore:
             if (not product or record.product == product)
             and (not context_name or record.context == context_name)
             and (not instance_name or record.instance == instance_name)
+            and (
+                not check_name
+                or canonical_health_check_record_token(record.check_name)
+                == canonical_health_check_record_token(check_name)
+            )
+            and (not check_kind or record.check_kind == check_kind)
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: (record.opened_at, record.incident_id), reverse=True)
@@ -890,10 +912,8 @@ class FilesystemRecordStore:
         return tuple(records)
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
-        return LaunchplaneProductProfileRecord.model_validate(
-            self._read_model(
-                LaunchplaneProductProfileRecord, "launchplane_product_profiles", product
-            ).model_dump(mode="json")
+        return self._read_product_profile_record_path(
+            self._record_path("launchplane_product_profiles", product)
         )
 
     def list_product_profile_records(
@@ -901,15 +921,30 @@ class FilesystemRecordStore:
         *,
         driver_id: str = "",
     ) -> tuple[LaunchplaneProductProfileRecord, ...]:
-        records = [
-            record
-            for record in self._list_models(
-                LaunchplaneProductProfileRecord, "launchplane_product_profiles"
-            )
-            if not driver_id or record.driver_id == driver_id
-        ]
+        record_dir = self._record_dir("launchplane_product_profiles")
+        records: list[LaunchplaneProductProfileRecord] = []
+        if record_dir.exists():
+            for record_path in sorted(record_dir.glob("*.json")):
+                record = self._read_product_profile_record_path(record_path)
+                if not driver_id or record.driver_id == driver_id:
+                    records.append(record)
         records.sort(key=lambda record: record.product)
         return tuple(records)
+
+    def _read_product_profile_record_path(
+        self, record_path: Path
+    ) -> LaunchplaneProductProfileRecord:
+        payload = json.loads(record_path.read_text(encoding="utf-8"))
+        migrated_payload = migrate_product_profile_health_monitoring_payload(payload)
+        record = LaunchplaneProductProfileRecord.model_validate(migrated_payload)
+        if migrated_payload != payload:
+            record_path.write_text(
+                json.dumps(
+                    record.model_dump(mode="json", exclude_none=True), indent=2, sort_keys=True
+                ),
+                encoding="utf-8",
+            )
+        return record
 
     def list_authz_policy_records(
         self,

--- a/control_plane/storage/migrations/versions/fa2c4e6f8a0b_migrate_lane_health_monitoring.py
+++ b/control_plane/storage/migrations/versions/fa2c4e6f8a0b_migrate_lane_health_monitoring.py
@@ -1,0 +1,67 @@
+"""migrate lane health monitoring
+
+Revision ID: fa2c4e6f8a0b
+Revises: f9b1c3d5e7a9
+Create Date: 2026-06-15 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+from control_plane.contracts.product_health_monitoring_migration import (
+    downgrade_product_profile_health_monitoring_payload,
+)
+from control_plane.contracts.product_health_monitoring_migration import (
+    migrate_product_profile_health_monitoring_payload,
+)
+
+revision: str = "fa2c4e6f8a0b"
+down_revision: str | None = "f9b1c3d5e7a9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_PRODUCT_PROFILES_TABLE = "launchplane_product_profiles"
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    product_profiles = _product_profiles_table()
+    for row in connection.execute(
+        sa.select(product_profiles.c.product, product_profiles.c.payload)
+    ):
+        migrated_payload = migrate_product_profile_health_monitoring_payload(row.payload)
+        if migrated_payload != row.payload:
+            connection.execute(
+                product_profiles.update()
+                .where(product_profiles.c.product == row.product)
+                .values(payload=migrated_payload)
+            )
+
+
+def downgrade() -> None:
+    connection = op.get_bind()
+    product_profiles = _product_profiles_table()
+    for row in connection.execute(
+        sa.select(product_profiles.c.product, product_profiles.c.payload)
+    ):
+        downgraded_payload = downgrade_product_profile_health_monitoring_payload(row.payload)
+        if downgraded_payload != row.payload:
+            connection.execute(
+                product_profiles.update()
+                .where(product_profiles.c.product == row.product)
+                .values(payload=downgraded_payload)
+            )
+
+
+def _product_profiles_table() -> sa.Table:
+    metadata = sa.MetaData()
+    return sa.Table(
+        _PRODUCT_PROFILES_TABLE,
+        metadata,
+        sa.Column("product", sa.String(), primary_key=True),
+        sa.Column("payload", sa.JSON(), nullable=False),
+    )

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -13,6 +13,7 @@ from sqlalchemy import (
     create_engine,
     delete,
     desc,
+    func,
     inspect,
     text,
     select,
@@ -75,6 +76,9 @@ from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyc
 from control_plane.contracts.preview_pr_feedback_record import PreviewPrFeedbackRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
+from control_plane.contracts.product_health_monitoring_migration import (
+    canonical_health_check_record_token,
+)
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressNotificationAttemptRecord,
@@ -2340,7 +2344,9 @@ class PostgresRecordStore(HumanSessionStore):
     ) -> tuple[EveryCodeNotificationPolicyRecord, ...]:
         filters: list[object] = []
         if repository:
-            filters.append(LaunchplaneEveryCodeNotificationPolicyRow.repository.in_(("", repository)))
+            filters.append(
+                LaunchplaneEveryCodeNotificationPolicyRow.repository.in_(("", repository))
+            )
         if status:
             filters.append(LaunchplaneEveryCodeNotificationPolicyRow.status == status)
         return self._list_models(
@@ -2384,8 +2390,7 @@ class PostgresRecordStore(HumanSessionStore):
             filters.append(LaunchplaneEveryCodeNotificationAttemptRow.event == event)
         if destination_kind:
             filters.append(
-                LaunchplaneEveryCodeNotificationAttemptRow.destination_kind
-                == destination_kind
+                LaunchplaneEveryCodeNotificationAttemptRow.destination_kind == destination_kind
             )
         return self._list_models(
             model_type=EveryCodeNotificationAttemptRecord,
@@ -3279,6 +3284,8 @@ class PostgresRecordStore(HumanSessionStore):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]:
         filters: list[object] = []
@@ -3288,7 +3295,15 @@ class PostgresRecordStore(HumanSessionStore):
             filters.append(LaunchplanePublicIngressObservationRow.context == context_name)
         if instance_name:
             filters.append(LaunchplanePublicIngressObservationRow.instance == instance_name)
-        return self._list_models(
+        if check_kind:
+            filters.append(
+                func.coalesce(
+                    LaunchplanePublicIngressObservationRow.payload["check_kind"].as_string(),
+                    "public_http",
+                )
+                == check_kind
+            )
+        records = self._list_models(
             model_type=PublicIngressObservationRecord,
             orm_model=LaunchplanePublicIngressObservationRow,
             filters=filters,
@@ -3296,8 +3311,18 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplanePublicIngressObservationRow.observed_at.desc(),
                 LaunchplanePublicIngressObservationRow.record_id.desc(),
             ),
-            limit=limit,
+            limit=None if check_name else limit,
         )
+        if check_name:
+            check_token = canonical_health_check_record_token(check_name)
+            records = tuple(
+                record
+                for record in records
+                if canonical_health_check_record_token(record.check_name) == check_token
+            )
+            if limit is not None:
+                records = records[:limit]
+        return records
 
     def write_public_ingress_incident_record(self, record: PublicIngressIncidentRecord) -> None:
         self._write_row(
@@ -3319,6 +3344,8 @@ class PostgresRecordStore(HumanSessionStore):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressIncidentRecord, ...]:
@@ -3329,9 +3356,17 @@ class PostgresRecordStore(HumanSessionStore):
             filters.append(LaunchplanePublicIngressIncidentRow.context == context_name)
         if instance_name:
             filters.append(LaunchplanePublicIngressIncidentRow.instance == instance_name)
+        if check_kind:
+            filters.append(
+                func.coalesce(
+                    LaunchplanePublicIngressIncidentRow.payload["check_kind"].as_string(),
+                    "public_http",
+                )
+                == check_kind
+            )
         if status:
             filters.append(LaunchplanePublicIngressIncidentRow.status == status)
-        return self._list_models(
+        records = self._list_models(
             model_type=PublicIngressIncidentRecord,
             orm_model=LaunchplanePublicIngressIncidentRow,
             filters=filters,
@@ -3339,8 +3374,18 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplanePublicIngressIncidentRow.opened_at.desc(),
                 LaunchplanePublicIngressIncidentRow.incident_id.desc(),
             ),
-            limit=limit,
+            limit=None if check_name else limit,
         )
+        if check_name:
+            check_token = canonical_health_check_record_token(check_name)
+            records = tuple(
+                record
+                for record in records
+                if canonical_health_check_record_token(record.check_name) == check_token
+            )
+            if limit is not None:
+                records = records[:limit]
+        return records
 
     def write_public_ingress_notification_policy_record(
         self, record: PublicIngressNotificationPolicyRecord

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -99,7 +99,7 @@ def build_product_profile_record(
                 odoo_stable_bootstrap=lane.odoo_stable_bootstrap,
                 odoo_prelaunch_rebuild=lane.odoo_prelaunch_rebuild,
                 odoo_data_policy=lane.odoo_data_policy,
-                public_ingress_monitoring=lane.public_ingress_monitoring,
+                health_monitoring=lane.health_monitoring,
             )
             for lane in manifest.lanes
         ),
@@ -112,7 +112,9 @@ def build_product_profile_record(
     )
 
 
-def _lane_health_url(*, manifest: ProductOnboardingManifest, lane: ProductOnboardingLaneManifest) -> str:
+def _lane_health_url(
+    *, manifest: ProductOnboardingManifest, lane: ProductOnboardingLaneManifest
+) -> str:
     health_url = lane.health_url.strip()
     if health_url:
         return health_url

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -17,8 +17,13 @@ import ssl
 from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.product_health_monitoring_migration import (
+    canonical_health_check_record_token,
+)
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
+    ProductLaneHealthCheck,
+    ProductLaneHealthCheckKind,
     ProductLaneProfile,
 )
 from control_plane.contracts.public_ingress_monitoring import (
@@ -71,6 +76,8 @@ class PublicIngressMonitorStore(Protocol):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]: ...
 
@@ -84,6 +91,8 @@ class PublicIngressMonitorStore(Protocol):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressIncidentRecord, ...]: ...
@@ -125,9 +134,13 @@ class PublicIngressMonitorTarget:
     instance: str
     base_url: str
     health_url: str
+    check_name: str
+    check_kind: ProductLaneHealthCheckKind
     expected_runtime_identity: RuntimeIdentity | None
     require_runtime_identity: bool
     alert_issue_url: str
+    provider: str = ""
+    provider_check: str = ""
 
 
 @dataclass(frozen=True)
@@ -210,30 +223,63 @@ def discover_public_ingress_monitor_targets(
         if not _profile_uses_generic_web(profile):
             continue
         for lane in profile.lanes:
-            if not lane.public_ingress_monitoring.enabled:
-                continue
-            base_url = lane.base_url.strip().rstrip("/")
-            health_url = _monitor_health_url(profile=profile, lane=lane, base_url=base_url)
-            if not (base_url or health_url):
-                continue
-            targets.append(
-                PublicIngressMonitorTarget(
-                    product=profile.product,
-                    repository=profile.repository,
-                    driver_id=profile.driver_id,
-                    context=lane.context,
-                    instance=lane.instance,
-                    base_url=base_url,
-                    health_url=health_url,
-                    expected_runtime_identity=_expected_runtime_identity(
-                        record_store=record_store,
-                        lane=lane,
-                    ),
-                    require_runtime_identity=lane.public_ingress_monitoring.require_runtime_identity,
-                    alert_issue_url=lane.public_ingress_monitoring.alert_issue_url,
+            for check in lane.health_monitoring.checks:
+                if not check.enabled:
+                    continue
+                target = _health_check_monitor_target(
+                    profile=profile,
+                    lane=lane,
+                    check=check,
+                    record_store=record_store,
                 )
-            )
+                if target is None:
+                    continue
+                targets.append(target)
     return tuple(targets)
+
+
+def _health_check_monitor_target(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+    check: ProductLaneHealthCheck,
+    record_store: object,
+) -> PublicIngressMonitorTarget | None:
+    base_url = ""
+    health_url = ""
+    if check.kind == "public_http":
+        base_url = lane.base_url.strip().rstrip("/")
+        health_url = check.url.strip() or _monitor_health_url(
+            profile=profile, lane=lane, base_url=base_url
+        )
+        if not (base_url or health_url):
+            return None
+    elif check.kind == "private_http":
+        health_url = check.url.strip()
+        if not health_url:
+            return None
+    else:
+        if not (check.provider.strip() and check.provider_check.strip()):
+            return None
+    return PublicIngressMonitorTarget(
+        product=profile.product,
+        repository=profile.repository,
+        driver_id=profile.driver_id,
+        context=lane.context,
+        instance=lane.instance,
+        base_url=base_url,
+        health_url=health_url,
+        check_name=check.name,
+        check_kind=check.kind,
+        expected_runtime_identity=_expected_runtime_identity(
+            record_store=record_store,
+            lane=lane,
+        ),
+        require_runtime_identity=check.require_runtime_identity,
+        alert_issue_url=check.alert_issue_url,
+        provider=check.provider,
+        provider_check=check.provider_check,
+    )
 
 
 def run_public_ingress_monitor_once(
@@ -382,6 +428,7 @@ def reconcile_public_ingress_incident(
             product=record.product,
             context=record.context,
             instance=record.instance,
+            check_name=record.check_name,
         )
         open_incident = next(
             (incident for incident in open_incidents if incident.incident_id == incident_id), None
@@ -403,6 +450,8 @@ def reconcile_public_ingress_incident(
                 driver_id=record.driver_id,
                 context=record.context,
                 instance=record.instance,
+                check_name=record.check_name,
+                check_kind=record.check_kind,
                 status="open",
                 opened_at=record.observed_at,
                 opened_observation_id=record.record_id,
@@ -500,12 +549,15 @@ def check_public_ingress_target(
             context=target.context,
             instance=target.instance,
             observed_at=checked_at,
+            check_name=target.check_name,
         ),
         product=target.product,
         repository=target.repository,
         driver_id=target.driver_id,
         context=target.context,
         instance=target.instance,
+        check_name=target.check_name,
+        check_kind=target.check_kind,
         observed_at=checked_at,
         status=status,
         failure_code=failure_code,
@@ -546,7 +598,11 @@ def _check_url(
     target: PublicIngressMonitorTarget,
     http_get: HttpGet,
 ) -> PublicIngressTargetObservation:
-    public_url_error = _public_url_error(url)
+    if target.check_kind == "provider":
+        return _provider_check_unavailable(target=target)
+    public_url_error = None
+    if target.check_kind != "private_http":
+        public_url_error = _public_url_error(url)
     if public_url_error is not None:
         status: PublicIngressObservationStatus = (
             "skipped" if public_url_error == "private_url" else "fail"
@@ -565,7 +621,11 @@ def _check_url(
             target=target_kind,
             url=url,
             status="fail",
-            failure_code=("health_status_error" if target_kind == "health_url" else "http_error"),
+            failure_code=(
+                "health_status_error"
+                if target_kind in {"health_url", "private_health_url"}
+                else "http_error"
+            ),
             http_status=error.code,
             final_url=error.url or "",
             summary=f"HTTP {error.code}",
@@ -599,7 +659,11 @@ def _check_url(
             target=target_kind,
             url=url,
             status="fail",
-            failure_code=("health_status_error" if target_kind == "health_url" else "http_error"),
+            failure_code=(
+                "health_status_error"
+                if target_kind in {"health_url", "private_health_url"}
+                else "http_error"
+            ),
             http_status=observation.status_code,
             final_url=observation.final_url,
             redirect_count=observation.redirect_count,
@@ -608,7 +672,10 @@ def _check_url(
     runtime_status: RuntimeIdentityStatus = "unchecked"
     runtime_detail = ""
     observed_runtime_identity: RuntimeIdentity | None = None
-    if target_kind == "health_url" and target.expected_runtime_identity is not None:
+    if (
+        target_kind in {"health_url", "private_health_url"}
+        and target.expected_runtime_identity is not None
+    ):
         runtime_status, runtime_detail, observed_runtime_identity = (
             health_payload_runtime_identity_status(
                 expected=target.expected_runtime_identity,
@@ -643,7 +710,23 @@ def _check_url(
         runtime_identity_status=runtime_status,
         runtime_identity_detail=runtime_detail,
         observed_runtime_identity=observed_runtime_identity,
-        summary="Public ingress returned a successful response.",
+        summary=_successful_target_summary(target),
+    )
+
+
+def _provider_check_unavailable(
+    *,
+    target: PublicIngressMonitorTarget,
+) -> PublicIngressTargetObservation:
+    return PublicIngressTargetObservation(
+        target="provider",
+        url=f"provider://{target.provider}/{target.provider_check}",
+        status="fail",
+        failure_code="provider_check_unavailable",
+        summary=(
+            f"Provider health check {target.provider}/{target.provider_check} "
+            "is not wired to a monitor driver."
+        ),
     )
 
 
@@ -685,6 +768,8 @@ def _latest_observation(
         product=target.product,
         context_name=target.context,
         instance_name=target.instance,
+        check_name=target.check_name,
+        check_kind=target.check_kind,
         limit=1,
     )
     return next(iter(records), None)
@@ -697,6 +782,8 @@ def _open_incidents(
         product=record.product,
         context_name=record.context,
         instance_name=record.instance,
+        check_name=record.check_name,
+        check_kind=record.check_kind,
         status="open",
     )
     return tuple(
@@ -705,6 +792,9 @@ def _open_incidents(
         if incident.product == record.product
         and incident.context == record.context
         and incident.instance == record.instance
+        and canonical_health_check_record_token(incident.check_name)
+        == canonical_health_check_record_token(record.check_name)
+        and incident.check_kind == record.check_kind
     )
 
 
@@ -723,6 +813,13 @@ def _target_urls(
     target: PublicIngressMonitorTarget,
 ) -> tuple[tuple[PublicIngressTargetKind, str], ...]:
     urls: list[tuple[PublicIngressTargetKind, str]] = []
+    if target.check_kind == "provider":
+        urls.append(("provider", f"provider://{target.provider}/{target.provider_check}"))
+        return tuple(urls)
+    if target.check_kind == "private_http":
+        if target.health_url:
+            urls.append(("private_health_url", target.health_url))
+        return tuple(urls)
     if target.base_url:
         urls.append(("base_url", target.base_url))
     if target.health_url and target.health_url != target.base_url:
@@ -750,13 +847,27 @@ def _record_summary(
     observations: list[PublicIngressTargetObservation],
 ) -> str:
     if status == "pass":
-        return f"Public ingress is reachable for {target.product}/{target.instance}."
+        return f"{_check_label(target)} is reachable for {target.product}/{target.instance}."
     failing = next(
         (observation for observation in observations if observation.status == "fail"), None
     )
     if failing is not None:
-        return f"Public ingress failed for {target.product}/{target.instance}: {failing.summary}"
-    return f"Public ingress monitoring skipped {target.product}/{target.instance}."
+        return f"{_check_label(target)} failed for {target.product}/{target.instance}: {failing.summary}"
+    return f"{_check_label(target)} monitoring skipped {target.product}/{target.instance}."
+
+
+def _check_label(target: PublicIngressMonitorTarget) -> str:
+    if target.check_kind == "private_http":
+        return "Private health check"
+    if target.check_kind == "provider":
+        return "Provider health check"
+    return "Public ingress"
+
+
+def _successful_target_summary(target: PublicIngressMonitorTarget) -> str:
+    if target.check_kind == "private_http":
+        return "Private health check returned a successful response."
+    return "Public ingress returned a successful response."
 
 
 def _public_url_error(url: str) -> PublicIngressFailureCode | None:
@@ -844,6 +955,20 @@ def _normalized_url(url: str) -> str:
 
 def _notification_key(target: PublicIngressMonitorTarget) -> str:
     return target.alert_issue_url or ""
+
+
+def public_http_health_check(
+    *,
+    name: str = "public-ingress",
+    require_runtime_identity: bool = False,
+    alert_issue_url: str = "",
+) -> ProductLaneHealthCheck:
+    return ProductLaneHealthCheck(
+        name=name,
+        kind="public_http",
+        require_runtime_identity=require_runtime_identity,
+        alert_issue_url=alert_issue_url,
+    )
 
 
 class PublicIngressNotificationDriverSet:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -276,20 +276,22 @@ topology from records.
 Grant requests return only authz policy record metadata and rule counts; they do
 not echo workflow refs, human logins, or the full policy body.
 
-Public ingress monitoring is a Launchplane-owned synthetic check for every
-public generic-web stable lane, including drivers that inherit generic-web
-behavior. The `Public Ingress Monitor` workflow owns both the recurring schedule
-and manual operator reruns, so its GitHub OIDC identity stays scoped only to
+Lane health monitoring is Launchplane-owned synthetic monitoring for
+generic-web stable lanes, including drivers that inherit generic-web behavior.
+The `Public Ingress Monitor` workflow owns both the recurring schedule and
+manual operator reruns, so its GitHub OIDC identity stays scoped only to
 `public_ingress_monitor.run_once`. Both paths call
 `POST /v1/products/public-ingress-monitor/run-once` through GitHub OIDC and are
-authorized in the Launchplane service context. Monitoring is default-on for
-lanes with public `base_url` or `health_url`; disable it per lane only for
-non-public or intentionally unreachable endpoints. Observations are sensor
-evidence; public-ingress incident records are the active operator lifecycle when
-a lane fails and later recovers. Notification routing is a separate
-service-backed policy and delivery concern, not lane-owned text config. The
-initial notification destinations are GitHub issues, email, and Discord; each is
-selected by DB-backed policy and evidenced by delivery-attempt records.
+authorized in the Launchplane service context. Lanes opt in by declaring
+`health_monitoring.checks[]`: `public_http` checks validate public reachability,
+`private_http` checks monitor an explicit internal URL, and `provider` checks
+fail closed until a provider-specific monitor is wired. Observations are sensor
+evidence; incident records are keyed by product, lane, and health-check name so
+public, private, and provider failures do not overwrite each other.
+Notification routing is a separate service-backed policy and delivery concern,
+not lane-owned text config. The initial notification destinations are GitHub
+issues, email, and Discord; each is selected by DB-backed policy and evidenced
+by delivery-attempt records.
 GitHub issue notification delivery uses the managed automation token projected
 as `LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN`; it does not fall back to active
 local `gh` authentication. Verify the configured actor with a token-scoped

--- a/docs/records.md
+++ b/docs/records.md
@@ -256,15 +256,18 @@ derived from runtime-environment records, managed secret binding records, driver
 support, and trust metadata; expected config requirements do not store runtime
 values, managed secret IDs, secret plaintext, or ciphertext.
 
-Stable lanes inherit public-ingress synthetic monitoring by default when their
-product uses `generic-web` or a driver based on it. A lane with a public
-`base_url` or `health_url` is eligible unless its
-`public_ingress_monitoring.enabled` policy is set false. The monitor records
-HTTP reachability, redirect failures, private/internal URL skips, and runtime
-identity comparison when current lane inventory or deployment evidence provides
-an expected identity. Lane policy may carry an `alert_issue_url`; Launchplane
-uses that issue for fail/recover transition comments, not as runtime
-configuration authority.
+Stable lanes declare synthetic monitoring through `health_monitoring.checks[]`.
+Each check has a stable name and kind. `public_http` checks use an explicit URL
+or the lane `health_url`, or derive one from lane `base_url` plus product
+`health_path`. `private_http` checks require an explicit URL and skip public URL
+validation so internal service endpoints can be monitored without publishing an
+ingress route. `provider` checks record provider-health intent and fail closed
+until a provider-specific monitor implementation is wired. The monitor records
+HTTP reachability, redirect failures, private/internal URL skips for public
+checks, and runtime identity comparison when current lane inventory or
+deployment evidence provides an expected identity. Check policy may carry an
+`alert_issue_url`; Launchplane uses that issue for fail/recover transition
+comments, not as runtime configuration authority.
 
 The product key is the durable workspace identity. For example,
 `sellyouroutboard` is the SellYourOutboard product workspace; `testing`, `prod`,

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -749,6 +750,61 @@ class FilesystemRecordStoreTests(unittest.TestCase):
         self.assertEqual(loaded_record.preview.context, "sellyouroutboard-testing")
         self.assertEqual(
             [listed_record.product for listed_record in listed_records], ["sellyouroutboard"]
+        )
+
+    def test_read_product_profile_record_migrates_legacy_health_monitoring(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            profile_dir = state_dir / "launchplane_product_profiles"
+            profile_dir.mkdir(parents=True)
+            (profile_dir / "example-site.json").write_text(
+                """
+                {
+                  "product": "example-site",
+                  "display_name": "Example Site",
+                  "repository": "example/example-site",
+                  "driver_id": "generic-web",
+                  "image": {"repository": "ghcr.io/example/example-site"},
+                  "runtime_port": 3000,
+                  "health_path": "/healthz",
+                  "updated_at": "2026-06-15T14:00:00Z",
+                  "source": "operator:test",
+                  "lanes": [
+                    {
+                      "instance": "prod",
+                      "context": "example-site",
+                      "base_url": "https://example.test",
+                      "public_ingress_monitoring": {
+                        "enabled": true,
+                        "require_runtime_identity": true,
+                        "alert_issue_url": "https://github.example.test/org/repo/issues/1"
+                      }
+                    }
+                  ]
+                }
+                """.strip(),
+                encoding="utf-8",
+            )
+            store = FilesystemRecordStore(state_dir=state_dir)
+
+            loaded_record = store.read_product_profile_record("example-site")
+            listed_records = store.list_product_profile_records(driver_id="generic-web")
+            persisted_payload = json.loads(
+                (state_dir / "launchplane_product_profiles" / "example-site.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+
+        check = loaded_record.lanes[0].health_monitoring.checks[0]
+        self.assertEqual(check.name, "public-ingress")
+        self.assertEqual(check.kind, "public_http")
+        self.assertTrue(check.require_runtime_identity)
+        self.assertEqual(check.alert_issue_url, "https://github.example.test/org/repo/issues/1")
+        self.assertEqual([record.product for record in listed_records], ["example-site"])
+        self.assertNotIn("public_ingress_monitoring", persisted_payload["lanes"][0])
+        self.assertEqual(
+            persisted_payload["lanes"][0]["health_monitoring"]["checks"][0]["name"],
+            "public-ingress",
         )
 
     def test_write_and_list_public_ingress_observation_records(self) -> None:

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -15,7 +15,8 @@ from control_plane.contracts.product_profile_record import (
     ProductImageProfile,
     ProductLaneProfile,
     ProductPreviewProfile,
-    ProductPublicIngressMonitoringPolicy,
+    ProductLaneHealthMonitoringPolicy,
+    ProductLaneHealthCheck,
 )
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
@@ -171,7 +172,7 @@ def _source_ref_worker_profile() -> LaunchplaneProductProfileRecord:
             ProductLaneProfile(
                 instance="prod",
                 context="repairshopr-sync",
-                public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=False),
+                health_monitoring=ProductLaneHealthMonitoringPolicy(checks=()),
             ),
         ),
         updated_at="2026-06-12T20:00:00Z",
@@ -183,7 +184,7 @@ def _source_ref_worker_lane() -> ProductLaneProfile:
     return ProductLaneProfile(
         instance="prod",
         context="repairshopr-sync",
-        public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=False),
+        health_monitoring=ProductLaneHealthMonitoringPolicy(checks=()),
     )
 
 
@@ -296,7 +297,7 @@ class GenericWebDeployTests(unittest.TestCase):
                 artifact_id="sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c",
             )
 
-    def test_product_profile_write_contract_rejects_inert_public_ingress_monitoring(
+    def test_product_profile_write_contract_rejects_inert_health_monitoring(
         self,
     ) -> None:
         profile = LaunchplaneProductProfileRecord(
@@ -309,6 +310,9 @@ class GenericWebDeployTests(unittest.TestCase):
                 ProductLaneProfile(
                     instance="prod",
                     context="repairshopr-sync",
+                    health_monitoring=ProductLaneHealthMonitoringPolicy(
+                        checks=(ProductLaneHealthCheck(name="public-ingress"),)
+                    ),
                 ),
             ),
             updated_at="2026-06-12T20:00:00Z",
@@ -332,6 +336,9 @@ class GenericWebDeployTests(unittest.TestCase):
                     instance="prod",
                     context="repairshopr-sync",
                     base_url="https://repairshopr-sync.example.test",
+                    health_monitoring=ProductLaneHealthMonitoringPolicy(
+                        checks=(ProductLaneHealthCheck(name="public-ingress"),)
+                    ),
                 ),
             ),
             updated_at="2026-06-12T20:00:00Z",

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -31,7 +31,7 @@ from control_plane.contracts.product_profile_record import (
     ProductOdooLaneDataPolicy,
     ProductOdooPrelaunchRebuildPolicy,
     ProductPreviewProfile,
-    ProductPublicIngressMonitoringPolicy,
+    ProductLaneHealthMonitoringPolicy,
     ProductSecretConfigRequirement,
 )
 from control_plane.contracts.promotion_record import (
@@ -183,7 +183,7 @@ def _profile(driver_id: str = "odoo") -> LaunchplaneProductProfileRecord:
             ProductLaneProfile(
                 instance="testing",
                 context="cm",
-                public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=False),
+                health_monitoring=ProductLaneHealthMonitoringPolicy(checks=()),
             ),
         ),
         preview=ProductPreviewProfile(enabled=True, context="cm"),

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -18,6 +18,9 @@ from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.product_health_monitoring_migration import (
+    canonical_health_check_record_token,
+)
 from control_plane.contracts.product_environment_read_model import (
     ACTION_AUTHZ_BY_ROUTE,
     ProductEnvironmentReadModelCapabilityError,
@@ -247,6 +250,8 @@ class _PublicIngressReadModelStore(_PreviewRecordStore):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]:
         records = [
@@ -255,6 +260,12 @@ class _PublicIngressReadModelStore(_PreviewRecordStore):
             if (not product or record.product == product)
             and (not context_name or record.context == context_name)
             and (not instance_name or record.instance == instance_name)
+            and (
+                not check_name
+                or canonical_health_check_record_token(record.check_name)
+                == canonical_health_check_record_token(check_name)
+            )
+            and (not check_kind or record.check_kind == check_kind)
         ]
         records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
         if limit is not None:
@@ -267,6 +278,8 @@ class _PublicIngressReadModelStore(_PreviewRecordStore):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressIncidentRecord, ...]:
@@ -276,6 +289,12 @@ class _PublicIngressReadModelStore(_PreviewRecordStore):
             if (not product or incident.product == product)
             and (not context_name or incident.context == context_name)
             and (not instance_name or incident.instance == instance_name)
+            and (
+                not check_name
+                or canonical_health_check_record_token(incident.check_name)
+                == canonical_health_check_record_token(check_name)
+            )
+            and (not check_kind or incident.check_kind == check_kind)
             and (not status or incident.status == status)
         ]
         incidents.sort(
@@ -301,6 +320,8 @@ class _PublicIngressObservationsOnlyStore(_PreviewRecordStore):
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]:
         records = [
@@ -309,6 +330,12 @@ class _PublicIngressObservationsOnlyStore(_PreviewRecordStore):
             if (not product or record.product == product)
             and (not context_name or record.context == context_name)
             and (not instance_name or record.instance == instance_name)
+            and (
+                not check_name
+                or canonical_health_check_record_token(record.check_name)
+                == canonical_health_check_record_token(check_name)
+            )
+            and (not check_kind or record.check_kind == check_kind)
         ]
         records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
         if limit is not None:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -4,7 +4,7 @@ import importlib.util
 from pathlib import Path
 import subprocess
 from tempfile import TemporaryDirectory
-from typing import cast
+from typing import Callable, cast
 import unittest
 
 from click import Command
@@ -2557,11 +2557,16 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             ],
         }
 
-        migrated = migration.migrate_product_profile_health_monitoring_payload(payload)
+        migrate_payload = cast(
+            Callable[[object], object],
+            getattr(migration, "migrate_product_profile_health_monitoring_payload"),
+        )
+        migrated = cast(dict[str, object], migrate_payload(payload))
 
-        lanes = migrated["lanes"]
+        lanes = cast(list[dict[str, object]], migrated["lanes"])
+        first_lane_health_monitoring = cast(dict[str, object], lanes[0]["health_monitoring"])
         self.assertEqual(
-            lanes[0]["health_monitoring"]["checks"],
+            first_lane_health_monitoring["checks"],
             [
                 {
                     "name": "public-ingress",

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1,5 +1,6 @@
 import json
 import os
+import importlib.util
 from pathlib import Path
 import subprocess
 from tempfile import TemporaryDirectory
@@ -18,6 +19,14 @@ from control_plane.workflows.product_onboarding import apply_product_onboarding_
 
 
 CLI_MAIN = cast(Command, main)
+_HEALTH_MONITORING_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "control_plane"
+    / "storage"
+    / "migrations"
+    / "versions"
+    / "fa2c4e6f8a0b_migrate_lane_health_monitoring.py"
+)
 ODOO_RUNTIME_KEYS = (
     "ODOO_DB_NAME",
     "ODOO_DB_USER",
@@ -47,6 +56,17 @@ OWNER_AUTHZ_ENV = {
 }
 
 
+def _load_health_monitoring_migration() -> object:
+    spec = importlib.util.spec_from_file_location(
+        "launchplane_health_monitoring_migration", _HEALTH_MONITORING_MIGRATION_PATH
+    )
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
 
@@ -65,8 +85,14 @@ def _manifest_payload() -> dict[str, object]:
                 "instance": "testing",
                 "context": "example-site-testing",
                 "base_url": "https://testing.example.invalid",
-                "public_ingress_monitoring": {
-                    "alert_issue_url": "https://github.com/cbusillo/launchplane/issues/929"
+                "health_monitoring": {
+                    "checks": [
+                        {
+                            "name": "public-ingress",
+                            "kind": "public_http",
+                            "alert_issue_url": "https://github.com/cbusillo/launchplane/issues/929",
+                        }
+                    ]
                 },
                 "odoo_stable_bootstrap": {
                     "enabled": True,
@@ -1609,10 +1635,11 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(profile.historical_contexts, ())
         self.assertEqual(profile.lanes[0].health_url, "https://testing.example.invalid/api/health")
         self.assertTrue(profile.lanes[0].odoo_stable_bootstrap.enabled)
-        self.assertTrue(profile.lanes[0].public_ingress_monitoring.enabled)
-        self.assertFalse(profile.lanes[0].public_ingress_monitoring.require_runtime_identity)
+        health_check = profile.lanes[0].health_monitoring.checks[0]
+        self.assertTrue(health_check.enabled)
+        self.assertFalse(health_check.require_runtime_identity)
         self.assertEqual(
-            profile.lanes[0].public_ingress_monitoring.alert_issue_url,
+            health_check.alert_issue_url,
             "https://github.com/cbusillo/launchplane/issues/929",
         )
         self.assertEqual(
@@ -1919,7 +1946,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -1958,7 +1985,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(profile.runtime_port, 0)
         self.assertEqual(profile.health_path, "")
         self.assertEqual(profile.lanes[0].health_url, "")
-        self.assertFalse(profile.lanes[0].public_ingress_monitoring.enabled)
+        self.assertEqual(profile.lanes[0].health_monitoring.checks, ())
         self.assertEqual(len(targets), 1)
         self.assertEqual(targets[0].target_type, "compose")
         self.assertFalse(targets[0].healthcheck_enabled)
@@ -1976,7 +2003,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2005,7 +2032,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2035,7 +2062,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2067,7 +2094,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2100,7 +2127,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                     "instance": "prod",
                     "context": "repairshopr-sync",
                     "base_url": "https://repairshopr-sync.example.test",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2134,7 +2161,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                     "instance": "prod",
                     "context": "repairshopr-sync",
                     "health_url": "https://repairshopr-sync.example.test/health",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2175,7 +2202,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             profile.lanes[0].health_url,
             "https://repairshopr-sync.example.test/health",
         )
-        self.assertFalse(profile.lanes[0].public_ingress_monitoring.enabled)
+        self.assertEqual(profile.lanes[0].health_monitoring.checks, ())
         self.assertEqual(len(targets), 1)
         self.assertEqual(targets[0].target_type, "compose")
         self.assertFalse(targets[0].healthcheck_enabled)
@@ -2193,9 +2220,14 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                     "instance": "prod",
                     "context": "repairshopr-sync",
                     "health_url": "https://repairshopr-sync.example.test/health",
-                    "public_ingress_monitoring": {
-                        "enabled": True,
-                        "alert_issue_url": "https://github.com/example/ops/issues/123",
+                    "health_monitoring": {
+                        "checks": [
+                            {
+                                "name": "public-ingress",
+                                "kind": "public_http",
+                                "alert_issue_url": "https://github.com/example/ops/issues/123",
+                            }
+                        ]
                     },
                 }
             ],
@@ -2232,9 +2264,9 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             profile.lanes[0].health_url,
             "https://repairshopr-sync.example.test/health",
         )
-        self.assertTrue(profile.lanes[0].public_ingress_monitoring.enabled)
+        self.assertTrue(profile.lanes[0].health_monitoring.checks[0].enabled)
         self.assertEqual(
-            profile.lanes[0].public_ingress_monitoring.alert_issue_url,
+            profile.lanes[0].health_monitoring.checks[0].alert_issue_url,
             "https://github.com/example/ops/issues/123",
         )
 
@@ -2250,7 +2282,9 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": True},
+                    "health_monitoring": {
+                        "checks": [{"name": "public-ingress", "kind": "public_http"}]
+                    },
                 }
             ],
             "provider_targets": [
@@ -2284,7 +2318,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                     "instance": "prod",
                     "context": "repairshopr-sync",
                     "health_url": "https://repairshopr-sync.example.test/health",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2318,7 +2352,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                     "instance": "prod",
                     "context": "repairshopr-sync",
                     "health_url": "https://repairshopr-sync.example.test/health",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2349,7 +2383,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2382,7 +2416,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2416,7 +2450,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2445,7 +2479,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2467,7 +2501,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         with self.assertRaisesRegex(ValueError, "requires disabled provider healthcheck"):
             ProductOnboardingManifest.model_validate(payload)
 
-    def test_product_onboarding_manifest_rejects_inert_public_ingress_monitoring(
+    def test_product_onboarding_manifest_rejects_inert_health_monitoring(
         self,
     ) -> None:
         payload: dict[str, object] = {
@@ -2475,24 +2509,146 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             "display_name": "RepairShopr Sync",
             "repository": "cbusillo/repairshopr_api",
             "driver_id": "generic-web",
+            "image_repository": "ghcr.io/cbusillo/repairshopr-sync",
+            "runtime_port": 3000,
+            "health_path": "/health",
             "lanes": [
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "healthcheck_enabled": False,
+                    "health_monitoring": {
+                        "checks": [{"name": "public-ingress", "kind": "public_http"}]
+                    },
                 }
             ],
         }
 
         with self.assertRaisesRegex(ValueError, "requires base_url or explicit health_url"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_manifest_rejects_legacy_public_ingress_monitoring(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+        lanes = payload["lanes"]
+        assert isinstance(lanes, list)
+        first_lane = lanes[0]
+        assert isinstance(first_lane, dict)
+        first_lane.pop("health_monitoring")
+        first_lane["public_ingress_monitoring"] = {"enabled": True}
+
+        with self.assertRaisesRegex(ValueError, "public_ingress_monitoring"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_health_monitoring_migration_preserves_legacy_default_public_check(
+        self,
+    ) -> None:
+        migration = _load_health_monitoring_migration()
+        payload = {
+            "product": "example-site",
+            "health_path": "/healthz",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "example-site",
+                    "base_url": "https://example.test",
+                },
+                {"instance": "worker", "context": "example-site"},
+            ],
+        }
+
+        migrated = migration.migrate_product_profile_health_monitoring_payload(payload)
+
+        lanes = migrated["lanes"]
+        self.assertEqual(
+            lanes[0]["health_monitoring"]["checks"],
+            [
+                {
+                    "name": "public-ingress",
+                    "kind": "public_http",
+                    "enabled": True,
+                    "url": "",
+                    "require_runtime_identity": False,
+                    "alert_issue_url": "",
+                    "provider": "",
+                    "provider_check": "",
+                }
+            ],
+        )
+        self.assertEqual(lanes[1]["health_monitoring"], {"checks": []})
+
+    def test_product_profile_rejects_colliding_health_check_names(self) -> None:
+        payload = {
+            "product": "example-site",
+            "display_name": "Example Site",
+            "driver_id": "generic-web",
+            "health_path": "/healthz",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "example-site",
+                    "base_url": "https://example.test",
+                    "health_monitoring": {
+                        "checks": [
+                            {"name": "api check", "kind": "public_http"},
+                            {
+                                "name": "api-check",
+                                "kind": "private_http",
+                                "url": "http://app:3000/healthz",
+                            },
+                        ]
+                    },
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "health check names must be unique"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_profile_rejects_reserved_non_public_health_check_name(self) -> None:
+        payload = {
+            "product": "example-site",
+            "display_name": "Example Site",
+            "driver_id": "generic-web",
+            "health_path": "/healthz",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "example-site",
+                    "base_url": "https://example.test",
+                    "health_monitoring": {
+                        "checks": [
+                            {
+                                "name": "public-ingress",
+                                "kind": "private_http",
+                                "url": "http://app:3000/healthz",
+                            }
+                        ]
+                    },
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "reserved public-ingress name"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_profile_rejects_degenerate_health_check_name(self) -> None:
+        payload = {
+            "product": "example-site",
+            "display_name": "Example Site",
+            "driver_id": "generic-web",
+            "health_path": "/healthz",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "example-site",
+                    "base_url": "https://example.test",
+                    "health_monitoring": {"checks": [{"name": "---", "kind": "public_http"}]},
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "alphanumeric"):
             ProductOnboardingManifest.model_validate(payload)
 
     def test_product_onboarding_manifest_rejects_base_url_without_health_path(
@@ -2503,25 +2659,20 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             "display_name": "RepairShopr Sync",
             "repository": "cbusillo/repairshopr_api",
             "driver_id": "generic-web",
+            "image_repository": "ghcr.io/cbusillo/repairshopr-sync",
             "lanes": [
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
                     "base_url": "https://repairshopr-sync.example.test",
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "healthcheck_enabled": False,
+                    "health_monitoring": {
+                        "checks": [{"name": "public-ingress", "kind": "public_http"}]
+                    },
                 }
             ],
         }
 
-        with self.assertRaisesRegex(ValueError, "base_url requires health_path"):
+        with self.assertRaisesRegex(ValueError, "with base_url requires health_path"):
             ProductOnboardingManifest.model_validate(payload)
 
     def test_product_onboarding_manifest_rejects_zero_runtime_port_with_health_path(
@@ -2538,7 +2689,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [
@@ -2568,7 +2719,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "instance": "prod",
                     "context": "repairshopr-sync",
-                    "public_ingress_monitoring": {"enabled": False},
+                    "health_monitoring": {"checks": []},
                 }
             ],
             "provider_targets": [

--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -166,9 +166,11 @@ class _ProductReadStore:
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]:
-        _ = (self, product, context_name, instance_name, limit)
+        _ = (self, product, context_name, instance_name, check_name, check_kind, limit)
         return ()
 
     def list_public_ingress_incident_records(
@@ -177,10 +179,12 @@ class _ProductReadStore:
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressIncidentRecord, ...]:
-        _ = (self, product, context_name, instance_name, status, limit)
+        _ = (self, product, context_name, instance_name, check_name, check_kind, status, limit)
         return ()
 
     def list_runtime_environment_records(

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -7,11 +7,15 @@ from urllib.request import Request
 
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.product_health_monitoring_migration import (
+    canonical_health_check_record_token,
+)
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
     ProductLaneProfile,
-    ProductPublicIngressMonitoringPolicy,
+    ProductLaneHealthMonitoringPolicy,
+    ProductLaneHealthCheck,
 )
 from control_plane.contracts.promotion_record import DeploymentEvidence
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
@@ -31,6 +35,20 @@ from control_plane.workflows.public_ingress_monitor import (
     discover_public_ingress_monitor_targets,
     run_public_ingress_monitor_once,
 )
+
+
+def _public_health_monitoring(
+    *, require_runtime_identity: bool = False, alert_issue_url: str = ""
+) -> ProductLaneHealthMonitoringPolicy:
+    return ProductLaneHealthMonitoringPolicy(
+        checks=(
+            ProductLaneHealthCheck(
+                name="public-ingress",
+                require_runtime_identity=require_runtime_identity,
+                alert_issue_url=alert_issue_url,
+            ),
+        )
+    )
 
 
 class _Store:
@@ -58,6 +76,8 @@ class _Store:
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressObservationRecord, ...]:
         records = [
@@ -66,6 +86,12 @@ class _Store:
             if (not product or record.product == product)
             and (not context_name or record.context == context_name)
             and (not instance_name or record.instance == instance_name)
+            and (
+                not check_name
+                or canonical_health_check_record_token(record.check_name)
+                == canonical_health_check_record_token(check_name)
+            )
+            and (not check_kind or record.check_kind == check_kind)
         ]
         records.sort(key=lambda record: (record.observed_at, record.record_id), reverse=True)
         if limit is not None:
@@ -83,6 +109,8 @@ class _Store:
         product: str = "",
         context_name: str = "",
         instance_name: str = "",
+        check_name: str = "",
+        check_kind: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[PublicIngressIncidentRecord, ...]:
@@ -92,6 +120,12 @@ class _Store:
             if (not product or incident.product == product)
             and (not context_name or incident.context == context_name)
             and (not instance_name or incident.instance == instance_name)
+            and (
+                not check_name
+                or canonical_health_check_record_token(incident.check_name)
+                == canonical_health_check_record_token(check_name)
+            )
+            and (not check_kind or incident.check_kind == check_kind)
             and (not status or incident.status == status)
         ]
         incidents.sort(
@@ -177,7 +211,7 @@ def _profile(
                 instance="prod",
                 context="example-site",
                 base_url="https://example.test",
-                public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(
+                health_monitoring=_public_health_monitoring(
                     alert_issue_url="https://github.com/cbusillo/launchplane/issues/929"
                 ),
             ),
@@ -283,7 +317,7 @@ class PublicIngressMonitorTests(unittest.TestCase):
             context="example-site",
             base_url="https://example.test/",
             health_url="HTTPS://EXAMPLE.TEST/cm-website/health/",
-            public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=True),
+            health_monitoring=_public_health_monitoring(),
         )
         store = _Store(
             (
@@ -304,7 +338,7 @@ class PublicIngressMonitorTests(unittest.TestCase):
             context="example-site",
             base_url="https://example.test",
             health_url="https://internal.example.test/web/health",
-            public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=True),
+            health_monitoring=_public_health_monitoring(),
         )
         store = _Store(
             (
@@ -324,7 +358,7 @@ class PublicIngressMonitorTests(unittest.TestCase):
             instance="prod",
             context="example-site",
             base_url="https://example.test",
-            public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(enabled=False),
+            health_monitoring=ProductLaneHealthMonitoringPolicy(checks=()),
         )
         store = _Store((_profile(lane=lane),))
 
@@ -335,6 +369,7 @@ class PublicIngressMonitorTests(unittest.TestCase):
             instance="prod",
             context="example-site",
             base_url="https://localhost:3000",
+            health_monitoring=_public_health_monitoring(),
         )
         store = _Store((_profile(lane=lane),))
         requested_urls: list[str] = []
@@ -348,6 +383,103 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(result.skipped_count, 1)
         self.assertEqual(requested_urls, [])
         self.assertEqual(store.records[0].failure_code, "private_url")
+
+    def test_private_http_check_requests_private_health_url(self) -> None:
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            health_monitoring=ProductLaneHealthMonitoringPolicy(
+                checks=(
+                    ProductLaneHealthCheck(
+                        name="private-runtime",
+                        kind="private_http",
+                        url="http://10.0.0.5:8080/health",
+                    ),
+                )
+            ),
+        )
+        store = _Store((_profile(lane=lane),))
+        requested_urls: list[str] = []
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:06:00Z",
+            http_get=lambda url, _timeout: _capture_request(requested_urls, url),
+        )
+
+        self.assertEqual(result.pass_count, 1)
+        self.assertEqual(requested_urls, ["http://10.0.0.5:8080/health"])
+        self.assertEqual(store.records[0].check_name, "private-runtime")
+        self.assertEqual(store.records[0].check_kind, "private_http")
+        self.assertEqual(store.records[0].targets[0].target, "private_health_url")
+
+    def test_provider_check_fails_closed_until_provider_monitor_is_wired(self) -> None:
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            health_monitoring=ProductLaneHealthMonitoringPolicy(
+                checks=(
+                    ProductLaneHealthCheck(
+                        name="provider-target",
+                        kind="provider",
+                        provider="dokploy",
+                        provider_check="target-health",
+                    ),
+                )
+            ),
+        )
+        store = _Store((_profile(lane=lane),))
+        requested_urls: list[str] = []
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:07:00Z",
+            http_get=lambda url, _timeout: _capture_request(requested_urls, url),
+        )
+
+        self.assertEqual(result.fail_count, 1)
+        self.assertEqual(requested_urls, [])
+        self.assertEqual(store.records[0].check_name, "provider-target")
+        self.assertEqual(store.records[0].check_kind, "provider")
+        self.assertEqual(store.records[0].failure_code, "provider_check_unavailable")
+        self.assertEqual(store.incidents[0].check_name, "provider-target")
+
+    def test_multiple_lane_checks_write_separate_records_and_incidents(self) -> None:
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            base_url="https://example.test",
+            health_monitoring=ProductLaneHealthMonitoringPolicy(
+                checks=(
+                    ProductLaneHealthCheck(name="public-ingress"),
+                    ProductLaneHealthCheck(
+                        name="private-runtime",
+                        kind="private_http",
+                        url="http://10.0.0.5:8080/health",
+                    ),
+                )
+            ),
+        )
+        store = _Store((_profile(lane=lane),))
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:08:00Z",
+            http_get=lambda url, _timeout: HttpObservation(
+                status_code=503,
+                final_url=url,
+                redirect_count=0,
+            ),
+        )
+
+        self.assertEqual(result.fail_count, 2)
+        self.assertEqual(len(store.records), 2)
+        self.assertEqual(len({record.record_id for record in store.records}), 2)
+        self.assertEqual(len(store.incidents), 2)
+        self.assertEqual(
+            {incident.check_name for incident in store.incidents},
+            {"public-ingress", "private-runtime"},
+        )
 
     def test_compares_runtime_identity_when_lane_evidence_exists(self) -> None:
         identity = _identity()
@@ -431,9 +563,7 @@ class PublicIngressMonitorTests(unittest.TestCase):
             instance="prod",
             context="example-site",
             base_url="https://example.test",
-            public_ingress_monitoring=ProductPublicIngressMonitoringPolicy(
-                require_runtime_identity=True
-            ),
+            health_monitoring=_public_health_monitoring(require_runtime_identity=True),
         )
         store = _Store((_profile(lane=lane),))
         store.lane_summaries[("example-site", "prod")] = LaunchplaneLaneSummary(
@@ -761,6 +891,97 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(github_calls[0][0], "create")
         self.assertEqual(email_subjects, ["[Launchplane] Public ingress opened: example-site/prod"])
         self.assertEqual(discord_posts[0][0], "https://discord.com/api/webhooks/test/webhook")
+
+    def test_notification_policies_can_scope_to_health_check_kind(self) -> None:
+        lane = ProductLaneProfile(
+            instance="prod",
+            context="example-site",
+            base_url="https://example.test",
+            health_monitoring=ProductLaneHealthMonitoringPolicy(
+                checks=(
+                    ProductLaneHealthCheck(name="public-ingress"),
+                    ProductLaneHealthCheck(
+                        name="private-runtime",
+                        kind="private_http",
+                        url="http://10.0.0.5:8080/health",
+                    ),
+                )
+            ),
+        )
+        store = _Store((_profile(lane=lane),))
+        store.notification_policies.extend(
+            (
+                PublicIngressNotificationPolicyRecord(
+                    policy_id="public-health-notifications",
+                    product="example-site",
+                    context="example-site",
+                    instance="prod",
+                    check_kind="public_http",
+                    destinations=(
+                        PublicIngressNotificationDestination(
+                            destination_id="public-discord",
+                            kind="discord",
+                            discord_webhook_secret="public-discord-webhook",
+                        ),
+                    ),
+                    created_at="2026-05-29T12:00:00Z",
+                    updated_at="2026-05-29T12:00:00Z",
+                    source="test",
+                ),
+                PublicIngressNotificationPolicyRecord(
+                    policy_id="private-health-notifications",
+                    product="example-site",
+                    context="example-site",
+                    instance="prod",
+                    check_kind="private_http",
+                    destinations=(
+                        PublicIngressNotificationDestination(
+                            destination_id="private-discord",
+                            kind="discord",
+                            discord_webhook_secret="private-discord-webhook",
+                        ),
+                    ),
+                    created_at="2026-05-29T12:00:00Z",
+                    updated_at="2026-05-29T12:00:00Z",
+                    source="test",
+                ),
+            )
+        )
+        discord_posts: list[tuple[str, dict[str, object]]] = []
+        drivers = PublicIngressNotificationDriverSet(
+            discord_sender=lambda webhook_url, payload: discord_posts.append(
+                (webhook_url, payload)
+            ),
+            secret_resolver=lambda secret_name: {
+                "public-discord-webhook": "https://discord.com/api/webhooks/public/webhook",
+                "private-discord-webhook": "https://discord.com/api/webhooks/private/webhook",
+            }.get(secret_name, ""),
+        )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:25:00Z",
+            http_get=lambda _url, _timeout: HttpObservation(
+                status_code=503,
+                final_url="https://example.test",
+                redirect_count=0,
+            ),
+            notification_drivers=drivers,
+        )
+
+        self.assertEqual(result.open_incident_count, 2)
+        self.assertEqual(result.delivery_attempt_count, 2)
+        self.assertEqual(
+            {attempt.destination_id for attempt in store.notification_attempts},
+            {"public-discord", "private-discord"},
+        )
+        self.assertEqual(
+            {post[0] for post in discord_posts},
+            {
+                "https://discord.com/api/webhooks/public/webhook",
+                "https://discord.com/api/webhooks/private/webhook",
+            },
+        )
 
     def test_policy_delivery_failures_are_recorded_per_destination(self) -> None:
         store = _Store((_profile(),))

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -921,9 +921,7 @@ def _merge_train_service_identity() -> GitHubActionsIdentity:
     )
 
 
-def _every_code_worker_policy(
-    *, extra_actions: tuple[str, ...] = ()
-) -> LaunchplaneAuthzPolicy:
+def _every_code_worker_policy(*, extra_actions: tuple[str, ...] = ()) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
             "github_actions": [
@@ -4743,21 +4741,15 @@ class LaunchplaneServiceTests(unittest.TestCase):
             public_discord_url_error("http://169.254.169.254/latest/meta-data"),
             "private_url",
         )
-        self.assertEqual(
-            public_discord_url_error("http://224.0.0.1/hook"), "private_url"
-        )
-        self.assertEqual(
-            public_discord_url_error("http://0.0.0.0/hook"), "private_url"
-        )
+        self.assertEqual(public_discord_url_error("http://224.0.0.1/hook"), "private_url")
+        self.assertEqual(public_discord_url_error("http://0.0.0.0/hook"), "private_url")
         self.assertEqual(public_url_error("https://example.com/health"), "")
         self.assertEqual(public_url_error("https://93.184.216.34/health"), "")
         self.assertEqual(
             public_discord_url_error("https://93.184.216.34/api/webhooks/test/webhook"),
             "invalid_url",
         )
-        self.assertEqual(
-            public_discord_url_error("https://example.com/hook"), "invalid_url"
-        )
+        self.assertEqual(public_discord_url_error("https://example.com/hook"), "invalid_url")
         self.assertEqual(
             public_discord_url_error("https://discord.com/api/webhooks/test/webhook"),
             "",
@@ -14512,7 +14504,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ["sellyouroutboard"],
         )
 
-    def test_product_profile_endpoint_rejects_inert_public_ingress_monitoring(
+    def test_product_profile_endpoint_rejects_inert_health_monitoring(
         self,
     ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -14544,6 +14536,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {
                     "instance": "testing",
                     "context": "sellyouroutboard-testing",
+                    "health_monitoring": {
+                        "checks": [{"name": "public-ingress", "kind": "public_http"}]
+                    },
                 },
             )
 
@@ -14559,7 +14554,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "invalid_request")
         self.assertEqual(
             payload["error"]["message"],
-            "public ingress monitoring requires base_url or explicit health_url",
+            "public HTTP health check requires base_url or explicit health_url",
         )
 
     def test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle(self) -> None:
@@ -28484,7 +28479,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         artifact_id="artifact-20260420-a1b2c3d4",
                         source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
                         image_reference="artifact-20260420-a1b2c3d4",
-                    )
+                    ),
                 )
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
@@ -28541,12 +28536,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                                 "deployment_record_id": "deployment-20260420T153000Z-cm-testing",
                                 "artifact_id": "artifact-20260420-a1b2c3d4",
                                 "source_git_ref": "6b3c9d7e8f901234567890abcdef1234567890ab",
-                                "image_reference": "artifact-20260420-a1b2c3d4"
+                                "image_reference": "artifact-20260420-a1b2c3d4",
                             }
-                        }
+                        },
                     },
                 },
-                headers={"Idempotency-Key": "generic-stable-verification:cm:testing:health-payload"},
+                headers={
+                    "Idempotency-Key": "generic-stable-verification:cm:testing:health-payload"
+                },
             )
 
             deployment = store.read_deployment_record("deployment-20260420T153000Z-cm-testing")


### PR DESCRIPTION
## Summary
- Replace lane public_ingress_monitoring with health_monitoring.checks[] for public HTTP, private HTTP, and provider health checks.
- Add one-time product profile payload migration for Postgres and file-backed state, including persisted cleanup for local files.
- Canonicalize health check identity across validation, observation IDs, incident IDs, storage filters, notifications, and monitor reconciliation.
- Update docs and focused tests for the new health monitoring model.

## Verification
- uv run python -m unittest tests.test_product_onboarding tests.test_generic_web_deploy tests.test_odoo_stable_target_replacement tests.test_service.LaunchplaneServiceTests tests.test_filesystem_store tests.test_postgres_store tests.test_product_environment_read_model tests.test_product_read_service tests.test_public_ingress_monitor
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_health_monitoring_migration_preserves_legacy_default_public_check tests.test_product_onboarding.ProductOnboardingTests.test_product_profile_rejects_colliding_health_check_names tests.test_product_onboarding.ProductOnboardingTests.test_product_profile_rejects_reserved_non_public_health_check_name tests.test_product_onboarding.ProductOnboardingTests.test_product_profile_rejects_degenerate_health_check_name tests.test_filesystem_store.FilesystemRecordStoreTests.test_read_product_profile_record_migrates_legacy_health_monitoring tests.test_public_ingress_monitor.PublicIngressMonitorTests
- uv run --extra dev ruff check control_plane/contracts/product_environment_read_model.py control_plane/contracts/product_onboarding_manifest.py control_plane/contracts/product_profile_record.py control_plane/contracts/product_health_monitoring_migration.py control_plane/contracts/public_ingress_monitoring.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/fa2c4e6f8a0b_migrate_lane_health_monitoring.py control_plane/workflows/product_onboarding.py control_plane/workflows/public_ingress_monitor.py tests/test_filesystem_store.py tests/test_generic_web_deploy.py tests/test_odoo_stable_target_replacement.py tests/test_product_environment_read_model.py tests/test_product_onboarding.py tests/test_product_read_service.py tests/test_public_ingress_monitor.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/contracts/product_environment_read_model.py control_plane/contracts/product_onboarding_manifest.py control_plane/contracts/product_profile_record.py control_plane/contracts/product_health_monitoring_migration.py control_plane/contracts/public_ingress_monitoring.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/storage/migrations/versions/fa2c4e6f8a0b_migrate_lane_health_monitoring.py control_plane/workflows/product_onboarding.py control_plane/workflows/public_ingress_monitor.py tests/test_filesystem_store.py tests/test_generic_web_deploy.py tests/test_odoo_stable_target_replacement.py tests/test_product_environment_read_model.py tests/test_product_onboarding.py tests/test_product_read_service.py tests/test_public_ingress_monitor.py tests/test_service.py

## Review
- Planning and final review agents were used.
- Final review found check-name canonicalization and file-state cleanup gaps; both were fixed before this PR.
- No checked-in live product or lane config was added.