### PR TITLE
Migrate secret status reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -13,6 +13,7 @@ from jwt import InvalidTokenError
 from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane import product_read_service as control_plane_product_read_service
+from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
     authz_policy_sha256,
@@ -49,6 +50,7 @@ from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrat
 from control_plane.contracts.runner_lane_registration_evidence import (
     RunnerLaneRegistrationAuditEvidenceEnvelope,
 )
+from control_plane.contracts.secret_record import SecretScope
 from control_plane.drivers.registry import build_driver_context_view, list_driver_descriptors
 from control_plane.drivers.registry import read_driver_descriptor as read_driver_descriptor_record
 from control_plane.service_auth import (
@@ -213,6 +215,70 @@ class RecentOperationsResponse(BaseModel):
     recent_deployments: tuple[DeploymentRecord, ...]
     recent_promotions: tuple[PromotionRecord, ...]
     recent_previews: tuple[PreviewRecord, ...]
+
+
+class SecretStatusBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    binding_id: str
+    binding_type: str
+    binding_key: str
+    status: str
+    context: str
+    instance: str
+    updated_at: str
+
+
+class SecretStatusAuditEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str
+    event_type: str
+    recorded_at: str
+    actor: str
+    detail: str
+    metadata: dict[str, str]
+
+
+class SecretStatusReadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    secret_id: str
+    scope: SecretScope
+    integration: str
+    name: str
+    context: str
+    instance: str
+    policy: str
+    status: str
+    description: str
+    created_at: str
+    updated_at: str
+    updated_by: str
+    last_validated_at: str
+    current_version_id: str
+    version_count: int
+    current_version_created_at: str
+    binding: SecretStatusBinding | None = None
+    recent_audit_events: tuple[SecretStatusAuditEvent, ...]
+
+
+class SecretStatusResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    secret: SecretStatusReadModel
+
+
+class SecretStatusListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    context: str
+    instance: str
+    secrets: tuple[SecretStatusReadModel, ...]
 
 
 class ProtectedArtifactsResponse(BaseModel):
@@ -620,6 +686,28 @@ def require_recent_operations_read_store(record_store: object) -> _RecentOperati
             f"Launchplane record store does not support recent operation reads: {missing_summary}"
         )
     return cast(_RecentOperationsReadStore, record_store)
