### PR TITLE
Migrate context cutover audit read to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from jwt import InvalidTokenError
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
@@ -30,6 +31,7 @@ from control_plane.contracts.idempotency_record import (
 from control_plane.contracts.product_environment_read_model import (
     ProductEnvironmentConfigStatus,
 )
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.preview_evidence import (
     PreviewDestroyedEvidenceEnvelope,
     PreviewGenerationEvidenceEnvelope,
@@ -279,6 +281,14 @@ class SecretStatusListResponse(BaseModel):
     context: str
     instance: str
     secrets: tuple[SecretStatusReadModel, ...]
+
+
+class ProductContextCutoverAuditResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    audit: dict[str, object]
 
 
 class ProtectedArtifactsResponse(BaseModel):
@@ -708,6 +718,61 @@ def require_secret_status_read_store(record_store: object) -> control_plane_secr
             f"Launchplane record store does not support secret status reads: {missing_summary}"
         )
     return cast(control_plane_secrets.SecretReadStore, record_store)
+
+
+def require_product_context_audit_store(
+    record_store: object,
+) -> control_plane_product_context_audit.ProductContextAuditStore:
+    required_methods = (
+        "read_product_profile_record",
+        "list_runtime_environment_records",
+        "list_secret_records",
+        "list_secret_bindings",
+        "list_dokploy_target_records",
+        "list_dokploy_target_id_records",
+        "list_environment_inventory",
+        "list_release_tuple_records",
+        "list_backup_gate_records",
+        "list_deployment_records",
+        "list_promotion_records",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods or not isinstance(record_store, PostgresRecordStore):
+        missing_summary = ", ".join(missing_methods) or "postgres_storage"
+        raise TypeError(
+            "Launchplane record store does not support context cutover audit reads: "
+            f"{missing_summary}"
+        )
+    return cast(control_plane_product_context_audit.ProductContextAuditStore, record_store)
+
+
+def product_profile_context_cutover_allowed_contexts(
+    profile: LaunchplaneProductProfileRecord,
+) -> frozenset[str]:
+    contexts = {profile.product.strip()}
+    contexts.update(lane.context.strip() for lane in profile.lanes if lane.context.strip())
+    if profile.preview.enabled and profile.preview.context.strip():
+        contexts.add(profile.preview.context.strip())
+    return frozenset(context for context in contexts if context)
+
+
+def product_profile_context_cutover_contexts_allowed(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    source_context: str,
+    target_context: str,
+    preview_context: str,
+) -> bool:
+    allowed_contexts = product_profile_context_cutover_allowed_contexts(profile)
+    requested_contexts = {source_context.strip(), target_context.strip()}
+    if preview_context.strip():
+        requested_contexts.add(preview_context.strip())
+    requested_contexts.discard("")
+    return requested_contexts.issubset(allowed_contexts)
 
 
 def idempotency_capable_store(record_store: object) -> _IdempotencyCapableStore | None:
@@ -1425,6 +1490,76 @@ def create_launchplane_fastapi_app(
             recent_promotions=recent_promotions,
             recent_previews=recent_previews,
         )
+
+    def read_product_context_cutover_audit(
+        product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        source_context: Annotated[str, Query()] = "",
+        target_context: Annotated[str, Query()] = "",
+        preview_context: Annotated[str, Query()] = "",
+    ) -> ProductContextCutoverAuditResponse:
+        trace_id = next_trace_id()
+        try:
+            audit_store = require_product_context_audit_store(record_store)
+            profile = audit_store.read_product_profile_record(product)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="product_profile.read",
+            product=profile.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read the requested product profile.",
+            )
+        normalized_source_context = source_context.strip()
+        normalized_target_context = target_context.strip()
+        normalized_preview_context = preview_context.strip()
+        if not product_profile_context_cutover_contexts_allowed(
+            profile=profile,
+            source_context=normalized_source_context,
+            target_context=normalized_target_context,
+            preview_context=normalized_preview_context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="context_not_in_product_boundary",
+                message="Requested audit contexts are not owned by the product profile.",
+            )
+        try:
+            audit_payload = control_plane_product_context_audit.build_product_context_cutover_audit(
+                record_store=audit_store,
+                product=profile.product,
+                source_context=normalized_source_context,
+                target_context=normalized_target_context,
+                preview_context=normalized_preview_context,
+            )
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_context_cutover_audit_request",
+                message="Context cutover audit request is invalid.",
+            ) from error
+        return ProductContextCutoverAuditResponse(trace_id=trace_id, audit=audit_payload)
 
     def read_secret_status(
         secret_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -2417,6 +2552,22 @@ def create_launchplane_fastapi_app(
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/product-profiles/{product}/context-cutover-audit",
+        read_product_context_cutover_audit,
+        methods=["GET"],
+        response_model=ProductContextCutoverAuditResponse,
+        operation_id="read_product_context_cutover_audit",
+        summary="Read a product context cutover audit",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -26,7 +26,6 @@ from control_plane.dokploy_target_inspect import (
     DokployTargetInspectRequest,
     inspect_dokploy_target,
 )
-from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane import product_read_service as control_plane_product_read_service
@@ -4556,12 +4555,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "product_environment.read", {"repo_product_mapping": "true"}
     if len(segments) == 2 and segments == ["v1", "product-profiles"]:
         return "product_profile.read", {}
-    if (
-        len(segments) == 4
-        and segments[:2] == ["v1", "product-profiles"]
-        and segments[3] == "context-cutover-audit"
-    ):
-        return "product_profile.read", {"product": segments[2], "context_cutover_audit": "true"}
     if len(segments) == 3 and segments[:2] == ["v1", "product-profiles"]:
         return "product_profile.read", {"product": segments[2]}
     if len(segments) == 2 and segments == ["v1", "products"]:
@@ -11378,77 +11371,6 @@ def create_launchplane_service_app(
                                         authz_policy_sha256_value=resolved_authz_policy_sha256,
                                         authz_policy_source=resolved_authz_policy_source,
                                     ),
-                                },
-                            )
-                        if params.get("context_cutover_audit") == "true":
-                            if not isinstance(record_store, PostgresRecordStore):
-                                return _json_response(
-                                    start_response=start_response,
-                                    status_code=503,
-                                    payload={
-                                        "status": "rejected",
-                                        "trace_id": request_trace_id,
-                                        "error": {
-                                            "code": "database_required",
-                                            "message": "Context cutover audit requires Launchplane database storage.",
-                                        },
-                                    },
-                                )
-                            source_context = str(
-                                (query.get("source_context") or [""])[0] or ""
-                            ).strip()
-                            target_context = str(
-                                (query.get("target_context") or [""])[0] or ""
-                            ).strip()
-                            preview_context = str(
-                                (query.get("preview_context") or [""])[0] or ""
-                            ).strip()
-                            if not _product_profile_context_cutover_contexts_allowed(
-                                profile=profile,
-                                source_context=source_context,
-                                target_context=target_context,
-                                preview_context=preview_context,
-                            ):
-                                return _json_response(
-                                    start_response=start_response,
-                                    status_code=403,
-                                    payload={
-                                        "status": "rejected",
-                                        "trace_id": request_trace_id,
-                                        "error": {
-                                            "code": "context_not_in_product_boundary",
-                                            "message": "Requested audit contexts are not owned by the product profile.",
-                                        },
-                                    },
-                                )
-                            try:
-                                audit_payload = control_plane_product_context_audit.build_product_context_cutover_audit(
-                                    record_store=record_store,
-                                    product=profile.product,
-                                    source_context=source_context,
-                                    target_context=target_context,
-                                    preview_context=preview_context,
-                                )
-                            except ValueError:
-                                return _json_response(
-                                    start_response=start_response,
-                                    status_code=400,
-                                    payload={
-                                        "status": "rejected",
-                                        "trace_id": request_trace_id,
-                                        "error": {
-                                            "code": "invalid_context_cutover_audit_request",
-                                            "message": "Context cutover audit request is invalid.",
-                                        },
-                                    },
-                                )
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=200,
-                                payload={
-                                    "status": "ok",
-                                    "trace_id": request_trace_id,
-                                    "audit": audit_payload,
                                 },
                             )
                         return _json_response(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -60,11 +60,11 @@ Keep a compatibility surface only when it is one of these:
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
-- Deployment, promotion, preview, inventory, recent-operations, and
-  managed-secret status reads use native FastAPI routes for bearer-token and
-  human-session callers. Their legacy WSGI branches are deleted; direct fallback
-  calls fail closed while the mounted fallback remains for retained non-native
-  routes.
+- Deployment, promotion, preview, inventory, recent-operations,
+  managed-secret status, and product context cutover audit reads use native
+  FastAPI routes for bearer-token and human-session callers. Their legacy WSGI
+  branches are deleted; direct fallback calls fail closed while the mounted
+  fallback remains for retained non-native routes.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -70,6 +70,9 @@ VeriReel product paths:
     `secret.list` for the path context
   - `GET /v1/secrets/{secret_id}`, requiring `secret.read` for the stored
     secret context
+  - `GET /v1/product-profiles/{product}/context-cutover-audit`, requiring
+    `product_profile.read` for the stored product profile in the Launchplane
+    service context and returning redacted current-authority metadata only
 - authenticated evidence routes:
   - `POST /v1/evidence/backup-gates` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
@@ -1277,7 +1280,8 @@ only after a passing plan and a matching stored preview record are present.
   human-session callers)
 - `GET /v1/contexts/{context}/operations/recent` (native FastAPI for
   bearer-token and human-session callers)
