### PR TITLE
Migrate runner host hygiene evidence to FastAPI

### DIFF
--- a/control_plane/contracts/runner_host_hygiene_evidence.py
+++ b/control_plane/contracts/runner_host_hygiene_evidence.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+
+
+class RunnerHostHygieneAuditEvidenceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    audit: RunnerHostHygieneApplyAuditRecord
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "RunnerHostHygieneAuditEvidenceEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("runner host hygiene audit evidence requires product 'launchplane'")
+        self.product = "launchplane"
+        return self

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -38,6 +38,10 @@ from control_plane.contracts.protected_artifacts import (
     ProtectedArtifactSet,
     build_protected_artifact_set,
 )
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene_evidence import (
+    RunnerHostHygieneAuditEvidenceEnvelope,
+)
 from control_plane.drivers.registry import build_driver_context_view, list_driver_descriptors
 from control_plane.drivers.registry import read_driver_descriptor as read_driver_descriptor_record
 from control_plane.service_auth import (
@@ -79,6 +83,8 @@ _BACKUP_GATE_EVIDENCE_ROUTE = "/v1/evidence/backup-gates"
 _PROMOTION_EVIDENCE_ROUTE = "/v1/evidence/promotions"
 _PREVIEW_GENERATION_EVIDENCE_ROUTE = "/v1/evidence/previews/generations"
 _PREVIEW_DESTROYED_EVIDENCE_ROUTE = "/v1/evidence/previews/destroyed"
+_RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-host-hygiene/audits"
+_LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 
 
 class LaunchplaneErrorDetail(BaseModel):
@@ -217,6 +223,7 @@ class AcceptedEvidenceResponse(BaseModel):
     status: Literal["accepted"] = "accepted"
     trace_id: str
     records: dict[str, str]
+    result: dict[str, object] | None = None
     replayed: bool | None = None
     original_trace_id: str | None = None
 
@@ -239,6 +246,13 @@ class _IdempotencyCapableStore(Protocol):
 
 class _BackupGateEvidenceStore(Protocol):
     def write_backup_gate_record(self, record: BackupGateRecord) -> object: ...
+
+
+class _RunnerHostHygieneAuditEvidenceStore(Protocol):
+    def write_runner_host_hygiene_audit_record(
+        self,
+        record: RunnerHostHygieneApplyAuditRecord,
+    ) -> object: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -363,6 +377,24 @@ def require_backup_gate_evidence_store(record_store: object) -> _BackupGateEvide
             f"{missing_summary}"
         )
     return cast(_BackupGateEvidenceStore, record_store)
+
+
+def require_runner_host_hygiene_audit_evidence_store(
+    record_store: object,
+) -> _RunnerHostHygieneAuditEvidenceStore:
+    required_methods = ("write_runner_host_hygiene_audit_record",)
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support runner host hygiene audit "
+            f"evidence writes: {missing_summary}"
+        )
+    return cast(_RunnerHostHygieneAuditEvidenceStore, record_store)
 
 
 def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -808,12 +840,14 @@ def create_launchplane_fastapi_app(
         *,
         trace_id: str,
         records: dict[str, str],
+        result: dict[str, object] | None = None,
         replayed: bool = False,
         original_trace_id: str = "",
     ) -> AcceptedEvidenceResponse:
         return AcceptedEvidenceResponse(
             trace_id=trace_id,
             records=records,
+            result=result,
             replayed=True if replayed else None,
             original_trace_id=original_trace_id or None,
         )
@@ -825,9 +859,11 @@ def create_launchplane_fastapi_app(
             str(key): str(value)
             for key, value in dict(stored_record.response_payload.get("records") or {}).items()
         }
+        stored_result = stored_record.response_payload.get("result")
         return accepted_evidence_response(
             trace_id=trace_id,
             records=stored_records,
+            result=stored_result if isinstance(stored_result, dict) else None,
             replayed=True,
             original_trace_id=stored_record.response_trace_id,
         )
@@ -1293,6 +1329,102 @@ def create_launchplane_fastapi_app(
             )
         return response
 
