### PR TITLE
Migrate deployment and promotion reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -158,6 +158,22 @@ class DriverContextViewResponse(BaseModel):
     view: DriverContextView
 
 
+class DeploymentRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: DeploymentRecord
+
+
+class PromotionRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: PromotionRecord
+
+
 class ProtectedArtifactsResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -265,6 +281,14 @@ class _RunnerLaneRegistrationAuditEvidenceStore(Protocol):
         self,
         record: RunnerLaneRegistrationAuditRecord,
     ) -> object: ...
+
+
+class _DeploymentReadStore(Protocol):
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
+
+
+class _PromotionReadStore(Protocol):
+    def read_promotion_record(self, record_id: str) -> PromotionRecord: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -425,6 +449,26 @@ def require_runner_lane_registration_audit_evidence_store(
             f"evidence writes: {missing_summary}"
         )
     return cast(_RunnerLaneRegistrationAuditEvidenceStore, record_store)
+
+
+def require_deployment_read_store(record_store: object) -> _DeploymentReadStore:
+    read_record = getattr(record_store, "read_deployment_record", None)
+    if not callable(read_record):
+        raise TypeError(
+            "Launchplane record store does not support deployment record reads: "
+            "read_deployment_record"
+        )
+    return cast(_DeploymentReadStore, record_store)
+
+
+def require_promotion_read_store(record_store: object) -> _PromotionReadStore:
+    read_record = getattr(record_store, "read_promotion_record", None)
+    if not callable(read_record):
+        raise TypeError(
+            "Launchplane record store does not support promotion record reads: "
+            "read_promotion_record"
+        )
+    return cast(_PromotionReadStore, record_store)
 
 
 def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -865,6 +909,80 @@ def create_launchplane_fastapi_app(
             instance_name=instance,
         )
         return DriverContextViewResponse(trace_id=trace_id, view=view)
+
+    def read_deployment_record(
+        record_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> DeploymentRecordResponse:
+        trace_id = next_trace_id()
+        try:
+            deployment_store = require_deployment_read_store(record_store)
+            deployment = deployment_store.read_deployment_record(record_id)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="deployment.read",
+            product="launchplane",
+            context=deployment.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read deployment records for the requested context.",
+            )
+        return DeploymentRecordResponse(trace_id=trace_id, record=deployment)
+
+    def read_promotion_record(
+        record_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> PromotionRecordResponse:
+        trace_id = next_trace_id()
+        try:
+            promotion_store = require_promotion_read_store(record_store)
+            promotion = promotion_store.read_promotion_record(record_id)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="promotion.read",
+            product="launchplane",
+            context=promotion.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read promotion records for the requested context.",
+            )
+        return PromotionRecordResponse(trace_id=trace_id, record=promotion)
 
     def accepted_evidence_response(
         *,
@@ -1645,6 +1763,38 @@ def create_launchplane_fastapi_app(
         responses={
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/deployments/{record_id}",
+        read_deployment_record,
+        methods=["GET"],
+        response_model=DeploymentRecordResponse,
+        operation_id="read_deployment_record",
+        summary="Read one deployment record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/promotions/{record_id}",
+        read_promotion_record,
+        methods=["GET"],
+        response_model=PromotionRecordResponse,
+        operation_id="read_promotion_record",
+        summary="Read one promotion record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
         },
     )
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4513,10 +4513,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
-    if len(segments) == 3 and segments[:2] == ["v1", "deployments"]:
-        return "deployment.read", {"record_id": segments[2]}
-    if len(segments) == 3 and segments[:2] == ["v1", "promotions"]:
-        return "promotion.read", {"record_id": segments[2]}
     if len(segments) == 4 and segments[:2] == ["v1", "inventory"]:
         return "inventory.read", {"context": segments[2], "instance": segments[3]}
     if len(segments) == 3 and segments[:2] == ["v1", "previews"]:
@@ -10966,64 +10962,6 @@ def create_launchplane_service_app(
                             "records": [
                                 record.model_dump(mode="json") for record in canary_records
                             ],
-                        },
-                    )
-                if action == "deployment.read":
-                    deployment = record_store.read_deployment_record(params["record_id"])
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=deployment.context,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read deployment records for the requested context.",
-                                },
-                            },
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "record": deployment.model_dump(mode="json"),
-                        },
-                    )
-                if action == "promotion.read":
-                    promotion = record_store.read_promotion_record(params["record_id"])
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=promotion.context,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read promotion records for the requested context.",
-                                },
-                            },
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "record": promotion.model_dump(mode="json"),
                         },
                     )
                 if action == "inventory.read":

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -60,6 +60,10 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
+- Deployment and promotion single-record reads use native FastAPI routes for
+  bearer-token and human-session callers. Their legacy WSGI branches are
+  deleted; direct fallback calls fail closed while the mounted fallback remains
+  for retained non-native routes.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -50,6 +50,11 @@ VeriReel product paths:
     context
   - `GET /v1/drivers/{driver_id}`, requiring `driver.read` for the Launchplane
     discovery context