-- `GET /v1/product-profiles/{product}/context-cutover-audit`
+- `GET /v1/product-profiles/{product}/context-cutover-audit` (native FastAPI
+  for bearer-token and human-session callers)
 
 These operator reads use the same Launchplane authn/authz boundary as evidence
 ingress. The intent is to give operators a minimal typed read surface for the
@@ -1301,9 +1305,13 @@ envelope. Managed-secret status list reads authorize `secret.list` against the
 path context before store access. Single managed-secret status reads load the
 metadata-only secret status to discover the stored secret context, then check
 `secret.read` against product `launchplane` and that stored context before
-returning the typed status envelope. Their legacy WSGI branches are deleted;
-direct fallback calls fail closed while the mounted fallback remains for
-retained non-native routes.
+returning the typed status envelope. Product context cutover audit reads load
+the product profile from DB-backed records, check `product_profile.read` against
+the stored profile product and Launchplane service context, and require the
+requested source, target, and optional preview contexts to belong to that
+profile before returning the typed audit envelope. Their legacy WSGI branches
+are deleted; direct fallback calls fail closed while the mounted fallback
+remains for retained non-native routes.
 
 Product/site reads use action `product_environment.read`. They compose
 Launchplane-owned product profiles, driver descriptors, stable lane records,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -64,7 +64,12 @@ from control_plane.service_human_auth import (
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from tests.test_service import create_launchplane_service_app
-from tests.test_service import _generic_site_profile_payload, _identity, _sqlite_database_url
+from tests.test_service import (
+    _generic_site_profile_payload,
+    _identity,
+    _product_profile_payload_with_prod,
+    _sqlite_database_url,
+)
 from tests.test_service import _StubVerifier
 from tests.test_protected_artifacts import _seed_store as seed_protected_artifact_store
 
@@ -930,6 +935,201 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
         self.assertEqual(health_payload["status"], "ok")
         self.assertEqual(health_payload["storage_backend"], "filesystem")
         self.assertIn("trace_id", health_payload)
+
+
+class FastApiProductContextCutoverAuditReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_context_cutover_audit_returns_redacted_metadata(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _write_context_cutover_audit_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_read_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_context_cutover_audit(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        payload_text = json.dumps(payload, sort_keys=True)
+        self.assertEqual(set(payload), {"status", "trace_id", "audit"})
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(payload["audit"]["status"], "ok")
+        self.assertEqual(payload["audit"]["product"], "sellyouroutboard")
+        self.assertEqual(
+            payload["audit"]["contexts"]["source"]["runtime_environment_records"][0]["env_keys"],
+            ["TAWK_PROPERTY_ID"],
+        )
+        self.assertEqual(
+            payload["audit"]["contexts"]["target"]["runtime_environment_records"][0]["env_keys"],
+            ["TAWK_WIDGET_ID"],
+        )
+        self.assertIn("SMTP_PASSWORD", payload_text)
+        self.assertNotIn("property-legacy", payload_text)
+        self.assertNotIn("widget-canonical", payload_text)
+        self.assertNotIn("smtp-password-secret", payload_text)
+        self.assertNotIn("ciphertext", payload_text)
+        self.assertNotIn("plaintext", payload_text)
+
+    async def test_context_cutover_audit_requires_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_read_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_context_cutover_audit(app, authorization="")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_context_cutover_audit_rejects_unowned_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _write_context_cutover_audit_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_read_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_context_cutover_audit(
+                app,
+                source_context="other-site",
+                target_context="sellyouroutboard",
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "context_not_in_product_boundary")
+
+    async def test_context_cutover_audit_invalid_request_is_generic(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _write_context_cutover_audit_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_read_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_context_cutover_audit(
+                app,
+                source_context="sellyouroutboard",
+                target_context="sellyouroutboard",
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_context_cutover_audit_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Context cutover audit request is invalid.",
+        )
+
+    async def test_context_cutover_audit_rejects_unauthorized_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _write_context_cutover_audit_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_read_policy(product="verireel"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_context_cutover_audit(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertNotIn("authz", payload)
+
+    async def test_context_cutover_audit_requires_database_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_read_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_context_cutover_audit(app)
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("read_product_profile_record", payload["error"]["message"])
+
+    async def test_openapi_includes_context_cutover_audit_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_read_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/product-profiles/{product}/context-cutover-audit"]["get"]
+        self.assertEqual(route["operationId"], "read_product_context_cutover_audit")
+        self.assertEqual(
+            route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/ProductContextCutoverAuditResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(route))
+        for status_code in ("400", "401", "403", "404", "503"):
+            self.assertIn(status_code, route["responses"])
+        self.assertEqual(
+            openapi["components"]["schemas"]["ProductContextCutoverAuditResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+
+    async def test_fastapi_context_cutover_audit_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _write_context_cutover_audit_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            policy = _product_profile_read_policy(product="sellyouroutboard")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: app_store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _get_context_cutover_audit(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
 
 
 class FastApiProtectedArtifactsTests(unittest.IsolatedAsyncioTestCase):
@@ -5906,6 +6106,72 @@ def _driver_context_store(state_dir: Path) -> FilesystemRecordStore:
     return store
 
 
+def _write_context_cutover_audit_records(database_url: str) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        store.write_product_profile_record(
+            LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
+        )
+        store.write_runtime_environment_record(
+            RuntimeEnvironmentRecord(
+                scope="instance",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                env={"TAWK_PROPERTY_ID": "property-legacy"},
+                updated_at="2026-05-01T00:03:00Z",
+                source_label="legacy",
+            )
+        )
+        store.write_runtime_environment_record(
+            RuntimeEnvironmentRecord(
+                scope="instance",
+                context="sellyouroutboard",
+                instance="prod",
+                env={"TAWK_WIDGET_ID": "widget-canonical"},
+                updated_at="2026-05-01T00:04:00Z",
+                source_label="operator:mistake",
+            )
+        )
+        with patch.dict(
+            "os.environ",
+            {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+            clear=True,
+        ):
+            control_plane_secrets.write_secret_value(
+                record_store=store,
+                scope="context_instance",
+                integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                name="smtp-password",
+                plaintext_value="smtp-password-secret",
+                binding_key="SMTP_PASSWORD",
+                context_name="sellyouroutboard-testing",
+                instance_name="prod",
+                actor="test",
+            )
+    finally:
+        store.close()
+
+
+def _product_profile_read_policy(*, product: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": [product],
+                    "contexts": ["launchplane"],
+                    "actions": ["product_profile.read"],
+                }
+            ]
+        }
+    )
+
+
 def _local_operator_product_environment_read_policy(*, context: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -6172,6 +6438,32 @@ async def _get_recent_operations(
     return await _asgi_get(
         app,
         f"/v1/contexts/{context}/operations/recent",
+        headers=request_headers,
+    )
+
+
+async def _get_context_cutover_audit(
+    app: FastAPI,
+    *,
+    product: str = "sellyouroutboard",
+    source_context: str = "sellyouroutboard-testing",
+    target_context: str = "sellyouroutboard",
+    preview_context: str = "",
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    params = {
+        "source_context": source_context,
+        "target_context": target_context,
+    }
+    if preview_context:
+        params["preview_context"] = preview_context
+    return await _asgi_get(
+        app,
+        f"/v1/product-profiles/{product}/context-cutover-audit?{urlencode(params)}",
         headers=request_headers,
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -18067,7 +18067,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertFalse(payload["result"]["blocked"])
         self.assertEqual(payload["result"]["groups"]["runtime_environment_records"], [])
 
-    def test_product_profile_context_cutover_audit_returns_redacted_metadata(self) -> None:
+    def test_context_cutover_audit_route_is_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
@@ -18077,26 +18077,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 store.write_product_profile_record(
                     LaunchplaneProductProfileRecord.model_validate(
                         _product_profile_payload_with_prod()
-                    )
-                )
-                store.write_runtime_environment_record(
-                    RuntimeEnvironmentRecord(
-                        scope="instance",
-                        context="sellyouroutboard-testing",
-                        instance="prod",
-                        env={"TAWK_PROPERTY_ID": "property-legacy"},
-                        updated_at="2026-05-01T00:03:00Z",
-                        source_label="legacy",
-                    )
-                )
-                store.write_runtime_environment_record(
-                    RuntimeEnvironmentRecord(
-                        scope="instance",
-                        context="sellyouroutboard",
-                        instance="prod",
-                        env={"TAWK_WIDGET_ID": "widget-canonical"},
-                        updated_at="2026-05-01T00:04:00Z",
-                        source_label="operator:mistake",
                     )
                 )
             finally:
@@ -18134,178 +18114,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
             )
 
-        payload_text = json.dumps(payload, sort_keys=True)
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["audit"]["status"], "ok")
-        self.assertNotIn("property-legacy", payload_text)
-        self.assertNotIn("widget-canonical", payload_text)
-        self.assertEqual(
-            payload["audit"]["contexts"]["source"]["runtime_environment_records"][0]["env_keys"],
-            ["TAWK_PROPERTY_ID"],
-        )
-        self.assertEqual(
-            payload["audit"]["contexts"]["target"]["runtime_environment_records"][0]["env_keys"],
-            ["TAWK_WIDGET_ID"],
-        )
-
-    def test_product_profile_context_cutover_audit_rejects_unowned_context(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            try:
-                store.write_product_profile_record(
-                    LaunchplaneProductProfileRecord.model_validate(
-                        _product_profile_payload_with_prod()
-                    )
-                )
-            finally:
-                store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["sellyouroutboard"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
-                query_string="source_context=opw&target_context=sellyouroutboard",
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "context_not_in_product_boundary")
-
-    def test_product_profile_context_cutover_audit_invalid_request_is_generic(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            try:
-                store.write_product_profile_record(
-                    LaunchplaneProductProfileRecord.model_validate(
-                        _product_profile_payload_with_prod()
-                    )
-                )
-            finally:
-                store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["sellyouroutboard"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
-                query_string="source_context=sellyouroutboard&target_context=sellyouroutboard",
-            )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_context_cutover_audit_request")
-        self.assertEqual(
-            payload["error"]["message"],
-            "Context cutover audit request is invalid.",
-        )
-
-    def test_product_profile_context_cutover_audit_rejects_unauthorized_product(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            try:
-                store.write_product_profile_record(
-                    LaunchplaneProductProfileRecord.model_validate(
-                        _product_profile_payload_with_prod()
-                    )
-                )
-            finally:
-                store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["verireel"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
-                query_string=(
-                    "source_context=sellyouroutboard-testing&target_context=sellyouroutboard"
-                ),
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-        self.assertEqual(payload["authz"]["identity"]["repository"], "every/verireel")
-        self.assertEqual(payload["authz"]["agent_consumer"]["subject_type"], "github_actions")
-        self.assertEqual(payload["authz"]["agent_consumer"]["action_safety"], "read")
-        self.assertTrue(payload["authz"]["agent_consumer"]["read_only_context"])
-        self.assertFalse(payload["authz"]["agent_consumer"]["approval_capable"])
-        self.assertEqual(payload["authz"]["agent_audit"]["decision"], "denied")
-        self.assertEqual(payload["authz"]["agent_audit"]["reason_code"], "authorization_denied")
-        self.assertEqual(payload["authz"]["agent_audit"]["subject"]["action_safety"], "read")
-        self.assertEqual(payload["authz"]["policy_source"], "bootstrap_seeded_store")
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_product_profile_list_denial_includes_authz_diagnostics(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add native FastAPI GET /v1/product-profiles/{product}/context-cutover-audit
- preserve product_profile.read authz, DB-backed audit storage gating, context-boundary checks, and redacted audit response wrapper
- delete the exact legacy WSGI read branch and document the compatibility retirement

## Validation
- uv run python -m unittest tests.test_http_app.FastApiProductContextCutoverAuditReadTests tests.test_service.LaunchplaneServiceTests.test_context_cutover_audit_route_is_retired_from_legacy_wsgi_app tests.test_product_profile_context_audit
- uv run python -m unittest
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff check --diff .
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "/Users/cbusillo/Developer/launchplane" --scope changed_files

## Notes
- full repo ruff format check still reports pre-existing unrelated formatting drift in 56 untouched files; changed files are formatted
- three read-only review agents returned green before push