### PR TITLE
Move target logs read to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -13,10 +13,12 @@ from fastapi.responses import JSONResponse
 from jwt import InvalidTokenError
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane import dokploy as control_plane_dokploy
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import secrets as control_plane_secrets
 from control_plane import service_status as control_plane_service_status
+from control_plane import tracked_target_logs as control_plane_tracked_target_logs
 from control_plane.agent_context_service import (
     AgentContextPayload,
     agent_context_action_allowed,
@@ -345,6 +347,45 @@ class DriverContextViewResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     view: DriverContextView
+
+
+class TrackedTargetLogTargetResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    target_id: str
+    target_type: str
+    target_name: str
+    app_name: str
+    server_id: str
+    source_label: str
+
+
+class TrackedTargetLogRequestResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    line_count: int
+    since: str
+    search: str
+
+
+class TrackedTargetLogLinesResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    line_count: int
+    lines: tuple[str, ...]
+    redacted: bool
+
+
+class TrackedTargetLogsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    context: str
+    instance: str
+    target: TrackedTargetLogTargetResponse
+    request: TrackedTargetLogRequestResponse
+    logs: TrackedTargetLogLinesResponse
 
 
 class DeploymentRecordResponse(BaseModel):
@@ -967,6 +1008,26 @@ def require_product_context_audit_store(
             f"{missing_summary}"
         )
     return cast(control_plane_product_context_audit.ProductContextAuditStore, record_store)
+
+
+def require_tracked_target_logs_store(
+    record_store: object,
+) -> control_plane_tracked_target_logs.TrackedTargetLogsStore:
+    required_methods = (
+        "read_dokploy_target_record",
+        "read_dokploy_target_id_record",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods or not isinstance(record_store, PostgresRecordStore):
+        missing_summary = ", ".join(missing_methods) or "postgres_storage"
+        raise TypeError(
+            f"Tracked target logs require DB-backed Launchplane storage: {missing_summary}"
+        )
+    return cast(control_plane_tracked_target_logs.TrackedTargetLogsStore, record_store)
 
 
 def product_profile_context_cutover_allowed_contexts(
@@ -1913,6 +1974,90 @@ def create_launchplane_fastapi_app(
             instance_name=instance,
         )
         return DriverContextViewResponse(trace_id=trace_id, view=view)
+
+    def read_tracked_target_logs(
+        context: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        instance: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        lines: Annotated[str, Query()] = str(control_plane_dokploy.DEFAULT_DOKPLOY_LOG_LINE_COUNT),
+        since: Annotated[str, Query()] = "all",
+        search: Annotated[str, Query()] = "",
+    ) -> TrackedTargetLogsResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="target_logs.read",
+            product="launchplane",
+            context=context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read tracked target logs for the requested context.",
+            )
+        try:
+            line_count = control_plane_service_status.query_int_value(
+                lines,
+                "lines",
+                default=control_plane_dokploy.DEFAULT_DOKPLOY_LOG_LINE_COUNT,
+                minimum=1,
+                maximum=control_plane_dokploy.MAX_DOKPLOY_LOG_LINE_COUNT,
+            )
+            assert line_count is not None
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        try:
+            normalized_since = control_plane_dokploy.normalize_dokploy_log_since(since)
+            normalized_search = control_plane_dokploy.normalize_dokploy_log_search(search)
+        except click.ClickException as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        try:
+            target_logs_store = require_tracked_target_logs_store(record_store)
+            logs_payload = control_plane_tracked_target_logs.build_tracked_target_logs_payload(
+                record_store=target_logs_store,
+                control_plane_root=resolved_control_plane_root,
+                context_name=context,
+                instance_name=instance,
+                line_count=line_count,
+                since=normalized_since,
+                search=normalized_search,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message=str(error),
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message=str(error),
+            ) from error
+        except click.ClickException as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="target_logs_unavailable",
+                message=str(error),
+            ) from error
+        return TrackedTargetLogsResponse.model_validate(
+            {"status": "ok", "trace_id": trace_id, **logs_payload}
+        )
 
     def read_deployment_record(
         record_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -3269,6 +3414,21 @@ def create_launchplane_fastapi_app(
         responses={
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/contexts/{context}/instances/{instance}/logs",
+        read_tracked_target_logs,
+        methods=["GET"],
+        response_model=TrackedTargetLogsResponse,
+        operation_id="read_tracked_target_logs",
+        summary="Read tracked target logs",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
         },
     )
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -322,7 +322,6 @@ from control_plane.service_human_auth import (
 )
 from control_plane.storage.factory import build_shared_record_store
 from control_plane.storage.postgres import PostgresRecordStore
-from control_plane.tracked_target_logs import build_tracked_target_logs_payload
 from control_plane.ui_static_http import serve_ui_route
 from control_plane.product_config_http import (
     ProductConfigRouteResult,
@@ -4499,13 +4498,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
-    if (
-        len(segments) == 6
-        and segments[:2] == ["v1", "contexts"]
-        and segments[3] == "instances"
-        and segments[5] == "logs"
-    ):
-        return "target_logs.read", {"context": segments[2], "instance": segments[4]}
     if len(segments) == 4 and segments == ["v1", "ingress", "route-audits", "records"]:
         return "ingress_route.plan", {"ingress_route_audit_list": "true"}
     if len(segments) == 5 and segments[:4] == ["v1", "ingress", "route-audits", "records"]:
@@ -10840,68 +10832,6 @@ def create_launchplane_service_app(
                             "records": [
                                 record.model_dump(mode="json") for record in canary_records
                             ],
-                        },
-                    )
-                if action == "target_logs.read":
-                    context_name = params["context"]
-                    instance_name = params["instance"]
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=context_name,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read tracked target logs for the requested context.",
-                                },
-                            },
-                        )
-                    line_count = int(
-                        str(
-                            (
-                                query.get("lines")
-                                or [str(control_plane_dokploy.DEFAULT_DOKPLOY_LOG_LINE_COUNT)]
-                            )[0]
-                        )
-                    )
-                    since = str((query.get("since") or ["all"])[0])
-                    search = str((query.get("search") or [""])[0])
-                    if not isinstance(record_store, PostgresRecordStore):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=503,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "database_required",
-                                    "message": "Tracked target logs require DB-backed Launchplane storage.",
-                                },
-                            },
-                        )
-                    log_payload = build_tracked_target_logs_payload(
-                        record_store=record_store,
-                        control_plane_root=resolved_root,
-                        context_name=context_name,
-                        instance_name=instance_name,
-                        line_count=line_count,
-                        since=since,
-                        search=search,
-                    )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            **log_payload,
                         },
                     )
                 if action == "every_code_work_request.read":

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -83,7 +83,10 @@ def build_tracked_target_logs_payload(
             since=normalized_since,
             search=normalized_search,
         )
