### PR TITLE
Move edge endpoint reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -33,6 +33,7 @@ from control_plane.contracts.authz_policy_record import (
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.driver_descriptor import DriverContextView, DriverDescriptor
+from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
@@ -388,6 +389,24 @@ class TrackedTargetLogsResponse(BaseModel):
     logs: TrackedTargetLogLinesResponse
 
 
+class EdgeEndpointRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: EdgeEndpointRecord
+
+
+class EdgeEndpointRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    limit: int
+    count: int
+    records: tuple[EdgeEndpointRecord, ...]
+
+
 class DeploymentRecordResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -700,6 +719,18 @@ class _RecentOperationsReadStore(Protocol):
         anchor_pr_number: int | None = None,
         limit: int | None = None,
     ) -> tuple[PreviewRecord, ...]: ...
+
+
+class _EdgeEndpointReadStore(Protocol):
+    def read_edge_endpoint_record(self, endpoint_key: str) -> EdgeEndpointRecord: ...
+
+    def list_edge_endpoint_records(
+        self,
+        *,
+        provider: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EdgeEndpointRecord, ...]: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -1028,6 +1059,24 @@ def require_tracked_target_logs_store(
             f"Tracked target logs require DB-backed Launchplane storage: {missing_summary}"
         )
     return cast(control_plane_tracked_target_logs.TrackedTargetLogsStore, record_store)
