### PR TITLE
Fix deployment evidence store gate

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -218,6 +218,25 @@ def require_protected_artifact_store(record_store: object) -> ProtectedArtifactS
     return cast(ProtectedArtifactStore, record_store)
 
 
+def require_deployment_evidence_store(record_store: object) -> EvidenceIngestionStore:
+    required_methods = (
+        "write_deployment_record",
+        "write_environment_inventory",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support deployment evidence writes: "
+            f"{missing_summary}"
+        )
+    return cast(EvidenceIngestionStore, record_store)
+
+
 def require_evidence_ingestion_store(record_store: object) -> EvidenceIngestionStore:
     required_methods = (
         "write_deployment_record",
@@ -726,16 +745,6 @@ def create_launchplane_fastapi_app(
                 ),
             )
 
-        try:
-            evidence_store = require_evidence_ingestion_store(record_store)
-        except TypeError as error:
-            raise _launchplane_http_error(
-                status_code=503,
-                trace_id=trace_id,
-                code="database_storage_required",
-                message=str(error),
-            ) from error
-
         idempotency_store = idempotency_capable_store(record_store)
         normalized_idempotency_key = idempotency_key.strip()
         normalized_scope = idempotency_scope(identity)
@@ -762,6 +771,16 @@ def create_launchplane_fastapi_app(
                     trace_id=trace_id,
                     stored_record=stored_record,
                 )
+
+        try:
+            evidence_store = require_deployment_evidence_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
 
         records = {
             str(key): str(value)

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -821,6 +821,11 @@ writes, not on every possible operator action.
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
 
+`POST /v1/evidence/deployments` only requires the deployment-write record-store
+capability and any available idempotency store. Replay handling runs before the
+deployment-write capability check so a stored response can still be returned if
+the backing store is temporarily write-restricted for deployment evidence.
+
 ### Preview lifecycle endpoints
 
 - `POST /v1/previews/lifecycle-plan`

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from collections.abc import MutableMapping
+from collections.abc import Callable, MutableMapping
 from typing import Any, cast
 from urllib.parse import urlencode
 from unittest.mock import patch
@@ -83,6 +83,64 @@ class FastApiHealthContractTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("launchplane_req_00000000000000000000000000000000", example_text)
         self.assertNotIn("example-site", example_text)
         self.assertNotIn("shinycomputers", example_text)
+
+
+class FastApiDeploymentEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_deployment_evidence_accepts_store_without_promotion_methods(self) -> None:
+        store = _DeploymentEvidenceOnlyStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_deployment_evidence(app, _deployment_evidence_payload())
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"]["deployment_record_id"], "deployment-example-site-prod")
+        self.assertEqual(
+            store.deployment_records["deployment-example-site-prod"]["context"],
+            "example-site",
+        )
+        self.assertEqual(
+            store.environment_inventories[0]["deployment_record_id"],
+            "deployment-example-site-prod",
+        )
+
+    async def test_deployment_evidence_replays_idempotency_before_deployment_gate(self) -> None:
+        store = _IdempotencyOnlyReplayStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: store,
+        )
+        request_payload = _deployment_evidence_payload()
+
+        first_response = await _post_deployment_evidence(
+            app,
+            request_payload,
+            idempotency_key="deployment-example-site-prod",
+        )
+        store.write_deployment_record = None
+        store.write_environment_inventory = None
+        second_response = await _post_deployment_evidence(
+            app,
+            request_payload,
+            idempotency_key="deployment-example-site-prod",
+        )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(store.read_idempotency_calls, 2)
+        self.assertEqual(store.write_deployment_calls, 1)
+        self.assertEqual(store.write_environment_inventory_calls, 1)
 
 
 class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCase):
@@ -2044,6 +2102,59 @@ class _CaseInsensitiveHeaders(dict[str, str]):
 
 class _MissingProductReadStore:
     pass
+
+
+class _DeploymentEvidenceOnlyStore:
+    def __init__(self) -> None:
+        self.deployment_records: dict[str, dict[str, Any]] = {}
+        self.environment_inventories: list[dict[str, Any]] = []
+
+    def write_deployment_record(self, record: DeploymentRecord) -> None:
+        self.deployment_records[record.record_id] = record.model_dump(mode="json")
+
+    def write_environment_inventory(self, inventory: Any) -> None:
+        self.environment_inventories.append(inventory.model_dump(mode="json"))
+
+
+class _IdempotencyOnlyReplayStore:
+    def __init__(self) -> None:
+        self.read_idempotency_calls = 0
+        self.write_deployment_calls = 0
+        self.write_environment_inventory_calls = 0
+        self._stored_record: Any | None = None
+        self.write_deployment_record: Callable[[DeploymentRecord], None] | None = (
+            self._write_deployment_record
+        )
+        self.write_environment_inventory: Callable[[Any], None] | None = (
+            self._write_environment_inventory
+        )
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> Any:
+        self.read_idempotency_calls += 1
+        if self._stored_record is None:
+            return None
+        if (
+            self._stored_record.scope != scope
+            or self._stored_record.route_path != route_path
+            or self._stored_record.idempotency_key != idempotency_key
+        ):
+            return None
+        return self._stored_record
+
+    def write_idempotency_record(self, record: Any) -> None:
+        self._stored_record = record
+
+    def _write_deployment_record(self, record: DeploymentRecord) -> None:
+        self.write_deployment_calls += 1
+
+    def _write_environment_inventory(self, inventory: Any) -> None:
+        self.write_environment_inventory_calls += 1
 
 
 class _RejectingVerifier:


### PR DESCRIPTION
## Summary
- Moves deployment-evidence idempotency replay before the deployment-write store capability check.
- Narrows the deployment-evidence store gate to the methods the route actually needs: `write_deployment_record` and `write_environment_inventory`.
- Adds regression coverage for stores without promotion methods and replay when deployment-write capabilities are temporarily unavailable.
- Documents the route-specific store/idempotency ordering in the service boundary.

## Review
- Revalidated detached auto-review findings against the active branch; both applied to the merged deployment-evidence route and are addressed here.
- Narrow read-only agent review reported no findings on the current diff.

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiDeploymentEvidenceStoreGateTests tests.test_http_app.FastApiDeploymentEvidenceTests`
- `uv run --extra dev ruff check control_plane/http_app.py tests/test_http_app.py docs/service-boundary.md --diff`
- `uv run --extra dev ruff check control_plane/http_app.py tests/test_http_app.py docs/service-boundary.md`
- `uv run --extra dev ruff format control_plane/http_app.py tests/test_http_app.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py tests/test_http_app.py`
- `uv run --extra dev mypy control_plane/http_app.py tests/test_http_app.py`
- JetBrains inspection closeout: PyCharm 2026.1.2, changed-files scope, clean, 0 problems, cleanup closed