### PR TITLE
Move Every Code reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -36,6 +36,12 @@ from control_plane.contracts.driver_descriptor import DriverContextView, DriverD
 from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
+from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
+from control_plane.contracts.every_code_notifications import EveryCodeNotificationAttemptRecord
+from control_plane.contracts.every_code_summary_read_model import (
+    EveryCodeSummaryReadModel,
+    build_every_code_summary_read_model,
+)
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
@@ -58,6 +64,13 @@ from control_plane.contracts.preview_evidence import (
     PreviewGenerationEvidenceEnvelope,
 )
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_pr_feedback_notifications import (
+    PreviewPrFeedbackNotificationAttemptRecord,
+)
+from control_plane.contracts.preview_readiness_read_model import (
+    PreviewReadinessReadModel,
+    build_preview_readiness_read_model,
+)
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.protected_artifacts import (
@@ -448,6 +461,84 @@ class IngressCanaryRouteRecordsResponse(BaseModel):
     records: tuple[IngressCanaryRouteRecord, ...]
 
 
+class EveryCodeWorkRequestRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    state: str
+    repository: str
+    requests: tuple[EveryCodeWorkRequestRecord, ...]
+
+
+class EveryCodeWorkRequestRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    request: EveryCodeWorkRequestRecord
+
+
+class EveryCodeSummaryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    summary: EveryCodeSummaryReadModel
+
+
+class PreviewReadinessResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    readiness: PreviewReadinessReadModel
+
+
+class EveryCodePrFeedbackRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    request_id: str
+    repository: str
+    status_filter: str
+    feedback: tuple[EveryCodePrFeedbackRecord, ...]
+
+
+class EveryCodePreviewGateRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    request_id: str
+    repository: str
+    status_filter: str
+    gates: tuple[EveryCodePreviewGateRecord, ...]
+
+
+class EveryCodeNotificationAttemptRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    request_id: str
+    event_filter: str
+    destination_kind_filter: str
+    attempts: tuple[EveryCodeNotificationAttemptRecord, ...]
+
+
+class PreviewPrFeedbackNotificationAttemptRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    feedback_id: str
+    event_filter: str
+    destination_kind_filter: str
+    attempts: tuple[PreviewPrFeedbackNotificationAttemptRecord, ...]
+
+
 class DeploymentRecordResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -801,6 +892,71 @@ class _IngressCanaryRouteReadStore(Protocol):
         status: str = "",
         limit: int | None = None,
     ) -> tuple[IngressCanaryRouteRecord, ...]: ...