+
+
+def require_edge_endpoint_read_store(record_store: object) -> _EdgeEndpointReadStore:
+    required_methods = (
+        "read_edge_endpoint_record",
+        "list_edge_endpoint_records",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            f"Launchplane record store does not support edge endpoint reads: {missing_summary}"
+        )
+    return cast(_EdgeEndpointReadStore, record_store)
 
 
 def product_profile_context_cutover_allowed_contexts(
@@ -2058,6 +2107,96 @@ def create_launchplane_fastapi_app(
         return TrackedTargetLogsResponse.model_validate(
             {"status": "ok", "trace_id": trace_id, **logs_payload}
         )
+
+    def ensure_edge_endpoint_read_allowed(
+        *,
+        identity: LaunchplaneIdentity,
+        trace_id: str,
+    ) -> None:
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="edge_endpoint.read",
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read Launchplane edge endpoint records.",
+            )
+
+    def list_edge_endpoint_records(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        limit: Annotated[str, Query()] = "25",
+        provider: Annotated[str, Query()] = "",
+        status: Annotated[str, Query()] = "",
+    ) -> EdgeEndpointRecordsResponse:
+        trace_id = next_trace_id()
+        ensure_edge_endpoint_read_allowed(identity=identity, trace_id=trace_id)
+        try:
+            normalized_limit = control_plane_service_status.query_int_value(
+                limit,
+                "limit",
+                default=25,
+                minimum=1,
+                maximum=100,
+            )
+            assert normalized_limit is not None
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        try:
+            edge_endpoint_store = require_edge_endpoint_read_store(record_store)
+            records = edge_endpoint_store.list_edge_endpoint_records(
+                provider=provider.strip(),
+                status=status.strip(),
+                limit=normalized_limit,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        return EdgeEndpointRecordsResponse(
+            trace_id=trace_id,
+            limit=normalized_limit,
+            count=len(records),
+            records=records,
+        )
+
+    def read_edge_endpoint_record(
+        endpoint_key: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> EdgeEndpointRecordResponse:
+        trace_id = next_trace_id()
+        ensure_edge_endpoint_read_allowed(identity=identity, trace_id=trace_id)
+        try:
+            edge_endpoint_store = require_edge_endpoint_read_store(record_store)
+            record = edge_endpoint_store.read_edge_endpoint_record(endpoint_key)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        return EdgeEndpointRecordResponse(trace_id=trace_id, record=record)
 
     def read_deployment_record(
         record_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -3428,6 +3567,36 @@ def create_launchplane_fastapi_app(
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/edge-endpoints/records",
+        list_edge_endpoint_records,
+        methods=["GET"],
+        response_model=EdgeEndpointRecordsResponse,
+        operation_id="list_edge_endpoint_records",
+        summary="List edge endpoint records",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/edge-endpoints/records/{endpoint_key}",
+        read_edge_endpoint_record,
+        methods=["GET"],
+        response_model=EdgeEndpointRecordResponse,
+        operation_id="read_edge_endpoint_record",
+        summary="Read one edge endpoint record",
+        responses={
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -860,14 +860,6 @@ class _EdgeEndpointRecordStore(Protocol):
 
     def read_edge_endpoint_record(self, endpoint_key: str) -> EdgeEndpointRecord: ...
 
-    def list_edge_endpoint_records(
-        self,
-        *,
-        provider: str = "",
-        status: str = "",
-        limit: int | None = None,
-    ) -> tuple[EdgeEndpointRecord, ...]: ...
-
 
 class _PrivateHealthEndpointRecordStore(Protocol):
     def write_private_health_endpoint_record(
@@ -4502,10 +4494,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "ingress_route.plan", {"ingress_route_audit_list": "true"}
     if len(segments) == 5 and segments[:4] == ["v1", "ingress", "route-audits", "records"]:
         return "ingress_route.plan", {"ingress_route_audit_record_id": segments[4]}
-    if len(segments) == 3 and segments == ["v1", "edge-endpoints", "records"]:
-        return "edge_endpoint.read", {"edge_endpoint_list": "true"}
-    if len(segments) == 4 and segments[:3] == ["v1", "edge-endpoints", "records"]:
-        return "edge_endpoint.read", {"edge_endpoint_key": segments[3]}
     if len(segments) == 3 and segments == ["v1", "private-health-endpoints", "records"]:
         return "private_health_endpoint.read", {"private_health_endpoint_list": "true"}
     if len(segments) == 4 and segments[:3] == ["v1", "private-health-endpoints", "records"]:
@@ -6944,7 +6932,6 @@ def _edge_endpoint_record_store(record_store: object) -> _EdgeEndpointRecordStor
     required_methods = (
         "write_edge_endpoint_record",
         "read_edge_endpoint_record",
-        "list_edge_endpoint_records",
     )
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_EdgeEndpointRecordStore, record_store)
@@ -10494,83 +10481,6 @@ def create_launchplane_service_app(
                             "count": len(limited_records),
                             "records": [
                                 record.model_dump(mode="json") for record in limited_records
-                            ],
-                        },
-                    )
-                if action == "edge_endpoint.read":
-                    endpoint_store = _edge_endpoint_record_store(record_store)
-                    if "edge_endpoint_key" in params:
-                        if not authz_policy.allows(
-                            identity=identity,
-                            action=action,
-                            product="launchplane",
-                            context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                        ):
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=403,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "authorization_denied",
-                                        "message": "Workflow cannot read Launchplane edge endpoint records.",
-                                    },
-                                },
-                            )
-                        try:
-                            endpoint_record = endpoint_store.read_edge_endpoint_record(
-                                params["edge_endpoint_key"]
-                            )
-                        except FileNotFoundError:
-                            return _not_found_response(
-                                start_response=start_response,
-                                trace_id=request_trace_id,
-                                path=path,
-                            )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "record": endpoint_record.model_dump(mode="json"),
-                            },
-                        )
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read Launchplane edge endpoint records.",
-                                },
-                            },
-                        )
-                    limit = _query_int_value(query, "limit", default=25, minimum=1, maximum=100)
-                    endpoint_records = endpoint_store.list_edge_endpoint_records(
-                        provider=_query_string_value(query, "provider"),
-                        status=_query_string_value(query, "status"),
-                        limit=limit,
-                    )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "limit": limit,
-                            "count": len(endpoint_records),
-                            "records": [
-                                record.model_dump(mode="json") for record in endpoint_records
                             ],
                         },
                     )

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -64,6 +64,10 @@ Keep a compatibility surface only when it is one of these:
   `GET /v1/contexts/{context}/instances/{instance}/logs` route. The legacy WSGI
   branch is deleted; direct fallback calls fail closed while the mounted fallback
   remains for retained non-native routes.
+- Edge endpoint record reads use native FastAPI `GET /v1/edge-endpoints/records`
+  and `GET /v1/edge-endpoints/records/{endpoint_key}` routes. Their legacy WSGI
+  read branch is deleted; edge endpoint apply remains on the retained fallback
+  until that write path has its own native replacement.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -56,6 +56,12 @@ VeriReel product paths:
     context
   - `GET /v1/drivers/{driver_id}`, requiring `driver.read` for the Launchplane
     discovery context
+- native FastAPI edge endpoint record reads:
+  - `GET /v1/edge-endpoints/records`, requiring `edge_endpoint.read` for the
+    Launchplane service context and supporting `provider`, `status`, and
+    bounded `limit` filters
+  - `GET /v1/edge-endpoints/records/{endpoint_key}`, requiring
+    `edge_endpoint.read` for the Launchplane service context
 - native FastAPI deployment, promotion, preview, inventory, operations, and
   managed-secret status reads:
   - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
@@ -1305,6 +1311,10 @@ only after a passing plan and a matching stored preview record are present.
   callers)
 - `GET /v1/service/odoo-workers/status` (native FastAPI for bearer-token and
   human-session callers)
