### PR TITLE
Migrate preview generation evidence to FastAPI

### DIFF
--- a/control_plane/contracts/preview_evidence.py
+++ b/control_plane/contracts/preview_evidence.py
@@ -1,0 +1,44 @@
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.preview_mutation_request import (
+    PreviewDestroyMutationRequest,
+    PreviewGenerationMutationRequest,
+    PreviewMutationRequest,
+)
+
+
+class PreviewGenerationEvidenceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    preview: PreviewMutationRequest
+    generation: PreviewGenerationMutationRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "PreviewGenerationEvidenceEnvelope":
+        if not self.product.strip():
+            raise ValueError("preview generation evidence requires product")
+        if self.preview.context != self.generation.context:
+            raise ValueError("preview generation evidence requires matching contexts")
+        if self.preview.anchor_repo != self.generation.anchor_repo:
+            raise ValueError("preview generation evidence requires matching anchor_repo")
+        if self.preview.anchor_pr_number != self.generation.anchor_pr_number:
+            raise ValueError("preview generation evidence requires matching anchor_pr_number")
+        if self.preview.anchor_pr_url != self.generation.anchor_pr_url:
+            raise ValueError("preview generation evidence requires matching anchor_pr_url")
+        return self
+
+
+class PreviewDestroyedEvidenceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    destroy: PreviewDestroyMutationRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "PreviewDestroyedEvidenceEnvelope":
+        if not self.product.strip():
+            raise ValueError("preview destroyed evidence requires product")
+        return self

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -2,8 +2,10 @@ import hashlib
 import json
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path as FilePath
 from typing import Annotated, Literal, Protocol, cast
 from uuid import uuid4