+
+
+class _EveryCodeWorkRequestListStore(Protocol):
+    def list_every_code_work_request_records(
+        self,
+        *,
+        state: str = "",
+        repository: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodeWorkRequestRecord, ...]: ...
+
+
+class _EveryCodeWorkRequestRecordStore(Protocol):
+    def read_every_code_work_request_record(
+        self, request_id: str
+    ) -> EveryCodeWorkRequestRecord: ...
+
+
+class _EveryCodePrFeedbackReadStore(Protocol):
+    def list_every_code_pr_feedback_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
+
+
+class _EveryCodePreviewGateReadStore(Protocol):
+    def list_every_code_preview_gate_records(
+        self,
+        *,
+        request_id: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
+
+
+class _EveryCodeNotificationAttemptReadStore(Protocol):
+    def list_every_code_notification_attempt_records(
+        self,
+        *,
+        request_id: str = "",
+        event: str = "",
+        destination_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodeNotificationAttemptRecord, ...]: ...
+
+
+class _PreviewPrFeedbackNotificationAttemptReadStore(Protocol):
+    def list_preview_pr_feedback_notification_attempt_records(
+        self,
+        *,
+        feedback_id: str = "",
+        event: str = "",
+        destination_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[PreviewPrFeedbackNotificationAttemptRecord, ...]: ...
 
 
 def require_protected_artifact_store(record_store: object) -> ProtectedArtifactStore:
@@ -1476,6 +1632,21 @@ def create_launchplane_fastapi_app(
             cookie=cookie,
         )
 
+    def read_every_code_worker_read_identity(
+        request: Request,
+        response: Response,
+        authorization: Annotated[str, Header(alias="Authorization")] = "",
+        cookie: Annotated[str, Header(alias="Cookie")] = "",
+    ) -> LaunchplaneIdentity | None:
+        if every_code_worker_token_authorized(authorization):
+            return None
+        return read_identity(
+            request=request,
+            response=response,
+            authorization=authorization,
+            cookie=cookie,
+        )
+
     def read_write_identity(
         authorization: Annotated[str, Header(alias="Authorization")] = "",
     ) -> LaunchplaneIdentity:
@@ -1811,6 +1982,173 @@ def create_launchplane_fastapi_app(
         )
         return cast(AgentContextReadStore, record_store)
 
+    def require_every_code_read_methods(
+        record_store: object,
+        *,
+        required_methods: tuple[str, ...],
+        capability: str,
+    ) -> None:
+        missing_methods = [
+            method_name
+            for method_name in required_methods
+            if not callable(getattr(record_store, method_name, None))
+        ]
+        if missing_methods:
+            missing_summary = ", ".join(missing_methods)
+            raise TypeError(f"record store does not support {capability}: {missing_summary}")
+
+    def require_every_code_work_request_list_store(
+        record_store: object,
+    ) -> _EveryCodeWorkRequestListStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=("list_every_code_work_request_records",),
+            capability="Every Code work request list reads",
+        )
+        return cast(_EveryCodeWorkRequestListStore, record_store)
+
+    def require_every_code_work_request_record_store(
+        record_store: object,
+    ) -> _EveryCodeWorkRequestRecordStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=("read_every_code_work_request_record",),
+            capability="Every Code work request record reads",
+        )
+        return cast(_EveryCodeWorkRequestRecordStore, record_store)
+
+    def require_every_code_pr_feedback_read_store(
+        record_store: object,
+    ) -> _EveryCodePrFeedbackReadStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=("list_every_code_pr_feedback_records",),
+            capability="Every Code PR feedback reads",
+        )
+        return cast(_EveryCodePrFeedbackReadStore, record_store)
+
+    def require_every_code_preview_gate_read_store(
+        record_store: object,
+    ) -> _EveryCodePreviewGateReadStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=("list_every_code_preview_gate_records",),
+            capability="Every Code preview gate reads",
+        )
+        return cast(_EveryCodePreviewGateReadStore, record_store)
+
+    def require_every_code_notification_attempt_read_store(
+        record_store: object,
+    ) -> _EveryCodeNotificationAttemptReadStore:
+        list_records = getattr(record_store, "list_every_code_notification_attempt_records", None)
+        if not callable(list_records):
+            raise TypeError("record store does not support Every Code notification attempt reads")
+        return cast(_EveryCodeNotificationAttemptReadStore, record_store)
+
+    def require_preview_pr_feedback_notification_attempt_read_store(
+        record_store: object,
+    ) -> _PreviewPrFeedbackNotificationAttemptReadStore:
+        list_records = getattr(
+            record_store,
+            "list_preview_pr_feedback_notification_attempt_records",
+            None,
+        )
+        if not callable(list_records):
+            raise TypeError(
+                "record store does not support preview PR feedback notification attempt reads"
+            )
+        return cast(_PreviewPrFeedbackNotificationAttemptReadStore, record_store)
+
+    def ensure_every_code_read_allowed(
+        *,
+        identity: LaunchplaneIdentity | None,
+        trace_id: str,
+        action: str,
+        message: str,
+    ) -> None:
+        if identity is None:
+            return
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=action,
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=message,
+            )
+
+    def every_code_pagination_value(
+        raw_value: str,
+        key: str,
+        *,
+        default: int,
+        trace_id: str,
+    ) -> int:
+        try:
+            value = int(raw_value.strip() or str(default))
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=f"Every Code pagination {key} must be an integer",
+            ) from error
+        if value < 0:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=f"Every Code pagination {key} must be non-negative",
+            )
+        return value
+
+    def every_code_optional_int(raw_value: str, key: str, *, trace_id: str) -> int | None:
+        normalized_value = raw_value.strip()
+        if not normalized_value:
+            return None
+        try:
+            return int(normalized_value)
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=f"Query parameter {key} must be an integer",
+            ) from error
+
+    def every_code_read_store_or_503(
+        record_store: object, *, trace_id: str, capability: str
+    ) -> object:
+        try:
+            if capability == "work_request_list":
+                return require_every_code_work_request_list_store(record_store)
+            if capability == "work_request_record":
+                return require_every_code_work_request_record_store(record_store)
+            if capability == "pr_feedback":
+                return require_every_code_pr_feedback_read_store(record_store)
+            if capability == "preview_gate":
+                return require_every_code_preview_gate_read_store(record_store)
+            raise TypeError(f"unknown Every Code read capability: {capability}")
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+
+    def every_code_invalid_payload_error(*, trace_id: str, error: ValueError) -> HTTPException:
+        return _launchplane_http_error(
+            status_code=400,
+            trace_id=trace_id,
+            code="invalid_payload",
+            message=str(error),
+        )
+
     def read_repo_product_mapping(
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
         record_store: Annotated[object, Depends(get_record_store)],
@@ -1861,6 +2199,351 @@ def create_launchplane_fastapi_app(
             planning_facts_provider=work_graph_planning_facts_provider,
         )
         return AgentContextResponse(trace_id=trace_id, context=context)
+
+    def read_every_code_summary(
+        identity: Annotated[
+            LaunchplaneIdentity | None, Depends(read_every_code_worker_read_identity)
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        repository: Annotated[str, Query()] = "",
+        issue_number: Annotated[str, Query()] = "",
+        state: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "50",
+        offset: Annotated[str, Query()] = "0",
+    ) -> EveryCodeSummaryResponse:
+        trace_id = next_trace_id()
+        ensure_every_code_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            action="every_code_work_request.read",
+            message="Workflow cannot read Every Code work requests.",
+        )
+        every_code_store = cast(
+            _EveryCodeWorkRequestListStore,
+            every_code_read_store_or_503(
+                record_store,
+                trace_id=trace_id,
+                capability="work_request_list",
+            ),
+        )
+        try:
+            summary = build_every_code_summary_read_model(
+                generated_at=utc_now_timestamp(),
+                record_store=every_code_store,
+                repository=repository.strip(),
+                issue_number=every_code_optional_int(
+                    issue_number,
+                    "issue_number",
+                    trace_id=trace_id,
+                ),
+                state=state.strip(),
+                limit=every_code_pagination_value(
+                    limit,
+                    "limit",
+                    default=50,
+                    trace_id=trace_id,
+                ),
+                offset=every_code_pagination_value(
+                    offset,
+                    "offset",
+                    default=0,
+                    trace_id=trace_id,
+                ),
+            )
+        except ValueError as error:
+            raise every_code_invalid_payload_error(trace_id=trace_id, error=error) from error
+        return EveryCodeSummaryResponse(trace_id=trace_id, summary=summary)
+
+    def read_preview_readiness(
+        identity: Annotated[
+            LaunchplaneIdentity | None, Depends(read_every_code_worker_read_identity)
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        repository: Annotated[str, Query()] = "",
+        pr_number: Annotated[str, Query()] = "",
+        status: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "50",
+        offset: Annotated[str, Query()] = "0",
+    ) -> PreviewReadinessResponse:
+        trace_id = next_trace_id()
+        ensure_every_code_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            action="every_code_preview_gate.read",
+            message="Workflow cannot read Every Code preview readiness.",
+        )
+        every_code_store = cast(
+            _EveryCodePreviewGateReadStore,
+            every_code_read_store_or_503(
+                record_store,
+                trace_id=trace_id,
+                capability="preview_gate",
+            ),
+        )
+        try:
+            readiness = build_preview_readiness_read_model(
+                generated_at=utc_now_timestamp(),
+                record_store=every_code_store,
+                repository=repository.strip(),
+                pr_number=every_code_optional_int(
+                    pr_number,
+                    "pr_number",
+                    trace_id=trace_id,
+                ),
+                status=status.strip(),
+                limit=every_code_pagination_value(
+                    limit,
+                    "limit",
+                    default=50,
+                    trace_id=trace_id,
+                ),
+                offset=every_code_pagination_value(
+                    offset,
+                    "offset",
+                    default=0,
+                    trace_id=trace_id,
+                ),
+            )
+        except ValueError as error:
+            raise every_code_invalid_payload_error(trace_id=trace_id, error=error) from error
+        return PreviewReadinessResponse(trace_id=trace_id, readiness=readiness)
+
+    def list_every_code_work_requests(
+        identity: Annotated[
+            LaunchplaneIdentity | None, Depends(read_every_code_worker_read_identity)
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        state: Annotated[str, Query()] = "",
+        repository: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "50",
+        offset: Annotated[str, Query()] = "0",
+    ) -> EveryCodeWorkRequestRecordsResponse:
+        trace_id = next_trace_id()
+        ensure_every_code_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            action="every_code_work_request.read",
+            message="Workflow cannot read Every Code work requests.",
+        )
+        every_code_store = cast(
+            _EveryCodeWorkRequestListStore,
+            every_code_read_store_or_503(
+                record_store,
+                trace_id=trace_id,
+                capability="work_request_list",
+            ),
+        )
+        records = every_code_store.list_every_code_work_request_records(
+            state=state.strip(),
+            repository=repository.strip(),
+            limit=every_code_pagination_value(limit, "limit", default=50, trace_id=trace_id),
+            offset=every_code_pagination_value(offset, "offset", default=0, trace_id=trace_id),
+        )
+        return EveryCodeWorkRequestRecordsResponse(
+            trace_id=trace_id,
+            state=state.strip(),
+            repository=repository.strip(),
+            requests=records,
+        )
+
+    def read_every_code_work_request(
+        request_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[
+            LaunchplaneIdentity | None, Depends(read_every_code_worker_read_identity)
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> EveryCodeWorkRequestRecordResponse:
+        trace_id = next_trace_id()
+        ensure_every_code_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            action="every_code_work_request.read",
+            message="Workflow cannot read Every Code work requests.",
+        )
+        every_code_store = cast(
+            _EveryCodeWorkRequestRecordStore,
+            every_code_read_store_or_503(
+                record_store,
+                trace_id=trace_id,
+                capability="work_request_record",
+            ),
+        )
+        try:
+            record = every_code_store.read_every_code_work_request_record(request_id)
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        return EveryCodeWorkRequestRecordResponse(trace_id=trace_id, request=record)
+
+    def list_every_code_pr_feedback(
+        identity: Annotated[
+            LaunchplaneIdentity | None, Depends(read_every_code_worker_read_identity)
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        request_id: Annotated[str, Query()] = "",
+        repository: Annotated[str, Query()] = "",
+        pr_number: Annotated[str, Query()] = "",
+        status: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "50",
+        offset: Annotated[str, Query()] = "0",
+    ) -> EveryCodePrFeedbackRecordsResponse:
+        trace_id = next_trace_id()
+        ensure_every_code_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            action="every_code_pr_feedback.read",
+            message="Workflow cannot read Every Code PR feedback.",
+        )
+        every_code_store = cast(
+            _EveryCodePrFeedbackReadStore,
+            every_code_read_store_or_503(
+                record_store,
+                trace_id=trace_id,
+                capability="pr_feedback",
+            ),
+        )
+        records = every_code_store.list_every_code_pr_feedback_records(
+            request_id=request_id.strip(),
+            repository=repository.strip(),
+            pr_number=every_code_optional_int(pr_number, "pr_number", trace_id=trace_id),
+            status=status.strip(),
+            limit=every_code_pagination_value(limit, "limit", default=50, trace_id=trace_id),
+            offset=every_code_pagination_value(offset, "offset", default=0, trace_id=trace_id),
+        )
+        return EveryCodePrFeedbackRecordsResponse(
+            trace_id=trace_id,
+            request_id=request_id.strip(),
+            repository=repository.strip(),
+            status_filter=status.strip(),
+            feedback=records,
+        )
+
+    def list_every_code_preview_gates(
+        identity: Annotated[
+            LaunchplaneIdentity | None, Depends(read_every_code_worker_read_identity)
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        request_id: Annotated[str, Query()] = "",
+        repository: Annotated[str, Query()] = "",
+        pr_number: Annotated[str, Query()] = "",
+        status: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "50",
+        offset: Annotated[str, Query()] = "0",
+    ) -> EveryCodePreviewGateRecordsResponse:
+        trace_id = next_trace_id()
+        ensure_every_code_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            action="every_code_preview_gate.read",
+            message="Workflow cannot read Every Code preview readiness.",
+        )
+        every_code_store = cast(
+            _EveryCodePreviewGateReadStore,
+            every_code_read_store_or_503(
+                record_store,
+                trace_id=trace_id,
+                capability="preview_gate",
+            ),
+        )
+        records = every_code_store.list_every_code_preview_gate_records(
+            request_id=request_id.strip(),
+            repository=repository.strip(),
+            pr_number=every_code_optional_int(pr_number, "pr_number", trace_id=trace_id),
+            status=status.strip(),
+            limit=every_code_pagination_value(limit, "limit", default=50, trace_id=trace_id),
+            offset=every_code_pagination_value(offset, "offset", default=0, trace_id=trace_id),
+        )
+        return EveryCodePreviewGateRecordsResponse(
+            trace_id=trace_id,
+            request_id=request_id.strip(),
+            repository=repository.strip(),
+            status_filter=status.strip(),
+            gates=records,
+        )
+
+    def list_every_code_notification_attempts(
+        identity: Annotated[
+            LaunchplaneIdentity | None, Depends(read_every_code_worker_read_identity)
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        request_id: Annotated[str, Query()] = "",
+        event: Annotated[str, Query()] = "",
+        destination_kind: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "50",
+    ) -> EveryCodeNotificationAttemptRecordsResponse:
+        trace_id = next_trace_id()
+        ensure_every_code_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            action="every_code_notification_attempt.read",
+            message="Workflow cannot read Every Code notification attempts.",
+        )
+        try:
+            notification_store = require_every_code_notification_attempt_read_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        records = notification_store.list_every_code_notification_attempt_records(
+            request_id=request_id.strip(),
+            event=event.strip(),
+            destination_kind=destination_kind.strip(),
+            limit=every_code_pagination_value(limit, "limit", default=50, trace_id=trace_id),
+        )
+        return EveryCodeNotificationAttemptRecordsResponse(
+            trace_id=trace_id,
+            request_id=request_id.strip(),
+            event_filter=event.strip(),
+            destination_kind_filter=destination_kind.strip(),
+            attempts=records,
+        )
+
+    def list_preview_pr_feedback_notification_attempts(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        feedback_id: Annotated[str, Query()] = "",
+        event: Annotated[str, Query()] = "",
+        destination_kind: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "50",
+    ) -> PreviewPrFeedbackNotificationAttemptRecordsResponse:
+        trace_id = next_trace_id()
+        ensure_every_code_read_allowed(
+            identity=identity,
+            trace_id=trace_id,
+            action="preview_pr_feedback_notification_attempt.read",
+            message="Workflow cannot read preview PR feedback notification attempts.",
+        )
+        try:
+            notification_store = require_preview_pr_feedback_notification_attempt_read_store(
+                record_store
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        records = notification_store.list_preview_pr_feedback_notification_attempt_records(
+            feedback_id=feedback_id.strip(),
+            event=event.strip(),
+            destination_kind=destination_kind.strip(),
+            limit=every_code_pagination_value(limit, "limit", default=50, trace_id=trace_id),
+        )
+        return PreviewPrFeedbackNotificationAttemptRecordsResponse(
+            trace_id=trace_id,
+            feedback_id=feedback_id.strip(),
+            event_filter=event.strip(),
+            destination_kind_filter=destination_kind.strip(),
+            attempts=records,
+        )
 
     def list_product_environment_overviews(
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
@@ -4048,6 +4731,24 @@ def create_launchplane_fastapi_app(
         },
     )
 
+    every_code_read_error_responses: dict[int | str, dict[str, object]] = {
+        400: {"model": LaunchplaneErrorResponse},
+        401: {"model": LaunchplaneErrorResponse},
+        403: {"model": LaunchplaneErrorResponse},
+        404: {"model": LaunchplaneErrorResponse},
+        503: {"model": LaunchplaneErrorResponse},
+    }
+
+    app.add_api_route(
+        "/v1/previews/readiness",
+        read_preview_readiness,
+        methods=["GET"],
+        response_model=PreviewReadinessResponse,
+        operation_id="read_preview_readiness",
+        summary="Read preview readiness",
+        responses=every_code_read_error_responses,
+    )
+
     app.add_api_route(
         "/v1/previews/{preview_id}",
         read_preview_record,
@@ -4143,6 +4844,76 @@ def create_launchplane_fastapi_app(
         operation_id="read_agent_context",
         summary="Read Launchplane agent context",
         responses=agent_context_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/summary",
+        read_every_code_summary,
+        methods=["GET"],
+        response_model=EveryCodeSummaryResponse,
+        operation_id="read_every_code_summary",
+        summary="Read Every Code work request summary",
+        responses=every_code_read_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/work-requests",
+        list_every_code_work_requests,
+        methods=["GET"],
+        response_model=EveryCodeWorkRequestRecordsResponse,
+        operation_id="list_every_code_work_requests",
+        summary="List Every Code work requests",
+        responses=every_code_read_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/work-requests/{request_id}",
+        read_every_code_work_request,
+        methods=["GET"],
+        response_model=EveryCodeWorkRequestRecordResponse,
+        operation_id="read_every_code_work_request",
+        summary="Read one Every Code work request",
+        responses=every_code_read_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/pr-feedback",
+        list_every_code_pr_feedback,
+        methods=["GET"],
+        response_model=EveryCodePrFeedbackRecordsResponse,
+        operation_id="list_every_code_pr_feedback",
+        summary="List Every Code PR feedback records",
+        responses=every_code_read_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/preview-gates",
+        list_every_code_preview_gates,
+        methods=["GET"],
+        response_model=EveryCodePreviewGateRecordsResponse,
+        operation_id="list_every_code_preview_gates",
+        summary="List Every Code preview gates",
+        responses=every_code_read_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/notification-attempts",
+        list_every_code_notification_attempts,
+        methods=["GET"],
+        response_model=EveryCodeNotificationAttemptRecordsResponse,
+        operation_id="list_every_code_notification_attempts",
+        summary="List Every Code notification attempts",
+        responses=every_code_read_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/previews/pr-feedback/notification-attempts",
+        list_preview_pr_feedback_notification_attempts,
+        methods=["GET"],
+        response_model=PreviewPrFeedbackNotificationAttemptRecordsResponse,
+        operation_id="list_preview_pr_feedback_notification_attempts",
+        summary="List preview PR feedback notification attempts",
+        responses=every_code_read_error_responses,
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -83,9 +83,6 @@ from control_plane.contracts.every_code_pr_feedback_record import (
     apply_every_code_pr_feedback_status,
     build_every_code_pr_feedback_id,
 )
-from control_plane.contracts.every_code_summary_read_model import (
-    build_every_code_summary_read_model,
-)
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
 from control_plane.contracts.ingress_route_audit_record import (
@@ -171,9 +168,6 @@ from control_plane.contracts.preview_pr_feedback_notifications import (
     PreviewPrFeedbackNotificationPolicyRecord,
     build_preview_pr_feedback_notification_attempt_id,
     preview_pr_feedback_notification_event,
-)
-from control_plane.contracts.preview_readiness_read_model import (
-    build_preview_readiness_read_model,
 )
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
@@ -4438,27 +4432,6 @@ def _not_found_response(
 
 def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
     segments = [segment for segment in path.split("/") if segment]
-    if len(segments) == 3 and segments == ["v1", "previews", "readiness"]:
-        return "every_code_preview_gate.read", {"readiness": "true"}
-    if len(segments) == 3 and segments == ["v1", "every-code", "summary"]:
-        return "every_code_work_request.read", {"summary": "true"}
-    if len(segments) == 3 and segments == ["v1", "every-code", "work-requests"]:
-        return "every_code_work_request.read", {}
-    if len(segments) == 3 and segments == ["v1", "every-code", "pr-feedback"]:
-        return "every_code_pr_feedback.read", {}
-    if len(segments) == 3 and segments == ["v1", "every-code", "preview-gates"]:
-        return "every_code_preview_gate.read", {}
-    if len(segments) == 3 and segments == ["v1", "every-code", "notification-attempts"]:
-        return "every_code_notification_attempt.read", {}
-    if len(segments) == 4 and segments == [
-        "v1",
-        "previews",
-        "pr-feedback",
-        "notification-attempts",
-    ]:
-        return "preview_pr_feedback_notification_attempt.read", {}
-    if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
-        return "every_code_work_request.read", {"request_id": segments[3]}
     if (
         len(segments) == 6
         and segments[:4] == ["v1", "drivers", "odoo", "stable-bootstrap"]
@@ -4494,28 +4467,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         "run-once",
     ]:
         return "public_ingress_monitor.run_once", {}
-    if len(segments) == 4 and segments == [
-        "v1",
-        "public-ingress",
-        "notification-policies",
-        "apply",
-    ]:
-        return "public_ingress_notification_policy.apply", {}
-    if len(segments) == 4 and segments == [
-        "v1",
-        "every-code",
-        "notification-policies",
-        "apply",
-    ]:
-        return "every_code_notification_policy.apply", {}
-    if len(segments) == 5 and segments == [
-        "v1",
-        "previews",
-        "pr-feedback",
-        "notification-policies",
-        "apply",
-    ]:
-        return "preview_pr_feedback_notification_policy.apply", {}
     return None
 
 
@@ -8335,20 +8286,6 @@ def _owner_agent_identity_from_bearer(environ: dict[str, object]) -> Launchplane
 
 
 def _is_every_code_worker_route(*, method: str, path: str) -> bool:
-    if method == "GET" and path == "/v1/previews/readiness":
-        return True
-    if method == "GET" and path == "/v1/every-code/summary":
-        return True
-    if method == "GET" and path == "/v1/every-code/work-requests":
-        return True
-    if method == "GET" and path == "/v1/every-code/pr-feedback":
-        return True
-    if method == "GET" and path == "/v1/every-code/preview-gates":
-        return True
-    if method == "GET" and path.startswith("/v1/every-code/work-requests/"):
-        return True
-    if method == "GET" and path == "/v1/every-code/notification-attempts":
-        return True
     return method == "POST" and path in {
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
@@ -8372,180 +8309,6 @@ def _every_code_worker_token_authorized(
     except PermissionError:
         return False
     return secrets.compare_digest(provided_token, expected_token)
-
-
-def _every_code_pagination_value(query: dict[str, list[str]], *, key: str, default: int) -> int:
-    value = int(str((query.get(key) or [str(default)])[0] or str(default)))
-    if value < 0:
-        raise ValueError(f"Every Code pagination {key} must be non-negative")
-    return value
-
-
-def _every_code_read_payload(
-    *,
-    record_store: object,
-    path: str,
-    query: dict[str, list[str]],
-) -> dict[str, object]:
-    segments = [segment for segment in path.split("/") if segment]
-    every_code_store = _every_code_work_request_store(record_store)
-    if path == "/v1/previews/readiness":
-        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
-        pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()
-        pr_number_filter = int(pr_number_value) if pr_number_value else None
-        status_filter = str((query.get("status") or [""])[0] or "").strip()
-        limit = _every_code_pagination_value(query, key="limit", default=50)
-        offset = _every_code_pagination_value(query, key="offset", default=0)
-        readiness = build_preview_readiness_read_model(
-            generated_at=_utc_now_timestamp(),
-            record_store=every_code_store,
-            repository=repository_filter,
-            pr_number=pr_number_filter,
-            status=status_filter,
-            limit=limit,
-            offset=offset,
-        )
-        return {"readiness": readiness.model_dump(mode="json")}
-    if path == "/v1/every-code/summary":
-        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
-        issue_number_value = str((query.get("issue_number") or [""])[0] or "").strip()
-        issue_number_filter = int(issue_number_value) if issue_number_value else None
-        state_filter = str((query.get("state") or [""])[0] or "").strip()
-        limit = _every_code_pagination_value(query, key="limit", default=50)
-        offset = _every_code_pagination_value(query, key="offset", default=0)
-        summary = build_every_code_summary_read_model(
-            generated_at=_utc_now_timestamp(),
-            record_store=every_code_store,
-            repository=repository_filter,
-            issue_number=issue_number_filter,
-            state=state_filter,
-            limit=limit,
-            offset=offset,
-        )
-        return {"summary": summary.model_dump(mode="json")}
-    if path == "/v1/every-code/pr-feedback":
-        request_id_filter = str((query.get("request_id") or [""])[0] or "").strip()
-        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
-        status_filter = str((query.get("status") or [""])[0] or "").strip()
-        pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()
-        pr_number_filter = int(pr_number_value) if pr_number_value else None
-        limit = _every_code_pagination_value(query, key="limit", default=50)
-        offset = _every_code_pagination_value(query, key="offset", default=0)
-        feedback_records = every_code_store.list_every_code_pr_feedback_records(
-            request_id=request_id_filter,
-            repository=repository_filter,
-            pr_number=pr_number_filter,
-            status=status_filter,
-            limit=limit,
-            offset=offset,
-        )
-        return {
-            "request_id": request_id_filter,
-            "repository": repository_filter,
-            "status_filter": status_filter,
-            "feedback": [record.model_dump(mode="json") for record in feedback_records],
-        }
-    if path == "/v1/every-code/preview-gates":
-        request_id_filter = str((query.get("request_id") or [""])[0] or "").strip()
-        repository_filter = str((query.get("repository") or [""])[0] or "").strip()
-        status_filter = str((query.get("status") or [""])[0] or "").strip()
-        pr_number_value = str((query.get("pr_number") or [""])[0] or "").strip()
-        pr_number_filter = int(pr_number_value) if pr_number_value else None
-        limit = _every_code_pagination_value(query, key="limit", default=50)
-        offset = _every_code_pagination_value(query, key="offset", default=0)
-        gate_records = every_code_store.list_every_code_preview_gate_records(
-            request_id=request_id_filter,
-            repository=repository_filter,
-            pr_number=pr_number_filter,
-            status=status_filter,
-            limit=limit,
-            offset=offset,
-        )
-        return {
-            "request_id": request_id_filter,
-            "repository": repository_filter,
-            "status_filter": status_filter,
-            "gates": [record.model_dump(mode="json") for record in gate_records],
-        }
-    if path == "/v1/every-code/notification-attempts":
-        notification_store = _every_code_notification_store(record_store)
-        if notification_store is None:
-            raise ValueError("record store does not support Every Code notifications")
-        request_id_filter = str((query.get("request_id") or [""])[0] or "").strip()
-        event_filter = str((query.get("event") or [""])[0] or "").strip()
-        destination_kind_filter = str((query.get("destination_kind") or [""])[0] or "").strip()
-        limit = _every_code_pagination_value(query, key="limit", default=50)
-        attempts = notification_store.list_every_code_notification_attempt_records(
-            request_id=request_id_filter,
-            event=event_filter,
-            destination_kind=destination_kind_filter,
-            limit=limit,
-        )
-        return {
-            "request_id": request_id_filter,
-            "event_filter": event_filter,
-            "destination_kind_filter": destination_kind_filter,
-            "attempts": [record.model_dump(mode="json") for record in attempts],
-        }
-    if path == "/v1/previews/pr-feedback/notification-attempts":
-        preview_notification_store = _preview_pr_feedback_notification_store(record_store)
-        if preview_notification_store is None:
-            raise ValueError("record store does not support preview PR feedback notifications")
-        feedback_id_filter = str((query.get("feedback_id") or [""])[0] or "").strip()
-        event_filter = str((query.get("event") or [""])[0] or "").strip()
-        destination_kind_filter = str((query.get("destination_kind") or [""])[0] or "").strip()
-        limit = _every_code_pagination_value(query, key="limit", default=50)
-        preview_attempts = (
-            preview_notification_store.list_preview_pr_feedback_notification_attempt_records(
-                feedback_id=feedback_id_filter,
-                event=event_filter,
-                destination_kind=destination_kind_filter,
-                limit=limit,
-            )
-        )
-        return {
-            "feedback_id": feedback_id_filter,
-            "event_filter": event_filter,
-            "destination_kind_filter": destination_kind_filter,
-            "attempts": [record.model_dump(mode="json") for record in preview_attempts],
-        }
-    if len(segments) == 4 and segments[:3] == ["v1", "every-code", "work-requests"]:
-        record = every_code_store.read_every_code_work_request_record(segments[3])
-        return {"request": record.model_dump(mode="json")}
-    state_filter = str((query.get("state") or [""])[0] or "").strip()
-    repository_filter = str((query.get("repository") or [""])[0] or "").strip()
-    limit = _every_code_pagination_value(query, key="limit", default=50)
-    offset = _every_code_pagination_value(query, key="offset", default=0)
-    work_request_records = every_code_store.list_every_code_work_request_records(
-        state=state_filter,
-        repository=repository_filter,
-        limit=limit,
-        offset=offset,
-    )
-    return {
-        "state": state_filter,
-        "repository": repository_filter,
-        "requests": [record.model_dump(mode="json") for record in work_request_records],
-    }
-
-
-def _handle_every_code_work_request_read(
-    *,
-    start_response: _StartResponse,
-    trace_id: str,
-    record_store: object,
-    path: str,
-    query: dict[str, list[str]],
-) -> list[bytes]:
-    return _json_response(
-        start_response=start_response,
-        status_code=200,
-        payload={
-            "status": "ok",
-            "trace_id": trace_id,
-            **_every_code_read_payload(record_store=record_store, path=path, query=query),
-        },
-    )
 
 
 def _handle_every_code_worker_write(
@@ -10136,28 +9899,6 @@ def create_launchplane_service_app(
                     },
                 )
         if _every_code_worker_token_authorized(environ=environ, method=method, path=path):
-            if method == "GET":
-                try:
-                    return _handle_every_code_work_request_read(
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                        record_store=record_store,
-                        path=path,
-                        query=query,
-                    )
-                except (ValueError, click.ClickException) as error:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "invalid_payload",
-                                "message": str(error),
-                            },
-                        },
-                    )
             payload = _read_json_request(environ)
             try:
                 return _handle_every_code_worker_write(
@@ -10535,115 +10276,6 @@ def create_launchplane_service_app(
                             "trace_id": request_trace_id,
                             "inspect": inspect_result,
                         },
-                    )
-                if action == "every_code_work_request.read":
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read Every Code work requests.",
-                                },
-                            },
-                        )
-                    return _handle_every_code_work_request_read(
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                        record_store=record_store,
-                        path=path,
-                        query=query,
-                    )
-                if action == "every_code_preview_gate.read":
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read Every Code preview readiness.",
-                                },
-                            },
-                        )
-                    return _handle_every_code_work_request_read(
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                        record_store=record_store,
-                        path=path,
-                        query=query,
-                    )
-                if action == "every_code_notification_attempt.read":
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": (
-                                        "Workflow cannot read Every Code notification attempts."
-                                    ),
-                                },
-                            },
-                        )
-                    return _handle_every_code_work_request_read(
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                        record_store=record_store,
-                        path=path,
-                        query=query,
-                    )
-                if action == "preview_pr_feedback_notification_attempt.read":
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": (
-                                        "Workflow cannot read preview PR feedback"
-                                        " notification attempts."
-                                    ),
-                                },
-                            },
-                        )
-                    return _handle_every_code_work_request_read(
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                        record_store=record_store,
-                        path=path,
-                        query=query,
                     )
                 if action == "work_graph.rank":
                     return handle_work_graph_snapshot_read(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -89,6 +89,14 @@ Keep a compatibility surface only when it is one of these:
   product-profile collection also preserves the dedicated Every Code worker
   token. Their legacy WSGI branches are deleted; direct fallback calls fail
   closed while the mounted fallback remains for retained non-native routes.
+- Every Code work-request, summary, PR-feedback, preview-gate,
+  notification-attempt, and preview-readiness reads use native FastAPI routes.
+  The worker-facing read routes preserve the dedicated Every Code worker token;
+  preview PR-feedback notification-attempt reads stay bearer/human authorized.
+  The legacy WSGI read map, read payload helper, and worker-token GET bypass are
+  deleted; Every Code write, claim, status, rerun, webhook, notification-policy,
+  PR-feedback write/status, and preview-gate write routes remain on the mounted
+  WSGI fallback until their native write replacements land.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -143,22 +143,30 @@ VeriReel product paths:
   - `POST /v1/authz-policies/local-operators/grants`
   - `POST /v1/authz-policies/local-admins/grants`
 - Every Code local automation work-request routes:
+  - `GET /v1/every-code/summary` (native FastAPI for bearer-token,
+    human-session, and Every Code worker-token callers)
+  - `GET /v1/previews/readiness` (native FastAPI for bearer-token,
+    human-session, and Every Code worker-token callers)
+  - `GET /v1/every-code/work-requests` (native FastAPI for bearer-token,
+    human-session, and Every Code worker-token callers)
+  - `GET /v1/every-code/work-requests/{request_id}` (native FastAPI for
+    bearer-token, human-session, and Every Code worker-token callers)
+  - `GET /v1/every-code/pr-feedback` (native FastAPI for bearer-token,
+    human-session, and Every Code worker-token callers)
+  - `GET /v1/every-code/preview-gates` (native FastAPI for bearer-token,
+    human-session, and Every Code worker-token callers)
+  - `GET /v1/every-code/notification-attempts` (native FastAPI for
+    bearer-token, human-session, and Every Code worker-token callers)
+  - `GET /v1/previews/pr-feedback/notification-attempts` (native FastAPI for
+    bearer-token and human-session callers)
   - `POST /v1/every-code/github-webhook`
-  - `GET /v1/every-code/summary`
-  - `GET /v1/previews/readiness`
-  - `GET /v1/every-code/work-requests`
-  - `GET /v1/every-code/work-requests/{request_id}`
-  - `GET /v1/every-code/notification-attempts`
-  - `GET /v1/previews/pr-feedback/notification-attempts`
   - `POST /v1/every-code/work-requests/create`
   - `POST /v1/every-code/work-requests/claim`
   - `POST /v1/every-code/work-requests/rerun`
   - `POST /v1/every-code/work-requests/status`
   - `POST /v1/every-code/notification-policies/apply`
-  - `GET /v1/every-code/pr-feedback`
   - `POST /v1/every-code/pr-feedback`
   - `POST /v1/every-code/pr-feedback/status`
-  - `GET /v1/every-code/preview-gates`
   - `POST /v1/every-code/preview-gates`
 - work graph chooser route:
   - `GET /v1/agent/context`
@@ -361,6 +369,16 @@ agent-facing states such as waiting on checks, ready, needs attention, or
 cancelled, include source links and freshness/provenance, and avoid provider-only
 internals, local paths, or secrets. Detail fields and check summaries are bounded
 and redacted before they leave the read-model projection.
+
+The direct Every Code record reads are also native FastAPI routes. Work-request
+reads use `every_code_work_request.read`; PR-feedback reads use
+`every_code_pr_feedback.read`; preview-gate reads use
+`every_code_preview_gate.read`; Every Code notification-attempt reads use
+`every_code_notification_attempt.read`; preview PR-feedback notification-attempt
+reads use `preview_pr_feedback_notification_attempt.read`. The dedicated Every
+Code worker token is accepted only for the worker-facing Every Code read routes,
+not for the preview PR-feedback notification-attempt route. The legacy WSGI
+fallback no longer owns these read paths.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the
@@ -1335,6 +1353,22 @@ only after a passing plan and a matching stored preview record are present.
 - `GET /v1/ingress/canary-routes/records` (native FastAPI for bearer-token and
   human-session callers)
 - `GET /v1/ingress/canary-routes/records/{canary_key}` (native FastAPI for
+  bearer-token and human-session callers)
+- `GET /v1/every-code/summary` (native FastAPI for bearer-token,
+  human-session, and Every Code worker-token callers)
+- `GET /v1/previews/readiness` (native FastAPI for bearer-token,
+  human-session, and Every Code worker-token callers)
+- `GET /v1/every-code/work-requests` (native FastAPI for bearer-token,
+  human-session, and Every Code worker-token callers)
+- `GET /v1/every-code/work-requests/{request_id}` (native FastAPI for
+  bearer-token, human-session, and Every Code worker-token callers)
+- `GET /v1/every-code/pr-feedback` (native FastAPI for bearer-token,
+  human-session, and Every Code worker-token callers)
+- `GET /v1/every-code/preview-gates` (native FastAPI for bearer-token,
+  human-session, and Every Code worker-token callers)
+- `GET /v1/every-code/notification-attempts` (native FastAPI for bearer-token,
+  human-session, and Every Code worker-token callers)
+- `GET /v1/previews/pr-feedback/notification-attempts` (native FastAPI for
   bearer-token and human-session callers)
 
 These operator reads use the same Launchplane authn/authz boundary as evidence

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -25,7 +25,9 @@ from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.every_code_notifications import EveryCodeNotificationAttemptRecord
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
+from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
@@ -36,6 +38,9 @@ from control_plane.contracts.preview_generation_record import (
     PreviewGenerationState,
     PreviewGenerationRecord,
     PreviewPullRequestSummary,
+)
+from control_plane.contracts.preview_pr_feedback_notifications import (
+    PreviewPrFeedbackNotificationAttemptRecord,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import (
@@ -1834,6 +1839,312 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(activity_response.status_code, 200)
         self.assertEqual(environments_response.status_code, 200)
         self.assertEqual(config_status_response.status_code, 200)
+
+
+class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_every_code_read_routes_return_native_payloads(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_read_records(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            summary_response = await _get_every_code_summary(
+                app,
+                repository="cbusillo/code",
+                issue_number="123",
+                state="queued",
+                limit="1",
+                offset="0",
+            )
+            readiness_response = await _get_preview_readiness(
+                app,
+                repository="cbusillo/code",
+                pr_number="31",
+                status="blocked",
+            )
+            list_response = await _get_every_code_work_requests(
+                app,
+                state="queued",
+                repository="cbusillo/code",
+            )
+            read_response = await _get_every_code_work_request(
+                app,
+                seeded["request_id"],
+            )
+            feedback_response = await _get_every_code_pr_feedback(
+                app,
+                request_id=seeded["request_id"],
+                repository="cbusillo/code",
+                pr_number="31",
+                status="pending",
+            )
+            gates_response = await _get_every_code_preview_gates(
+                app,
+                request_id=seeded["request_id"],
+                repository="cbusillo/code",
+                pr_number="31",
+                status="blocked",
+            )
+            notification_response = await _get_every_code_notification_attempts(
+                app,
+                request_id=seeded["request_id"],
+                event="work_request_blocked",
+                destination_kind="discord",
+            )
+            preview_notification_response = await _get_preview_pr_feedback_notification_attempts(
+                app,
+                feedback_id=seeded["preview_feedback_id"],
+                event="delivery_skipped",
+                destination_kind="discord",
+            )
+
+        for response in (
+            summary_response,
+            readiness_response,
+            list_response,
+            read_response,
+            feedback_response,
+            gates_response,
+            notification_response,
+            preview_notification_response,
+        ):
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["status"], "ok")
+            self.assertIn("trace_id", response.json())
+
+        summary = summary_response.json()["summary"]
+        self.assertEqual(summary["repository"], "cbusillo/code")
+        self.assertEqual(summary["issue_number"], 123)
+        self.assertEqual(summary["state_filter"], "queued")
+        self.assertEqual(summary["summaries"][0]["request_id"], seeded["request_id"])
+        self.assertEqual(summary["summaries"][0]["summary_status"], "active")
+
+        readiness = readiness_response.json()["readiness"]
+        self.assertEqual(readiness["repository"], "cbusillo/code")
+        self.assertEqual(readiness["pr_number"], 31)
+        self.assertEqual(readiness["status_filter"], "blocked")
+        self.assertEqual(readiness["items"][0]["gate_id"], seeded["gate_id"])
+        self.assertEqual(readiness["items"][0]["readiness_status"], "needs_attention")
+
+        self.assertEqual(list_response.json()["requests"][0]["request_id"], seeded["request_id"])
+        self.assertEqual(read_response.json()["request"]["request_id"], seeded["request_id"])
+        self.assertEqual(
+            feedback_response.json()["feedback"][0]["feedback_id"], seeded["feedback_id"]
+        )
+        self.assertEqual(gates_response.json()["gates"][0]["gate_id"], seeded["gate_id"])
+        self.assertEqual(
+            notification_response.json()["attempts"][0]["attempt_id"],
+            seeded["notification_attempt_id"],
+        )
+        self.assertEqual(
+            preview_notification_response.json()["attempts"][0]["attempt_id"],
+            seeded["preview_notification_attempt_id"],
+        )
+
+    async def test_every_code_worker_token_reads_without_policy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_read_records(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            responses = (
+                await _get_every_code_summary(
+                    app,
+                    repository="cbusillo/code",
+                    authorization="Bearer worker-token",
+                ),
+                await _get_preview_readiness(
+                    app,
+                    repository="cbusillo/code",
+                    authorization="Bearer worker-token",
+                ),
+                await _get_every_code_work_request(
+                    app,
+                    seeded["request_id"],
+                    authorization="Bearer worker-token",
+                ),
+                await _get_every_code_pr_feedback(
+                    app,
+                    request_id=seeded["request_id"],
+                    authorization="Bearer worker-token",
+                ),
+            )
+
+        for response in responses:
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json()["status"], "ok")
+
+    async def test_every_code_reads_reject_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _seed_every_code_read_records(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+            )
+
+            responses = (
+                await _get_every_code_work_requests(app),
+                await _get_preview_readiness(app),
+                await _get_every_code_notification_attempts(app),
+                await _get_preview_pr_feedback_notification_attempts(app),
+            )
+
+        for response in responses:
+            self.assertEqual(response.status_code, 403)
+            self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_every_code_reads_require_store_capability(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_every_code_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        responses = (
+            await _get_every_code_work_requests(app),
+            await _get_every_code_notification_attempts(app),
+            await _get_preview_pr_feedback_notification_attempts(app),
+        )
+
+        for response in responses:
+            self.assertEqual(response.status_code, 503)
+            self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
+    async def test_every_code_reads_reject_invalid_query_values(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            _seed_every_code_read_records(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            offset_response = await _get_every_code_work_requests(
+                app,
+                offset="-1",
+                authorization="Bearer worker-token",
+            )
+            pr_number_response = await _get_every_code_pr_feedback(
+                app,
+                pr_number="not-a-number",
+                authorization="Bearer worker-token",
+            )
+            status_response = await _get_preview_readiness(
+                app,
+                status="unknown",
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(offset_response.status_code, 400)
+        self.assertEqual(offset_response.json()["error"]["code"], "invalid_payload")
+        self.assertIn("offset must be non-negative", offset_response.json()["error"]["message"])
+        self.assertEqual(pr_number_response.status_code, 400)
+        self.assertEqual(pr_number_response.json()["error"]["code"], "invalid_payload")
+        self.assertEqual(status_response.status_code, 400)
+        self.assertEqual(status_response.json()["error"]["code"], "invalid_payload")
+
+    async def test_openapi_includes_every_code_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_every_code_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        expected_routes = {
+            "/v1/every-code/summary": (
+                "read_every_code_summary",
+                "EveryCodeSummaryResponse",
+            ),
+            "/v1/previews/readiness": (
+                "read_preview_readiness",
+                "PreviewReadinessResponse",
+            ),
+            "/v1/every-code/work-requests": (
+                "list_every_code_work_requests",
+                "EveryCodeWorkRequestRecordsResponse",
+            ),
+            "/v1/every-code/work-requests/{request_id}": (
+                "read_every_code_work_request",
+                "EveryCodeWorkRequestRecordResponse",
+            ),
+            "/v1/every-code/pr-feedback": (
+                "list_every_code_pr_feedback",
+                "EveryCodePrFeedbackRecordsResponse",
+            ),
+            "/v1/every-code/preview-gates": (
+                "list_every_code_preview_gates",
+                "EveryCodePreviewGateRecordsResponse",
+            ),
+            "/v1/every-code/notification-attempts": (
+                "list_every_code_notification_attempts",
+                "EveryCodeNotificationAttemptRecordsResponse",
+            ),
+            "/v1/previews/pr-feedback/notification-attempts": (
+                "list_preview_pr_feedback_notification_attempts",
+                "PreviewPrFeedbackNotificationAttemptRecordsResponse",
+            ),
+        }
+        for path, (operation_id, response_model_name) in expected_routes.items():
+            route = openapi["paths"][path]["get"]
+            self.assertEqual(route["operationId"], operation_id)
+            self.assertEqual(
+                route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+                f"#/components/schemas/{response_model_name}",
+            )
+            self.assertFalse(
+                openapi["components"]["schemas"][response_model_name]["additionalProperties"]
+            )
+            for status_code in ("400", "401", "403", "404", "503"):
+                self.assertIn(
+                    "LaunchplaneErrorResponse", json.dumps(route["responses"][status_code])
+                )
+
+    async def test_fastapi_every_code_reads_precede_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            seeded = _seed_every_code_read_records(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_read_policy(),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "legacy-state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            work_request_response = await _get_every_code_work_request(
+                app,
+                seeded["request_id"],
+            )
+            notification_response = await _get_preview_pr_feedback_notification_attempts(
+                app,
+                feedback_id=seeded["preview_feedback_id"],
+            )
+
+        self.assertEqual(work_request_response.status_code, 200)
+        self.assertEqual(notification_response.status_code, 200)
 
 
 class FastApiProductProfileReadTests(unittest.IsolatedAsyncioTestCase):
@@ -8720,6 +9031,133 @@ def _seed_agent_context_read_records(database_url: str) -> None:
         store.close()
 
 
+def _seed_every_code_read_records(store: Any) -> dict[str, str]:
+    request_id = "every-code-cbusillo-code-123-test"
+    gate_id = "every-code-preview-gate-cbusillo-code-31-test"
+    feedback_id = "every-code-pr-feedback-cbusillo-code-31-review-1"
+    preview_feedback_id = "preview-feedback-cbusillo-code-31-skipped"
+    notification_attempt_id = "every-code-notification-cbusillo-code-123-test"
+    preview_notification_attempt_id = "preview-pr-feedback-notification-cbusillo-code-31-skipped"
+    store.write_every_code_work_request_record(
+        EveryCodeWorkRequestRecord(
+            request_id=request_id,
+            source="manual",
+            state="queued",
+            repository="cbusillo/code",
+            issue_number=123,
+            issue_url="https://github.com/cbusillo/code/issues/123",
+            issue_title="Finish v2 Every Code read cutover",
+            trigger_label="every-code",
+            trigger_actor="cbusillo",
+            queued_at="2026-06-18T12:00:00Z",
+            updated_at="2026-06-18T12:00:00Z",
+        )
+    )
+    store.write_every_code_work_request_record(
+        EveryCodeWorkRequestRecord(
+            request_id="every-code-cbusillo-other-456-test",
+            source="manual",
+            state="done",
+            repository="cbusillo/other",
+            issue_number=456,
+            issue_url="https://github.com/cbusillo/other/issues/456",
+            issue_title="Unrelated completed request",
+            trigger_label="every-code",
+            trigger_actor="cbusillo",
+            queued_at="2026-06-17T12:00:00Z",
+            claimed_at="2026-06-17T12:01:00Z",
+            claimed_by_host="test-host",
+            started_at="2026-06-17T12:02:00Z",
+            finished_at="2026-06-17T12:03:00Z",
+            updated_at="2026-06-17T12:03:00Z",
+            result_pr_url="https://github.com/cbusillo/other/pull/4",
+        )
+    )
+    store.write_every_code_preview_gate_record(
+        EveryCodePreviewGateRecord(
+            gate_id=gate_id,
+            request_id=request_id,
+            repository="cbusillo/code",
+            issue_number=123,
+            issue_url="https://github.com/cbusillo/code/issues/123",
+            pr_number=31,
+            pr_url="https://github.com/cbusillo/code/pull/31",
+            head_sha="abcdef1234567890",
+            status="blocked",
+            created_at="2026-06-18T12:05:00Z",
+            updated_at="2026-06-18T12:06:00Z",
+            blocked_at="2026-06-18T12:06:00Z",
+            last_checked_at="2026-06-18T12:06:00Z",
+            blocked_reason="Required preview checks failed.",
+        )
+    )
+    store.write_every_code_pr_feedback_record(
+        EveryCodePrFeedbackRecord(
+            feedback_id=feedback_id,
+            request_id=request_id,
+            repository="cbusillo/code",
+            pr_number=31,
+            pr_url="https://github.com/cbusillo/code/pull/31",
+            feedback_kind="pull_request_review_comment",
+            github_delivery_id="delivery-feedback-1",
+            github_node_id="PRRC_kwDOTest123",
+            actor="reviewer",
+            author_association="MEMBER",
+            body="Please tighten the FastAPI read route coverage.",
+            html_url="https://github.com/cbusillo/code/pull/31#discussion_r1",
+            received_at="2026-06-18T12:07:00Z",
+            status="pending",
+        )
+    )
+    store.write_every_code_notification_attempt_record(
+        EveryCodeNotificationAttemptRecord(
+            attempt_id=notification_attempt_id,
+            request_id=request_id,
+            event="work_request_blocked",
+            policy_id="every-code-notification-discord",
+            destination_id="discord",
+            destination_kind="discord",
+            delivery_status="delivered",
+            attempted_at="2026-06-18T12:08:00Z",
+            action="posted_discord",
+        )
+    )
+    store.write_preview_pr_feedback_notification_attempt_record(
+        PreviewPrFeedbackNotificationAttemptRecord(
+            attempt_id=preview_notification_attempt_id,
+            feedback_id=preview_feedback_id,
+            event="delivery_skipped",
+            policy_id="preview-pr-feedback-notification-discord",
+            destination_id="discord",
+            destination_kind="discord",
+            delivery_status="delivered",
+            attempted_at="2026-06-18T12:09:00Z",
+            action="posted_discord",
+        )
+    )
+    return {
+        "request_id": request_id,
+        "gate_id": gate_id,
+        "feedback_id": feedback_id,
+        "preview_feedback_id": preview_feedback_id,
+        "notification_attempt_id": notification_attempt_id,
+        "preview_notification_attempt_id": preview_notification_attempt_id,
+    }
+
+
+def _every_code_read_policy() -> LaunchplaneAuthzPolicy:
+    return _record_read_policy(
+        action="every_code_work_request.read",
+        context="launchplane",
+        extra_actions=(
+            "every_code_preview_gate.read",
+            "every_code_pr_feedback.read",
+            "every_code_notification_attempt.read",
+            "preview_pr_feedback_notification_attempt.read",
+        ),
+    )
+
+
 def _product_profile_read_policy(*, product: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -8940,6 +9378,184 @@ async def _get_agent_context(
     headers = {"Authorization": authorization} if authorization else {}
     suffix = f"?{urlencode({'repository': repository})}" if repository else ""
     return await _asgi_get(app, f"/v1/agent/context{suffix}", headers=headers)
+
+
+async def _get_every_code_summary(
+    app: FastAPI,
+    *,
+    repository: str = "",
+    issue_number: str = "",
+    state: str = "",
+    limit: str = "",
+    offset: str = "",
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    params = _query_params(
+        repository=repository,
+        issue_number=issue_number,
+        state=state,
+        limit=limit,
+        offset=offset,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(app, f"/v1/every-code/summary{suffix}", headers=headers)
+
+
+async def _get_preview_readiness(
+    app: FastAPI,
+    *,
+    repository: str = "",
+    pr_number: str = "",
+    status: str = "",
+    limit: str = "",
+    offset: str = "",
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    params = _query_params(
+        repository=repository,
+        pr_number=pr_number,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(app, f"/v1/previews/readiness{suffix}", headers=headers)
+
+
+async def _get_every_code_work_requests(
+    app: FastAPI,
+    *,
+    state: str = "",
+    repository: str = "",
+    limit: str = "",
+    offset: str = "",
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    params = _query_params(
+        state=state,
+        repository=repository,
+        limit=limit,
+        offset=offset,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(app, f"/v1/every-code/work-requests{suffix}", headers=headers)
+
+
+async def _get_every_code_work_request(
+    app: FastAPI,
+    request_id: str,
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(
+        app,
+        f"/v1/every-code/work-requests/{request_id}",
+        headers=headers,
+    )
+
+
+async def _get_every_code_pr_feedback(
+    app: FastAPI,
+    *,
+    request_id: str = "",
+    repository: str = "",
+    pr_number: str = "",
+    status: str = "",
+    limit: str = "",
+    offset: str = "",
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    params = _query_params(
+        request_id=request_id,
+        repository=repository,
+        pr_number=pr_number,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(app, f"/v1/every-code/pr-feedback{suffix}", headers=headers)
+
+
+async def _get_every_code_preview_gates(
+    app: FastAPI,
+    *,
+    request_id: str = "",
+    repository: str = "",
+    pr_number: str = "",
+    status: str = "",
+    limit: str = "",
+    offset: str = "",
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    params = _query_params(
+        request_id=request_id,
+        repository=repository,
+        pr_number=pr_number,
+        status=status,
+        limit=limit,
+        offset=offset,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(app, f"/v1/every-code/preview-gates{suffix}", headers=headers)
+
+
+async def _get_every_code_notification_attempts(
+    app: FastAPI,
+    *,
+    request_id: str = "",
+    event: str = "",
+    destination_kind: str = "",
+    limit: str = "",
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    params = _query_params(
+        request_id=request_id,
+        event=event,
+        destination_kind=destination_kind,
+        limit=limit,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/every-code/notification-attempts{suffix}",
+        headers=headers,
+    )
+
+
+async def _get_preview_pr_feedback_notification_attempts(
+    app: FastAPI,
+    *,
+    feedback_id: str = "",
+    event: str = "",
+    destination_kind: str = "",
+    limit: str = "",
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    params = _query_params(
+        feedback_id=feedback_id,
+        event=event,
+        destination_kind=destination_kind,
+        limit=limit,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/previews/pr-feedback/notification-attempts{suffix}",
+        headers=headers,
+    )
+
+
+def _query_params(**values: str) -> dict[str, str]:
+    return {key: value for key, value in values.items() if value != ""}
 
 
 async def _get_products(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -27,7 +27,6 @@ from control_plane import secrets as control_plane_secrets
 from control_plane import service as control_plane_service
 from control_plane.notifications import public_discord_url_error, public_url_error
 from control_plane.contracts.environment_inventory import EnvironmentInventory
-from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_notifications import (
     EveryCodeNotificationAttemptRecord,
     EveryCodeNotificationDestination,
@@ -4053,6 +4052,28 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["mode"], "apply")
 
+    def test_notification_policy_apply_routes_reject_legacy_get_requests(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+
+            responses = tuple(
+                _invoke_app(app, method="GET", path=path)
+                for path in (
+                    "/v1/public-ingress/notification-policies/apply",
+                    "/v1/every-code/notification-policies/apply",
+                    "/v1/previews/pr-feedback/notification-policies/apply",
+                )
+            )
+
+        for status_code, payload in responses:
+            self.assertEqual(status_code, 405)
+            self.assertEqual(payload["error"]["code"], "method_not_allowed")
+
     def test_every_code_notification_policy_apply_writes_db_policy(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -4594,12 +4615,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
                 headers={"Idempotency-Key": "every-code-blocked-notify-status"},
             )
-            attempts_status, attempts_payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/notification-attempts",
-                query_string=f"request_id={request_id}&event=work_request_blocked",
-            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                attempts = store.list_every_code_notification_attempt_records(
+                    request_id=request_id,
+                    event="work_request_blocked",
+                )
+            finally:
+                store.close()
 
         self.assertEqual(create_status, 202)
         self.assertEqual(claim_status, 202)
@@ -4610,8 +4633,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(webhook_url, "https://discord.com/api/webhooks/test/webhook")
         self.assertIn("embeds", discord_payload)
         self.assertEqual(payload["result"]["notifications"][0]["delivery_status"], "delivered")
-        self.assertEqual(attempts_status, 200)
-        self.assertEqual(attempts_payload["attempts"][0]["delivery_status"], "delivered")
+        self.assertEqual(attempts[0].delivery_status, "delivered")
 
     def test_every_code_blocked_status_records_discord_failure(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
@@ -4711,12 +4733,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
                 headers={"Idempotency-Key": "every-code-blocked-notify-failed-status"},
             )
-            attempts_status, attempts_payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/notification-attempts",
-                query_string=f"request_id={request_id}&event=work_request_blocked",
-            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                attempts = store.list_every_code_notification_attempt_records(
+                    request_id=request_id,
+                    event="work_request_blocked",
+                )
+            finally:
+                store.close()
 
         self.assertEqual(create_status, 202)
         self.assertEqual(claim_status, 202)
@@ -4725,9 +4749,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["request"]["state"], "blocked")
         self.assertEqual(payload["result"]["notifications"][0]["delivery_status"], "failed")
         self.assertIn("discord unavailable", payload["result"]["notifications"][0]["error_message"])
-        self.assertEqual(attempts_status, 200)
-        self.assertEqual(attempts_payload["attempts"][0]["delivery_status"], "failed")
-        self.assertIn("discord unavailable", attempts_payload["attempts"][0]["error_message"])
+        self.assertEqual(attempts[0].delivery_status, "failed")
+        self.assertIn("discord unavailable", attempts[0].error_message)
 
     def test_every_code_discord_delivery_keeps_pending_marker_on_attempt_write_failure(
         self,
@@ -9446,8 +9469,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -9464,26 +9488,22 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
                 },
             )
-            list_status, list_payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/work-requests",
-                query_string="state=queued",
+            work_requests = FilesystemRecordStore(state_dir).list_every_code_work_request_records(
+                state="queued"
             )
 
         self.assertEqual(webhook_status, 202)
         self.assertFalse(webhook_response["deduped"])
         self.assertEqual(webhook_response["records"]["state"], "queued")
         self.assertEqual(webhook_response["github_delivery_id"], "delivery-1")
-        self.assertEqual(list_status, 200)
-        self.assertEqual(len(list_payload["requests"]), 1)
-        request = list_payload["requests"][0]
-        self.assertEqual(request["source"], "github_issue_label")
-        self.assertEqual(request["repository"], "cbusillo/code")
-        self.assertEqual(request["issue_number"], 123)
-        self.assertEqual(request["trigger_label"], "every-code")
-        self.assertEqual(request["trigger_actor"], "cbusillo")
-        self.assertEqual(request["github_delivery_id"], "delivery-1")
+        self.assertEqual(len(work_requests), 1)
+        request = work_requests[0]
+        self.assertEqual(request.source, "github_issue_label")
+        self.assertEqual(request.repository, "cbusillo/code")
+        self.assertEqual(request.issue_number, 123)
+        self.assertEqual(request.trigger_label, "every-code")
+        self.assertEqual(request.trigger_actor, "cbusillo")
+        self.assertEqual(request.github_delivery_id, "delivery-1")
 
     def test_every_code_github_webhook_dedupes_existing_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
@@ -9522,8 +9542,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -9560,10 +9581,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
                 },
             )
-            show_status, show_payload = _invoke_app(
-                app,
-                method="GET",
-                path=f"/v1/every-code/work-requests/{request_id}",
+            stored_request = FilesystemRecordStore(state_dir).read_every_code_work_request_record(
+                request_id
             )
 
         self.assertEqual(first_status, 202)
@@ -9571,53 +9590,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(second_status, 202)
         self.assertTrue(second_payload["deduped"])
         self.assertEqual(second_payload["records"]["state"], "claimed")
-        self.assertEqual(show_status, 200)
-        self.assertEqual(show_payload["request"]["state"], "claimed")
-        self.assertEqual(show_payload["request"]["github_delivery_id"], "delivery-1")
+        self.assertEqual(stored_request.state, "claimed")
+        self.assertEqual(stored_request.github_delivery_id, "delivery-1")
 
-    def test_every_code_summary_returns_agent_safe_projection(self) -> None:
-        secret = "launchplane-every-code-webhook-secret"
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["every_code_work_request.read"],
-                    }
-                ]
-            }
-        )
-        issue_payload = _every_code_github_issue_labeled_payload()
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict(
-                os.environ,
-                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
-            ),
-        ):
+    def test_every_code_summary_read_route_is_retired_from_legacy_wsgi_app(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(
-                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
-                ),
-                authz_policy=policy,
+                verifier=_StubVerifier(_every_code_worker_identity()),
+                authz_policy=_every_code_worker_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
-            )
-            webhook_status, _ = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/github-webhook",
-                payload=issue_payload,
-                authorization="",
-                headers={
-                    "X-GitHub-Event": "issues",
-                    "X-GitHub-Delivery": "delivery-1",
-                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
-                },
             )
             summary_status, summary_payload = _invoke_app(
                 app,
@@ -9626,81 +9608,44 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 query_string="repository=cbusillo/code&issue_number=123&state=queued",
             )
 
-        self.assertEqual(webhook_status, 202)
-        self.assertEqual(summary_status, 200)
-        summary = summary_payload["summary"]
-        self.assertEqual(summary["repository"], "cbusillo/code")
-        self.assertEqual(summary["issue_number"], 123)
-        self.assertEqual(summary["state_filter"], "queued")
-        self.assertEqual(len(summary["summaries"]), 1)
-        request_summary = summary["summaries"][0]
-        self.assertEqual(request_summary["repository"], "cbusillo/code")
-        self.assertEqual(request_summary["issue_number"], 123)
-        self.assertEqual(request_summary["summary_status"], "active")
-        self.assertFalse(request_summary["safe_to_rerun"])
-        self.assertNotIn("github_delivery_id", request_summary)
+        self.assertEqual(summary_status, 404)
+        self.assertEqual(summary_payload["error"]["code"], "not_found")
 
-    def test_every_code_summary_rejects_unauthorized_identity(self) -> None:
+    def test_every_code_work_request_read_routes_are_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                verifier=_StubVerifier(_every_code_worker_identity()),
+                authz_policy=_every_code_worker_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            status_code, payload = _invoke_app(
+            list_status, list_payload = _invoke_app(
                 app,
                 method="GET",
-                path="/v1/every-code/summary",
+                path="/v1/every-code/work-requests",
+            )
+            read_status, read_payload = _invoke_app(
+                app,
+                method="GET",
+                path="/v1/every-code/work-requests/every-code-cbusillo-code-123-test",
             )
 
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(list_status, 404)
+        self.assertEqual(read_status, 404)
+        self.assertEqual(list_payload["error"]["code"], "not_found")
+        self.assertEqual(read_payload["error"]["code"], "not_found")
 
-    def test_preview_readiness_returns_agent_safe_projection(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["every_code_preview_gate.read"],
-                    }
-                ]
-            }
-        )
+    def test_preview_readiness_read_route_is_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_every_code_preview_gate_record(
-                EveryCodePreviewGateRecord(
-                    gate_id="every-code-preview-gate-cbusillo-code-26-abcdef",
-                    request_id="every-code-cbusillo-code-26-test",
-                    repository="cbusillo/code",
-                    issue_number=26,
-                    issue_url="https://github.com/cbusillo/code/issues/26",
-                    pr_number=31,
-                    pr_url="https://github.com/cbusillo/code/pull/31",
-                    head_sha="abcdef1234567890",
-                    status="blocked",
-                    created_at="2026-05-08T18:00:00Z",
-                    updated_at="2026-05-08T18:01:00Z",
-                    blocked_at="2026-05-08T18:01:00Z",
-                    last_checked_at="2026-05-08T18:01:00Z",
-                    blocked_reason="static_checks failed.",
-                    check_summary="static_checks=failure",
-                )
-            )
             app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                state_dir=root / "state",
+                verifier=_StubVerifier(_every_code_worker_identity()),
+                authz_policy=_every_code_worker_policy(
+                    extra_actions=("every_code_preview_gate.read",)
                 ),
-                authz_policy=policy,
                 control_plane_root_path=root,
             )
             status_code, payload = _invoke_app(
@@ -9710,34 +9655,40 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 query_string="repository=cbusillo/code&pr_number=31&status=blocked",
             )
 
-        self.assertEqual(status_code, 200)
-        readiness = payload["readiness"]
-        self.assertEqual(readiness["repository"], "cbusillo/code")
-        self.assertEqual(readiness["pr_number"], 31)
-        self.assertEqual(readiness["status_filter"], "blocked")
-        self.assertEqual(len(readiness["items"]), 1)
-        item = readiness["items"][0]
-        self.assertEqual(item["readiness_status"], "needs_attention")
-        self.assertEqual(item["freshness_status"], "verified")
-        self.assertEqual(item["source_of_truth_url"], "https://github.com/cbusillo/code/pull/31")
-        self.assertTrue(item["needs_operator_attention"])
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
-    def test_preview_readiness_rejects_unauthorized_identity(self) -> None:
+    def test_every_code_auxiliary_read_routes_are_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                verifier=_StubVerifier(_every_code_worker_identity()),
+                authz_policy=_every_code_worker_policy(
+                    extra_actions=(
+                        "every_code_preview_gate.read",
+                        "every_code_notification_attempt.read",
+                        "preview_pr_feedback_notification_attempt.read",
+                    )
+                ),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/previews/readiness",
-            )
+            responses = {
+                path: _invoke_app(app, method="GET", path=path)
+                for path in (
+                    "/v1/every-code/pr-feedback",
+                    "/v1/every-code/preview-gates",
+                    "/v1/every-code/notification-attempts",
+                    "/v1/previews/pr-feedback/notification-attempts",
+                )
+            }
 
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(responses["/v1/every-code/pr-feedback"][0], 405)
+        self.assertEqual(responses["/v1/every-code/preview-gates"][0], 405)
+        self.assertEqual(responses["/v1/every-code/notification-attempts"][0], 404)
+        self.assertEqual(
+            responses["/v1/previews/pr-feedback/notification-attempts"][0],
+            404,
+        )
 
     def test_every_code_github_webhook_dedupes_finished_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
@@ -9777,8 +9728,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -9882,8 +9834,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -9984,8 +9937,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -10273,8 +10227,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -10306,12 +10261,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "X-Hub-Signature-256": _github_webhook_signature(pr_payload, secret),
                 },
             )
-            list_status, list_payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/work-requests",
-                authorization="Bearer dev-worker-token",
-            )
+            persisted_requests = FilesystemRecordStore(
+                state_dir
+            ).list_every_code_work_request_records()
 
         self.assertEqual(close_status, 202)
         self.assertEqual(close_payload["result"]["closed_count"], 2)
@@ -10324,9 +10276,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 for request in closed_requests
             )
         )
-        self.assertEqual(list_status, 200)
         self.assertEqual(
-            {request["state"] for request in list_payload["requests"]},
+            {request.state for request in persisted_requests},
             {"done"},
         )
 
@@ -10569,8 +10520,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -10792,8 +10744,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 return_value={"id": 987},
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -10872,8 +10825,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -11276,9 +11230,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             _write_github_planning_config(Path(home_directory_name), repo_managers={})
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -11308,20 +11263,15 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
                 },
             )
-            list_status, list_response = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/pr-feedback",
-                query_string=f"request_id={request_id}",
-                authorization="Bearer dev-worker-token",
+            feedback_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
+                request_id=request_id
             )
 
         self.assertEqual(issue_status, 202)
         self.assertEqual(feedback_status, 202, feedback_response)
-        self.assertEqual(list_status, 200, list_response)
         self.assertTrue(feedback_response["skipped"])
         self.assertEqual(feedback_response["reason"], "untrusted_actor")
-        self.assertEqual(list_response["feedback"], [])
+        self.assertEqual(feedback_records, ())
 
     def test_every_code_pr_comment_webhook_ignores_bot_feedback(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
@@ -11343,8 +11293,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -11394,21 +11345,15 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
                 },
             )
-
-            list_status, list_response = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/pr-feedback",
-                query_string=f"request_id={request_id}",
-                authorization="Bearer dev-worker-token",
+            feedback_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
+                request_id=request_id
             )
 
         self.assertEqual(issue_status, 202)
         self.assertEqual(feedback_status, 202, feedback_response)
-        self.assertEqual(list_status, 200, list_response)
         self.assertTrue(feedback_response["skipped"])
         self.assertEqual(feedback_response["reason"], "automation_actor")
-        self.assertEqual(list_response["feedback"], [])
+        self.assertEqual(feedback_records, ())
 
     def test_every_code_pr_comment_webhook_dedupes_feedback(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
@@ -11512,8 +11457,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -11564,15 +11510,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
                 },
             )
-            list_status, list_response = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/pr-feedback",
-                query_string=f"request_id={request_id}&status=pending",
-                authorization="Bearer dev-worker-token",
+            feedback_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
+                request_id=request_id,
+                status="pending",
             )
