### PR TITLE
Migrate backup gate evidence ingress to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -17,6 +17,7 @@ from control_plane.contracts.authz_policy_record import (
     authz_policy_sha256,
     build_authz_policy_record_id,
 )
+from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.driver_descriptor import DriverContextView, DriverDescriptor
 from control_plane.contracts.idempotency_record import (
@@ -60,6 +61,7 @@ _BEARER_CHALLENGE_HEADER = {"WWW-Authenticate": 'Bearer realm="Launchplane API"'
 _LAUNCHPLANE_DRIVER_READ_PRODUCT = "launchplane"
 _LAUNCHPLANE_DRIVER_READ_CONTEXT = "launchplane"
 _DEPLOYMENT_EVIDENCE_ROUTE = "/v1/evidence/deployments"
+_BACKUP_GATE_EVIDENCE_ROUTE = "/v1/evidence/backup-gates"
 
 
 class LaunchplaneErrorDetail(BaseModel):
@@ -168,6 +170,18 @@ class DeploymentEvidenceRequest(BaseModel):
             raise ValueError("deployment evidence requires product")
 
 
+class BackupGateEvidenceRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    backup_gate: BackupGateRecord
+
+    def model_post_init(self, _context: object) -> None:
+        if not self.product.strip():
+            raise ValueError("backup gate evidence requires product")
+
+
 class AcceptedEvidenceResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -192,6 +206,10 @@ class _IdempotencyCapableStore(Protocol):
     ) -> LaunchplaneIdempotencyRecord | None: ...
 
     def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> object: ...
+
+
+class _BackupGateEvidenceStore(Protocol):
+    def write_backup_gate_record(self, record: BackupGateRecord) -> object: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -237,14 +255,8 @@ def require_deployment_evidence_store(record_store: object) -> EvidenceIngestion
     return cast(EvidenceIngestionStore, record_store)
 
 
-def require_evidence_ingestion_store(record_store: object) -> EvidenceIngestionStore:
-    required_methods = (
-        "write_deployment_record",
-        "read_deployment_record",
-        "read_promotion_record",
-        "write_promotion_record",
-        "write_environment_inventory",
-    )
+def require_backup_gate_evidence_store(record_store: object) -> _BackupGateEvidenceStore:
+    required_methods = ("write_backup_gate_record",)
     missing_methods = [
         method_name
         for method_name in required_methods
@@ -253,10 +265,10 @@ def require_evidence_ingestion_store(record_store: object) -> EvidenceIngestionS
     if missing_methods:
         missing_summary = ", ".join(missing_methods)
         raise TypeError(
-            "Launchplane record store does not support evidence ingestion writes: "
+            "Launchplane record store does not support backup gate evidence writes: "
             f"{missing_summary}"
         )
-    return cast(EvidenceIngestionStore, record_store)
+    return cast(_BackupGateEvidenceStore, record_store)
 
 
 def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -808,6 +820,89 @@ def create_launchplane_fastapi_app(
             )
         return response
 
+    async def write_backup_gate_evidence(
+        request: Request,
+        backup_gate_request: BackupGateEvidenceRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="backup_gate.write",
+            product=backup_gate_request.product,
+            context=backup_gate_request.backup_gate.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot write backup gate evidence for the requested product/context."
+                ),
+            )
+
+        idempotency_store = idempotency_capable_store(record_store)
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_scope = idempotency_scope(identity)
+        raw_payload = await request.json()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if idempotency_store is not None and normalized_idempotency_key:
+            stored_record = idempotency_store.read_idempotency_record(
+                scope=normalized_scope,
+                route_path=_BACKUP_GATE_EVIDENCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            )
+            if stored_record is not None:
+                if stored_record.request_fingerprint != payload_fingerprint:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different "
+                            "Launchplane request payload on this route."
+                        ),
+                    )
+                return replay_idempotent_response(
+                    trace_id=trace_id,
+                    stored_record=stored_record,
+                )
+
+        try:
+            evidence_store = require_backup_gate_evidence_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+
+        evidence_store.write_backup_gate_record(backup_gate_request.backup_gate)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"backup_gate_record_id": backup_gate_request.backup_gate.record_id},
+        )
+        if idempotency_store is not None and normalized_idempotency_key:
+            idempotency_store.write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id=build_launchplane_idempotency_record_id(
+                        response_trace_id=trace_id,
+                    ),
+                    scope=normalized_scope,
+                    route_path=_BACKUP_GATE_EVIDENCE_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint=payload_fingerprint,
+                    response_status_code=202,
+                    response_trace_id=trace_id,
+                    recorded_at=utc_now_timestamp(),
+                    response_payload=response.model_dump(mode="json", exclude_none=True),
+                )
+            )
+        return response
+
     def read_health(record_store: Annotated[object, Depends(get_record_store)]) -> HealthResponse:
         return HealthResponse(
             trace_id=next_trace_id(),
@@ -898,6 +993,24 @@ def create_launchplane_fastapi_app(
         responses={
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _BACKUP_GATE_EVIDENCE_ROUTE,
+        write_backup_gate_evidence,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_backup_gate_evidence",
+        summary="Write backup gate evidence",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
         },
     )
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -57,12 +57,13 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment evidence ingestion uses a native FastAPI route for bearer-token
-  callers and preserves the existing `Idempotency-Key` replay/conflict contract.
-  The legacy WSGI branch is shadowed by the native route while the mounted
-  fallback remains for the rest of the evidence family; delete the WSGI branch
-  after caller evidence proves the native deployment-evidence path and the
-  adjacent evidence routes have native coverage or an explicit retained status.
+- Deployment and backup-gate evidence ingestion use native FastAPI routes for
+  bearer-token callers and preserve the existing `Idempotency-Key`
+  replay/conflict contract. Their legacy WSGI branches are shadowed by native
+  routes while the mounted fallback remains for the rest of the evidence family;
+  delete those WSGI branches after caller evidence proves the native paths and
+  the adjacent evidence routes have native coverage or an explicit retained
+  status.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -50,7 +50,8 @@ VeriReel product paths:
   - `GET /v1/drivers/{driver_id}`, requiring `driver.read` for the Launchplane
     discovery context
 - authenticated evidence routes:
-  - `POST /v1/evidence/backup-gates`
+  - `POST /v1/evidence/backup-gates` (native FastAPI for bearer-token callers,
+    with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
   - `POST /v1/evidence/deployments` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
   - `POST /v1/evidence/promotions`
@@ -825,6 +826,11 @@ writes, not on every possible operator action.
 capability and any available idempotency store. Replay handling runs before the
 deployment-write capability check so a stored response can still be returned if
 the backing store is temporarily write-restricted for deployment evidence.
+
+`POST /v1/evidence/backup-gates` only requires the backup-gate record-write
+capability and any available idempotency store. Replay handling runs before the
+backup-gate capability check so a stored response can still be returned if the
+backing store is temporarily write-restricted for backup-gate evidence.
 
 ### Preview lifecycle endpoints
 

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -15,6 +15,7 @@ from jwt import InvalidTokenError
 from starlette.types import ASGIApp
 
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import ArtifactIdentityReference, DeploymentEvidence
@@ -141,6 +142,74 @@ class FastApiDeploymentEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(store.read_idempotency_calls, 2)
         self.assertEqual(store.write_deployment_calls, 1)
         self.assertEqual(store.write_environment_inventory_calls, 1)
+
+
+class FastApiBackupGateEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_backup_gate_evidence_accepts_store_with_only_backup_gate_method(self) -> None:
+        store = _BackupGateEvidenceOnlyStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_backup_gate_write_identity()),
+            authz_policy=_backup_gate_write_policy(context="example-site"),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_backup_gate_evidence(app, _backup_gate_evidence_payload())
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["backup_gate_record_id"], "backup-gate-example-site-prod"
+        )
+        self.assertEqual(
+            store.backup_gate_records["backup-gate-example-site-prod"]["context"],
+            "example-site",
+        )
+
+    async def test_backup_gate_evidence_requires_backup_gate_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_backup_gate_write_identity()),
+            authz_policy=_backup_gate_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_backup_gate_evidence(app, _backup_gate_evidence_payload())
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_backup_gate_evidence_replays_idempotency_before_backup_gate_gate(self) -> None:
+        store = _IdempotencyOnlyBackupGateReplayStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_backup_gate_write_identity()),
+            authz_policy=_backup_gate_write_policy(context="example-site"),
+            record_store_factory=lambda: store,
+        )
+        request_payload = _backup_gate_evidence_payload()
+
+        first_response = await _post_backup_gate_evidence(
+            app,
+            request_payload,
+            idempotency_key="backup-gate-example-site-prod",
+        )
+        store.write_backup_gate_record = None
+        second_response = await _post_backup_gate_evidence(
+            app,
+            request_payload,
+            idempotency_key="backup-gate-example-site-prod",
+        )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(store.read_idempotency_calls, 2)
+        self.assertEqual(store.write_backup_gate_calls, 1)
 
 
 class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCase):
