### PR TITLE
Migrate promotion evidence ingress to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -4,7 +4,6 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Annotated, Literal, Protocol, cast
 from uuid import uuid4
-
 from fastapi import Depends, FastAPI, Header, HTTPException, Path, Query, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -27,6 +26,7 @@ from control_plane.contracts.idempotency_record import (
 from control_plane.contracts.product_environment_read_model import (
     ProductEnvironmentConfigStatus,
 )
+from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.protected_artifacts import (
     ProtectedArtifactStore,
     ProtectedArtifactSet,
@@ -52,7 +52,9 @@ from control_plane.storage.factory import storage_backend_name
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.evidence_ingestion import (
     EvidenceIngestionStore,
+    PromotionEvidenceValidationError,
     apply_deployment_evidence,
+    apply_promotion_evidence,
 )
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -62,6 +64,7 @@ _LAUNCHPLANE_DRIVER_READ_PRODUCT = "launchplane"
 _LAUNCHPLANE_DRIVER_READ_CONTEXT = "launchplane"
 _DEPLOYMENT_EVIDENCE_ROUTE = "/v1/evidence/deployments"
 _BACKUP_GATE_EVIDENCE_ROUTE = "/v1/evidence/backup-gates"
+_PROMOTION_EVIDENCE_ROUTE = "/v1/evidence/promotions"
 
 
 class LaunchplaneErrorDetail(BaseModel):
@@ -182,6 +185,18 @@ class BackupGateEvidenceRequest(BaseModel):
             raise ValueError("backup gate evidence requires product")
 
 
+class PromotionEvidenceRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    promotion: PromotionRecord
+
+    def model_post_init(self, _context: object) -> None:
+        if not self.product.strip():
+            raise ValueError("promotion evidence requires product")
+
+
 class AcceptedEvidenceResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -250,6 +265,28 @@ def require_deployment_evidence_store(record_store: object) -> EvidenceIngestion
         missing_summary = ", ".join(missing_methods)
         raise TypeError(
             "Launchplane record store does not support deployment evidence writes: "
+            f"{missing_summary}"
+        )
+    return cast(EvidenceIngestionStore, record_store)
+
+
+def require_promotion_evidence_store(
+    record_store: object,
+    promotion_record: PromotionRecord,
+) -> EvidenceIngestionStore:
+    if promotion_record.deployment_record_id.strip():
+        required_methods = ["read_deployment_record", "write_promotion_evidence_records"]
+    else:
+        required_methods = ["write_promotion_record"]
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support promotion evidence writes: "
             f"{missing_summary}"
         )
     return cast(EvidenceIngestionStore, record_store)
@@ -903,6 +940,104 @@ def create_launchplane_fastapi_app(
             )
         return response
 
+    async def write_promotion_evidence(
+        request: Request,
+        promotion_request: PromotionEvidenceRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="promotion.write",
+            product=promotion_request.product,
+            context=promotion_request.promotion.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot write promotion evidence for the requested product/context."
+                ),
+            )
+
+        idempotency_store = idempotency_capable_store(record_store)
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_scope = idempotency_scope(identity)
+        raw_payload = await request.json()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if idempotency_store is not None and normalized_idempotency_key:
+            stored_record = idempotency_store.read_idempotency_record(
+                scope=normalized_scope,
+                route_path=_PROMOTION_EVIDENCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            )
+            if stored_record is not None:
+                if stored_record.request_fingerprint != payload_fingerprint:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different "
+                            "Launchplane request payload on this route."
+                        ),
+                    )
+                return replay_idempotent_response(
+                    trace_id=trace_id,
+                    stored_record=stored_record,
+                )
+
+        try:
+            evidence_store = require_promotion_evidence_store(
+                record_store,
+                promotion_request.promotion,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+
+        try:
+            records = {
+                str(key): str(value)
+                for key, value in apply_promotion_evidence(
+                    record_store=evidence_store,
+                    promotion_record=promotion_request.promotion,
+                ).items()
+            }
+        except PromotionEvidenceValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message=str(error).strip() or "Request could not be completed.",
+            ) from error
+
+        response = accepted_evidence_response(trace_id=trace_id, records=records)
+        if idempotency_store is not None and normalized_idempotency_key:
+            idempotency_store.write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id=build_launchplane_idempotency_record_id(
+                        response_trace_id=trace_id,
+                    ),
+                    scope=normalized_scope,
+                    route_path=_PROMOTION_EVIDENCE_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint=payload_fingerprint,
+                    response_status_code=202,
+                    response_trace_id=trace_id,
+                    recorded_at=utc_now_timestamp(),
+                    response_payload=response.model_dump(mode="json", exclude_none=True),
+                )
+            )
+        return response
+
     def read_health(record_store: Annotated[object, Depends(get_record_store)]) -> HealthResponse:
         return HealthResponse(
             trace_id=next_trace_id(),
@@ -1005,6 +1140,24 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_backup_gate_evidence",
         summary="Write backup gate evidence",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PROMOTION_EVIDENCE_ROUTE,
+        write_promotion_evidence,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_promotion_evidence",
+        summary="Write promotion evidence",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import os
 import time
+from contextlib import suppress
 from json import JSONDecodeError
 from pathlib import Path
 from typing import TypeVar
@@ -1507,9 +1508,7 @@ class FilesystemRecordStore:
         self, record: VeriReelProdBackupGateOperationRecord
     ) -> tuple[VeriReelProdBackupGateOperationRecord, bool]:
         try:
-            return self.read_verireel_prod_backup_gate_operation_record(
-                record.operation_id
-            ), False
+            return self.read_verireel_prod_backup_gate_operation_record(record.operation_id), False
         except FileNotFoundError:
             pass
         active_records = self.list_verireel_prod_backup_gate_operation_records(
@@ -1571,9 +1570,7 @@ class FilesystemRecordStore:
         if not normalized_lease_owner:
             raise ValueError("VeriReel prod backup gate operation claim requires lease_owner.")
         if not lease_expires_at.strip():
-            raise ValueError(
-                "VeriReel prod backup gate operation claim requires lease_expires_at."
-            )
+            raise ValueError("VeriReel prod backup gate operation claim requires lease_expires_at.")
         if not claimed_at.strip():
             raise ValueError("VeriReel prod backup gate operation claim requires claimed_at.")
         pending_records = self.list_verireel_prod_backup_gate_operation_records(
@@ -1696,9 +1693,7 @@ class FilesystemRecordStore:
         max_attempts: int,
     ) -> tuple[str, ...]:
         affected_operation_ids: list[str] = []
-        for record in self.list_verireel_prod_backup_gate_operation_records(
-            statuses=("running",)
-        ):
+        for record in self.list_verireel_prod_backup_gate_operation_records(statuses=("running",)):
             if record.lease_expires_at and record.lease_expires_at >= now:
                 continue
             affected_operation_ids.append(record.operation_id)
@@ -1800,6 +1795,34 @@ class FilesystemRecordStore:
 
     def write_promotion_record(self, record: PromotionRecord) -> Path:
         return self._write_model("promotions", record.record_id, record)
+
+    def write_promotion_evidence_records(
+        self,
+        *,
+        promotion_record: PromotionRecord,
+        inventory: EnvironmentInventory,
+    ) -> Path:
+        promotion_path = self._record_path("promotions", promotion_record.record_id)
+        inventory_path = self._record_path("inventory", f"{inventory.context}-{inventory.instance}")
+        previous_promotion = promotion_path.read_bytes() if promotion_path.exists() else None
+        previous_inventory = inventory_path.read_bytes() if inventory_path.exists() else None
+        try:
+            self.write_environment_inventory(inventory)
+            return self.write_promotion_record(promotion_record)
+        except Exception:
+            with suppress(Exception):
+                self._restore_record_path(promotion_path, previous_promotion)
+            with suppress(Exception):
+                self._restore_record_path(inventory_path, previous_inventory)
+            raise
+
+    @staticmethod
+    def _restore_record_path(record_path: Path, payload: bytes | None) -> None:
+        if payload is None:
+            record_path.unlink(missing_ok=True)
+            return
+        record_path.parent.mkdir(parents=True, exist_ok=True)
+        record_path.write_bytes(payload)
 
     def read_promotion_record(self, record_id: str) -> PromotionRecord:
         return PromotionRecord.model_validate(

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -2409,9 +2409,7 @@ class PostgresRecordStore(HumanSessionStore):
         self, record: VeriReelProdBackupGateOperationRecord
     ) -> tuple[VeriReelProdBackupGateOperationRecord, bool]:
         try:
-            return self.read_verireel_prod_backup_gate_operation_record(
-                record.operation_id
-            ), False
+            return self.read_verireel_prod_backup_gate_operation_record(record.operation_id), False
         except FileNotFoundError:
             pass
         with self._session_factory() as session:
@@ -2477,8 +2475,7 @@ class PostgresRecordStore(HumanSessionStore):
             filters.append(LaunchplaneVeriReelProdBackupGateOperationRow.instance == instance_name)
         if backup_record_id:
             filters.append(
-                LaunchplaneVeriReelProdBackupGateOperationRow.backup_record_id
-                == backup_record_id
+                LaunchplaneVeriReelProdBackupGateOperationRow.backup_record_id == backup_record_id
             )
         if statuses:
             filters.append(LaunchplaneVeriReelProdBackupGateOperationRow.status.in_(statuses))
@@ -2504,9 +2501,7 @@ class PostgresRecordStore(HumanSessionStore):
         if not normalized_lease_owner:
             raise ValueError("VeriReel prod backup gate operation claim requires lease_owner.")
         if not lease_expires_at.strip():
-            raise ValueError(
-                "VeriReel prod backup gate operation claim requires lease_expires_at."
-            )
+            raise ValueError("VeriReel prod backup gate operation claim requires lease_expires_at.")
         if not claimed_at.strip():
             raise ValueError("VeriReel prod backup gate operation claim requires claimed_at.")
         statement = (
@@ -2921,6 +2916,40 @@ class PostgresRecordStore(HumanSessionStore):
                 payload=self._payload_dict(record),
             )
         )