-    logs = tuple(logs[-normalized_line_count:])
+    logs = tuple(
+        control_plane_dokploy.redact_dokploy_log_line(line)
+        for line in logs[-normalized_line_count:]
+    )
     return {
         "context": normalized_context,
         "instance": normalized_instance,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -60,6 +60,10 @@ Keep a compatibility surface only when it is one of these:
   routes for bearer-token and human-session callers. Their legacy WSGI branch is
   deleted; direct fallback calls fail closed while the mounted fallback remains
   for retained non-native routes.
+- Tracked target logs use the native FastAPI
+  `GET /v1/contexts/{context}/instances/{instance}/logs` route. The legacy WSGI
+  branch is deleted; direct fallback calls fail closed while the mounted fallback
+  remains for retained non-native routes.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -657,7 +657,7 @@ Current derived-state behavior:
   includes route/target/app/server metadata, accepts optional `--since` and
   `--search`, and redacts likely secret values from returned log lines.
 - `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200` exposes the
-  same tracked-target log reader through the authenticated service API using
+  same tracked-target log reader through a native FastAPI service route using
   action `target_logs.read`.
 - The manual Tracked Target Logs workflow calls that service route with GitHub
   OIDC and uploads the redacted JSON result, so operators can inspect compose

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1494,9 +1494,10 @@ expose Launchplane capabilities and repository-backed read state, not
 runtime-provider primitives.
 
 The logs route is the exception to the `driver.read` action because it reads live
-provider output. It uses action `target_logs.read`, resolves DB-backed tracked
-target records by context/instance, supports bounded Dokploy `application` and
-`compose` logs, and redacts likely secret values before returning lines.
+provider output. It is a native FastAPI route, uses action `target_logs.read`,
+resolves DB-backed tracked target records by context/instance, supports bounded
+Dokploy `application` and `compose` logs, validates log query parameters before
+provider access, and redacts likely secret values before returning lines.
 
 The preview driver cut stays intentionally narrow but keeps topology in
 Launchplane: Launchplane owns preview URL derivation from the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -12,6 +12,7 @@ from urllib.parse import urlencode
 from unittest.mock import patch
 
 from a2wsgi import WSGIMiddleware
+from click import ClickException
 from fastapi import FastAPI
 from jwt import InvalidTokenError
 from starlette.types import ASGIApp
@@ -82,6 +83,7 @@ from tests.test_service import (
     _identity,
     _product_profile_payload,
     _product_profile_payload_with_prod,
+    _seed_tracked_target_records,
     _sqlite_database_url,
 )
 from tests.test_service import _StubVerifier
@@ -3123,6 +3125,555 @@ class FastApiDriverContextViewTests(unittest.IsolatedAsyncioTestCase):
             openapi["components"]["schemas"]["DriverContextViewResponse"]["additionalProperties"],
             False,
         )
