### PR TITLE
Move service runtime reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import secrets as control_plane_secrets
+from control_plane import service_status as control_plane_service_status
 from control_plane.agent_context_service import (
     AgentContextPayload,
     agent_context_action_allowed,
@@ -190,6 +191,64 @@ class HealthResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     storage_backend: str
+
+
+class LaunchplaneRuntimeStatus(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    authz_policy_sha256: str
+    authz_policy_source: str
+    bootstrap_authz_policy_sha256: str
+    docker_image_reference: str
+    service_audience: str
+    storage_backend: str
+
+
+class LaunchplaneRuntimeResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    runtime: LaunchplaneRuntimeStatus
+
+
+class OdooStableOperationLeaseSummaryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    operation_kind: str
+    operation_id: str
+    product: str
+    context: str
+    instance: str
+    status: str
+    phase: str
+    attempt: int
+    lease_owner: str
+    lease_expires_at: str
+    heartbeat_at: str
+    heartbeat_age_seconds: int | None
+    lease_expired: bool
+
+
+class OdooStableOperationWorkerStatusResponseModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: str
+    recorded_at: str
+    pending_count: int
+    running_count: int
+    stalled_count: int
+    terminal_count: int
+    counts_by_kind_status: dict[str, int]
+    operations: tuple[OdooStableOperationLeaseSummaryResponse, ...]
+
+
+class OdooStableOperationWorkerStatusResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    worker_status: OdooStableOperationWorkerStatusResponseModel
 
 
 class ProductEnvironmentConfigStatusResponse(BaseModel):
@@ -970,15 +1029,40 @@ def request_fingerprint(payload: dict[str, object]) -> str:
 
 
 class LaunchplaneAuthzPolicyRuntime:
-    def __init__(self, policy: LaunchplaneAuthzPolicy) -> None:
+    def __init__(
+        self,
+        policy: LaunchplaneAuthzPolicy,
+        *,
+        policy_sha256: str = "",
+        source: str = "bootstrap",
+    ) -> None:
         self._policy = policy
+        self._policy_sha256 = policy_sha256 or authz_policy_sha256(policy)
+        self._source = source.strip() or "bootstrap"
 
     @property
     def policy(self) -> LaunchplaneAuthzPolicy:
         return self._policy
 
-    def update(self, policy: LaunchplaneAuthzPolicy) -> None:
+    @property
+    def policy_sha256(self) -> str:
+        return self._policy_sha256
+
+    @property
+    def source(self) -> str:
+        return self._source
+
+    def update(
+        self,
+        policy: LaunchplaneAuthzPolicy,
+        *,
+        policy_sha256: str = "",
+        source: str = "",
+    ) -> None:
         self._policy = policy
+        self._policy_sha256 = policy_sha256 or authz_policy_sha256(policy)
+        if source.strip():
+            self._source = source.strip()
 
 
 class ResolvedLaunchplaneAuthzPolicy(BaseModel):
@@ -1203,6 +1287,78 @@ def create_launchplane_fastapi_app(
         if not isinstance(oidc_identity, GitHubActionsIdentity):
             raise _authentication_required_error("Mutation routes require GitHub Actions OIDC.")
         return oidc_identity
+
+    def require_launchplane_service_read_authorization(
+        *, identity: LaunchplaneIdentity, trace_id: str
+    ) -> None:
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="launchplane_service.read",
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read Launchplane service runtime state.",
+            )
+
+    def read_launchplane_runtime(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> LaunchplaneRuntimeResponse:
+        trace_id = next_trace_id()
+        require_launchplane_service_read_authorization(identity=identity, trace_id=trace_id)
+        runtime = LaunchplaneRuntimeStatus.model_validate(
+            control_plane_service_status.launchplane_runtime_payload(
+                storage_backend=storage_backend_name(record_store),
+                authz_policy_sha256_value=resolved_authz_policy_runtime.policy_sha256,
+                authz_policy_source=resolved_authz_policy_runtime.source,
+            )
+        )
+        return LaunchplaneRuntimeResponse(trace_id=trace_id, runtime=runtime)
+
+    def read_odoo_stable_operation_worker_status(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        recent_terminal_limit: Annotated[str, Query()] = "10",
+    ) -> OdooStableOperationWorkerStatusResponse:
+        trace_id = next_trace_id()
+        require_launchplane_service_read_authorization(identity=identity, trace_id=trace_id)
+        try:
+            parsed_recent_terminal_limit = control_plane_service_status.query_int_value(
+                recent_terminal_limit,
+                "recent_terminal_limit",
+                default=10,
+                minimum=0,
+                maximum=100,
+            )
+            assert parsed_recent_terminal_limit is not None
+            worker_status = OdooStableOperationWorkerStatusResponseModel.model_validate(
+                control_plane_service_status.odoo_stable_operation_worker_status_payload(
+                    record_store=record_store,
+                    recent_terminal_limit=parsed_recent_terminal_limit,
+                )
+            )
+        except click.ClickException as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="operation_record_storage_required",
+                message=str(error),
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        return OdooStableOperationWorkerStatusResponse(
+            trace_id=trace_id,
+            worker_status=worker_status,
+        )
 
     def read_product_environment_config_status(
         product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -3017,6 +3173,34 @@ def create_launchplane_fastapi_app(
         response_model=HealthResponse,
         operation_id="read_launchplane_health",
         summary="Read Launchplane service health",
+    )
+
+    app.add_api_route(
+        "/v1/service/runtime",
+        read_launchplane_runtime,
+        methods=["GET"],
+        response_model=LaunchplaneRuntimeResponse,
+        operation_id="read_launchplane_runtime",
+        summary="Read Launchplane service runtime",
+        responses={
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/service/odoo-workers/status",
+        read_odoo_stable_operation_worker_status,
+        methods=["GET"],
+        response_model=OdooStableOperationWorkerStatusResponse,
+        operation_id="read_odoo_stable_operation_worker_status",
+        summary="Read Odoo stable operation worker status",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import base64
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import hashlib
 import json
@@ -28,6 +27,7 @@ from control_plane.dokploy_target_inspect import (
 )
 from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
+from control_plane import service_status as control_plane_service_status
 from control_plane.http_app import (
     LaunchplaneAuthzPolicyRuntime,
     create_launchplane_fastapi_app,
@@ -320,7 +320,7 @@ from control_plane.service_human_auth import (
     build_pkce_verifier,
     load_github_oauth_config_from_env,
 )
-from control_plane.storage.factory import build_shared_record_store, storage_backend_name
+from control_plane.storage.factory import build_shared_record_store
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.tracked_target_logs import build_tracked_target_logs_payload
 from control_plane.ui_static_http import serve_ui_route
@@ -371,7 +371,6 @@ from control_plane.workflows.ingress_provider import (
     default_ingress_provider,
 )
 from control_plane.workflows.launchplane_self_deploy import (
-    LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY,
     LaunchplaneSelfDeployRequest,
     execute_launchplane_self_deploy,
 )
@@ -494,8 +493,6 @@ from control_plane.workflows.odoo_stable_target_replacement import (
 )
 from control_plane.workflows.odoo_stable_operation_worker import (
     DEFAULT_ODOO_STABLE_WORKER_MAX_ATTEMPTS,
-    OdooStableOperationWorkerStore,
-    build_odoo_stable_operation_worker_status,
     reconcile_stale_odoo_stable_operation_records,
 )
 from control_plane.workflows.verireel_stable_deploy import (
@@ -4509,10 +4506,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[5] == "logs"
     ):
         return "target_logs.read", {"context": segments[2], "instance": segments[4]}
-    if len(segments) == 3 and segments == ["v1", "service", "runtime"]:
-        return "launchplane_service.read", {}
-    if len(segments) == 4 and segments == ["v1", "service", "odoo-workers", "status"]:
-        return "launchplane_service.read", {"odoo_worker_status": "true"}
     if len(segments) == 4 and segments == ["v1", "ingress", "route-audits", "records"]:
         return "ingress_route.plan", {"ingress_route_audit_list": "true"}
     if len(segments) == 5 and segments[:4] == ["v1", "ingress", "route-audits", "records"]:
@@ -6939,28 +6932,6 @@ def _odoo_stable_target_replacement_operation_store(
         return cast(_OdooStableTargetReplacementOperationStore, record_store)
     raise click.ClickException(
         "Odoo stable target replacement operations require Launchplane operation-record storage."
-    )
-
-
-def _odoo_stable_operation_worker_store(
-    record_store: object,
-) -> OdooStableOperationWorkerStore:
-    required_methods = (
-        "list_odoo_stable_bootstrap_operation_records",
-        "claim_next_odoo_stable_bootstrap_operation_record",
-        "heartbeat_odoo_stable_bootstrap_operation_record",
-        "complete_odoo_stable_bootstrap_operation_record",
-        "recover_expired_odoo_stable_bootstrap_operation_records",
-        "list_odoo_stable_target_replacement_operation_records",
-        "claim_next_odoo_stable_target_replacement_operation_record",
-        "heartbeat_odoo_stable_target_replacement_operation_record",
-        "complete_odoo_stable_target_replacement_operation_record",
-        "recover_expired_odoo_stable_target_replacement_operation_records",
-    )
-    if all(hasattr(record_store, method_name) for method_name in required_methods):
-        return cast(OdooStableOperationWorkerStore, record_store)
-    raise click.ClickException(
-        "Odoo stable operation worker status requires Launchplane operation-record storage."
     )
 
 
@@ -9417,41 +9388,6 @@ def _resolve_authz_policy(
     )
 
 
-def _launchplane_policy_sha256_from_env() -> str:
-    policy_toml = os.environ.get("LAUNCHPLANE_POLICY_TOML", "").strip()
-    if policy_toml:
-        return hashlib.sha256(policy_toml.encode("utf-8")).hexdigest()
-
-    policy_b64 = os.environ.get("LAUNCHPLANE_POLICY_B64", "").strip()
-    if policy_b64:
-        try:
-            policy_bytes = base64.b64decode(policy_b64, validate=True)
-        except Exception:
-            return ""
-        return hashlib.sha256(policy_bytes).hexdigest()
-
-    policy_file = os.environ.get("LAUNCHPLANE_POLICY_FILE", "").strip()
-    if not policy_file:
-        return ""
-    try:
-        return hashlib.sha256(Path(policy_file).read_bytes()).hexdigest()
-    except OSError:
-        return ""
-
-
-def _launchplane_runtime_payload(
-    *, storage_backend: str, authz_policy_sha256_value: str, authz_policy_source: str
-) -> dict[str, object]:
-    return {
-        "authz_policy_sha256": authz_policy_sha256_value,
-        "authz_policy_source": authz_policy_source,
-        "bootstrap_authz_policy_sha256": _launchplane_policy_sha256_from_env(),
-        "docker_image_reference": os.environ.get(LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY, "").strip(),
-        "service_audience": os.environ.get("LAUNCHPLANE_SERVICE_AUDIENCE", "").strip(),
-        "storage_backend": storage_backend,
-    }
-
-
 def _latest_preview_inventory_scan(
     *, record_store: object, context_name: str
 ) -> PreviewInventoryScanRecord | None:
@@ -9948,14 +9884,19 @@ def create_launchplane_service_app(
         or local_record_store_for_tests
         or build_shared_record_store(database_url=database_url),
     )
-    storage_backend = storage_backend_name(record_store)
     authz_policy, resolved_authz_policy_sha256, resolved_authz_policy_source = (
         _resolve_authz_policy(record_store=record_store, bootstrap_policy=authz_policy)
     )
     resolved_authz_policy_runtime = authz_policy_runtime or LaunchplaneAuthzPolicyRuntime(
-        authz_policy
+        authz_policy,
+        policy_sha256=resolved_authz_policy_sha256,
+        source=resolved_authz_policy_source,
     )
-    resolved_authz_policy_runtime.update(authz_policy)
+    resolved_authz_policy_runtime.update(
+        authz_policy,
+        policy_sha256=resolved_authz_policy_sha256,
+        source=resolved_authz_policy_source,
+    )
     resolved_github_oauth_config = github_oauth_config or load_github_oauth_config_from_env()
     session_store = (
         human_session_store
@@ -10963,87 +10904,6 @@ def create_launchplane_service_app(
                             **log_payload,
                         },
                     )
-                if action == "launchplane_service.read":
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read Launchplane service runtime state.",
-                                },
-                            },
-                        )
-                    if params.get("odoo_worker_status") == "true":
-                        try:
-                            recent_terminal_limit = _query_int_value(
-                                query,
-                                "recent_terminal_limit",
-                                default=10,
-                                minimum=0,
-                                maximum=100,
-                            )
-                            assert recent_terminal_limit is not None
-                            worker_status = build_odoo_stable_operation_worker_status(
-                                record_store=_odoo_stable_operation_worker_store(record_store),
-                                recent_terminal_limit=recent_terminal_limit,
-                            )
-                        except click.ClickException as error:
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=503,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "operation_record_storage_required",
-                                        "message": str(error),
-                                    },
-                                },
-                            )
-                        except ValueError as error:
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=400,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "invalid_query",
-                                        "message": str(error),
-                                    },
-                                },
-                            )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "worker_status": asdict(worker_status),
-                            },
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "runtime": _launchplane_runtime_payload(
-                                storage_backend=storage_backend,
-                                authz_policy_sha256_value=resolved_authz_policy_sha256,
-                                authz_policy_source=resolved_authz_policy_source,
-                            ),
-                        },
-                    )
                 if action == "every_code_work_request.read":
                     if not authz_policy.allows(
                         identity=identity,
@@ -11343,7 +11203,9 @@ def create_launchplane_service_app(
                     )
                     assert max_attempts is not None
                     odoo_worker_reconcile_result = reconcile_stale_odoo_stable_operation_records(
-                        record_store=_odoo_stable_operation_worker_store(record_store),
+                        record_store=control_plane_service_status.require_odoo_stable_operation_worker_store(
+                            record_store
+                        ),
                         max_attempts=max_attempts,
                     )
                 except click.ClickException as error:
@@ -13499,7 +13361,11 @@ def create_launchplane_service_app(
                     )
                 if authz_grant_request.mode == "apply":
                     authz_policy = updated_policy
-                    resolved_authz_policy_runtime.update(updated_policy)
+                    resolved_authz_policy_runtime.update(
+                        updated_policy,
+                        policy_sha256=authz_policy_record.policy_sha256,
+                        source="db",
+                    )
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -13618,7 +13484,11 @@ def create_launchplane_service_app(
                     )
                 if authz_removal_request.mode == "apply":
                     authz_policy = updated_policy
-                    resolved_authz_policy_runtime.update(updated_policy)
+                    resolved_authz_policy_runtime.update(
+                        updated_policy,
+                        policy_sha256=authz_policy_record.policy_sha256,
+                        source="db",
+                    )
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -13737,7 +13607,11 @@ def create_launchplane_service_app(
                     )
                 if human_authz_grant_request.mode == "apply":
                     authz_policy = updated_policy
-                    resolved_authz_policy_runtime.update(updated_policy)
+                    resolved_authz_policy_runtime.update(
+                        updated_policy,
+                        policy_sha256=authz_policy_record.policy_sha256,
+                        source="db",
+                    )
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -13856,7 +13730,11 @@ def create_launchplane_service_app(
                     )
                 if terminal_authz_grant_request.mode == "apply":
                     authz_policy = updated_policy
-                    resolved_authz_policy_runtime.update(updated_policy)
+                    resolved_authz_policy_runtime.update(
+                        updated_policy,
+                        policy_sha256=authz_policy_record.policy_sha256,
+                        source="db",
+                    )
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -13953,7 +13831,11 @@ def create_launchplane_service_app(
                     )
                 if local_operator_grant_request.mode == "apply":
                     authz_policy = updated_policy
-                    resolved_authz_policy_runtime.update(updated_policy)
+                    resolved_authz_policy_runtime.update(
+                        updated_policy,
+                        policy_sha256=authz_policy_record.policy_sha256,
+                        source="db",
+                    )
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -14050,7 +13932,11 @@ def create_launchplane_service_app(
                     )
                 if local_admin_grant_request.mode == "apply":
                     authz_policy = updated_policy
-                    resolved_authz_policy_runtime.update(updated_policy)
+                    resolved_authz_policy_runtime.update(
+                        updated_policy,
+                        policy_sha256=authz_policy_record.policy_sha256,
+                        source="db",
+                    )
                     resolved_authz_policy_sha256 = authz_policy_record.policy_sha256
                     resolved_authz_policy_source = "db"
                 result, driver_result = (
@@ -15726,7 +15612,11 @@ def serve_launchplane_service(
         policy_source=_bootstrap_policy_source_from_env(),
         now_timestamp=_now_timestamp(),
     )
-    authz_policy_runtime = LaunchplaneAuthzPolicyRuntime(resolved_fastapi_policy.policy)
+    authz_policy_runtime = LaunchplaneAuthzPolicyRuntime(
+        resolved_fastapi_policy.policy,
+        policy_sha256=resolved_fastapi_policy.policy_sha256,
+        source=resolved_fastapi_policy.source,
+    )
     work_graph_project_config = load_github_project_planning_facts_config_from_env(dict(os.environ))
     work_graph_planning_facts_provider = (
         (lambda: build_github_project_planning_facts(work_graph_project_config))

--- a/control_plane/service_status.py
+++ b/control_plane/service_status.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import cast
+
+import click
+
+from control_plane.workflows.launchplane_self_deploy import LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY
+from control_plane.workflows.odoo_stable_operation_worker import (
+    OdooStableOperationWorkerStore,
+    build_odoo_stable_operation_worker_status,
+)
+
+
+def launchplane_policy_sha256_from_env() -> str:
+    policy_toml = os.environ.get("LAUNCHPLANE_POLICY_TOML", "").strip()
+    if policy_toml:
+        return hashlib.sha256(policy_toml.encode("utf-8")).hexdigest()
+
+    policy_b64 = os.environ.get("LAUNCHPLANE_POLICY_B64", "").strip()
+    if policy_b64:
+        try:
+            policy_bytes = base64.b64decode(policy_b64, validate=True)
+        except Exception:
+            return ""
+        return hashlib.sha256(policy_bytes).hexdigest()
+
+    policy_file = os.environ.get("LAUNCHPLANE_POLICY_FILE", "").strip()
+    if not policy_file:
+        return ""
+    try:
+        return hashlib.sha256(Path(policy_file).read_bytes()).hexdigest()
+    except OSError:
+        return ""
+
+
+def launchplane_runtime_payload(
+    *, storage_backend: str, authz_policy_sha256_value: str, authz_policy_source: str
+) -> dict[str, object]:
+    return {
+        "authz_policy_sha256": authz_policy_sha256_value,
+        "authz_policy_source": authz_policy_source,
+        "bootstrap_authz_policy_sha256": launchplane_policy_sha256_from_env(),
+        "docker_image_reference": os.environ.get(LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY, "").strip(),
+        "service_audience": os.environ.get("LAUNCHPLANE_SERVICE_AUDIENCE", "").strip(),
+        "storage_backend": storage_backend,
+    }
+
+
+def require_odoo_stable_operation_worker_store(
+    record_store: object,
+) -> OdooStableOperationWorkerStore:
+    required_methods = (
+        "list_odoo_stable_bootstrap_operation_records",
+        "claim_next_odoo_stable_bootstrap_operation_record",
+        "heartbeat_odoo_stable_bootstrap_operation_record",
+        "complete_odoo_stable_bootstrap_operation_record",
+        "recover_expired_odoo_stable_bootstrap_operation_records",
+        "list_odoo_stable_target_replacement_operation_records",
+        "claim_next_odoo_stable_target_replacement_operation_record",
+        "heartbeat_odoo_stable_target_replacement_operation_record",
+        "complete_odoo_stable_target_replacement_operation_record",
+        "recover_expired_odoo_stable_target_replacement_operation_records",
+    )
+    if all(callable(getattr(record_store, method_name, None)) for method_name in required_methods):
+        return cast(OdooStableOperationWorkerStore, record_store)
+    raise click.ClickException(
+        "Odoo stable operation worker status requires Launchplane operation-record storage."
+    )
+
+
+def odoo_stable_operation_worker_status_payload(
+    *,
+    record_store: object,
+    recent_terminal_limit: int,
+) -> dict[str, object]:
+    worker_status = build_odoo_stable_operation_worker_status(
+        record_store=require_odoo_stable_operation_worker_store(record_store),
+        recent_terminal_limit=recent_terminal_limit,
+    )
+    return asdict(worker_status)
+
+
+def query_int_value(
+    raw_value: str,
+    key: str,
+    *,
+    default: int | None = None,
+    minimum: int | None = None,
+    maximum: int | None = None,
+) -> int | None:
+    if not raw_value.strip():
+        value = default
+    else:
+        value = int(raw_value.strip())
+    if value is None:
+        return None
+    if minimum is not None and value < minimum:
+        raise ValueError(f"Query parameter {key} must be at least {minimum}")
+    if maximum is not None and value > maximum:
+        raise ValueError(f"Query parameter {key} must be at most {maximum}")
+    return value

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -56,6 +56,10 @@ Keep a compatibility surface only when it is one of these:
 - The Launchplane health read uses the native FastAPI `GET /v1/health` route.
   Its legacy WSGI branch is deleted; direct fallback calls fail closed while
   the mounted fallback remains for retained non-native routes.
+- Launchplane service runtime and Odoo worker status reads use native FastAPI
+  routes for bearer-token and human-session callers. Their legacy WSGI branch is
+  deleted; direct fallback calls fail closed while the mounted fallback remains
+  for retained non-native routes.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -41,6 +41,12 @@ VeriReel product paths:
 - native FastAPI health route: `GET /v1/health`, backed by a Pydantic response
   model, included in OpenAPI as the first v2 contract proof, and retired from
   the legacy WSGI fallback
+- native FastAPI Launchplane service runtime reads:
+  - `GET /v1/service/runtime`, requiring `launchplane_service.read` for the
+    Launchplane service context and returning runtime metadata only
+  - `GET /v1/service/odoo-workers/status`, requiring
+    `launchplane_service.read` for the Launchplane service context and returning
+    Odoo operation worker queue counters without request payloads
 - native FastAPI protected artifact inventory route:
   - `GET /v1/artifacts/protected`, requiring `artifact_protection.read` for
     the requested product and either the requested context or whole-product
@@ -1295,6 +1301,10 @@ only after a passing plan and a matching stored preview record are present.
   human-session callers)
 - `GET /v1/product-profiles/{product}/context-cutover-audit` (native FastAPI
   for bearer-token and human-session callers)
+- `GET /v1/service/runtime` (native FastAPI for bearer-token and human-session
+  callers)
+- `GET /v1/service/odoo-workers/status` (native FastAPI for bearer-token and
+  human-session callers)
 
 These operator reads use the same Launchplane authn/authz boundary as evidence
 ingress. The intent is to give operators a minimal typed read surface for the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -1,3 +1,5 @@
+import base64
+import hashlib
 import json
 import unittest
 from dataclasses import dataclass
@@ -5,7 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from collections.abc import Callable, MutableMapping
-from typing import Any, cast
+from typing import Any, Literal, cast
 from urllib.parse import urlencode
 from unittest.mock import patch
 
@@ -25,6 +27,9 @@ from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+)
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationState,
@@ -55,7 +60,7 @@ from control_plane.contracts.runner_lane_registration import (
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
-from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.http_app import LaunchplaneAuthzPolicyRuntime, create_launchplane_fastapi_app
 from control_plane.service_auth import (
     BearerIdentityConfig,
     GitHubHumanIdentity,
@@ -70,6 +75,7 @@ from control_plane.service_human_auth import (
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.workflows.launchplane_self_deploy import LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY
 from tests.test_service import create_launchplane_service_app
 from tests.test_service import (
     _generic_site_profile_payload,
@@ -125,6 +131,261 @@ class FastApiHealthContractTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("launchplane_req_00000000000000000000000000000000", example_text)
         self.assertNotIn("example-site", example_text)
         self.assertNotIn("shinycomputers", example_text)
+
+
+class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runtime_reports_current_image_and_policy_metadata(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy = _local_operator_launchplane_service_read_policy()
+            policy_text = "schema_version = 1\n"
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            authz_policy_runtime = LaunchplaneAuthzPolicyRuntime(
+                policy,
+                policy_sha256="resolved-policy-sha256",
+                source="db",
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                authz_policy_runtime=authz_policy_runtime,
+                record_store_factory=lambda: record_store,
+                bearer_identity_config=_local_operator_bearer_config(),
+            )
+            with patch.dict(
+                "os.environ",
+                {
+                    LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY: "ghcr.io/example/launchplane@sha256:test",
+                    "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane.example.com",
+                    "LAUNCHPLANE_POLICY_B64": base64.b64encode(policy_text.encode("utf-8")).decode(
+                        "ascii"
+                    ),
+                },
+                clear=True,
+            ):
+                response = await _asgi_get(
+                    app,
+                    "/v1/service/runtime",
+                    headers={"Authorization": "Bearer local-operator-token"},
+                )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        runtime = payload["runtime"]
+        self.assertEqual(runtime["storage_backend"], "filesystem")
+        self.assertEqual(
+            runtime["docker_image_reference"],
+            "ghcr.io/example/launchplane@sha256:test",
+        )
+        self.assertEqual(runtime["service_audience"], "launchplane.example.com")
+        self.assertEqual(runtime["authz_policy_sha256"], "resolved-policy-sha256")
+        self.assertEqual(runtime["authz_policy_source"], "db")
+        self.assertEqual(
+            runtime["bootstrap_authz_policy_sha256"],
+            hashlib.sha256(policy_text.encode("utf-8")).hexdigest(),
+        )
+
+    async def test_worker_status_reports_queue_status(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_odoo_stable_bootstrap_operation_record(
+                _pending_odoo_stable_bootstrap_record()
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_local_operator_launchplane_service_read_policy(),
+                record_store_factory=lambda: record_store,
+                bearer_identity_config=_local_operator_bearer_config(),
+            )
+
+            response = await _asgi_get(
+                app,
+                "/v1/service/odoo-workers/status",
+                headers={"Authorization": "Bearer local-operator-token"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        worker_status = payload["worker_status"]
+        self.assertEqual(worker_status["status"], "ok")
+        self.assertEqual(worker_status["pending_count"], 1)
+        self.assertEqual(worker_status["running_count"], 0)
+        self.assertEqual(worker_status["operations"][0]["operation_id"], "bootstrap-cm-testing")
+        self.assertNotIn("request", worker_status["operations"][0])
+
+    async def test_worker_status_requires_service_read_authz(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_driver_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=_local_operator_bearer_config(),
+        )
+
+        response = await _asgi_get(
+            app,
+            "/v1/service/odoo-workers/status",
+            headers={"Authorization": "Bearer local-operator-token"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_service_runtime_routes_require_authentication(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=_local_operator_bearer_config(),
+        )
+
+        runtime_response = await _asgi_get(app, "/v1/service/runtime")
+        worker_response = await _asgi_get(app, "/v1/service/odoo-workers/status")
+
+        self.assertEqual(runtime_response.status_code, 401)
+        self.assertEqual(worker_response.status_code, 401)
+        self.assertEqual(runtime_response.json()["error"]["code"], "authentication_required")
+        self.assertEqual(worker_response.json()["error"]["code"], "authentication_required")
+
+    async def test_runtime_rejects_human_session_without_service_read_authz(self) -> None:
+        oauth_config = _github_oauth_config()
+        session_store = InMemoryHumanSessionStore()
+        session_manager = HumanSessionManager(config=oauth_config, session_store=session_store)
+        human_session = session_manager.issue(_github_human_identity(role="read_only"))
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["example-operator"],
+                            "roles": ["read_only"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["driver.read"],
+                        }
+                    ]
+                }
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+
+        response = await _asgi_get(
+            app,
+            "/v1/service/runtime",
+            headers={"Cookie": session_manager.session_cookie_header(human_session)},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_worker_status_validates_recent_terminal_limit(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_local_operator_launchplane_service_read_policy(),
+                record_store_factory=lambda: record_store,
+                bearer_identity_config=_local_operator_bearer_config(),
+            )
+
+            response = await _asgi_get(
+                app,
+                "/v1/service/odoo-workers/status?recent_terminal_limit=101",
+                headers={"Authorization": "Bearer local-operator-token"},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_query")
+
+    async def test_worker_status_requires_operation_record_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _EmptyStore(),
+            bearer_identity_config=_local_operator_bearer_config(),
+        )
+
+        response = await _asgi_get(
+            app,
+            "/v1/service/odoo-workers/status",
+            headers={"Authorization": "Bearer local-operator-token"},
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "operation_record_storage_required")
+
+    async def test_openapi_includes_service_runtime_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=_local_operator_bearer_config(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        runtime_route = openapi["paths"]["/v1/service/runtime"]["get"]
+        worker_route = openapi["paths"]["/v1/service/odoo-workers/status"]["get"]
+        self.assertEqual(runtime_route["operationId"], "read_launchplane_runtime")
+        self.assertEqual(
+            runtime_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/LaunchplaneRuntimeResponse",
+        )
+        self.assertEqual(
+            worker_route["operationId"],
+            "read_odoo_stable_operation_worker_status",
+        )
+        self.assertEqual(
+            worker_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/OdooStableOperationWorkerStatusResponse",
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["LaunchplaneRuntimeResponse"]["additionalProperties"],
+            False,
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["OdooStableOperationWorkerStatusResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+        self.assertTrue(set(runtime_route["responses"]) >= {"200", "401", "403"})
+        self.assertTrue(set(worker_route["responses"]) >= {"200", "400", "401", "403", "503"})
+
+    async def test_fastapi_service_runtime_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_local_operator_launchplane_service_read_policy(),
+                record_store_factory=lambda: record_store,
+                bearer_identity_config=_local_operator_bearer_config(),
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+                local_record_store_for_tests=record_store,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _asgi_get(
+                app,
+                "/v1/service/runtime",
+                headers={"Authorization": "Bearer local-operator-token"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
 
 
 class FastApiDeploymentEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
@@ -7252,6 +7513,46 @@ def _local_operator_product_environment_read_policy(*, context: str) -> Launchpl
     )
 
 
+def _local_operator_launchplane_service_read_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "local_operators": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["launchplane_service.read"],
+                }
+            ]
+        }
+    )
+
+
+def _pending_odoo_stable_bootstrap_record() -> OdooStableBootstrapOperationRecord:
+    return OdooStableBootstrapOperationRecord.model_validate(
+        {
+            "operation_id": "bootstrap-cm-testing",
+            "product": "odoo-tenant-cm",
+            "context": "cm",
+            "instance": "testing",
+            "idempotency_key": "bootstrap-cm-testing",
+            "request_fingerprint": "fingerprint-123",
+            "request": {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm",
+                "context": "cm",
+                "instance": "testing",
+                "confirmation": "bootstrap cm testing",
+            },
+            "status": "pending",
+            "phase": "created",
+            "created_at": "2026-05-17T00:00:00Z",
+            "updated_at": "2026-05-17T00:00:00Z",
+        }
+    )
+
+
 def _terminal_agent_product_environment_read_policy(*, context: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -7334,7 +7635,7 @@ def _github_oauth_config() -> GitHubOAuthConfig:
     )
 
 
-def _github_human_identity() -> GitHubHumanIdentity:
+def _github_human_identity(*, role: Literal["read_only", "admin"] = "admin") -> GitHubHumanIdentity:
     return GitHubHumanIdentity(
         login="example-operator",
         github_id=123,
@@ -7342,7 +7643,7 @@ def _github_human_identity() -> GitHubHumanIdentity:
         email="operator@example.com",
         organizations=frozenset({"example-org"}),
         teams=frozenset({"example-org/launchplane-operators"}),
-        role="admin",
+        role=role,
     )
 
 
@@ -7962,6 +8263,13 @@ class _CaseInsensitiveHeaders(dict[str, str]):
 
 class _MissingProductReadStore:
     pass
+
+
+class _EmptyStore:
+    backend_name = "test-empty"
+
+    def close(self) -> None:
+        return None
 
 
 class _SecretStatusProbeStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -26,10 +26,6 @@ from control_plane import live_target_runtime as control_plane_live_target_runti
 from control_plane import secrets as control_plane_secrets
 from control_plane import service as control_plane_service
 from control_plane.notifications import public_discord_url_error, public_url_error
-from control_plane.contracts.authz_policy_record import (
-    LaunchplaneAuthzPolicyRecord,
-    authz_policy_sha256,
-)
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_notifications import (
@@ -2331,41 +2327,6 @@ class GitHubHumanAuthTests(unittest.TestCase):
 
         self.assertEqual(status_code, 200)
         self.assertEqual(payload["identity"]["login"], "alice")
-
-    def test_read_only_human_session_rejects_runtime_read(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_humans": [
-                    {
-                        "logins": ["alice"],
-                        "roles": ["read_only"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["driver.read"],
-                    }
-                ]
-            }
-        )
-        oauth_client = _StubGitHubOAuthClient(_human_identity())
-        with TemporaryDirectory() as tmpdir:
-            app = create_launchplane_service_app(
-                state_dir=Path(tmpdir),
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                github_oauth_config=_github_oauth_config(),
-                github_oauth_client=oauth_client,
-            )
-            cookie = self._signed_in_cookie(app)
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/service/runtime",
-                authorization="",
-                headers={"Cookie": cookie},
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_human_session_does_not_authorize_post_mutations(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
@@ -13298,6 +13259,35 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 404)
             self.assertEqual(payload["error"]["code"], "not_found")
 
+    def test_service_runtime_routes_are_retired_from_legacy_wsgi_app(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+                local_record_store_for_tests=FilesystemRecordStore(state_dir=state_dir),
+            )
+
+            runtime_status, runtime_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/service/runtime",
+                authorization="",
+            )
+            worker_status, worker_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/service/odoo-workers/status",
+                authorization="",
+            )
+
+        self.assertEqual(runtime_status, 404)
+        self.assertEqual(worker_status, 404)
+        self.assertEqual(runtime_payload["error"]["code"], "not_found")
+        self.assertEqual(worker_payload["error"]["code"], "not_found")
+
     def test_service_serve_rejects_missing_database_url(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
@@ -13483,247 +13473,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(
             authorized_config_response.json()["config_status"]["product"], "example-site"
         )
-
-    def test_service_runtime_endpoint_reports_current_image_reference(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "workflow_refs": [
-                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["launchplane"],
-                            "contexts": ["launchplane"],
-                            "actions": ["launchplane_service.read"],
-                        }
-                    ]
-                }
-            )
-            policy_text = "schema_version = 1\n"
-            with patch.dict(
-                os.environ,
-                {
-                    "DOCKER_IMAGE_REFERENCE": "ghcr.io/cbusillo/launchplane@sha256:test",
-                    "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane.shinycomputers.com",
-                    "LAUNCHPLANE_POLICY_B64": base64.b64encode(policy_text.encode("utf-8")).decode(
-                        "ascii"
-                    ),
-                },
-                clear=True,
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=Path(temporary_directory_name) / "state",
-                    verifier=_StubVerifier(
-                        _identity(
-                            repository="cbusillo/launchplane",
-                            workflow_ref=(
-                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                            ),
-                            event_name="workflow_dispatch",
-                        )
-                    ),
-                    authz_policy=policy,
-                    control_plane_root_path=Path(temporary_directory_name),
-                )
-
-                status_code, payload = _invoke_app(app, method="GET", path="/v1/service/runtime")
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["status"], "ok")
-        self.assertEqual(
-            payload["runtime"]["docker_image_reference"],
-            "ghcr.io/cbusillo/launchplane@sha256:test",
-        )
-        self.assertEqual(
-            payload["runtime"]["authz_policy_sha256"],
-            authz_policy_sha256(policy),
-        )
-        self.assertEqual(payload["runtime"]["authz_policy_source"], "bootstrap_seeded_store")
-        self.assertEqual(
-            payload["runtime"]["bootstrap_authz_policy_sha256"],
-            hashlib.sha256(policy_text.encode("utf-8")).hexdigest(),
-        )
-        self.assertEqual(payload["runtime"]["service_audience"], "launchplane.shinycomputers.com")
-
-    def test_service_odoo_workers_status_endpoint_reports_queue_status(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            record_store = FilesystemRecordStore(state_dir)
-            record_store.write_odoo_stable_bootstrap_operation_record(
-                OdooStableBootstrapOperationRecord.model_validate(
-                    {
-                        "operation_id": "bootstrap-cm-testing",
-                        "product": "odoo-tenant-cm",
-                        "context": "cm",
-                        "instance": "testing",
-                        "idempotency_key": "bootstrap-cm-testing",
-                        "request_fingerprint": "fingerprint-123",
-                        "request": {
-                            "schema_version": 1,
-                            "product": "odoo-tenant-cm",
-                            "context": "cm",
-                            "instance": "testing",
-                            "confirmation": "bootstrap cm testing",
-                        },
-                        "status": "pending",
-                        "phase": "created",
-                        "created_at": "2026-05-17T00:00:00Z",
-                        "updated_at": "2026-05-17T00:00:00Z",
-                    }
-                )
-            )
-            policy = _local_operator_policy(
-                actions=("launchplane_service.read",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=state_dir,
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=record_store,
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/service/odoo-workers/status",
-                    authorization="Bearer local-operator-token",
-                )
-
-        self.assertEqual(status_code, 200)
-        worker_status = payload["worker_status"]
-        self.assertEqual(payload["status"], "ok")
-        self.assertEqual(worker_status["status"], "ok")
-        self.assertEqual(worker_status["pending_count"], 1)
-        self.assertEqual(worker_status["running_count"], 0)
-        self.assertEqual(worker_status["operations"][0]["operation_id"], "bootstrap-cm-testing")
-        self.assertNotIn("request", worker_status["operations"][0])
-
-    def test_service_odoo_workers_status_endpoint_requires_service_read_authz(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            policy = _local_operator_policy(
-                actions=("driver.read",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=state_dir,
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=FilesystemRecordStore(state_dir),
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/service/odoo-workers/status",
-                    authorization="Bearer local-operator-token",
-                )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_service_odoo_workers_status_endpoint_validates_recent_terminal_limit(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            policy = _local_operator_policy(
-                actions=("launchplane_service.read",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=state_dir,
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=FilesystemRecordStore(state_dir),
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/service/odoo-workers/status",
-                    query_string="recent_terminal_limit=101",
-                    authorization="Bearer local-operator-token",
-                )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_query")
-
-    def test_service_odoo_workers_status_endpoint_requires_operation_record_storage(
-        self,
-    ) -> None:
-        class _EmptyStore:
-            backend_name = "test-empty"
-
-            def close(self) -> None:
-                return None
-
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            policy = _local_operator_policy(
-                actions=("launchplane_service.read",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=state_dir,
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=cast(Any, _EmptyStore()),
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/service/odoo-workers/status",
-                    authorization="Bearer local-operator-token",
-                )
-
-        self.assertEqual(status_code, 503)
-        self.assertEqual(payload["error"]["code"], "operation_record_storage_required")
 
     def test_service_odoo_workers_reconcile_endpoint_recovers_stale_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -13918,62 +13667,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 503)
         self.assertEqual(payload["error"]["code"], "operation_record_storage_required")
-
-    def test_service_uses_db_backed_authz_policy_when_present(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            database_url = (
-                f"sqlite+pysqlite:///{Path(temporary_directory_name) / 'launchplane.sqlite3'}"
-            )
-            db_policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "workflow_refs": [
-                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["launchplane"],
-                            "contexts": ["launchplane"],
-                            "actions": ["launchplane_service.read"],
-                        }
-                    ]
-                }
-            )
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            store.write_authz_policy_record(
-                LaunchplaneAuthzPolicyRecord(
-                    record_id="launchplane-authz-policy-test",
-                    status="active",
-                    source="test",
-                    updated_at="2026-04-20T10:05:00Z",
-                    policy=db_policy,
-                )
-            )
-            store.close()
-
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
-                database_url=database_url,
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-
-            status_code, payload = _invoke_app(app, method="GET", path="/v1/service/runtime")
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["runtime"]["authz_policy_sha256"], authz_policy_sha256(db_policy))
-        self.assertEqual(payload["runtime"]["authz_policy_source"], "db")
 
     def test_ui_route_serves_static_shell_without_authentication(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- Move `GET /v1/service/runtime` and `GET /v1/service/odoo-workers/status` onto native FastAPI routes with Pydantic response models and OpenAPI contracts.
- Share runtime/worker-status payload helpers through `control_plane.service_status`, including live authz policy digest/source metadata.
- Retire the legacy WSGI read-route ownership for these service runtime paths, add direct fallback retirement coverage, and update service-boundary/compatibility docs.

Refs #1322

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiServiceRuntimeReadTests tests.test_service.LaunchplaneServiceTests.test_service_runtime_routes_are_retired_from_legacy_wsgi_app tests.test_service.LaunchplaneServiceTests.test_service_odoo_workers_reconcile_endpoint_recovers_stale_records tests.test_service.LaunchplaneServiceTests.test_service_odoo_workers_reconcile_endpoint_requires_operation_record_storage`
- `uv run python -m unittest`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/service_status.py tests/test_http_app.py tests/test_service.py`
- `git diff --check`
- JetBrains inspection closeout, changed files: clean

Note: repo-wide `uv run --extra dev ruff format --check .` still reports the known unrelated 56-file formatting backlog outside this slice.

## Review

- Final committed-HEAD agent review found no blocking issues before push.
