### PR TITLE
Clean up health monitoring migration followups

### DIFF
--- a/docs/records.md
+++ b/docs/records.md
@@ -22,10 +22,11 @@ title: Records
 
 Launchplane uses SQLAlchemy ORM models as the persistence boundary and Alembic as
 the versioned migration mechanism for shared-service Postgres databases. Hosted
-service startup verifies that the shared database schema is already present; it
-does not create or migrate tables as a startup side effect. Runtime code can
-still call `ensure_schema()` for compatibility and ephemeral test/local
-databases, but new production schema changes should land as Alembic revisions.
+service startup runs Alembic to the checked-in head revision before starting the
+HTTP service; schema or payload changes must therefore land as explicit Alembic
+revisions. Runtime code can still call `ensure_schema()` for compatibility and
+ephemeral test/local databases, but new production schema changes should not rely
+on implicit table creation.
 
 For a fresh database, apply the current schema with:
 

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -2582,6 +2582,61 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         )
         self.assertEqual(lanes[1]["health_monitoring"], {"checks": []})
 
+    def test_health_monitoring_migration_downgrades_first_public_check(self) -> None:
+        migration = _load_health_monitoring_migration()
+        payload = {
+            "product": "example-site",
+            "health_path": "/healthz",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "example-site",
+                    "base_url": "https://example.test",
+                    "health_monitoring": {
+                        "checks": [
+                            {
+                                "name": "private-runtime",
+                                "kind": "private_http",
+                                "enabled": True,
+                                "url": "http://app:3000/healthz",
+                            },
+                            {
+                                "name": "public-ingress",
+                                "kind": "public_http",
+                                "enabled": True,
+                                "require_runtime_identity": True,
+                                "alert_issue_url": "https://github.example.test/org/repo/issues/1",
+                            },
+                        ]
+                    },
+                },
+                {
+                    "instance": "worker",
+                    "context": "example-site",
+                    "health_monitoring": {"checks": []},
+                },
+            ],
+        }
+
+        downgrade_payload = cast(
+            Callable[[object], object],
+            getattr(migration, "downgrade_product_profile_health_monitoring_payload"),
+        )
+        downgraded = cast(dict[str, object], downgrade_payload(payload))
+
+        lanes = cast(list[dict[str, object]], downgraded["lanes"])
+        self.assertEqual(
+            lanes[0]["public_ingress_monitoring"],
+            {
+                "enabled": True,
+                "require_runtime_identity": True,
+                "alert_issue_url": "https://github.example.test/org/repo/issues/1",
+            },
+        )
+        self.assertEqual(lanes[1]["public_ingress_monitoring"], {"enabled": False})
+        self.assertNotIn("health_monitoring", lanes[0])
+        self.assertNotIn("health_monitoring", lanes[1])
+
     def test_product_profile_rejects_colliding_health_check_names(self) -> None:
         payload = {
             "product": "example-site",


### PR DESCRIPTION
## Summary
- Add downgrade coverage for the health-monitoring product-profile migration helper.
- Update records docs to match hosted startup behavior: the service entrypoint runs Alembic to head before HTTP startup.

## Verification
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_health_monitoring_migration_preserves_legacy_default_public_check tests.test_product_onboarding.ProductOnboardingTests.test_health_monitoring_migration_downgrades_first_public_check
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff check tests/test_product_onboarding.py
- uv run --extra dev ruff format --check tests/test_product_onboarding.py

## Notes
- markdownlint on docs/records.md still reports pre-existing MD013 at docs/records.md:888; this PR does not touch that line.
- No checked-in live product/lane config added.