### PR TITLE
Add scoped private health endpoint authz grants

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -642,6 +642,8 @@ jobs:
           LAUNCHPLANE_SERVICE_URL: ${{ steps.service.outputs.service_url }}
           LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON: >-
             ${{ vars.LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON }}
+          LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON: >-
+            ${{ vars.LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON }}
           LAUNCHPLANE_AUTHZ_GRANTS_JSON: >-
             ${{ vars.LAUNCHPLANE_AUTHZ_GRANTS_JSON }}
         run: bash scripts/deploy/ensure-authz-grants.sh

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -265,6 +265,13 @@ operator-reviewed routine write access; use local-admin grants for rare broader
 repair authority instead of widening routine local-operator access. Checked-in
 catalogs are not deploy-time authority for these operator scopes.
 
+Private health endpoint grants follow the same scoped local-operator pattern.
+Set `LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON` to an array of
+product/context objects when the local operator should manage DB-backed private
+health endpoint records for those scopes. Scopes must use explicit product and
+context values; wildcard/glob scopes fail closed. Leave it unset to skip
+reconciliation, and do not place endpoint URLs in repo files.
+
 The `Ingress Route Canary Apply` workflow grant is also scoped by operator input,
 not a checked-in product catalog. By default the deploy reconciliation grants the
 workflow `ingress_route.apply` only for `launchplane`/`launchplane`. Set

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -229,16 +229,33 @@ local_operator_product_config_scopes_json() {
 	printf '[]\n'
 }
 
