### PR TITLE
Move ingress route audit reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -49,6 +49,7 @@ from control_plane.contracts.idempotency_record import (
 )
 from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
 from control_plane.contracts.ingress_canary_route_record import IngressCanaryRouteRecord
+from control_plane.contracts.ingress_route_audit_record import IngressRouteAuditRecord
 from control_plane.contracts.product_environment_read_model import (
     ProductActivityReadModel,
     ProductEnvironmentConfigStatus,
@@ -459,6 +460,26 @@ class IngressCanaryRouteRecordsResponse(BaseModel):
     limit: int
     count: int
     records: tuple[IngressCanaryRouteRecord, ...]
+
+
+class IngressRouteAuditRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: IngressRouteAuditRecord
+
+
+class IngressRouteAuditRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    product: str
+    context: str
+    limit: int
+    count: int
+    records: tuple[IngressRouteAuditRecord, ...]
 
 
 class EveryCodeWorkRequestRecordsResponse(BaseModel):
@@ -892,6 +913,18 @@ class _IngressCanaryRouteReadStore(Protocol):
         status: str = "",
         limit: int | None = None,
     ) -> tuple[IngressCanaryRouteRecord, ...]: ...
+
+
+class _IngressRouteAuditRecordReadStore(Protocol):
+    def read_ingress_route_audit_record(self, record_id: str) -> IngressRouteAuditRecord: ...
+
+    def list_ingress_route_audit_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[IngressRouteAuditRecord, ...]: ...
 
 
 class _EveryCodeWorkRequestListStore(Protocol):
@@ -1345,6 +1378,56 @@ def require_ingress_canary_route_read_store(
             f"{missing_summary}"
         )
     return cast(_IngressCanaryRouteReadStore, record_store)
