### PR TITLE
Migrate preview reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -33,6 +33,8 @@ from control_plane.contracts.preview_evidence import (
     PreviewDestroyedEvidenceEnvelope,
     PreviewGenerationEvidenceEnvelope,
 )
+from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.protected_artifacts import (
     ProtectedArtifactStore,
@@ -175,6 +177,23 @@ class PromotionRecordResponse(BaseModel):
     record: PromotionRecord
 
 
+class PreviewRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: PreviewRecord
+
+
+class PreviewHistoryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    preview: PreviewRecord
+    generations: tuple[PreviewGenerationRecord, ...]
+
+
 class EnvironmentInventoryResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -298,6 +317,21 @@ class _DeploymentReadStore(Protocol):
 
 class _PromotionReadStore(Protocol):
     def read_promotion_record(self, record_id: str) -> PromotionRecord: ...
+
+
+class _PreviewReadStore(Protocol):
+    def read_preview_record(self, preview_id: str) -> PreviewRecord: ...
+
+
+class _PreviewHistoryReadStore(Protocol):
+    def read_preview_record(self, preview_id: str) -> PreviewRecord: ...
+
+    def list_preview_generation_records(
+        self,
+        *,
+        preview_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewGenerationRecord, ...]: ...
 
 
 class _EnvironmentInventoryReadStore(Protocol):
@@ -487,6 +521,30 @@ def require_promotion_read_store(record_store: object) -> _PromotionReadStore:
             "read_promotion_record"
         )
     return cast(_PromotionReadStore, record_store)
+
+
+def require_preview_read_store(record_store: object) -> _PreviewReadStore:
+    read_record = getattr(record_store, "read_preview_record", None)
+    if not callable(read_record):
+        raise TypeError(
+            "Launchplane record store does not support preview reads: read_preview_record"
+        )
+    return cast(_PreviewReadStore, record_store)
+
+
+def require_preview_history_read_store(record_store: object) -> _PreviewHistoryReadStore:
+    required_methods = ("read_preview_record", "list_preview_generation_records")
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            f"Launchplane record store does not support preview history reads: {missing_summary}"
+        )
+    return cast(_PreviewHistoryReadStore, record_store)
 
 
 def require_environment_inventory_read_store(
@@ -1013,6 +1071,102 @@ def create_launchplane_fastapi_app(
                 message="Workflow cannot read promotion records for the requested context.",
             )
         return PromotionRecordResponse(trace_id=trace_id, record=promotion)
+
+    def read_preview_record(
+        preview_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> PreviewRecordResponse:
+        trace_id = next_trace_id()
+        try:
+            preview_store = require_preview_read_store(record_store)
+            preview = preview_store.read_preview_record(preview_id)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="preview.read",
+            product="launchplane",
+            context=preview.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read previews for the requested context.",
+            )
+        return PreviewRecordResponse(trace_id=trace_id, record=preview)
+
+    def read_preview_history(
+        preview_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> PreviewHistoryResponse:
+        trace_id = next_trace_id()
+        try:
+            preview_store = require_preview_history_read_store(record_store)
+            preview = preview_store.read_preview_record(preview_id)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="preview.read",
+            product="launchplane",
+            context=preview.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read previews for the requested context.",
+            )
+        try:
+            generations = preview_store.list_preview_generation_records(
+                preview_id=preview.preview_id
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        return PreviewHistoryResponse(
+            trace_id=trace_id,
+            preview=preview,
+            generations=generations,
+        )
 
     def read_environment_inventory(
         context: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -1872,6 +2026,38 @@ def create_launchplane_fastapi_app(
         response_model=PromotionRecordResponse,
         operation_id="read_promotion_record",
         summary="Read one promotion record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/previews/{preview_id}",
+        read_preview_record,
+        methods=["GET"],
+        response_model=PreviewRecordResponse,
+        operation_id="read_preview_record",
+        summary="Read one preview record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/previews/{preview_id}/history",
+        read_preview_history,
+        methods=["GET"],
+        response_model=PreviewHistoryResponse,
+        operation_id="read_preview_history",
+        summary="Read one preview record with generation history",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4513,10 +4513,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
-    if len(segments) == 3 and segments[:2] == ["v1", "previews"]:
-        return "preview.read", {"preview_id": segments[2]}
-    if len(segments) == 4 and segments[:2] == ["v1", "previews"] and segments[3] == "history":
-        return "preview.read", {"preview_id": segments[2], "include_history": "true"}
     if len(segments) == 3 and segments[:2] == ["v1", "secrets"]:
         return "secret.read", {"secret_id": segments[2]}
     if len(segments) == 4 and segments[:2] == ["v1", "contexts"] and segments[3] == "secrets":
@@ -10960,51 +10956,6 @@ def create_launchplane_service_app(
                             "records": [
                                 record.model_dump(mode="json") for record in canary_records
                             ],
-                        },
-                    )
-                if action == "preview.read":
-                    preview = record_store.read_preview_record(params["preview_id"])
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=preview.context,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read previews for the requested context.",
-                                },
-                            },
-                        )
-                    if params.get("include_history") == "true":
-                        generations = record_store.list_preview_generation_records(
-                            preview_id=preview.preview_id
-                        )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "preview": preview.model_dump(mode="json"),
-                                "generations": [
-                                    generation.model_dump(mode="json") for generation in generations
-                                ],
-                            },
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "record": preview.model_dump(mode="json"),
                         },
                     )
                 if action == "secret.read":

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -60,10 +60,10 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment, promotion, and inventory single-record reads use native FastAPI
-  routes for bearer-token and human-session callers. Their legacy WSGI branches
-  are deleted; direct fallback calls fail closed while the mounted fallback
-  remains for retained non-native routes.
+- Deployment, promotion, preview, and inventory single-record reads use native
+  FastAPI routes for bearer-token and human-session callers. Their legacy WSGI
+  branches are deleted; direct fallback calls fail closed while the mounted
+  fallback remains for retained non-native routes.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -50,11 +50,16 @@ VeriReel product paths:
     context
   - `GET /v1/drivers/{driver_id}`, requiring `driver.read` for the Launchplane
     discovery context