+
+
+def require_secret_status_read_store(record_store: object) -> control_plane_secrets.SecretReadStore:
+    required_methods = (
+        "read_secret_record",
+        "list_secret_records",
+        "read_secret_version",
+        "list_secret_versions",
+        "list_secret_bindings",
+        "list_secret_audit_events",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            f"Launchplane record store does not support secret status reads: {missing_summary}"
+        )
+    return cast(control_plane_secrets.SecretReadStore, record_store)
 
 
 def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -1336,6 +1424,124 @@ def create_launchplane_fastapi_app(
             recent_deployments=recent_deployments,
             recent_promotions=recent_promotions,
             recent_previews=recent_previews,
+        )
+
+    def read_secret_status(
+        secret_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> SecretStatusResponse:
+        trace_id = next_trace_id()
+        try:
+            secret_store = require_secret_status_read_store(record_store)
+            secret_status = SecretStatusReadModel.model_validate(
+                control_plane_secrets.build_secret_status(
+                    secret_store,
+                    secret_id=secret_id,
+                )
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="secret.read",
+            product="launchplane",
+            context=secret_status.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read Launchplane managed secret status for the requested context.",
+            )
+        return SecretStatusResponse(trace_id=trace_id, secret=secret_status)
+
+    def list_context_secret_statuses(
+        context: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> SecretStatusListResponse:
+        return list_secret_statuses_for_context(
+            context=context,
+            instance="",
+            identity=identity,
+            record_store=record_store,
+        )
+
+    def list_instance_secret_statuses(
+        context: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        instance: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> SecretStatusListResponse:
+        return list_secret_statuses_for_context(
+            context=context,
+            instance=instance,
+            identity=identity,
+            record_store=record_store,
+        )
+
+    def list_secret_statuses_for_context(
+        *,
+        context: str,
+        instance: str,
+        identity: LaunchplaneIdentity,
+        record_store: object,
+    ) -> SecretStatusListResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="secret.list",
+            product="launchplane",
+            context=context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot list Launchplane managed secret status for the requested context.",
+            )
+        try:
+            secret_store = require_secret_status_read_store(record_store)
+            statuses = tuple(
+                SecretStatusReadModel.model_validate(status)
+                for status in control_plane_secrets.list_secret_statuses(
+                    secret_store,
+                    context_name=context,
+                    instance_name=instance,
+                )
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        return SecretStatusListResponse(
+            trace_id=trace_id,
+            context=context,
+            instance=instance,
+            secrets=statuses,
         )
 
     def accepted_evidence_response(
@@ -2211,6 +2417,54 @@ def create_launchplane_fastapi_app(
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/contexts/{context}/secrets",
+        list_context_secret_statuses,
+        methods=["GET"],
+        response_model=SecretStatusListResponse,
+        operation_id="list_context_secret_statuses",
+        summary="List Launchplane managed secret status for a context",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/contexts/{context}/instances/{instance}/secrets",
+        list_instance_secret_statuses,
+        methods=["GET"],
+        response_model=SecretStatusListResponse,
+        operation_id="list_instance_secret_statuses",
+        summary="List Launchplane managed secret status for an instance",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/secrets/{secret_id}",
+        read_secret_status,
+        methods=["GET"],
+        response_model=SecretStatusResponse,
+        operation_id="read_secret_status",
+        summary="Read Launchplane managed secret status",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4513,17 +4513,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
-    if len(segments) == 3 and segments[:2] == ["v1", "secrets"]:
-        return "secret.read", {"secret_id": segments[2]}
-    if len(segments) == 4 and segments[:2] == ["v1", "contexts"] and segments[3] == "secrets":
-        return "secret.list", {"context": segments[2]}
-    if (
-        len(segments) == 6
-        and segments[:2] == ["v1", "contexts"]
-        and segments[3] == "instances"
-        and segments[5] == "secrets"
-    ):
-        return "secret.list", {"context": segments[2], "instance": segments[4]}
     if (
         len(segments) == 6
         and segments[:2] == ["v1", "contexts"]
@@ -10950,102 +10939,6 @@ def create_launchplane_service_app(
                             "records": [
                                 record.model_dump(mode="json") for record in canary_records
                             ],
-                        },
-                    )
-                if action == "secret.read":
-                    secret_store = _secret_capable_store(record_store)
-                    if secret_store is None:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=404,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "not_found",
-                                    "message": "Launchplane secret status routes require the Postgres storage backend.",
-                                },
-                            },
-                        )
-                    secret_status = control_plane_secrets.build_secret_status(
-                        secret_store,
-                        secret_id=params["secret_id"],
-                    )
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=str(secret_status["context"]),
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read Launchplane managed secret status for the requested context.",
-                                },
-                            },
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "secret": secret_status,
-                        },
-                    )
-                if action == "secret.list":
-                    context_name = params["context"]
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=context_name,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot list Launchplane managed secret status for the requested context.",
-                                },
-                            },
-                        )
-                    secret_store = _secret_capable_store(record_store)
-                    if secret_store is None:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=404,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "not_found",
-                                    "message": "Launchplane secret status routes require the Postgres storage backend.",
-                                },
-                            },
-                        )
-                    statuses = control_plane_secrets.list_secret_statuses(
-                        secret_store,
-                        context_name=context_name,
-                        instance_name=params.get("instance", ""),
-                    )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "context": context_name,
-                            "instance": params.get("instance", ""),
-                            "secrets": statuses,
                         },
                     )
                 if action == "target_logs.read":

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -60,10 +60,11 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment, promotion, preview, inventory, and recent-operations reads use
-  native FastAPI routes for bearer-token and human-session callers. Their legacy
-  WSGI branches are deleted; direct fallback calls fail closed while the mounted
-  fallback remains for retained non-native routes.
+- Deployment, promotion, preview, inventory, recent-operations, and
+  managed-secret status reads use native FastAPI routes for bearer-token and
+  human-session callers. Their legacy WSGI branches are deleted; direct fallback
+  calls fail closed while the mounted fallback remains for retained non-native
+  routes.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -50,8 +50,8 @@ VeriReel product paths:
     context
   - `GET /v1/drivers/{driver_id}`, requiring `driver.read` for the Launchplane
     discovery context
-- native FastAPI deployment, promotion, preview, inventory, and operations
-  reads:
+- native FastAPI deployment, promotion, preview, inventory, operations, and
+  managed-secret status reads:
   - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
     stored record context
   - `GET /v1/promotions/{record_id}`, requiring `promotion.read` for the stored
