### PR TITLE
Move ingress canary reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -42,6 +42,7 @@ from control_plane.contracts.idempotency_record import (
     build_launchplane_idempotency_record_id,
 )
 from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
+from control_plane.contracts.ingress_canary_route_record import IngressCanaryRouteRecord
 from control_plane.contracts.product_environment_read_model import (
     ProductActivityReadModel,
     ProductEnvironmentConfigStatus,
@@ -429,6 +430,24 @@ class PrivateHealthEndpointRecordsResponse(BaseModel):
     records: tuple[PrivateHealthEndpointRecord, ...]
 
 
+class IngressCanaryRouteRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: IngressCanaryRouteRecord
+
+
+class IngressCanaryRouteRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    limit: int
+    count: int
+    records: tuple[IngressCanaryRouteRecord, ...]
+
+
 class DeploymentRecordResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -769,6 +788,19 @@ class _PrivateHealthEndpointReadStore(Protocol):
         status: str = "",
         limit: int | None = None,
     ) -> tuple[PrivateHealthEndpointRecord, ...]: ...
+
+
+class _IngressCanaryRouteReadStore(Protocol):
+    def read_ingress_canary_route_record(self, canary_key: str) -> IngressCanaryRouteRecord: ...
+
+    def list_ingress_canary_route_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[IngressCanaryRouteRecord, ...]: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -1136,6 +1168,27 @@ def require_private_health_endpoint_read_store(
             f"{missing_summary}"
         )
     return cast(_PrivateHealthEndpointReadStore, record_store)
