### PR TITLE
Serve Launchplane through FastAPI boundary

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -4,11 +4,17 @@ from typing import Annotated, Protocol
 from uuid import uuid4
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Path, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from jwt import InvalidTokenError
 from pydantic import BaseModel, ConfigDict
 
 from control_plane import product_read_service as control_plane_product_read_service
+from control_plane.contracts.authz_policy_record import (
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+    build_authz_policy_record_id,
+)
 from control_plane.contracts.product_environment_read_model import (
     ProductEnvironmentConfigStatus,
 )
@@ -47,13 +53,83 @@ class _RecordStoreFactory(Protocol):
     def __call__(self) -> object: ...
 
 
+class LaunchplaneAuthzPolicyRuntime:
+    def __init__(self, policy: LaunchplaneAuthzPolicy) -> None:
+        self._policy = policy
+
+    @property
+    def policy(self) -> LaunchplaneAuthzPolicy:
+        return self._policy
+
+    def update(self, policy: LaunchplaneAuthzPolicy) -> None:
+        self._policy = policy
+
+
+class ResolvedLaunchplaneAuthzPolicy(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    policy: LaunchplaneAuthzPolicy
+    policy_sha256: str
+    source: str
+
+
+def resolve_launchplane_authz_policy(
+    *,
+    record_store: object,
+    bootstrap_policy: LaunchplaneAuthzPolicy,
+    policy_source: str,
+    now_timestamp: str,
+) -> ResolvedLaunchplaneAuthzPolicy:
+    list_records = getattr(record_store, "list_authz_policy_records", None)
+    if callable(list_records):
+        records = list_records(status="active", limit=1)
+        if records:
+            record = records[0]
+            return ResolvedLaunchplaneAuthzPolicy(
+                policy=record.policy,
+                policy_sha256=record.policy_sha256,
+                source="db",
+            )
+
+    policy_sha256 = authz_policy_sha256(bootstrap_policy)
+    write_record = getattr(record_store, "write_authz_policy_record", None)
+    if callable(write_record):
+        record = LaunchplaneAuthzPolicyRecord(
+            record_id=build_authz_policy_record_id(
+                updated_at=now_timestamp,
+                policy_sha256=policy_sha256,
+            ),
+            status="active",
+            source=policy_source,
+            updated_at=now_timestamp,
+            policy_sha256=policy_sha256,
+            policy=bootstrap_policy,
+        )
+        write_record(record)
+        return ResolvedLaunchplaneAuthzPolicy(
+            policy=record.policy,
+            policy_sha256=record.policy_sha256,
+            source="bootstrap_seeded_store",
+        )
+
+    return ResolvedLaunchplaneAuthzPolicy(
+        policy=bootstrap_policy,
+        policy_sha256=policy_sha256,
+        source="bootstrap",
+    )
+
+
 def create_launchplane_fastapi_app(
     *,
     verifier: TokenVerifier,
     authz_policy: LaunchplaneAuthzPolicy,
+    authz_policy_runtime: LaunchplaneAuthzPolicyRuntime | None = None,
     database_url: str | None = None,
     record_store_factory: _RecordStoreFactory | None = None,
 ) -> FastAPI:
+    resolved_authz_policy_runtime = authz_policy_runtime or LaunchplaneAuthzPolicyRuntime(
+        authz_policy
+    )
     shared_record_store: object | None = (
         None
         if record_store_factory is not None
@@ -97,8 +173,8 @@ def create_launchplane_fastapi_app(
             raise _authentication_required_error(str(error)) from error
 
     def read_product_environment_config_status(
-        product: Annotated[str, Path(min_length=1)],
-        environment: Annotated[str, Path(min_length=1)],
+        product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        environment: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
         record_store: Annotated[object, Depends(get_record_store)],
     ) -> ProductEnvironmentConfigStatusResponse:
@@ -107,7 +183,7 @@ def create_launchplane_fastapi_app(
         def product_action_allowed(
             requested_action: str, requested_product: str, requested_context: str
         ) -> bool:
-            return authz_policy.allows(
+            return resolved_authz_policy_runtime.policy.allows(
                 identity=identity,
                 action=requested_action,
                 product=requested_product,
@@ -196,6 +272,23 @@ def create_launchplane_fastapi_app(
             headers=http_error.headers,
         )
 
+    def launchplane_request_validation_exception_handler(
+        _request: Request, error: Exception
+    ) -> JSONResponse:
+        if not isinstance(error, RequestValidationError):
+            raise error
+        payload = LaunchplaneErrorResponse(
+            trace_id=next_trace_id(),
+            error=LaunchplaneErrorDetail(
+                code="invalid_request",
+                message="Launchplane request validation failed.",
+            ),
+        )
+        return JSONResponse(
+            status_code=400,
+            content=payload.model_dump(mode="json"),
+        )
+
     app.add_api_route(
         "/v1/products/{product}/environments/{environment}/config-status",
         read_product_environment_config_status,
@@ -210,6 +303,10 @@ def create_launchplane_fastapi_app(
         },
     )
     app.add_exception_handler(HTTPException, launchplane_http_exception_handler)
+    app.add_exception_handler(
+        RequestValidationError,
+        launchplane_request_validation_exception_handler,
+    )
 
     return app
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -10,17 +10,16 @@ import os
 import re
 import secrets
 import threading
-from socketserver import ThreadingMixIn
 import uuid
 from pathlib import Path
 from typing import Any, BinaryIO, Callable, Iterable, Literal, Protocol, cast
 from urllib.parse import parse_qs
-from wsgiref.simple_server import WSGIServer, make_server
-from wsgiref.types import WSGIApplication
 
 import click
+from a2wsgi import WSGIMiddleware
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 from jwt import InvalidTokenError
+from starlette.types import ASGIApp
 
 from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import dokploy as control_plane_dokploy
@@ -32,6 +31,11 @@ from control_plane import product_context_audit as control_plane_product_context
 from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane import product_read_service as control_plane_product_read_service
+from control_plane.http_app import (
+    LaunchplaneAuthzPolicyRuntime,
+    create_launchplane_fastapi_app,
+    resolve_launchplane_authz_policy,
+)
 from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
@@ -42,8 +46,6 @@ from control_plane.agent_context_service import (
 )
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
-    authz_policy_sha256,
-    build_authz_policy_record_id,
 )
 from control_plane.contracts.agent_write_intent import (
     AgentWriteIntentRecord,
@@ -2486,10 +2488,6 @@ class LiveTargetRuntimeApplyEnvelope(BaseModel):
     @property
     def apply_changes(self) -> bool:
         return self.mode == "apply"
-
-
-class ThreadingWSGIServer(ThreadingMixIn, WSGIServer):
-    daemon_threads = True
 
 
 def _redirect_response(
@@ -9863,32 +9861,17 @@ def _resolve_authz_policy(
     record_store: object,
     bootstrap_policy: LaunchplaneAuthzPolicy,
 ) -> tuple[LaunchplaneAuthzPolicy, str, str]:
-    list_records = getattr(record_store, "list_authz_policy_records", None)
-    if callable(list_records):
-        records = list_records(status="active", limit=1)
-        if records:
-            record = records[0]
-            return record.policy, record.policy_sha256, "db"
-
-    policy_sha256 = authz_policy_sha256(bootstrap_policy)
-    write_record = getattr(record_store, "write_authz_policy_record", None)
-    if callable(write_record):
-        updated_at = _now_timestamp()
-        record = LaunchplaneAuthzPolicyRecord(
-            record_id=build_authz_policy_record_id(
-                updated_at=updated_at,
-                policy_sha256=policy_sha256,
-            ),
-            status="active",
-            source=_bootstrap_policy_source_from_env(),
-            updated_at=updated_at,
-            policy_sha256=policy_sha256,
-            policy=bootstrap_policy,
-        )
-        write_record(record)
-        return record.policy, record.policy_sha256, "bootstrap_seeded_store"
-
-    return bootstrap_policy, policy_sha256, "bootstrap"
+    resolved_policy = resolve_launchplane_authz_policy(
+        record_store=record_store,
+        bootstrap_policy=bootstrap_policy,
+        policy_source=_bootstrap_policy_source_from_env(),
+        now_timestamp=_now_timestamp(),
+    )
+    return (
+        resolved_policy.policy,
+        resolved_policy.policy_sha256,
+        resolved_policy.source,
+    )
 
 
 def _launchplane_policy_sha256_from_env() -> str:
@@ -10411,17 +10394,25 @@ def create_launchplane_service_app(
     preview_pr_feedback_discord_sender: Callable[
         [str, dict[str, object]], object
     ] = post_discord_webhook,
+    authz_policy_runtime: LaunchplaneAuthzPolicyRuntime | None = None,
+    record_store_for_service: _TestLaunchplaneServiceRecordStore | None = None,
 ) -> _WsgiApp:
     resolved_root = control_plane_root_path or control_plane_root()
     ui_static_root = resolved_root / "control_plane" / "ui_static"
     record_store = cast(
         PostgresRecordStore,
-        local_record_store_for_tests or build_shared_record_store(database_url=database_url),
+        record_store_for_service
+        or local_record_store_for_tests
+        or build_shared_record_store(database_url=database_url),
     )
     storage_backend = storage_backend_name(record_store)
     authz_policy, resolved_authz_policy_sha256, resolved_authz_policy_source = (
         _resolve_authz_policy(record_store=record_store, bootstrap_policy=authz_policy)
     )
+    resolved_authz_policy_runtime = authz_policy_runtime or LaunchplaneAuthzPolicyRuntime(
+        authz_policy
+    )
+    resolved_authz_policy_runtime.update(authz_policy)
     resolved_github_oauth_config = github_oauth_config or load_github_oauth_config_from_env()
     oauth_login_states = OAuthLoginStateStore()
     session_manager = (
@@ -14762,6 +14753,7 @@ def create_launchplane_service_app(
                     )
                 if authz_grant_request.mode == "apply":
                     authz_policy = updated_policy
+                    resolved_authz_policy_runtime.update(updated_policy)
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -14880,6 +14872,7 @@ def create_launchplane_service_app(
                     )
                 if authz_removal_request.mode == "apply":
                     authz_policy = updated_policy
+                    resolved_authz_policy_runtime.update(updated_policy)
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -14998,6 +14991,7 @@ def create_launchplane_service_app(
                     )
                 if human_authz_grant_request.mode == "apply":
                     authz_policy = updated_policy
+                    resolved_authz_policy_runtime.update(updated_policy)
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -15116,6 +15110,7 @@ def create_launchplane_service_app(
                     )
                 if terminal_authz_grant_request.mode == "apply":
                     authz_policy = updated_policy
+                    resolved_authz_policy_runtime.update(updated_policy)
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -15212,6 +15207,7 @@ def create_launchplane_service_app(
                     )
                 if local_operator_grant_request.mode == "apply":
                     authz_policy = updated_policy
+                    resolved_authz_policy_runtime.update(updated_policy)
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -15308,6 +15304,7 @@ def create_launchplane_service_app(
                     )
                 if local_admin_grant_request.mode == "apply":
                     authz_policy = updated_policy
+                    resolved_authz_policy_runtime.update(updated_policy)
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -17084,10 +17081,20 @@ def serve_launchplane_service(
     audience: str,
     database_url: str | None = None,
 ) -> None:
+    import uvicorn
+
     from control_plane.service_auth import GitHubOidcVerifier
 
-    authz_policy = load_authz_policy(policy_file)
+    bootstrap_authz_policy = load_authz_policy(policy_file)
     verifier = GitHubOidcVerifier(audience=audience)
+    service_record_store = build_shared_record_store(database_url=database_url)
+    resolved_fastapi_policy = resolve_launchplane_authz_policy(
+        record_store=service_record_store,
+        bootstrap_policy=bootstrap_authz_policy,
+        policy_source=_bootstrap_policy_source_from_env(),
+        now_timestamp=_now_timestamp(),
+    )
+    authz_policy_runtime = LaunchplaneAuthzPolicyRuntime(resolved_fastapi_policy.policy)
     work_graph_project_config = load_github_project_planning_facts_config_from_env(dict(os.environ))
     work_graph_planning_facts_provider = (
         (lambda: build_github_project_planning_facts(work_graph_project_config))
@@ -17122,17 +17129,31 @@ def serve_launchplane_service(
     application = create_launchplane_service_app(
         state_dir=state_dir,
         verifier=verifier,
-        authz_policy=authz_policy,
+        authz_policy=bootstrap_authz_policy,
         database_url=database_url,
         work_graph_planning_facts_provider=work_graph_planning_facts_provider,
         work_graph_issue_inbox_provider=work_graph_issue_inbox_provider,
         work_graph_issue_inbox_reconcile_provider=work_graph_issue_inbox_reconcile_provider,
+        authz_policy_runtime=authz_policy_runtime,
+        record_store_for_service=service_record_store,
     )
-    with make_server(
-        host,
-        port,
-        cast(WSGIApplication, application),
-        server_class=ThreadingWSGIServer,
-    ) as server:
-        click.echo(f"Launchplane service listening on http://{host}:{port}")
-        server.serve_forever()
+    fastapi_application = create_launchplane_fastapi_app(
+        verifier=verifier,
+        authz_policy=resolved_fastapi_policy.policy,
+        authz_policy_runtime=authz_policy_runtime,
+        record_store_factory=lambda: service_record_store,
+    )
+    fastapi_application.mount(
+        "/",
+        cast(ASGIApp, WSGIMiddleware(cast(Any, application))),
+    )
+    click.echo(f"Launchplane service listening on http://{host}:{port}")
+    try:
+        uvicorn.run(
+            fastapi_application,
+            host=host,
+            port=port,
+            log_config=None,
+        )
+    finally:
+        service_record_store.close()

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -36,6 +36,8 @@ The service boundary is implemented and deployed for the current Odoo and
 VeriReel product paths:
 
 - CLI: `uv run launchplane service serve`
+- server runtime: FastAPI served by Uvicorn, with legacy WSGI routes mounted as
+  the fallback while route ownership is migrated incrementally
 - health route: `GET /v1/health`
 - protected artifact inventory route:
   - `GET /v1/artifacts/protected`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "sqlalchemy>=2.0.50",
     "uvicorn>=0.38.0",
     "alembic>=1.18.4",
+    "a2wsgi>=1.10.10",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4,18 +4,22 @@ from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from collections.abc import MutableMapping
-from typing import Any
+from typing import Any, cast
 from unittest.mock import patch
 
+from a2wsgi import WSGIMiddleware
 from fastapi import FastAPI
 from jwt import InvalidTokenError
+from starlette.types import ASGIApp
 
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
+from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from tests.test_service import create_launchplane_service_app
 from tests.test_service import _generic_site_profile_payload, _identity, _sqlite_database_url
 from tests.test_service import _StubVerifier
 
@@ -57,14 +61,16 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
                     actor="test",
                 )
             store.close()
+            app_store = PostgresRecordStore(database_url=database_url)
 
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_identity()),
                 authz_policy=_product_environment_read_policy(context="example-site"),
-                database_url=database_url,
+                record_store_factory=lambda: app_store,
             )
 
             response = await _get_config_status(app)
+            app_store.close()
 
         self.assertEqual(response.status_code, 200)
         payload = response.json()
@@ -97,13 +103,15 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
                 LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
             )
             store.close()
+            app_store = PostgresRecordStore(database_url=database_url)
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_identity()),
                 authz_policy=_product_environment_read_policy(context="launchplane"),
-                database_url=database_url,
+                record_store_factory=lambda: app_store,
             )
 
             response = await _get_config_status(app)
+            app_store.close()
 
         self.assertEqual(response.status_code, 403)
         payload = response.json()
@@ -120,13 +128,15 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
                 LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
             )
             store.close()
+            app_store = PostgresRecordStore(database_url=database_url)
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_identity()),
                 authz_policy=_product_environment_read_policy(context="example-site"),
-                database_url=database_url,
+                record_store_factory=lambda: app_store,
             )
 
             response = await _get_config_status(app, environment="staging")
+            app_store.close()
 
         self.assertEqual(response.status_code, 404)
         payload = response.json()
@@ -182,6 +192,26 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
         self.assertEqual(payload["status"], "rejected")
         self.assertEqual(payload["error"]["code"], "database_storage_required")
 
+    async def test_config_status_validation_errors_use_launchplane_error_shape(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_environment_read_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(
+            app,
+            "/v1/products/ /environments/prod/config-status",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertIn("trace_id", payload)
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertNotIn("detail", payload)
+
     async def test_openapi_includes_config_status_route(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_identity()),
@@ -198,6 +228,38 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
         ]
         self.assertIn("ProductEnvironmentConfigStatusResponse", json.dumps(route))
         self.assertIn("LaunchplaneErrorResponse", json.dumps(route))
+
+    async def test_fastapi_app_can_mount_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = FilesystemRecordStore(state_dir=root / "state")
+            policy = _product_environment_read_policy(context="example-site")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: record_store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                local_record_store_for_tests=record_store,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            openapi_response = await _asgi_get(app, "/openapi.json")
+            health_response = await _asgi_get(app, "/v1/health")
+
+        self.assertEqual(openapi_response.status_code, 200)
+        self.assertIn(
+            "/v1/products/{product}/environments/{environment}/config-status",
+            openapi_response.json()["paths"],
+        )
+        self.assertEqual(health_response.status_code, 200)
+        health_payload = health_response.json()
+        self.assertEqual(health_payload["status"], "ok")
+        self.assertEqual(health_payload["storage_backend"], "filesystem")
+        self.assertIn("trace_id", health_payload)
 
 
 def _product_environment_read_policy(*, context: str) -> LaunchplaneAuthzPolicy:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -6,7 +7,8 @@ import json
 import os
 import tempfile
 import unittest
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -2002,6 +2004,82 @@ def _invoke_raw_app(
         int(captured_status.split(" ", 1)[0]),
         dict(captured_headers),
         response_body,
+    )
+
+
+@dataclass(frozen=True)
+class _AsgiServiceTestResponse:
+    status_code: int
+    headers: dict[str, str]
+    body: bytes
+
+    def json(self) -> Any:
+        return json.loads(self.body.decode("utf-8"))
+
+
+async def _asgi_get_for_service_test(app: Any, path: str) -> _AsgiServiceTestResponse:
+    return await _asgi_request_for_service_test(app, method="GET", path=path)
+
+
+async def _asgi_request_for_service_test(
+    app: Any,
+    *,
+    method: str,
+    path: str,
+    payload: Mapping[str, object] | None = None,
+    authorization: str = "",
+    headers: Mapping[str, str] | None = None,
+) -> _AsgiServiceTestResponse:
+    body = json.dumps(payload).encode("utf-8") if payload is not None else b""
+    request_headers = [
+        (key.lower().encode("ascii"), value.encode("latin-1"))
+        for key, value in (headers or {}).items()
+    ]
+    if authorization:
+        request_headers.append((b"authorization", authorization.encode("latin-1")))
+    if body:
+        request_headers.append((b"content-type", b"application/json"))
+        request_headers.append((b"content-length", str(len(body)).encode("ascii")))
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": method,
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode("ascii"),
+        "query_string": b"",
+        "headers": request_headers,
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+        "root_path": "",
+    }
+    messages = [
+        {"type": "http.request", "body": body, "more_body": False},
+    ]
+    sent: list[MutableMapping[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message: MutableMapping[str, Any]) -> None:
+        sent.append(message)
+
+    await app(scope, receive, send)
+
+    start = next(message for message in sent if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"") for message in sent if message["type"] == "http.response.body"
+    )
+    response_headers = {
+        key.decode("latin-1"): value.decode("latin-1") for key, value in start.get("headers", [])
+    }
+    return _AsgiServiceTestResponse(
+        status_code=start["status"],
+        headers=response_headers,
+        body=body,
     )
 
 
@@ -14033,6 +14111,148 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 1, msg=result.output)
         self.assertIn("refuses startup without --audience", result.output)