+    async def write_runner_host_hygiene_audit_evidence(
+        request: Request,
+        runner_host_hygiene_request: RunnerHostHygieneAuditEvidenceEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="runner_host_hygiene_audit.write",
+            product=runner_host_hygiene_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot write runner host hygiene audit evidence.",
+            )
+
+        idempotency_store = idempotency_capable_store(record_store)
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_scope = idempotency_scope(identity)
+        raw_payload = await request.json()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if idempotency_store is not None and normalized_idempotency_key:
+            stored_record = idempotency_store.read_idempotency_record(
+                scope=normalized_scope,
+                route_path=_RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            )
+            if stored_record is not None:
+                if stored_record.request_fingerprint != payload_fingerprint:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different "
+                            "Launchplane request payload on this route."
+                        ),
+                    )
+                return replay_idempotent_response(
+                    trace_id=trace_id,
+                    stored_record=stored_record,
+                )
+
+        try:
+            evidence_store = require_runner_host_hygiene_audit_evidence_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+
+        evidence_store.write_runner_host_hygiene_audit_record(runner_host_hygiene_request.audit)
+        records = {
+            "runner_host_hygiene_audit_record_key": (
+                runner_host_hygiene_request.audit.audit_record_key
+            ),
+        }
+        result: dict[str, object] = {
+            "runner_host_hygiene_audit_record_key": (
+                runner_host_hygiene_request.audit.audit_record_key
+            ),
+            "host_name": runner_host_hygiene_request.audit.request.host_name,
+            "audit_status": runner_host_hygiene_request.audit.status,
+            "mutate": runner_host_hygiene_request.audit.request.mutate,
+            "audit": runner_host_hygiene_request.audit.model_dump(mode="json"),
+        }
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records=records,
+            result=result,
+        )
+        if idempotency_store is not None and normalized_idempotency_key:
+            idempotency_store.write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id=build_launchplane_idempotency_record_id(
+                        response_trace_id=trace_id,
+                    ),
+                    scope=normalized_scope,
+                    route_path=_RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint=payload_fingerprint,
+                    response_status_code=202,
+                    response_trace_id=trace_id,
+                    recorded_at=utc_now_timestamp(),
+                    response_payload=response.model_dump(mode="json", exclude_none=True),
+                )
+            )
+        return response
+
     def read_health(record_store: Annotated[object, Depends(get_record_store)]) -> HealthResponse:
         return HealthResponse(
             trace_id=next_trace_id(),
@@ -1449,6 +1581,24 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_preview_destroyed_evidence",
         summary="Write preview destroyed evidence",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE,
+        write_runner_host_hygiene_audit_evidence,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_runner_host_hygiene_audit_evidence",
+        summary="Write runner host hygiene audit evidence",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -204,8 +204,10 @@ from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressNotificationPolicyRecord,
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
-from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
+from control_plane.contracts.runner_host_hygiene_evidence import (
+    RunnerHostHygieneAuditEvidenceEnvelope,
+)
 from control_plane.runtime_key_safety import (
     evaluate_runtime_key_safety_from_store,
     latest_active_runtime_key_safety_policy,
@@ -944,21 +946,6 @@ class DeploymentEvidenceEnvelope(BaseModel):
     def _validate_alignment(self) -> "DeploymentEvidenceEnvelope":
         if not self.product.strip():
             raise ValueError("deployment evidence requires product")
-        return self
-
-
-class RunnerHostHygieneAuditEvidenceEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    audit: RunnerHostHygieneApplyAuditRecord
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "RunnerHostHygieneAuditEvidenceEnvelope":
-        if self.product.strip() != "launchplane":
-            raise ValueError("runner host hygiene audit evidence requires product 'launchplane'")
-        self.product = "launchplane"
         return self
 
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -57,14 +57,14 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment, backup-gate, promotion, preview generation, and preview destroyed
-  evidence ingestion use native FastAPI routes for bearer-token callers and
-  preserve the existing `Idempotency-Key` replay/conflict contract. Their legacy
-  WSGI branches are shadowed by native routes while the mounted fallback remains
-  for the rest of the evidence family; delete those WSGI branches after caller
-  evidence proves
-  the native paths and the adjacent evidence routes have native coverage or an
-  explicit retained status.
+- Deployment, backup-gate, promotion, preview generation, preview destroyed,
+  and runner-host hygiene audit evidence ingestion use native FastAPI routes for
+  bearer-token callers and preserve the existing `Idempotency-Key`
+  replay/conflict contract. Their legacy WSGI branches are shadowed by native
+  routes while the mounted fallback remains for the rest of the evidence family;
+  delete those WSGI branches after caller evidence proves the native paths and
+  the adjacent evidence routes have native coverage or an explicit retained
+  status.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -121,11 +121,13 @@ Launchplane storage supports durable runner-host hygiene audit records keyed by
 `audit_record_key`. Shared-service storage promotes the key, host, action,
 status, and mutate intent into columns, while the full typed request, plan,
 pre/post reports, retained warm-builder evidence, and operator message remain in
-the JSON payload. `POST /v1/evidence/runner-host-hygiene/audits` accepts planned,
+the JSON payload. `POST /v1/evidence/runner-host-hygiene/audits` is native
+FastAPI evidence ingress for bearer-token callers. It accepts planned,
 completed, and failed audit records for product/context `launchplane/launchplane`
-under `runner_host_hygiene_audit.write`. The local planner only prints the
-planned record; the approved executor calls the service route after it captures
-the required pre/post host evidence.
+under `runner_host_hygiene_audit.write`, preserves the `Idempotency-Key`
+replay/conflict contract, and returns the accepted record key plus audit result
+details. The local planner only prints the planned record; the approved executor
+calls the service route after it captures the required pre/post host evidence.
 
 ## Approved Ops-Lane Executor
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -62,7 +62,9 @@ VeriReel product paths:
   - `POST /v1/evidence/previews/destroyed` (native FastAPI for bearer-token
     callers, with Pydantic/OpenAPI contract coverage, idempotency replay
     preservation, and preview destroyed storage)
-  - `POST /v1/evidence/runner-host-hygiene/audits`
+  - `POST /v1/evidence/runner-host-hygiene/audits` (native FastAPI for
+    bearer-token callers, with Pydantic/OpenAPI contract coverage, idempotency
+    replay preservation, and runner-host hygiene audit storage)
 - product profile routes:
   - `GET /v1/product-profiles`
   - `GET /v1/product-profiles/{product}`
@@ -862,6 +864,14 @@ existing Launchplane preview record to `destroyed`; it does not create missing
 previews. Replay handling runs before those capability checks so a stored
 response can still be returned if the backing store is temporarily
 write-restricted for preview destroyed evidence.
+
+`POST /v1/evidence/runner-host-hygiene/audits` requires any available
+idempotency store plus runner-host hygiene audit write capability. It accepts
+only product/context `launchplane/launchplane`, writes the typed audit record,
+and returns the accepted record key plus result details for the stored audit.
+Replay handling runs before the audit-write capability check so a stored
+response can still be returned if the backing store is temporarily
+write-restricted for runner-host hygiene audit evidence.
 
 ### Preview lifecycle endpoints
 
@@ -1732,8 +1742,10 @@ Request payload:
 
 The route requires `runner_host_hygiene_audit.write` for product/context
 `launchplane/launchplane`, writes the typed audit record to Launchplane-owned
-storage, and returns the `runner_host_hygiene_audit_record_key`. It is evidence
-ingress only: it records planned, completed, or failed audit facts supplied by a
+storage, and returns the `runner_host_hygiene_audit_record_key` in both the
+accepted records and result details. It is native FastAPI evidence ingress for
+bearer-token callers with OpenAPI contract coverage and idempotency replay
+preservation. It records planned, completed, or failed audit facts supplied by a
 future approved executor, but it does not mutate runner hosts itself.
 
 ### Runner lane registration audit evidence

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -25,6 +25,15 @@ from control_plane.contracts.promotion_record import (
     DeploymentEvidence,
     PromotionRecord,
 )
+from control_plane.contracts.runner_host_hygiene import (
+    RunnerHostHygieneApplyAuditRecord,
+    RunnerHostHygieneApplyPolicy,
+    RunnerHostHygieneApplyRequest,
+    RunnerHostHygieneObservation,
+    RunnerHostHygienePolicy,
+    evaluate_runner_host_hygiene,
+    plan_runner_host_hygiene_apply,
+)
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import (
@@ -415,6 +424,59 @@ class FastApiPreviewDestroyedEvidenceStoreGateTests(unittest.IsolatedAsyncioTest
         self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
         self.assertEqual(store.read_idempotency_calls, 2)
         self.assertEqual(store.write_preview_record_calls, 1)
+
+
+class FastApiRunnerHostHygieneAuditEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runner_host_hygiene_audit_evidence_requires_audit_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+            authz_policy=_runner_host_hygiene_audit_write_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_runner_host_hygiene_audit_evidence(
+            app,
+            _runner_host_hygiene_audit_payload(),
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_runner_host_hygiene_audit_replays_idempotency_before_store_gate(
+        self,
+    ) -> None:
+        store = _IdempotencyOnlyRunnerHostHygieneAuditReplayStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+            authz_policy=_runner_host_hygiene_audit_write_policy(),
+            record_store_factory=lambda: store,
+        )
+        request_payload = _runner_host_hygiene_audit_payload()
+
+        first_response = await _post_runner_host_hygiene_audit_evidence(
+            app,
+            request_payload,
+            idempotency_key="runner-host-hygiene:chris-testing:planned",
+        )
+        store.write_runner_host_hygiene_audit_record = None
+        second_response = await _post_runner_host_hygiene_audit_evidence(
+            app,
+            request_payload,
+            idempotency_key="runner-host-hygiene:chris-testing:planned",
+        )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertEqual(second_payload["result"], first_payload["result"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(store.read_idempotency_calls, 2)
+        self.assertEqual(store.write_runner_host_hygiene_audit_calls, 1)
 
 
 class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCase):
@@ -2858,6 +2920,330 @@ class FastApiPreviewDestroyedEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["records"]["transition"], "destroyed")
 
 
+class FastApiRunnerHostHygieneAuditEvidenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runner_host_hygiene_audit_evidence_writes_record_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                _runner_host_hygiene_audit_payload(),
+            )
+            records = store.list_runner_host_hygiene_audit_records(
+                host_name="chris-testing",
+                status="planned",
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"],
+            {
+                "runner_host_hygiene_audit_record_key": (
+                    "runner-host-hygiene/2026-05-23/chris-testing"
+                ),
+            },
+        )
+        self.assertEqual(
+            payload["result"]["runner_host_hygiene_audit_record_key"],
+            "runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        self.assertEqual(payload["result"]["host_name"], "chris-testing")
+        self.assertEqual(payload["result"]["audit_status"], "planned")
+        self.assertFalse(payload["result"]["mutate"])
+        self.assertEqual(payload["result"]["audit"]["status"], "planned")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(
+            records[0].audit_record_key,
+            "runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        self.assertFalse(records[0].request.mutate)
+
+    async def test_runner_host_hygiene_audit_evidence_rejects_unauthorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                _runner_host_hygiene_audit_payload(),
+            )
+            records = store.list_runner_host_hygiene_audit_records()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(records, ())
+
+    async def test_runner_host_hygiene_audit_evidence_requires_bearer_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                _runner_host_hygiene_audit_payload(),
+                authorization="",
+            )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_runner_host_hygiene_audit_evidence_rejects_human_session_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            oauth_config = _github_oauth_config()
+            session_store = InMemoryHumanSessionStore()
+            session_manager = HumanSessionManager(
+                config=oauth_config,
+                session_store=session_store,
+            )
+            human_session = session_manager.issue(_github_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_github_human_runner_host_hygiene_audit_write_policy(),
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                _runner_host_hygiene_audit_payload(),
+                authorization="",
+                headers={"Cookie": session_manager.session_cookie_header(human_session)},
+            )
+            records = store.list_runner_host_hygiene_audit_records()
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+        self.assertEqual(records, ())
+
+    async def test_runner_host_hygiene_audit_evidence_rejects_terminal_agent_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_runner_host_hygiene_audit_write_policy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-agent-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                _runner_host_hygiene_audit_payload(),
+                authorization="Bearer terminal-agent-token",
+            )
+            records = store.list_runner_host_hygiene_audit_records()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(records, ())
+
+    async def test_runner_host_hygiene_audit_evidence_rejects_non_launchplane_product(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                _runner_host_hygiene_audit_payload(product="odoo"),
+            )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertNotIn("detail", payload)
+
+    async def test_runner_host_hygiene_audit_evidence_replays_idempotent_write(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            request_payload = _runner_host_hygiene_audit_payload()
+
+            first_response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                request_payload,
+                idempotency_key="runner-host-hygiene:chris-testing:planned",
+            )
+            second_response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                request_payload,
+                idempotency_key="runner-host-hygiene:chris-testing:planned",
+            )
+            records = store.list_runner_host_hygiene_audit_records(
+                host_name="chris-testing",
+                status="planned",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertEqual(second_payload["result"], first_payload["result"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(len(records), 1)
+
+    async def test_runner_host_hygiene_audit_evidence_rejects_idempotency_key_reuse(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            request_payload = _runner_host_hygiene_audit_payload()
+            changed_payload = _runner_host_hygiene_audit_payload(
+                audit_record_key="runner-host-hygiene/2026-05-23/chris-testing-retry"
+            )
+
+            first_response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                request_payload,
+                idempotency_key="runner-host-hygiene:chris-testing:planned",
+            )
+            second_response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                changed_payload,
+                idempotency_key="runner-host-hygiene:chris-testing:planned",
+            )
+            records = store.list_runner_host_hygiene_audit_records()
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        payload = second_response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+        self.assertEqual(len(records), 1)
+
+    async def test_openapi_includes_runner_host_hygiene_audit_evidence_contract(
+        self,
+    ) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+            authz_policy=_runner_host_hygiene_audit_write_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/evidence/runner-host-hygiene/audits"]["post"]
+        self.assertEqual(route["operationId"], "write_runner_host_hygiene_audit_evidence")
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(
+            request_schema["$ref"],
+            "#/components/schemas/RunnerHostHygieneAuditEvidenceEnvelope",
+        )
+        success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
+        self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
+        for status_code in ("400", "401", "403", "409", "503"):
+            error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
+            self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
+        envelope_schema = openapi["components"]["schemas"]["RunnerHostHygieneAuditEvidenceEnvelope"]
+        self.assertFalse(envelope_schema["additionalProperties"])
+
+    async def test_runner_host_hygiene_audit_evidence_native_route_precedes_wsgi_fallback(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _post_runner_host_hygiene_audit_evidence(
+                app,
+                _runner_host_hygiene_audit_payload(),
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["runner_host_hygiene_audit_record_key"],
+            "runner-host-hygiene/2026-05-23/chris-testing",
+        )
+
+
 class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
     async def test_deployment_evidence_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -3549,6 +3935,112 @@ def _preview_destroyed_evidence_payload(*, anchor_pr_number: int = 42) -> dict[s
     }
 
 
+def _runner_host_hygiene_audit_write_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="cbusillo/launchplane",
+        workflow_ref=(
+            "cbusillo/launchplane/.github/workflows/runner-host-hygiene.yml@refs/heads/main"
+        ),
+        event_name="workflow_dispatch",
+    )
+
+
+def _runner_host_hygiene_audit_write_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "cbusillo/launchplane",
+                    "workflow_refs": [
+                        "cbusillo/launchplane/.github/workflows/runner-host-hygiene.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["runner_host_hygiene_audit.write"],
+                }
+            ]
+        }
+    )
+
+
+def _github_human_runner_host_hygiene_audit_write_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_humans": [
+                {
+                    "logins": ["example-operator"],
+                    "roles": ["admin"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["runner_host_hygiene_audit.write"],
+                }
+            ]
+        }
+    )
+
+
+def _terminal_agent_runner_host_hygiene_audit_write_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["runner_host_hygiene_audit.write"],
+                }
+            ]
+        }
+    )
+
+
+def _runner_host_hygiene_audit_payload(
+    *,
+    audit_record_key: str = "runner-host-hygiene/2026-05-23/chris-testing",
+    product: str = "launchplane",
+) -> dict[str, object]:
+    report = evaluate_runner_host_hygiene(
+        policy=RunnerHostHygienePolicy(required_warm_builders=("odoo-docker-chris-testing",)),
+        observation=RunnerHostHygieneObservation(
+            host_name="chris-testing",
+            observed_at="2026-05-23T13:00:00Z",
+            free_disk_bytes=500,
+            warm_builders=("odoo-docker-chris-testing",),
+        ),
+    )
+    request = RunnerHostHygieneApplyRequest(
+        action="prune_docker_cache",
+        host_name="chris-testing",
+        mutate=False,
+        retained_warm_builders=("odoo-docker-chris-testing",),
+        audit_record_key=audit_record_key,
+    )
+    plan = plan_runner_host_hygiene_apply(
+        policy=RunnerHostHygieneApplyPolicy(
+            approved_hosts=("chris-testing",),
+            required_retained_warm_builders=("odoo-docker-chris-testing",),
+            allow_docker_cache_prune=True,
+        ),
+        request=request,
+        report=report,
+    )
+    audit_record = RunnerHostHygieneApplyAuditRecord(
+        audit_record_key=audit_record_key,
+        status="planned",
+        request=request,
+        plan=plan,
+        pre_apply_report=report,
+        message="planned runner host hygiene apply; no host mutation was executed",
+    )
+    return {
+        "schema_version": 1,
+        "product": product,
+        "audit": audit_record.model_dump(mode="json"),
+    }
+
+
 def _deployment_write_identity() -> GitHubActionsIdentity:
     return _identity(
         repository="every/example-site",
@@ -3995,6 +4487,28 @@ async def _post_preview_destroyed_evidence(
     )
 
 
+async def _post_runner_host_hygiene_audit_evidence(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/evidence/runner-host-hygiene/audits",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _post_deployment_evidence(
     app: FastAPI,
     payload: dict[str, object],
@@ -4136,6 +4650,43 @@ class _IdempotencyOnlyBackupGateReplayStore:
 
     def _write_backup_gate_record(self, record: BackupGateRecord) -> None:
         self.write_backup_gate_calls += 1
+
+
+class _IdempotencyOnlyRunnerHostHygieneAuditReplayStore:
+    def __init__(self) -> None:
+        self.read_idempotency_calls = 0
+        self.write_runner_host_hygiene_audit_calls = 0
+        self._stored_record: Any | None = None
+        self.write_runner_host_hygiene_audit_record: (
+            Callable[[RunnerHostHygieneApplyAuditRecord], None] | None
+        ) = self._write_runner_host_hygiene_audit_record
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> Any:
+        self.read_idempotency_calls += 1
+        if self._stored_record is None:
+            return None
+        if (
+            self._stored_record.scope != scope
+            or self._stored_record.route_path != route_path
+            or self._stored_record.idempotency_key != idempotency_key
+        ):
+            return None
+        return self._stored_record
+
+    def write_idempotency_record(self, record: Any) -> None:
+        self._stored_record = record
+
+    def _write_runner_host_hygiene_audit_record(
+        self,
+        record: RunnerHostHygieneApplyAuditRecord,
+    ) -> None:
+        self.write_runner_host_hygiene_audit_calls += 1
 
 
 class _PromotionEvidenceOnlyStore:


### PR DESCRIPTION
## Summary

- migrate `POST /v1/evidence/runner-host-hygiene/audits` to native FastAPI with shared Pydantic contract coverage
- preserve legacy response/result shape, bearer-only authz, idempotent replay/conflict behavior, and replay-before-store-gate behavior
- update service-boundary, runner-host hygiene, and compatibility-retirement docs for the native route

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiRunnerHostHygieneAuditEvidenceStoreGateTests tests.test_http_app.FastApiRunnerHostHygieneAuditEvidenceTests tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_writes_record_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_replays_idempotent_write tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_runner_host_hygiene_audit_endpoint_rejects_non_launchplane_product`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/contracts/runner_host_hygiene_evidence.py tests/test_http_app.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/contracts/runner_host_hygiene_evidence.py tests/test_http_app.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`
- review agents: code-gpt-5.5, claude-sonnet-4.6, antigravity; addressed the only clarity finding by using a service-context constant for the write route

Refs #1322