+- native FastAPI deployment and promotion single-record reads:
+  - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
+    stored record context
+  - `GET /v1/promotions/{record_id}`, requiring `promotion.read` for the stored
+    record context
 - authenticated evidence routes:
   - `POST /v1/evidence/backup-gates` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
@@ -1240,8 +1245,10 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/previews/{preview_id}`
 - `GET /v1/previews/{preview_id}/history`
 - `GET /v1/inventory/{context}/{instance}`
-- `GET /v1/promotions/{record_id}`
-- `GET /v1/deployments/{record_id}`
+- `GET /v1/promotions/{record_id}` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/deployments/{record_id}` (native FastAPI for bearer-token and
+  human-session callers)
 - `GET /v1/artifacts/protected` (native FastAPI for bearer-token and
   human-session callers)
 - `GET /v1/contexts/{context}/secrets`
@@ -1256,6 +1263,13 @@ current Launchplane record nouns without forcing them to infer state from
 workflow logs or host-local files. Secret status reads return metadata only:
 Launchplane does not expose plaintext secret retrieval through the service
 boundary.
+
+Deployment and promotion single-record reads use the stored record context for
+authorization. The service reads the record first, maps a missing record to
+`404 not_found`, then checks `deployment.read` or `promotion.read` against
+product `launchplane` and the record context before returning the typed record
+envelope. Their legacy WSGI branches are deleted; direct fallback calls fail
+closed while the mounted fallback remains for retained non-native routes.
 
 Product/site reads use action `product_environment.read`. They compose
 Launchplane-owned product profiles, driver descriptors, stable lane records,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -1758,6 +1758,290 @@ class FastApiDriverContextViewTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FastApiDeploymentPromotionReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_deployment_read_returns_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_deployment_record(_deployment_read_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="deployment.read",
+                    context="example-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_deployment_record(app, "deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(payload["record"]["record_id"], "deployment-example-site-prod")
+        self.assertEqual(
+            payload["record"]["resolved_target"]["target_id"],
+            "target-example-site-prod",
+        )
+
+    async def test_deployment_read_requires_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="deployment.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_deployment_record(
+            app,
+            "deployment-example-site-prod",
+            authorization="",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_deployment_read_rejects_wrong_context_grant(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_deployment_record(_deployment_read_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="deployment.read",
+                    context="other-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_deployment_record(app, "deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_deployment_read_returns_not_found_for_missing_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="deployment.read",
+                    context="other-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_deployment_record(app, "deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_deployment_read_requires_read_capable_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="deployment.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_deployment_record(app, "deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("read_deployment_record", payload["error"]["message"])
+
+    async def test_promotion_read_returns_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_promotion_record(_promotion_read_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="promotion.read",
+                    context="example-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_promotion_record(
+                app,
+                "promotion-example-site-testing-to-prod",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(
+            payload["record"]["record_id"],
+            "promotion-example-site-testing-to-prod",
+        )
+        self.assertEqual(payload["record"]["to_instance"], "prod")
+
+    async def test_promotion_read_requires_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="promotion.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_promotion_record(
+            app,
+            "promotion-example-site-testing-to-prod",
+            authorization="",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_promotion_read_rejects_wrong_context_grant(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_promotion_record(_promotion_read_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="promotion.read",
+                    context="other-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_promotion_record(
+                app,
+                "promotion-example-site-testing-to-prod",
+            )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_promotion_read_returns_not_found_for_missing_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="promotion.read",
+                    context="other-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_promotion_record(
+                app,
+                "promotion-example-site-testing-to-prod",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_promotion_read_requires_read_capable_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="promotion.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_promotion_record(
+            app,
+            "promotion-example-site-testing-to-prod",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("read_promotion_record", payload["error"]["message"])
+
+    async def test_openapi_includes_deployment_and_promotion_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="deployment.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        deployment_route = openapi["paths"]["/v1/deployments/{record_id}"]["get"]
+        promotion_route = openapi["paths"]["/v1/promotions/{record_id}"]["get"]
+        self.assertEqual(deployment_route["operationId"], "read_deployment_record")
+        self.assertEqual(promotion_route["operationId"], "read_promotion_record")
+        self.assertEqual(
+            deployment_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/DeploymentRecordResponse",
+        )
+        self.assertEqual(
+            promotion_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/PromotionRecordResponse",
+        )
+        for route in (deployment_route, promotion_route):
+            self.assertIn("LaunchplaneErrorResponse", json.dumps(route))
+            self.assertIn("401", route["responses"])
+            self.assertIn("403", route["responses"])
+            self.assertIn("404", route["responses"])
+            self.assertIn("503", route["responses"])
+        self.assertEqual(
+            openapi["components"]["schemas"]["DeploymentRecordResponse"]["additionalProperties"],
+            False,
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["PromotionRecordResponse"]["additionalProperties"],
+            False,
+        )
+
+    async def test_fastapi_record_reads_precede_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_deployment_record(_deployment_read_record())
+            store.write_promotion_record(_promotion_read_record())
+            policy = _record_read_policy(
+                action="deployment.read",
+                context="example-site",
+                extra_actions=("promotion.read",),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            deployment_response = await _get_deployment_record(
+                app,
+                "deployment-example-site-prod",
+            )
+            promotion_response = await _get_promotion_record(
+                app,
+                "promotion-example-site-testing-to-prod",
+            )
+
+        self.assertEqual(deployment_response.status_code, 200)
+        self.assertEqual(promotion_response.status_code, 200)
+        self.assertEqual(deployment_response.json()["status"], "ok")
+        self.assertEqual(promotion_response.json()["status"], "ok")
+
+
 class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
     async def test_backup_gate_evidence_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -4566,6 +4850,30 @@ def _deployment_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
     )
 
 
+def _record_read_policy(
+    *,
+    action: str,
+    context: str,
+    extra_actions: tuple[str, ...] = (),
+) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["launchplane"],
+                    "contexts": [context],
+                    "actions": [action, *extra_actions],
+                }
+            ]
+        }
+    )
+
+
 def _github_human_deployment_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -4637,6 +4945,16 @@ def _deployment_evidence_payload(
             },
         },
     }