+import click
 from fastapi import Depends, FastAPI, Header, HTTPException, Path, Query, Request, Response
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
@@ -26,6 +28,7 @@ from control_plane.contracts.idempotency_record import (
 from control_plane.contracts.product_environment_read_model import (
     ProductEnvironmentConfigStatus,
 )
+from control_plane.contracts.preview_evidence import PreviewGenerationEvidenceEnvelope
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.protected_artifacts import (
     ProtectedArtifactStore,
@@ -47,6 +50,10 @@ from control_plane.service_auth import (
     bearer_identity_from_token,
 )
 from control_plane.service_human_auth import HumanSessionManager, LaunchplaneHumanSession
+from control_plane.launchplane_mutations import (
+    LaunchplaneMutationStore,
+    apply_launchplane_generation_evidence,
+)
 from control_plane.storage.factory import build_shared_record_store
 from control_plane.storage.factory import storage_backend_name
 from control_plane.storage.postgres import PostgresRecordStore
@@ -65,6 +72,7 @@ _LAUNCHPLANE_DRIVER_READ_CONTEXT = "launchplane"
 _DEPLOYMENT_EVIDENCE_ROUTE = "/v1/evidence/deployments"
 _BACKUP_GATE_EVIDENCE_ROUTE = "/v1/evidence/backup-gates"
 _PROMOTION_EVIDENCE_ROUTE = "/v1/evidence/promotions"
+_PREVIEW_GENERATION_EVIDENCE_ROUTE = "/v1/evidence/previews/generations"
 
 
 class LaunchplaneErrorDetail(BaseModel):
@@ -292,6 +300,28 @@ def require_promotion_evidence_store(
     return cast(EvidenceIngestionStore, record_store)
 
 
+def require_preview_generation_evidence_store(record_store: object) -> LaunchplaneMutationStore:
+    required_methods = (
+        "list_preview_records",
+        "list_preview_generation_records",
+        "write_preview_record",
+        "write_preview_generation_record",
+        "write_preview_generation_evidence_records",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support preview generation evidence writes: "
+            f"{missing_summary}"
+        )
+    return cast(LaunchplaneMutationStore, record_store)
+
+
 def require_backup_gate_evidence_store(record_store: object) -> _BackupGateEvidenceStore:
     required_methods = ("write_backup_gate_record",)
     missing_methods = [
@@ -417,9 +447,13 @@ def create_launchplane_fastapi_app(
     record_store_factory: _RecordStoreFactory | None = None,
     bearer_identity_config: BearerIdentityConfig | None = None,
     human_session_manager: HumanSessionManager | None = None,
+    control_plane_root_path: FilePath | None = None,
 ) -> FastAPI:
     resolved_authz_policy_runtime = authz_policy_runtime or LaunchplaneAuthzPolicyRuntime(
         authz_policy
+    )
+    resolved_control_plane_root = (
+        control_plane_root_path or FilePath(__file__).resolve().parent.parent
     )
     shared_record_store: object | None = (
         None
@@ -1038,6 +1072,104 @@ def create_launchplane_fastapi_app(
             )
         return response
 
+    async def write_preview_generation_evidence(
+        request: Request,
+        preview_generation_request: PreviewGenerationEvidenceEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="preview_generation.write",
+            product=preview_generation_request.product,
+            context=preview_generation_request.preview.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot write preview generation evidence for the "
+                    "requested product/context."
+                ),
+            )
+
+        idempotency_store = idempotency_capable_store(record_store)
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_scope = idempotency_scope(identity)
+        raw_payload = await request.json()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if idempotency_store is not None and normalized_idempotency_key:
+            stored_record = idempotency_store.read_idempotency_record(
+                scope=normalized_scope,
+                route_path=_PREVIEW_GENERATION_EVIDENCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            )
+            if stored_record is not None:
+                if stored_record.request_fingerprint != payload_fingerprint:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different "
+                            "Launchplane request payload on this route."
+                        ),
+                    )
+                return replay_idempotent_response(
+                    trace_id=trace_id,
+                    stored_record=stored_record,
+                )
+
+        try:
+            evidence_store = require_preview_generation_evidence_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+
+        try:
+            records = {
+                str(key): str(value)
+                for key, value in apply_launchplane_generation_evidence(
+                    control_plane_root_path=resolved_control_plane_root,
+                    record_store=evidence_store,
+                    preview_request=preview_generation_request.preview,
+                    generation_request=preview_generation_request.generation,
+                ).items()
+            }
+        except click.ClickException as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message=str(error).strip() or "Request could not be completed.",
+            ) from error
+
+        response = accepted_evidence_response(trace_id=trace_id, records=records)
+        if idempotency_store is not None and normalized_idempotency_key:
+            idempotency_store.write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id=build_launchplane_idempotency_record_id(
+                        response_trace_id=trace_id,
+                    ),
+                    scope=normalized_scope,
+                    route_path=_PREVIEW_GENERATION_EVIDENCE_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint=payload_fingerprint,
+                    response_status_code=202,
+                    response_trace_id=trace_id,
+                    recorded_at=utc_now_timestamp(),
+                    response_payload=response.model_dump(mode="json", exclude_none=True),
+                )
+            )
+        return response
+
     def read_health(record_store: Annotated[object, Depends(get_record_store)]) -> HealthResponse:
         return HealthResponse(
             trace_id=next_trace_id(),
@@ -1158,6 +1290,24 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_promotion_evidence",
         summary="Write promotion evidence",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PREVIEW_GENERATION_EVIDENCE_ROUTE,
+        write_preview_generation_evidence,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_preview_generation_evidence",
+        summary="Write preview generation evidence",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/launchplane_mutations.py
+++ b/control_plane/launchplane_mutations.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, cast
 
 import click
 
@@ -16,6 +16,7 @@ from control_plane.workflows.launchplane import (
     apply_generation_ready_transition,
     apply_generation_requested_transition,
     apply_preview_destroyed_transition,
+    build_preview_generation_record,
     build_preview_generation_record_from_request,
     build_preview_record_from_request,
     find_preview_record,
@@ -35,6 +36,15 @@ class LaunchplaneMutationStore(PreviewMutationRecordStore, Protocol):
     def write_preview_generation_record(self, record: PreviewGenerationRecord) -> object: ...
 
 
+class _PreviewGenerationEvidenceWriteStore(Protocol):
+    def write_preview_generation_evidence_records(
+        self,
+        *,
+        preview_record: PreviewRecord,
+        generation_record: PreviewGenerationRecord,
+    ) -> tuple[object, object]: ...
+
+
 def control_plane_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
@@ -43,6 +53,21 @@ def upsert_launchplane_preview_from_request(
     *,
     control_plane_root_path: Path,
     record_store: LaunchplaneMutationStore,
+    request: PreviewMutationRequest,
+) -> PreviewRecord:
+    preview_record = build_launchplane_preview_from_request(
+        control_plane_root_path=control_plane_root_path,
+        record_store=record_store,
+        request=request,
+    )
+    record_store.write_preview_record(preview_record)
+    return preview_record
+
+
+def build_launchplane_preview_from_request(
+    *,
+    control_plane_root_path: Path,
+    record_store: PreviewMutationRecordStore,
     request: PreviewMutationRequest,
 ) -> PreviewRecord:
     existing_preview = find_preview_record(
@@ -76,8 +101,123 @@ def upsert_launchplane_preview_from_request(
             request=normalized_request,
         )
     )
-    record_store.write_preview_record(preview_record)
     return preview_record
+
+
+def build_launchplane_preview_generation_from_request(
+    *,
+    record_store: PreviewMutationRecordStore,
+    preview_record: PreviewRecord,
+    request: PreviewGenerationMutationRequest,
+) -> PreviewGenerationRecord:
+    existing_generations = record_store.list_preview_generation_records(
+        preview_id=preview_record.preview_id
+    )
+    existing_generation = next(
+        (
+            record
+            for record in existing_generations
+            if request.generation_id.strip() and record.generation_id == request.generation_id
+        ),
+        None,
+    )
+    if existing_generation is None and not request.generation_id.strip():
+        existing_generation = next(
+            (
+                record
+                for record in existing_generations
+                if _preview_generation_matches_request(record=record, request=request)
+            ),
+            None,
+        )
+    if existing_generation is not None:
+        resolved_sequence = existing_generation.sequence
+        resolved_generation_id = existing_generation.generation_id
+    else:
+        resolved_sequence = request.sequence or (
+            max((record.sequence for record in existing_generations), default=0) + 1
+        )
+        resolved_generation_id = request.generation_id.strip()
+
+    return build_preview_generation_record(
+        preview_id=preview_record.preview_id,
+        sequence=resolved_sequence,
+        state=request.state,
+        requested_reason=request.requested_reason,
+        requested_at=request.requested_at,
+        resolved_manifest_fingerprint=request.resolved_manifest_fingerprint,
+        anchor_repo=request.anchor_repo,
+        anchor_pr_number=request.anchor_pr_number,
+        anchor_pr_url=request.anchor_pr_url,
+        anchor_head_sha=request.anchor_head_sha,
+        generation_id=resolved_generation_id,
+        started_at=request.started_at,
+        ready_at=request.ready_at,
+        finished_at=request.finished_at,
+        superseded_at=request.superseded_at,
+        failed_at=request.failed_at,
+        expires_at=request.expires_at,
+        artifact_id=request.artifact_id,
+        baseline_release_tuple_id=request.baseline_release_tuple_id,
+        source_map=request.source_map,
+        companion_summaries=request.companion_summaries,
+        deploy_status=request.deploy_status,
+        verify_status=request.verify_status,
+        overall_health_status=request.overall_health_status,
+        failure_stage=request.failure_stage,
+        failure_summary=request.failure_summary,
+    )
+
+
+def _preview_generation_matches_request(
+    *,
+    record: PreviewGenerationRecord,
+    request: PreviewGenerationMutationRequest,
+) -> bool:
+    if request.sequence is not None and record.sequence != request.sequence:
+        return False
+    return (
+        record.state == request.state
+        and record.requested_reason == request.requested_reason
+        and record.requested_at == request.requested_at
+        and record.started_at == request.started_at
+        and record.ready_at == request.ready_at
+        and record.finished_at == request.finished_at
+        and record.superseded_at == request.superseded_at
+        and record.failed_at == request.failed_at
+        and record.expires_at == request.expires_at
+        and record.resolved_manifest_fingerprint == request.resolved_manifest_fingerprint
+        and record.artifact_id == request.artifact_id
+        and record.baseline_release_tuple_id == request.baseline_release_tuple_id
+        and record.source_map == request.source_map
+        and record.companion_summaries == request.companion_summaries
+        and record.deploy_status == request.deploy_status
+        and record.verify_status == request.verify_status
+        and record.overall_health_status == request.overall_health_status
+        and record.failure_stage == request.failure_stage
+        and record.failure_summary == request.failure_summary
+        and record.anchor_summary.repo == request.anchor_repo
+        and record.anchor_summary.pr_number == request.anchor_pr_number
+        and record.anchor_summary.pr_url == request.anchor_pr_url
+        and record.anchor_summary.head_sha == request.anchor_head_sha
+    )
+
+
+def _validate_preview_generation_request_alignment(
+    *,
+    preview_request: PreviewMutationRequest,
+    generation_request: PreviewGenerationMutationRequest,
+) -> None:
+    if preview_request.context != generation_request.context:
+        raise click.ClickException("Preview generation evidence requires matching contexts.")
+    if preview_request.anchor_repo != generation_request.anchor_repo:
+        raise click.ClickException("Preview generation evidence requires matching anchor_repo.")
+    if preview_request.anchor_pr_number != generation_request.anchor_pr_number:
+        raise click.ClickException(
+            "Preview generation evidence requires matching anchor_pr_number."
+        )
+    if preview_request.anchor_pr_url != generation_request.anchor_pr_url:
+        raise click.ClickException("Preview generation evidence requires matching anchor_pr_url.")
 
 
 def apply_launchplane_generation_evidence(
@@ -87,15 +227,32 @@ def apply_launchplane_generation_evidence(
     preview_request: PreviewMutationRequest,
     generation_request: PreviewGenerationMutationRequest,
 ) -> dict[str, object]:
-    preview_record = upsert_launchplane_preview_from_request(
-        control_plane_root_path=control_plane_root_path,
-        record_store=record_store,
-        request=preview_request,
+    _validate_preview_generation_request_alignment(
+        preview_request=preview_request,
+        generation_request=generation_request,
     )
-    generation_record = build_preview_generation_record_from_request(
-        record_store=record_store,
-        request=generation_request,
-    )
+    bundled_write = getattr(record_store, "write_preview_generation_evidence_records", None)
+    if callable(bundled_write):
+        preview_record = build_launchplane_preview_from_request(
+            control_plane_root_path=control_plane_root_path,
+            record_store=record_store,
+            request=preview_request,
+        )
+        generation_record = build_launchplane_preview_generation_from_request(
+            record_store=record_store,
+            preview_record=preview_record,
+            request=generation_request,
+        )
+    else:
+        preview_record = upsert_launchplane_preview_from_request(
+            control_plane_root_path=control_plane_root_path,
+            record_store=record_store,
+            request=preview_request,
+        )
+        generation_record = build_preview_generation_record_from_request(
+            record_store=record_store,
+            request=generation_request,
+        )
     if generation_record.state == "ready":
         transitioned_preview = apply_generation_ready_transition(
             preview=preview_record,
@@ -111,8 +268,17 @@ def apply_launchplane_generation_evidence(
             preview=preview_record,
             generation=generation_record,
         )
-    generation_path = record_store.write_preview_generation_record(generation_record)
-    preview_path = record_store.write_preview_record(transitioned_preview)
+    if callable(bundled_write):
+        generation_path, preview_path = cast(
+            _PreviewGenerationEvidenceWriteStore,
+            record_store,
+        ).write_preview_generation_evidence_records(
+            preview_record=transitioned_preview,
+            generation_record=generation_record,
+        )
+    else:
+        generation_path = record_store.write_preview_generation_record(generation_record)
+        preview_path = record_store.write_preview_record(transitioned_preview)
     return {
         "generation_id": generation_record.generation_id,
         "generation_path": _record_locator(generation_path, generation_record.generation_id),

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -161,6 +161,10 @@ from control_plane.contracts.preview_mutation_request import (
     PreviewGenerationMutationRequest,
     PreviewMutationRequest,
 )
+from control_plane.contracts.preview_evidence import (
+    PreviewDestroyedEvidenceEnvelope,
+    PreviewGenerationEvidenceEnvelope,
+)
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_lifecycle_plan_record import (
     PreviewLifecycleDesiredPreview,
@@ -927,43 +931,6 @@ _WsgiApp = Callable[[dict[str, object], _StartResponse], list[bytes]]
 
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class PreviewGenerationEvidenceEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    preview: PreviewMutationRequest
-    generation: PreviewGenerationMutationRequest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "PreviewGenerationEvidenceEnvelope":
-        if not self.product.strip():
-            raise ValueError("preview generation evidence requires product")
-        if self.preview.context != self.generation.context:
-            raise ValueError("preview generation evidence requires matching contexts")
-        if self.preview.anchor_repo != self.generation.anchor_repo:
-            raise ValueError("preview generation evidence requires matching anchor_repo")
-        if self.preview.anchor_pr_number != self.generation.anchor_pr_number:
-            raise ValueError("preview generation evidence requires matching anchor_pr_number")
-        if self.preview.anchor_pr_url != self.generation.anchor_pr_url:
-            raise ValueError("preview generation evidence requires matching anchor_pr_url")
-        return self
-
-
-class PreviewDestroyedEvidenceEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    destroy: PreviewDestroyMutationRequest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "PreviewDestroyedEvidenceEnvelope":
-        if not self.product.strip():
-            raise ValueError("preview destroyed evidence requires product")
-        return self
 
 
 class DeploymentEvidenceEnvelope(BaseModel):
@@ -16895,6 +16862,7 @@ def serve_launchplane_service(
         record_store_factory=lambda: service_record_store,
         bearer_identity_config=_bearer_identity_config_from_env(),
         human_session_manager=human_session_manager,
+        control_plane_root_path=control_plane_root(),
     )
     fastapi_application.mount(
         "/",

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -2009,6 +2009,30 @@ class FilesystemRecordStore:
     def write_preview_generation_record(self, record: PreviewGenerationRecord) -> Path:
         return self._write_model("launchplane_preview_generations", record.generation_id, record)
 
+    def write_preview_generation_evidence_records(
+        self,
+        *,
+        preview_record: PreviewRecord,
+        generation_record: PreviewGenerationRecord,
+    ) -> tuple[Path, Path]:
+        generation_path = self._record_path(
+            "launchplane_preview_generations",
+            generation_record.generation_id,
+        )
+        preview_path = self._record_path("launchplane_previews", preview_record.preview_id)
+        previous_generation = generation_path.read_bytes() if generation_path.exists() else None
+        previous_preview = preview_path.read_bytes() if preview_path.exists() else None
+        try:
+            written_generation_path = self.write_preview_generation_record(generation_record)
+            written_preview_path = self.write_preview_record(preview_record)
+        except Exception:
+            with suppress(Exception):
+                self._restore_record_path(generation_path, previous_generation)
+            with suppress(Exception):
+                self._restore_record_path(preview_path, previous_preview)
+            raise
+        return written_generation_path, written_preview_path
+
     def read_preview_generation_record(self, generation_id: str) -> PreviewGenerationRecord:
         return PreviewGenerationRecord.model_validate(
             self._read_model(

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -3082,6 +3082,39 @@ class PostgresRecordStore(HumanSessionStore):
             )
         )
 
+    def write_preview_generation_evidence_records(
+        self,
+        *,
+        preview_record: PreviewRecord,
+        generation_record: PreviewGenerationRecord,
+    ) -> tuple[None, None]:
+        with self._session_factory() as session:
+            session.merge(
+                LaunchplanePreviewGenerationRow(
+                    generation_id=generation_record.generation_id,
+                    preview_id=generation_record.preview_id,
+                    sequence=generation_record.sequence,
+                    state=generation_record.state,
+                    requested_at=generation_record.requested_at,
+                    finished_at=generation_record.finished_at,
+                    artifact_id=generation_record.artifact_id,
+                    payload=self._payload_dict(generation_record),
+                )
+            )
+            session.merge(
+                LaunchplanePreviewRow(
+                    preview_id=preview_record.preview_id,
+                    context=preview_record.context,
+                    anchor_repo=preview_record.anchor_repo,
+                    anchor_pr_number=preview_record.anchor_pr_number,
+                    state=preview_record.state,
+                    updated_at=preview_record.updated_at,
+                    payload=self._payload_dict(preview_record),
+                )
+            )
+            session.commit()
+        return None, None
+
     def read_preview_generation_record(self, generation_id: str) -> PreviewGenerationRecord:
         return self._read_model(
             model_type=PreviewGenerationRecord,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -57,13 +57,13 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment, backup-gate, and promotion evidence ingestion use native FastAPI
-  routes for bearer-token callers and preserve the existing `Idempotency-Key`
-  replay/conflict contract. Their legacy WSGI branches are shadowed by native
-  routes while the mounted fallback remains for the rest of the evidence family;
-  delete those WSGI branches after caller evidence proves the native paths and
-  the adjacent evidence routes have native coverage or an explicit retained
-  status.
+- Deployment, backup-gate, promotion, and preview generation evidence ingestion
+  use native FastAPI routes for bearer-token callers and preserve the existing
+  `Idempotency-Key` replay/conflict contract. Their legacy WSGI branches are
+  shadowed by native routes while the mounted fallback remains for the rest of
+  the evidence family; delete those WSGI branches after caller evidence proves
+  the native paths and the adjacent evidence routes have native coverage or an
+  explicit retained status.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -56,7 +56,9 @@ VeriReel product paths:
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
   - `POST /v1/evidence/promotions` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
-  - `POST /v1/evidence/previews/generations`
+  - `POST /v1/evidence/previews/generations` (native FastAPI for bearer-token
+    callers, with Pydantic/OpenAPI contract coverage, idempotency replay
+    preservation, and bundled preview/generation evidence storage)
   - `POST /v1/evidence/previews/destroyed`
   - `POST /v1/evidence/runner-host-hygiene/audits`
 - product profile routes:
@@ -842,6 +844,15 @@ validation.
 Replay handling runs before those capability checks so a stored response can
 still be returned if the backing store is temporarily write-restricted for
 promotion evidence.
+
+`POST /v1/evidence/previews/generations` requires any available idempotency
+store plus preview record list, preview generation list, preview write,
+generation write, and the bundled preview-generation evidence write capability.
+The bundled write commits the generation record and transitioned preview record
+together after request validation, avoiding a partial initial-preview write on
+native FastAPI ingestion. Replay handling runs before those capability checks so
+a stored response can still be returned if the backing store is temporarily
+write-restricted for preview generation evidence.
 
 ### Preview lifecycle endpoints
 

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -48,6 +48,11 @@ from control_plane.contracts.preview_pr_feedback_notifications import (
     PreviewPrFeedbackNotificationDestination,
     PreviewPrFeedbackNotificationPolicyRecord,
 )
+from control_plane.contracts.preview_generation_record import (
+    PreviewGenerationRecord,
+    PreviewPullRequestSummary,
+)
+from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.merge_train_stack_collapse import (
     MergeTrainStackCollapseEntry,
     MergeTrainStackCollapseMutation,
@@ -135,6 +140,58 @@ def _health_pass() -> HealthcheckEvidence:
         urls=("https://prod.example.com/web/health",),
         timeout_seconds=45,
         status="pass",
+    )
+
+
+def _preview_record(
+    *,
+    preview_id: str = "preview-example-site-pr-42",
+    generation_id: str = "preview-example-site-pr-42-generation-0001",
+) -> PreviewRecord:
+    return PreviewRecord(
+        preview_id=preview_id,
+        context="example-site",
+        anchor_repo="example-site",
+        anchor_pr_number=42,
+        anchor_pr_url="https://github.com/example/site/pull/42",
+        preview_label="example-site/example-site/pr-42",
+        canonical_url="https://pr-42.example-preview.test",
+        state="active",
+        created_at="2026-05-03T00:00:00Z",
+        updated_at="2026-05-03T00:05:00Z",
+        eligible_at="2026-05-03T00:00:00Z",
+        active_generation_id=generation_id,
+        serving_generation_id=generation_id,
+        latest_generation_id=generation_id,
+        latest_manifest_fingerprint="preview-manifest-123",
+    )
+
+
+def _preview_generation_record(
+    *,
+    generation_id: str = "preview-example-site-pr-42-generation-0001",
+    preview_id: str = "preview-example-site-pr-42",
+) -> PreviewGenerationRecord:
+    return PreviewGenerationRecord(
+        generation_id=generation_id,
+        preview_id=preview_id,
+        sequence=1,
+        state="ready",
+        requested_reason="external_preview_refresh",
+        requested_at="2026-05-03T00:01:00Z",
+        ready_at="2026-05-03T00:05:00Z",
+        finished_at="2026-05-03T00:05:00Z",
+        resolved_manifest_fingerprint="preview-manifest-123",
+        artifact_id="artifact-preview-42",
+        anchor_summary=PreviewPullRequestSummary(
+            repo="example-site",
+            pr_number=42,
+            head_sha="6b3c9d7e8f901234567890abcdef1234567890ab",
+            pr_url="https://github.com/example/site/pull/42",
+        ),
+        deploy_status="pass",
+        verify_status="pass",
+        overall_health_status="pass",
     )
 
 
@@ -1573,6 +1630,52 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             self.assertEqual(loaded_promotion.record_id, promotion_record.record_id)
             self.assertEqual(loaded_inventory.promotion_record_id, promotion_record.record_id)
             self.assertEqual(loaded_inventory.promoted_from_instance, "testing")
+
+    def test_write_preview_generation_evidence_records_writes_generation_and_preview(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            preview = _preview_record()
+            generation = _preview_generation_record()
+
+            generation_path, preview_path = store.write_preview_generation_evidence_records(
+                preview_record=preview,
+                generation_record=generation,
+            )
+            loaded_generation = store.read_preview_generation_record(generation.generation_id)
+            loaded_preview = store.read_preview_record(preview.preview_id)
+
+            self.assertTrue(generation_path.exists())
+            self.assertTrue(preview_path.exists())
+            self.assertEqual(loaded_generation.generation_id, generation.generation_id)
+            self.assertEqual(loaded_preview.preview_id, preview.preview_id)
+            self.assertEqual(loaded_preview.serving_generation_id, generation.generation_id)
+
+    def test_write_preview_generation_evidence_records_rolls_back_generation_on_preview_failure(
+        self,
+    ) -> None:
+        class FailingPreviewFilesystemRecordStore(FilesystemRecordStore):
+            def write_preview_record(self, record: PreviewRecord) -> Path:
+                raise RuntimeError("preview write failed")
+
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name)
+            store = FailingPreviewFilesystemRecordStore(state_dir=state_dir)
+            preview = _preview_record()
+            generation = _preview_generation_record()
+
+            with self.assertRaises(RuntimeError):
+                store.write_preview_generation_evidence_records(
+                    preview_record=preview,
+                    generation_record=generation,
+                )
+
+            with self.assertRaises(FileNotFoundError):
+                store.read_preview_generation_record(generation.generation_id)
+            with self.assertRaises(FileNotFoundError):
+                store.read_preview_record(preview.preview_id)
 
     def test_list_promotion_records_filters_and_sorts_latest_first(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -17,6 +17,7 @@ from starlette.types import ASGIApp
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -306,6 +307,58 @@ class FastApiPromotionEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
         self.assertEqual(store.read_idempotency_calls, 2)
         self.assertEqual(store.write_promotion_calls, 1)
+
+
+class FastApiPreviewGenerationEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_preview_generation_evidence_requires_preview_generation_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_preview_generation_write_identity()),
+            authz_policy=_preview_generation_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_preview_generation_evidence(
+            app,
+            _preview_generation_evidence_payload(),
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_preview_generation_evidence_replays_idempotency_before_store_gate(
+        self,
+    ) -> None:
+        store = _IdempotencyOnlyPreviewGenerationReplayStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_preview_generation_write_identity()),
+            authz_policy=_preview_generation_write_policy(context="example-site"),
+            record_store_factory=lambda: store,
+        )
+        request_payload = _preview_generation_evidence_payload()
+
+        first_response = await _post_preview_generation_evidence(
+            app,
+            request_payload,
+            idempotency_key="preview-generation-example-site-pr-42",
+        )
+        store.write_preview_generation_evidence_records = None
+        second_response = await _post_preview_generation_evidence(
+            app,
+            request_payload,
+            idempotency_key="preview-generation-example-site-pr-42",
+        )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(store.read_idempotency_calls, 2)
+        self.assertEqual(store.write_preview_generation_evidence_calls, 1)
 
 
 class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCase):
@@ -2082,6 +2135,355 @@ class FastApiPromotionEvidenceTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FastApiPreviewGenerationEvidenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_preview_generation_evidence_writes_records_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_generation_write_identity()),
+                authz_policy=_preview_generation_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_preview_generation_evidence(
+                app,
+                _preview_generation_evidence_payload(),
+            )
+            preview = store.read_preview_record("preview-example-site-example-site-pr-42")
+            generation = store.read_preview_generation_record(
+                "preview-example-site-example-site-pr-42-generation-0001"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["preview_id"],
+            "preview-example-site-example-site-pr-42",
+        )
+        self.assertEqual(
+            payload["records"]["generation_id"],
+            "preview-example-site-example-site-pr-42-generation-0001",
+        )
+        self.assertEqual(payload["records"]["transition"], "ready")
+        self.assertNotIn("replayed", payload)
+        self.assertEqual(preview.state, "active")
+        self.assertEqual(preview.serving_generation_id, generation.generation_id)
+        self.assertEqual(generation.state, "ready")
+        self.assertEqual(generation.artifact_id, "ghcr.io/every/example-site:pr-42-abcdef")
+
+    async def test_preview_generation_evidence_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_generation_write_identity()),
+                authz_policy=_preview_generation_write_policy(context="other-site"),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_preview_generation_evidence(
+                app,
+                _preview_generation_evidence_payload(),
+            )
+            self.assertEqual(store.list_preview_records(), ())
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_preview_generation_evidence_rejects_human_session_mutation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            oauth_config = _github_oauth_config()
+            session_store = InMemoryHumanSessionStore()
+            session_manager = HumanSessionManager(
+                config=oauth_config,
+                session_store=session_store,
+            )
+            human_session = session_manager.issue(_github_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_github_human_preview_generation_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_preview_generation_evidence(
+                app,
+                _preview_generation_evidence_payload(),
+                authorization="",
+                headers={"Cookie": session_manager.session_cookie_header(human_session)},
+            )
+            self.assertEqual(store.list_preview_records(), ())
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_preview_generation_evidence_rejects_terminal_agent_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_preview_generation_write_policy(
+                    context="example-site"
+                ),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-agent-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+                control_plane_root_path=root,
+            )
+
+            response = await _post_preview_generation_evidence(
+                app,
+                _preview_generation_evidence_payload(),
+                authorization="Bearer terminal-agent-token",
+            )
+            self.assertEqual(store.list_preview_records(), ())
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_preview_generation_evidence_validation_errors_use_launchplane_shape(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_generation_write_identity()),
+                authz_policy=_preview_generation_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            invalid_payload = _preview_generation_evidence_payload()
+            invalid_payload["product"] = ""
+
+            response = await _post_preview_generation_evidence(app, invalid_payload)
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertNotIn("detail", payload)
+
+    async def test_preview_generation_evidence_rejects_mismatched_generation_context(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_generation_write_identity()),
+                authz_policy=_preview_generation_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            invalid_payload = _preview_generation_evidence_payload()
+            generation = cast(dict[str, object], invalid_payload["generation"])
+            generation["context"] = "other-site"
+
+            response = await _post_preview_generation_evidence(app, invalid_payload)
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(store.list_preview_records(), ())
+
+    async def test_preview_generation_evidence_replays_idempotent_write(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_generation_write_identity()),
+                authz_policy=_preview_generation_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            request_payload = _preview_generation_evidence_payload()
+
+            first_response = await _post_preview_generation_evidence(
+                app,
+                request_payload,
+                idempotency_key="preview-generation-example-site-pr-42",
+            )
+            second_response = await _post_preview_generation_evidence(
+                app,
+                request_payload,
+                idempotency_key="preview-generation-example-site-pr-42",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertNotEqual(second_payload["trace_id"], first_payload["trace_id"])
+
+    async def test_preview_generation_evidence_retry_after_idempotency_write_failure_converges(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = _FailingOnceIdempotencyPreviewGenerationStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_generation_write_identity()),
+                authz_policy=_preview_generation_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            request_payload = _preview_generation_evidence_payload()
+
+            with self.assertRaises(RuntimeError):
+                await _post_preview_generation_evidence(
+                    app,
+                    request_payload,
+                    idempotency_key="preview-generation-example-site-pr-42",
+                )
+            generations_after_failure = store.list_preview_generation_records(
+                preview_id="preview-example-site-example-site-pr-42"
+            )
+
+            retry_response = await _post_preview_generation_evidence(
+                app,
+                request_payload,
+                idempotency_key="preview-generation-example-site-pr-42",
+            )
+            generations_after_retry = store.list_preview_generation_records(
+                preview_id="preview-example-site-example-site-pr-42"
+            )
+
+        self.assertEqual(
+            [record.generation_id for record in generations_after_failure],
+            ["preview-example-site-example-site-pr-42-generation-0001"],
+        )
+        self.assertEqual(retry_response.status_code, 202)
+        retry_payload = retry_response.json()
+        self.assertEqual(
+            retry_payload["records"]["generation_id"],
+            "preview-example-site-example-site-pr-42-generation-0001",
+        )
+        self.assertNotIn("replayed", retry_payload)
+        self.assertEqual(
+            [record.generation_id for record in generations_after_retry],
+            ["preview-example-site-example-site-pr-42-generation-0001"],
+        )
+
+    async def test_preview_generation_evidence_rejects_idempotency_key_reuse(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_generation_write_identity()),
+                authz_policy=_preview_generation_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            request_payload = _preview_generation_evidence_payload()
+            changed_payload = _preview_generation_evidence_payload(anchor_pr_number=43)
+
+            first_response = await _post_preview_generation_evidence(
+                app,
+                request_payload,
+                idempotency_key="preview-generation-example-site-pr-42",
+            )
+            second_response = await _post_preview_generation_evidence(
+                app,
+                changed_payload,
+                idempotency_key="preview-generation-example-site-pr-42",
+            )
+            preview_count = len(store.list_preview_records())
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        payload = second_response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+        self.assertEqual(preview_count, 1)
+
+    async def test_openapi_includes_preview_generation_evidence_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_preview_generation_write_identity()),
+            authz_policy=_preview_generation_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/evidence/previews/generations"]["post"]
+        self.assertEqual(route["operationId"], "write_preview_generation_evidence")
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(
+            request_schema["$ref"], "#/components/schemas/PreviewGenerationEvidenceEnvelope"
+        )
+        success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
+        self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
+        for status_code in ("400", "401", "403", "409", "503"):
+            error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
+            self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
+        envelope_schema = openapi["components"]["schemas"]["PreviewGenerationEvidenceEnvelope"]
+        self.assertFalse(envelope_schema["additionalProperties"])
+
+    async def test_preview_generation_evidence_native_route_precedes_wsgi_fallback(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_generation_write_identity()),
+                authz_policy=_preview_generation_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _post_preview_generation_evidence(
+                app,
+                _preview_generation_evidence_payload(),
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["generation_id"],
+            "preview-example-site-example-site-pr-42-generation-0001",
+        )
+
+
 class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
     async def test_deployment_evidence_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2582,6 +2984,102 @@ def _promotion_evidence_store(
     return store
 
 
+def _preview_generation_write_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="every/example-site",
+        workflow_ref="every/example-site/.github/workflows/preview-control-plane.yml@refs/heads/main",
+        event_name="pull_request",
+    )
+
+
+def _preview_generation_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/example-site",
+                    "workflow_refs": [
+                        "every/example-site/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["preview_generation.write"],
+                }
+            ]
+        }
+    )
+
+
+def _github_human_preview_generation_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_humans": [
+                {
+                    "logins": ["example-operator"],
+                    "roles": ["admin"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["preview_generation.write"],
+                }
+            ]
+        }
+    )
+
+
+def _terminal_agent_preview_generation_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["example-site"],
+                    "contexts": [context],
+                    "actions": ["preview_generation.write"],
+                }
+            ]
+        }
+    )
+
+
+def _preview_generation_evidence_payload(*, anchor_pr_number: int = 42) -> dict[str, object]:
+    pr_url = f"https://github.com/every/example-site/pull/{anchor_pr_number}"
+    return {
+        "schema_version": 1,
+        "product": "example-site",
+        "preview": {
+            "schema_version": 1,
+            "context": "example-site",
+            "anchor_repo": "example-site",
+            "anchor_pr_number": anchor_pr_number,
+            "anchor_pr_url": pr_url,
+            "canonical_url": f"https://pr-{anchor_pr_number}.example.invalid",
+            "state": "active",
+            "updated_at": "2026-04-16T08:10:00Z",
+            "eligible_at": "2026-04-16T08:10:00Z",
+        },
+        "generation": {
+            "schema_version": 1,
+            "context": "example-site",
+            "anchor_repo": "example-site",
+            "anchor_pr_number": anchor_pr_number,
+            "anchor_pr_url": pr_url,
+            "anchor_head_sha": "abcdef1234567890abcdef1234567890abcdef12",
+            "state": "ready",
+            "requested_reason": "external_preview_refresh",
+            "requested_at": "2026-04-16T08:02:00Z",
+            "ready_at": "2026-04-16T08:10:00Z",
+            "finished_at": "2026-04-16T08:10:00Z",
+            "resolved_manifest_fingerprint": f"example-preview-pr-{anchor_pr_number}-abcdef",
+            "artifact_id": "ghcr.io/every/example-site:pr-42-abcdef",
+            "deploy_status": "pass",
+            "verify_status": "pass",
+            "overall_health_status": "pass",
+        },
+    }
+
+
 def _deployment_write_identity() -> GitHubActionsIdentity:
     return _identity(
         repository="every/example-site",
@@ -2984,6 +3482,28 @@ async def _post_promotion_evidence(
     )
 
 
+async def _post_preview_generation_evidence(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/evidence/previews/generations",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _post_deployment_evidence(
     app: FastAPI,
     payload: dict[str, object],
@@ -3167,6 +3687,101 @@ class _IdempotencyOnlyPromotionReplayStore:
 
     def _write_promotion_record(self, record: PromotionRecord) -> None:
         self.write_promotion_calls += 1
+
+
+class _IdempotencyOnlyPreviewGenerationReplayStore:
+    def __init__(self) -> None:
+        self.read_idempotency_calls = 0
+        self.write_preview_generation_evidence_calls = 0
+        self._stored_record: Any | None = None
+        self._preview_records: dict[str, Any] = {}
+        self._generation_records: dict[str, Any] = {}
+        self.write_preview_generation_evidence_records: Callable[..., tuple[str, str]] | None = (
+            self._write_preview_generation_evidence_records
+        )
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> Any:
+        self.read_idempotency_calls += 1
+        if self._stored_record is None:
+            return None
+        if (
+            self._stored_record.scope != scope
+            or self._stored_record.route_path != route_path
+            or self._stored_record.idempotency_key != idempotency_key
+        ):
+            return None
+        return self._stored_record
+
+    def write_idempotency_record(self, record: Any) -> None:
+        self._stored_record = record
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[Any, ...]:
+        records = [
+            record
+            for record in self._preview_records.values()
+            if (not context_name or record.context == context_name)
+            and (not anchor_repo or record.anchor_repo == anchor_repo)
+            and (anchor_pr_number is None or record.anchor_pr_number == anchor_pr_number)
+        ]
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_preview_record(self, record: Any) -> str:
+        self._preview_records[record.preview_id] = record
+        return f"preview://{record.preview_id}"
+
+    def list_preview_generation_records(
+        self, *, preview_id: str = "", limit: int | None = None
+    ) -> tuple[Any, ...]:
+        records = [
+            record
+            for record in self._generation_records.values()
+            if not preview_id or record.preview_id == preview_id
+        ]
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_preview_generation_record(self, record: Any) -> str:
+        self._generation_records[record.generation_id] = record
+        return f"generation://{record.generation_id}"
+
+    def _write_preview_generation_evidence_records(
+        self,
+        *,
+        preview_record: Any,
+        generation_record: Any,
+    ) -> tuple[str, str]:
+        self.write_preview_generation_evidence_calls += 1
+        generation_path = self.write_preview_generation_record(generation_record)
+        preview_path = self.write_preview_record(preview_record)
+        return generation_path, preview_path
+
+
+class _FailingOnceIdempotencyPreviewGenerationStore(FilesystemRecordStore):
+    def __init__(self, *, state_dir: Path) -> None:
+        super().__init__(state_dir=state_dir)
+        self.fail_next_idempotency_write = True
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> Path:
+        if self.fail_next_idempotency_write:
+            self.fail_next_idempotency_write = False
+            raise RuntimeError("idempotency write failed")
+        return super().write_idempotency_record(record)
 
 
 class _DeploymentEvidenceOnlyStore:

--- a/tests/test_launchplane_mutations.py
+++ b/tests/test_launchplane_mutations.py
@@ -64,6 +64,39 @@ class _FakePreviewMutationStore:
         return f"generation://{record.generation_id}"
 
 
+class _BundledPreviewMutationStore(_FakePreviewMutationStore):
+    def __init__(self, *, fail_evidence_write: bool = False) -> None:
+        super().__init__()
+        self.fail_evidence_write = fail_evidence_write
+        self.preview_write_count = 0
+        self.generation_write_count = 0
+        self.evidence_write_count = 0
+
+    def write_preview_record(self, record: PreviewRecord) -> str:
+        self.preview_write_count += 1
+        return super().write_preview_record(record)
+
+    def write_preview_generation_record(self, record: PreviewGenerationRecord) -> str:
+        self.generation_write_count += 1
+        return super().write_preview_generation_record(record)
+
+    def write_preview_generation_evidence_records(
+        self,
+        *,
+        preview_record: PreviewRecord,
+        generation_record: PreviewGenerationRecord,
+    ) -> tuple[str, str]:
+        self.evidence_write_count += 1
+        if self.fail_evidence_write:
+            raise RuntimeError("bundled write failed")
+        self.generations[generation_record.generation_id] = generation_record
+        self.previews[preview_record.preview_id] = preview_record
+        return (
+            f"generation-evidence://{generation_record.generation_id}",
+            f"preview-evidence://{preview_record.preview_id}",
+        )
+
+
 def _preview_request(**updates: object) -> PreviewMutationRequest:
     payload: dict[str, object] = {
         "context": "site-testing",
@@ -131,6 +164,108 @@ class LaunchplaneMutationTests(unittest.TestCase):
         preview = store.previews["preview-site-testing-cbusillo-site-pr-42"]
         self.assertEqual(preview.state, "active")
         self.assertEqual(preview.serving_generation_id, result["generation_id"])
+
+    def test_generation_evidence_uses_bundled_store_write_when_available(self) -> None:
+        store = _BundledPreviewMutationStore()
+
+        result = apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(),
+        )
+
+        self.assertEqual(store.preview_write_count, 0)
+        self.assertEqual(store.generation_write_count, 0)
+        self.assertEqual(store.evidence_write_count, 1)
+        self.assertEqual(
+            result["generation_path"],
+            "generation-evidence://preview-site-testing-cbusillo-site-pr-42-generation-0001",
+        )
+        self.assertEqual(
+            result["preview_path"],
+            "preview-evidence://preview-site-testing-cbusillo-site-pr-42",
+        )
+        preview = store.previews["preview-site-testing-cbusillo-site-pr-42"]
+        self.assertEqual(preview.state, "active")
+        self.assertEqual(preview.serving_generation_id, result["generation_id"])
+
+    def test_generation_evidence_bundled_write_failure_leaves_no_partial_preview(
+        self,
+    ) -> None:
+        store = _BundledPreviewMutationStore(fail_evidence_write=True)
+
+        with self.assertRaises(RuntimeError):
+            apply_launchplane_generation_evidence(
+                control_plane_root_path=Path("/launchplane"),
+                record_store=store,
+                preview_request=_preview_request(),
+                generation_request=_generation_request(),
+            )
+
+        self.assertEqual(store.preview_write_count, 0)
+        self.assertEqual(store.generation_write_count, 0)
+        self.assertEqual(store.evidence_write_count, 1)
+        self.assertEqual(store.previews, {})
+        self.assertEqual(store.generations, {})
+
+    def test_generation_evidence_retry_with_different_explicit_sequence_creates_new_generation(
+        self,
+    ) -> None:
+        store = _BundledPreviewMutationStore()
+        apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(),
+        )
+
+        result = apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(sequence=2),
+        )
+
+        self.assertEqual(
+            result["generation_id"],
+            "preview-site-testing-cbusillo-site-pr-42-generation-0002",
+        )
+        self.assertEqual(
+            store.generations["preview-site-testing-cbusillo-site-pr-42-generation-0001"].sequence,
+            1,
+        )
+        self.assertEqual(
+            store.generations["preview-site-testing-cbusillo-site-pr-42-generation-0002"].sequence,
+            2,
+        )
+
+    def test_generation_evidence_preserves_existing_sequence_for_explicit_generation_id(
+        self,
+    ) -> None:
+        store = _BundledPreviewMutationStore()
+        first_result = apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(),
+        )
+
+        result = apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(
+                generation_id=str(first_result["generation_id"]),
+                sequence=2,
+            ),
+        )
+
+        self.assertEqual(result["generation_id"], first_result["generation_id"])
+        self.assertEqual(
+            store.generations[str(first_result["generation_id"])].sequence,
+            1,
+        )
 
     def test_destroy_preview_requires_existing_preview(self) -> None:
         store = _FakePreviewMutationStore()

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1035,6 +1035,47 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(loaded_inventory.promotion_record_id, promotion_record.record_id)
         self.assertEqual(loaded_inventory.promoted_from_instance, "testing")
 
