### PR TITLE
Move agent context reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -16,6 +16,12 @@ from pydantic import BaseModel, ConfigDict, Field
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import secrets as control_plane_secrets
+from control_plane.agent_context_service import (
+    AgentContextPayload,
+    agent_context_action_allowed,
+    agent_context_allowed,
+    build_agent_context_service_payload,
+)
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
     authz_policy_sha256,
@@ -25,6 +31,8 @@ from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.driver_descriptor import DriverContextView, DriverDescriptor
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
     build_launchplane_idempotency_record_id,
@@ -39,6 +47,7 @@ from control_plane.contracts.product_environment_read_model import (
     ProductSiteOverview,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.repo_product_mapping_read_model import RepoProductMapping
 from control_plane.contracts.preview_evidence import (
     PreviewDestroyedEvidenceEnvelope,
     PreviewGenerationEvidenceEnvelope,
@@ -91,6 +100,10 @@ from control_plane.workflows.evidence_ingestion import (
     apply_promotion_evidence,
 )
 from control_plane.workflows.ship import utc_now_timestamp
+from control_plane.work_graph_service import (
+    WorkGraphPlanningFactsProvider,
+    build_repo_product_mapping_service_payload,
+)
 
 
 _BEARER_CHALLENGE_HEADER = {"WWW-Authenticate": 'Bearer realm="Launchplane API"'}
@@ -104,6 +117,45 @@ _PREVIEW_DESTROYED_EVIDENCE_ROUTE = "/v1/evidence/previews/destroyed"
 _RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-host-hygiene/audits"
 _RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-lane-registration/audits"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+
+
+class RepoProductMappingReadStore(Protocol):
+    def list_product_profile_records(
+        self,
+        *,
+        driver_id: str = "",
+    ) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
+
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+
+class AgentContextReadStore(ProductReadModelStore, Protocol):
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
 
 
 class LaunchplaneErrorDetail(BaseModel):
@@ -193,6 +245,23 @@ class ProductEnvironmentResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     environment: ProductEnvironmentDetail
+
+
+class RepoProductMappingResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    mapping: RepoProductMapping
+    source: dict[str, object]
+
+
+class AgentContextResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    context: AgentContextPayload
 
 
 class DriverDescriptorsResponse(BaseModel):
@@ -976,6 +1045,7 @@ def create_launchplane_fastapi_app(
     bearer_identity_config: BearerIdentityConfig | None = None,
     human_session_manager: HumanSessionManager | None = None,
     control_plane_root_path: FilePath | None = None,
+    work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
 ) -> FastAPI:
     resolved_authz_policy_runtime = authz_policy_runtime or LaunchplaneAuthzPolicyRuntime(
         authz_policy
@@ -1293,6 +1363,126 @@ def create_launchplane_fastapi_app(
             code="authorization_denied",
             message=result.denial_message,
         )
+
+    def require_agent_context_read_authorization(
+        *, identity: LaunchplaneIdentity, trace_id: str, message: str
+    ) -> None:
+        if agent_context_allowed(
+            authz_policy=resolved_authz_policy_runtime.policy,
+            identity=identity,
+        ):
+            return
+        raise _launchplane_http_error(
+            status_code=403,
+            trace_id=trace_id,
+            code="authorization_denied",
+            message=message,
+        )
+
+    def require_read_store_methods(
+        record_store: object,
+        *,
+        trace_id: str,
+        method_names: tuple[str, ...],
+        message: str,
+    ) -> None:
+        missing_methods = tuple(
+            method_name
+            for method_name in method_names
+            if not callable(getattr(record_store, method_name, None))
+        )
+        if not missing_methods:
+            if isinstance(record_store, PostgresRecordStore):
+                return
+            missing_methods = ("postgres_storage",)
+        missing_method_list = ", ".join(missing_methods)
+        raise _launchplane_http_error(
+            status_code=503,
+            trace_id=trace_id,
+            code="database_storage_required",
+            message=f"{message} Missing store method(s): {missing_method_list}.",
+        )
+
+    def require_repo_product_mapping_read_store(
+        record_store: object, *, trace_id: str
+    ) -> RepoProductMappingReadStore:
+        require_read_store_methods(
+            record_store,
+            trace_id=trace_id,
+            method_names=(
+                "list_product_profile_records",
+                "list_every_code_work_request_records",
+            ),
+            message="Repo product mapping reads require a database-backed record store.",
+        )
+        return cast(RepoProductMappingReadStore, record_store)
+
+    def require_agent_context_read_store(
+        record_store: object, *, trace_id: str
+    ) -> AgentContextReadStore:
+        require_read_store_methods(
+            record_store,
+            trace_id=trace_id,
+            method_names=(
+                "list_product_profile_records",
+                "read_product_profile_record",
+                "list_every_code_work_request_records",
+                "list_every_code_preview_gate_records",
+            ),
+            message="Agent context reads require a database-backed record store.",
+        )
+        return cast(AgentContextReadStore, record_store)
+
+    def read_repo_product_mapping(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> RepoProductMappingResponse:
+        trace_id = next_trace_id()
+        require_agent_context_read_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            message="Workflow cannot read the Launchplane repo product mapping.",
+        )
+        mapping_store = require_repo_product_mapping_read_store(
+            record_store,
+            trace_id=trace_id,
+        )
+        payload = build_repo_product_mapping_service_payload(
+            generated_at=utc_now_timestamp(),
+            product_store=mapping_store,
+            work_request_store=mapping_store,
+        )
+        return RepoProductMappingResponse(
+            trace_id=trace_id,
+            mapping=RepoProductMapping.model_validate(payload["mapping"]),
+            source=cast(dict[str, object], payload["source"]),
+        )
+
+    def read_agent_context(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        repository: Annotated[str, Query()] = "",
+    ) -> AgentContextResponse:
+        trace_id = next_trace_id()
+        require_agent_context_read_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            message="Workflow cannot read Launchplane agent context.",
+        )
+        context_store = require_agent_context_read_store(record_store, trace_id=trace_id)
+        context = build_agent_context_service_payload(
+            generated_at=utc_now_timestamp(),
+            repository=repository,
+            product_store=context_store,
+            work_request_store=context_store,
+            preview_readiness_store=context_store,
+            action_allowed=agent_context_action_allowed(
+                authz_policy=resolved_authz_policy_runtime.policy,
+                identity=identity,
+            ),
+            planning_facts_provider=work_graph_planning_facts_provider,
+        )
+        return AgentContextResponse(trace_id=trace_id, context=context)
 
     def list_product_environment_overviews(
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
@@ -3000,6 +3190,32 @@ def create_launchplane_fastapi_app(
         404: {"model": LaunchplaneErrorResponse},
         503: {"model": LaunchplaneErrorResponse},
     }
+
+    agent_context_error_responses: dict[int | str, dict[str, object]] = {
+        401: {"model": LaunchplaneErrorResponse},
+        403: {"model": LaunchplaneErrorResponse},
+        503: {"model": LaunchplaneErrorResponse},
+    }
+
+    app.add_api_route(
+        "/v1/repo-product-mapping",
+        read_repo_product_mapping,
+        methods=["GET"],
+        response_model=RepoProductMappingResponse,
+        operation_id="read_repo_product_mapping",
+        summary="Read repository product mapping",
+        responses=agent_context_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/agent/context",
+        read_agent_context,
+        methods=["GET"],
+        response_model=AgentContextResponse,
+        operation_id="read_agent_context",
+        summary="Read Launchplane agent context",
+        responses=agent_context_error_responses,
+    )
 
     app.add_api_route(
         "/v1/products",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -36,11 +36,6 @@ from control_plane.http_app import (
 from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
-from control_plane.agent_context_service import (
-    agent_context_action_allowed,
-    agent_context_allowed,
-    build_agent_context_service_payload,
-)
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
 )
@@ -359,7 +354,6 @@ from control_plane.work_graph_service import (
 )
 from control_plane.work_graph_http import (
     handle_work_graph_issue_inbox_read,
-    handle_repo_product_mapping_read,
     handle_work_graph_snapshot_read,
     rank_work_graph_snapshot,
     reconcile_work_graph_issue_inbox,
@@ -4494,8 +4488,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         "notification-attempts",
     ]:
         return "preview_pr_feedback_notification_attempt.read", {}
-    if len(segments) == 3 and segments == ["v1", "agent", "context"]:
-        return "product_environment.read", {"agent_context": "true"}
     if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
         return "every_code_work_request.read", {"request_id": segments[3]}
     if (
@@ -4549,8 +4541,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "work_graph.rank", {}
     if len(segments) == 4 and segments == ["v1", "work-graph", "github", "issues"]:
         return "work_graph.issue_inbox", {}
-    if len(segments) == 2 and segments == ["v1", "repo-product-mapping"]:
-        return "product_environment.read", {"repo_product_mapping": "true"}
     if len(segments) == 4 and segments == [
         "v1",
         "products",
@@ -11324,58 +11314,6 @@ def create_launchplane_service_app(
                             "targets": targets,
                         },
                     )
-                if action == "product_environment.read":
-                    if params.get("agent_context") == "true":
-                        if not agent_context_allowed(
-                            authz_policy=authz_policy,
-                            identity=identity,
-                        ):
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=403,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "authorization_denied",
-                                        "message": "Workflow cannot read Launchplane agent context.",
-                                    },
-                                },
-                            )
-                        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
-                        agent_context = build_agent_context_service_payload(
-                            generated_at=_utc_now_timestamp(),
-                            repository=repository_filter,
-                            product_store=record_store,
-                            work_request_store=_every_code_work_request_store(record_store),
-                            preview_readiness_store=_every_code_work_request_store(record_store),
-                            action_allowed=agent_context_action_allowed(
-                                authz_policy=authz_policy,
-                                identity=identity,
-                            ),
-                            planning_facts_provider=work_graph_planning_facts_provider,
-                        )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "context": agent_context.model_dump(mode="json"),
-                            },
-                        )
-
-                    if params.get("repo_product_mapping") == "true":
-                        return handle_repo_product_mapping_read(
-                            authz_policy=authz_policy,
-                            identity=identity,
-                            trace_id=request_trace_id,
-                            product_store=record_store,
-                            work_request_store=_every_code_work_request_store(record_store),
-                            utc_now=_utc_now_timestamp,
-                            json_response=_json_response,
-                            start_response=start_response,
-                        )
             if path == "/v1/service/odoo-workers/reconcile":
                 if not authz_policy.allows(
                     identity=identity,
@@ -15848,6 +15786,7 @@ def serve_launchplane_service(
         bearer_identity_config=_bearer_identity_config_from_env(),
         human_session_manager=human_session_manager,
         control_plane_root_path=control_plane_root(),
+        work_graph_planning_facts_provider=work_graph_planning_facts_provider,
     )
     fastapi_application.mount(
         "/",

--- a/control_plane/work_graph_http.py
+++ b/control_plane/work_graph_http.py
@@ -21,7 +21,6 @@ from control_plane.work_graph_service import (
     WorkGraphPlanningFactsProvider,
     WorkGraphRankEnvelope,
     WorkGraphWorkRequestStore,
-    build_repo_product_mapping_service_payload,
     build_work_graph_rank_result,
     build_work_graph_snapshot_service_payload,
 )
@@ -181,52 +180,6 @@ def reconcile_work_graph_issue_inbox(
     if issue_inbox_reconcile_provider is None:
         raise ValueError("GitHub issue inbox reconciliation is not configured.")
     return issue_inbox_reconcile_provider(request)
-
-
-def handle_repo_product_mapping_read(
-    *,
-    authz_policy: LaunchplaneAuthzPolicy,
-    identity: ResolvedLaunchplaneIdentity,
-    trace_id: str,
-    product_store: ProductReadModelStore,
-    work_request_store: WorkGraphWorkRequestStore,
-    utc_now: UtcNow,
-    json_response: JsonResponse,
-    start_response: StartResponse,
-) -> list[bytes]:
-    if not authz_policy.allows(
-        identity=identity,
-        action="product_environment.read",
-        product="launchplane",
-        context=LAUNCHPLANE_SERVICE_CONTEXT,
-    ):
-        return json_response(
-            start_response=start_response,
-            status_code=403,
-            payload={
-                "status": "rejected",
-                "trace_id": trace_id,
-                "error": {
-                    "code": "authorization_denied",
-                    "message": "Workflow cannot read the Launchplane repo product mapping.",
-                },
-            },
-        )
-
-    mapping_payload = build_repo_product_mapping_service_payload(
-        generated_at=utc_now(),
-        product_store=product_store,
-        work_request_store=work_request_store,
-    )
-    return json_response(
-        start_response=start_response,
-        status_code=200,
-        payload={
-            "status": "ok",
-            "trace_id": trace_id,
-            **mapping_payload,
-        },
-    )
 
 
 def rank_work_graph_snapshot(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -61,12 +61,12 @@ Keep a compatibility surface only when it is one of these:
   WSGI branches are deleted; cleanup callers use the service route instead of a
   second production implementation.
 - Deployment, promotion, preview, inventory, recent-operations,
-  managed-secret status, product-profile, product/site read-model, and product
-  context cutover audit reads use native FastAPI routes for bearer-token and
-  human-session callers. The product-profile collection also preserves the
-  dedicated Every Code worker token. Their legacy WSGI branches are deleted;
-  direct fallback calls fail closed while the mounted fallback remains for
-  retained non-native routes.
+  managed-secret status, product-profile, product/site read-model,
+  repo-product mapping, agent-context, and product context cutover audit reads
+  use native FastAPI routes for bearer-token and human-session callers. The
+  product-profile collection also preserves the dedicated Every Code worker
+  token. Their legacy WSGI branches are deleted; direct fallback calls fail
+  closed while the mounted fallback remains for retained non-native routes.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -442,8 +442,9 @@ Workflow dispatches may select at most one non-`none` phase input across
 batch-candidate, batch-landing, and stack-collapse modes; the runner validates
 that exclusivity before any phase step mutates state.
 
-`GET /v1/repo-product-mapping` returns the repository ownership/awareness read
-model used by work graph and future agent context. The route requires
+`GET /v1/repo-product-mapping` is a native FastAPI route that returns the
+repository ownership/awareness read model used by work graph and agent context.
+The route requires
 `product_environment.read` for product/context `launchplane`, performs no
 writes, and distinguishes Launchplane-managed runtime repos from awareness-only
 Every Code work-request repos. Managed runtime entries come from product profile
@@ -471,15 +472,16 @@ until that secret exists, so prepared repo variables do not enable
 unauthenticated runtime reads. That token is not a Launchplane record and must
 remain outside the repo.
 
-`GET /v1/agent/context` is a thin read-only aggregation endpoint for public-safe
-skill preflight. It requires `product_environment.read` for product/context
-`launchplane`, accepts an optional `repository` filter, and composes the existing
-repo-product mapping, work graph snapshot, Every Code summary, and preview
-readiness projections under named sections. Each section reports `available`,
-`unauthorized`, or `unavailable`; optional work-graph planning provider failures
-mark only that section unavailable instead of dropping the whole context or
-silently omitting the failure. The endpoint writes no records, fetches no issue
-bodies, and must preserve the lower-level redaction/provenance rules.
+`GET /v1/agent/context` is a native FastAPI thin read-only aggregation endpoint
+for public-safe skill preflight. It requires `product_environment.read` for
+product/context `launchplane`, accepts an optional `repository` filter, and
+composes the existing repo-product mapping, work graph snapshot, Every Code
+summary, and preview readiness projections under named sections. Each section
+reports `available`, `unauthorized`, or `unavailable`; optional work-graph
+planning provider failures mark only that section unavailable instead of dropping
+the whole context or silently omitting the failure. The endpoint writes no
+records, fetches no issue bodies, and must preserve the lower-level
+redaction/provenance rules.
 
 `POST /v1/work-graph/merge-train/run-once` is the authenticated service ingress
 for one ordered-queue read or mutation pass. It resolves repository/base policy
@@ -1341,8 +1343,8 @@ context. Raw context names and provider target identifiers remain evidence
 metadata; runtime values, secret plaintext, secret ciphertext, and
 product-specific driver payloads are not exposed as shared top-level fields.
 Their legacy WSGI product-read branches are deleted; direct fallback calls fail
-closed while `/v1/repo-product-mapping` and `/v1/agent/context` remain on the
-retained fallback until their own native cutovers.
+closed. `/v1/repo-product-mapping` and `/v1/agent/context` are also native
+FastAPI routes, and their legacy WSGI branches are deleted.
 
 `GET /v1/products/{product}/environments` returns the product's stable
 environment summaries from DB-backed Launchplane records. It is the collection

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -22,6 +22,8 @@ from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_generation_record import (
@@ -52,6 +54,7 @@ from control_plane.contracts.runner_lane_registration import (
     plan_runner_lane_registration,
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
+from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import (
     BearerIdentityConfig,
@@ -943,6 +946,275 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
 
 
 class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_repo_product_mapping_returns_managed_and_awareness_repos(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_agent_context_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(
+                    context="launchplane", products=("launchplane", "example-site")
+                ),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_repo_product_mapping(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(set(payload), {"status", "trace_id", "mapping", "source"})
+        repositories = payload["mapping"]["repositories"]
+        by_repository = {repository["repository"]: repository for repository in repositories}
+        self.assertEqual(by_repository["every/example-site"]["classification"], "managed_runtime")
+        self.assertEqual(by_repository["every/example-site"]["product"], "example-site")
+        self.assertEqual(by_repository["every/example-site"]["environments"], ["testing", "prod"])
+        self.assertEqual(by_repository["cbusillo/tooling"]["classification"], "active_awareness")
+        self.assertEqual(payload["source"]["product_count"], 1)
+        self.assertEqual(payload["source"]["work_request_count"], 2)
+
+    async def test_agent_context_returns_thin_aggregated_read_models(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_agent_context_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(
+                    contexts=("launchplane", "example-site"),
+                    products=("launchplane", "example-site"),
+                ),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_agent_context(app, repository="every/example-site")
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        context = response.json()["context"]
+        self.assertEqual(context["schema_version"], 1)
+        self.assertEqual(context["repository"], "every/example-site")
+        sections = context["sections"]
+        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
+        self.assertEqual(sections["work_graph_snapshot"]["status"], "available")
+        self.assertEqual(sections["every_code_summary"]["status"], "available")
+        self.assertEqual(sections["preview_readiness"]["status"], "available")
+        summary = sections["every_code_summary"]["payload"]["summary"]
+        self.assertEqual(summary["repository"], "every/example-site")
+        self.assertEqual(summary["summaries"][0]["issue_number"], 190)
+        readiness = sections["preview_readiness"]["payload"]["readiness"]
+        self.assertEqual(readiness["repository"], "every/example-site")
+        self.assertEqual(readiness["items"][0]["readiness_status"], "ready")
+
+    async def test_agent_context_marks_work_graph_unavailable_without_dropping_sections(
+        self,
+    ) -> None:
+        def unavailable_planning_facts() -> tuple[WorkGraphPlanningIssueFacts, ...]:
+            raise RuntimeError("planning provider unavailable")
+
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_empty_agent_context_read_store(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(
+                    context="launchplane", products=("launchplane",)
+                ),
+                record_store_factory=lambda: app_store,
+                work_graph_planning_facts_provider=unavailable_planning_facts,
+            )
+
+            response = await _get_agent_context(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        sections = response.json()["context"]["sections"]
+        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
+        self.assertEqual(sections["work_graph_snapshot"]["status"], "unavailable")
+        self.assertEqual(sections["work_graph_snapshot"]["reason_code"], "work_graph_unavailable")
+        self.assertEqual(sections["every_code_summary"]["status"], "available")
+        self.assertEqual(sections["preview_readiness"]["status"], "available")
+
+    async def test_agent_context_reads_require_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_environment_read_policy(
+                context="launchplane", products=("launchplane",)
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        responses = [
+            await _get_repo_product_mapping(app, authorization=""),
+            await _get_agent_context(app, authorization=""),
+        ]
+
+        for response in responses:
+            self.assertEqual(response.status_code, 401)
+            self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_agent_context_reads_reject_unauthorized_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        mapping_response = await _get_repo_product_mapping(app)
+        context_response = await _get_agent_context(app)
+
+        self.assertEqual(mapping_response.status_code, 403)
+        self.assertEqual(context_response.status_code, 403)
+        self.assertEqual(mapping_response.json()["error"]["code"], "authorization_denied")
+        self.assertEqual(context_response.json()["error"]["code"], "authorization_denied")
+
+    async def test_agent_context_reads_require_database_backed_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_environment_read_policy(
+                context="launchplane", products=("launchplane",)
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        mapping_response = await _get_repo_product_mapping(app)
+        context_response = await _get_agent_context(app)
+
+        self.assertEqual(mapping_response.status_code, 503)
+        self.assertEqual(context_response.status_code, 503)
+        self.assertEqual(mapping_response.json()["error"]["code"], "database_storage_required")
+        self.assertEqual(context_response.json()["error"]["code"], "database_storage_required")
+
+    async def test_agent_context_reads_reject_filesystem_store(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_environment_read_policy(
+                    context="launchplane", products=("launchplane",)
+                ),
+                record_store_factory=lambda: record_store,
+            )
+
+            mapping_response = await _get_repo_product_mapping(app)
+            context_response = await _get_agent_context(app)
+
+        self.assertEqual(mapping_response.status_code, 503)
+        self.assertEqual(context_response.status_code, 503)
+        self.assertEqual(mapping_response.json()["error"]["code"], "database_storage_required")
+        self.assertEqual(context_response.json()["error"]["code"], "database_storage_required")
+        self.assertIn("postgres_storage", mapping_response.json()["error"]["message"])
+        self.assertIn("postgres_storage", context_response.json()["error"]["message"])
+
+    async def test_agent_context_accepts_terminal_agent_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_agent_context_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_launchplane_read_policy(),
+                record_store_factory=lambda: app_store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-read-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+            )
+
+            response = await _get_agent_context(
+                app,
+                repository="every/example-site",
+                authorization="Bearer terminal-read-token",
+            )
+            mapping_response = await _get_repo_product_mapping(
+                app,
+                authorization="Bearer terminal-read-token",
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(mapping_response.status_code, 200)
+        sections = response.json()["context"]["sections"]
+        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
+        self.assertEqual(sections["work_graph_snapshot"]["status"], "available")
+        self.assertEqual(sections["every_code_summary"]["status"], "available")
+        self.assertEqual(sections["preview_readiness"]["status"], "available")
+
+    async def test_openapi_includes_agent_context_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_environment_read_policy(
+                context="launchplane", products=("launchplane",)
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        expected_routes = {
+            "/v1/repo-product-mapping": (
+                "read_repo_product_mapping",
+                "RepoProductMappingResponse",
+            ),
+            "/v1/agent/context": ("read_agent_context", "AgentContextResponse"),
+        }
+        for path, (operation_id, response_model_name) in expected_routes.items():
+            route = openapi["paths"][path]["get"]
+            self.assertEqual(route["operationId"], operation_id)
+            self.assertEqual(
+                route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+                f"#/components/schemas/{response_model_name}",
+            )
+            for status_code in ("401", "403", "503"):
+                self.assertIn(
+                    "LaunchplaneErrorResponse", json.dumps(route["responses"][status_code])
+                )
+            self.assertFalse(
+                openapi["components"]["schemas"][response_model_name]["additionalProperties"]
+            )
+
+    async def test_fastapi_agent_context_reads_precede_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_agent_context_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            policy = _product_environment_read_policy(
+                contexts=("launchplane", "example-site"),
+                products=("launchplane", "example-site"),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                record_store_factory=lambda: app_store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "legacy-state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            mapping_response = await _get_repo_product_mapping(app)
+            context_response = await _get_agent_context(app, repository="every/example-site")
+            app_store.close()
+
+        self.assertEqual(mapping_response.status_code, 200)
+        self.assertEqual(context_response.status_code, 200)
+
     async def test_list_products_returns_db_backed_overviews(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -6880,6 +7152,71 @@ def _seed_product_environment_read_records(database_url: str) -> None:
         store.close()
 
 
+def _seed_empty_agent_context_read_store(database_url: str) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    store.close()
+
+
+def _seed_agent_context_read_records(database_url: str) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        store.write_product_profile_record(
+            LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+        )
+        request_id = "every-code-every-example-site-190-test"
+        store.write_every_code_work_request_record(
+            EveryCodeWorkRequestRecord(
+                request_id=request_id,
+                source="manual",
+                state="queued",
+                repository="every/example-site",
+                issue_number=190,
+                issue_url="https://github.com/every/example-site/issues/190",
+                issue_title="Build operator chooser",
+                trigger_label="every-code",
+                trigger_actor="cbusillo",
+                queued_at="2026-05-06T02:00:00Z",
+                updated_at="2026-05-06T02:00:00Z",
+            )
+        )
+        store.write_every_code_work_request_record(
+            EveryCodeWorkRequestRecord(
+                request_id="every-code-cbusillo-tooling-12-test",
+                source="manual",
+                state="queued",
+                repository="cbusillo/tooling",
+                issue_number=12,
+                issue_url="https://github.com/cbusillo/tooling/issues/12",
+                issue_title="Support repo follow-up",
+                trigger_label="every-code",
+                trigger_actor="cbusillo",
+                queued_at="2026-05-08T18:00:00Z",
+                updated_at="2026-05-08T18:00:00Z",
+            )
+        )
+        store.write_every_code_preview_gate_record(
+            EveryCodePreviewGateRecord(
+                gate_id="every-code-preview-gate-every-example-site-190-31",
+                request_id=request_id,
+                repository="every/example-site",
+                issue_number=190,
+                issue_url="https://github.com/every/example-site/issues/190",
+                pr_number=31,
+                pr_url="https://github.com/every/example-site/pull/31",
+                head_sha="abcdef1234567890",
+                status="ready",
+                created_at="2026-05-08T18:00:00Z",
+                updated_at="2026-05-08T18:01:00Z",
+                ready_at="2026-05-08T18:01:00Z",
+                last_checked_at="2026-05-08T18:01:00Z",
+            )
+        )
+    finally:
+        store.close()
+
+
 def _product_profile_read_policy(*, product: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -6924,6 +7261,22 @@ def _terminal_agent_product_environment_read_policy(*, context: str) -> Launchpl
                     "token_labels": ["local-owner-read"],
                     "products": ["example-site"],
                     "contexts": [context],
+                    "actions": ["product_environment.read"],
+                }
+            ]
+        }
+    )
+
+
+def _terminal_agent_launchplane_read_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["launchplane", "example-site"],
+                    "contexts": ["launchplane", "example-site"],
                     "actions": ["product_environment.read"],
                 }
             ]
@@ -7024,6 +7377,26 @@ async def _get_config_status(
         f"/v1/products/{product}/environments/{environment}/config-status",
         headers=headers,
     )
+
+
+async def _get_repo_product_mapping(
+    app: FastAPI,
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(app, "/v1/repo-product-mapping", headers=headers)
+
+
+async def _get_agent_context(
+    app: FastAPI,
+    *,
+    repository: str = "",
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    suffix = f"?{urlencode({'repository': repository})}" if repository else ""
+    return await _asgi_get(app, f"/v1/agent/context{suffix}", headers=headers)
 
 
 async def _get_products(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13241,307 +13241,32 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["reconcile"]["added_count"], 1)
         self.assertEqual(payload["result"]["reconcile"]["items"][0]["action"], "added")
 
-    def test_repo_product_mapping_returns_managed_and_awareness_repos(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": [
-                            "product_environment.read",
-                            "every_code_work_request.write",
-                        ],
-                    }
-                ]
-            }
-        )
+    def test_agent_context_routes_are_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
                 state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-            create_status, _ = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "cbusillo/tooling",
-                    "issue_number": 12,
-                    "issue_url": "https://github.com/cbusillo/tooling/issues/12",
-                    "issue_title": "Support repo follow-up",
-                    "trigger_label": "every-code",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-08T18:00:00Z",
-                },
-                headers={"Idempotency-Key": "every-code-create-tooling-12"},
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/repo-product-mapping",
-            )
-
-        self.assertEqual(create_status, 202)
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["status"], "ok")
-        repositories = payload["mapping"]["repositories"]
-        by_repository = {repository["repository"]: repository for repository in repositories}
-        self.assertEqual(by_repository["every/example-site"]["classification"], "managed_runtime")
-        self.assertEqual(by_repository["every/example-site"]["product"], "example-site")
-        self.assertEqual(by_repository["every/example-site"]["environments"], ["testing", "prod"])
-        self.assertEqual(by_repository["cbusillo/tooling"]["classification"], "active_awareness")
-        self.assertEqual(payload["source"]["product_count"], 1)
-        self.assertEqual(payload["source"]["work_request_count"], 1)
-
-    def test_repo_product_mapping_rejects_unauthorized_identity(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
+                verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
                 control_plane_root_path=Path(temporary_directory_name),
+                local_record_store_for_tests=FilesystemRecordStore(state_dir=state_dir),
             )
-            status_code, payload = _invoke_app(
+
+            mapping_status, mapping_payload = _invoke_app(
                 app,
                 method="GET",
                 path="/v1/repo-product-mapping",
             )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_agent_context_returns_thin_aggregated_read_models(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane", "example-site"],
-                        "contexts": ["launchplane", "example-site"],
-                        "actions": [
-                            "product_environment.read",
-                            "every_code_work_request.write",
-                        ],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            store.write_every_code_preview_gate_record(
-                EveryCodePreviewGateRecord(
-                    gate_id="every-code-preview-gate-every-example-site-190-31",
-                    request_id="every-code-every-example-site-190-test",
-                    repository="every/example-site",
-                    issue_number=190,
-                    issue_url="https://github.com/every/example-site/issues/190",
-                    pr_number=31,
-                    pr_url="https://github.com/every/example-site/pull/31",
-                    head_sha="abcdef1234567890",
-                    status="ready",
-                    created_at="2026-05-08T18:00:00Z",
-                    updated_at="2026-05-08T18:01:00Z",
-                    ready_at="2026-05-08T18:01:00Z",
-                    last_checked_at="2026-05-08T18:01:00Z",
-                )
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-            create_status, _ = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "every/example-site",
-                    "issue_number": 190,
-                    "issue_url": "https://github.com/every/example-site/issues/190",
-                    "issue_title": "Build operator chooser",
-                    "trigger_label": "every-code",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-06T02:00:00Z",
-                },
-                headers={"Idempotency-Key": "every-code-create-agent-context-190"},
-            )
-            status_code, payload = _invoke_app(
+            context_status, context_payload = _invoke_app(
                 app,
                 method="GET",
                 path="/v1/agent/context",
-                query_string="repository=every/example-site",
             )
 
-        self.assertEqual(create_status, 202)
-        self.assertEqual(status_code, 200)
-        context = payload["context"]
-        self.assertEqual(context["schema_version"], 1)
-        self.assertEqual(context["repository"], "every/example-site")
-        sections = context["sections"]
-        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
-        self.assertEqual(sections["work_graph_snapshot"]["status"], "available")
-        self.assertEqual(sections["every_code_summary"]["status"], "available")
-        self.assertEqual(sections["preview_readiness"]["status"], "available")
-        summary = sections["every_code_summary"]["payload"]["summary"]
-        self.assertEqual(summary["repository"], "every/example-site")
-        self.assertEqual(summary["summaries"][0]["issue_number"], 190)
-        readiness = sections["preview_readiness"]["payload"]["readiness"]
-        self.assertEqual(readiness["repository"], "every/example-site")
-        self.assertEqual(readiness["items"][0]["readiness_status"], "ready")
-
-    def test_agent_context_rejects_unauthorized_identity(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            status_code, payload = _invoke_app(app, method="GET", path="/v1/agent/context")
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_terminal_agent_read_token_can_read_agent_context(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "terminal_agents": [
-                    {
-                        "subjects": ["local-owner-agent"],
-                        "token_labels": ["local-owner-read"],
-                        "products": ["launchplane", "example-site"],
-                        "contexts": ["launchplane", "example-site"],
-                        "actions": [
-                            "product_environment.read",
-                            "work_graph.rank",
-                            "every_code_work_request.read",
-                            "every_code_preview_gate.read",
-                        ],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            store.write_every_code_preview_gate_record(
-                EveryCodePreviewGateRecord(
-                    gate_id="every-code-preview-gate-every-example-site-190-abcdef",
-                    request_id="every-code-every-example-site-190-test",
-                    repository="every/example-site",
-                    issue_number=190,
-                    issue_url="https://github.com/every/example-site/issues/190",
-                    pr_number=191,
-                    pr_url="https://github.com/every/example-site/pull/191",
-                    head_sha="abcdef1234567890",
-                    status="ready",
-                    created_at="2026-05-08T18:00:00Z",
-                    updated_at="2026-05-08T18:01:00Z",
-                    ready_at="2026-05-08T18:01:00Z",
-                    last_checked_at="2026-05-08T18:01:00Z",
-                )
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN": "terminal-read-token",
-                    "LAUNCHPLANE_TERMINAL_AGENT_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL": "local-owner-read",
-                },
-                clear=True,
-            ):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/agent/context",
-                    query_string="repository=every/example-site",
-                    authorization="Bearer terminal-read-token",
-                )
-
-        self.assertEqual(status_code, 200)
-        context = payload["context"]
-        self.assertEqual(context["repository"], "every/example-site")
-        sections = context["sections"]
-        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
-        self.assertEqual(sections["work_graph_snapshot"]["status"], "available")
-        self.assertEqual(sections["every_code_summary"]["status"], "available")
-        self.assertEqual(sections["preview_readiness"]["status"], "available")
-
-    def test_agent_context_marks_work_graph_unavailable_without_dropping_sections(
-        self,
-    ) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["product_environment.read"],
-                    }
-                ]
-            }
-        )
-
-        def unavailable_planning_facts() -> tuple[WorkGraphPlanningIssueFacts, ...]:
-            raise RuntimeError("planning provider unavailable")
-
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(
-                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
-                ),
-                authz_policy=policy,
-                control_plane_root_path=Path(temporary_directory_name),
-                work_graph_planning_facts_provider=unavailable_planning_facts,
-            )
-            status_code, payload = _invoke_app(app, method="GET", path="/v1/agent/context")
-
-        self.assertEqual(status_code, 200)
-        sections = payload["context"]["sections"]
-        self.assertEqual(sections["repo_product_mapping"]["status"], "available")
-        self.assertEqual(sections["work_graph_snapshot"]["status"], "unavailable")
-        self.assertEqual(sections["work_graph_snapshot"]["reason_code"], "work_graph_unavailable")
-        self.assertEqual(sections["every_code_summary"]["status"], "available")
+        self.assertEqual(mapping_status, 404)
+        self.assertEqual(context_status, 404)
+        self.assertEqual(mapping_payload["error"]["code"], "not_found")
+        self.assertEqual(context_payload["error"]["code"], "not_found")
 
     def test_create_service_app_requires_database_url_without_explicit_local_test_store(
         self,


### PR DESCRIPTION
## Summary
- move `GET /v1/repo-product-mapping` and `GET /v1/agent/context` to native FastAPI routes
- require Postgres-backed read stores for the new native routes and fail closed for filesystem/missing stores
- delete the retired legacy WSGI repo-product mapping helper and update v2 compatibility docs

Refs #1322

## Validation
- `uv run python -m unittest` (2686 tests)
- `uv run python -m unittest tests.test_http_app.FastApiProductEnvironmentReadTests tests.test_service.LaunchplaneServiceTests.test_agent_context_routes_are_retired_from_legacy_wsgi_app` (25 tests)
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/work_graph_http.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `git diff --check`
- JetBrains changed-files closeout: clean, 0 problems
- Final review agents: green after filesystem-store gate and dead-helper cleanup

## Notes
- Repo-wide `uv run --extra dev ruff format --check .` has an existing unrelated formatting backlog outside this diff; touched-file format check is clean.