@@ -64,6 +64,12 @@ VeriReel product paths:
     the stored inventory context
   - `GET /v1/contexts/{context}/operations/recent`, requiring
     `operations.read` for the path context
+  - `GET /v1/contexts/{context}/secrets`, requiring `secret.list` for the path
+    context
+  - `GET /v1/contexts/{context}/instances/{instance}/secrets`, requiring
+    `secret.list` for the path context
+  - `GET /v1/secrets/{secret_id}`, requiring `secret.read` for the stored
+    secret context
 - authenticated evidence routes:
   - `POST /v1/evidence/backup-gates` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
@@ -1263,9 +1269,12 @@ only after a passing plan and a matching stored preview record are present.
   human-session callers)
 - `GET /v1/artifacts/protected` (native FastAPI for bearer-token and
   human-session callers)
-- `GET /v1/contexts/{context}/secrets`
-- `GET /v1/contexts/{context}/instances/{instance}/secrets`
-- `GET /v1/secrets/{secret_id}`
+- `GET /v1/contexts/{context}/secrets` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/contexts/{context}/instances/{instance}/secrets` (native FastAPI
+  for bearer-token and human-session callers)
+- `GET /v1/secrets/{secret_id}` (native FastAPI for bearer-token and
+  human-session callers)
 - `GET /v1/contexts/{context}/operations/recent` (native FastAPI for
   bearer-token and human-session callers)
 - `GET /v1/product-profiles/{product}/context-cutover-audit`
@@ -1288,8 +1297,13 @@ against the path context before store access, then verify the stored inventory
 context before returning the typed record envelope. Recent operations reads
 authorize `operations.read` against the path context before store access, then
 return the typed recent inventory/deployment/promotion/preview operation
-envelope. Their legacy WSGI branches are deleted; direct fallback calls fail
-closed while the mounted fallback remains for retained non-native routes.
+envelope. Managed-secret status list reads authorize `secret.list` against the
+path context before store access. Single managed-secret status reads load the
+metadata-only secret status to discover the stored secret context, then check
+`secret.read` against product `launchplane` and that stored context before
+returning the typed status envelope. Their legacy WSGI branches are deleted;
+direct fallback calls fail closed while the mounted fallback remains for
+retained non-native routes.
 
 Product/site reads use action `product_environment.read`. They compose
 Launchplane-owned product profiles, driver descriptors, stable lane records,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -2338,6 +2338,253 @@ class FastApiRecentOperationsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
+class FastApiSecretStatusReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_secret_status_routes_return_metadata_only_models(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            secret_ids = _write_secret_status_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="secret.list",
+                    context="example-site",
+                    extra_actions=("secret.read",),
+                ),
+                record_store_factory=lambda: app_store,
+            )
+
+            context_response = await _get_context_secret_statuses(app, "example-site")
+            instance_response = await _get_instance_secret_statuses(
+                app,
+                "example-site",
+                "prod",
+            )
+            show_response = await _get_secret_status(app, secret_ids["context"])
+            app_store.close()
+
+        self.assertEqual(context_response.status_code, 200)
+        self.assertEqual(instance_response.status_code, 200)
+        self.assertEqual(show_response.status_code, 200)
+        context_payload = context_response.json()
+        instance_payload = instance_response.json()
+        show_payload = show_response.json()
+        self.assertEqual(context_payload["status"], "ok")
+        self.assertEqual(context_payload["context"], "example-site")
+        self.assertEqual(context_payload["instance"], "")
+        self.assertEqual(
+            {secret["secret_id"] for secret in context_payload["secrets"]},
+            {secret_ids["global"], secret_ids["context"]},
+        )
+        self.assertEqual(instance_payload["context"], "example-site")
+        self.assertEqual(instance_payload["instance"], "prod")
+        self.assertEqual(
+            {secret["secret_id"] for secret in instance_payload["secrets"]},
+            {secret_ids["global"], secret_ids["context"], secret_ids["instance"]},
+        )
+        self.assertNotIn(secret_ids["other_instance"], json.dumps(instance_payload))
+        self.assertEqual(show_payload["status"], "ok")
+        self.assertEqual(show_payload["secret"]["secret_id"], secret_ids["context"])
+        self.assertEqual(show_payload["secret"]["context"], "example-site")
+        self.assertEqual(
+            show_payload["secret"]["binding"]["binding_key"],
+            "GITHUB_WEBHOOK_SECRET",
+        )
+        response_text = json.dumps(
+            {"context": context_payload, "instance": instance_payload, "show": show_payload}
+        )
+        self.assertNotIn("global-token", response_text)
+        self.assertNotIn("plain-secret-value-alpha", response_text)
+        self.assertNotIn("plain-secret-value-beta", response_text)
+        self.assertNotIn("plain-secret-value-gamma", response_text)
+        self.assertNotIn("ciphertext", response_text)
+
+    async def test_secret_status_routes_require_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="secret.list", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        list_response = await _get_context_secret_statuses(
+            app,
+            "example-site",
+            authorization="",
+        )
+        show_response = await _get_secret_status(
+            app,
+            "secret-runtime-environment-github-webhook-secret-example-site",
+            authorization="",
+        )
+
+        self.assertEqual(list_response.status_code, 401)
+        self.assertEqual(list_response.json()["error"]["code"], "authentication_required")
+        self.assertEqual(show_response.status_code, 401)
+        self.assertEqual(show_response.json()["error"]["code"], "authentication_required")
+
+    async def test_secret_list_rejects_wrong_context_before_store_access(self) -> None:
+        store = _SecretStatusProbeStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="secret.list", context="other-site"),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _get_context_secret_statuses(app, "example-site")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(store.calls, [])
+
+    async def test_secret_read_uses_stored_context_for_authorization(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            secret_ids = _write_secret_status_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(action="secret.read", context="other-site"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_secret_status(app, secret_ids["context"])
+            app_store.close()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertNotIn("plain-secret-value-alpha", json.dumps(payload))
+
+    async def test_secret_status_routes_require_read_capable_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="secret.list",
+                context="example-site",
+                extra_actions=("secret.read",),
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        list_response = await _get_context_secret_statuses(app, "example-site")
+        show_response = await _get_secret_status(
+            app,
+            "secret-runtime-environment-github-webhook-secret-example-site",
+        )
+
+        self.assertEqual(list_response.status_code, 503)
+        self.assertEqual(show_response.status_code, 503)
+        self.assertEqual(list_response.json()["error"]["code"], "database_storage_required")
+        self.assertEqual(show_response.json()["error"]["code"], "database_storage_required")
+        self.assertIn("read_secret_record", list_response.json()["error"]["message"])
+        self.assertIn("read_secret_record", show_response.json()["error"]["message"])
+
+    async def test_secret_read_returns_not_found_for_missing_secret(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(action="secret.read", context="example-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_secret_status(app, "secret-runtime-environment-missing")
+            store.close()
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_openapi_includes_secret_status_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="secret.list", context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route_expectations = {
+            "/v1/contexts/{context}/secrets": (
+                "list_context_secret_statuses",
+                "SecretStatusListResponse",
+            ),
+            "/v1/contexts/{context}/instances/{instance}/secrets": (
+                "list_instance_secret_statuses",
+                "SecretStatusListResponse",
+            ),
+            "/v1/secrets/{secret_id}": ("read_secret_status", "SecretStatusResponse"),
+        }
+        for path, (operation_id, response_model) in route_expectations.items():
+            route = openapi["paths"][path]["get"]
+            self.assertEqual(route["operationId"], operation_id)
+            self.assertEqual(
+                route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+                f"#/components/schemas/{response_model}",
+            )
+            self.assertIn("LaunchplaneErrorResponse", json.dumps(route))
+            for status_code in ("401", "403", "404", "503"):
+                self.assertIn(status_code, route["responses"])
+        for schema_name in (
+            "SecretStatusResponse",
+            "SecretStatusListResponse",
+            "SecretStatusReadModel",
+            "SecretStatusBinding",
+            "SecretStatusAuditEvent",
+        ):
+            self.assertEqual(
+                openapi["components"]["schemas"][schema_name]["additionalProperties"],
+                False,
+            )
+        schema_text = json.dumps(openapi["components"]["schemas"]["SecretStatusReadModel"])
+        self.assertNotIn("ciphertext", schema_text)
+        self.assertNotIn("plaintext", schema_text)
+
+    async def test_fastapi_secret_status_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            secret_ids = _write_secret_status_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            policy = _record_read_policy(
+                action="secret.list",
+                context="example-site",
+                extra_actions=("secret.read",),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: app_store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            list_response = await _get_context_secret_statuses(app, "example-site")
+            show_response = await _get_secret_status(app, secret_ids["context"])
+            app_store.close()
+
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(show_response.status_code, 200)
+        self.assertEqual(list_response.json()["status"], "ok")
+        self.assertEqual(show_response.json()["status"], "ok")
+
+
 class FastApiPreviewReadTests(unittest.IsolatedAsyncioTestCase):
     async def test_preview_read_returns_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -5178,6 +5425,64 @@ def _write_recent_operations_records(store: FilesystemRecordStore) -> None:
     store.write_preview_record(_preview_read_record())
 
 
+def _write_secret_status_records(database_url: str) -> dict[str, str]:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    with patch.dict(
+        "os.environ",
+        {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+        clear=True,
+    ):
+        global_secret = control_plane_secrets.write_secret_value(
+            record_store=store,
+            scope="global",
+            integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+            name="token",
+            plaintext_value="global-token",
+            binding_key="DOKPLOY_TOKEN",
+            actor="test",
+        )
+        context_secret = control_plane_secrets.write_secret_value(
+            record_store=store,
+            scope="context",
+            integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            name="GITHUB_WEBHOOK_SECRET",
+            plaintext_value="plain-secret-value-alpha",
+            binding_key="GITHUB_WEBHOOK_SECRET",
+            context_name="example-site",
+            actor="test",
+        )
+        instance_secret = control_plane_secrets.write_secret_value(
+            record_store=store,
+            scope="context_instance",
+            integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            name="SMTP_PASSWORD",
+            plaintext_value="plain-secret-value-beta",
+            binding_key="SMTP_PASSWORD",
+            context_name="example-site",
+            instance_name="prod",
+            actor="test",
+        )
+        other_instance_secret = control_plane_secrets.write_secret_value(
+            record_store=store,
+            scope="context_instance",
+            integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+            name="SMTP_PASSWORD",
+            plaintext_value="plain-secret-value-gamma",
+            binding_key="SMTP_PASSWORD",
+            context_name="example-site",
+            instance_name="testing",
+            actor="test",
+        )
+    store.close()
+    return {
+        "global": str(global_secret["secret_id"]),
+        "context": str(context_secret["secret_id"]),
+        "instance": str(instance_secret["secret_id"]),
+        "other_instance": str(other_instance_secret["secret_id"]),
+    }
+
+
 def _preview_destroyed_evidence_payload(*, anchor_pr_number: int = 42) -> dict[str, object]:
     return {
         "schema_version": 1,
@@ -5871,6 +6176,54 @@ async def _get_recent_operations(
     )
 
 
+async def _get_context_secret_statuses(
+    app: FastAPI,
+    context: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(
+        app,
+        f"/v1/contexts/{context}/secrets",
+        headers=request_headers,
+    )
+
+
+async def _get_instance_secret_statuses(
+    app: FastAPI,
+    context: str,
+    instance: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(
+        app,
+        f"/v1/contexts/{context}/instances/{instance}/secrets",
+        headers=request_headers,
+    )
+
+
+async def _get_secret_status(
+    app: FastAPI,
+    secret_id: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(app, f"/v1/secrets/{secret_id}", headers=request_headers)
+
+
 async def _get_preview_record(
     app: FastAPI,
     preview_id: str,
@@ -6132,6 +6485,51 @@ class _CaseInsensitiveHeaders(dict[str, str]):
 
 class _MissingProductReadStore:
     pass
+
+
+class _SecretStatusProbeStore:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def read_secret_record(self, secret_id: str) -> object:
+        self.calls.append(f"read_secret_record:{secret_id}")
+        raise FileNotFoundError(secret_id)
+
+    def list_secret_records(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]:
+        del integration, context_name, instance_name, limit
+        self.calls.append("list_secret_records")
+        return ()
+
+    def read_secret_version(self, version_id: str) -> object:
+        self.calls.append(f"read_secret_version:{version_id}")
+        raise FileNotFoundError(version_id)
+
+    def list_secret_versions(self, *, secret_id: str) -> tuple[object, ...]:
+        self.calls.append(f"list_secret_versions:{secret_id}")
+        return ()
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[object, ...]:
+        del integration, context_name, instance_name, limit
+        self.calls.append("list_secret_bindings")
+        return ()
+
+    def list_secret_audit_events(self, *, secret_id: str) -> tuple[object, ...]:
+        self.calls.append(f"list_secret_audit_events:{secret_id}")
+        return ()
 
 
 class _RecentOperationsProbeStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -37462,6 +37462,21 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 method="GET",
                 path="/v1/contexts/opw/operations/recent",
             )
+            context_secrets_status_code, context_secrets_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/contexts/opw/secrets",
+            )
+            instance_secrets_status_code, instance_secrets_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/contexts/opw/instances/prod/secrets",
+            )
+            secret_status_code, secret_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/secrets/secret-runtime-environment-github-webhook-secret-opw",
+            )
 
         self.assertEqual(deployment_status_code, 404)
         self.assertEqual(deployment_payload["status"], "rejected")
@@ -37481,85 +37496,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(recent_operations_status_code, 404)
         self.assertEqual(recent_operations_payload["status"], "rejected")
         self.assertEqual(recent_operations_payload["error"]["code"], "not_found")
-
-    def test_secret_status_endpoints_return_operator_read_models(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = f"sqlite+pysqlite:///{root / 'launchplane.sqlite3'}"
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            with patch.dict(
-                os.environ,
-                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
-                clear=True,
-            ):
-                control_plane_secrets.write_secret_value(
-                    record_store=store,
-                    scope="global",
-                    integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
-                    name="token",
-                    plaintext_value="dokploy-token",
-                    binding_key="DOKPLOY_TOKEN",
-                    actor="test",
-                )
-                context_secret = control_plane_secrets.write_secret_value(
-                    record_store=store,
-                    scope="context",
-                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
-                    name="GITHUB_WEBHOOK_SECRET",
-                    plaintext_value="webhook-secret",
-                    binding_key="GITHUB_WEBHOOK_SECRET",
-                    context_name="opw",
-                    actor="test",
-                )
-            store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "contexts": ["opw"],
-                            "actions": ["secret.read", "secret.list"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            with patch.dict(
-                os.environ,
-                {
-                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
-                    "LAUNCHPLANE_DATABASE_URL": database_url,
-                },
-                clear=True,
-            ):
-                list_status_code, list_payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/contexts/opw/secrets",
-                )
-                show_status_code, show_payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path=f"/v1/secrets/{context_secret['secret_id']}",
-                )
-
-            self.assertEqual(list_status_code, 200)
-            self.assertEqual(list_payload["context"], "opw")
-            self.assertEqual(len(list_payload["secrets"]), 2)
-            self.assertEqual(show_status_code, 200)
-            self.assertEqual(show_payload["secret"]["secret_id"], context_secret["secret_id"])
-            self.assertEqual(
-                show_payload["secret"]["binding"]["binding_key"], "GITHUB_WEBHOOK_SECRET"
-            )
+        self.assertEqual(context_secrets_status_code, 404)
+        self.assertEqual(context_secrets_payload["status"], "rejected")
+        self.assertEqual(context_secrets_payload["error"]["code"], "not_found")
+        self.assertEqual(instance_secrets_status_code, 404)
+        self.assertEqual(instance_secrets_payload["status"], "rejected")
+        self.assertEqual(instance_secrets_payload["error"]["code"], "not_found")
+        self.assertEqual(secret_status_code, 404)
+        self.assertEqual(secret_payload["status"], "rejected")
+        self.assertEqual(secret_payload["error"]["code"], "not_found")


### PR DESCRIPTION
## Summary
- migrate managed-secret status read routes to native FastAPI with strict metadata-only response models and OpenAPI contracts
- retire the legacy WSGI `secret.read` / `secret.list` matcher and handler branches for direct fallback calls
- document native ownership and authz ordering for list-by-path-context and single-read-by-stored-context behavior

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiSecretStatusReadTests tests.test_service.LaunchplaneServiceTests.test_single_record_read_routes_are_retired_from_legacy_wsgi_app`
- `uv run python -m unittest tests.test_http_app tests.test_service`
- `uv run python -m unittest`
- `uv run --extra dev ruff check --diff .`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- JetBrains changed-files inspection: clean, 0 problems

Note: `uv run --extra dev ruff format --check .` still reports the known unrelated repo-wide 56-file format baseline drift outside this diff; changed Python files are formatted.

## Review
- 3 final read-only review agents: no blocking findings, ready to merge.