-- native FastAPI deployment, promotion, and inventory single-record reads:
+- native FastAPI deployment, promotion, preview, and inventory single-record
+  reads:
   - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
     stored record context
   - `GET /v1/promotions/{record_id}`, requiring `promotion.read` for the stored
     record context
+  - `GET /v1/previews/{preview_id}`, requiring `preview.read` for the stored
+    preview context
+  - `GET /v1/previews/{preview_id}/history`, requiring `preview.read` for the
+    stored preview context
   - `GET /v1/inventory/{context}/{instance}`, requiring `inventory.read` for
     the stored inventory context
 - authenticated evidence routes:
@@ -1244,8 +1249,10 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/products/{product}/activity`
 - `GET /v1/products/{product}/environments`
 - `GET /v1/products/{product}/environments/{environment}`
-- `GET /v1/previews/{preview_id}`
-- `GET /v1/previews/{preview_id}/history`
+- `GET /v1/previews/{preview_id}` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/previews/{preview_id}/history` (native FastAPI for bearer-token and
+  human-session callers)
 - `GET /v1/inventory/{context}/{instance}` (native FastAPI for bearer-token and
   human-session callers)
 - `GET /v1/promotions/{record_id}` (native FastAPI for bearer-token and
@@ -1267,15 +1274,17 @@ workflow logs or host-local files. Secret status reads return metadata only:
 Launchplane does not expose plaintext secret retrieval through the service
 boundary.
 
-Deployment and promotion single-record reads use the stored record context for
-authorization. The service reads the record first, maps a missing record to
-`404 not_found`, then checks `deployment.read` or `promotion.read` against
-product `launchplane` and the record context before returning the typed record
-envelope. Inventory single-record reads authorize `inventory.read` against the
-path context before store access, then verify the stored inventory context before
-returning the typed record envelope. Their legacy WSGI branches are deleted;
-direct fallback calls fail closed while the mounted fallback remains for
-retained non-native routes.
+Deployment, promotion, and preview single-record reads use the stored record
+context for authorization. The service reads the record first, maps a missing
+record to `404 not_found`, then checks `deployment.read`, `promotion.read`, or
+`preview.read` against product `launchplane` and the record context before
+returning the typed record envelope. Preview history reads share the same stored
+preview authorization decision, then return the typed preview record plus its
+generation history. Inventory single-record reads authorize `inventory.read`
+against the path context before store access, then verify the stored inventory
+context before returning the typed record envelope. Their legacy WSGI branches
+are deleted; direct fallback calls fail closed while the mounted fallback remains
+for retained non-native routes.
 
 Product/site reads use action `product_environment.read`. They compose
 Launchplane-owned product profiles, driver descriptors, stable lane records,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -20,6 +20,11 @@ from control_plane.contracts.deployment_record import DeploymentRecord, Resolved
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.preview_generation_record import (
+    PreviewGenerationState,
+    PreviewGenerationRecord,
+    PreviewPullRequestSummary,
+)
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
@@ -2192,6 +2197,248 @@ class FastApiEnvironmentInventoryReadTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "ok")
+
+
+class FastApiPreviewReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_preview_read_returns_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_preview_record(_preview_read_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="preview.read",
+                    context="example-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_preview_record(app, "preview-example-site-example-site-pr-42")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(payload["record"]["preview_id"], "preview-example-site-example-site-pr-42")
+        self.assertEqual(payload["record"]["context"], "example-site")
+        self.assertEqual(payload["record"]["state"], "active")
+
+    async def test_preview_history_returns_preview_and_generations(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            preview = _preview_read_record()
+            store.write_preview_record(preview)
+            store.write_preview_generation_record(
+                _preview_generation_read_record(sequence=1, state="ready")
+            )
+            store.write_preview_generation_record(
+                _preview_generation_read_record(sequence=2, state="verifying")
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="preview.read",
+                    context="example-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_preview_history(app, preview.preview_id)
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(
+            payload["preview"]["preview_id"], "preview-example-site-example-site-pr-42"
+        )
+        self.assertNotIn("record", payload)
+        self.assertEqual(
+            [generation["sequence"] for generation in payload["generations"]],
+            [2, 1],
+        )
+        self.assertEqual(payload["generations"][0]["state"], "verifying")
+
+    async def test_preview_read_requires_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="preview.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_preview_record(
+            app,
+            "preview-example-site-example-site-pr-42",
+            authorization="",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_preview_read_rejects_wrong_context_grant(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_preview_record(_preview_read_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="preview.read",
+                    context="other-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_preview_record(app, "preview-example-site-example-site-pr-42")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_preview_history_rejects_wrong_context_before_listing_generations(
+        self,
+    ) -> None:
+        store = _PreviewHistoryProbeStore(_preview_read_record())
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="preview.read",
+                context="other-site",
+            ),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _get_preview_history(
+            app,
+            "preview-example-site-example-site-pr-42",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(store.list_preview_generation_calls, 0)
+
+    async def test_preview_read_returns_not_found_for_missing_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="preview.read",
+                    context="example-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_preview_record(app, "preview-example-site-example-site-pr-42")
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_preview_read_requires_read_capable_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="preview.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_preview_record(app, "preview-example-site-example-site-pr-42")
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("read_preview_record", payload["error"]["message"])
+
+    async def test_preview_history_requires_history_capable_store(self) -> None:
+        store = _PreviewRecordOnlyStore(_preview_read_record())
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="preview.read", context="example-site"),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _get_preview_history(app, "preview-example-site-example-site-pr-42")
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("list_preview_generation_records", payload["error"]["message"])
+
+    async def test_openapi_includes_preview_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="preview.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        preview_route = openapi["paths"]["/v1/previews/{preview_id}"]["get"]
+        history_route = openapi["paths"]["/v1/previews/{preview_id}/history"]["get"]
+        self.assertEqual(preview_route["operationId"], "read_preview_record")
+        self.assertEqual(history_route["operationId"], "read_preview_history")
+        self.assertEqual(
+            preview_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/PreviewRecordResponse",
+        )
+        self.assertEqual(
+            history_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/PreviewHistoryResponse",
+        )
+        for route in (preview_route, history_route):
+            self.assertIn("LaunchplaneErrorResponse", json.dumps(route))
+            self.assertIn("401", route["responses"])
+            self.assertIn("403", route["responses"])
+            self.assertIn("404", route["responses"])
+            self.assertIn("503", route["responses"])
+        self.assertEqual(
+            openapi["components"]["schemas"]["PreviewRecordResponse"]["additionalProperties"],
+            False,
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["PreviewHistoryResponse"]["additionalProperties"],
+            False,
+        )
+
+    async def test_fastapi_preview_reads_precede_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            preview = _preview_read_record()
+            store.write_preview_record(preview)
+            store.write_preview_generation_record(_preview_generation_read_record())
+            policy = _record_read_policy(
+                action="preview.read",
+                context="example-site",
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            preview_response = await _get_preview_record(app, preview.preview_id)
+            history_response = await _get_preview_history(app, preview.preview_id)
+
+        self.assertEqual(preview_response.status_code, 200)
+        self.assertEqual(history_response.status_code, 200)
+        self.assertEqual(preview_response.json()["status"], "ok")
+        self.assertEqual(history_response.json()["status"], "ok")
 
 
 class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
@@ -4750,6 +4997,41 @@ def _preview_record_for_destroy(*, anchor_pr_number: int = 42) -> PreviewRecord:
     )
 
 
+def _preview_read_record(*, anchor_pr_number: int = 42) -> PreviewRecord:
+    return _preview_record_for_destroy(anchor_pr_number=anchor_pr_number)
+
+
+def _preview_generation_read_record(
+    *,
+    anchor_pr_number: int = 42,
+    sequence: int = 1,
+    state: PreviewGenerationState = "ready",
+) -> PreviewGenerationRecord:
+    preview_id = f"preview-example-site-example-site-pr-{anchor_pr_number}"
+    generation_id = f"{preview_id}-generation-{sequence:04d}"
+    return PreviewGenerationRecord(
+        generation_id=generation_id,
+        preview_id=preview_id,
+        sequence=sequence,
+        state=state,
+        requested_reason="external_preview_refresh",
+        requested_at="2026-04-16T08:02:00Z",
+        ready_at="2026-04-16T08:10:00Z" if state == "ready" else "",
+        finished_at="2026-04-16T08:10:00Z" if state == "ready" else "",
+        resolved_manifest_fingerprint=f"example-preview-pr-{anchor_pr_number}-abcdef",
+        artifact_id=f"ghcr.io/every/example-site:pr-{anchor_pr_number}-abcdef",
+        anchor_summary=PreviewPullRequestSummary(
+            repo="example-site",
+            pr_number=anchor_pr_number,
+            head_sha="abcdef1234567890abcdef1234567890abcdef12",
+            pr_url=f"https://github.com/every/example-site/pull/{anchor_pr_number}",
+        ),
+        deploy_status="pass" if state == "ready" else "pending",
+        verify_status="pass" if state == "ready" else "pending",
+        overall_health_status="pass" if state == "ready" else "pending",
+    )
+
+
 def _preview_destroyed_evidence_payload(*, anchor_pr_number: int = 42) -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -5426,6 +5708,36 @@ async def _get_environment_inventory(
     )
 
 
+async def _get_preview_record(
+    app: FastAPI,
+    preview_id: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(app, f"/v1/previews/{preview_id}", headers=request_headers)
+
+
+async def _get_preview_history(
+    app: FastAPI,
+    preview_id: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(
+        app,
+        f"/v1/previews/{preview_id}/history",
+        headers=request_headers,
+    )
+
+
 async def _post_backup_gate_evidence(
     app: FastAPI,
     payload: dict[str, object],
@@ -5657,6 +5969,37 @@ class _CaseInsensitiveHeaders(dict[str, str]):
 
 class _MissingProductReadStore:
     pass
+
+
+class _PreviewRecordOnlyStore:
+    def __init__(self, record: PreviewRecord) -> None:
+        self._record = record
+
+    def read_preview_record(self, preview_id: str) -> PreviewRecord:
+        if preview_id != self._record.preview_id:
+            raise FileNotFoundError(f"No preview record found for {preview_id}.")
+        return self._record
+
+
+class _PreviewHistoryProbeStore:
+    def __init__(self, record: PreviewRecord) -> None:
+        self._record = record
+        self.list_preview_generation_calls = 0
+
+    def read_preview_record(self, preview_id: str) -> PreviewRecord:
+        if preview_id != self._record.preview_id:
+            raise FileNotFoundError(f"No preview record found for {preview_id}.")
+        return self._record
+
+    def list_preview_generation_records(
+        self,
+        *,
+        preview_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewGenerationRecord, ...]:
+        del preview_id, limit
+        self.list_preview_generation_calls += 1
+        return ()
 
 
 class _BackupGateEvidenceOnlyStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -37447,6 +37447,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 method="GET",
                 path="/v1/inventory/opw/testing",
             )
+            preview_status_code, preview_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/previews/preview-opw-opw-pr-42",
+            )
+            preview_history_status_code, preview_history_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/previews/preview-opw-opw-pr-42/history",
+            )
 
         self.assertEqual(deployment_status_code, 404)
         self.assertEqual(deployment_payload["status"], "rejected")
@@ -37457,8 +37467,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(inventory_status_code, 404)
         self.assertEqual(inventory_payload["status"], "rejected")
         self.assertEqual(inventory_payload["error"]["code"], "not_found")
+        self.assertEqual(preview_status_code, 404)
+        self.assertEqual(preview_payload["status"], "rejected")
+        self.assertEqual(preview_payload["error"]["code"], "not_found")
+        self.assertEqual(preview_history_status_code, 404)
+        self.assertEqual(preview_history_payload["status"], "rejected")
+        self.assertEqual(preview_history_payload["error"]["code"], "not_found")
 
-    def test_preview_history_and_recent_operations_endpoints_return_operator_read_models(
+    def test_recent_operations_endpoint_returns_operator_read_model(
         self,
     ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -37593,23 +37609,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
             )
 
-            history_status_code, history_payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/previews/preview-verireel-testing-verireel-pr-123/history",
-            )
             operations_status_code, operations_payload = _invoke_app(
                 app,
                 method="GET",
                 path="/v1/contexts/verireel-testing/operations/recent",
             )
-
-            self.assertEqual(history_status_code, 200)
-            self.assertEqual(
-                history_payload["preview"]["preview_id"], "preview-verireel-testing-verireel-pr-123"
-            )
-            self.assertEqual(len(history_payload["generations"]), 1)
-            self.assertEqual(history_payload["generations"][0]["state"], "ready")
 
             self.assertEqual(operations_status_code, 200)
             self.assertEqual(operations_payload["context"], "verireel-testing")


### PR DESCRIPTION
## Summary
- migrate preview record and preview history reads to native FastAPI routes
- delete the legacy WSGI `preview.read` route matching/handler branch
- document preview read retirement and add regression coverage for stored-context auth before history listing

## Validation
- `uv run python -m unittest` (2648 tests)
- `uv run --extra dev ruff check --diff .`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`

## Review
- Scout agents confirmed preview record/history are a safe single v2 slice.
- First review pass found history generation listing before authz; fixed before commit.
- Second review pass: 2/2 agents reported no blocking findings and merge-ready.

## Notes
- Full `ruff format --check .` still reports existing repo-wide formatting drift outside touched files; touched files are formatted.

Refs #1322