-            self.assertEqual(list_status, 200, list_response)
-            feedback_id = list_response["feedback"][0]["feedback_id"]
+            feedback_id = feedback_records[0].feedback_id
             status_status, status_response = _invoke_app(
                 app,
                 method="POST",
@@ -11596,8 +11538,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authorization="Bearer dev-worker-token",
             )
 
-        self.assertEqual(list_status, 200)
-        self.assertEqual(len(list_response["feedback"]), 1)
+        self.assertEqual(len(feedback_records), 1)
         self.assertEqual(status_status, 202)
         self.assertEqual(status_response["result"]["feedback"]["status"], "applied")
         self.assertEqual(second_status, 409)
@@ -11628,8 +11569,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
             )
@@ -11640,12 +11582,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload=feedback_record.model_dump(mode="json"),
                 authorization="Bearer dev-worker-token",
             )
-            list_status, list_response = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/pr-feedback",
-                query_string=f"request_id={feedback_record.request_id}&status=pending",
-                authorization="Bearer dev-worker-token",
+            feedback_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
+                request_id=feedback_record.request_id,
+                status="pending",
             )
 
         self.assertEqual(write_status, 202, write_response)
@@ -11653,9 +11592,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(
             write_response["result"]["feedback"]["feedback_id"], feedback_record.feedback_id
         )