@@ -1360,6 +1429,251 @@ class FastApiDriverContextViewTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_backup_gate_evidence_writes_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_backup_gate_write_identity()),
+                authz_policy=_backup_gate_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_backup_gate_evidence(app, _backup_gate_evidence_payload())
+            backup_gate = store.read_backup_gate_record("backup-gate-example-site-prod")
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"],
+            {"backup_gate_record_id": "backup-gate-example-site-prod"},
+        )
+        self.assertNotIn("replayed", payload)
+        self.assertEqual(backup_gate.context, "example-site")
+        self.assertEqual(backup_gate.instance, "prod")
+        self.assertEqual(backup_gate.status, "pass")
+        self.assertEqual(backup_gate.evidence["snapshot_name"], "snapshot-example-site-prod")
+
+    async def test_backup_gate_evidence_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_backup_gate_write_identity()),
+                authz_policy=_backup_gate_write_policy(context="other-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_backup_gate_evidence(app, _backup_gate_evidence_payload())
+            with self.assertRaises(FileNotFoundError):
+                store.read_backup_gate_record("backup-gate-example-site-prod")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_backup_gate_evidence_rejects_human_session_mutation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            oauth_config = _github_oauth_config()
+            session_store = InMemoryHumanSessionStore()
+            session_manager = HumanSessionManager(
+                config=oauth_config,
+                session_store=session_store,
+            )
+            human_session = session_manager.issue(_github_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_github_human_backup_gate_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+            )
+
+            response = await _post_backup_gate_evidence(
+                app,
+                _backup_gate_evidence_payload(),
+                authorization="",
+                headers={"Cookie": session_manager.session_cookie_header(human_session)},
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_backup_gate_record("backup-gate-example-site-prod")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_backup_gate_evidence_rejects_terminal_agent_mutation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_backup_gate_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-agent-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+            )
+
+            response = await _post_backup_gate_evidence(
+                app,
+                _backup_gate_evidence_payload(),
+                authorization="Bearer terminal-agent-token",
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_backup_gate_record("backup-gate-example-site-prod")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_backup_gate_evidence_validation_errors_use_launchplane_shape(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_backup_gate_write_identity()),
+                authz_policy=_backup_gate_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            invalid_payload = _backup_gate_evidence_payload()
+            invalid_payload["product"] = ""
+
+            response = await _post_backup_gate_evidence(app, invalid_payload)
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertNotIn("detail", payload)
+
+    async def test_backup_gate_evidence_replays_idempotent_write(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_backup_gate_write_identity()),
+                authz_policy=_backup_gate_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _backup_gate_evidence_payload()
+
+            first_response = await _post_backup_gate_evidence(
+                app,
+                request_payload,
+                idempotency_key="backup-gate-example-site-prod",
+            )
+            second_response = await _post_backup_gate_evidence(
+                app,
+                request_payload,
+                idempotency_key="backup-gate-example-site-prod",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertNotEqual(second_payload["trace_id"], first_payload["trace_id"])
+
+    async def test_backup_gate_evidence_rejects_idempotency_key_reuse(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_backup_gate_write_identity()),
+                authz_policy=_backup_gate_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _backup_gate_evidence_payload()
+            changed_payload = _backup_gate_evidence_payload(
+                record_id="backup-gate-example-site-prod-2"
+            )
+
+            first_response = await _post_backup_gate_evidence(
+                app,
+                request_payload,
+                idempotency_key="backup-gate-example-site-prod",
+            )
+            second_response = await _post_backup_gate_evidence(
+                app,
+                changed_payload,
+                idempotency_key="backup-gate-example-site-prod",
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_backup_gate_record("backup-gate-example-site-prod-2")
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        payload = second_response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+
+    async def test_openapi_includes_backup_gate_evidence_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_backup_gate_write_identity()),
+            authz_policy=_backup_gate_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/evidence/backup-gates"]["post"]
+        self.assertEqual(route["operationId"], "write_backup_gate_evidence")
+        self.assertEqual(
+            route["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/BackupGateEvidenceRequest",
+        )
+        self.assertEqual(
+            route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        for status_code in ("400", "401", "403", "409", "503"):
+            self.assertIn("LaunchplaneErrorResponse", json.dumps(route["responses"][status_code]))
+        self.assertEqual(
+            openapi["components"]["schemas"]["BackupGateEvidenceRequest"]["additionalProperties"],
+            False,
+        )
+
+    async def test_backup_gate_evidence_native_route_precedes_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_backup_gate_write_identity()),
+                authz_policy=_backup_gate_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _post_backup_gate_evidence(app, _backup_gate_evidence_payload())
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["backup_gate_record_id"], "backup-gate-example-site-prod"
+        )
+
+
 class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
     async def test_deployment_evidence_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1643,6 +1957,86 @@ def _driver_read_policy(*, context: str = "launchplane") -> LaunchplaneAuthzPoli
             ]
         }
     )
