### PR TITLE
Move private health reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -64,6 +64,7 @@ from control_plane.contracts.protected_artifacts import (
     ProtectedArtifactSet,
     build_protected_artifact_set,
 )
+from control_plane.contracts.private_health_endpoint_record import PrivateHealthEndpointRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.contracts.runner_host_hygiene_evidence import (
     RunnerHostHygieneAuditEvidenceEnvelope,
@@ -407,6 +408,27 @@ class EdgeEndpointRecordsResponse(BaseModel):
     records: tuple[EdgeEndpointRecord, ...]
 
 
+class PrivateHealthEndpointRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: PrivateHealthEndpointRecord
+
+
+class PrivateHealthEndpointRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    product: str
+    context: str
+    instance: str
+    limit: int
+    count: int
+    records: tuple[PrivateHealthEndpointRecord, ...]
+
+
 class DeploymentRecordResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -731,6 +753,22 @@ class _EdgeEndpointReadStore(Protocol):
         status: str = "",
         limit: int | None = None,
     ) -> tuple[EdgeEndpointRecord, ...]: ...
+
+
+class _PrivateHealthEndpointReadStore(Protocol):
+    def read_private_health_endpoint_record(
+        self, endpoint_key: str
+    ) -> PrivateHealthEndpointRecord: ...
+
+    def list_private_health_endpoint_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[PrivateHealthEndpointRecord, ...]: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -1077,6 +1115,27 @@ def require_edge_endpoint_read_store(record_store: object) -> _EdgeEndpointReadS
             f"Launchplane record store does not support edge endpoint reads: {missing_summary}"
         )
     return cast(_EdgeEndpointReadStore, record_store)