+
+
+def _deployment_read_record() -> DeploymentRecord:
+    payload = _deployment_evidence_payload()["deployment"]
+    return DeploymentRecord.model_validate(payload)
+
+
+def _promotion_read_record() -> PromotionRecord:
+    payload = _promotion_evidence_payload()["promotion"]
+    return PromotionRecord.model_validate(payload)
 
 
 def _github_human_driver_read_policy(*, context: str = "launchplane") -> LaunchplaneAuthzPolicy:
@@ -4895,6 +5213,32 @@ async def _get_driver_instance_view(
         f"/v1/contexts/{context}/instances/{instance}/driver-view",
         headers=headers,
     )
+
+
+async def _get_deployment_record(
+    app: FastAPI,
+    record_id: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(app, f"/v1/deployments/{record_id}", headers=request_headers)
+
+
+async def _get_promotion_record(
+    app: FastAPI,
+    record_id: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(app, f"/v1/promotions/{record_id}", headers=request_headers)
 
 
 async def _post_backup_gate_evidence(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -37419,70 +37419,36 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 403)
             self.assertEqual(payload["error"]["code"], "authorization_denied")
 
-    def test_deployment_read_endpoint_returns_record_for_authorized_workflow(self) -> None:
+    def test_deployment_and_promotion_read_routes_are_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_deployment_record(
-                DeploymentRecord(
-                    record_id="deployment-20260420T153000Z-opw-testing",
-                    artifact_identity=ArtifactIdentityReference(
-                        artifact_id="artifact-20260420-a1b2c3d4"
-                    ),
-                    context="opw",
-                    instance="testing",
-                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
-                    resolved_target=ResolvedTargetEvidence(
-                        target_type="compose",
-                        target_id="compose-123",
-                        target_name="opw-testing",
-                    ),
-                    deploy=DeploymentEvidence(
-                        target_name="opw-testing",
-                        target_type="compose",
-                        deploy_mode="dokploy-compose-api",
-                        deployment_id="delegated-compose-ship",
-                        status="pass",
-                        started_at="2026-04-20T15:30:00Z",
-                        finished_at="2026-04-20T15:32:10Z",
-                    ),
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "contexts": ["opw"],
-                            "actions": ["deployment.read"],
-                        }
-                    ]
-                }
-            )
             app = create_launchplane_service_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
                 control_plane_root_path=root,
             )
 