+
+
+class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_tracked_target_logs_returns_redacted_application_logs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
+                    return_value=("contact form submitted",),
+                ) as logs_mock,
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="sellyouroutboard-testing",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "sellyouroutboard-testing",
+                    "testing",
+                    lines="2",
+                    since="5m",
+                    search="contact",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            application_id="app-123",
+            line_count=2,
+            since="5m",
+            search="contact",
+        )
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["context"], "sellyouroutboard-testing")
+        self.assertEqual(payload["instance"], "testing")
+        self.assertEqual(payload["target"]["target_name"], "syo-testing-app")
+        self.assertEqual(payload["target"]["app_name"], "syo-testing-gfbiqh")
+        self.assertEqual(payload["request"], {"line_count": 2, "since": "5m", "search": "contact"})
+        self.assertEqual(payload["logs"]["lines"], ["contact form submitted"])
+        self.assertTrue(payload["logs"]["redacted"])
+        self.assertNotIn("secret-token", json.dumps(payload))
+
+    async def test_tracked_target_logs_redacts_raw_secret_values_from_provider_logs(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
+                    return_value=("API_TOKEN=plain-secret-value",),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="sellyouroutboard-testing",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "sellyouroutboard-testing",
+                    "testing",
+                    lines="2",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["logs"]["lines"], ["API_TOKEN=[redacted]"])
+        self.assertNotIn("plain-secret-value", json.dumps(payload))
+
+    async def test_tracked_target_logs_normalizes_uppercase_path_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
+                    return_value=("contact form submitted",),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="SELLYOUROUTBOARD-TESTING",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "SELLYOUROUTBOARD-TESTING",
+                    "TESTING",
+                    lines="2",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["context"], "sellyouroutboard-testing")
+        self.assertEqual(payload["instance"], "testing")
+
+    async def test_tracked_target_logs_returns_redacted_compose_logs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm_website",
+                instance="testing",
+                target_id="compose-123",
+                target_type="compose",
+                target_name="cm-website-testing",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "cm-website-testing-iul0ql", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_compose_logs",
+                    return_value=("booting", "ODOO_ADMIN_PASSWORD=[redacted]"),
+                ) as logs_mock,
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="cm_website",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "cm_website",
+                    "testing",
+                    lines="2",
+                    since="5m",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            compose_id="compose-123",
+            app_name="cm-website-testing-iul0ql",
+            server_id="server-1",
+            line_count=2,
+            since="5m",
+            search="",
+        )
+        payload = response.json()
+        self.assertEqual(payload["target"]["target_type"], "compose")
+        self.assertEqual(payload["target"]["target_name"], "cm-website-testing")
+        self.assertEqual(payload["target"]["app_name"], "cm-website-testing-iul0ql")
+        self.assertEqual(payload["logs"]["lines"], ["booting", "ODOO_ADMIN_PASSWORD=[redacted]"])
+        self.assertNotIn("secret-token", json.dumps(payload))
+
+    async def test_tracked_target_logs_delegates_compose_log_search_to_provider(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm_website",
+                instance="testing",
+                target_id="compose-123",
+                target_type="compose",
+                target_name="cm-website-testing",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "cm-website-testing-iul0ql", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_compose_logs",
+                    return_value=("website_bootstrap_applied name=Cell Mechanic",),
+                ) as logs_mock,
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="cm_website",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "cm_website",
+                    "testing",
+                    lines="2",
+                    since="2h",
+                    search="website_bootstrap_applied",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            compose_id="compose-123",
+            app_name="cm-website-testing-iul0ql",
+            server_id="server-1",
+            line_count=2,
+            since="2h",
+            search="website_bootstrap_applied",
+        )
+        payload = response.json()
+        self.assertEqual(
+            payload["request"],
+            {"line_count": 2, "since": "2h", "search": "website_bootstrap_applied"},
+        )
+        self.assertEqual(payload["logs"]["lines"], ["website_bootstrap_applied name=Cell Mechanic"])
+
+    async def test_tracked_target_logs_requires_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="target_logs.read",
+                context="sellyouroutboard-testing",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            authorization="",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_tracked_target_logs_requires_authz_action(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="driver.read",
+                context="sellyouroutboard-testing",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_tracked_target_logs_requires_db_backed_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="target_logs.read",
+                context="sellyouroutboard-testing",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_required")
+
+    async def test_tracked_target_logs_returns_invalid_request_for_missing_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            app_store = PostgresRecordStore(database_url=database_url)
+            app_store.ensure_schema()
+            with patch(
+                "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config"
+            ) as read_config_mock:
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="sellyouroutboard-testing",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "sellyouroutboard-testing",
+                    "missing",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        read_config_mock.assert_not_called()
+
+    async def test_tracked_target_logs_reports_provider_unavailable(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with patch(
+                "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                side_effect=ClickException("Dokploy credentials unavailable."),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="sellyouroutboard-testing",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "sellyouroutboard-testing",
+                    "testing",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "target_logs_unavailable")
+
+    async def test_tracked_target_logs_validates_query_values(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="target_logs.read",
+                context="sellyouroutboard-testing",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        line_response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            lines="0",
+        )
+        since_response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            since="yesterday",
+        )
+        max_line_response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            lines="1001",
+        )
+
+        self.assertEqual(line_response.status_code, 400)
+        self.assertEqual(since_response.status_code, 400)
+        self.assertEqual(max_line_response.status_code, 400)
+        self.assertEqual(line_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(since_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(max_line_response.json()["error"]["code"], "invalid_query")
+
+    async def test_openapi_includes_tracked_target_logs_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="target_logs.read",
+                context="sellyouroutboard-testing",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/contexts/{context}/instances/{instance}/logs"]["get"]
+        self.assertEqual(route["operationId"], "read_tracked_target_logs")
+        self.assertEqual(
+            route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/TrackedTargetLogsResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(route))
+        self.assertIn("400", route["responses"])
+        self.assertIn("401", route["responses"])
+        self.assertIn("403", route["responses"])
+        self.assertIn("503", route["responses"])
+        self.assertEqual(
+            openapi["components"]["schemas"]["TrackedTargetLogsResponse"]["additionalProperties"],
+            False,
+        )
+
+    async def test_fastapi_tracked_target_logs_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
+                    return_value=("contact form submitted",),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="sellyouroutboard-testing",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                legacy_app = create_launchplane_service_app(
+                    state_dir=root / "state",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                    control_plane_root_path=root,
+                )
+                app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+                response = await _get_tracked_target_logs(
+                    app,
+                    "sellyouroutboard-testing",
+                    "testing",
+                    lines="2",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
 
 
 class FastApiDeploymentPromotionReadTests(unittest.IsolatedAsyncioTestCase):
@@ -7833,6 +8384,35 @@ async def _get_driver_instance_view(
         app,
         f"/v1/contexts/{context}/instances/{instance}/driver-view",
         headers=headers,
+    )
+
+
+async def _get_tracked_target_logs(
+    app: FastAPI,
+    context: str,
+    instance: str,
+    *,
+    lines: str = "",
+    since: str = "",
+    search: str = "",
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    params = {}
+    if lines:
+        params["lines"] = lines
+    if since:
+        params["since"] = since
+    if search:
+        params["search"] = search
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/contexts/{context}/instances/{instance}/logs{suffix}",
+        headers=request_headers,
     )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13288,6 +13288,27 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(runtime_payload["error"]["code"], "not_found")
         self.assertEqual(worker_payload["error"]["code"], "not_found")
 
+    def test_target_logs_route_is_retired_from_legacy_wsgi_app(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+                local_record_store_for_tests=FilesystemRecordStore(state_dir=state_dir),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/contexts/sellyouroutboard-testing/instances/testing/logs",
+                authorization="",
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
+
     def test_service_serve_rejects_missing_database_url(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
@@ -14119,305 +14140,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 500)
         self.assertEqual(payload["error"]["code"], "driver_route_not_registered")
-
-    def test_tracked_target_logs_endpoint_returns_redacted_application_logs(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            _seed_tracked_target_records(
-                database_url=database_url,
-                context="sellyouroutboard-testing",
-                instance="testing",
-                target_id="app-123",
-                target_type="application",
-                target_name="syo-testing-app",
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane"],
-                            "contexts": ["sellyouroutboard-testing"],
-                            "actions": ["target_logs.read"],
-                        }
-                    ]
-                }
-            )
-            with (
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
-                    return_value=("https://dokploy.example.com", "secret-token"),
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
-                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs",
-                    return_value=("contact form submitted",),
-                ) as logs_mock,
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=root / "state",
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    database_url=database_url,
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/contexts/sellyouroutboard-testing/instances/testing/logs",
-                    query_string="lines=2&since=5m&search=contact",
-                )
-
-        self.assertEqual(status_code, 200)
-        logs_mock.assert_called_once_with(
-            host="https://dokploy.example.com",
-            token="secret-token",
-            application_id="app-123",
-            line_count=2,
-            since="5m",
-            search="contact",
-        )
-        self.assertEqual(payload["status"], "ok")
-        self.assertEqual(payload["target"]["target_name"], "syo-testing-app")
-        self.assertEqual(payload["target"]["app_name"], "syo-testing-gfbiqh")
-        self.assertEqual(payload["request"], {"line_count": 2, "since": "5m", "search": "contact"})
-        self.assertEqual(payload["logs"]["lines"], ["contact form submitted"])
-        self.assertNotIn("secret-token", json.dumps(payload))
-
-    def test_tracked_target_logs_endpoint_returns_redacted_compose_logs(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            _seed_tracked_target_records(
-                database_url=database_url,
-                context="cm_website",
-                instance="testing",
-                target_id="compose-123",
-                target_type="compose",
-                target_name="cm-website-testing",
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane"],
-                            "contexts": ["cm_website"],
-                            "actions": ["target_logs.read"],
-                        }
-                    ]
-                }
-            )
-            with (
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
-                    return_value=("https://dokploy.example.com", "secret-token"),
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
-                    return_value={"appName": "cm-website-testing-iul0ql", "serverId": "server-1"},
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_compose_logs",
-                    return_value=("booting", "ODOO_ADMIN_PASSWORD=[redacted]"),
-                ) as logs_mock,
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=root / "state",
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    database_url=database_url,
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/contexts/cm_website/instances/testing/logs",
-                    query_string="lines=2&since=5m",
-                )
-
-        self.assertEqual(status_code, 200)
-        logs_mock.assert_called_once_with(
-            host="https://dokploy.example.com",
-            token="secret-token",
-            compose_id="compose-123",
-            app_name="cm-website-testing-iul0ql",
-            server_id="server-1",
-            line_count=2,
-            since="5m",
-            search="",
-        )
-        self.assertEqual(payload["status"], "ok")
-        self.assertEqual(payload["target"]["target_type"], "compose")
-        self.assertEqual(payload["target"]["target_name"], "cm-website-testing")
-        self.assertEqual(payload["target"]["app_name"], "cm-website-testing-iul0ql")
-        self.assertEqual(payload["logs"]["lines"], ["booting", "ODOO_ADMIN_PASSWORD=[redacted]"])
-        self.assertNotIn("secret-token", json.dumps(payload))
-
-    def test_tracked_target_logs_endpoint_delegates_compose_log_search_to_provider(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            _seed_tracked_target_records(
-                database_url=database_url,
-                context="cm_website",
-                instance="testing",
-                target_id="compose-123",
-                target_type="compose",
-                target_name="cm-website-testing",
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane"],
-                            "contexts": ["cm_website"],
-                            "actions": ["target_logs.read"],
-                        }
-                    ]
-                }
-            )
-            with (
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
-                    return_value=("https://dokploy.example.com", "secret-token"),
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
-                    return_value={"appName": "cm-website-testing-iul0ql", "serverId": "server-1"},
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_compose_logs",
-                    return_value=("website_bootstrap_applied name=Cell Mechanic",),
-                ) as logs_mock,
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=root / "state",
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    database_url=database_url,
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/contexts/cm_website/instances/testing/logs",
-                    query_string="lines=2&since=2h&search=website_bootstrap_applied",
-                )
-
-        self.assertEqual(status_code, 200)
-        logs_mock.assert_called_once_with(
-            host="https://dokploy.example.com",
-            token="secret-token",
-            compose_id="compose-123",
-            app_name="cm-website-testing-iul0ql",
-            server_id="server-1",
-            line_count=2,
-            since="2h",
-            search="website_bootstrap_applied",
-        )
-        self.assertEqual(
-            payload["request"],
-            {"line_count": 2, "since": "2h", "search": "website_bootstrap_applied"},
-        )
-        self.assertEqual(payload["logs"]["lines"], ["website_bootstrap_applied name=Cell Mechanic"])
-
-    def test_tracked_target_logs_endpoint_requires_authz_action(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            _seed_tracked_target_records(
-                database_url=database_url,
-                context="sellyouroutboard-testing",
-                instance="testing",
-                target_id="app-123",
-                target_type="application",
-                target_name="syo-testing-app",
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane"],
-                            "contexts": ["sellyouroutboard-testing"],
-                            "actions": ["driver.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/contexts/sellyouroutboard-testing/instances/testing/logs",
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_tracked_target_logs_endpoint_requires_db_backed_storage(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane"],
-                            "contexts": ["sellyouroutboard-testing"],
-                            "actions": ["target_logs.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/contexts/sellyouroutboard-testing/instances/testing/logs",
-            )
-
-        self.assertEqual(status_code, 503)
-        self.assertEqual(payload["error"]["code"], "database_required")
 
     def test_product_profile_write_endpoint_persists_authorized_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- move `/v1/contexts/{context}/instances/{instance}/logs` to a native FastAPI route with Pydantic/OpenAPI response models
- preserve `target_logs.read` authz, DB-backed tracked-target requirements, provider error mapping, and legacy response shape
- harden query validation (`lines` bounded 1-1000, normalized `since`/`search`) before store/provider access
- defensively redact provider log lines at the API payload boundary
- remove the legacy WSGI route matcher/handler and keep a fail-closed legacy retirement test
- update service-boundary, operations, and compatibility-retirement docs

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiTrackedTargetLogsReadTests tests.test_service.LaunchplaneServiceTests.test_target_logs_route_is_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/tracked_target_logs.py tests/test_http_app.py tests/test_service.py`
- `git diff --check`
- `uv run python -m unittest` (2698 tests)
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files` (clean, 0 problems)

## Review
- final Claude review agent: green to merge, no blocking findings
- final Antigravity review agent: green to merge, no blocking findings
- one Code review agent was cancelled after hanging once the other reviews and full local gates were green
