### PR TITLE
Migrate runner lane evidence to FastAPI

### DIFF
--- a/control_plane/contracts/runner_lane_registration_evidence.py
+++ b/control_plane/contracts/runner_lane_registration_evidence.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
+
+
+class RunnerLaneRegistrationAuditEvidenceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    audit: RunnerLaneRegistrationAuditRecord
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "RunnerLaneRegistrationAuditEvidenceEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError(
+                "runner lane registration audit evidence requires product 'launchplane'"
+            )
+        self.product = "launchplane"
+        return self

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -42,6 +42,10 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAu
 from control_plane.contracts.runner_host_hygiene_evidence import (
     RunnerHostHygieneAuditEvidenceEnvelope,
 )
+from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
+from control_plane.contracts.runner_lane_registration_evidence import (
+    RunnerLaneRegistrationAuditEvidenceEnvelope,
+)
 from control_plane.drivers.registry import build_driver_context_view, list_driver_descriptors
 from control_plane.drivers.registry import read_driver_descriptor as read_driver_descriptor_record
 from control_plane.service_auth import (
@@ -84,6 +88,7 @@ _PROMOTION_EVIDENCE_ROUTE = "/v1/evidence/promotions"
 _PREVIEW_GENERATION_EVIDENCE_ROUTE = "/v1/evidence/previews/generations"
 _PREVIEW_DESTROYED_EVIDENCE_ROUTE = "/v1/evidence/previews/destroyed"
 _RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-host-hygiene/audits"
+_RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-lane-registration/audits"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 
 
@@ -255,6 +260,13 @@ class _RunnerHostHygieneAuditEvidenceStore(Protocol):
     ) -> object: ...
 
 
+class _RunnerLaneRegistrationAuditEvidenceStore(Protocol):
+    def write_runner_lane_registration_audit_record(
+        self,
+        record: RunnerLaneRegistrationAuditRecord,
+    ) -> object: ...
+
+
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
     required_methods = (
         "list_artifact_manifests",
@@ -395,6 +407,24 @@ def require_runner_host_hygiene_audit_evidence_store(
             f"evidence writes: {missing_summary}"
         )
     return cast(_RunnerHostHygieneAuditEvidenceStore, record_store)
+
+
+def require_runner_lane_registration_audit_evidence_store(
+    record_store: object,
+) -> _RunnerLaneRegistrationAuditEvidenceStore:
+    required_methods = ("write_runner_lane_registration_audit_record",)
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support runner lane registration audit "
+            f"evidence writes: {missing_summary}"
+        )
+    return cast(_RunnerLaneRegistrationAuditEvidenceStore, record_store)
 
 
 def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -1425,6 +1455,106 @@ def create_launchplane_fastapi_app(
             )
         return response
 