+
+    def write_promotion_evidence_records(
+        self,
+        *,
+        promotion_record: PromotionRecord,
+        inventory: EnvironmentInventory,
+    ) -> None:
+        with self._session_factory() as session:
+            session.merge(
+                LaunchplanePromotionRow(
+                    record_id=promotion_record.record_id,
+                    context=promotion_record.context,
+                    from_instance=promotion_record.from_instance,
+                    to_instance=promotion_record.to_instance,
+                    artifact_id=promotion_record.artifact_identity.artifact_id,
+                    deploy_started_at=promotion_record.deploy.started_at,
+                    deploy_finished_at=promotion_record.deploy.finished_at,
+                    payload=self._payload_dict(promotion_record),
+                )
+            )
+            session.merge(
+                LaunchplaneInventoryRow(
+                    context=inventory.context,
+                    instance=inventory.instance,
+                    artifact_id=_artifact_id_from_model(inventory),
+                    source_git_ref=inventory.source_git_ref,
+                    updated_at=inventory.updated_at,
+                    deployment_record_id=inventory.deployment_record_id,
+                    promotion_record_id=inventory.promotion_record_id,
+                    promoted_from_instance=inventory.promoted_from_instance,
+                    payload=self._payload_dict(inventory),
+                )
+            )
+            session.commit()
 
     def read_promotion_record(self, record_id: str) -> PromotionRecord:
         return self._read_model(

--- a/control_plane/workflows/evidence_ingestion.py
+++ b/control_plane/workflows/evidence_ingestion.py
@@ -11,6 +11,10 @@ from control_plane.workflows.inventory import build_environment_inventory, inven
 from control_plane.workflows.ship import utc_now_timestamp
 
 
+class PromotionEvidenceValidationError(click.ClickException):
+    pass
+
+
 class EvidenceIngestionStore(Protocol):
     def write_deployment_record(self, record: DeploymentRecord) -> object: ...
 
@@ -19,6 +23,13 @@ class EvidenceIngestionStore(Protocol):
     def read_promotion_record(self, promotion_record_id: str) -> PromotionRecord: ...
 
     def write_promotion_record(self, record: PromotionRecord) -> object: ...
+
+    def write_promotion_evidence_records(
+        self,
+        *,
+        promotion_record: PromotionRecord,
+        inventory: EnvironmentInventory,
+    ) -> object: ...
 
     def write_environment_inventory(self, inventory: EnvironmentInventory) -> object: ...
 
@@ -52,6 +63,13 @@ def _write_environment_inventory(
     )
 
 
+def _inventory_record_id(inventory: EnvironmentInventory) -> str:
+    return inventory_record_id(
+        context_name=inventory.context,
+        instance_name=inventory.instance,
+    )
+
+
 def apply_deployment_evidence(
     *,
     record_store: EvidenceIngestionStore,
@@ -72,20 +90,25 @@ def apply_promotion_evidence(
     record_store: EvidenceIngestionStore,
     promotion_record: PromotionRecord,
 ) -> dict[str, str]:
-    record_store.write_promotion_record(promotion_record)
     result = {"promotion_record_id": promotion_record.record_id}
 
     deployment_record_id = promotion_record.deployment_record_id.strip()
     if not deployment_record_id:
+        record_store.write_promotion_record(promotion_record)
         return result
 
-    deployment_record = record_store.read_deployment_record(deployment_record_id)
+    try:
+        deployment_record = record_store.read_deployment_record(deployment_record_id)
+    except FileNotFoundError as error:
+        raise PromotionEvidenceValidationError(
+            f"Promotion linked deployment record {deployment_record_id!r} was not found."
+        ) from error
     if deployment_record.context != promotion_record.context:
-        raise click.ClickException(
+        raise PromotionEvidenceValidationError(
             "Promotion record context does not match linked deployment record context."
         )
     if deployment_record.instance != promotion_record.to_instance:
-        raise click.ClickException(
+        raise PromotionEvidenceValidationError(
             "Promotion destination instance does not match linked deployment record instance."
         )
 
@@ -96,14 +119,19 @@ def apply_promotion_evidence(
         and deployment_artifact_id
         and promotion_artifact_id != deployment_artifact_id
     ):
-        raise click.ClickException(
+        raise PromotionEvidenceValidationError(
             "Promotion artifact_id does not match linked deployment record artifact_id."
         )
 
-    result["inventory_record_id"] = _write_environment_inventory(
-        record_store=record_store,
+    inventory_record = build_environment_inventory(
         deployment_record=deployment_record,
+        updated_at=utc_now_timestamp(),
         promotion_record_id=promotion_record.record_id,
         promoted_from_instance=promotion_record.from_instance,
     )
+    record_store.write_promotion_evidence_records(
+        promotion_record=promotion_record,
+        inventory=inventory_record,
+    )
+    result["inventory_record_id"] = _inventory_record_id(inventory_record)
     return result

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -57,8 +57,8 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment and backup-gate evidence ingestion use native FastAPI routes for
-  bearer-token callers and preserve the existing `Idempotency-Key`
+- Deployment, backup-gate, and promotion evidence ingestion use native FastAPI
+  routes for bearer-token callers and preserve the existing `Idempotency-Key`
   replay/conflict contract. Their legacy WSGI branches are shadowed by native
   routes while the mounted fallback remains for the rest of the evidence family;
   delete those WSGI branches after caller evidence proves the native paths and

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -54,7 +54,8 @@ VeriReel product paths:
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
   - `POST /v1/evidence/deployments` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
-  - `POST /v1/evidence/promotions`
+  - `POST /v1/evidence/promotions` (native FastAPI for bearer-token callers,
+    with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
   - `POST /v1/evidence/previews/generations`
   - `POST /v1/evidence/previews/destroyed`
   - `POST /v1/evidence/runner-host-hygiene/audits`
@@ -831,6 +832,16 @@ the backing store is temporarily write-restricted for deployment evidence.
 capability and any available idempotency store. Replay handling runs before the
 backup-gate capability check so a stored response can still be returned if the
 backing store is temporarily write-restricted for backup-gate evidence.
+
+`POST /v1/evidence/promotions` requires any available idempotency store. Unlinked
+promotion evidence requires the promotion record-write capability. When a
+promotion links a deployment record, the route requires the linked deployment
+read capability and the bundled promotion-evidence write capability used to
+commit the promotion record and promoted inventory projection together after
+validation.
+Replay handling runs before those capability checks so a stored response can
+still be returned if the backing store is temporarily write-restricted for
+promotion evidence.
 
 ### Preview lifecycle endpoints
 

--- a/tests/test_evidence_ingestion.py
+++ b/tests/test_evidence_ingestion.py
@@ -20,6 +20,7 @@ class _FakeEvidenceStore:
         self.deployments: dict[str, DeploymentRecord] = {}
         self.promotions: dict[str, PromotionRecord] = {}
         self.inventories: dict[tuple[str, str], EnvironmentInventory] = {}
+        self.promotion_evidence_write_calls = 0
 
     def write_deployment_record(self, record: DeploymentRecord) -> None:
         self.deployments[record.record_id] = record
@@ -30,11 +31,32 @@ class _FakeEvidenceStore:
     def write_promotion_record(self, record: PromotionRecord) -> None:
         self.promotions[record.record_id] = record
 
+    def write_promotion_evidence_records(
+        self,
+        *,
+        promotion_record: PromotionRecord,
+        inventory: EnvironmentInventory,
+    ) -> None:
+        self.promotion_evidence_write_calls += 1
+        self.promotions[promotion_record.record_id] = promotion_record
+        self.inventories[(inventory.context, inventory.instance)] = inventory
+
     def read_promotion_record(self, promotion_record_id: str) -> PromotionRecord:
         return self.promotions[promotion_record_id]
 
     def write_environment_inventory(self, inventory: EnvironmentInventory) -> None:
         self.inventories[(inventory.context, inventory.instance)] = inventory
+
+
+class _FailingPromotionEvidenceStore(_FakeEvidenceStore):
+    def write_promotion_evidence_records(
+        self,
+        *,
+        promotion_record: PromotionRecord,
+        inventory: EnvironmentInventory,
+    ) -> None:
+        self.promotion_evidence_write_calls += 1
+        raise RuntimeError("promotion evidence bundle failed")
 
 
 def _deployment_record(
@@ -112,6 +134,18 @@ class EvidenceIngestionTests(unittest.TestCase):
         inventory = store.inventories[("site", "prod")]
         self.assertEqual(inventory.promotion_record_id, "promotion-site-testing-to-prod")
         self.assertEqual(inventory.promoted_from_instance, "testing")
+        self.assertEqual(store.promotion_evidence_write_calls, 1)
+
+    def test_apply_promotion_evidence_uses_bundled_linked_write(self) -> None:
+        store = _FailingPromotionEvidenceStore()
+        store.write_deployment_record(_deployment_record())
+
+        with self.assertRaisesRegex(RuntimeError, "promotion evidence bundle failed"):
+            apply_promotion_evidence(record_store=store, promotion_record=_promotion_record())
+
+        self.assertEqual(store.promotion_evidence_write_calls, 1)
+        self.assertEqual(store.promotions, {})
+        self.assertEqual(store.inventories, {})
 
     def test_apply_promotion_evidence_rejects_mismatched_deployment_context(self) -> None:
         store = _FakeEvidenceStore()

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -1529,6 +1529,51 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             self.assertEqual(loaded_record.record_id, record.record_id)
             self.assertEqual(loaded_record.deploy.target_name, "opw-prod")
 
+    def test_write_promotion_evidence_records_writes_promotion_and_inventory(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            promotion_record = PromotionRecord(
+                record_id="promotion-20260410-182231-opw-testing-prod",
+                artifact_identity=_artifact_identity("artifact-20260410-f45db648"),
+                deployment_record_id="deployment-20260410T182231Z-opw-prod",
+                backup_record_id="backup-opw-prod-20260410T182231Z",
+                context="opw",
+                from_instance="testing",
+                to_instance="prod",
+                deploy=DeploymentEvidence(
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                    status="pass",
+                ),
+            )
+            inventory = EnvironmentInventory(
+                context="opw",
+                instance="prod",
+                artifact_identity=_artifact_identity("artifact-20260410-f45db648"),
+                source_git_ref="abc123",
+                deploy=promotion_record.deploy,
+                updated_at="2026-04-10T18:24:01Z",
+                deployment_record_id="deployment-20260410T182231Z-opw-prod",
+                promotion_record_id=promotion_record.record_id,
+                promoted_from_instance="testing",
+            )
+
+            written_path = store.write_promotion_evidence_records(
+                promotion_record=promotion_record,
+                inventory=inventory,
+            )
+            loaded_promotion = store.read_promotion_record(promotion_record.record_id)
+            loaded_inventory = store.read_environment_inventory(
+                context_name="opw", instance_name="prod"
+            )
+
+            self.assertTrue(written_path.exists())
+            self.assertEqual(loaded_promotion.record_id, promotion_record.record_id)
+            self.assertEqual(loaded_inventory.promotion_record_id, promotion_record.record_id)
+            self.assertEqual(loaded_inventory.promoted_from_instance, "testing")
+
     def test_list_promotion_records_filters_and_sorts_latest_first(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -76,6 +76,15 @@ class _GenericWebPromotionStore:
     def write_promotion_record(self, record: PromotionRecord) -> None:
         self.promotions[record.record_id] = record
 
+    def write_promotion_evidence_records(
+        self,
+        *,
+        promotion_record: PromotionRecord,
+        inventory: EnvironmentInventory,
+    ) -> None:
+        self.promotions[promotion_record.record_id] = promotion_record
+        self.inventories[(inventory.context, inventory.instance)] = inventory
+
     def write_environment_inventory(self, record: EnvironmentInventory) -> None:
         self.inventories[(record.context, record.instance)] = record
 

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -18,7 +18,11 @@ from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
-from control_plane.contracts.promotion_record import ArtifactIdentityReference, DeploymentEvidence
+from control_plane.contracts.promotion_record import (
+    ArtifactIdentityReference,
+    DeploymentEvidence,
+    PromotionRecord,
+)
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import (
@@ -210,6 +214,98 @@ class FastApiBackupGateEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
         self.assertEqual(store.read_idempotency_calls, 2)
         self.assertEqual(store.write_backup_gate_calls, 1)
+
+
+class FastApiPromotionEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_promotion_evidence_accepts_record_only_store_without_deployment_methods(
+        self,
+    ) -> None:
+        store = _PromotionEvidenceOnlyStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_promotion_write_identity()),
+            authz_policy=_promotion_write_policy(context="example-site"),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_promotion_evidence(
+            app,
+            _promotion_evidence_payload(link_deployment=False),
+        )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"],
+            {"promotion_record_id": "promotion-example-site-testing-to-prod"},
+        )
+        self.assertEqual(
+            store.promotion_records["promotion-example-site-testing-to-prod"]["context"],
+            "example-site",
+        )
+
+    async def test_promotion_evidence_requires_linked_deployment_store_methods(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_promotion_write_identity()),
+            authz_policy=_promotion_write_policy(context="example-site"),
+            record_store_factory=lambda: _PromotionEvidenceOnlyStore(),
+        )
+
+        response = await _post_promotion_evidence(app, _promotion_evidence_payload())
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_promotion_evidence_requires_promotion_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_promotion_write_identity()),
+            authz_policy=_promotion_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_promotion_evidence(
+            app,
+            _promotion_evidence_payload(link_deployment=False),
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_promotion_evidence_replays_idempotency_before_promotion_gate(self) -> None:
+        store = _IdempotencyOnlyPromotionReplayStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_promotion_write_identity()),
+            authz_policy=_promotion_write_policy(context="example-site"),
+            record_store_factory=lambda: store,
+        )
+        request_payload = _promotion_evidence_payload(link_deployment=False)
+
+        first_response = await _post_promotion_evidence(
+            app,
+            request_payload,
+            idempotency_key="promotion-example-site-testing-to-prod",
+        )
+        # The second request must replay before capability checks or write calls.
+        store.write_promotion_record = None
+        second_response = await _post_promotion_evidence(
+            app,
+            request_payload,
+            idempotency_key="promotion-example-site-testing-to-prod",
+        )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(store.read_idempotency_calls, 2)
+        self.assertEqual(store.write_promotion_calls, 1)
 
 
 class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCase):
@@ -1674,6 +1770,318 @@ class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FastApiPromotionEvidenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_promotion_evidence_writes_record_and_inventory_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_promotion_evidence(app, _promotion_evidence_payload())
+            promotion = store.read_promotion_record("promotion-example-site-testing-to-prod")
+            inventory = store.read_environment_inventory(
+                context_name="example-site",
+                instance_name="prod",
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"],
+            {
+                "promotion_record_id": "promotion-example-site-testing-to-prod",
+                "inventory_record_id": "example-site-prod",
+            },
+        )
+        self.assertNotIn("replayed", payload)
+        self.assertEqual(promotion.context, "example-site")
+        self.assertEqual(promotion.from_instance, "testing")
+        self.assertEqual(promotion.to_instance, "prod")
+        self.assertEqual(promotion.deploy.status, "pass")
+        self.assertEqual(promotion.backup_gate.status, "pass")
+        self.assertEqual(inventory.deployment_record_id, "deployment-example-site-prod")
+        self.assertEqual(inventory.promotion_record_id, promotion.record_id)
+        self.assertEqual(inventory.promoted_from_instance, "testing")
+
+    async def test_promotion_evidence_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="other-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_promotion_evidence(app, _promotion_evidence_payload())
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_promotion_evidence_rejects_human_session_mutation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            oauth_config = _github_oauth_config()
+            session_store = InMemoryHumanSessionStore()
+            session_manager = HumanSessionManager(
+                config=oauth_config,
+                session_store=session_store,
+            )
+            human_session = session_manager.issue(_github_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_github_human_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+            )
+
+            response = await _post_promotion_evidence(
+                app,
+                _promotion_evidence_payload(),
+                authorization="",
+                headers={"Cookie": session_manager.session_cookie_header(human_session)},
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_promotion_evidence_rejects_terminal_agent_mutation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-agent-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+            )
+
+            response = await _post_promotion_evidence(
+                app,
+                _promotion_evidence_payload(),
+                authorization="Bearer terminal-agent-token",
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_promotion_evidence_validation_errors_use_launchplane_shape(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = _promotion_evidence_store(Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            invalid_payload = _promotion_evidence_payload()
+            invalid_payload["product"] = ""
+
+            response = await _post_promotion_evidence(app, invalid_payload)
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertNotIn("detail", payload)
+
+    async def test_promotion_evidence_rejects_mismatched_linked_deployment(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir, deployment_instance="testing")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_promotion_evidence(app, _promotion_evidence_payload())
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    async def test_promotion_evidence_rejects_context_mismatched_linked_deployment(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir, deployment_context="other-site")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_promotion_evidence(app, _promotion_evidence_payload())
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    async def test_promotion_evidence_rejects_missing_linked_deployment(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_promotion_evidence(app, _promotion_evidence_payload())
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    async def test_promotion_evidence_replays_idempotent_write(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _promotion_evidence_payload()
+
+            first_response = await _post_promotion_evidence(
+                app,
+                request_payload,
+                idempotency_key="promotion-example-site-testing-to-prod",
+            )
+            second_response = await _post_promotion_evidence(
+                app,
+                request_payload,
+                idempotency_key="promotion-example-site-testing-to-prod",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertNotEqual(second_payload["trace_id"], first_payload["trace_id"])
+
+    async def test_promotion_evidence_rejects_idempotency_key_reuse(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _promotion_evidence_payload()
+            changed_payload = _promotion_evidence_payload(
+                record_id="promotion-example-site-testing-to-prod-2"
+            )
+
+            first_response = await _post_promotion_evidence(
+                app,
+                request_payload,
+                idempotency_key="promotion-example-site-testing-to-prod",
+            )
+            second_response = await _post_promotion_evidence(
+                app,
+                changed_payload,
+                idempotency_key="promotion-example-site-testing-to-prod",
+            )
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod-2")
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        payload = second_response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+
+    async def test_openapi_includes_promotion_evidence_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_promotion_write_identity()),
+            authz_policy=_promotion_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/evidence/promotions"]["post"]
+        self.assertEqual(route["operationId"], "write_promotion_evidence")
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(request_schema["$ref"], "#/components/schemas/PromotionEvidenceRequest")
+        success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
+        self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
+        for status_code in ("400", "401", "403", "409", "503"):
+            error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
+            self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
+        promotion_schema = openapi["components"]["schemas"]["PromotionEvidenceRequest"]
+        self.assertFalse(promotion_schema["additionalProperties"])
+
+    async def test_promotion_evidence_native_route_precedes_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _post_promotion_evidence(app, _promotion_evidence_payload())
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["promotion_record_id"], "promotion-example-site-testing-to-prod"
+        )
+
+
 class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
     async def test_deployment_evidence_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2037,6 +2445,141 @@ def _backup_gate_evidence_payload(
             },
         },
     }
+
+
+def _promotion_write_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="every/example-site",
+        workflow_ref="every/example-site/.github/workflows/promote-prod.yml@refs/heads/main",
+        event_name="workflow_dispatch",
+    )
+
+
+def _promotion_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/example-site",
+                    "workflow_refs": [
+                        "every/example-site/.github/workflows/promote-prod.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["promotion.write"],
+                }
+            ]
+        }
+    )
+
+
+def _github_human_promotion_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_humans": [
+                {
+                    "logins": ["example-operator"],
+                    "roles": ["admin"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["promotion.write"],
+                }
+            ]
+        }
+    )
+
+
+def _terminal_agent_promotion_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["promotion.write"],
+                }
+            ]
+        }
+    )
+
+
+def _promotion_evidence_payload(
+    *,
+    record_id: str = "promotion-example-site-testing-to-prod",
+    link_deployment: bool = True,
+) -> dict[str, object]:
+    promotion: dict[str, object] = {
+        "record_id": record_id,
+        "artifact_identity": {"artifact_id": "artifact-example-site-prod"},
+        "backup_record_id": "backup-example-site-prod-20260420T155000Z",
+        "context": "example-site",
+        "from_instance": "testing",
+        "to_instance": "prod",
+        "backup_gate": {
+            "required": True,
+            "status": "pass",
+            "evidence": {"recorded_by": "launchplane-service"},
+        },
+        "deploy": {
+            "target_name": "example-site-prod",
+            "target_type": "application",
+            "deploy_mode": "runtime-provider-api",
+            "deployment_id": "provider-deployment-example-site-prod",
+            "status": "pass",
+            "started_at": "2026-04-20T16:05:00Z",
+            "finished_at": "2026-04-20T16:08:30Z",
+        },
+        "destination_health": {
+            "verified": True,
+            "urls": ["https://example.invalid/health"],
+            "timeout_seconds": 45,
+            "status": "pass",
+        },
+    }
+    if link_deployment:
+        promotion["deployment_record_id"] = "deployment-example-site-prod"
+    return {
+        "schema_version": 1,
+        "product": "example-site",
+        "promotion": promotion,
+    }
+
+
+def _promotion_evidence_store(
+    state_dir: Path,
+    *,
+    deployment_context: str = "example-site",
+    deployment_instance: str = "prod",
+    artifact_id: str = "artifact-example-site-prod",
+) -> FilesystemRecordStore:
+    store = FilesystemRecordStore(state_dir=state_dir)
+    store.write_deployment_record(
+        DeploymentRecord(
+            record_id="deployment-example-site-prod",
+            artifact_identity=ArtifactIdentityReference(artifact_id=artifact_id),
+            context=deployment_context,
+            instance=deployment_instance,
+            source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+            resolved_target=ResolvedTargetEvidence(
+                target_type="application",
+                target_id="target-example-site-prod",
+                target_name="example-site-prod",
+            ),
+            deploy=DeploymentEvidence(
+                target_name="example-site-prod",
+                target_type="application",
+                deploy_mode="runtime-provider-api",
+                deployment_id="provider-deployment-example-site-prod",
+                status="pass",
+                started_at="2026-04-20T16:05:00Z",
+                finished_at="2026-04-20T16:08:30Z",
+            ),
+        )
+    )
+    return store
 
 
 def _deployment_write_identity() -> GitHubActionsIdentity:
@@ -2419,6 +2962,28 @@ async def _post_backup_gate_evidence(
     )
 
 
+async def _post_promotion_evidence(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/evidence/promotions",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _post_deployment_evidence(
     app: FastAPI,
     payload: dict[str, object],
@@ -2560,6 +3125,48 @@ class _IdempotencyOnlyBackupGateReplayStore:
 
     def _write_backup_gate_record(self, record: BackupGateRecord) -> None:
         self.write_backup_gate_calls += 1
+
+
+class _PromotionEvidenceOnlyStore:
+    def __init__(self) -> None:
+        self.promotion_records: dict[str, dict[str, Any]] = {}
+
+    def write_promotion_record(self, record: PromotionRecord) -> None:
+        self.promotion_records[record.record_id] = record.model_dump(mode="json")
+
+
+class _IdempotencyOnlyPromotionReplayStore:
+    def __init__(self) -> None:
+        self.read_idempotency_calls = 0
+        self.write_promotion_calls = 0
+        self._stored_record: Any | None = None
+        self.write_promotion_record: Callable[[PromotionRecord], None] | None = (
+            self._write_promotion_record
+        )
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> Any:
+        self.read_idempotency_calls += 1
+        if self._stored_record is None:
+            return None
+        if (
+            self._stored_record.scope != scope
+            or self._stored_record.route_path != route_path
+            or self._stored_record.idempotency_key != idempotency_key
+        ):
+            return None
+        return self._stored_record
+
+    def write_idempotency_record(self, record: Any) -> None:
+        self._stored_record = record
+
+    def _write_promotion_record(self, record: PromotionRecord) -> None:
+        self.write_promotion_calls += 1
 
 
 class _DeploymentEvidenceOnlyStore:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1000,6 +1000,41 @@ class PostgresRecordStoreTests(unittest.TestCase):
 
         self.assertEqual(too_long_index_names, ())
 
+    def test_write_promotion_evidence_records_writes_promotion_and_inventory(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            promotion_record = _promotion_record(
+                record_id="promotion-20260420T160500Z-opw-testing-to-prod"
+            )
+            inventory = _inventory_record().model_copy(
+                update={
+                    "instance": "prod",
+                    "deploy": promotion_record.deploy,
+                    "promotion_record_id": promotion_record.record_id,
+                    "promoted_from_instance": "testing",
+                    "updated_at": "2026-04-20T16:08:00Z",
+                }
+            )
+
+            store.write_promotion_evidence_records(
+                promotion_record=promotion_record,
+                inventory=inventory,
+            )
+            loaded_promotion = store.read_promotion_record(promotion_record.record_id)
+            loaded_inventory = store.read_environment_inventory(
+                context_name="opw", instance_name="prod"
+            )
+            store.close()
+
+        self.assertEqual(loaded_promotion.record_id, promotion_record.record_id)
+        self.assertEqual(loaded_inventory.promotion_record_id, promotion_record.record_id)
+        self.assertEqual(loaded_inventory.promoted_from_instance, "testing")
+
     def test_alembic_baseline_creates_schema_used_by_record_store(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(


### PR DESCRIPTION
## Summary
- migrate `POST /v1/evidence/promotions` to a native FastAPI route with Pydantic/OpenAPI, workflow authorization, and idempotency replay
- add bundled promotion-evidence writes so linked promotions commit the promotion record and promoted inventory projection together after validation
- document promotion evidence ingress capability requirements and compatibility-retirement progress

## Validation
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/workflows/evidence_ingestion.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_evidence_ingestion.py tests/test_filesystem_store.py tests/test_generic_web_promotion.py tests/test_http_app.py tests/test_postgres_store.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/workflows/evidence_ingestion.py control_plane/storage/filesystem.py control_plane/storage/postgres.py tests/test_evidence_ingestion.py tests/test_filesystem_store.py tests/test_generic_web_promotion.py tests/test_http_app.py tests/test_postgres_store.py`
- `git diff --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_evidence_ingestion tests.test_http_app.FastApiPromotionEvidenceStoreGateTests tests.test_http_app.FastApiPromotionEvidenceTests tests.test_generic_web_promotion tests.test_filesystem_store.FilesystemRecordStoreTests.test_write_promotion_evidence_records_writes_promotion_and_inventory tests.test_postgres_store.PostgresRecordStoreTests.test_write_promotion_evidence_records_writes_promotion_and_inventory tests.test_service.LaunchplaneServiceTests.test_promotion_endpoint_writes_record_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_generic_web_stable_verification_updates_linked_promotion_health`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo $PWD --scope changed_files`

Final agent reviews: no findings on the validation boundary, bundled write semantics, filesystem rollback, auth, or idempotency behavior.

Refs #1322
