### PR TITLE
Migrate inventory read to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -21,6 +21,7 @@ from control_plane.contracts.authz_policy_record import (
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.driver_descriptor import DriverContextView, DriverDescriptor
+from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
     build_launchplane_idempotency_record_id,
@@ -174,6 +175,14 @@ class PromotionRecordResponse(BaseModel):
     record: PromotionRecord
 
 
+class EnvironmentInventoryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: EnvironmentInventory
+
+
 class ProtectedArtifactsResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -289,6 +298,15 @@ class _DeploymentReadStore(Protocol):
 
 class _PromotionReadStore(Protocol):
     def read_promotion_record(self, record_id: str) -> PromotionRecord: ...
+
+
+class _EnvironmentInventoryReadStore(Protocol):
+    def read_environment_inventory(
+        self,
+        *,
+        context_name: str,
+        instance_name: str,
+    ) -> EnvironmentInventory: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -469,6 +487,18 @@ def require_promotion_read_store(record_store: object) -> _PromotionReadStore:
             "read_promotion_record"
         )
     return cast(_PromotionReadStore, record_store)
+
+
+def require_environment_inventory_read_store(
+    record_store: object,
+) -> _EnvironmentInventoryReadStore:
+    read_record = getattr(record_store, "read_environment_inventory", None)
+    if not callable(read_record):
+        raise TypeError(
+            "Launchplane record store does not support environment inventory reads: "
+            "read_environment_inventory"
+        )
+    return cast(_EnvironmentInventoryReadStore, record_store)
 
 
 def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -983,6 +1013,59 @@ def create_launchplane_fastapi_app(
                 message="Workflow cannot read promotion records for the requested context.",
             )
         return PromotionRecordResponse(trace_id=trace_id, record=promotion)
+
+    def read_environment_inventory(
+        context: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        instance: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> EnvironmentInventoryResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="inventory.read",
+            product="launchplane",
+            context=context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read inventory for the requested context.",
+            )
+        try:
+            inventory_store = require_environment_inventory_read_store(record_store)
+            inventory = inventory_store.read_environment_inventory(
+                context_name=context,
+                instance_name=instance,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="inventory.read",
+            product="launchplane",
+            context=inventory.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read inventory for the requested context.",
+            )
+        return EnvironmentInventoryResponse(trace_id=trace_id, record=inventory)
 
     def accepted_evidence_response(
         *,
@@ -1789,6 +1872,22 @@ def create_launchplane_fastapi_app(
         response_model=PromotionRecordResponse,
         operation_id="read_promotion_record",
         summary="Read one promotion record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/inventory/{context}/{instance}",
+        read_environment_inventory,
+        methods=["GET"],
+        response_model=EnvironmentInventoryResponse,
+        operation_id="read_environment_inventory",
+        summary="Read one environment inventory record",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4513,8 +4513,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
-    if len(segments) == 4 and segments[:2] == ["v1", "inventory"]:
-        return "inventory.read", {"context": segments[2], "instance": segments[3]}
     if len(segments) == 3 and segments[:2] == ["v1", "previews"]:
         return "preview.read", {"preview_id": segments[2]}
     if len(segments) == 4 and segments[:2] == ["v1", "previews"] and segments[3] == "history":
@@ -10962,38 +10960,6 @@ def create_launchplane_service_app(
                             "records": [
                                 record.model_dump(mode="json") for record in canary_records
                             ],
-                        },
-                    )
-                if action == "inventory.read":
-                    inventory = record_store.read_environment_inventory(
-                        context_name=params["context"],
-                        instance_name=params["instance"],
-                    )
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=inventory.context,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read inventory for the requested context.",
-                                },
-                            },
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "record": inventory.model_dump(mode="json"),
                         },
                     )
                 if action == "preview.read":

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -60,10 +60,10 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment and promotion single-record reads use native FastAPI routes for
-  bearer-token and human-session callers. Their legacy WSGI branches are
-  deleted; direct fallback calls fail closed while the mounted fallback remains
-  for retained non-native routes.
+- Deployment, promotion, and inventory single-record reads use native FastAPI
+  routes for bearer-token and human-session callers. Their legacy WSGI branches
+  are deleted; direct fallback calls fail closed while the mounted fallback
+  remains for retained non-native routes.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -50,11 +50,13 @@ VeriReel product paths:
     context
   - `GET /v1/drivers/{driver_id}`, requiring `driver.read` for the Launchplane
     discovery context