+
+
+def _backup_gate_write_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="every/example-site",
+        workflow_ref="every/example-site/.github/workflows/backup-gate.yml@refs/heads/main",
+        event_name="workflow_dispatch",
+    )
+
+
+def _backup_gate_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/example-site",
+                    "workflow_refs": [
+                        "every/example-site/.github/workflows/backup-gate.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["backup_gate.write"],
+                }
+            ]
+        }
+    )
+
+
+def _github_human_backup_gate_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_humans": [
+                {
+                    "logins": ["example-operator"],
+                    "roles": ["admin"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["backup_gate.write"],
+                }
+            ]
+        }
+    )
+
+
+def _terminal_agent_backup_gate_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["backup_gate.write"],
+                }
+            ]
+        }
+    )
+
+
+def _backup_gate_evidence_payload(
+    *, record_id: str = "backup-gate-example-site-prod"
+) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": "example-site",
+        "backup_gate": {
+            "record_id": record_id,
+            "context": "example-site",
+            "instance": "prod",
+            "created_at": "2026-04-21T18:05:00Z",
+            "source": "example-site-prod-gate",
+            "status": "pass",
+            "evidence": {
+                "snapshot_name": "snapshot-example-site-prod",
+                "manifest_path": "scratch/prod-gates/snapshot-example-site-prod.json",
+            },
+        },
+    }
 
 
 def _deployment_write_identity() -> GitHubActionsIdentity:
@@ -2003,6 +2397,28 @@ async def _get_driver_instance_view(
     )
 
 
+async def _post_backup_gate_evidence(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/evidence/backup-gates",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _post_deployment_evidence(
     app: FastAPI,
     payload: dict[str, object],
@@ -2102,6 +2518,48 @@ class _CaseInsensitiveHeaders(dict[str, str]):
 
 class _MissingProductReadStore:
     pass
+
+
+class _BackupGateEvidenceOnlyStore:
+    def __init__(self) -> None:
+        self.backup_gate_records: dict[str, dict[str, Any]] = {}
+
+    def write_backup_gate_record(self, record: BackupGateRecord) -> None:
+        self.backup_gate_records[record.record_id] = record.model_dump(mode="json")
+
+
+class _IdempotencyOnlyBackupGateReplayStore:
+    def __init__(self) -> None:
+        self.read_idempotency_calls = 0
+        self.write_backup_gate_calls = 0
+        self._stored_record: Any | None = None
+        self.write_backup_gate_record: Callable[[BackupGateRecord], None] | None = (
+            self._write_backup_gate_record
+        )
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> Any:
+        self.read_idempotency_calls += 1
+        if self._stored_record is None:
+            return None
+        if (
+            self._stored_record.scope != scope
+            or self._stored_record.route_path != route_path
+            or self._stored_record.idempotency_key != idempotency_key
+        ):
+            return None
+        return self._stored_record
+
+    def write_idempotency_record(self, record: Any) -> None:
+        self._stored_record = record
+
+    def _write_backup_gate_record(self, record: BackupGateRecord) -> None:
+        self.write_backup_gate_calls += 1
 
 
 class _DeploymentEvidenceOnlyStore:


### PR DESCRIPTION
## Summary

- Migrate `POST /v1/evidence/backup-gates` to a native FastAPI route for bearer-token workflow callers.
- Preserve backup-gate write authz, idempotency replay/conflict behavior, narrow storage capability checks, and accepted response shape.
- Add focused FastAPI coverage for success, auth boundaries, validation shape, idempotency, OpenAPI contract, store gating, and WSGI fallback precedence.
- Update service-boundary and compatibility-retirement docs for the native route and shadowed WSGI fallback.

## Validation

- `uv run python -m unittest`
- `uv run python -m unittest tests.test_http_app.FastApiBackupGateEvidenceStoreGateTests tests.test_http_app.FastApiBackupGateEvidenceTests tests.test_http_app.FastApiDeploymentEvidenceStoreGateTests tests.test_http_app.FastApiDeploymentEvidenceTests`
- `uv run python -m unittest tests.test_http_app tests.test_service.LaunchplaneServiceTests.test_backup_gate_endpoint_writes_record_for_authorized_workflow`
- `uv run python -m unittest tests.test_docs_contracts`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff check control_plane/http_app.py tests/test_http_app.py docs/service-boundary.md docs/compatibility-retirement.md`
- `uv run --extra dev ruff format --check control_plane/http_app.py tests/test_http_app.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev mypy control_plane/http_app.py tests/test_http_app.py`
- JetBrains changed-files inspection: clean
- Final review agents: no blocking findings

## Notes

`uv run --extra dev ruff format --check .` still reports pre-existing formatting drift in untouched files; the files changed in this PR are format-clean.

Refs #1322
