### PR TITLE
Migrate recent operations read to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -202,6 +202,19 @@ class EnvironmentInventoryResponse(BaseModel):
     record: EnvironmentInventory
 
 
+class RecentOperationsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    context: str
+    storage_backend: str
+    inventory: tuple[EnvironmentInventory, ...]
+    recent_deployments: tuple[DeploymentRecord, ...]
+    recent_promotions: tuple[PromotionRecord, ...]
+    recent_previews: tuple[PreviewRecord, ...]
+
+
 class ProtectedArtifactsResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -341,6 +354,36 @@ class _EnvironmentInventoryReadStore(Protocol):
         context_name: str,
         instance_name: str,
     ) -> EnvironmentInventory: ...
+
+
+class _RecentOperationsReadStore(Protocol):
+    def list_environment_inventory(self) -> tuple[EnvironmentInventory, ...]: ...
+
+    def list_deployment_records(
+        self,
+        *,
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[DeploymentRecord, ...]: ...
+
+    def list_promotion_records(
+        self,
+        *,
+        context_name: str = "",
+        from_instance_name: str = "",
+        to_instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PromotionRecord, ...]: ...
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[PreviewRecord, ...]: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -557,6 +600,26 @@ def require_environment_inventory_read_store(
             "read_environment_inventory"
         )
     return cast(_EnvironmentInventoryReadStore, record_store)
+
+
+def require_recent_operations_read_store(record_store: object) -> _RecentOperationsReadStore:
+    required_methods = (
+        "list_environment_inventory",
+        "list_deployment_records",
+        "list_promotion_records",
+        "list_preview_records",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            f"Launchplane record store does not support recent operation reads: {missing_summary}"
+        )
+    return cast(_RecentOperationsReadStore, record_store)
 
 
 def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -1220,6 +1283,60 @@ def create_launchplane_fastapi_app(
                 message="Workflow cannot read inventory for the requested context.",
             )
         return EnvironmentInventoryResponse(trace_id=trace_id, record=inventory)
+
+    def read_recent_operations(
+        context: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> RecentOperationsResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="operations.read",
+            product="launchplane",
+            context=context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read recent operations for the requested context.",
+            )
+        try:
+            operations_store = require_recent_operations_read_store(record_store)
+            inventory = tuple(
+                record
+                for record in operations_store.list_environment_inventory()
+                if record.context == context
+            )
+            recent_deployments = operations_store.list_deployment_records(
+                context_name=context,
+                limit=10,
+            )
+            recent_promotions = operations_store.list_promotion_records(
+                context_name=context,
+                limit=10,
+            )
+            recent_previews = operations_store.list_preview_records(
+                context_name=context,
+                limit=10,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        return RecentOperationsResponse(
+            trace_id=trace_id,
+            context=context,
+            storage_backend=storage_backend_name(record_store),
+            inventory=inventory,
+            recent_deployments=recent_deployments,
+            recent_promotions=recent_promotions,
+            recent_previews=recent_previews,
+        )
 
     def accepted_evidence_response(
         *,
@@ -2079,6 +2196,21 @@ def create_launchplane_fastapi_app(
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
             404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/contexts/{context}/operations/recent",
+        read_recent_operations,
+        methods=["GET"],
+        response_model=RecentOperationsResponse,
+        operation_id="read_recent_operations",
+        summary="Read recent Launchplane operations for a context",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4531,12 +4531,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[5] == "logs"
     ):
         return "target_logs.read", {"context": segments[2], "instance": segments[4]}
-    if (
-        len(segments) == 5
-        and segments[:2] == ["v1", "contexts"]
-        and segments[3:] == ["operations", "recent"]
-    ):
-        return "operations.read", {"context": segments[2]}
     if len(segments) == 3 and segments == ["v1", "service", "runtime"]:
         return "launchplane_service.read", {}
     if len(segments) == 4 and segments == ["v1", "service", "odoo-workers", "status"]:
@@ -11803,57 +11797,6 @@ def create_launchplane_service_app(
                             **product_list_payload,
                         },
                     )
-                context_name = params["context"]
-                if not authz_policy.allows(
-                    identity=identity,
-                    action=action,
-                    product="launchplane",
-                    context=context_name,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot read recent operations for the requested context.",
-                            },
-                        },
-                    )
-                deployments = record_store.list_deployment_records(
-                    context_name=context_name, limit=10
-                )
-                promotions = record_store.list_promotion_records(
-                    context_name=context_name, limit=10
-                )
-                previews = record_store.list_preview_records(context_name=context_name, limit=10)
-                recent_inventory = [
-                    record
-                    for record in record_store.list_environment_inventory()
-                    if record.context == context_name
-                ]
-                return _json_response(
-                    start_response=start_response,
-                    status_code=200,
-                    payload={
-                        "status": "ok",
-                        "trace_id": request_trace_id,
-                        "context": context_name,
-                        "storage_backend": storage_backend,
-                        "inventory": [
-                            record.model_dump(mode="json") for record in recent_inventory
-                        ],
-                        "recent_deployments": [
-                            record.model_dump(mode="json") for record in deployments
-                        ],
-                        "recent_promotions": [
-                            record.model_dump(mode="json") for record in promotions
-                        ],
-                        "recent_previews": [record.model_dump(mode="json") for record in previews],
-                    },
-                )
             if path == "/v1/service/odoo-workers/reconcile":
                 if not authz_policy.allows(
                     identity=identity,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -60,9 +60,9 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment, promotion, preview, and inventory single-record reads use native
-  FastAPI routes for bearer-token and human-session callers. Their legacy WSGI
-  branches are deleted; direct fallback calls fail closed while the mounted
+- Deployment, promotion, preview, inventory, and recent-operations reads use
+  native FastAPI routes for bearer-token and human-session callers. Their legacy
+  WSGI branches are deleted; direct fallback calls fail closed while the mounted
   fallback remains for retained non-native routes.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -50,7 +50,7 @@ VeriReel product paths:
     context
   - `GET /v1/drivers/{driver_id}`, requiring `driver.read` for the Launchplane
     discovery context
-- native FastAPI deployment, promotion, preview, and inventory single-record
+- native FastAPI deployment, promotion, preview, inventory, and operations
   reads:
   - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
     stored record context
@@ -62,6 +62,8 @@ VeriReel product paths:
     stored preview context
   - `GET /v1/inventory/{context}/{instance}`, requiring `inventory.read` for
     the stored inventory context
+  - `GET /v1/contexts/{context}/operations/recent`, requiring
+    `operations.read` for the path context
 - authenticated evidence routes:
   - `POST /v1/evidence/backup-gates` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
@@ -1264,7 +1266,8 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/contexts/{context}/secrets`
 - `GET /v1/contexts/{context}/instances/{instance}/secrets`
 - `GET /v1/secrets/{secret_id}`
-- `GET /v1/contexts/{context}/operations/recent`
+- `GET /v1/contexts/{context}/operations/recent` (native FastAPI for
+  bearer-token and human-session callers)
 - `GET /v1/product-profiles/{product}/context-cutover-audit`
 
 These operator reads use the same Launchplane authn/authz boundary as evidence
@@ -1282,9 +1285,11 @@ returning the typed record envelope. Preview history reads share the same stored
 preview authorization decision, then return the typed preview record plus its
 generation history. Inventory single-record reads authorize `inventory.read`
 against the path context before store access, then verify the stored inventory
-context before returning the typed record envelope. Their legacy WSGI branches
-are deleted; direct fallback calls fail closed while the mounted fallback remains
-for retained non-native routes.
+context before returning the typed record envelope. Recent operations reads
+authorize `operations.read` against the path context before store access, then
+return the typed recent inventory/deployment/promotion/preview operation
+envelope. Their legacy WSGI branches are deleted; direct fallback calls fail
+closed while the mounted fallback remains for retained non-native routes.
 
 Product/site reads use action `product_environment.read`. They compose
 Launchplane-owned product profiles, driver descriptors, stable lane records,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -2199,6 +2199,145 @@ class FastApiEnvironmentInventoryReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
+class FastApiRecentOperationsReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_recent_operations_returns_operator_read_model(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _write_recent_operations_records(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="operations.read",
+                    context="example-site",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_recent_operations(app, "example-site")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(payload["context"], "example-site")
+        self.assertEqual(payload["storage_backend"], "filesystem")
+        self.assertEqual(len(payload["inventory"]), 1)
+        self.assertEqual(len(payload["recent_deployments"]), 1)
+        self.assertEqual(len(payload["recent_promotions"]), 1)
+        self.assertEqual(len(payload["recent_previews"]), 1)
+        self.assertEqual(payload["inventory"][0]["context"], "example-site")
+        self.assertEqual(payload["recent_deployments"][0]["context"], "example-site")
+        self.assertEqual(payload["recent_promotions"][0]["context"], "example-site")
+        self.assertEqual(payload["recent_previews"][0]["context"], "example-site")
+
+    async def test_recent_operations_requires_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="operations.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_recent_operations(
+            app,
+            "example-site",
+            authorization="",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_recent_operations_rejects_wrong_context_before_store_access(
+        self,
+    ) -> None:
+        store = _RecentOperationsProbeStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="operations.read",
+                context="other-site",
+            ),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _get_recent_operations(app, "example-site")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(store.calls, [])
+
+    async def test_recent_operations_requires_read_capable_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="operations.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_recent_operations(app, "example-site")
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("list_environment_inventory", payload["error"]["message"])
+
+    async def test_openapi_includes_recent_operations_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="operations.read", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/contexts/{context}/operations/recent"]["get"]
+        self.assertEqual(route["operationId"], "read_recent_operations")
+        self.assertEqual(
+            route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/RecentOperationsResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(route))
+        self.assertIn("401", route["responses"])
+        self.assertIn("403", route["responses"])
+        self.assertIn("503", route["responses"])
+        self.assertEqual(
+            openapi["components"]["schemas"]["RecentOperationsResponse"]["additionalProperties"],
+            False,
+        )
+
+    async def test_fastapi_recent_operations_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            _write_recent_operations_records(store)
+            policy = _record_read_policy(
+                action="operations.read",
+                context="example-site",
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _get_recent_operations(app, "example-site")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+
 class FastApiPreviewReadTests(unittest.IsolatedAsyncioTestCase):
     async def test_preview_read_returns_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -5032,6 +5171,13 @@ def _preview_generation_read_record(
     )
 
 
+def _write_recent_operations_records(store: FilesystemRecordStore) -> None:
+    store.write_environment_inventory(_environment_inventory_read_record())
+    store.write_deployment_record(_deployment_read_record())
+    store.write_promotion_record(_promotion_read_record())
+    store.write_preview_record(_preview_read_record())
+
+
 def _preview_destroyed_evidence_payload(*, anchor_pr_number: int = 42) -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -5708,6 +5854,23 @@ async def _get_environment_inventory(
     )
 
 
+async def _get_recent_operations(
+    app: FastAPI,
+    context: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(
+        app,
+        f"/v1/contexts/{context}/operations/recent",
+        headers=request_headers,
+    )
+
+
 async def _get_preview_record(
     app: FastAPI,
     preview_id: str,
@@ -5969,6 +6132,50 @@ class _CaseInsensitiveHeaders(dict[str, str]):
 
 class _MissingProductReadStore:
     pass
+
+
+class _RecentOperationsProbeStore:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def list_environment_inventory(self) -> tuple[EnvironmentInventory, ...]:
+        self.calls.append("list_environment_inventory")
+        return ()
+
+    def list_deployment_records(
+        self,
+        *,
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[DeploymentRecord, ...]:
+        del context_name, instance_name, limit
+        self.calls.append("list_deployment_records")
+        return ()
+
+    def list_promotion_records(
+        self,
+        *,
+        context_name: str = "",
+        from_instance_name: str = "",
+        to_instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[PromotionRecord, ...]:
+        del context_name, from_instance_name, to_instance_name, limit
+        self.calls.append("list_promotion_records")
+        return ()
+
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[PreviewRecord, ...]:
+        del context_name, anchor_repo, anchor_pr_number, limit
+        self.calls.append("list_preview_records")
+        return ()
 
 
 class _PreviewRecordOnlyStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -37457,6 +37457,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 method="GET",
                 path="/v1/previews/preview-opw-opw-pr-42/history",
             )
+            recent_operations_status_code, recent_operations_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/contexts/opw/operations/recent",
+            )
 
         self.assertEqual(deployment_status_code, 404)
         self.assertEqual(deployment_payload["status"], "rejected")
@@ -37473,155 +37478,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(preview_history_status_code, 404)
         self.assertEqual(preview_history_payload["status"], "rejected")
         self.assertEqual(preview_history_payload["error"]["code"], "not_found")
-
-    def test_recent_operations_endpoint_returns_operator_read_model(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_preview_record(
-                PreviewRecord(
-                    preview_id="preview-verireel-testing-verireel-pr-123",
-                    context="verireel-testing",
-                    anchor_repo="verireel",
-                    anchor_pr_number=123,
-                    anchor_pr_url="https://github.com/every/verireel/pull/123",
-                    preview_label="verireel/pr-123",
-                    canonical_url="https://pr-123.ver-preview.shinycomputers.com",
-                    state="active",
-                    created_at="2026-04-20T10:00:00Z",
-                    updated_at="2026-04-20T10:05:00Z",
-                    eligible_at="2026-04-20T10:05:00Z",
-                )
-            )
-            store.write_preview_generation_record(
-                PreviewGenerationRecord(
-                    generation_id="preview-verireel-testing-verireel-pr-123-generation-0001",
-                    preview_id="preview-verireel-testing-verireel-pr-123",
-                    sequence=1,
-                    state="ready",
-                    requested_reason="external_preview_refresh",
-                    requested_at="2026-04-20T10:01:00Z",
-                    ready_at="2026-04-20T10:05:00Z",
-                    finished_at="2026-04-20T10:05:00Z",
-                    resolved_manifest_fingerprint="preview-manifest-123",
-                    artifact_id="ghcr.io/every/verireel-app:pr-123",
-                    anchor_summary=PreviewPullRequestSummary(
-                        repo="verireel",
-                        pr_number=123,
-                        head_sha="6b3c9d7e8f901234567890abcdef1234567890ab",
-                        pr_url="https://github.com/every/verireel/pull/123",
-                    ),
-                    deploy_status="pass",
-                    verify_status="pass",
-                    overall_health_status="pass",
-                )
-            )
-            store.write_deployment_record(
-                DeploymentRecord(
-                    record_id="deployment-20260420T153000Z-verireel-testing",
-                    artifact_identity=ArtifactIdentityReference(
-                        artifact_id="artifact-20260420-a1b2c3d4"
-                    ),
-                    context="verireel-testing",
-                    instance="testing",
-                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
-                    resolved_target=ResolvedTargetEvidence(
-                        target_type="application",
-                        target_id="app-123",
-                        target_name="verireel-testing",
-                    ),
-                    deploy=DeploymentEvidence(
-                        target_name="verireel-testing",
-                        target_type="application",
-                        deploy_mode="dokploy-application-api",
-                        deployment_id="delegated-app-ship",
-                        status="pass",
-                        started_at="2026-04-20T15:30:00Z",
-                        finished_at="2026-04-20T15:32:10Z",
-                    ),
-                )
-            )
-            store.write_promotion_record(
-                PromotionRecord(
-                    record_id="promotion-20260420T160500Z-verireel-testing-to-prod",
-                    artifact_identity=ArtifactIdentityReference(
-                        artifact_id="artifact-20260420-a1b2c3d4"
-                    ),
-                    deployment_record_id="deployment-20260420T153000Z-verireel-testing",
-                    backup_record_id="backup-verireel-prod-20260420T160000Z",
-                    context="verireel-testing",
-                    from_instance="testing",
-                    to_instance="prod",
-                    deploy=DeploymentEvidence(
-                        target_name="verireel-prod",
-                        target_type="application",
-                        deploy_mode="dokploy-application-api",
-                        deployment_id="delegated-app-promote",
-                        status="pass",
-                        started_at="2026-04-20T16:05:00Z",
-                        finished_at="2026-04-20T16:07:00Z",
-                    ),
-                )
-            )
-            store.write_environment_inventory(
-                EnvironmentInventory(
-                    context="verireel-testing",
-                    instance="testing",
-                    artifact_identity=ArtifactIdentityReference(
-                        artifact_id="artifact-20260420-a1b2c3d4"
-                    ),
-                    source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
-                    deploy=DeploymentEvidence(
-                        target_name="verireel-testing",
-                        target_type="application",
-                        deploy_mode="dokploy-application-api",
-                        deployment_id="delegated-app-ship",
-                        status="pass",
-                        started_at="2026-04-20T15:30:00Z",
-                        finished_at="2026-04-20T15:32:10Z",
-                    ),
-                    updated_at="2026-04-20T15:33:00Z",
-                    deployment_record_id="deployment-20260420T153000Z-verireel-testing",
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "contexts": ["verireel-testing"],
-                            "actions": ["preview.read", "operations.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            operations_status_code, operations_payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/contexts/verireel-testing/operations/recent",
-            )
-
-            self.assertEqual(operations_status_code, 200)
-            self.assertEqual(operations_payload["context"], "verireel-testing")
-            self.assertEqual(operations_payload["storage_backend"], "filesystem")
-            self.assertEqual(len(operations_payload["inventory"]), 1)
-            self.assertEqual(len(operations_payload["recent_deployments"]), 1)
-            self.assertEqual(len(operations_payload["recent_promotions"]), 1)
-            self.assertEqual(len(operations_payload["recent_previews"]), 1)
+        self.assertEqual(recent_operations_status_code, 404)
+        self.assertEqual(recent_operations_payload["status"], "rejected")
+        self.assertEqual(recent_operations_payload["error"]["code"], "not_found")
 
     def test_secret_status_endpoints_return_operator_read_models(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- migrate `GET /v1/contexts/{context}/operations/recent` to a native FastAPI route
- delete the legacy WSGI `operations.read` matcher/handler path
- add typed Pydantic/OpenAPI coverage plus auth-before-store and fallback-retirement tests

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiRecentOperationsReadTests tests.test_service.LaunchplaneServiceTests.test_single_record_read_routes_are_retired_from_legacy_wsgi_app`
- `uv run python -m unittest tests.test_http_app tests.test_service`
- `uv run python -m unittest`
- `uv run --extra dev ruff check --diff .`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`

## Review
- Scout agents confirmed the route can move alone and should pre-authorize `operations.read` before store access.
- Final review agents: 3/3 reported no blocking findings and merge-ready.

## Notes
- Full `ruff format --check .` still reports existing repo-wide formatting drift outside touched files; touched files are formatted.

Refs #1322
