### PR TITLE
Migrate deployment evidence ingress to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Annotated, Literal, Protocol, cast
@@ -7,7 +9,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException, Path, Query, Reques
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from jwt import InvalidTokenError
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane.contracts.authz_policy_record import (
@@ -15,7 +17,12 @@ from control_plane.contracts.authz_policy_record import (
     authz_policy_sha256,
     build_authz_policy_record_id,
 )
+from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.driver_descriptor import DriverContextView, DriverDescriptor
+from control_plane.contracts.idempotency_record import (
+    LaunchplaneIdempotencyRecord,
+    build_launchplane_idempotency_record_id,
+)
 from control_plane.contracts.product_environment_read_model import (
     ProductEnvironmentConfigStatus,
 )
@@ -28,9 +35,13 @@ from control_plane.drivers.registry import build_driver_context_view, list_drive
 from control_plane.drivers.registry import read_driver_descriptor as read_driver_descriptor_record
 from control_plane.service_auth import (
     BearerIdentityConfig,
+    GitHubActionsIdentity,
     GitHubHumanIdentity,
     LaunchplaneAuthzPolicy,
     LaunchplaneIdentity,
+    LocalAdminIdentity,
+    LocalOperatorIdentity,
+    TerminalAgentIdentity,
     TokenVerifier,
     bearer_identity_from_token,
 )
@@ -38,11 +49,17 @@ from control_plane.service_human_auth import HumanSessionManager, LaunchplaneHum
 from control_plane.storage.factory import build_shared_record_store
 from control_plane.storage.factory import storage_backend_name
 from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.evidence_ingestion import (
+    EvidenceIngestionStore,
+    apply_deployment_evidence,
+)
+from control_plane.workflows.ship import utc_now_timestamp
 
 
 _BEARER_CHALLENGE_HEADER = {"WWW-Authenticate": 'Bearer realm="Launchplane API"'}
 _LAUNCHPLANE_DRIVER_READ_PRODUCT = "launchplane"
 _LAUNCHPLANE_DRIVER_READ_CONTEXT = "launchplane"
+_DEPLOYMENT_EVIDENCE_ROUTE = "/v1/evidence/deployments"
 
 
 class LaunchplaneErrorDetail(BaseModel):
@@ -139,8 +156,42 @@ class ProtectedArtifactsResponse(BaseModel):
     protected_artifacts: ProtectedArtifactSet
 
 
+class DeploymentEvidenceRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    deployment: DeploymentRecord
+
+    def model_post_init(self, _context: object) -> None:
+        if not self.product.strip():
+            raise ValueError("deployment evidence requires product")
+
+
+class AcceptedEvidenceResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["accepted"] = "accepted"
+    trace_id: str
+    records: dict[str, str]
+    replayed: bool | None = None
+    original_trace_id: str | None = None
+
+
 class _RecordStoreFactory(Protocol):
     def __call__(self) -> object: ...
+
+
+class _IdempotencyCapableStore(Protocol):
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> LaunchplaneIdempotencyRecord | None: ...
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> object: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -165,6 +216,62 @@ def require_protected_artifact_store(record_store: object) -> ProtectedArtifactS
             f"reads: {missing_summary}"
         )
     return cast(ProtectedArtifactStore, record_store)