+
+
+def require_ingress_route_audit_record_read_store(
+    record_store: object,
+) -> _IngressRouteAuditRecordReadStore:
+    required_methods = (
+        "read_ingress_route_audit_record",
+        "list_ingress_route_audit_records",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support ingress route audit reads: "
+            f"{missing_summary}"
+        )
+    return cast(_IngressRouteAuditRecordReadStore, record_store)
+
+
+def filter_ingress_route_audit_records(
+    records: tuple[IngressRouteAuditRecord, ...],
+    *,
+    status: str = "",
+    mode: str = "",
+    provider_host_id: int | None = None,
+    trace_id: str = "",
+    idempotency_key: str = "",
+) -> tuple[IngressRouteAuditRecord, ...]:
+    filtered_records = records
+    if status:
+        filtered_records = tuple(record for record in filtered_records if record.status == status)
+    if mode:
+        filtered_records = tuple(record for record in filtered_records if record.mode == mode)
+    if provider_host_id is not None:
+        filtered_records = tuple(
+            record for record in filtered_records if record.provider_host_id == provider_host_id
+        )
+    if trace_id:
+        filtered_records = tuple(
+            record for record in filtered_records if record.trace_id == trace_id
+        )
+    if idempotency_key:
+        filtered_records = tuple(
+            record for record in filtered_records if record.idempotency_key == idempotency_key
+        )
+    return filtered_records
 
 
 def product_profile_context_cutover_allowed_contexts(
@@ -3235,6 +3318,156 @@ def create_launchplane_fastapi_app(
             ) from error
         return IngressCanaryRouteRecordResponse(trace_id=trace_id, record=record)
 
+    def ensure_ingress_route_audit_read_allowed(
+        *,
+        identity: LaunchplaneIdentity,
+        trace_id: str,
+        product: str,
+        context_name: str,
+    ) -> None:
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="ingress_route.plan",
+            product=product,
+            context=context_name,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read ingress route audit records for the requested product/context.",
+            )
+
+    def list_ingress_route_audit_records(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        product: Annotated[str, Query()] = "",
+        context: Annotated[str, Query()] = "",
+        status: Annotated[str, Query()] = "",
+        mode: Annotated[str, Query()] = "",
+        provider_host_id: Annotated[str, Query()] = "",
+        trace_id: Annotated[str, Query()] = "",
+        idempotency_key: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "25",
+    ) -> IngressRouteAuditRecordsResponse:
+        request_trace_id = next_trace_id()
+        normalized_product = product.strip()
+        context_name = context.strip()
+        if not normalized_product or not context_name:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=request_trace_id,
+                code="invalid_query",
+                message="Ingress route audit list requires product and context query parameters.",
+            )
+        ensure_ingress_route_audit_read_allowed(
+            identity=identity,
+            trace_id=request_trace_id,
+            product=normalized_product,
+            context_name=context_name,
+        )
+        try:
+            normalized_limit = control_plane_service_status.query_int_value(
+                limit,
+                "limit",
+                default=25,
+                minimum=1,
+                maximum=100,
+            )
+            assert normalized_limit is not None
+            normalized_provider_host_id = control_plane_service_status.query_int_value(
+                provider_host_id,
+                "provider_host_id",
+                minimum=1,
+            )
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=request_trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        try:
+            audit_store = require_ingress_route_audit_record_read_store(record_store)
+            records = audit_store.list_ingress_route_audit_records(
+                product=normalized_product,
+                context_name=context_name,
+                limit=None,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=request_trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        records = filter_ingress_route_audit_records(
+            records,
+            status=status.strip(),
+            mode=mode.strip(),
+            provider_host_id=normalized_provider_host_id,
+            trace_id=trace_id.strip(),
+            idempotency_key=idempotency_key.strip(),
+        )
+        limited_records = records[:normalized_limit]
+        return IngressRouteAuditRecordsResponse(
+            trace_id=request_trace_id,
+            product=normalized_product,
+            context=context_name,
+            limit=normalized_limit,
+            count=len(limited_records),
+            records=limited_records,
+        )
+
+    def read_ingress_route_audit_record(
+        record_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        product: Annotated[str, Query()] = "",
+        context: Annotated[str, Query()] = "",
+    ) -> IngressRouteAuditRecordResponse:
+        request_trace_id = next_trace_id()
+        normalized_product = product.strip()
+        context_name = context.strip()
+        if not normalized_product or not context_name:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=request_trace_id,
+                code="invalid_query",
+                message="Ingress route audit record reads require product and context query parameters.",
+            )
+        ensure_ingress_route_audit_read_allowed(
+            identity=identity,
+            trace_id=request_trace_id,
+            product=normalized_product,
+            context_name=context_name,
+        )
+        try:
+            audit_store = require_ingress_route_audit_record_read_store(record_store)
+            record = audit_store.read_ingress_route_audit_record(record_id)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=request_trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=request_trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if record.product != normalized_product or record.context != context_name:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=request_trace_id,
+                code="not_found",
+                message=f"Record not found: {record_id}",
+            )
+        return IngressRouteAuditRecordResponse(trace_id=request_trace_id, record=record)
+
     def read_deployment_record(
         record_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
@@ -4692,6 +4925,37 @@ def create_launchplane_fastapi_app(
         operation_id="read_ingress_canary_route_record",
         summary="Read one ingress canary route record",
         responses={
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/ingress/route-audits/records",
+        list_ingress_route_audit_records,
+        methods=["GET"],
+        response_model=IngressRouteAuditRecordsResponse,
+        operation_id="list_ingress_route_audit_records",
+        summary="List ingress route audit records",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/ingress/route-audits/records/{record_id}",
+        read_ingress_route_audit_record,
+        methods=["GET"],
+        response_model=IngressRouteAuditRecordResponse,
+        operation_id="read_ingress_route_audit_record",
+        summary="Read one ingress route audit record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
             404: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -835,20 +835,6 @@ class _OdooStableTargetReplacementOperationStore(Protocol):
     ) -> tuple[OdooStableTargetReplacementOperationRecord, ...]: ...
 
 
-class _IngressRouteAuditRecordStore(Protocol):
-    def write_ingress_route_audit_record(self, record: IngressRouteAuditRecord) -> object: ...
-
-    def read_ingress_route_audit_record(self, record_id: str) -> IngressRouteAuditRecord: ...
-
-    def list_ingress_route_audit_records(
-        self,
-        *,
-        product: str = "",
-        context_name: str = "",
-        limit: int | None = None,
-    ) -> tuple[IngressRouteAuditRecord, ...]: ...
-
-
 class _EdgeEndpointRecordStore(Protocol):
     def write_edge_endpoint_record(self, record: EdgeEndpointRecord) -> object: ...
 
@@ -4444,10 +4430,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
-    if len(segments) == 4 and segments == ["v1", "ingress", "route-audits", "records"]:
-        return "ingress_route.plan", {"ingress_route_audit_list": "true"}
-    if len(segments) == 5 and segments[:4] == ["v1", "ingress", "route-audits", "records"]:
-        return "ingress_route.plan", {"ingress_route_audit_record_id": segments[4]}
     if len(segments) == 3 and segments == ["v1", "dokploy-targets", "inspect"]:
         return "dokploy_target.inspect", {}
     if path == _MERGE_TRAIN_ADMISSION_ROUTE:
@@ -6839,19 +6821,6 @@ def _odoo_stable_target_replacement_operation_store(
     )
 
 
-def _ingress_route_audit_record_store(record_store: object) -> _IngressRouteAuditRecordStore:
-    required_methods = (
-        "write_ingress_route_audit_record",
-        "read_ingress_route_audit_record",
-        "list_ingress_route_audit_records",
-    )
-    if all(hasattr(record_store, method_name) for method_name in required_methods):
-        return cast(_IngressRouteAuditRecordStore, record_store)
-    raise click.ClickException(
-        "Ingress route audit reads require Launchplane ingress-audit record storage."
-    )
-
-
 def _edge_endpoint_record_store(record_store: object) -> _EdgeEndpointRecordStore:
     required_methods = (
         "write_edge_endpoint_record",
@@ -6994,35 +6963,6 @@ def _query_int_value(
     if maximum is not None and value > maximum:
         raise ValueError(f"Query parameter {key} must be at most {maximum}")
     return value
-
-
-def _filter_ingress_route_audit_records(
-    records: tuple[IngressRouteAuditRecord, ...],
-    *,
-    status: str = "",
-    mode: str = "",
-    provider_host_id: int | None = None,
-    trace_id: str = "",
-    idempotency_key: str = "",
-) -> tuple[IngressRouteAuditRecord, ...]:
-    filtered_records = records
-    if status:
-        filtered_records = tuple(record for record in filtered_records if record.status == status)
-    if mode:
-        filtered_records = tuple(record for record in filtered_records if record.mode == mode)
-    if provider_host_id is not None:
-        filtered_records = tuple(
-            record for record in filtered_records if record.provider_host_id == provider_host_id
-        )
-    if trace_id:
-        filtered_records = tuple(
-            record for record in filtered_records if record.trace_id == trace_id
-        )
-    if idempotency_key:
-        filtered_records = tuple(
-            record for record in filtered_records if record.idempotency_key == idempotency_key
-        )
-    return filtered_records
 
 
 def _find_odoo_stable_bootstrap_operation_by_idempotency_key(
@@ -10069,131 +10009,6 @@ def create_launchplane_service_app(
                                 if replacement_operation.result is not None
                                 else {}
                             ),
-                        },
-                    )
-                if action == "ingress_route.plan":
-                    audit_store = _ingress_route_audit_record_store(record_store)
-                    if "ingress_route_audit_record_id" in params:
-                        product = _query_string_value(query, "product")
-                        context_name = _query_string_value(query, "context")
-                        if not product or not context_name:
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=400,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "invalid_query",
-                                        "message": "Ingress route audit record reads require product and context query parameters.",
-                                    },
-                                },
-                            )
-                        if not authz_policy.allows(
-                            identity=identity,
-                            action=action,
-                            product=product,
-                            context=context_name,
-                        ):
-                            return _json_response(
-                                start_response=start_response,
-                                status_code=403,
-                                payload={
-                                    "status": "rejected",
-                                    "trace_id": request_trace_id,
-                                    "error": {
-                                        "code": "authorization_denied",
-                                        "message": "Workflow cannot read ingress route audit records for the requested product/context.",
-                                    },
-                                },
-                            )
-                        try:
-                            audit_record = audit_store.read_ingress_route_audit_record(
-                                params["ingress_route_audit_record_id"]
-                            )
-                        except FileNotFoundError:
-                            return _not_found_response(
-                                start_response=start_response,
-                                trace_id=request_trace_id,
-                                path=path,
-                            )
-                        if audit_record.product != product or audit_record.context != context_name:
-                            return _not_found_response(
-                                start_response=start_response,
-                                trace_id=request_trace_id,
-                                path=path,
-                            )
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=200,
-                            payload={
-                                "status": "ok",
-                                "trace_id": request_trace_id,
-                                "record": audit_record.model_dump(mode="json"),
-                            },
-                        )
-                    product = _query_string_value(query, "product")
-                    context_name = _query_string_value(query, "context")
-                    if not product or not context_name:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=400,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "invalid_query",
-                                    "message": "Ingress route audit list requires product and context query parameters.",
-                                },
-                            },
-                        )
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product=product,
-                        context=context_name,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read ingress route audit records for the requested product/context.",
-                                },
-                            },
-                        )
-                    limit = _query_int_value(query, "limit", default=25, minimum=1, maximum=100)
-                    provider_host_id = _query_int_value(query, "provider_host_id", minimum=1)
-                    listed_records = audit_store.list_ingress_route_audit_records(
-                        product=product,
-                        context_name=context_name,
-                        limit=None,
-                    )
-                    listed_records = _filter_ingress_route_audit_records(
-                        listed_records,
-                        status=_query_string_value(query, "status"),
-                        mode=_query_string_value(query, "mode"),
-                        provider_host_id=provider_host_id,
-                        trace_id=_query_string_value(query, "trace_id"),
-                        idempotency_key=_query_string_value(query, "idempotency_key"),
-                    )
-                    limited_records = listed_records[:limit]
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "product": product,
-                            "context": context_name,
-                            "limit": limit,
-                            "count": len(limited_records),
-                            "records": [
-                                record.model_dump(mode="json") for record in limited_records
-                            ],
                         },
                     )
                 if action == "dokploy_target.inspect":

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -78,6 +78,11 @@ Keep a compatibility surface only when it is one of these:
   `GET /v1/ingress/canary-routes/records/{canary_key}` routes. Their legacy
   WSGI read branch is deleted; ingress canary route apply remains on the
   retained fallback until that write path has its own native replacement.