+
+    def test_service_serve_runs_fastapi_app_with_legacy_wsgi_fallback(self) -> None:
+        fastapi_response: _AsgiServiceTestResponse | None = None
+        legacy_response: _AsgiServiceTestResponse | None = None
+        denied_config_response: _AsgiServiceTestResponse | None = None
+        grant_response: _AsgiServiceTestResponse | None = None
+        authorized_config_response: _AsgiServiceTestResponse | None = None
+
+        def capture_uvicorn_run(app: Any, **_kwargs: object) -> None:
+            nonlocal fastapi_response, legacy_response, denied_config_response
+            nonlocal grant_response, authorized_config_response
+            fastapi_response = asyncio.run(_asgi_get_for_service_test(app, "/openapi.json"))
+            legacy_response = asyncio.run(_asgi_get_for_service_test(app, "/v1/health"))
+            denied_config_response = asyncio.run(
+                _asgi_request_for_service_test(
+                    app,
+                    method="GET",
+                    path="/v1/products/example-site/environments/prod/config-status",
+                    authorization="Bearer valid-token",
+                )
+            )
+            grant_response = asyncio.run(
+                _asgi_request_for_service_test(
+                    app,
+                    method="POST",
+                    path="/v1/authz-policies/github-actions/grants",
+                    authorization="Bearer valid-token",
+                    payload={
+                        "schema_version": 1,
+                        "product": "launchplane",
+                        "mode": "apply",
+                        "reason": "Grant FastAPI config-status read for runtime policy refresh test.",
+                        "related_issue": "cbusillo/launchplane#1323",
+                        "grant": {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["example-site"],
+                            "contexts": ["example-site"],
+                            "actions": ["product_environment.read"],
+                            "source_label": "test:fastapi-runtime-policy-refresh",
+                        },
+                    },
+                    headers={"Idempotency-Key": "authz-grant:fastapi-runtime-refresh"},
+                )
+            )
+            authorized_config_response = asyncio.run(
+                _asgi_request_for_service_test(
+                    app,
+                    method="GET",
+                    path="/v1/products/example-site/environments/prod/config-status",
+                    authorization="Bearer valid-token",
+                )
+            )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy_file = root / "policy.toml"
+            policy_file.write_text(
+                "\n".join(
+                    (
+                        "schema_version = 1",
+                        "",
+                        "[[github_actions]]",
+                        'repository = "cbusillo/launchplane"',
+                        "workflow_refs = [",
+                        '  "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main",',
+                        "]",
+                        'event_names = ["workflow_dispatch"]',
+                        'products = ["launchplane"]',
+                        'contexts = ["launchplane"]',
+                        'actions = ["authz_policy_grant.write"]',
+                        "",
+                    )
+                ),
+                encoding="utf-8",
+            )
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            store.close()
+
+            with (
+                patch("uvicorn.run", side_effect=capture_uvicorn_run) as run_uvicorn,
+                patch(
+                    "control_plane.service_auth.GitHubOidcVerifier",
+                    return_value=_StubVerifier(
+                        _identity(
+                            repository="cbusillo/launchplane",
+                            workflow_ref=(
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ),
+                            event_name="workflow_dispatch",
+                        )
+                    ),
+                ),
+            ):
+                control_plane_service.serve_launchplane_service(
+                    state_dir=root / "state",
+                    policy_file=policy_file,
+                    host="127.0.0.1",
+                    port=8080,
+                    audience="launchplane-service",
+                    database_url=database_url,
+                )
+
+            run_uvicorn.assert_called_once()
+
+        self.assertIsNotNone(fastapi_response)
+        self.assertIsNotNone(legacy_response)
+        self.assertIsNotNone(denied_config_response)
+        self.assertIsNotNone(grant_response)
+        self.assertIsNotNone(authorized_config_response)
+        assert fastapi_response is not None
+        assert legacy_response is not None
+        assert denied_config_response is not None
+        assert grant_response is not None
+        assert authorized_config_response is not None
+        self.assertEqual(fastapi_response.status_code, 200)
+        self.assertIn(
+            "/v1/products/{product}/environments/{environment}/config-status",
+            fastapi_response.json()["paths"],
+        )
+        self.assertEqual(legacy_response.status_code, 200)
+        self.assertEqual(legacy_response.json()["status"], "ok")
+        self.assertEqual(legacy_response.json()["storage_backend"], "postgres")
+        self.assertEqual(
+            denied_config_response.status_code,
+            403,
+            msg=denied_config_response.body.decode("utf-8"),
+        )
+        self.assertEqual(grant_response.status_code, 202)
+        self.assertEqual(grant_response.json()["result"]["changed"], True)
+        self.assertEqual(authorized_config_response.status_code, 200)
+        self.assertEqual(
+            authorized_config_response.json()["config_status"]["product"], "example-site"
+        )
 
     def test_service_runtime_endpoint_reports_current_image_reference(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "a2wsgi"
+version = "1.10.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/cb/822c56fbea97e9eee201a2e434a80437f6750ebcb1ed307ee3a0a7505b14/a2wsgi-1.10.10.tar.gz", hash = "sha256:a5bcffb52081ba39df0d5e9a884fc6f819d92e3a42389343ba77cbf809fe1f45", size = 18799, upload-time = "2025-06-18T09:00:10.843Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/d5/349aba3dc421e73cbd4958c0ce0a4f1aa3a738bc0d7de75d2f40ed43a535/a2wsgi-1.10.10-py3-none-any.whl", hash = "sha256:d2b21379479718539dc15fce53b876251a0efe7615352dfe49f6ad1bc507848d", size = 17389, upload-time = "2025-06-18T09:00:09.676Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -371,6 +380,7 @@ name = "launchplane"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "a2wsgi" },
     { name = "alembic" },
     { name = "authlib" },
     { name = "click" },
@@ -391,6 +401,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2wsgi", specifier = ">=1.10.10" },
     { name = "alembic", specifier = ">=1.18.4" },
     { name = "authlib", specifier = ">=1.7.0" },
     { name = "click", specifier = ">=8.4.1" },


### PR DESCRIPTION
## Summary
- serve Launchplane via Uvicorn/FastAPI with legacy WSGI mounted as fallback
- share DB-backed authz policy runtime and record store across FastAPI and WSGI layers
- add maintained a2wsgi bridge, Launchplane-shaped FastAPI validation errors, and serving-boundary docs

## Tests
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev mypy control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run python -m unittest tests.test_http_app tests.test_service.LaunchplaneServiceTests.test_service_serve_runs_fastapi_app_with_legacy_wsgi_fallback tests.test_service.LaunchplaneServiceTests.test_service_serve_rejects_missing_database_url tests.test_service.LaunchplaneServiceTests.test_service_serve_rejects_missing_audience
- uv run python -m unittest

## Review
- Reviewed by GPT, Claude, and Antigravity agents after initial fixes; second pass found no blocking correctness findings and recommended merge after CI.