+
+
+def require_evidence_ingestion_store(record_store: object) -> EvidenceIngestionStore:
+    required_methods = (
+        "write_deployment_record",
+        "read_deployment_record",
+        "read_promotion_record",
+        "write_promotion_record",
+        "write_environment_inventory",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support evidence ingestion writes: "
+            f"{missing_summary}"
+        )
+    return cast(EvidenceIngestionStore, record_store)
+
+
+def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
+    if callable(getattr(record_store, "read_idempotency_record", None)) and callable(
+        getattr(record_store, "write_idempotency_record", None)
+    ):
+        return cast(_IdempotencyCapableStore, record_store)
+    return None
+
+
+def idempotency_scope(identity: LaunchplaneIdentity) -> str:
+    if isinstance(identity, GitHubHumanIdentity):
+        return "|".join(("github-human", identity.login, str(identity.github_id)))
+    if isinstance(identity, LocalOperatorIdentity):
+        return "|".join(("local-operator", identity.subject, identity.token_label))
+    if isinstance(identity, LocalAdminIdentity):
+        return "|".join(("local-admin", identity.subject, identity.token_label))
+    if isinstance(identity, TerminalAgentIdentity):
+        return "|".join(("terminal-agent", identity.subject, identity.token_label))
+    if isinstance(identity, GitHubActionsIdentity):
+        workflow_ref = identity.workflow_ref or identity.job_workflow_ref or ""
+        return "|".join(
+            (
+                str(identity.repository).strip(),
+                str(workflow_ref).strip(),
+                str(identity.subject).strip(),
+            )
+        )
+    raise TypeError(f"Unsupported Launchplane identity type: {type(identity).__name__}")
+
+
+def request_fingerprint(payload: dict[str, object]) -> str:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 class LaunchplaneAuthzPolicyRuntime:
@@ -334,6 +441,40 @@ def create_launchplane_fastapi_app(
         if human_identity is not None:
             return human_identity
         raise _authentication_required_error("Authorization header is required.")
+
+    def read_write_identity(
+        authorization: Annotated[str, Header(alias="Authorization")] = "",
+    ) -> LaunchplaneIdentity:
+        header = authorization.strip()
+        if not header:
+            raise _authentication_required_error("Authorization header is required.")
+        scheme, _, token = header.partition(" ")
+        bearer_token = token.strip()
+        if scheme.lower() != "bearer" or not bearer_token:
+            raise _authentication_required_error("Bearer token is required.")
+        try:
+            owner_agent_identity = bearer_identity_from_token(
+                token=bearer_token,
+                config=bearer_identity_config or BearerIdentityConfig(),
+            )
+        except PermissionError as error:
+            raise _authentication_required_error(str(error)) from error
+        if isinstance(owner_agent_identity, LocalAdminIdentity | LocalOperatorIdentity):
+            return owner_agent_identity
+        if owner_agent_identity is not None:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=next_trace_id(),
+                code="authorization_denied",
+                message=("Terminal agent credentials can only read redacted Launchplane context."),
+            )
+        try:
+            oidc_identity = verifier.verify(bearer_token)
+        except (InvalidTokenError, ValueError) as error:
+            raise _authentication_required_error(str(error)) from error
+        if not isinstance(oidc_identity, GitHubActionsIdentity):
+            raise _authentication_required_error("Mutation routes require GitHub Actions OIDC.")
+        return oidc_identity
 
     def read_product_environment_config_status(
         product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -534,6 +675,120 @@ def create_launchplane_fastapi_app(
         )
         return DriverContextViewResponse(trace_id=trace_id, view=view)
 
+    def accepted_evidence_response(
+        *,
+        trace_id: str,
+        records: dict[str, str],
+        replayed: bool = False,
+        original_trace_id: str = "",
+    ) -> AcceptedEvidenceResponse:
+        return AcceptedEvidenceResponse(
+            trace_id=trace_id,
+            records=records,
+            replayed=True if replayed else None,
+            original_trace_id=original_trace_id or None,
+        )
+
+    def replay_idempotent_response(
+        *, trace_id: str, stored_record: LaunchplaneIdempotencyRecord
+    ) -> AcceptedEvidenceResponse:
+        stored_records = {
+            str(key): str(value)
+            for key, value in dict(stored_record.response_payload.get("records") or {}).items()
+        }
+        return accepted_evidence_response(
+            trace_id=trace_id,
+            records=stored_records,
+            replayed=True,
+            original_trace_id=stored_record.response_trace_id,
+        )
+
+    async def write_deployment_evidence(
+        request: Request,
+        deployment_request: DeploymentEvidenceRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="deployment.write",
+            product=deployment_request.product,
+            context=deployment_request.deployment.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot write deployment evidence for the requested product/context."
+                ),
+            )
+
+        try:
+            evidence_store = require_evidence_ingestion_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+
+        idempotency_store = idempotency_capable_store(record_store)
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_scope = idempotency_scope(identity)
+        raw_payload = await request.json()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if idempotency_store is not None and normalized_idempotency_key:
+            stored_record = idempotency_store.read_idempotency_record(
+                scope=normalized_scope,
+                route_path=_DEPLOYMENT_EVIDENCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            )
+            if stored_record is not None:
+                if stored_record.request_fingerprint != payload_fingerprint:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different "
+                            "Launchplane request payload on this route."
+                        ),
+                    )
+                return replay_idempotent_response(
+                    trace_id=trace_id,
+                    stored_record=stored_record,
+                )
+
+        records = {
+            str(key): str(value)
+            for key, value in apply_deployment_evidence(
+                record_store=evidence_store,
+                deployment_record=deployment_request.deployment,
+            ).items()
+        }
+        response = accepted_evidence_response(trace_id=trace_id, records=records)
+        if idempotency_store is not None and normalized_idempotency_key:
+            idempotency_store.write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id=build_launchplane_idempotency_record_id(
+                        response_trace_id=trace_id,
+                    ),
+                    scope=normalized_scope,
+                    route_path=_DEPLOYMENT_EVIDENCE_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint=payload_fingerprint,
+                    response_status_code=202,
+                    response_trace_id=trace_id,
+                    recorded_at=utc_now_timestamp(),
+                    response_payload=response.model_dump(mode="json", exclude_none=True),
+                )
+            )
+        return response
+
     def read_health(record_store: Annotated[object, Depends(get_record_store)]) -> HealthResponse:
         return HealthResponse(
             trace_id=next_trace_id(),
@@ -624,6 +879,24 @@ def create_launchplane_fastapi_app(
         responses={
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _DEPLOYMENT_EVIDENCE_ROUTE,
+        write_deployment_evidence,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_deployment_evidence",
+        summary="Write deployment evidence",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
         },
     )
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -57,6 +57,12 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
+- Deployment evidence ingestion uses a native FastAPI route for bearer-token
+  callers and preserves the existing `Idempotency-Key` replay/conflict contract.
+  The legacy WSGI branch is shadowed by the native route while the mounted
+  fallback remains for the rest of the evidence family; delete the WSGI branch
+  after caller evidence proves the native deployment-evidence path and the
+  adjacent evidence routes have native coverage or an explicit retained status.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -51,7 +51,8 @@ VeriReel product paths:
     discovery context
 - authenticated evidence routes:
   - `POST /v1/evidence/backup-gates`
-  - `POST /v1/evidence/deployments`
+  - `POST /v1/evidence/deployments` (native FastAPI for bearer-token callers,
+    with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
   - `POST /v1/evidence/promotions`
   - `POST /v1/evidence/previews/generations`
   - `POST /v1/evidence/previews/destroyed`

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -1302,6 +1302,256 @@ class FastApiDriverContextViewTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_deployment_evidence_writes_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_deployment_evidence(app, _deployment_evidence_payload())
+            deployment = store.read_deployment_record("deployment-example-site-prod")
+            inventory = store.read_environment_inventory(
+                context_name="example-site",
+                instance_name="prod",
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"],
+            {
+                "deployment_record_id": "deployment-example-site-prod",
+                "inventory_record_id": "example-site-prod",
+            },
+        )
+        self.assertNotIn("replayed", payload)
+        self.assertEqual(deployment.context, "example-site")
+        self.assertEqual(deployment.instance, "prod")
+        self.assertEqual(deployment.deploy.status, "pass")
+        self.assertEqual(inventory.deployment_record_id, deployment.record_id)
+
+    async def test_deployment_evidence_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="other-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_deployment_evidence(app, _deployment_evidence_payload())
+            with self.assertRaises(FileNotFoundError):
+                store.read_deployment_record("deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_deployment_evidence_rejects_human_session_mutation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            oauth_config = _github_oauth_config()
+            session_store = InMemoryHumanSessionStore()
+            session_manager = HumanSessionManager(
+                config=oauth_config,
+                session_store=session_store,
+            )
+            human_session = session_manager.issue(_github_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_github_human_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+            )
+
+            response = await _post_deployment_evidence(
+                app,
+                _deployment_evidence_payload(),
+                authorization="",
+                headers={"Cookie": session_manager.session_cookie_header(human_session)},
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_deployment_record("deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_deployment_evidence_rejects_terminal_agent_mutation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-agent-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+            )
+
+            response = await _post_deployment_evidence(
+                app,
+                _deployment_evidence_payload(),
+                authorization="Bearer terminal-agent-token",
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_deployment_record("deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_deployment_evidence_validation_errors_use_launchplane_shape(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            invalid_payload = _deployment_evidence_payload()
+            invalid_payload["product"] = ""
+
+            response = await _post_deployment_evidence(app, invalid_payload)
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertNotIn("detail", payload)
+
+    async def test_deployment_evidence_replays_idempotent_write(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _deployment_evidence_payload()
+
+            first_response = await _post_deployment_evidence(
+                app,
+                request_payload,
+                idempotency_key="deployment-example-site-prod",
+            )
+            second_response = await _post_deployment_evidence(
+                app,
+                request_payload,
+                idempotency_key="deployment-example-site-prod",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertNotEqual(second_payload["trace_id"], first_payload["trace_id"])
+
+    async def test_deployment_evidence_rejects_idempotency_key_reuse(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _deployment_evidence_payload()
+            changed_payload = _deployment_evidence_payload(
+                record_id="deployment-example-site-prod-2"
+            )
+
+            first_response = await _post_deployment_evidence(
+                app,
+                request_payload,
+                idempotency_key="deployment-example-site-prod",
+            )
+            second_response = await _post_deployment_evidence(
+                app,
+                changed_payload,
+                idempotency_key="deployment-example-site-prod",
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_deployment_record("deployment-example-site-prod-2")
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        payload = second_response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+
+    async def test_openapi_includes_deployment_evidence_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/evidence/deployments"]["post"]
+        self.assertEqual(route["operationId"], "write_deployment_evidence")
+        self.assertEqual(
+            route["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/DeploymentEvidenceRequest",
+        )
+        self.assertEqual(
+            route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        for status_code in ("400", "401", "403", "409", "503"):
+            self.assertIn("LaunchplaneErrorResponse", json.dumps(route["responses"][status_code]))
+        self.assertEqual(
+            openapi["components"]["schemas"]["DeploymentEvidenceRequest"]["additionalProperties"],
+            False,
+        )
+
+    async def test_deployment_evidence_native_route_precedes_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _post_deployment_evidence(app, _deployment_evidence_payload())
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"]["deployment_record_id"], "deployment-example-site-prod")
+
+
 def _product_environment_read_policy(*, context: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -1335,6 +1585,106 @@ def _driver_read_policy(*, context: str = "launchplane") -> LaunchplaneAuthzPoli
             ]
         }
     )
+
+
+def _deployment_write_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="every/example-site",
+        workflow_ref="every/example-site/.github/workflows/deploy-prod.yml@refs/heads/main",
+        event_name="workflow_dispatch",
+    )
+
+
+def _deployment_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/example-site",
+                    "workflow_refs": [
+                        "every/example-site/.github/workflows/deploy-prod.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["deployment.write"],
+                }
+            ]
+        }
+    )
+
+
+def _github_human_deployment_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_humans": [
+                {
+                    "logins": ["example-operator"],
+                    "roles": ["admin"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["deployment.write"],
+                }
+            ]
+        }
+    )
+
+
+def _terminal_agent_deployment_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["deployment.write"],
+                }
+            ]
+        }
+    )
+
+
+def _deployment_evidence_payload(
+    *, record_id: str = "deployment-example-site-prod"
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": "example-site",
+        "deployment": {
+            "record_id": record_id,
+            "artifact_identity": {"artifact_id": "artifact-example-site-prod"},
+            "context": "example-site",
+            "instance": "prod",
+            "source_git_ref": "6b3c9d7e8f901234567890abcdef1234567890ab",
+            "resolved_target": {
+                "target_type": "application",
+                "target_id": "target-example-site-prod",
+                "target_name": "example-site-prod",
+            },
+            "deploy": {
+                "target_name": "example-site-prod",
+                "target_type": "application",
+                "deploy_mode": "runtime-provider-api",
+                "deployment_id": "provider-deployment-example-site-prod",
+                "status": "pass",
+                "started_at": "2026-04-20T15:30:00Z",
+                "finished_at": "2026-04-20T15:32:00Z",
+            },
+            "post_deploy_update": {
+                "attempted": True,
+                "status": "pass",
+                "detail": "Update completed.",
+            },
+            "destination_health": {
+                "verified": True,
+                "urls": ["https://example.invalid/health"],
+                "timeout_seconds": 45,
+                "status": "pass",
+            },
+        },
+    }
 
 
 def _github_human_driver_read_policy(*, context: str = "launchplane") -> LaunchplaneAuthzPolicy:
@@ -1595,19 +1945,58 @@ async def _get_driver_instance_view(
     )
 
 
+async def _post_deployment_evidence(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/evidence/deployments",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _asgi_get(
     app: FastAPI, path: str, *, headers: dict[str, str] | None = None
 ) -> _AsgiResponse:
+    return await _asgi_request(app, "GET", path, headers=headers)
+
+
+async def _asgi_request(
+    app: FastAPI,
+    method: str,
+    path: str,
+    *,
+    headers: dict[str, str] | None = None,
+    payload: dict[str, object] | None = None,
+) -> _AsgiResponse:
     request_path, separator, raw_query_string = path.partition("?")
+    request_headers_dict = dict(headers or {})
+    body = b""
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        request_headers_dict.setdefault("Content-Type", "application/json")
+    request_headers_dict.setdefault("Content-Length", str(len(body)))
     request_headers = [
         (key.lower().encode("ascii"), value.encode("latin-1"))
-        for key, value in (headers or {}).items()
+        for key, value in request_headers_dict.items()
     ]
     scope = {
         "type": "http",
         "asgi": {"version": "3.0", "spec_version": "2.3"},
         "http_version": "1.1",
-        "method": "GET",
+        "method": method,
         "scheme": "http",
         "path": request_path,
         "raw_path": request_path.encode("ascii"),
@@ -1617,7 +2006,7 @@ async def _asgi_get(
         "server": ("testserver", 80),
     }
     messages = [
-        {"type": "http.request", "body": b"", "more_body": False},
+        {"type": "http.request", "body": body, "more_body": False},
     ]
     sent: list[MutableMapping[str, Any]] = []
 


### PR DESCRIPTION
## Summary
- Adds native FastAPI handling for `POST /v1/evidence/deployments` while the mounted WSGI fallback remains for adjacent evidence routes.
- Preserves bearer-token mutation boundaries, `deployment.write` policy checks, deployment/inventory writes, and `Idempotency-Key` replay/conflict behavior.
- Adds focused FastAPI route, auth, idempotency, route precedence, and OpenAPI contract coverage, plus service-boundary and compatibility-retirement docs.

## Review Notes
- Used GPT, Claude, and Antigravity agents for pre-implementation guidance and patch review.
- Addressed the main review finding by replacing generic read identity handling with a stricter bearer write dependency and regression tests for human-session and terminal-agent rejection.
- Kept the idempotency read-before-write shape scoped to the legacy contract; concurrent first-write hardening remains a broader storage concern rather than part of this route migration.

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiDeploymentEvidenceTests`
- `uv run --extra dev ruff format control_plane/http_app.py tests/test_http_app.py`
- `uv run --extra dev ruff check control_plane/http_app.py tests/test_http_app.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py tests/test_http_app.py`
- `uv run --extra dev mypy control_plane/http_app.py tests/test_http_app.py`
- `uv run python -m unittest tests.test_http_app tests.test_service.LaunchplaneServiceTests.test_deployment_endpoint_writes_record_for_authorized_workflow tests.test_evidence_ingestion`
- `uv run python -m unittest`
- `uv run python -m unittest tests.test_docs_contracts`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains inspection closeout: PyCharm 2026.1.2, changed-files scope, clean, 0 problems, cleanup closed