-            status_code, payload = _invoke_app(
+            deployment_status_code, deployment_payload = _invoke_app(
                 app,
                 method="GET",
                 path="/v1/deployments/deployment-20260420T153000Z-opw-testing",
             )
-
-            self.assertEqual(status_code, 200)
-            self.assertEqual(payload["status"], "ok")
-            self.assertEqual(
-                payload["record"]["record_id"], "deployment-20260420T153000Z-opw-testing"
+            promotion_status_code, promotion_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/promotions/promotion-20260420T153500Z-opw-testing-to-prod",
             )
-            self.assertEqual(payload["record"]["resolved_target"]["target_id"], "compose-123")
+
+        self.assertEqual(deployment_status_code, 404)
+        self.assertEqual(deployment_payload["status"], "rejected")
+        self.assertEqual(deployment_payload["error"]["code"], "not_found")
+        self.assertEqual(promotion_status_code, 404)
+        self.assertEqual(promotion_payload["status"], "rejected")
+        self.assertEqual(promotion_payload["error"]["code"], "not_found")
 
     def test_preview_history_and_recent_operations_endpoints_return_operator_read_models(
         self,


### PR DESCRIPTION
## Summary
- move GET /v1/deployments/{record_id} and GET /v1/promotions/{record_id} to native FastAPI routes with typed response models and OpenAPI coverage
- retire the matching direct WSGI read branches so fallback calls fail closed
- add native success/authn/authz/not-found/store-capability/fallback-precedence coverage and update service-boundary docs

Refs #1322

## Validation
- uv run python -m unittest tests.test_http_app.FastApiDeploymentPromotionReadTests tests.test_service.LaunchplaneServiceTests.test_deployment_and_promotion_read_routes_are_retired_from_legacy_wsgi_app
- uv run python -m unittest tests.test_http_app tests.test_service
- uv run python -m unittest
- uv run --extra dev ruff check --diff control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff check --diff .
- uv run --extra dev ruff check .
- JetBrains changed-files inspection: clean

## Review
- Scout agents confirmed migrating both read routes together is safe and identified authz-order constraints
- Review agents: implementation reviewers green; Launchplane boundary reviewer green

## Notes
- Repo-wide `uv run --extra dev ruff format --check .` still reports pre-existing formatting drift outside this slice; changed Python files are format-clean.