+- Ingress route audit record reads use native FastAPI
+  `GET /v1/ingress/route-audits/records` and
+  `GET /v1/ingress/route-audits/records/{record_id}` routes. Their legacy WSGI
+  read branch is deleted; ingress route apply remains on the retained fallback
+  until that write path has its own native replacement.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/driver-development.md
+++ b/docs/driver-development.md
@@ -295,7 +295,7 @@ or secret values in the public contract. Keep this workflow canary-scoped until
 broader route ownership and approval UX are explicit.
 
 Operators with `ingress_route.plan` for the target product/context can inspect
-those audit records through the service. List records with
+those audit records through the native FastAPI service reads. List records with
 `GET /v1/ingress/route-audits/records?product=launchplane&context=example-prod`
 and optional `status`, `mode`, `provider_host_id`, `trace_id`,
 `idempotency_key`, and `limit` filters. Read one record with

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1354,6 +1354,10 @@ only after a passing plan and a matching stored preview record are present.
   human-session callers)
 - `GET /v1/ingress/canary-routes/records/{canary_key}` (native FastAPI for
   bearer-token and human-session callers)
+- `GET /v1/ingress/route-audits/records` (native FastAPI for bearer-token and
+  human-session callers)
+- `GET /v1/ingress/route-audits/records/{record_id}` (native FastAPI for
+  bearer-token and human-session callers)
 - `GET /v1/every-code/summary` (native FastAPI for bearer-token,
   human-session, and Every Code worker-token callers)
 - `GET /v1/previews/readiness` (native FastAPI for bearer-token,
@@ -1403,9 +1407,13 @@ profile envelope. Product context cutover audit reads load the product profile
 from DB-backed records, check `product_profile.read` against the stored profile
 product and Launchplane service context, and require the requested source,
 target, and optional preview contexts to belong to that profile before returning
-the typed audit envelope. Their legacy WSGI branches are deleted; direct
-fallback calls fail closed while the mounted fallback remains for retained
-non-native routes.
+the typed audit envelope. Ingress route audit reads check `ingress_route.plan`
+against the requested query product/context before storage access, require those
+scope query parameters for list and single-record reads, preserve optional
+`status`, `mode`, `provider_host_id`, `trace_id`, `idempotency_key`, and `limit`
+list filters, and return `404 not_found` when a record exists outside the
+requested scope. Their legacy WSGI branches are deleted; direct fallback calls
+fail closed while the mounted fallback remains for retained non-native routes.
 
 Product/site reads use action `product_environment.read`. They are native
 FastAPI routes backed by DB-owned product environment read-model composition.

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -30,6 +30,10 @@ from control_plane.contracts.every_code_preview_gate_record import EveryCodePrev
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.contracts.ingress_route_audit_record import (
+    IngressRouteAuditOperation,
+    IngressRouteAuditRecord,
+)
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
 )