+    def test_write_preview_generation_evidence_records_writes_generation_and_preview(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            generation_id = "preview-verireel-testing-verireel-pr-123-generation-0001"
+            preview = _preview_record(
+                preview_id="preview-verireel-testing-verireel-pr-123",
+                updated_at="2026-04-20T10:05:00Z",
+                pr_number=123,
+            ).model_copy(
+                update={
+                    "active_generation_id": generation_id,
+                    "serving_generation_id": generation_id,
+                    "latest_generation_id": generation_id,
+                    "latest_manifest_fingerprint": "preview-manifest-123",
+                }
+            )
+            generation = _preview_generation_record(
+                generation_id=generation_id,
+                preview_id=preview.preview_id,
+            )
+
+            store.write_preview_generation_evidence_records(
+                preview_record=preview,
+                generation_record=generation,
+            )
+            loaded_generation = store.read_preview_generation_record(generation_id)
+            loaded_preview = store.read_preview_record(preview.preview_id)
+            store.close()
+
+        self.assertEqual(loaded_generation.generation_id, generation_id)
+        self.assertEqual(loaded_generation.preview_id, preview.preview_id)
+        self.assertEqual(loaded_preview.preview_id, preview.preview_id)
+        self.assertEqual(loaded_preview.serving_generation_id, generation_id)
+
     def test_alembic_baseline_creates_schema_used_by_record_store(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(


### PR DESCRIPTION
## Summary

- Migrate `POST /v1/evidence/previews/generations` to native FastAPI while keeping the legacy WSGI fallback available behind the native route.
- Move preview evidence envelopes into a shared contract module and wire FastAPI/service to use them.
- Add bundled preview-generation evidence writes for filesystem/Postgres, with filesystem rollback and Postgres single-transaction storage.
- Make preview-generation retries converge when evidence commits but the idempotency record write fails, without corrupting generation id/sequence consistency.
- Update service-boundary and compatibility-retirement docs.

Refs #1322

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiPreviewGenerationEvidenceStoreGateTests tests.test_http_app.FastApiPreviewGenerationEvidenceTests tests.test_launchplane_mutations tests.test_filesystem_store.FilesystemRecordStoreTests.test_write_preview_generation_evidence_records_writes_generation_and_preview tests.test_filesystem_store.FilesystemRecordStoreTests.test_write_preview_generation_evidence_records_rolls_back_generation_on_preview_failure tests.test_postgres_store.PostgresRecordStoreTests.test_write_preview_generation_evidence_records_writes_generation_and_preview`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/launchplane_mutations.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/contracts/preview_evidence.py tests/test_http_app.py tests/test_launchplane_mutations.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/launchplane_mutations.py control_plane/storage/filesystem.py control_plane/storage/postgres.py control_plane/contracts/preview_evidence.py tests/test_http_app.py tests/test_launchplane_mutations.py tests/test_filesystem_store.py tests/test_postgres_store.py`
- `git diff --check`
- `uv run --extra dev mypy control_plane tests`
- `TMPDIR="$PWD/.tmp/test-tmp" uv run python -m unittest` (2,602 tests passed)
- JetBrains inspection closeout, scope `changed_files`: clean, zero problems

Note: whole-repo `uv run --extra dev ruff format --check .` still reports pre-existing formatting drift in unrelated files; touched-file format check is clean.

## Review Evidence

- Read-only review agents checked route/authz/idempotency/storage/docs and found one idempotency-loss edge; fixed with a regression.
- Follow-up review found one sequence/id false-match edge; fixed with unit regressions.
- Final sequence/id confirmation agents reported no blocking findings.
