### PR TITLE
Retire WSGI health fallback

### DIFF
--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -10243,16 +10243,6 @@ def create_launchplane_service_app(
                 json_response=_json_response,
                 http_status_text=_http_status_text,
             )
-        if method == "GET" and path == "/v1/health":
-            return _json_response(
-                start_response=start_response,
-                status_code=200,
-                payload={
-                    "status": "ok",
-                    "trace_id": request_trace_id,
-                    "storage_backend": storage_backend,
-                },
-            )
         read_route = _match_read_route(path)
         if path not in write_routes and read_route is None:
             return _not_found_response(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -53,6 +53,9 @@ Keep a compatibility surface only when it is one of these:
   shared store.
 - File-backed JSON state is local-dev/test scaffolding. Production truth is
   Launchplane service-owned persistence.
+- The Launchplane health read uses the native FastAPI `GET /v1/health` route.
+  Its legacy WSGI branch is deleted; direct fallback calls fail closed while
+  the mounted fallback remains for retained non-native routes.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -39,7 +39,8 @@ VeriReel product paths:
 - server runtime: FastAPI served by Uvicorn, with legacy WSGI routes mounted as
   the fallback while route ownership is migrated incrementally
 - native FastAPI health route: `GET /v1/health`, backed by a Pydantic response
-  model and included in OpenAPI as the first v2 contract proof
+  model, included in OpenAPI as the first v2 contract proof, and retired from
+  the legacy WSGI fallback
 - native FastAPI protected artifact inventory route:
   - `GET /v1/artifacts/protected`, requiring `artifact_protection.read` for
     the requested product and either the requested context or whole-product
@@ -189,8 +190,8 @@ Before a migrated route is done, verify all of the following:
   retained with an owning follow-up issue.
 
 `GET /v1/health` is the first proven pattern: native FastAPI route ownership,
-typed Pydantic response, focused OpenAPI assertions, and mounted-fallback
-precedence. Do not turn that route into a migration framework; use it as the
+typed Pydantic response, focused OpenAPI assertions, and direct WSGI fallback
+retirement. Do not turn that route into a migration framework; use it as the
 small contract shape for the next route-family slice.
 
 Launchplane verifies GitHub OIDC, authorizes workflow identity claims, accepts

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13641,7 +13641,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     control_plane_root_path=Path(temporary_directory_name),
                 )
 
-    def test_health_endpoint_reports_explicit_local_test_storage_backend(self) -> None:
+    def test_health_route_is_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
@@ -13656,9 +13656,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 app, method="GET", path="/v1/health", authorization=""
             )
 
-            self.assertEqual(status_code, 200)
-            self.assertEqual(payload["status"], "ok")
-            self.assertEqual(payload["storage_backend"], "filesystem")
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_service_serve_rejects_missing_database_url(self) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary

- retire the direct legacy WSGI `/v1/health` branch so fallback calls fail closed
- keep the native FastAPI health route as the service-owned v2 health contract
- update WSGI retirement coverage and docs for the health route boundary

Refs #1322

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiHealthContractTests tests.test_service.LaunchplaneServiceTests.test_health_route_is_retired_from_legacy_wsgi_app tests.test_service.LaunchplaneServiceTests.test_service_serve_runs_fastapi_app_with_legacy_wsgi_fallback`
- `uv run python -m unittest tests.test_http_app tests.test_service`
- `uv run python -m unittest`
- `uv run --extra dev ruff check control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- JetBrains changed-files inspection: clean

Note: `uv run --extra dev ruff format --check .` still reports unrelated pre-existing repo-wide format drift outside this PR's changed files; changed Python files are formatted.

## Review

- scout agents agreed `GET /v1/health` is the smallest safe next WSGI cleanup slice
- review agents: green/no blocking findings