+
+
+def require_private_health_endpoint_read_store(
+    record_store: object,
+) -> _PrivateHealthEndpointReadStore:
+    required_methods = (
+        "read_private_health_endpoint_record",
+        "list_private_health_endpoint_records",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support private health endpoint reads: "
+            f"{missing_summary}"
+        )
+    return cast(_PrivateHealthEndpointReadStore, record_store)
 
 
 def product_profile_context_cutover_allowed_contexts(
@@ -2197,6 +2256,156 @@ def create_launchplane_fastapi_app(
                 message=str(error),
             ) from error
         return EdgeEndpointRecordResponse(trace_id=trace_id, record=record)
+
+    def ensure_private_health_endpoint_read_allowed(
+        *,
+        identity: LaunchplaneIdentity,
+        trace_id: str,
+        product: str,
+        context_name: str,
+    ) -> None:
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="private_health_endpoint.read",
+            product=product,
+            context=context_name,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot read private health endpoints for the requested "
+                    "product/context."
+                ),
+            )
+
+    def list_private_health_endpoint_records(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        product: Annotated[str, Query()] = "",
+        context: Annotated[str, Query()] = "",
+        instance: Annotated[str, Query()] = "",
+        status: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "25",
+    ) -> PrivateHealthEndpointRecordsResponse:
+        trace_id = next_trace_id()
+        normalized_product = product.strip()
+        context_name = context.strip()
+        instance_name = instance.strip()
+        if not normalized_product or not context_name:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=(
+                    "Private health endpoint reads require product and context query parameters."
+                ),
+            )
+        ensure_private_health_endpoint_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            product=normalized_product,
+            context_name=context_name,
+        )
+        try:
+            normalized_limit = control_plane_service_status.query_int_value(
+                limit,
+                "limit",
+                default=25,
+                minimum=1,
+                maximum=100,
+            )
+            assert normalized_limit is not None
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        try:
+            private_endpoint_store = require_private_health_endpoint_read_store(record_store)
+            records = private_endpoint_store.list_private_health_endpoint_records(
+                product=normalized_product,
+                context_name=context_name,
+                instance_name=instance_name,
+                status=status.strip(),
+                limit=normalized_limit,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        return PrivateHealthEndpointRecordsResponse(
+            trace_id=trace_id,
+            product=normalized_product,
+            context=context_name,
+            instance=instance_name,
+            limit=normalized_limit,
+            count=len(records),
+            records=records,
+        )
+
+    def read_private_health_endpoint_record(
+        endpoint_key: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        product: Annotated[str, Query()] = "",
+        context: Annotated[str, Query()] = "",
+        instance: Annotated[str, Query()] = "",
+    ) -> PrivateHealthEndpointRecordResponse:
+        trace_id = next_trace_id()
+        normalized_product = product.strip()
+        context_name = context.strip()
+        instance_name = instance.strip()
+        if not normalized_product or not context_name:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=(
+                    "Private health endpoint reads require product and context query parameters."
+                ),
+            )
+        ensure_private_health_endpoint_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            product=normalized_product,
+            context_name=context_name,
+        )
+        try:
+            private_endpoint_store = require_private_health_endpoint_read_store(record_store)
+            record = private_endpoint_store.read_private_health_endpoint_record(endpoint_key)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if (
+            record.product != normalized_product
+            or record.context != context_name
+            or (instance_name and record.instance != instance_name)
+        ):
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=f"Record not found: {endpoint_key}",
+            )
+        return PrivateHealthEndpointRecordResponse(trace_id=trace_id, record=record)
 
     def read_deployment_record(
         record_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -3594,6 +3803,37 @@ def create_launchplane_fastapi_app(
         operation_id="read_edge_endpoint_record",
         summary="Read one edge endpoint record",
         responses={
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/private-health-endpoints/records",
+        list_private_health_endpoint_records,
+        methods=["GET"],
+        response_model=PrivateHealthEndpointRecordsResponse,
+        operation_id="list_private_health_endpoint_records",
+        summary="List private health endpoint records",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/private-health-endpoints/records/{endpoint_key}",
+        read_private_health_endpoint_record,
+        methods=["GET"],
+        response_model=PrivateHealthEndpointRecordResponse,
+        operation_id="read_private_health_endpoint_record",
+        summary="Read one private health endpoint record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
             404: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -870,16 +870,6 @@ class _PrivateHealthEndpointRecordStore(Protocol):
         self, endpoint_key: str
     ) -> PrivateHealthEndpointRecord: ...
 
-    def list_private_health_endpoint_records(
-        self,
-        *,
-        product: str = "",
-        context_name: str = "",
-        instance_name: str = "",
-        status: str = "",
-        limit: int | None = None,
-    ) -> tuple[PrivateHealthEndpointRecord, ...]: ...
-
 
 class _IngressCanaryRouteRecordStore(Protocol):
     def write_ingress_canary_route_record(self, record: IngressCanaryRouteRecord) -> object: ...
@@ -4494,10 +4484,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "ingress_route.plan", {"ingress_route_audit_list": "true"}
     if len(segments) == 5 and segments[:4] == ["v1", "ingress", "route-audits", "records"]:
         return "ingress_route.plan", {"ingress_route_audit_record_id": segments[4]}
-    if len(segments) == 3 and segments == ["v1", "private-health-endpoints", "records"]:
-        return "private_health_endpoint.read", {"private_health_endpoint_list": "true"}
-    if len(segments) == 4 and segments[:3] == ["v1", "private-health-endpoints", "records"]:
-        return "private_health_endpoint.read", {"private_health_endpoint_key": segments[3]}
     if len(segments) == 3 and segments == ["v1", "dokploy-targets", "inspect"]:
         return "dokploy_target.inspect", {}
     if len(segments) == 4 and segments == ["v1", "ingress", "canary-routes", "records"]:
@@ -6944,7 +6930,6 @@ def _private_health_endpoint_record_store(
     required_methods = (
         "write_private_health_endpoint_record",
         "read_private_health_endpoint_record",
-        "list_private_health_endpoint_records",
     )
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_PrivateHealthEndpointRecordStore, record_store)
@@ -10481,107 +10466,6 @@ def create_launchplane_service_app(
                             "count": len(limited_records),
                             "records": [
                                 record.model_dump(mode="json") for record in limited_records
-                            ],
-                        },
-                    )
-                if action == "private_health_endpoint.read":
-                    private_endpoint_store = _private_health_endpoint_record_store(record_store)
-                    product = _query_string_value(query, "product")
-                    context_name = _query_string_value(query, "context")
-                    instance_name = _query_string_value(query, "instance")
-                    if not product or not context_name:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=400,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "invalid_query",
-                                    "message": (
-                                        "Private health endpoint reads require product and "
-                                        "context query parameters."
-                                    ),
-                                },
-                            },
-                        )
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product=product,
-                        context=context_name,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": (
-                                        "Workflow cannot read private health endpoints "
-                                        "for the requested product/context."
-                                    ),
-                                },
-                            },
-                        )
-                    if "private_health_endpoint_key" in params:
-                        try:
-                            private_endpoint_record = (
-                                private_endpoint_store.read_private_health_endpoint_record(
-                                    params["private_health_endpoint_key"]
-                                )
-                            )
-                        except FileNotFoundError:
-                            return _not_found_response(
-                                start_response=start_response,
-                                trace_id=request_trace_id,
-                                path=path,
-                            )
-                        if (
-                            private_endpoint_record.product != product
-                            or private_endpoint_record.context != context_name
-                            or (instance_name and private_endpoint_record.instance != instance_name)
-                        ):
-                            return _not_found_response(
-                                start_response=start_response,
-                                trace_id=request_trace_id,
-                                path=path,
-                            )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "record": private_endpoint_record.model_dump(mode="json"),
-                            },
-                        )
-                    limit = _query_int_value(query, "limit", default=25, minimum=1, maximum=100)
-                    private_endpoint_records = (
-                        private_endpoint_store.list_private_health_endpoint_records(
-                            product=product,
-                            context_name=context_name,
-                            instance_name=instance_name,
-                            status=_query_string_value(query, "status"),
-                            limit=limit,
-                        )
-                    )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "product": product,
-                            "context": context_name,
-                            "instance": instance_name,
-                            "limit": limit,
-                            "count": len(private_endpoint_records),
-                            "records": [
-                                record.model_dump(mode="json")
-                                for record in private_endpoint_records
                             ],
                         },
                     )

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -68,6 +68,11 @@ Keep a compatibility surface only when it is one of these:
   and `GET /v1/edge-endpoints/records/{endpoint_key}` routes. Their legacy WSGI
   read branch is deleted; edge endpoint apply remains on the retained fallback
   until that write path has its own native replacement.