-        self.assertEqual(list_status, 200, list_response)
-        self.assertEqual(len(list_response["feedback"]), 1)
-        self.assertEqual(list_response["feedback"][0]["feedback_id"], feedback_record.feedback_id)
+        self.assertEqual(len(feedback_records), 1)
+        self.assertEqual(feedback_records[0].feedback_id, feedback_record.feedback_id)
 
     def test_every_code_worker_token_reruns_terminal_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
@@ -11965,8 +11903,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
             event_name="workflow_dispatch",
         )
         with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -11988,11 +11927,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 headers={"Idempotency-Key": "every-code-create-code-123"},
             )
             request_id = str(create_payload["records"]["request_id"])
-            list_status, list_payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/work-requests",
-                query_string="state=queued",
+            queued_requests = FilesystemRecordStore(state_dir).list_every_code_work_request_records(
+                state="queued"
             )
             claim_status, claim_payload = _invoke_app(
                 app,
@@ -12021,30 +11957,26 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
                 headers={"Idempotency-Key": "every-code-status-code-123-done"},
             )
-            show_status, show_payload = _invoke_app(
-                app,
-                method="GET",
-                path=f"/v1/every-code/work-requests/{request_id}",
+            stored_request = FilesystemRecordStore(state_dir).read_every_code_work_request_record(
+                request_id
             )
 
         self.assertEqual(create_status, 202)
         self.assertEqual(create_payload["records"]["state"], "queued")
-        self.assertEqual(list_status, 200)
-        self.assertEqual(len(list_payload["requests"]), 1)
+        self.assertEqual(len(queued_requests), 1)
         self.assertEqual(claim_status, 202)
         self.assertEqual(claim_payload["records"]["state"], "claimed")
         self.assertEqual(second_claim_status, 409)
         self.assertEqual(second_claim_payload["error"]["code"], "work_request_already_claimed")
         self.assertEqual(status_status, 202)
         self.assertEqual(status_payload["records"]["state"], "done")
-        self.assertEqual(show_status, 200)
-        self.assertEqual(show_payload["request"]["state"], "done")
+        self.assertEqual(stored_request.state, "done")
         self.assertEqual(
-            show_payload["request"]["result_pr_url"],
+            stored_request.result_pr_url,
             "https://github.com/cbusillo/code/pull/26",
         )
 
-    def test_every_code_worker_token_can_read_claim_and_update_requests(self) -> None:
+    def test_every_code_worker_token_can_claim_and_update_requests(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {
                 "github_actions": [
@@ -12076,8 +12008,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -12098,12 +12031,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(create_payload["records"]["request_id"])
-            list_status, list_payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/every-code/work-requests",
-                query_string="state=queued",
-                authorization="Bearer worker-token",
+            queued_requests = FilesystemRecordStore(state_dir).list_every_code_work_request_records(
+                state="queued"
             )
             claim_status, claim_payload = _invoke_app(
                 app,
@@ -12127,8 +12056,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
         self.assertEqual(create_status, 202)
-        self.assertEqual(list_status, 200)
-        self.assertEqual(list_payload["requests"][0]["request_id"], request_id)
+        self.assertEqual(queued_requests[0].request_id, request_id)
         self.assertEqual(claim_status, 202)
         self.assertEqual(claim_payload["result"]["request"]["claimed_by_host"], "Chris-Studio")
         self.assertEqual(status_status, 202)
@@ -12537,7 +12465,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(stale_status, 409)
         self.assertEqual(stale_payload["error"]["code"], "agent_write_intent_stale")
 
-    def test_every_code_worker_token_is_required_for_unauthenticated_request(self) -> None:
+    def test_every_code_worker_read_route_is_retired_before_authentication(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
@@ -12558,10 +12486,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authorization="",
             )
 
-        self.assertEqual(status_code, 401)
-        self.assertEqual(payload["error"]["code"], "authentication_required")
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
-    def test_every_code_worker_reads_reject_negative_offsets(self) -> None:
+    def test_every_code_worker_read_routes_are_removed_from_legacy_worker_token_bypass(
+        self,
+    ) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
@@ -12590,12 +12520,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authorization="Bearer worker-token",
             )
 
-        self.assertEqual(work_status, 400)
-        self.assertEqual(work_payload["error"]["code"], "invalid_payload")
-        self.assertIn("offset must be non-negative", work_payload["error"]["message"])
-        self.assertEqual(feedback_status, 400)
-        self.assertEqual(feedback_payload["error"]["code"], "invalid_payload")
-        self.assertIn("offset must be non-negative", feedback_payload["error"]["message"])
+        self.assertEqual(work_status, 404)
+        self.assertEqual(work_payload["error"]["code"], "not_found")
+        self.assertEqual(feedback_status, 405)
+        self.assertEqual(feedback_payload["error"]["code"], "method_not_allowed")
 
     def test_every_code_work_request_create_rejects_unauthorized_identity(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -28943,7 +28871,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(attempts[0].delivery_status, "delivered")
         self.assertEqual(attempts[0].action, "posted_discord")
 
-    def test_preview_pr_feedback_notification_attempts_can_be_read(self) -> None:
+    def test_preview_pr_feedback_notification_attempt_read_route_is_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
@@ -28980,12 +28910,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 query_string="feedback_id=feedback-1&event=delivery_skipped",
             )
 
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["feedback_id"], "feedback-1")
-        self.assertEqual(payload["event_filter"], "delivery_skipped")
-        self.assertEqual(payload["attempts"], [attempt_record.model_dump(mode="json")])
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
-    def test_preview_pr_feedback_notification_attempt_read_requires_authz(self) -> None:
+    def test_preview_pr_feedback_notification_attempt_read_authz_moved_to_fastapi(
+        self,
+    ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
@@ -29003,8 +28933,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 path="/v1/previews/pr-feedback/notification-attempts",
             )
 
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_preview_pr_feedback_notification_not_duplicated_on_idempotent_retry(
         self,


### PR DESCRIPTION
## Summary
- move Every Code work request, PR feedback, preview gate, notification attempt, summary, and preview readiness reads into the native FastAPI app
- retire the matching legacy WSGI read routes and worker-token GET bypass while preserving WSGI write/worker POST flows
- remove stale GET matcher compatibility for notification-policy apply routes and update service boundary docs

## Validation
- uv run --extra dev ruff check .
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- git diff --check
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest
- JetBrains changed-files closeout clean
- final review agents green