+- `GET /v1/edge-endpoints/records` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/edge-endpoints/records/{endpoint_key}` (native FastAPI for
+  bearer-token and human-session callers)
 
 These operator reads use the same Launchplane authn/authz boundary as evidence
 ingress. The intent is to give operators a minimal typed read surface for the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -80,6 +80,7 @@ from control_plane.workflows.launchplane_self_deploy import LAUNCHPLANE_IMAGE_RE
 from tests.test_service import create_launchplane_service_app
 from tests.test_service import (
     _generic_site_profile_payload,
+    _edge_endpoint_record,
     _identity,
     _product_profile_payload,
     _product_profile_payload_with_prod,
@@ -3671,6 +3672,203 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
                     lines="2",
                 )
                 app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+
+class FastApiEdgeEndpointReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_edge_endpoint_read_returns_record_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_edge_endpoint_record(_edge_endpoint_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="edge_endpoint.read",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_edge_endpoint_record(app, "cm-prod-dokploy")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["record"]["endpoint_key"], "cm-prod-dokploy")
+        self.assertEqual(payload["record"]["server_name"], "docker-cm-prod")
+        self.assertEqual(payload["record"]["upstream_host"], "100.73.170.113")
+
+    async def test_edge_endpoint_list_filters_records(self) -> None:
+        active_record = _edge_endpoint_record()
+        disabled_record = active_record.model_copy(
+            update={
+                "endpoint_key": "disabled-edge",
+                "server_name": "docker-disabled",
+                "upstream_host": "100.73.170.114",
+                "status": "disabled",
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_edge_endpoint_record(active_record)
+            store.write_edge_endpoint_record(disabled_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="edge_endpoint.read",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_edge_endpoint_records(
+                app,
+                provider="dokploy",
+                status="active",
+                limit="1",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["limit"], 1)
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["records"][0]["endpoint_key"], "cm-prod-dokploy")
+
+    async def test_edge_endpoint_reads_require_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="edge_endpoint.read", context="launchplane"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_edge_endpoint_records(app, authorization="")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_edge_endpoint_reads_require_authz_action(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="driver.read", context="launchplane"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_edge_endpoint_record(app, "cm-prod-dokploy")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_edge_endpoint_reads_require_record_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="edge_endpoint.read", context="launchplane"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_edge_endpoint_records(app)
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_edge_endpoint_read_returns_not_found_for_missing_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="edge_endpoint.read",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_edge_endpoint_record(app, "missing-edge")
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_edge_endpoint_list_validates_limit(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="edge_endpoint.read", context="launchplane"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        low_response = await _get_edge_endpoint_records(app, limit="0")
+        high_response = await _get_edge_endpoint_records(app, limit="101")
+
+        self.assertEqual(low_response.status_code, 400)
+        self.assertEqual(high_response.status_code, 400)
+        self.assertEqual(low_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(high_response.json()["error"]["code"], "invalid_query")
+
+    async def test_openapi_includes_edge_endpoint_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="edge_endpoint.read", context="launchplane"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        list_route = openapi["paths"]["/v1/edge-endpoints/records"]["get"]
+        read_route = openapi["paths"]["/v1/edge-endpoints/records/{endpoint_key}"]["get"]
+        self.assertEqual(list_route["operationId"], "list_edge_endpoint_records")
+        self.assertEqual(read_route["operationId"], "read_edge_endpoint_record")
+        self.assertEqual(
+            list_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/EdgeEndpointRecordsResponse",
+        )
+        self.assertEqual(
+            read_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/EdgeEndpointRecordResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(list_route))
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(read_route))
+        self.assertEqual(
+            openapi["components"]["schemas"]["EdgeEndpointRecordResponse"]["additionalProperties"],
+            False,
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["EdgeEndpointRecordsResponse"]["additionalProperties"],
+            False,
+        )
+
+    async def test_fastapi_edge_endpoint_reads_precede_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_edge_endpoint_record(_edge_endpoint_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="edge_endpoint.read",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _get_edge_endpoint_record(app, "cm-prod-dokploy")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "ok")
@@ -8412,6 +8610,50 @@ async def _get_tracked_target_logs(
     return await _asgi_get(
         app,
         f"/v1/contexts/{context}/instances/{instance}/logs{suffix}",
+        headers=request_headers,
+    )
+
+
+async def _get_edge_endpoint_records(
+    app: FastAPI,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+    limit: str = "",
+    provider: str = "",
+    status: str = "",
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    params = {}
+    if limit:
+        params["limit"] = limit
+    if provider:
+        params["provider"] = provider
+    if status:
+        params["status"] = status
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/edge-endpoints/records{suffix}",
+        headers=request_headers,
+    )
+
+
+async def _get_edge_endpoint_record(
+    app: FastAPI,
+    endpoint_key: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(
+        app,
+        f"/v1/edge-endpoints/records/{endpoint_key}",
         headers=request_headers,
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2415,9 +2415,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(records[0].trace_id, payload["trace_id"])
 
-    def test_edge_endpoint_apply_and_read_routes_store_db_backed_upstream(self) -> None:
+    def test_edge_endpoint_apply_route_stores_db_backed_upstream(self) -> None:
         policy = _local_operator_policy(
-            actions=("edge_endpoint.apply", "edge_endpoint.read"),
+            actions=("edge_endpoint.apply",),
             products=("launchplane",),
             contexts=("launchplane",),
         )
@@ -2448,23 +2448,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     authorization="Bearer local-operator-token",
                     headers={"Idempotency-Key": "edge-endpoint-apply"},
                 )
-                read_status_code, read_payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/edge-endpoints/records/cm-prod-dokploy",
-                    authorization="Bearer local-operator-token",
-                )
+                stored_record = record_store.read_edge_endpoint_record("cm-prod-dokploy")
 
         self.assertEqual(apply_status_code, 202)
         self.assertEqual(apply_payload["records"]["edge_endpoint_key"], "cm-prod-dokploy")
         self.assertEqual(apply_payload["records"]["edge_endpoint_status"], "applied")
-        self.assertEqual(read_status_code, 200)
-        self.assertEqual(read_payload["record"]["server_name"], "docker-cm-prod")
-        self.assertEqual(read_payload["record"]["upstream_host"], "100.73.170.113")
+        self.assertEqual(stored_record.server_name, "docker-cm-prod")
+        self.assertEqual(stored_record.upstream_host, "100.73.170.113")
 
     def test_edge_endpoint_dry_run_does_not_store_upstream(self) -> None:
         policy = _local_operator_policy(
-            actions=("edge_endpoint.apply", "edge_endpoint.read"),
+            actions=("edge_endpoint.apply",),
             products=("launchplane",),
             contexts=("launchplane",),
         )
@@ -2493,20 +2487,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     payload=_edge_endpoint_apply_payload(mode="dry-run"),
                     authorization="Bearer local-operator-token",
                 )
-                read_status_code, read_payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/edge-endpoints/records/cm-prod-dokploy",
-                    authorization="Bearer local-operator-token",
-                )
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["records"]["edge_endpoint_status"], "planned")
         self.assertEqual(payload["result"]["mode"], "dry-run")
         self.assertEqual(payload["result"]["endpoint_key"], "cm-prod-dokploy")
-        self.assertEqual(read_status_code, 404)
-        self.assertEqual(read_payload["status"], "rejected")
-        self.assertEqual(read_payload["error"]["code"], "not_found")
+        with self.assertRaises(FileNotFoundError):
+            record_store.read_edge_endpoint_record("cm-prod-dokploy")
 
     def test_private_health_endpoint_apply_and_read_routes_store_db_backed_url(
         self,
@@ -13308,6 +13295,35 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 404)
         self.assertEqual(payload["error"]["code"], "not_found")
+
+    def test_edge_endpoint_read_routes_are_retired_from_legacy_wsgi_app(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+                local_record_store_for_tests=FilesystemRecordStore(state_dir=state_dir),
+            )
+
+            list_status_code, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/edge-endpoints/records",
+                authorization="",
+            )
+            read_status_code, read_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/edge-endpoints/records/cm-prod-dokploy",
+                authorization="",
+            )
+
+        self.assertEqual(list_status_code, 404)
+        self.assertEqual(read_status_code, 404)
+        self.assertEqual(list_payload["error"]["code"], "not_found")
+        self.assertEqual(read_payload["error"]["code"], "not_found")
 
     def test_service_serve_rejects_missing_database_url(self) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- Move edge endpoint record list/read routes to native FastAPI with typed response models and OpenAPI contracts.
- Preserve edge_endpoint.read authorization parity for the Launchplane service context and bounded provider/status/limit query behavior.
- Remove the legacy WSGI edge endpoint read matcher/handler and stale list-store requirement while keeping edge endpoint apply on the retained WSGI fallback.
- Update service-boundary and compatibility-retirement docs for the new cutover point.

Refs #1322

## Validation
- uv run python -m unittest tests.test_http_app.FastApiEdgeEndpointReadTests tests.test_service.LaunchplaneServiceTests.test_edge_endpoint_apply_route_stores_db_backed_upstream tests.test_service.LaunchplaneServiceTests.test_edge_endpoint_dry_run_does_not_store_upstream tests.test_service.LaunchplaneServiceTests.test_edge_endpoint_read_routes_are_retired_from_legacy_wsgi_app
- uv run --extra dev ruff check .
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- git diff --check
- uv run python -m unittest (2708 tests)
- JetBrains changed-files closeout: clean, 0 problems
- Follow-up review agents: GREEN TO MERGE from claude-sonnet-4.6 and antigravity