-post_local_operator_product_config_grants() {
+local_operator_private_health_endpoint_scopes_json() {
+	if [ -n "${LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON:-}" ]; then
+		jq -c \
+			'if type != "array" then error("LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON must be a JSON array") else . end
+       | map({product: (.product // ""), context: (.context // "")})
+       | map(select((.product | length) > 0 and (.context | length) > 0))
+       | if any(.[]; (.product | test("[\\*\\?\\[]")) or (.context | test("[\\*\\?\\[]"))) then error("LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON must use explicit product/context values") else . end
+       | unique_by(.product, .context)' \
+			<<<"${LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON}" ||
+			return 1
+		return 0
+	fi
+
+	printf '[]\n'
+}
+
+post_scoped_local_operator_grants() {
 	local action_name="$1"
 	local source_label_prefix="$2"
 	local idempotency_prefix="$3"
-	local scopes_json scope_count product_name context_name scope_suffix
+	local scopes_json="$4"
+	local missing_message="$5"
+	local scope_count product_name context_name scope_suffix
 
-	scopes_json="$(local_operator_product_config_scopes_json)"
 	scope_count="$(jq 'length' <<<"$scopes_json")"
 	if [ "$scope_count" = "0" ]; then
-		echo "LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON is unset or empty; skipping local-operator ${action_name} grant reconciliation."
+		echo "$missing_message"
 		return 0
 	fi
 
@@ -254,6 +271,36 @@ post_local_operator_product_config_grants() {
 			"${source_label_prefix}-${scope_suffix}" \
 			"${idempotency_prefix}-${scope_suffix}"
 	done
+}
+
+post_local_operator_product_config_grants() {
+	local action_name="$1"
+	local source_label_prefix="$2"
+	local idempotency_prefix="$3"
+	local scopes_json
+
+	scopes_json="$(local_operator_product_config_scopes_json)"
+	post_scoped_local_operator_grants \
+		"$action_name" \
+		"$source_label_prefix" \
+		"$idempotency_prefix" \
+		"$scopes_json" \
+		"LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON is unset or empty; skipping local-operator ${action_name} grant reconciliation."
+}
+
+post_local_operator_private_health_endpoint_grants() {
+	local action_name="$1"
+	local source_label_prefix="$2"
+	local idempotency_prefix="$3"
+	local scopes_json
+
+	scopes_json="$(local_operator_private_health_endpoint_scopes_json)"
+	post_scoped_local_operator_grants \
+		"$action_name" \
+		"$source_label_prefix" \
+		"$idempotency_prefix" \
+		"$scopes_json" \
+		"LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON is unset or empty; skipping local-operator ${action_name} grant reconciliation."
 }
 
 ingress_canary_route_scopes_json() {
@@ -645,6 +692,14 @@ post_local_owner_grant \
 	edge_endpoint.read \
 	deploy:local-operator-edge-endpoint-read-grant \
 	local-operator-edge-endpoint-read
+post_local_operator_private_health_endpoint_grants \
+	private_health_endpoint.read \
+	deploy:local-operator-private-health-endpoint-read-grant \
+	local-operator-private-health-endpoint-read
+post_local_operator_private_health_endpoint_grants \
+	private_health_endpoint.apply \
+	deploy:local-operator-private-health-endpoint-apply-grant \
+	local-operator-private-health-endpoint-apply
 post_local_owner_grant \
 	local-operator \
 	launchplane \

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1304,6 +1304,22 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("deploy:local-operator-edge-endpoint-apply-grant", script_text)
         self.assertIn("deploy:local-operator-edge-endpoint-read-grant", script_text)
 
+    def test_deploy_authz_grants_include_private_health_endpoint_authority(
+        self,
+    ) -> None:
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
+
+        self.assertIn("private_health_endpoint.apply", script_text)
+        self.assertIn("private_health_endpoint.read", script_text)
+        self.assertIn(
+            "deploy:local-operator-private-health-endpoint-apply-grant",
+            script_text,
+        )
+        self.assertIn(
+            "deploy:local-operator-private-health-endpoint-read-grant",
+            script_text,
+        )
+
     def test_deploy_authz_grants_include_ingress_canary_route_authority(
         self,
     ) -> None:
@@ -1399,13 +1415,29 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             and "subjects" in grant
             and "token_labels" in grant
         ]
+        private_health_endpoint_grants = [
+            grant
+            for grant in grants
+            if grant["actions"][0].startswith("private_health_endpoint.")
+            and "subjects" in grant
+            and "token_labels" in grant
+        ]
         self.assertEqual(product_config_grants, [])
+        self.assertEqual(private_health_endpoint_grants, [])
         self.assertIn(
             "LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON is unset or empty; skipping local-operator product_config.plan grant reconciliation.",
             result.stdout,
         )
         self.assertIn(
             "LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON is unset or empty; skipping local-operator product_config.apply grant reconciliation.",
+            result.stdout,
+        )
+        self.assertIn(
+            "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON is unset or empty; skipping local-operator private_health_endpoint.read grant reconciliation.",
+            result.stdout,
+        )
+        self.assertIn(
+            "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON is unset or empty; skipping local-operator private_health_endpoint.apply grant reconciliation.",
             result.stdout,
         )
 
@@ -1472,6 +1504,137 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("parse error", result.stderr)
 
+    def test_deploy_authz_grants_fail_on_malformed_private_health_endpoint_scopes(
+        self,
+    ) -> None:
+        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
+        extractor = """
+set -euo pipefail
+PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
+"""
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            captured_bin_directory = temporary_directory / "bin"
+            captured_bin_directory.mkdir()
+            (captured_bin_directory / "curl").write_text(
+                "#!/usr/bin/env bash\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
+                "  *)\n"
+                "    output_file=''\n"
+                '    while [ "$#" -gt 0 ]; do\n'
+                '      case "$1" in\n'
+                '        -o) shift; output_file="$1" ;;\n'
+                "      esac\n"
+                "      shift || true\n"
+                "    done\n"
+                '    if [ -n "$output_file" ]; then\n'
+                '      printf \'{"status":"ok"}\' > "$output_file"\n'
+                "    fi\n"
+                "    printf '200'\n"
+                "    ;;\n"
+                "esac\n"
+            )
+            (captured_bin_directory / "mktemp").write_text(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+            )
+            (captured_bin_directory / "curl").chmod(0o755)
+            (captured_bin_directory / "mktemp").chmod(0o755)
+            captured_response_file = temporary_directory / "response.json"
+            env = {
+                **os.environ,
+                **OWNER_AUTHZ_ENV,
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "GITHUB_SHA": "test-sha",
+                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
+                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+                "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON": "not-json",
+                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
+                "CAPTURED_BIN_DIR": str(captured_bin_directory),
+            }
+
+            result = subprocess.run(
+                ["bash", "-c", extractor],
+                check=False,
+                cwd=script_path.parent.parent.parent,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("parse error", result.stderr)
+
+    def test_deploy_authz_grants_reject_private_health_endpoint_wildcard_scopes(
+        self,
+    ) -> None:
+        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
+        extractor = """
+set -euo pipefail
+PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
+"""
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            captured_bin_directory = temporary_directory / "bin"
+            captured_bin_directory.mkdir()
+            (captured_bin_directory / "curl").write_text(
+                "#!/usr/bin/env bash\n"
+                'case "$*" in\n'
+                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
+                "  *)\n"
+                "    output_file=''\n"
+                '    while [ "$#" -gt 0 ]; do\n'
+                '      case "$1" in\n'
+                '        -o) shift; output_file="$1" ;;\n'
+                "      esac\n"
+                "      shift || true\n"
+                "    done\n"
+                '    if [ -n "$output_file" ]; then\n'
+                '      printf \'{"status":"ok"}\' > "$output_file"\n'
+                "    fi\n"
+                "    printf '200'\n"
+                "    ;;\n"
+                "esac\n"
+            )
+            (captured_bin_directory / "mktemp").write_text(
+                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
+            )
+            (captured_bin_directory / "curl").chmod(0o755)
+            (captured_bin_directory / "mktemp").chmod(0o755)
+            captured_response_file = temporary_directory / "response.json"
+            env = {
+                **os.environ,
+                **OWNER_AUTHZ_ENV,
+                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
+                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "GITHUB_SHA": "test-sha",
+                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
+                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+                "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON": json.dumps(
+                    [{"product": "*", "context": "*"}]
+                ),
+                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
+                "CAPTURED_BIN_DIR": str(captured_bin_directory),
+            }
+
+            result = subprocess.run(
+                ["bash", "-c", extractor],
+                check=False,
+                cwd=script_path.parent.parent.parent,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON must use explicit product/context values",
+            result.stderr,
+        )
+
     def test_deploy_authz_grants_scope_configured_local_operator_product_config(
         self,
     ) -> None:
@@ -1533,6 +1696,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
                 "LAUNCHPLANE_INGRESS_CANARY_ROUTE_SCOPES_JSON": configured_scopes,
                 "LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON": configured_scopes,
+                "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON": configured_scopes,
                 "CAPTURED_GRANTS": str(captured_grants),
                 "CAPTURED_RESPONSE_FILE": str(captured_response_file),
                 "CAPTURED_BIN_DIR": str(captured_bin_directory),
@@ -1561,9 +1725,16 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             and "subjects" in grant
             and "token_labels" in grant
         ]
+        private_health_endpoint_grants = [
+            grant
+            for grant in grants
+            if grant["actions"][0].startswith("private_health_endpoint.")
+            and "subjects" in grant
+            and "token_labels" in grant
+        ]
         scoped_grants = {
             (grant["products"][0], grant["contexts"][0], grant["actions"][0])
-            for grant in product_config_grants
+            for grant in product_config_grants + private_health_endpoint_grants
         }
         canary_workflow_grants = [
             grant
@@ -1586,7 +1757,12 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             {
                 (product, context, action)
                 for product, context in expected_scopes
-                for action in ("product_config.plan", "product_config.apply")
+                for action in (
+                    "product_config.plan",
+                    "product_config.apply",
+                    "private_health_endpoint.read",
+                    "private_health_endpoint.apply",
+                )
             },
         )
         self.assertEqual(canary_scoped_grants, expected_scopes)
@@ -1595,6 +1771,14 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             self.assertNotEqual(grant["contexts"], ["*"])
             self.assertTrue(
                 grant["source_label"].startswith("deploy:local-operator-product-config-")
+            )
+        for grant in private_health_endpoint_grants:
+            self.assertNotEqual(grant["products"], ["*"])
+            self.assertNotEqual(grant["contexts"], ["*"])
+            self.assertTrue(
+                grant["source_label"].startswith(
+                    "deploy:local-operator-private-health-endpoint-"
+                )
             )
         for grant in canary_workflow_grants:
             self.assertNotEqual(grant["products"], ["*"])


### PR DESCRIPTION
## Summary

Adds deploy-time authz reconciliation for local-operator private health endpoint management without granting wildcard authority.

- Adds `LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON` to the deploy authz reconciliation env.
- Reconciles local-operator grants for `private_health_endpoint.read` and `private_health_endpoint.apply` from explicit product/context scopes.
- Fails closed for malformed JSON and wildcard/glob scope values.
- Documents the scoped private-health endpoint grant flow.
- Extends authz grant tests for skip, malformed, wildcard rejection, and scoped grant behavior.

## Security / Runtime Authority

This keeps private endpoint URLs out of checked-in files. The repo only owns the scoped grant mechanism; Launchplane records/operator input own the actual private health endpoint values.

The first draft used wildcard local-operator grants. Agent review rejected that, and this PR now requires explicit scopes via `LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON`.

## Validation

- `bash -n scripts/deploy/ensure-authz-grants.sh`
- `git diff --check`
- `uv run python -m unittest \
  tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_edge_endpoint_authority \
  tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_private_health_endpoint_authority \
  tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_ingress_canary_route_authority \
  tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_skip_local_operator_product_config_without_scopes \
  tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_fail_on_malformed_local_operator_product_config_scopes \
  tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_fail_on_malformed_private_health_endpoint_scopes \
  tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_reject_private_health_endpoint_wildcard_scopes \
  tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_scope_configured_local_operator_product_config`

Agent reviews completed, including final review of wildcard/glob rejection: no blocking findings.