+- Private health endpoint record reads use native FastAPI
+  `GET /v1/private-health-endpoints/records` and
+  `GET /v1/private-health-endpoints/records/{endpoint_key}` routes. Their
+  legacy WSGI read branch is deleted; private health endpoint apply remains on
+  the retained fallback until that write path has its own native replacement.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -62,6 +62,13 @@ VeriReel product paths:
     bounded `limit` filters
   - `GET /v1/edge-endpoints/records/{endpoint_key}`, requiring
     `edge_endpoint.read` for the Launchplane service context
+- native FastAPI private health endpoint record reads:
+  - `GET /v1/private-health-endpoints/records`, requiring
+    `private_health_endpoint.read` for the requested product/context and
+    supporting `instance`, `status`, and bounded `limit` filters
+  - `GET /v1/private-health-endpoints/records/{endpoint_key}`, requiring
+    `private_health_endpoint.read` for the requested product/context and
+    returning 404 when the stored record is outside that query scope
 - native FastAPI deployment, promotion, preview, inventory, operations, and
   managed-secret status reads:
   - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
@@ -1314,6 +1321,10 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/edge-endpoints/records` (native FastAPI for bearer-token and
   human-session callers)
 - `GET /v1/edge-endpoints/records/{endpoint_key}` (native FastAPI for
+  bearer-token and human-session callers)
+- `GET /v1/private-health-endpoints/records` (native FastAPI for bearer-token
+  and human-session callers)
+- `GET /v1/private-health-endpoints/records/{endpoint_key}` (native FastAPI for
   bearer-token and human-session callers)
 
 These operator reads use the same Launchplane authn/authz boundary as evidence

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -82,6 +82,7 @@ from tests.test_service import (
     _generic_site_profile_payload,
     _edge_endpoint_record,
     _identity,
+    _private_health_endpoint_record,
     _product_profile_payload,
     _product_profile_payload_with_prod,
     _seed_tracked_target_records,
@@ -3869,6 +3870,258 @@ class FastApiEdgeEndpointReadTests(unittest.IsolatedAsyncioTestCase):
             app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
 
             response = await _get_edge_endpoint_record(app, "cm-prod-dokploy")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+
+class FastApiPrivateHealthEndpointReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_private_health_endpoint_read_returns_record_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_private_health_endpoint_record(_private_health_endpoint_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_private_health_endpoint_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_private_health_endpoint_record(
+                app,
+                "repairshopr-sync-prod-runtime",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["record"]["endpoint_key"], "repairshopr-sync-prod-runtime")
+        self.assertEqual(payload["record"]["product"], "repairshopr-sync")
+        self.assertEqual(payload["record"]["url"], "http://10.0.0.5:8000/health")
+
+    async def test_private_health_endpoint_list_filters_records(self) -> None:
+        active_record = _private_health_endpoint_record()
+        disabled_record = active_record.model_copy(
+            update={
+                "endpoint_key": "repairshopr-sync-disabled-runtime",
+                "instance": "disabled",
+                "url": "http://10.0.0.6:8000/health",
+                "status": "disabled",
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_private_health_endpoint_record(active_record)
+            store.write_private_health_endpoint_record(disabled_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_private_health_endpoint_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_private_health_endpoint_records(
+                app,
+                instance="prod",
+                status="active",
+                limit="1",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["product"], "repairshopr-sync")
+        self.assertEqual(payload["context"], "repairshopr-sync")
+        self.assertEqual(payload["instance"], "prod")
+        self.assertEqual(payload["limit"], 1)
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["records"][0]["endpoint_key"], "repairshopr-sync-prod-runtime")
+
+    async def test_private_health_endpoint_reads_require_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_private_health_endpoint_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_private_health_endpoint_records(app, authorization="")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_private_health_endpoint_reads_require_product_and_context(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_private_health_endpoint_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        missing_product = await _get_private_health_endpoint_records(app, product="")
+        missing_context = await _get_private_health_endpoint_record(
+            app,
+            "repairshopr-sync-prod-runtime",
+            context="",
+        )
+
+        self.assertEqual(missing_product.status_code, 400)
+        self.assertEqual(missing_context.status_code, 400)
+        self.assertEqual(missing_product.json()["error"]["code"], "invalid_query")
+        self.assertEqual(missing_context.json()["error"]["code"], "invalid_query")
+
+    async def test_private_health_endpoint_reads_require_authz_action(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="edge_endpoint.read",
+                context="repairshopr-sync",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_private_health_endpoint_record(
+            app,
+            "repairshopr-sync-prod-runtime",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_private_health_endpoint_reads_require_record_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_private_health_endpoint_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_private_health_endpoint_records(app)
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_private_health_endpoint_read_returns_not_found_for_missing_record(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_private_health_endpoint_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_private_health_endpoint_record(app, "missing-runtime")
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_private_health_endpoint_read_returns_not_found_outside_scope(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_private_health_endpoint_record(_private_health_endpoint_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_private_health_endpoint_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_private_health_endpoint_record(
+                app,
+                "repairshopr-sync-prod-runtime",
+                instance="preview",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_private_health_endpoint_list_validates_limit(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_private_health_endpoint_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        low_response = await _get_private_health_endpoint_records(app, limit="0")
+        high_response = await _get_private_health_endpoint_records(app, limit="101")
+
+        self.assertEqual(low_response.status_code, 400)
+        self.assertEqual(high_response.status_code, 400)
+        self.assertEqual(low_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(high_response.json()["error"]["code"], "invalid_query")
+
+    async def test_openapi_includes_private_health_endpoint_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_private_health_endpoint_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        list_route = openapi["paths"]["/v1/private-health-endpoints/records"]["get"]
+        read_route = openapi["paths"]["/v1/private-health-endpoints/records/{endpoint_key}"]["get"]
+        self.assertEqual(list_route["operationId"], "list_private_health_endpoint_records")
+        self.assertEqual(read_route["operationId"], "read_private_health_endpoint_record")
+        self.assertEqual(
+            list_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/PrivateHealthEndpointRecordsResponse",
+        )
+        self.assertEqual(
+            read_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/PrivateHealthEndpointRecordResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(list_route))
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(read_route))
+        self.assertEqual(
+            openapi["components"]["schemas"]["PrivateHealthEndpointRecordResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["PrivateHealthEndpointRecordsResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+
+    async def test_fastapi_private_health_endpoint_reads_precede_legacy_wsgi_fallback(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_private_health_endpoint_record(_private_health_endpoint_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_private_health_endpoint_read_policy(),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _get_private_health_endpoint_record(
+                app,
+                "repairshopr-sync-prod-runtime",
+            )
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "ok")
@@ -7875,6 +8128,25 @@ def _record_read_policy(
     )
 
 
+def _private_health_endpoint_read_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["repairshopr-sync"],
+                    "contexts": ["repairshopr-sync"],
+                    "actions": ["private_health_endpoint.read"],
+                }
+            ]
+        }
+    )
+
+
 def _github_human_deployment_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -8654,6 +8926,67 @@ async def _get_edge_endpoint_record(
     return await _asgi_get(
         app,
         f"/v1/edge-endpoints/records/{endpoint_key}",
+        headers=request_headers,
+    )
+
+
+async def _get_private_health_endpoint_records(
+    app: FastAPI,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+    product: str = "repairshopr-sync",
+    context: str = "repairshopr-sync",
+    instance: str = "",
+    status: str = "",
+    limit: str = "",
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    params = {}
+    if product:
+        params["product"] = product
+    if context:
+        params["context"] = context
+    if instance:
+        params["instance"] = instance
+    if status:
+        params["status"] = status
+    if limit:
+        params["limit"] = limit
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/private-health-endpoints/records{suffix}",
+        headers=request_headers,
+    )
+
+
+async def _get_private_health_endpoint_record(
+    app: FastAPI,
+    endpoint_key: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+    product: str = "repairshopr-sync",
+    context: str = "repairshopr-sync",
+    instance: str = "prod",
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    params = {}
+    if product:
+        params["product"] = product
+    if context:
+        params["context"] = context
+    if instance:
+        params["instance"] = instance
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/private-health-endpoints/records/{endpoint_key}{suffix}",
         headers=request_headers,
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2495,11 +2495,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
         with self.assertRaises(FileNotFoundError):
             record_store.read_edge_endpoint_record("cm-prod-dokploy")
 
-    def test_private_health_endpoint_apply_and_read_routes_store_db_backed_url(
+    def test_private_health_endpoint_apply_route_stores_db_backed_url(
         self,
     ) -> None:
         policy = _local_operator_policy(
-            actions=("private_health_endpoint.apply", "private_health_endpoint.read"),
+            actions=("private_health_endpoint.apply",),
             products=("repairshopr-sync",),
             contexts=("repairshopr-sync",),
         )
@@ -2529,12 +2529,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     authorization="Bearer local-operator-token",
                     headers={"Idempotency-Key": "private-health-endpoint-apply"},
                 )
-                read_status_code, read_payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path=("/v1/private-health-endpoints/records/repairshopr-sync-prod-runtime"),
-                    query_string="product=repairshopr-sync&context=repairshopr-sync&instance=prod",
-                    authorization="Bearer local-operator-token",
+                stored_record = record_store.read_private_health_endpoint_record(
+                    "repairshopr-sync-prod-runtime"
                 )
 
         self.assertEqual(apply_status_code, 202)
@@ -2546,9 +2542,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
             apply_payload["result"]["endpoint_status"],
             "applied",
         )
-        self.assertEqual(read_status_code, 200)
-        self.assertEqual(read_payload["record"]["product"], "repairshopr-sync")
-        self.assertEqual(read_payload["record"]["url"], "http://10.0.0.5:8000/health")
+        self.assertEqual(stored_record.product, "repairshopr-sync")
+        self.assertEqual(stored_record.url, "http://10.0.0.5:8000/health")
 
     def test_private_health_endpoint_apply_rejects_public_url(self) -> None:
         policy = _local_operator_policy(
@@ -13317,6 +13312,37 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 app,
                 method="GET",
                 path="/v1/edge-endpoints/records/cm-prod-dokploy",
+                authorization="",
+            )
+
+        self.assertEqual(list_status_code, 404)
+        self.assertEqual(read_status_code, 404)
+        self.assertEqual(list_payload["error"]["code"], "not_found")
+        self.assertEqual(read_payload["error"]["code"], "not_found")
+
+    def test_private_health_endpoint_read_routes_are_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+                local_record_store_for_tests=FilesystemRecordStore(state_dir=state_dir),
+            )
+
+            list_status_code, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/private-health-endpoints/records",
+                authorization="",
+            )
+            read_status_code, read_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/private-health-endpoints/records/repairshopr-sync-prod-runtime",
                 authorization="",
             )
 


### PR DESCRIPTION
## Summary
- Move private health endpoint record list/read routes to native FastAPI with typed response models and OpenAPI contracts.
- Preserve legacy product/context query requirements, requested-scope authorization, instance/status/limit filters, and 404 behavior for missing or out-of-scope keyed records.
- Remove the legacy WSGI private_health_endpoint.read matcher/handler and stale list-store requirement while keeping private health endpoint apply on the retained WSGI fallback.
- Update service-boundary and compatibility-retirement docs for the new cutover point.

Refs #1322

## Validation
- uv run python -m unittest tests.test_http_app.FastApiPrivateHealthEndpointReadTests tests.test_service.LaunchplaneServiceTests.test_private_health_endpoint_apply_route_stores_db_backed_url tests.test_service.LaunchplaneServiceTests.test_private_health_endpoint_apply_rejects_public_url tests.test_service.LaunchplaneServiceTests.test_private_health_endpoint_apply_rejects_cross_product_overwrite tests.test_service.LaunchplaneServiceTests.test_private_health_endpoint_read_routes_are_retired_from_legacy_wsgi_app
- uv run --extra dev ruff check --exit-zero control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py docs/service-boundary.md docs/compatibility-retirement.md
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- git diff --check
- uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py docs/service-boundary.md docs/compatibility-retirement.md
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff check .
- uv run python -m unittest (2720 tests)
- JetBrains changed-files closeout: clean, 0 problems
- Review agents: GREEN TO MERGE from claude-sonnet-4.6 and antigravity
