### PR TITLE
Migrate product environment reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -29,9 +29,14 @@ from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
     build_launchplane_idempotency_record_id,
 )
+from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
 from control_plane.contracts.product_environment_read_model import (
+    ProductActivityReadModel,
     ProductEnvironmentConfigStatus,
+    ProductEnvironmentDetail,
+    ProductEnvironmentSummary,
     ProductReadModelStore,
+    ProductSiteOverview,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.preview_evidence import (
@@ -141,6 +146,53 @@ class ProductEnvironmentConfigStatusResponse(BaseModel):
     status: str = "ok"
     trace_id: str
     config_status: ProductEnvironmentConfigStatus
+
+
+class ProductEnvironmentListResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    products: tuple[ProductSiteOverview, ...]
+
+
+class ProductOverviewResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    product: ProductSiteOverview
+
+
+class ProductActivityResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    activity: ProductActivityReadModel
+
+
+class ProductEnvironmentsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    product: str
+    display_name: str
+    repository: str
+    driver_id: str
+    base_driver_id: str = ""
+    environments: tuple[ProductEnvironmentSummary, ...]
+    trust_state: FreshnessStatus
+    provenance: DataProvenance
+
+
+class ProductEnvironmentResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    environment: ProductEnvironmentDetail
 
 
 class DriverDescriptorsResponse(BaseModel):
@@ -1157,6 +1209,241 @@ def create_launchplane_fastapi_app(
         return ProductEnvironmentConfigStatusResponse(
             trace_id=trace_id,
             config_status=config_status,
+        )
+
+    def product_environment_action_allowed(
+        identity: LaunchplaneIdentity,
+        requested_action: str,
+        requested_product: str,
+        requested_context: str,
+    ) -> bool:
+        return resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=requested_action,
+            product=requested_product,
+            context=requested_context,
+        )
+
+    def build_product_environment_read_result(
+        *,
+        identity: LaunchplaneIdentity,
+        record_store: object,
+        trace_id: str,
+        params: dict[str, str],
+    ) -> control_plane_product_read_service.ProductEnvironmentReadServiceResult:
+        def action_allowed(
+            requested_action: str, requested_product: str, requested_context: str
+        ) -> bool:
+            return product_environment_action_allowed(
+                identity,
+                requested_action,
+                requested_product,
+                requested_context,
+            )
+
+        try:
+            product_read_store = (
+                control_plane_product_read_service.require_product_environment_read_model_store(
+                    record_store
+                )
+            )
+            return control_plane_product_read_service.build_product_environment_read_service_result(
+                record_store=product_read_store,
+                params=params,
+                action_allowed=action_allowed,
+            )
+        except control_plane_product_read_service.ProductReadModelStoreCapabilityError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message=str(error),
+            ) from error
+
+    def require_product_environment_result_authorization(
+        *,
+        identity: LaunchplaneIdentity,
+        trace_id: str,
+        result: control_plane_product_read_service.ProductEnvironmentReadServiceResult,
+    ) -> None:
+        if product_environment_action_allowed(
+            identity,
+            "product_environment.read",
+            result.authorization_product,
+            result.authorization_context,
+        ):
+            return
+        raise _launchplane_http_error(
+            status_code=403,
+            trace_id=trace_id,
+            code="authorization_denied",
+            message=result.denial_message,
+        )
+
+    def list_product_environment_overviews(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> ProductEnvironmentListResponse:
+        trace_id = next_trace_id()
+
+        def action_allowed(
+            requested_action: str, requested_product: str, requested_context: str
+        ) -> bool:
+            return product_environment_action_allowed(
+                identity,
+                requested_action,
+                requested_product,
+                requested_context,
+            )
+
+        if not product_environment_action_allowed(
+            identity,
+            "product_environment.read",
+            "launchplane",
+            _LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot list product overviews.",
+            )
+        try:
+            product_read_store = (
+                control_plane_product_read_service.require_product_environment_read_model_store(
+                    record_store
+                )
+            )
+            payload = (
+                control_plane_product_read_service.build_product_environment_list_service_payload(
+                    record_store=product_read_store,
+                    action_allowed=action_allowed,
+                )
+            )
+        except control_plane_product_read_service.ProductReadModelStoreCapabilityError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        products = tuple(
+            ProductSiteOverview.model_validate(product)
+            for product in cast(list[object], payload["products"])
+        )
+        return ProductEnvironmentListResponse(trace_id=trace_id, products=products)
+
+    def read_product_overview(
+        product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> ProductOverviewResponse:
+        trace_id = next_trace_id()
+        result = build_product_environment_read_result(
+            identity=identity,
+            record_store=record_store,
+            trace_id=trace_id,
+            params={"product": product},
+        )
+        require_product_environment_result_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            result=result,
+        )
+        overview = ProductSiteOverview.model_validate(result.payload["product"])
+        return ProductOverviewResponse(trace_id=trace_id, product=overview)
+
+    def read_product_activity(
+        product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> ProductActivityResponse:
+        trace_id = next_trace_id()
+        result = build_product_environment_read_result(
+            identity=identity,
+            record_store=record_store,
+            trace_id=trace_id,
+            params={"product": product, "activity": "true"},
+        )
+        require_product_environment_result_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            result=result,
+        )
+        activity = ProductActivityReadModel.model_validate(result.payload["activity"])
+        return ProductActivityResponse(trace_id=trace_id, activity=activity)
+
+    def list_product_environments(
+        product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> ProductEnvironmentsResponse:
+        trace_id = next_trace_id()
+        result = build_product_environment_read_result(
+            identity=identity,
+            record_store=record_store,
+            trace_id=trace_id,
+            params={"product": product, "environments": "true"},
+        )
+        require_product_environment_result_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            result=result,
+        )
+        payload = result.payload
+        environments = tuple(
+            ProductEnvironmentSummary.model_validate(environment)
+            for environment in cast(list[object], payload["environments"])
+        )
+        provenance = DataProvenance.model_validate(payload["provenance"])
+        return ProductEnvironmentsResponse(
+            trace_id=trace_id,
+            product=str(payload["product"]),
+            display_name=str(payload["display_name"]),
+            repository=str(payload["repository"]),
+            driver_id=str(payload["driver_id"]),
+            base_driver_id=str(payload.get("base_driver_id", "")),
+            environments=environments,
+            trust_state=cast(FreshnessStatus, payload["trust_state"]),
+            provenance=provenance,
+        )
+
+    def read_product_environment(
+        product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        environment: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> ProductEnvironmentResponse:
+        trace_id = next_trace_id()
+        result = build_product_environment_read_result(
+            identity=identity,
+            record_store=record_store,
+            trace_id=trace_id,
+            params={"product": product, "environment": environment},
+        )
+        require_product_environment_result_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            result=result,
+        )
+        environment_detail = ProductEnvironmentDetail.model_validate(result.payload["environment"])
+        return ProductEnvironmentResponse(
+            trace_id=trace_id,
+            environment=environment_detail,
         )
 
     def read_protected_artifacts(
@@ -2704,6 +2991,64 @@ def create_launchplane_fastapi_app(
             403: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
+    )
+
+    product_environment_error_responses: dict[int | str, dict[str, object]] = {
+        400: {"model": LaunchplaneErrorResponse},
+        401: {"model": LaunchplaneErrorResponse},
+        403: {"model": LaunchplaneErrorResponse},
+        404: {"model": LaunchplaneErrorResponse},
+        503: {"model": LaunchplaneErrorResponse},
+    }
+
+    app.add_api_route(
+        "/v1/products",
+        list_product_environment_overviews,
+        methods=["GET"],
+        response_model=ProductEnvironmentListResponse,
+        operation_id="list_products",
+        summary="List product environment overviews",
+        responses=product_environment_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/products/{product}",
+        read_product_overview,
+        methods=["GET"],
+        response_model=ProductOverviewResponse,
+        operation_id="read_product",
+        summary="Read a product environment overview",
+        responses=product_environment_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/products/{product}/activity",
+        read_product_activity,
+        methods=["GET"],
+        response_model=ProductActivityResponse,
+        operation_id="read_product_activity",
+        summary="Read product activity",
+        responses=product_environment_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/products/{product}/environments",
+        list_product_environments,
+        methods=["GET"],
+        response_model=ProductEnvironmentsResponse,
+        operation_id="list_product_environments",
+        summary="List product environments",
+        responses=product_environment_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/products/{product}/environments/{environment}",
+        read_product_environment,
+        methods=["GET"],
+        response_model=ProductEnvironmentResponse,
+        operation_id="read_product_environment",
+        summary="Read one product environment",
+        responses=product_environment_error_responses,
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -28,7 +28,6 @@ from control_plane.dokploy_target_inspect import (
 )
 from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
-from control_plane import product_read_service as control_plane_product_read_service
 from control_plane.http_app import (
     LaunchplaneAuthzPolicyRuntime,
     create_launchplane_fastapi_app,
@@ -4552,8 +4551,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "work_graph.issue_inbox", {}
     if len(segments) == 2 and segments == ["v1", "repo-product-mapping"]:
         return "product_environment.read", {"repo_product_mapping": "true"}
-    if len(segments) == 2 and segments == ["v1", "products"]:
-        return "product_environment.read", {}
     if len(segments) == 4 and segments == [
         "v1",
         "products",
@@ -4583,14 +4580,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         "apply",
     ]:
         return "preview_pr_feedback_notification_policy.apply", {}
-    if len(segments) == 4 and segments[:2] == ["v1", "products"] and segments[3] == "activity":
-        return "product_environment.read", {"product": segments[2], "activity": "true"}
-    if len(segments) == 3 and segments[:2] == ["v1", "products"]:
-        return "product_environment.read", {"product": segments[2]}
-    if len(segments) == 4 and segments[:2] == ["v1", "products"] and segments[3] == "environments":
-        return "product_environment.read", {"product": segments[2], "environments": "true"}
-    if len(segments) == 5 and segments[:2] == ["v1", "products"] and segments[3] == "environments":
-        return "product_environment.read", {"product": segments[2], "environment": segments[4]}
     return None
 
 
@@ -11336,17 +11325,6 @@ def create_launchplane_service_app(
                         },
                     )
                 if action == "product_environment.read":
-
-                    def product_action_allowed(
-                        requested_action: str, requested_product: str, requested_context: str
-                    ) -> bool:
-                        return authz_policy.allows(
-                            identity=identity,
-                            action=requested_action,
-                            product=requested_product,
-                            context=requested_context,
-                        )
-
                     if params.get("agent_context") == "true":
                         if not agent_context_allowed(
                             authz_policy=authz_policy,
@@ -11398,136 +11376,6 @@ def create_launchplane_service_app(
                             json_response=_json_response,
                             start_response=start_response,
                         )
-
-                    if control_plane_product_read_service.is_product_environment_detail_request(
-                        params
-                    ):
-                        try:
-                            product_read_store = control_plane_product_read_service.require_product_environment_read_model_store(
-                                record_store
-                            )
-                        except (
-                            control_plane_product_read_service.ProductReadModelStoreCapabilityError
-                        ) as error:
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=503,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "database_storage_required",
-                                        "message": str(error),
-                                    },
-                                },
-                            )
-                        try:
-                            product_read_result = control_plane_product_read_service.build_product_environment_read_service_result(
-                                record_store=product_read_store,
-                                params=params,
-                                action_allowed=product_action_allowed,
-                            )
-                        except FileNotFoundError as error:
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=404,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "not_found",
-                                        "message": str(error),
-                                    },
-                                },
-                            )
-                        except ValueError as error:
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=400,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "invalid_request",
-                                        "message": str(error),
-                                    },
-                                },
-                            )
-                        if not product_action_allowed(
-                            "product_environment.read",
-                            product_read_result.authorization_product,
-                            product_read_result.authorization_context,
-                        ):
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=403,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "authorization_denied",
-                                        "message": product_read_result.denial_message,
-                                    },
-                                },
-                            )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                **product_read_result.payload,
-                            },
-                        )
-                    if not product_action_allowed(
-                        "product_environment.read",
-                        "launchplane",
-                        _LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot list product overviews.",
-                                },
-                            },
-                        )
-                    try:
-                        product_read_store = control_plane_product_read_service.require_product_environment_read_model_store(
-                            record_store
-                        )
-                    except (
-                        control_plane_product_read_service.ProductReadModelStoreCapabilityError
-                    ) as error:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=503,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "database_storage_required",
-                                    "message": str(error),
-                                },
-                            },
-                        )
-                    product_list_payload = control_plane_product_read_service.build_product_environment_list_service_payload(
-                        record_store=product_read_store,
-                        action_allowed=product_action_allowed,
-                    )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            **product_list_payload,
-                        },
-                    )
             if path == "/v1/service/odoo-workers/reconcile":
                 if not authz_policy.allows(
                     identity=identity,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -61,11 +61,12 @@ Keep a compatibility surface only when it is one of these:
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
 - Deployment, promotion, preview, inventory, recent-operations,
-  managed-secret status, product-profile, and product context cutover audit
-  reads use native FastAPI routes for bearer-token and human-session callers.
-  The product-profile collection also preserves the dedicated Every Code worker
-  token. Their legacy WSGI branches are deleted; direct fallback calls fail
-  closed while the mounted fallback remains for retained non-native routes.
+  managed-secret status, product-profile, product/site read-model, and product
+  context cutover audit reads use native FastAPI routes for bearer-token and
+  human-session callers. The product-profile collection also preserves the
+  dedicated Every Code worker token. Their legacy WSGI branches are deleted;
+  direct fallback calls fail closed while the mounted fallback remains for
+  retained non-native routes.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1257,11 +1257,16 @@ only after a passing plan and a matching stored preview record are present.
 
 ### Operator read endpoints
 
-- `GET /v1/products`
-- `GET /v1/products/{product}`
-- `GET /v1/products/{product}/activity`
-- `GET /v1/products/{product}/environments`
-- `GET /v1/products/{product}/environments/{environment}`
+- `GET /v1/products` (native FastAPI for bearer-token and human-session
+  callers)
+- `GET /v1/products/{product}` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/products/{product}/activity` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/products/{product}/environments` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/products/{product}/environments/{environment}` (native FastAPI for
+  bearer-token and human-session callers)
 - `GET /v1/previews/{preview_id}` (native FastAPI for bearer-token and
   human-session callers)
 - `GET /v1/previews/{preview_id}/history` (native FastAPI for bearer-token and
@@ -1325,13 +1330,19 @@ the typed audit envelope. Their legacy WSGI branches are deleted; direct
 fallback calls fail closed while the mounted fallback remains for retained
 non-native routes.
 
-Product/site reads use action `product_environment.read`. They compose
-Launchplane-owned product profiles, driver descriptors, stable lane records,
-preview summaries, runtime-environment key summaries, managed secret binding
-metadata, action availability, and trust state. Raw context names and provider
-target identifiers remain evidence metadata; runtime values, secret plaintext,
-secret ciphertext, and product-specific driver payloads are not exposed as
-shared top-level fields.
+Product/site reads use action `product_environment.read`. They are native
+FastAPI routes backed by DB-owned product environment read-model composition.
+They compose Launchplane-owned product profiles, driver descriptors, stable lane
+records, preview summaries, runtime-environment key summaries, managed secret
+binding metadata, action availability, and trust state. The collection, product,
+activity, and environments routes authorize against the Launchplane service
+context. Single environment detail reads authorize against the selected lane
+context. Raw context names and provider target identifiers remain evidence
+metadata; runtime values, secret plaintext, secret ciphertext, and
+product-specific driver payloads are not exposed as shared top-level fields.
+Their legacy WSGI product-read branches are deleted; direct fallback calls fail
+closed while `/v1/repo-product-mapping` and `/v1/agent/context` remain on the
+retained fallback until their own native cutovers.
 
 `GET /v1/products/{product}/environments` returns the product's stable
 environment summaries from DB-backed Launchplane records. It is the collection

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -15,8 +15,12 @@ from jwt import InvalidTokenError
 from starlette.types import ASGIApp
 
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.preview_record import PreviewRecord
@@ -936,6 +940,362 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
         self.assertEqual(health_payload["status"], "ok")
         self.assertEqual(health_payload["storage_backend"], "filesystem")
         self.assertIn("trace_id", health_payload)
+
+
+class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_list_products_returns_db_backed_overviews(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(
+                    context="launchplane", products=("launchplane", "example-site")
+                ),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_products(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        response_text = json.dumps(payload)
+        self.assertEqual(set(payload), {"status", "trace_id", "products"})
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual([product["product"] for product in payload["products"]], ["example-site"])
+        self.assertEqual(payload["products"][0]["driver_id"], "generic-web")
+        self.assertNotIn("https://internal.example-site.invalid", response_text)
+        self.assertNotIn("super-secret-password", response_text)
+
+    async def test_read_product_returns_overview(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(context="launchplane"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_product(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(set(payload), {"status", "trace_id", "product"})
+        product = payload["product"]
+        self.assertEqual(product["product"], "example-site")
+        self.assertEqual(product["driver_id"], "generic-web")
+        self.assertEqual(
+            [environment["environment"] for environment in product["environments"]],
+            ["testing", "prod"],
+        )
+
+    async def test_read_product_activity_returns_timeline(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(context="launchplane"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_product_activity(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(set(payload), {"status", "trace_id", "activity"})
+        self.assertEqual(payload["activity"]["product"], "example-site")
+        self.assertEqual(payload["activity"]["events"][0]["event_type"], "authz_policy")
+
+    async def test_list_product_environments_returns_redacted_summaries(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(context="launchplane"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_product_environments(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        response_text = json.dumps(payload)
+        self.assertEqual(payload["product"], "example-site")
+        self.assertEqual(
+            [environment["environment"] for environment in payload["environments"]],
+            ["testing", "prod"],
+        )
+        self.assertNotIn("https://internal.example-site.invalid", response_text)
+        self.assertNotIn("super-secret-password", response_text)
+
+    async def test_read_product_environment_redacts_runtime_and_secret_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(context="example-site"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_product_environment(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        response_text = json.dumps(payload)
+        environment = payload["environment"]
+        self.assertEqual(environment["product"], "example-site")
+        self.assertEqual(environment["environment"], "prod")
+        self.assertEqual(environment["target"]["target_name"], "example-site-prod")
+        self.assertTrue(environment["target"]["target_id_recorded"])
+        self.assertEqual(environment["runtime_settings"][0]["env_keys"], ["INTERNAL_CALLBACK_URL"])
+        self.assertEqual(environment["managed_secrets"][0]["binding_key"], "SMTP_PASSWORD")
+        self.assertNotIn("https://internal.example-site.invalid", response_text)
+        self.assertNotIn("super-secret-password", response_text)
+
+    async def test_product_environment_reads_require_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_environment_read_policy(context="launchplane"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        responses = [
+            await _get_products(app, authorization=""),
+            await _get_product(app, authorization=""),
+            await _get_product_activity(app, authorization=""),
+            await _get_product_environments(app, authorization=""),
+            await _get_product_environment(app, authorization=""),
+        ]
+
+        for response in responses:
+            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_list_products_rejects_unauthorized_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_products(app)
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_product_environment_reads_reject_unauthorized_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(context="launchplane"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_product_environment(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_product_environment_reads_return_not_found(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(context="example-site"),
+                record_store_factory=lambda: app_store,
+            )
+
+            missing_product = await _get_product_environment(app, product="missing-site")
+            missing_environment = await _get_product_environment(app, environment="staging")
+            app_store.close()
+
+        self.assertEqual(missing_product.status_code, 404)
+        self.assertEqual(
+            missing_product.json()["error"]["message"], "Product 'missing-site' was not found."
+        )
+        self.assertEqual(missing_environment.status_code, 404)
+        self.assertEqual(
+            missing_environment.json()["error"]["message"],
+            "Product 'example-site' has no environment 'staging'.",
+        )
+
+    async def test_product_environment_reads_require_db_backed_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_environment_read_policy(
+                context="launchplane", products=("launchplane", "example-site")
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        list_response = await _get_products(app)
+        detail_response = await _get_product_environment(app)
+
+        self.assertEqual(list_response.status_code, 503)
+        self.assertEqual(detail_response.status_code, 503)
+        self.assertEqual(list_response.json()["error"]["code"], "database_storage_required")
+        self.assertEqual(detail_response.json()["error"]["code"], "database_storage_required")
+
+    async def test_product_environment_reads_accept_local_operator_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_local_operator_product_environment_read_policy(
+                    context="example-site"
+                ),
+                record_store_factory=lambda: app_store,
+                bearer_identity_config=_local_operator_bearer_config(),
+            )
+
+            response = await _get_product_environment(
+                app,
+                authorization="Bearer local-operator-token",
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["environment"]["product"], "example-site")
+
+    async def test_product_environment_reads_accept_terminal_agent_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_product_environment_read_policy(
+                    context="example-site"
+                ),
+                record_store_factory=lambda: app_store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-read-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+            )
+
+            response = await _get_product_environment(
+                app,
+                authorization="Bearer terminal-read-token",
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["environment"]["product"], "example-site")
+
+    async def test_openapi_includes_product_environment_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_environment_read_policy(context="launchplane"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        expected_routes = {
+            "/v1/products": ("list_products", "ProductEnvironmentListResponse"),
+            "/v1/products/{product}": ("read_product", "ProductOverviewResponse"),
+            "/v1/products/{product}/activity": (
+                "read_product_activity",
+                "ProductActivityResponse",
+            ),
+            "/v1/products/{product}/environments": (
+                "list_product_environments",
+                "ProductEnvironmentsResponse",
+            ),
+            "/v1/products/{product}/environments/{environment}": (
+                "read_product_environment",
+                "ProductEnvironmentResponse",
+            ),
+        }
+        for path, (operation_id, response_model_name) in expected_routes.items():
+            route = openapi["paths"][path]["get"]
+            self.assertEqual(route["operationId"], operation_id)
+            self.assertEqual(
+                route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+                f"#/components/schemas/{response_model_name}",
+            )
+            for status_code in ("400", "401", "403", "404", "503"):
+                self.assertIn(
+                    "LaunchplaneErrorResponse", json.dumps(route["responses"][status_code])
+                )
+            self.assertFalse(
+                openapi["components"]["schemas"][response_model_name]["additionalProperties"]
+            )
+
+    async def test_fastapi_product_environment_reads_precede_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_product_environment_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            policy = _product_environment_read_policy(
+                contexts=("launchplane", "example-site"),
+                products=("launchplane", "example-site"),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: app_store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "legacy-state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            list_response = await _get_products(app)
+            overview_response = await _get_product(app)
+            activity_response = await _get_product_activity(app)
+            environments_response = await _get_product_environments(app)
+            config_status_response = await _get_config_status(app)
+            app_store.close()
+
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(overview_response.status_code, 200)
+        self.assertEqual(activity_response.status_code, 200)
+        self.assertEqual(environments_response.status_code, 200)
+        self.assertEqual(config_status_response.status_code, 200)
 
 
 class FastApiProductProfileReadTests(unittest.IsolatedAsyncioTestCase):
@@ -5425,7 +5785,13 @@ class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["records"]["deployment_record_id"], "deployment-example-site-prod")
 
 
-def _product_environment_read_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+def _product_environment_read_policy(
+    *,
+    context: str = "launchplane",
+    contexts: tuple[str, ...] | None = None,
+    products: tuple[str, ...] = ("example-site",),
+) -> LaunchplaneAuthzPolicy:
+    allowed_contexts = contexts if contexts is not None else (context,)
     return LaunchplaneAuthzPolicy.model_validate(
         {
             "github_actions": [
@@ -5435,8 +5801,8 @@ def _product_environment_read_policy(*, context: str) -> LaunchplaneAuthzPolicy:
                         "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
                     ],
                     "event_names": ["pull_request"],
-                    "products": ["example-site"],
-                    "contexts": [context],
+                    "products": list(products),
+                    "contexts": list(allowed_contexts),
                     "actions": ["product_environment.read"],
                 }
             ]
@@ -6421,6 +6787,99 @@ def _write_context_cutover_audit_records(database_url: str) -> None:
         store.close()
 
 
+def _seed_product_environment_read_records(database_url: str) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        store.write_product_profile_record(
+            LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+        )
+        store.write_runtime_environment_record(
+            RuntimeEnvironmentRecord(
+                scope="instance",
+                context="example-site",
+                instance="prod",
+                env={"INTERNAL_CALLBACK_URL": "https://internal.example-site.invalid"},
+                updated_at="2026-05-02T22:32:00Z",
+                source_label="test",
+            )
+        )
+        store.write_dokploy_target_record(
+            DokployTargetRecord(
+                context="example-site",
+                instance="prod",
+                target_type="application",
+                target_name="example-site-prod",
+                updated_at="2026-05-02T22:33:00Z",
+                source_label="test",
+            )
+        )
+        store.write_dokploy_target_id_record(
+            DokployTargetIdRecord(
+                context="example-site",
+                instance="prod",
+                target_id="app-prod-123",
+                updated_at="2026-05-02T22:33:00Z",
+                source_label="test",
+            )
+        )
+        store.write_provider_target_record(
+            ProviderTargetRecord(
+                context="example-site",
+                instance="prod",
+                provider_id="dokploy",
+                target_category="application",
+                target_id="app-prod-123",
+                display_name="example-site-prod",
+                provider_target_type="application",
+                updated_at="2026-05-02T22:33:00Z",
+                source_label="test",
+            )
+        )
+        with patch.dict(
+            "os.environ",
+            {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+            clear=True,
+        ):
+            control_plane_secrets.write_secret_value(
+                record_store=store,
+                scope="context_instance",
+                integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                name="SMTP_PASSWORD",
+                plaintext_value="super-secret-password",
+                binding_key="SMTP_PASSWORD",
+                context_name="example-site",
+                instance_name="prod",
+                actor="test",
+            )
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "every/verireel",
+                        "workflow_refs": [
+                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                        ],
+                        "event_names": ["pull_request"],
+                        "products": ["example-site"],
+                        "contexts": ["launchplane"],
+                        "actions": ["product_environment.read"],
+                    }
+                ]
+            }
+        )
+        store.write_authz_policy_record(
+            LaunchplaneAuthzPolicyRecord(
+                record_id="launchplane-authz-policy-product-environment-read-test",
+                source="test",
+                updated_at="2026-05-02T22:35:00Z",
+                policy=policy,
+            )
+        )
+    finally:
+        store.close()
+
+
 def _product_profile_read_policy(*, product: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -6563,6 +7022,60 @@ async def _get_config_status(
     return await _asgi_get(
         app,
         f"/v1/products/{product}/environments/{environment}/config-status",
+        headers=headers,
+    )
+
+
+async def _get_products(
+    app: FastAPI,
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(app, "/v1/products", headers=headers)
+
+
+async def _get_product(
+    app: FastAPI,
+    product: str = "example-site",
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(app, f"/v1/products/{product}", headers=headers)
+
+
+async def _get_product_activity(
+    app: FastAPI,
+    product: str = "example-site",
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(app, f"/v1/products/{product}/activity", headers=headers)
+
+
+async def _get_product_environments(
+    app: FastAPI,
+    product: str = "example-site",
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(app, f"/v1/products/{product}/environments", headers=headers)
+
+
+async def _get_product_environment(
+    app: FastAPI,
+    product: str = "example-site",
+    environment: str = "prod",
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(
+        app,
+        f"/v1/products/{product}/environments/{environment}",
         headers=headers,
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -17209,478 +17209,31 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "idempotency_key_required")
         self.assertEqual(provider_targets, ())
 
-    def test_product_overview_endpoint_is_generic_web_profile_driven(self) -> None:
+    def test_product_environment_read_legacy_wsgi_routes_are_retired(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane", "example-site"],
-                            "contexts": ["launchplane", "example-site"],
-                            "actions": [
-                                "product_environment.read",
-                                "generic_web_prod_promotion.dispatch",
-                            ],
-                        }
-                    ]
-                }
-            )
             app = create_launchplane_service_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/products/example-site",
-            )
-
-        self.assertEqual(status_code, 200)
-        product = payload["product"]
-        response_text = json.dumps(payload)
-        self.assertEqual(product["product"], "example-site")
-        self.assertEqual(product["driver_id"], "generic-web")
-        self.assertEqual(
-            [environment["environment"] for environment in product["environments"]],
-            ["testing", "prod"],
-        )
-        actions = {action["action_id"]: action for action in product["available_actions"]}
-        self.assertTrue(actions["prod_promotion_workflow"]["enabled"])
-        self.assertFalse(actions["prod_backup_gate"]["enabled"])
-        self.assertEqual(actions["prod_backup_gate"]["trust_state"], "unsupported")
-        self.assertNotIn("sellyouroutboard", response_text)
-
-    def test_products_endpoint_lists_db_backed_product_overviews(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane", "example-site"],
-                            "contexts": ["launchplane", "example-site"],
-                            "actions": ["product_environment.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/products",
-            )
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(
-            [product["product"] for product in payload["products"]],
-            ["example-site"],
-        )
-        self.assertEqual(payload["products"][0]["driver_id"], "generic-web")
-        self.assertEqual(
-            [environment["environment"] for environment in payload["products"][0]["environments"]],
-            ["testing", "prod"],
-        )
-
-    def test_products_endpoint_requires_database_backed_read_model_store(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane", "example-site"],
-                            "contexts": ["launchplane", "example-site"],
-                            "actions": ["product_environment.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
+                authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=root,
             )
 
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/products",
-            )
-
-        self.assertEqual(status_code, 503)
-        self.assertEqual(payload["status"], "rejected")
-        self.assertEqual(payload["error"]["code"], "database_storage_required")
-        self.assertIn("DB-backed Launchplane storage", payload["error"]["message"])
-
-    def test_product_activity_endpoint_returns_product_timeline(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["example-site"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_environment.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/products/example-site/activity",
-            )
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["activity"]["product"], "example-site")
-        self.assertEqual(payload["activity"]["events"][0]["event_type"], "authz_policy")
-        self.assertEqual(payload["activity"]["events"][0]["action_id"], "authz_policy.update")
-
-    def test_product_environments_endpoint_lists_db_backed_environment_summaries(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            store.write_runtime_environment_record(
-                RuntimeEnvironmentRecord(
-                    scope="instance",
-                    context="example-site",
-                    instance="prod",
-                    env={"INTERNAL_CALLBACK_URL": "https://internal.example-site.invalid"},
-                    updated_at="2026-05-02T22:32:00Z",
-                    source_label="test",
+            responses = [
+                _invoke_app(app, method="GET", path=path)
+                for path in (
+                    "/v1/products",
+                    "/v1/products/example-site",
+                    "/v1/products/example-site/activity",
+                    "/v1/products/example-site/environments",
+                    "/v1/products/example-site/environments/prod",
                 )
-            )
-            store.write_dokploy_target_record(
-                DokployTargetRecord(
-                    context="example-site",
-                    instance="prod",
-                    target_type="application",
-                    target_name="example-site-prod",
-                    updated_at="2026-05-02T22:33:00Z",
-                    source_label="test",
-                )
-            )
-            store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["example-site"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_environment.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
+            ]
 
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/products/example-site/environments",
-            )
-
-        response_text = json.dumps(payload)
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["product"], "example-site")
-        self.assertEqual(
-            [environment["environment"] for environment in payload["environments"]],
-            ["testing", "prod"],
-        )
-        prod_environment = payload["environments"][1]
-        self.assertEqual(prod_environment["context"], "example-site")
-        self.assertEqual(prod_environment["trust_state"], "missing")
-        self.assertEqual(payload["trust_state"], "missing")
-        self.assertNotIn("https://internal.example-site.invalid", response_text)
-
-    def test_product_environment_detail_redacts_runtime_and_secret_values(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            store.write_dokploy_target_record(
-                DokployTargetRecord(
-                    context="example-site",
-                    instance="prod",
-                    target_type="application",
-                    target_name="example-site-prod",
-                    updated_at="2026-05-02T22:31:00Z",
-                    source_label="test",
-                )
-            )
-            store.write_dokploy_target_id_record(
-                DokployTargetIdRecord(
-                    context="example-site",
-                    instance="prod",
-                    target_id="app-prod-123",
-                    updated_at="2026-05-02T22:31:00Z",
-                    source_label="test",
-                )
-            )
-            store.write_provider_target_record(
-                ProviderTargetRecord(
-                    context="example-site",
-                    instance="prod",
-                    provider_id="dokploy",
-                    target_category="application",
-                    target_id="app-prod-123",
-                    display_name="example-site-prod",
-                    provider_target_type="application",
-                    updated_at="2026-05-02T22:32:00Z",
-                    source_label="test",
-                )
-            )
-            store.write_runtime_environment_record(
-                RuntimeEnvironmentRecord(
-                    scope="instance",
-                    context="example-site",
-                    instance="prod",
-                    env={"INTERNAL_CALLBACK_URL": "https://internal.example-site.invalid"},
-                    updated_at="2026-05-02T22:32:00Z",
-                    source_label="test",
-                )
-            )
-            with patch.dict(
-                os.environ,
-                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
-                clear=True,
-            ):
-                control_plane_secrets.write_secret_value(
-                    record_store=store,
-                    scope="context_instance",
-                    integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
-                    name="SMTP_PASSWORD",
-                    plaintext_value="super-secret-password",
-                    binding_key="SMTP_PASSWORD",
-                    context_name="example-site",
-                    instance_name="prod",
-                    actor="test",
-                )
-            store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["example-site"],
-                            "contexts": ["example-site"],
-                            "actions": ["product_environment.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/products/example-site/environments/prod",
-            )
-
-        response_text = json.dumps(payload)
-        self.assertEqual(status_code, 200)
-        environment = payload["environment"]
-        self.assertEqual(environment["target"]["target_name"], "example-site-prod")
-        self.assertTrue(environment["target"]["target_id_recorded"])
-        self.assertEqual(environment["runtime_settings"][0]["env_keys"], ["INTERNAL_CALLBACK_URL"])
-        self.assertEqual(environment["managed_secrets"][0]["binding_key"], "SMTP_PASSWORD")
-        self.assertNotIn("https://internal.example-site.invalid", response_text)
-        self.assertNotIn("super-secret-password", response_text)
-
-    def test_product_environment_detail_returns_not_found_for_unknown_product(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["missing-site"],
-                            "contexts": ["missing-site"],
-                            "actions": ["product_environment.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/products/missing-site/environments/prod",
-            )
-
-        self.assertEqual(status_code, 404)
-        self.assertEqual(payload["status"], "rejected")
-        self.assertEqual(payload["error"]["code"], "not_found")
-        self.assertEqual(payload["error"]["message"], "Product 'missing-site' was not found.")
-
-    def test_product_environment_detail_returns_not_found_for_unknown_environment(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["example-site"],
-                            "contexts": ["example-site"],
-                            "actions": ["product_environment.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/products/example-site/environments/staging",
-            )
-
-        self.assertEqual(status_code, 404)
-        self.assertEqual(payload["status"], "rejected")
-        self.assertEqual(payload["error"]["code"], "not_found")
-        self.assertEqual(
-            payload["error"]["message"],
-            "Product 'example-site' has no environment 'staging'.",
-        )
+        for status_code, payload in responses:
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["status"], "rejected")
+            self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_product_environment_config_status_legacy_wsgi_route_is_retired(
         self,
@@ -25954,25 +25507,21 @@ class LaunchplaneServiceTests(unittest.TestCase):
             finally:
                 store.close()
 
-            with patch.dict(
-                os.environ,
-                TERMINAL_AGENT_AUTH_ENV,
-                clear=True,
-            ):
-                read_status_code, read_payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/products/example-site/environments/prod",
-                    authorization="Bearer terminal-read-token",
-                )
-
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["mode"], "dry_run")
         self.assertEqual(payload["result"]["changed"], True)
         self.assertEqual(len(active_records), 1)
         self.assertIsNone(dry_run_idempotency_record)
-        self.assertEqual(read_status_code, 403)
-        self.assertEqual(read_payload["error"]["code"], "authorization_denied")
+        self.assertFalse(
+            active_records[0].policy.allows(
+                identity=TerminalAgentIdentity(
+                    subject="local-owner-agent", token_label="local-owner-read"
+                ),
+                action="product_environment.read",
+                product="example-site",
+                context="example-site",
+            )
+        )
 
     def test_local_operator_authz_policy_grant_endpoint_writes_db_record_and_updates_runtime(
         self,


### PR DESCRIPTION
## Summary
- migrate core `/v1/products` product/site read-model routes from legacy WSGI to native FastAPI
- retire the direct WSGI product-environment read branches while keeping `/v1/repo-product-mapping` and `/v1/agent/context` on the retained fallback
- add native FastAPI contract, authz, redaction, fallback-precedence, and retirement coverage
- update service-boundary and compatibility-retirement docs

## Local Validation
- `uv run python -m unittest` (2681 tests)
- `uv run python -m unittest tests.test_http_app tests.test_service` (706 tests)
- `uv run python -m unittest tests.test_http_app.FastApiProductEnvironmentReadTests`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `git diff --check`
- JetBrains changed-files closeout: clean, 0 problems

## Review
- Scout/review agents green; final post-polish review found no blockers.

Note: whole-repo `ruff format --check .` still reports pre-existing unrelated formatting drift in 56 files; touched files are formatted.