+
+
+def require_ingress_canary_route_read_store(
+    record_store: object,
+) -> _IngressCanaryRouteReadStore:
+    required_methods = (
+        "read_ingress_canary_route_record",
+        "list_ingress_canary_route_records",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support ingress canary route reads: "
+            f"{missing_summary}"
+        )
+    return cast(_IngressCanaryRouteReadStore, record_store)
 
 
 def product_profile_context_cutover_allowed_contexts(
@@ -2406,6 +2459,98 @@ def create_launchplane_fastapi_app(
                 message=f"Record not found: {endpoint_key}",
             )
         return PrivateHealthEndpointRecordResponse(trace_id=trace_id, record=record)
+
+    def ensure_ingress_canary_route_read_allowed(
+        *,
+        identity: LaunchplaneIdentity,
+        trace_id: str,
+    ) -> None:
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="ingress_canary_route.read",
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read Launchplane ingress canary route records.",
+            )
+
+    def list_ingress_canary_route_records(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        limit: Annotated[str, Query()] = "25",
+        product: Annotated[str, Query()] = "",
+        context: Annotated[str, Query()] = "",
+        status: Annotated[str, Query()] = "",
+    ) -> IngressCanaryRouteRecordsResponse:
+        trace_id = next_trace_id()
+        ensure_ingress_canary_route_read_allowed(identity=identity, trace_id=trace_id)
+        try:
+            normalized_limit = control_plane_service_status.query_int_value(
+                limit,
+                "limit",
+                default=25,
+                minimum=1,
+                maximum=100,
+            )
+            assert normalized_limit is not None
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        try:
+            canary_store = require_ingress_canary_route_read_store(record_store)
+            records = canary_store.list_ingress_canary_route_records(
+                product=product.strip(),
+                context_name=context.strip(),
+                status=status.strip(),
+                limit=normalized_limit,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        return IngressCanaryRouteRecordsResponse(
+            trace_id=trace_id,
+            limit=normalized_limit,
+            count=len(records),
+            records=records,
+        )
+
+    def read_ingress_canary_route_record(
+        canary_key: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> IngressCanaryRouteRecordResponse:
+        trace_id = next_trace_id()
+        ensure_ingress_canary_route_read_allowed(identity=identity, trace_id=trace_id)
+        try:
+            canary_store = require_ingress_canary_route_read_store(record_store)
+            record = canary_store.read_ingress_canary_route_record(canary_key)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        return IngressCanaryRouteRecordResponse(trace_id=trace_id, record=record)
 
     def read_deployment_record(
         record_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -3834,6 +3979,36 @@ def create_launchplane_fastapi_app(
         summary="Read one private health endpoint record",
         responses={
             400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/ingress/canary-routes/records",
+        list_ingress_canary_route_records,
+        methods=["GET"],
+        response_model=IngressCanaryRouteRecordsResponse,
+        operation_id="list_ingress_canary_route_records",
+        summary="List ingress canary route records",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/ingress/canary-routes/records/{canary_key}",
+        read_ingress_canary_route_record,
+        methods=["GET"],
+        response_model=IngressCanaryRouteRecordResponse,
+        operation_id="read_ingress_canary_route_record",
+        summary="Read one ingress canary route record",
+        responses={
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
             404: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -876,15 +876,6 @@ class _IngressCanaryRouteRecordStore(Protocol):
 
     def read_ingress_canary_route_record(self, canary_key: str) -> IngressCanaryRouteRecord: ...
 
-    def list_ingress_canary_route_records(
-        self,
-        *,
-        product: str = "",
-        context_name: str = "",
-        status: str = "",
-        limit: int | None = None,
-    ) -> tuple[IngressCanaryRouteRecord, ...]: ...
-
 
 _StartResponse = Callable[[str, list[tuple[str, str]]], None]
 _WsgiApp = Callable[[dict[str, object], _StartResponse], list[bytes]]
@@ -4486,10 +4477,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         return "ingress_route.plan", {"ingress_route_audit_record_id": segments[4]}
     if len(segments) == 3 and segments == ["v1", "dokploy-targets", "inspect"]:
         return "dokploy_target.inspect", {}
-    if len(segments) == 4 and segments == ["v1", "ingress", "canary-routes", "records"]:
-        return "ingress_canary_route.read", {"ingress_canary_route_list": "true"}
-    if len(segments) == 5 and segments[:4] == ["v1", "ingress", "canary-routes", "records"]:
-        return "ingress_canary_route.read", {"ingress_canary_route_key": segments[4]}
     if path == _MERGE_TRAIN_ADMISSION_ROUTE:
         return "merge_train.admission", {}
     if path == _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE:
@@ -6944,7 +6931,6 @@ def _ingress_canary_route_record_store(
     required_methods = (
         "write_ingress_canary_route_record",
         "read_ingress_canary_route_record",
-        "list_ingress_canary_route_records",
     )
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_IngressCanaryRouteRecordStore, record_store)
@@ -10548,84 +10534,6 @@ def create_launchplane_service_app(
                             "status": "ok",
                             "trace_id": request_trace_id,
                             "inspect": inspect_result,
-                        },
-                    )
-                if action == "ingress_canary_route.read":
-                    canary_store = _ingress_canary_route_record_store(record_store)
-                    if "ingress_canary_route_key" in params:
-                        if not authz_policy.allows(
-                            identity=identity,
-                            action=action,
-                            product="launchplane",
-                            context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                        ):
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=403,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "authorization_denied",
-                                        "message": "Workflow cannot read Launchplane ingress canary route records.",
-                                    },
-                                },
-                            )
-                        try:
-                            canary_record = canary_store.read_ingress_canary_route_record(
-                                params["ingress_canary_route_key"]
-                            )
-                        except FileNotFoundError:
-                            return _not_found_response(
-                                start_response=start_response,
-                                trace_id=request_trace_id,
-                                path=path,
-                            )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "record": canary_record.model_dump(mode="json"),
-                            },
-                        )
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read Launchplane ingress canary route records.",
-                                },
-                            },
-                        )
-                    limit = _query_int_value(query, "limit", default=25, minimum=1, maximum=100)
-                    canary_records = canary_store.list_ingress_canary_route_records(
-                        product=_query_string_value(query, "product"),
-                        context_name=_query_string_value(query, "context"),
-                        status=_query_string_value(query, "status"),
-                        limit=limit,
-                    )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "limit": limit,
-                            "count": len(canary_records),
-                            "records": [
-                                record.model_dump(mode="json") for record in canary_records
-                            ],
                         },
                     )
                 if action == "every_code_work_request.read":

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -73,6 +73,11 @@ Keep a compatibility surface only when it is one of these:
   `GET /v1/private-health-endpoints/records/{endpoint_key}` routes. Their
   legacy WSGI read branch is deleted; private health endpoint apply remains on
   the retained fallback until that write path has its own native replacement.
+- Ingress canary route record reads use native FastAPI
+  `GET /v1/ingress/canary-routes/records` and
+  `GET /v1/ingress/canary-routes/records/{canary_key}` routes. Their legacy
+  WSGI read branch is deleted; ingress canary route apply remains on the
+  retained fallback until that write path has its own native replacement.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -69,6 +69,12 @@ VeriReel product paths:
   - `GET /v1/private-health-endpoints/records/{endpoint_key}`, requiring
     `private_health_endpoint.read` for the requested product/context and
     returning 404 when the stored record is outside that query scope
+- native FastAPI ingress canary route record reads:
+  - `GET /v1/ingress/canary-routes/records`, requiring
+    `ingress_canary_route.read` for the Launchplane service context and
+    supporting `product`, `context`, `status`, and bounded `limit` filters
+  - `GET /v1/ingress/canary-routes/records/{canary_key}`, requiring
+    `ingress_canary_route.read` for the Launchplane service context
 - native FastAPI deployment, promotion, preview, inventory, operations, and
   managed-secret status reads:
   - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