-- native FastAPI deployment and promotion single-record reads:
+- native FastAPI deployment, promotion, and inventory single-record reads:
   - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
     stored record context
   - `GET /v1/promotions/{record_id}`, requiring `promotion.read` for the stored
     record context
+  - `GET /v1/inventory/{context}/{instance}`, requiring `inventory.read` for
+    the stored inventory context
 - authenticated evidence routes:
   - `POST /v1/evidence/backup-gates` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
@@ -1244,7 +1246,8 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/products/{product}/environments/{environment}`
 - `GET /v1/previews/{preview_id}`
 - `GET /v1/previews/{preview_id}/history`
-- `GET /v1/inventory/{context}/{instance}`
+- `GET /v1/inventory/{context}/{instance}` (native FastAPI for bearer-token and
+  human-session callers)
 - `GET /v1/promotions/{record_id}` (native FastAPI for bearer-token and
   human-session callers)
 - `GET /v1/deployments/{record_id}` (native FastAPI for bearer-token and
@@ -1268,8 +1271,11 @@ Deployment and promotion single-record reads use the stored record context for
 authorization. The service reads the record first, maps a missing record to
 `404 not_found`, then checks `deployment.read` or `promotion.read` against
 product `launchplane` and the record context before returning the typed record
-envelope. Their legacy WSGI branches are deleted; direct fallback calls fail
-closed while the mounted fallback remains for retained non-native routes.
+envelope. Inventory single-record reads authorize `inventory.read` against the
+path context before store access, then verify the stored inventory context before
+returning the typed record envelope. Their legacy WSGI branches are deleted;
+direct fallback calls fail closed while the mounted fallback remains for
+retained non-native routes.
 
 Product/site reads use action `product_environment.read`. They compose
 Launchplane-owned product profiles, driver descriptors, stable lane records,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -17,6 +17,7 @@ from starlette.types import ASGIApp
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
@@ -2040,6 +2041,157 @@ class FastApiDeploymentPromotionReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(promotion_response.status_code, 200)
         self.assertEqual(deployment_response.json()["status"], "ok")
         self.assertEqual(promotion_response.json()["status"], "ok")
+
+
+class FastApiEnvironmentInventoryReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_inventory_read_returns_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_environment_inventory(_environment_inventory_read_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="inventory.read",
+                    context="example-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_environment_inventory(app, "example-site", "prod")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(payload["record"]["context"], "example-site")
+        self.assertEqual(payload["record"]["instance"], "prod")
+        self.assertEqual(payload["record"]["deployment_record_id"], "deployment-example-site-prod")
+
+    async def test_inventory_read_requires_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="inventory.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_environment_inventory(
+            app,
+            "example-site",
+            "prod",
+            authorization="",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_inventory_read_rejects_wrong_context_grant(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="inventory.read",
+                context="other-site",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_environment_inventory(app, "example-site", "prod")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_inventory_read_returns_not_found_for_missing_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="inventory.read",
+                    context="example-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_environment_inventory(app, "example-site", "prod")
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_inventory_read_requires_read_capable_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="inventory.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_environment_inventory(app, "example-site", "prod")
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("read_environment_inventory", payload["error"]["message"])
+
+    async def test_openapi_includes_inventory_read_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="inventory.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/inventory/{context}/{instance}"]["get"]
+        self.assertEqual(route["operationId"], "read_environment_inventory")
+        self.assertEqual(
+            route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/EnvironmentInventoryResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(route))
+        self.assertIn("401", route["responses"])
+        self.assertIn("403", route["responses"])
+        self.assertIn("404", route["responses"])
+        self.assertIn("503", route["responses"])
+        self.assertEqual(
+            openapi["components"]["schemas"]["EnvironmentInventoryResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+
+    async def test_fastapi_inventory_read_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_environment_inventory(_environment_inventory_read_record())
+            policy = _record_read_policy(
+                action="inventory.read",
+                context="example-site",
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _get_environment_inventory(app, "example-site", "prod")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
 
 
 class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
@@ -4957,6 +5109,21 @@ def _promotion_read_record() -> PromotionRecord:
     return PromotionRecord.model_validate(payload)
 
 
+def _environment_inventory_read_record() -> EnvironmentInventory:
+    deployment = _deployment_read_record()
+    return EnvironmentInventory(
+        context=deployment.context,
+        instance=deployment.instance,
+        artifact_identity=deployment.artifact_identity,
+        source_git_ref=deployment.source_git_ref,
+        deploy=deployment.deploy,
+        post_deploy_update=deployment.post_deploy_update,
+        destination_health=deployment.destination_health,
+        updated_at="2026-04-20T15:33:00Z",
+        deployment_record_id=deployment.record_id,
+    )
+
+
 def _github_human_driver_read_policy(*, context: str = "launchplane") -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -5239,6 +5406,24 @@ async def _get_promotion_record(
     if authorization:
         request_headers["Authorization"] = authorization
     return await _asgi_get(app, f"/v1/promotions/{record_id}", headers=request_headers)
+
+
+async def _get_environment_inventory(
+    app: FastAPI,
+    context: str,
+    instance: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(
+        app,
+        f"/v1/inventory/{context}/{instance}",
+        headers=request_headers,
+    )
 
 
 async def _post_backup_gate_evidence(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -37419,7 +37419,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 403)
             self.assertEqual(payload["error"]["code"], "authorization_denied")
 
-    def test_deployment_and_promotion_read_routes_are_retired_from_legacy_wsgi_app(
+    def test_single_record_read_routes_are_retired_from_legacy_wsgi_app(
         self,
     ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -37442,6 +37442,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 method="GET",
                 path="/v1/promotions/promotion-20260420T153500Z-opw-testing-to-prod",
             )
+            inventory_status_code, inventory_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/inventory/opw/testing",
+            )
 
         self.assertEqual(deployment_status_code, 404)
         self.assertEqual(deployment_payload["status"], "rejected")
@@ -37449,6 +37454,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(promotion_status_code, 404)
         self.assertEqual(promotion_payload["status"], "rejected")
         self.assertEqual(promotion_payload["error"]["code"], "not_found")
+        self.assertEqual(inventory_status_code, 404)
+        self.assertEqual(inventory_payload["status"], "rejected")
+        self.assertEqual(inventory_payload["error"]["code"], "not_found")
 
     def test_preview_history_and_recent_operations_endpoints_return_operator_read_models(
         self,


### PR DESCRIPTION
## Summary
- add a native FastAPI `GET /v1/inventory/{context}/{instance}` route with typed response and OpenAPI contract coverage
- pre-authorize `inventory.read` against the path context before store access, then verify the stored inventory context before returning the record
- remove the legacy WSGI inventory read matcher/handler and document the retirement

Refs #1322

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiEnvironmentInventoryReadTests tests.test_service.LaunchplaneServiceTests.test_single_record_read_routes_are_retired_from_legacy_wsgi_app`
- `uv run python -m unittest tests.test_http_app tests.test_service`
- `uv run python -m unittest`
- `uv run --extra dev ruff check --diff .`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- JetBrains changed-files closeout: clean
- two read-only review agents: green to merge

## Notes
- `uv run --extra dev ruff format --check .` still reports 56 unrelated pre-existing files that would reformat; changed Python files are formatted.