+    async def write_runner_lane_registration_audit_evidence(
+        request: Request,
+        runner_lane_registration_request: RunnerLaneRegistrationAuditEvidenceEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="runner_lane_registration_audit.write",
+            product=runner_lane_registration_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot write runner lane registration audit evidence.",
+            )
+
+        idempotency_store = idempotency_capable_store(record_store)
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_scope = idempotency_scope(identity)
+        raw_payload = await request.json()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if idempotency_store is not None and normalized_idempotency_key:
+            stored_record = idempotency_store.read_idempotency_record(
+                scope=normalized_scope,
+                route_path=_RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            )
+            if stored_record is not None:
+                if stored_record.request_fingerprint != payload_fingerprint:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different "
+                            "Launchplane request payload on this route."
+                        ),
+                    )
+                return replay_idempotent_response(
+                    trace_id=trace_id,
+                    stored_record=stored_record,
+                )
+
+        try:
+            evidence_store = require_runner_lane_registration_audit_evidence_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+
+        evidence_store.write_runner_lane_registration_audit_record(
+            runner_lane_registration_request.audit
+        )
+        records = {
+            "runner_lane_registration_audit_record_key": (
+                runner_lane_registration_request.audit.audit_record_key
+            ),
+        }
+        result: dict[str, object] = {
+            "runner_lane_registration_audit_record_key": (
+                runner_lane_registration_request.audit.audit_record_key
+            ),
+            "repository": runner_lane_registration_request.audit.request.repository,
+            "host_name": runner_lane_registration_request.audit.request.host_name,
+            "lane_name": runner_lane_registration_request.audit.request.lane_name,
+            "audit_status": runner_lane_registration_request.audit.status,
+            "mutate": runner_lane_registration_request.audit.request.mutate,
+            "audit": runner_lane_registration_request.audit.model_dump(mode="json"),
+        }
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records=records,
+            result=result,
+        )
+        if idempotency_store is not None and normalized_idempotency_key:
+            idempotency_store.write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id=build_launchplane_idempotency_record_id(
+                        response_trace_id=trace_id,
+                    ),
+                    scope=normalized_scope,
+                    route_path=_RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint=payload_fingerprint,
+                    response_status_code=202,
+                    response_trace_id=trace_id,
+                    recorded_at=utc_now_timestamp(),
+                    response_payload=response.model_dump(mode="json", exclude_none=True),
+                )
+            )
+        return response
+
     def read_health(record_store: Annotated[object, Depends(get_record_store)]) -> HealthResponse:
         return HealthResponse(
             trace_id=next_trace_id(),
@@ -1599,6 +1729,24 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_runner_host_hygiene_audit_evidence",
         summary="Write runner host hygiene audit evidence",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE,
+        write_runner_lane_registration_audit_evidence,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_runner_lane_registration_audit_evidence",
+        summary="Write runner lane registration audit evidence",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -204,9 +204,11 @@ from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressNotificationPolicyRecord,
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
-from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
 from control_plane.contracts.runner_host_hygiene_evidence import (
     RunnerHostHygieneAuditEvidenceEnvelope,
+)
+from control_plane.contracts.runner_lane_registration_evidence import (
+    RunnerLaneRegistrationAuditEvidenceEnvelope,
 )
 from control_plane.runtime_key_safety import (
     evaluate_runtime_key_safety_from_store,
@@ -946,23 +948,6 @@ class DeploymentEvidenceEnvelope(BaseModel):
     def _validate_alignment(self) -> "DeploymentEvidenceEnvelope":
         if not self.product.strip():
             raise ValueError("deployment evidence requires product")
-        return self
-
-
-class RunnerLaneRegistrationAuditEvidenceEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    audit: RunnerLaneRegistrationAuditRecord
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "RunnerLaneRegistrationAuditEvidenceEnvelope":
-        if self.product.strip() != "launchplane":
-            raise ValueError(
-                "runner lane registration audit evidence requires product 'launchplane'"
-            )
-        self.product = "launchplane"
         return self
 
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -58,13 +58,13 @@ Keep a compatibility surface only when it is one of these:
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
-  and runner-host hygiene audit evidence ingestion use native FastAPI routes for
-  bearer-token callers and preserve the existing `Idempotency-Key`
-  replay/conflict contract. Their legacy WSGI branches are shadowed by native
-  routes while the mounted fallback remains for the rest of the evidence family;
-  delete those WSGI branches after caller evidence proves the native paths and
-  the adjacent evidence routes have native coverage or an explicit retained
-  status.
+  runner-host hygiene audit, and runner-lane registration audit evidence
+  ingestion use native FastAPI routes for bearer-token callers and preserve the
+  existing `Idempotency-Key` replay/conflict contract. Their legacy WSGI
+  branches are shadowed by native routes while the mounted fallback remains for
+  the rest of the evidence family; delete those WSGI branches after caller
+  evidence proves the native paths and the adjacent evidence routes have native
+  coverage or an explicit retained status.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -65,6 +65,9 @@ VeriReel product paths:
   - `POST /v1/evidence/runner-host-hygiene/audits` (native FastAPI for
     bearer-token callers, with Pydantic/OpenAPI contract coverage, idempotency
     replay preservation, and runner-host hygiene audit storage)
+  - `POST /v1/evidence/runner-lane-registration/audits` (native FastAPI for
+    bearer-token callers, with Pydantic/OpenAPI contract coverage, idempotency
+    replay preservation, and runner-lane registration audit storage)
 - product profile routes:
   - `GET /v1/product-profiles`
   - `GET /v1/product-profiles/{product}`
@@ -828,6 +831,8 @@ writes, not on every possible operator action.
 - `POST /v1/evidence/promotions`
 - `POST /v1/evidence/previews/generations`
 - `POST /v1/evidence/previews/destroyed`
+- `POST /v1/evidence/runner-host-hygiene/audits`
+- `POST /v1/evidence/runner-lane-registration/audits`
 
 `POST /v1/evidence/deployments` only requires the deployment-write record-store
 capability and any available idempotency store. Replay handling runs before the
@@ -872,6 +877,14 @@ and returns the accepted record key plus result details for the stored audit.
 Replay handling runs before the audit-write capability check so a stored
 response can still be returned if the backing store is temporarily
 write-restricted for runner-host hygiene audit evidence.
+
+`POST /v1/evidence/runner-lane-registration/audits` requires any available
+idempotency store plus runner-lane registration audit write capability. It
+accepts only product/context `launchplane/launchplane`, writes the typed audit
+record, and returns the accepted record key plus result details for the stored
+audit. Replay handling runs before the audit-write capability check so a stored
+response can still be returned if the backing store is temporarily
+write-restricted for runner-lane registration audit evidence.
 
 ### Preview lifecycle endpoints
 
@@ -1773,9 +1786,11 @@ Request payload:
 
 The route requires `runner_lane_registration_audit.write` for product/context
 `launchplane/launchplane`, writes the typed audit record to Launchplane-owned
-storage, and returns the `runner_lane_registration_audit_record_key`. It is
-evidence ingress only; the host-side registration executor owns any GitHub
-registration token request and runner `config.sh` execution.
+storage, and returns the `runner_lane_registration_audit_record_key` in both the
+accepted records and result details. It is native FastAPI evidence ingress for
+bearer-token callers with OpenAPI contract coverage and idempotency replay
+preservation. The host-side registration executor owns any GitHub registration
+token request and runner `config.sh` execution.
 
 For VeriReel's first stable-lane Launchplane slice, use context `verireel` for the
 long-lived `testing` and `prod` instances. Preview evidence remains separate

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -34,6 +34,13 @@ from control_plane.contracts.runner_host_hygiene import (
     evaluate_runner_host_hygiene,
     plan_runner_host_hygiene_apply,
 )
+from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
+from control_plane.contracts.runner_lane_registration import (
+    RunnerLaneRegistrationAuditRecord,
+    RunnerLaneRegistrationPolicy,
+    RunnerLaneRegistrationRequest,
+    plan_runner_lane_registration,
+)
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import (
@@ -477,6 +484,61 @@ class FastApiRunnerHostHygieneAuditEvidenceStoreGateTests(unittest.IsolatedAsync
         self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
         self.assertEqual(store.read_idempotency_calls, 2)
         self.assertEqual(store.write_runner_host_hygiene_audit_calls, 1)
+
+
+class FastApiRunnerLaneRegistrationAuditEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runner_lane_registration_audit_evidence_requires_audit_store(
+        self,
+    ) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+            authz_policy=_runner_lane_registration_audit_write_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_runner_lane_registration_audit_evidence(
+            app,
+            _runner_lane_registration_audit_payload(),
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_runner_lane_registration_audit_replays_idempotency_before_store_gate(
+        self,
+    ) -> None:
+        store = _IdempotencyOnlyRunnerLaneRegistrationAuditReplayStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+            authz_policy=_runner_lane_registration_audit_write_policy(),
+            record_store_factory=lambda: store,
+        )
+        request_payload = _runner_lane_registration_audit_payload()
+
+        first_response = await _post_runner_lane_registration_audit_evidence(
+            app,
+            request_payload,
+            idempotency_key="runner-lane-registration:cm-website:planned",
+        )
+        store.write_runner_lane_registration_audit_record = None
+        second_response = await _post_runner_lane_registration_audit_evidence(
+            app,
+            request_payload,
+            idempotency_key="runner-lane-registration:cm-website:planned",
+        )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertEqual(second_payload["result"], first_payload["result"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(store.read_idempotency_calls, 2)
+        self.assertEqual(store.write_runner_lane_registration_audit_calls, 1)
 
 
 class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCase):
@@ -3244,6 +3306,338 @@ class FastApiRunnerHostHygieneAuditEvidenceTests(unittest.IsolatedAsyncioTestCas
         )
 
 
+class FastApiRunnerLaneRegistrationAuditEvidenceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runner_lane_registration_audit_evidence_writes_record_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+                authz_policy=_runner_lane_registration_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                _runner_lane_registration_audit_payload(),
+            )
+            records = store.list_runner_lane_registration_audit_records(
+                repository="cbusillo/odoo-tenant-cm-website",
+                host_name="chris-testing",
+                status="planned",
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"],
+            {
+                "runner_lane_registration_audit_record_key": (
+                    "runner-lane-registration/2026-06-08/cm-website/dry-run"
+                ),
+            },
+        )
+        self.assertEqual(
+            payload["result"]["runner_lane_registration_audit_record_key"],
+            "runner-lane-registration/2026-06-08/cm-website/dry-run",
+        )
+        self.assertEqual(payload["result"]["repository"], "cbusillo/odoo-tenant-cm-website")
+        self.assertEqual(payload["result"]["host_name"], "chris-testing")
+        self.assertEqual(payload["result"]["lane_name"], "cm-website-runner-1")
+        self.assertEqual(payload["result"]["audit_status"], "planned")
+        self.assertFalse(payload["result"]["mutate"])
+        self.assertEqual(payload["result"]["audit"]["status"], "planned")
+        self.assertEqual(len(records), 1)
+        self.assertEqual(
+            records[0].audit_record_key,
+            "runner-lane-registration/2026-06-08/cm-website/dry-run",
+        )
+        self.assertFalse(records[0].request.mutate)
+
+    async def test_runner_lane_registration_audit_evidence_rejects_unauthorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                _runner_lane_registration_audit_payload(),
+            )
+            records = store.list_runner_lane_registration_audit_records()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(records, ())
+
+    async def test_runner_lane_registration_audit_evidence_requires_bearer_token(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+                authz_policy=_runner_lane_registration_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                _runner_lane_registration_audit_payload(),
+                authorization="",
+            )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_runner_lane_registration_audit_evidence_rejects_human_session_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            oauth_config = _github_oauth_config()
+            session_store = InMemoryHumanSessionStore()
+            session_manager = HumanSessionManager(
+                config=oauth_config,
+                session_store=session_store,
+            )
+            human_session = session_manager.issue(_github_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_github_human_runner_lane_registration_audit_write_policy(),
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                _runner_lane_registration_audit_payload(),
+                authorization="",
+                headers={"Cookie": session_manager.session_cookie_header(human_session)},
+            )
+            records = store.list_runner_lane_registration_audit_records()
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+        self.assertEqual(records, ())
+
+    async def test_runner_lane_registration_audit_evidence_rejects_terminal_agent_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_runner_lane_registration_audit_write_policy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-agent-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                _runner_lane_registration_audit_payload(),
+                authorization="Bearer terminal-agent-token",
+            )
+            records = store.list_runner_lane_registration_audit_records()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(records, ())
+
+    async def test_runner_lane_registration_audit_evidence_rejects_non_launchplane_product(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+                authz_policy=_runner_lane_registration_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                _runner_lane_registration_audit_payload(product="odoo"),
+            )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertNotIn("detail", payload)
+
+    async def test_runner_lane_registration_audit_evidence_replays_idempotent_write(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+                authz_policy=_runner_lane_registration_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            request_payload = _runner_lane_registration_audit_payload()
+
+            first_response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                request_payload,
+                idempotency_key="runner-lane-registration:cm-website:planned",
+            )
+            second_response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                request_payload,
+                idempotency_key="runner-lane-registration:cm-website:planned",
+            )
+            records = store.list_runner_lane_registration_audit_records(
+                repository="cbusillo/odoo-tenant-cm-website",
+                host_name="chris-testing",
+                status="planned",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertEqual(second_payload["result"], first_payload["result"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(len(records), 1)
+
+    async def test_runner_lane_registration_audit_evidence_rejects_idempotency_key_reuse(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+                authz_policy=_runner_lane_registration_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            request_payload = _runner_lane_registration_audit_payload()
+            changed_payload = _runner_lane_registration_audit_payload(
+                audit_record_key="runner-lane-registration/2026-06-08/cm-website/retry"
+            )
+
+            first_response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                request_payload,
+                idempotency_key="runner-lane-registration:cm-website:planned",
+            )
+            second_response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                changed_payload,
+                idempotency_key="runner-lane-registration:cm-website:planned",
+            )
+            records = store.list_runner_lane_registration_audit_records()
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        payload = second_response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+        self.assertEqual(len(records), 1)
+
+    async def test_openapi_includes_runner_lane_registration_audit_evidence_contract(
+        self,
+    ) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+            authz_policy=_runner_lane_registration_audit_write_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/evidence/runner-lane-registration/audits"]["post"]
+        self.assertEqual(route["operationId"], "write_runner_lane_registration_audit_evidence")
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(
+            request_schema["$ref"],
+            "#/components/schemas/RunnerLaneRegistrationAuditEvidenceEnvelope",
+        )
+        success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
+        self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
+        for status_code in ("400", "401", "403", "409", "503"):
+            error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
+            self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
+        envelope_schema = openapi["components"]["schemas"][
+            "RunnerLaneRegistrationAuditEvidenceEnvelope"
+        ]
+        self.assertFalse(envelope_schema["additionalProperties"])
+
+    async def test_runner_lane_registration_audit_evidence_native_route_precedes_wsgi_fallback(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_lane_registration_audit_write_identity()),
+                authz_policy=_runner_lane_registration_audit_write_policy(),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _post_runner_lane_registration_audit_evidence(
+                app,
+                _runner_lane_registration_audit_payload(),
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["runner_lane_registration_audit_record_key"],
+            "runner-lane-registration/2026-06-08/cm-website/dry-run",
+        )
+
+
 class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
     async def test_deployment_evidence_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -4041,6 +4435,110 @@ def _runner_host_hygiene_audit_payload(
     }
 
 
+def _runner_lane_registration_audit_write_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="cbusillo/launchplane",
+        workflow_ref=(
+            "cbusillo/launchplane/.github/workflows/runner-lane-registration.yml@refs/heads/main"
+        ),
+        event_name="workflow_dispatch",
+    )
+
+
+def _runner_lane_registration_audit_write_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "cbusillo/launchplane",
+                    "workflow_refs": [
+                        "cbusillo/launchplane/.github/workflows/runner-lane-registration.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["runner_lane_registration_audit.write"],
+                }
+            ]
+        }
+    )
+
+
+def _github_human_runner_lane_registration_audit_write_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_humans": [
+                {
+                    "logins": ["example-operator"],
+                    "roles": ["admin"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["runner_lane_registration_audit.write"],
+                }
+            ]
+        }
+    )
+
+
+def _terminal_agent_runner_lane_registration_audit_write_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["runner_lane_registration_audit.write"],
+                }
+            ]
+        }
+    )
+
+
+def _runner_lane_registration_audit_payload(
+    *,
+    audit_record_key: str = "runner-lane-registration/2026-06-08/cm-website/dry-run",
+    product: str = "launchplane",
+) -> dict[str, object]:
+    inventory = build_runner_lane_inventory(
+        repository="cbusillo/odoo-tenant-cm-website",
+        observed_at="2026-06-08T17:30:00Z",
+        lanes=(),
+    )
+    request = RunnerLaneRegistrationRequest(
+        repository="cbusillo/odoo-tenant-cm-website",
+        host_name="chris-testing",
+        lane_name="cm-website-runner-1",
+        registration_root="/opt/actions-runners",
+        labels=("self-hosted", "launchplane", "launchplane-managed"),
+        mutate=False,
+        audit_record_key=audit_record_key,
+    )
+    plan = plan_runner_lane_registration(
+        policy=RunnerLaneRegistrationPolicy(
+            allowed_repositories=("cbusillo/odoo-tenant-cm-website",),
+            approved_hosts=("chris-testing",),
+            allowed_registration_roots=("/opt/actions-runners",),
+        ),
+        request=request,
+        inventory=inventory,
+    )
+    audit_record = RunnerLaneRegistrationAuditRecord(
+        audit_record_key=audit_record_key,
+        status="planned",
+        request=request,
+        plan=plan,
+        pre_inventory=inventory,
+        message="planned runner lane registration; no host mutation was executed",
+    )
+    return {
+        "schema_version": 1,
+        "product": product,
+        "audit": audit_record.model_dump(mode="json"),
+    }
+
+
 def _deployment_write_identity() -> GitHubActionsIdentity:
     return _identity(
         repository="every/example-site",
@@ -4509,6 +5007,28 @@ async def _post_runner_host_hygiene_audit_evidence(
     )
 
 
+async def _post_runner_lane_registration_audit_evidence(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/evidence/runner-lane-registration/audits",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _post_deployment_evidence(
     app: FastAPI,
     payload: dict[str, object],
@@ -4687,6 +5207,43 @@ class _IdempotencyOnlyRunnerHostHygieneAuditReplayStore:
         record: RunnerHostHygieneApplyAuditRecord,
     ) -> None:
         self.write_runner_host_hygiene_audit_calls += 1
+
+
+class _IdempotencyOnlyRunnerLaneRegistrationAuditReplayStore:
+    def __init__(self) -> None:
+        self.read_idempotency_calls = 0
+        self.write_runner_lane_registration_audit_calls = 0
+        self._stored_record: Any | None = None
+        self.write_runner_lane_registration_audit_record: (
+            Callable[[RunnerLaneRegistrationAuditRecord], None] | None
+        ) = self._write_runner_lane_registration_audit_record
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> Any:
+        self.read_idempotency_calls += 1
+        if self._stored_record is None:
+            return None
+        if (
+            self._stored_record.scope != scope
+            or self._stored_record.route_path != route_path
+            or self._stored_record.idempotency_key != idempotency_key
+        ):
+            return None
+        return self._stored_record
+
+    def write_idempotency_record(self, record: Any) -> None:
+        self._stored_record = record
+
+    def _write_runner_lane_registration_audit_record(
+        self,
+        record: RunnerLaneRegistrationAuditRecord,
+    ) -> None:
+        self.write_runner_lane_registration_audit_calls += 1
 
 
 class _PromotionEvidenceOnlyStore:


### PR DESCRIPTION
## Summary

- migrate `POST /v1/evidence/runner-lane-registration/audits` to native FastAPI with shared Pydantic contract coverage
- preserve legacy response/result shape, bearer mutation auth, `runner_lane_registration_audit.write` authorization, idempotent replay/conflict behavior, and replay-before-store-gate behavior
- update service-boundary and compatibility-retirement docs for the native route

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiRunnerLaneRegistrationAuditEvidenceStoreGateTests tests.test_http_app.FastApiRunnerLaneRegistrationAuditEvidenceTests tests.test_service.LaunchplaneServiceTests.test_runner_lane_registration_audit_endpoint_writes_record_for_authorized_workflow tests.test_service.LaunchplaneServiceTests.test_runner_lane_registration_audit_endpoint_replays_idempotent_write tests.test_service.LaunchplaneServiceTests.test_runner_lane_registration_audit_endpoint_rejects_unauthorized_workflow tests.test_service.LaunchplaneServiceTests.test_runner_lane_registration_audit_endpoint_rejects_non_launchplane_product`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/contracts/runner_lane_registration_evidence.py tests/test_http_app.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/contracts/runner_lane_registration_evidence.py tests/test_http_app.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`
- review agents: code-gpt-5.5, claude-sonnet-4.6, antigravity; no blocking findings

Refs #1322