@@ -4659,6 +4663,269 @@ class FastApiIngressCanaryRouteReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
+class FastApiIngressRouteAuditReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_ingress_route_audit_reads_return_native_payloads(self) -> None:
+        planned_record = _ingress_route_audit_record()
+        newer_applied_record = _ingress_route_audit_record(
+            record_id="ingress-route-audit-applied",
+            mode="apply",
+            status="applied",
+            dry_run=False,
+            provider_host_id=79,
+            trace_id="trace-audit-2",
+            idempotency_key="audit-key-2",
+            recorded_at="2026-06-02T00:00:00Z",
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_ingress_route_audit_record(planned_record)
+            store.write_ingress_route_audit_record(newer_applied_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(action="ingress_route.plan", context="reon-prod"),
+                record_store_factory=lambda: store,
+            )
+
+            list_response = await _get_ingress_route_audit_records(
+                app,
+                product="launchplane",
+                context="reon-prod",
+                status="planned",
+                mode="dry-run",
+                provider_host_id="78",
+                trace_id="trace-audit-1",
+                idempotency_key="audit-key-1",
+                limit="1",
+            )
+            read_response = await _get_ingress_route_audit_record(
+                app,
+                planned_record.record_id,
+                product="launchplane",
+                context="reon-prod",
+            )
+
+        self.assertEqual(list_response.status_code, 200)
+        list_payload = list_response.json()
+        self.assertEqual(list_payload["status"], "ok")
+        self.assertEqual(list_payload["product"], "launchplane")
+        self.assertEqual(list_payload["context"], "reon-prod")
+        self.assertEqual(list_payload["limit"], 1)
+        self.assertEqual(list_payload["count"], 1)
+        self.assertEqual(list_payload["records"][0]["record_id"], planned_record.record_id)
+        self.assertEqual(read_response.status_code, 200)
+        read_payload = read_response.json()
+        self.assertEqual(read_payload["status"], "ok")
+        self.assertEqual(read_payload["record"]["record_id"], planned_record.record_id)
+        self.assertEqual(read_payload["record"]["provider_host_id"], 78)
+
+    async def test_ingress_route_audit_read_hides_record_outside_requested_scope(
+        self,
+    ) -> None:
+        record = _ingress_route_audit_record()
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_ingress_route_audit_record(record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_ingress_route_audit_read_policy(contexts=("reon-prod", "cm-prod")),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_ingress_route_audit_record(
+                app,
+                record.record_id,
+                product="launchplane",
+                context="cm-prod",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_ingress_route_audit_reads_require_scoped_query(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="ingress_route.plan", context="reon-prod"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        list_response = await _get_ingress_route_audit_records(
+            app,
+            product="launchplane",
+        )
+        read_response = await _get_ingress_route_audit_record(
+            app,
+            "ingress-route-audit-test",
+        )
+
+        self.assertEqual(list_response.status_code, 400)
+        self.assertEqual(read_response.status_code, 400)
+        self.assertEqual(list_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(read_response.json()["error"]["code"], "invalid_query")
+
+    async def test_ingress_route_audit_reads_reject_unauthorized_context(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="ingress_route.plan", context="reon-prod"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_ingress_route_audit_records(
+            app,
+            product="launchplane",
+            context="cm-prod",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_ingress_route_audit_reads_require_record_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="ingress_route.plan", context="reon-prod"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_ingress_route_audit_records(
+            app,
+            product="launchplane",
+            context="reon-prod",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+
+    async def test_ingress_route_audit_read_returns_not_found_for_missing_record(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(action="ingress_route.plan", context="reon-prod"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _get_ingress_route_audit_record(
+                app,
+                "missing-audit-record",
+                product="launchplane",
+                context="reon-prod",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_ingress_route_audit_reads_reject_invalid_query_values(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="ingress_route.plan", context="reon-prod"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        low_limit_response = await _get_ingress_route_audit_records(
+            app,
+            product="launchplane",
+            context="reon-prod",
+            limit="0",
+        )
+        high_limit_response = await _get_ingress_route_audit_records(
+            app,
+            product="launchplane",
+            context="reon-prod",
+            limit="101",
+        )
+        provider_host_response = await _get_ingress_route_audit_records(
+            app,
+            product="launchplane",
+            context="reon-prod",
+            provider_host_id="0",
+        )
+
+        self.assertEqual(low_limit_response.status_code, 400)
+        self.assertEqual(high_limit_response.status_code, 400)
+        self.assertEqual(provider_host_response.status_code, 400)
+        self.assertEqual(low_limit_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(high_limit_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(provider_host_response.json()["error"]["code"], "invalid_query")
+
+    async def test_openapi_includes_ingress_route_audit_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(action="ingress_route.plan", context="reon-prod"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        list_route = openapi["paths"]["/v1/ingress/route-audits/records"]["get"]
+        read_route = openapi["paths"]["/v1/ingress/route-audits/records/{record_id}"]["get"]
+        self.assertEqual(list_route["operationId"], "list_ingress_route_audit_records")
+        self.assertEqual(read_route["operationId"], "read_ingress_route_audit_record")
+        self.assertEqual(
+            list_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/IngressRouteAuditRecordsResponse",
+        )
+        self.assertEqual(
+            read_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/IngressRouteAuditRecordResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(list_route))
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(read_route))
+        self.assertEqual(
+            openapi["components"]["schemas"]["IngressRouteAuditRecordResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["IngressRouteAuditRecordsResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+
+    async def test_fastapi_ingress_route_audit_reads_precede_legacy_wsgi_fallback(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            record = _ingress_route_audit_record()
+            store.write_ingress_route_audit_record(record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(action="ingress_route.plan", context="reon-prod"),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _get_ingress_route_audit_record(
+                app,
+                record.record_id,
+                product="launchplane",
+                context="reon-prod",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+
 class FastApiDeploymentPromotionReadTests(unittest.IsolatedAsyncioTestCase):
     async def test_deployment_read_returns_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -9158,6 +9425,65 @@ def _every_code_read_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
+def _ingress_route_audit_record(
+    *,
+    record_id: str = "ingress-route-audit-test",
+    product: str = "launchplane",
+    context: str = "reon-prod",
+    mode: Literal["dry-run", "apply"] = "dry-run",
+    status: Literal["pending", "planned", "applied", "unchanged"] = "planned",
+    dry_run: bool = True,
+    provider_host_id: int | None = 78,
+    trace_id: str = "trace-audit-1",
+    idempotency_key: str = "audit-key-1",
+    recorded_at: str = "2026-06-01T00:00:00Z",
+) -> IngressRouteAuditRecord:
+    return IngressRouteAuditRecord(
+        record_id=record_id,
+        product=product,
+        context=context,
+        mode=mode,
+        status=status,
+        dry_run=dry_run,
+        requested_domains=("app.example.com",),
+        edge_endpoint_key="edge-app",
+        expected_host_id=None,
+        provider_host_id=provider_host_id,
+        operations=(
+            IngressRouteAuditOperation(
+                action="create",
+                host_id=provider_host_id,
+                domain_names=("app.example.com",),
+                requires_apply=mode == "dry-run",
+                change_categories=("create",),
+            ),
+        ),
+        trace_id=trace_id,
+        idempotency_key=idempotency_key,
+        reason="test",
+        recorded_at=recorded_at,
+    )
+
+
+def _ingress_route_audit_read_policy(*, contexts: tuple[str, ...]) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["launchplane"],
+                    "contexts": list(contexts),
+                    "actions": ["ingress_route.plan"],
+                }
+            ]
+        }
+    )
+
+
 def _product_profile_read_policy(*, product: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -9871,6 +10197,62 @@ async def _get_ingress_canary_route_record(
     return await _asgi_get(
         app,
         f"/v1/ingress/canary-routes/records/{canary_key}",
+        headers=request_headers,
+    )
+
+
+async def _get_ingress_route_audit_records(
+    app: FastAPI,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+    product: str = "",
+    context: str = "",
+    status: str = "",
+    mode: str = "",
+    provider_host_id: str = "",
+    trace_id: str = "",
+    idempotency_key: str = "",
+    limit: str = "",
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    params = _query_params(
+        product=product,
+        context=context,
+        status=status,
+        mode=mode,
+        provider_host_id=provider_host_id,
+        trace_id=trace_id,
+        idempotency_key=idempotency_key,
+        limit=limit,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/ingress/route-audits/records{suffix}",
+        headers=request_headers,
+    )
+
+
+async def _get_ingress_route_audit_record(
+    app: FastAPI,
+    record_id: str,
+    *,
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+    product: str = "",
+    context: str = "",
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    params = _query_params(product=product, context=context)
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(
+        app,
+        f"/v1/ingress/route-audits/records/{record_id}{suffix}",
         headers=request_headers,
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -3098,24 +3098,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "invalid_edge_endpoint")
         self.assertEqual(client.calls, [])
 
-    def test_ingress_route_audit_record_api_lists_and_reads_records(self) -> None:
-        client = _FakeNpmplusIngressClient()
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "every/verireel",
-                        "workflow_refs": [
-                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                        ],
-                        "event_names": ["pull_request"],
-                        "products": ["launchplane"],
-                        "contexts": ["reon-prod"],
-                        "actions": ["ingress_route.plan"],
-                    }
-                ]
-            }
-        )
+    def test_ingress_route_audit_record_reads_are_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate({"github_actions": []})
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             app = create_launchplane_service_app(
@@ -3124,217 +3110,25 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=root,
                 local_record_store_for_tests=FilesystemRecordStore(root / "state"),
-                npmplus_ingress_client_factory=lambda: client,
             )
-            _, apply_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/ingress/route-apply",
-                payload=_npmplus_ingress_route_payload(),
-                headers={"Idempotency-Key": "npmplus-ingress-dry-run"},
-            )
-            audit_record_id = apply_payload["records"]["ingress_route_audit_record_id"]
 
             list_status_code, list_payload = _invoke_app(
                 app,
                 method="GET",
                 path="/v1/ingress/route-audits/records",
-                query_string="product=launchplane&context=reon-prod&mode=dry-run&status=planned&limit=10",
+                query_string="product=launchplane&context=reon-prod",
             )
             read_status_code, read_payload = _invoke_app(
                 app,
                 method="GET",
-                path=f"/v1/ingress/route-audits/records/{audit_record_id}",
+                path="/v1/ingress/route-audits/records/ingress-route-audit-test",
                 query_string="product=launchplane&context=reon-prod",
             )
 
-        self.assertEqual(list_status_code, 200)
-        self.assertEqual(list_payload["status"], "ok")
-        self.assertEqual(list_payload["count"], 1)
-        self.assertEqual(list_payload["records"][0]["record_id"], audit_record_id)
-        self.assertEqual(read_status_code, 200)
-        self.assertEqual(read_payload["record"]["record_id"], audit_record_id)
-        self.assertEqual(read_payload["record"]["trace_id"], apply_payload["trace_id"])
-
-    def test_ingress_route_audit_record_api_requires_scope_for_single_record_read(
-        self,
-    ) -> None:
-        client = _FakeNpmplusIngressClient()
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "every/verireel",
-                        "workflow_refs": [
-                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                        ],
-                        "event_names": ["pull_request"],
-                        "products": ["launchplane"],
-                        "contexts": ["reon-prod"],
-                        "actions": ["ingress_route.plan"],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
-                npmplus_ingress_client_factory=lambda: client,
-            )
-            _, apply_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/ingress/route-apply",
-                payload=_npmplus_ingress_route_payload(),
-                headers={"Idempotency-Key": "npmplus-ingress-dry-run"},
-            )
-            audit_record_id = apply_payload["records"]["ingress_route_audit_record_id"]
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path=f"/v1/ingress/route-audits/records/{audit_record_id}",
-            )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_query")
-
-    def test_ingress_route_audit_record_api_hides_record_outside_requested_scope(
-        self,
-    ) -> None:
-        client = _FakeNpmplusIngressClient()
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "every/verireel",
-                        "workflow_refs": [
-                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                        ],
-                        "event_names": ["pull_request"],
-                        "products": ["launchplane"],
-                        "contexts": ["reon-prod", "cm-prod"],
-                        "actions": ["ingress_route.plan"],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
-                npmplus_ingress_client_factory=lambda: client,
-            )
-            _, apply_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/ingress/route-apply",
-                payload=_npmplus_ingress_route_payload(),
-                headers={"Idempotency-Key": "npmplus-ingress-dry-run"},
-            )
-            audit_record_id = apply_payload["records"]["ingress_route_audit_record_id"]
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path=f"/v1/ingress/route-audits/records/{audit_record_id}",
-                query_string="product=launchplane&context=cm-prod",
-            )
-
-        self.assertEqual(status_code, 404)
-        self.assertEqual(payload["error"]["code"], "not_found")
-
-    def test_ingress_route_audit_record_api_requires_scoped_list_query(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "every/verireel",
-                        "workflow_refs": [
-                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                        ],
-                        "event_names": ["pull_request"],
-                        "products": ["launchplane"],
-                        "contexts": ["reon-prod"],
-                        "actions": ["ingress_route.plan"],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/ingress/route-audits/records",
-                query_string="product=launchplane",
-            )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_query")
-
-    def test_ingress_route_audit_record_api_rejects_unauthorized_context(self) -> None:
-        client = _FakeNpmplusIngressClient()
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "every/verireel",
-                        "workflow_refs": [
-                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                        ],
-                        "event_names": ["pull_request"],
-                        "products": ["launchplane"],
-                        "contexts": ["reon-prod"],
-                        "actions": ["ingress_route.plan"],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
-                npmplus_ingress_client_factory=lambda: client,
-            )
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/drivers/ingress/route-apply",
-                payload=_npmplus_ingress_route_payload(),
-                headers={"Idempotency-Key": "npmplus-ingress-dry-run"},
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/ingress/route-audits/records",
-                query_string="product=launchplane&context=cm-prod",
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(list_status_code, 404)
+        self.assertEqual(read_status_code, 404)
+        self.assertEqual(list_payload["error"]["code"], "not_found")
+        self.assertEqual(read_payload["error"]["code"], "not_found")
 
     def test_npmplus_ingress_dry_run_idempotency_key_does_not_replay(self) -> None:
         client = _FakeNpmplusIngressClient()


### PR DESCRIPTION
## Summary
- move ingress route audit record list/read endpoints to native FastAPI
- delete the legacy WSGI read matcher/branch and keep direct fallback reads fail-closed
- add FastAPI behavior/OpenAPI/fallback-order coverage and update service boundary docs

## Validation
- uv run python -m unittest tests.test_http_app.FastApiIngressRouteAuditReadTests tests.test_service.LaunchplaneServiceTests.test_ingress_route_audit_record_reads_are_retired_from_legacy_wsgi_app tests.test_service.LaunchplaneServiceTests.test_npmplus_ingress_route_apply_dry_run_returns_plan_without_mutation tests.test_service.LaunchplaneServiceTests.test_npmplus_ingress_route_apply_fails_before_mutation_when_audit_unavailable
- uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- git diff --check
- uv run --extra dev ruff check .
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo /Users/cbusillo/Developer/launchplane --scope changed_files

Note: repo-wide Would reformat: control_plane/agent_context_service.py
Would reformat: control_plane/authz_grant_service.py
Would reformat: control_plane/cli_dokploy_targets.py
Would reformat: control_plane/cli_preview_workflow.py
Would reformat: control_plane/contracts/agent_write_intent.py
Would reformat: control_plane/contracts/every_code_preview_gate_record.py
Would reformat: control_plane/contracts/merge_train_admission.py
Would reformat: control_plane/contracts/merge_train_batch.py
Would reformat: control_plane/contracts/merge_train_run_record.py
Would reformat: control_plane/contracts/odoo_instance_override_record.py
Would reformat: control_plane/contracts/runner_lane_inventory.py
Would reformat: control_plane/contracts/runtime_key_safety_policy.py
Would reformat: control_plane/contracts/verireel_prod_backup_gate.py
Would reformat: control_plane/contracts/verireel_prod_backup_gate_operation.py
Would reformat: control_plane/contracts/work_graph_read_model.py
Would reformat: control_plane/every_code_worker.py
Would reformat: control_plane/merge_train.py
Would reformat: control_plane/merge_train_admission.py
Would reformat: control_plane/provider_target_operations_http.py
Would reformat: control_plane/runtime_key_safety.py
Would reformat: control_plane/runtime_key_safety_service.py
Would reformat: control_plane/service_human_auth.py
Would reformat: control_plane/storage/migrations/versions/b7d9f1a3c5e7_add_odoo_worker_leases.py
Would reformat: control_plane/storage/migrations/versions/c9d1e3f5a7b9_add_verireel_backup_gate_operations.py
Would reformat: control_plane/storage/schema_adoption.py
Would reformat: control_plane/work_graph_issue_inbox.py
Would reformat: control_plane/workflows/odoo_preview_runtime.py
Would reformat: control_plane/workflows/odoo_stable_bootstrap.py
Would reformat: control_plane/workflows/odoo_verification.py
Would reformat: control_plane/workflows/preview_pr_feedback.py
Would reformat: control_plane/workflows/provider_target_audit.py
Would reformat: control_plane/workflows/provider_target_backfill.py
Would reformat: control_plane/workflows/verireel_prod_backup_gate.py
Would reformat: control_plane/workflows/verireel_prod_backup_gate_operation_worker.py
Would reformat: scripts/deploy/capture-launchplane-deploy-diagnostics.py
Would reformat: scripts/merge_train_controller_feedback.py
Would reformat: tests/test_authz_grant_service.py
Would reformat: tests/test_config_authority_audit.py
Would reformat: tests/test_deploy_diagnostics.py
Would reformat: tests/test_emergency_dokploy_rollback.py
Would reformat: tests/test_every_code_reconciliation.py
Would reformat: tests/test_every_code_summary_read_model.py
Would reformat: tests/test_every_code_worker.py
Would reformat: tests/test_generic_web_preview.py
Would reformat: tests/test_launchplane_request_action.py
Would reformat: tests/test_merge_train_admission.py
Would reformat: tests/test_odoo_preview_runtime.py
Would reformat: tests/test_odoo_prod_rollback.py
Would reformat: tests/test_odoo_stable_authority.py
Would reformat: tests/test_odoo_stable_bootstrap.py
Would reformat: tests/test_odoo_verification.py
Would reformat: tests/test_preview_pr_feedback.py
Would reformat: tests/test_public_ingress_monitor.py
Would reformat: tests/test_runtime_identity_health.py
Would reformat: tests/test_runtime_key_safety_service.py
Would reformat: tests/test_verireel_prod_backup_gate.py
56 files would be reformatted, 328 files already formatted still reports pre-existing formatting drift in unrelated files; the changed Python files are formatted.