@@ -1325,6 +1331,10 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/private-health-endpoints/records` (native FastAPI for bearer-token
   and human-session callers)
 - `GET /v1/private-health-endpoints/records/{endpoint_key}` (native FastAPI for
+  bearer-token and human-session callers)
+- `GET /v1/ingress/canary-routes/records` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/ingress/canary-routes/records/{canary_key}` (native FastAPI for
   bearer-token and human-session callers)
 
 These operator reads use the same Launchplane authn/authz boundary as evidence

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -82,6 +82,7 @@ from tests.test_service import (
     _generic_site_profile_payload,
     _edge_endpoint_record,
     _identity,
+    _ingress_canary_route_record,
     _private_health_endpoint_record,
     _product_profile_payload,
     _product_profile_payload_with_prod,
@@ -4122,6 +4123,226 @@ class FastApiPrivateHealthEndpointReadTests(unittest.IsolatedAsyncioTestCase):
                 app,
                 "repairshopr-sync-prod-runtime",
             )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+
+class FastApiIngressCanaryRouteReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_ingress_canary_route_read_returns_record_for_authorized_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_ingress_canary_route_record(_ingress_canary_route_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="ingress_canary_route.read",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_ingress_canary_route_record(app, "ingress-canary")
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["record"]["canary_key"], "ingress-canary")
+        self.assertEqual(payload["record"]["domain_name"], "ingress-canary.example.test")
+        self.assertEqual(payload["record"]["edge_endpoint_key"], "cm-prod-dokploy")
+
+    async def test_ingress_canary_route_list_filters_records(self) -> None:
+        active_record = _ingress_canary_route_record()
+        disabled_record = active_record.model_copy(
+            update={
+                "canary_key": "disabled-canary",
+                "domain_name": "disabled-canary.example.test",
+                "expected_host_id": 79,
+                "status": "disabled",
+            }
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_ingress_canary_route_record(active_record)
+            store.write_ingress_canary_route_record(disabled_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="ingress_canary_route.read",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_ingress_canary_route_records(
+                app,
+                product="launchplane",
+                context="reon-prod",
+                status="active",
+                limit="1",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["limit"], 1)
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(payload["records"][0]["canary_key"], "ingress-canary")
+
+    async def test_ingress_canary_route_reads_require_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="ingress_canary_route.read",
+                context="launchplane",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_ingress_canary_route_records(app, authorization="")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_ingress_canary_route_reads_require_authz_action(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="driver.read", context="launchplane"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_ingress_canary_route_record(app, "ingress-canary")
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_ingress_canary_route_reads_require_record_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="ingress_canary_route.read",
+                context="launchplane",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_ingress_canary_route_records(app)
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_ingress_canary_route_read_returns_not_found_for_missing_record(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="ingress_canary_route.read",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_ingress_canary_route_record(app, "missing-canary")
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_ingress_canary_route_list_validates_limit(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="ingress_canary_route.read",
+                context="launchplane",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        low_response = await _get_ingress_canary_route_records(app, limit="0")
+        high_response = await _get_ingress_canary_route_records(app, limit="101")
+
+        self.assertEqual(low_response.status_code, 400)
+        self.assertEqual(high_response.status_code, 400)
+        self.assertEqual(low_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(high_response.json()["error"]["code"], "invalid_query")
+
+    async def test_openapi_includes_ingress_canary_route_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="ingress_canary_route.read",
+                context="launchplane",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        list_route = openapi["paths"]["/v1/ingress/canary-routes/records"]["get"]
+        read_route = openapi["paths"]["/v1/ingress/canary-routes/records/{canary_key}"]["get"]
+        self.assertEqual(list_route["operationId"], "list_ingress_canary_route_records")
+        self.assertEqual(read_route["operationId"], "read_ingress_canary_route_record")
+        self.assertEqual(
+            list_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/IngressCanaryRouteRecordsResponse",
+        )
+        self.assertEqual(
+            read_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/IngressCanaryRouteRecordResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(list_route))
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(read_route))
+        self.assertEqual(
+            openapi["components"]["schemas"]["IngressCanaryRouteRecordResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["IngressCanaryRouteRecordsResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+
+    async def test_fastapi_ingress_canary_route_reads_precede_legacy_wsgi_fallback(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_ingress_canary_route_record(_ingress_canary_route_record())
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="ingress_canary_route.read",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _get_ingress_canary_route_record(app, "ingress-canary")
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "ok")
@@ -8987,6 +9208,53 @@ async def _get_private_health_endpoint_record(
     return await _asgi_get(
         app,
         f"/v1/private-health-endpoints/records/{endpoint_key}{suffix}",
+        headers=request_headers,
+    )
+
+
+async def _get_ingress_canary_route_records(
+    app: FastAPI,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+    product: str = "",
+    context: str = "",
+    status: str = "",
+    limit: str = "",
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    params = {}
+    if product:
+        params["product"] = product
+    if context:
+        params["context"] = context
+    if status:
+        params["status"] = status
+    if limit:
+        params["limit"] = limit
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/ingress/canary-routes/records{suffix}",
+        headers=request_headers,
+    )
+
+
+async def _get_ingress_canary_route_record(
+    app: FastAPI,
+    canary_key: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_get(
+        app,
+        f"/v1/ingress/canary-routes/records/{canary_key}",
         headers=request_headers,
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2638,11 +2638,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
             "conflicting_private_health_endpoint",
         )
 
-    def test_ingress_canary_route_record_apply_and_read_store_route_authority(
+    def test_ingress_canary_route_record_apply_stores_route_authority(
         self,
     ) -> None:
         policy = _local_operator_policy(
-            actions=("ingress_canary_route.apply", "ingress_canary_route.read"),
+            actions=("ingress_canary_route.apply",),
             products=("launchplane",),
             contexts=("launchplane",),
         )
@@ -2672,19 +2672,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     authorization="Bearer local-operator-token",
                     headers={"Idempotency-Key": "ingress-canary-record-apply"},
                 )
-                read_status_code, read_payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/ingress/canary-routes/records/ingress-canary",
-                    authorization="Bearer local-operator-token",
-                )
+                stored_record = record_store.read_ingress_canary_route_record("ingress-canary")
 
         self.assertEqual(apply_status_code, 202)
         self.assertEqual(apply_payload["records"]["ingress_canary_route_key"], "ingress-canary")
         self.assertEqual(apply_payload["records"]["ingress_canary_route_status"], "applied")
-        self.assertEqual(read_status_code, 200)
-        self.assertEqual(read_payload["record"]["domain_name"], "ingress-canary.example.test")
-        self.assertEqual(read_payload["record"]["edge_endpoint_key"], "cm-prod-dokploy")
+        self.assertEqual(stored_record.domain_name, "ingress-canary.example.test")
+        self.assertEqual(stored_record.edge_endpoint_key, "cm-prod-dokploy")
 
     def test_ingress_canary_route_apply_resolves_profile_and_edge_endpoint(self) -> None:
         client = _FakeNpmplusIngressClient((_npmplus_proxy_host(id=78),))
@@ -13343,6 +13337,37 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 app,
                 method="GET",
                 path="/v1/private-health-endpoints/records/repairshopr-sync-prod-runtime",
+                authorization="",
+            )
+
+        self.assertEqual(list_status_code, 404)
+        self.assertEqual(read_status_code, 404)
+        self.assertEqual(list_payload["error"]["code"], "not_found")
+        self.assertEqual(read_payload["error"]["code"], "not_found")
+
+    def test_ingress_canary_route_read_routes_are_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+                local_record_store_for_tests=FilesystemRecordStore(state_dir=state_dir),
+            )
+
+            list_status_code, list_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/ingress/canary-routes/records",
+                authorization="",
+            )
+            read_status_code, read_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/ingress/canary-routes/records/ingress-canary",
                 authorization="",
             )
 


### PR DESCRIPTION
## Summary
- Move ingress canary route record list/read endpoints to native FastAPI handlers.
- Preserve `ingress_canary_route.read` authorization and record-store read semantics, including list filters and bounded limit parsing.
- Remove the retired WSGI read matcher/handler and stale list-store requirement while keeping ingress canary apply on the legacy write path.
- Update service-boundary and compatibility-retirement docs for the v2 cutover checkpoint.

Refs #1322

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiIngressCanaryRouteReadTests tests.test_service.LaunchplaneServiceTests.test_ingress_canary_route_record_apply_stores_route_authority tests.test_service.LaunchplaneServiceTests.test_ingress_canary_route_apply_resolves_profile_and_edge_endpoint tests.test_service.LaunchplaneServiceTests.test_ingress_canary_route_apply_idempotency_ignores_record_changes tests.test_service.LaunchplaneServiceTests.test_ingress_canary_route_apply_rejects_missing_profile tests.test_service.LaunchplaneServiceTests.test_ingress_canary_route_apply_rejects_disabled_profile tests.test_service.LaunchplaneServiceTests.test_ingress_canary_route_apply_authorizes_before_profile_lookup tests.test_service.LaunchplaneServiceTests.test_ingress_canary_route_read_routes_are_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff check --exit-zero control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py docs/service-boundary.md docs/compatibility-retirement.md`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `git diff --check`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py docs/service-boundary.md docs/compatibility-retirement.md`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- JetBrains changed-files closeout: clean
- Review agents: antigravity and claude-sonnet both GREEN TO MERGE
