### PR TITLE
Move Dokploy inspect read to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -14,6 +14,11 @@ from jwt import InvalidTokenError
 from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane.dokploy_target_inspect import (
+    DokployTargetInspectRequest,
+    DokployTargetInspectStore,
+    inspect_dokploy_target,
+)
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import secrets as control_plane_secrets
@@ -364,6 +369,14 @@ class DriverContextViewResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     view: DriverContextView
+
+
+class DokployTargetInspectResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    inspect: dict[str, object]
 
 
 class TrackedTargetLogTargetResponse(BaseModel):
@@ -1318,6 +1331,22 @@ def require_tracked_target_logs_store(
             f"Tracked target logs require DB-backed Launchplane storage: {missing_summary}"
         )
     return cast(control_plane_tracked_target_logs.TrackedTargetLogsStore, record_store)
+
+
+def require_dokploy_target_inspect_store(record_store: object) -> DokployTargetInspectStore:
+    required_methods = (
+        "read_dokploy_target_record",
+        "read_dokploy_target_id_record",
+        "read_provider_target_record",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods or not isinstance(record_store, PostgresRecordStore):
+        raise TypeError("Dokploy target inspect requires Launchplane database storage.")
+    return cast(DokployTargetInspectStore, record_store)
 
 
 def require_edge_endpoint_read_store(record_store: object) -> _EdgeEndpointReadStore:
@@ -2901,6 +2930,73 @@ def create_launchplane_fastapi_app(
             instance_name=instance,
         )
         return DriverContextViewResponse(trace_id=trace_id, view=view)
+
+    def read_dokploy_target_inspect(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        context: Annotated[str, Query()] = "",
+        instance: Annotated[str, Query()] = "",
+        target_type: Annotated[str, Query()] = "",
+        target_id: Annotated[str, Query()] = "",
+    ) -> DokployTargetInspectResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="dokploy_target.inspect",
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot inspect Launchplane Dokploy targets.",
+            )
+        try:
+            inspect_store = require_dokploy_target_inspect_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message=str(error),
+            ) from error
+        try:
+            inspect_request = DokployTargetInspectRequest.model_validate(
+                {
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "context": context,
+                    "instance": instance,
+                    "target_type": target_type,
+                    "target_id": target_id,
+                }
+            )
+            host, token = control_plane_dokploy.read_dokploy_config(
+                control_plane_root=resolved_control_plane_root,
+                database_url=database_url,
+            )
+            inspect_result = inspect_dokploy_target(
+                record_store=inspect_store,
+                host=host,
+                token=token,
+                request=inspect_request,
+            )
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_dokploy_target_inspect",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        return DokployTargetInspectResponse(trace_id=trace_id, inspect=inspect_result)
 
     def read_tracked_target_logs(
         context: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
@@ -4823,6 +4919,22 @@ def create_launchplane_fastapi_app(
         responses={
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/dokploy-targets/inspect",
+        read_dokploy_target_inspect,
+        methods=["GET"],
+        response_model=DokployTargetInspectResponse,
+        operation_id="read_dokploy_target_inspect",
+        summary="Read redacted Dokploy target identity",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
         },
     )
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -21,10 +21,6 @@ from starlette.types import ASGIApp
 
 from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import dokploy as control_plane_dokploy
-from control_plane.dokploy_target_inspect import (
-    DokployTargetInspectRequest,
-    inspect_dokploy_target,
-)
 from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane import service_status as control_plane_service_status
@@ -545,7 +541,6 @@ _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-c
 _NPMPLUS_INGRESS_APPLY_ROUTE_PATH = "/v1/drivers/ingress/route-apply"
 _EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
 _PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE = "/v1/private-health-endpoints/apply"
-_DOKPLOY_TARGET_INSPECT_ROUTE = "/v1/dokploy-targets/inspect"
 _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE = "/v1/ingress/canary-routes/records/apply"
 _INGRESS_CANARY_ROUTE_APPLY_ROUTE = "/v1/ingress/canary-routes/apply"
 _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/controller/run-once"
@@ -4430,8 +4425,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
-    if len(segments) == 3 and segments == ["v1", "dokploy-targets", "inspect"]:
-        return "dokploy_target.inspect", {}
     if path == _MERGE_TRAIN_ADMISSION_ROUTE:
         return "merge_train.admission", {}
     if path == _MERGE_TRAIN_CONTROLLER_STATUS_ROUTE:
@@ -10009,87 +10002,6 @@ def create_launchplane_service_app(
                                 if replacement_operation.result is not None
                                 else {}
                             ),
-                        },
-                    )
-                if action == "dokploy_target.inspect":
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product="launchplane",
-                        context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot inspect Launchplane Dokploy targets.",
-                                },
-                            },
-                        )
-                    if not isinstance(record_store, PostgresRecordStore):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=503,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "database_required",
-                                    "message": "Dokploy target inspect requires Launchplane database storage.",
-                                },
-                            },
-                        )
-                    try:
-                        inspect_request = DokployTargetInspectRequest.model_validate(
-                            {
-                                "schema_version": 1,
-                                "product": "launchplane",
-                                "context": _query_string_value(query, "context"),
-                                "instance": _query_string_value(query, "instance"),
-                                "target_type": _query_string_value(query, "target_type"),
-                                "target_id": _query_string_value(query, "target_id"),
-                            }
-                        )
-                        host, token = control_plane_dokploy.read_dokploy_config(
-                            control_plane_root=resolved_root,
-                            database_url=database_url,
-                        )
-                        inspect_result = inspect_dokploy_target(
-                            record_store=record_store,
-                            host=host,
-                            token=token,
-                            request=inspect_request,
-                        )
-                    except ValueError as error:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=400,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "invalid_dokploy_target_inspect",
-                                    "message": str(error),
-                                },
-                            },
-                        )
-                    except FileNotFoundError:
-                        return _not_found_response(
-                            start_response=start_response,
-                            trace_id=request_trace_id,
-                            path=path,
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "inspect": inspect_result,
                         },
                     )
                 if action == "work_graph.rank":

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -83,6 +83,10 @@ Keep a compatibility surface only when it is one of these:
   `GET /v1/ingress/route-audits/records/{record_id}` routes. Their legacy WSGI
   read branch is deleted; ingress route apply remains on the retained fallback
   until that write path has its own native replacement.
+- Dokploy target inspect uses the native FastAPI
+  `GET /v1/dokploy-targets/inspect` route. Its legacy WSGI read branch is
+  deleted; Dokploy target setup remains on the retained fallback until that
+  write path has its own native replacement.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -75,6 +75,10 @@ VeriReel product paths:
     supporting `product`, `context`, `status`, and bounded `limit` filters
   - `GET /v1/ingress/canary-routes/records/{canary_key}`, requiring
     `ingress_canary_route.read` for the Launchplane service context
+- native FastAPI Dokploy target inspect read:
+  - `GET /v1/dokploy-targets/inspect`, requiring `dokploy_target.inspect` for
+    the Launchplane service context and returning redacted provider identity
+    evidence only
 - native FastAPI deployment, promotion, preview, inventory, operations, and
   managed-secret status reads:
   - `GET /v1/deployments/{record_id}`, requiring `deployment.read` for the
@@ -1202,18 +1206,18 @@ before records are written, recover by re-running the workflow with
 `operation=adopt` and the created provider target id, not by creating a second
 target for the same lane.
 
-Dokploy target inspect uses `GET /v1/dokploy-targets/inspect`. The route is a
-read-only proof surface for provider identity before an adoption, creation, or
-repair: callers may pass either `context` and `instance` to inspect the current
-tracked target, or `target_type` and `target_id` to inspect an explicit provider
-target. It requires `dokploy_target.inspect` authz for product/context
-`launchplane`, reads Dokploy through Launchplane-managed secrets, and returns a
-redacted identity summary only: target ids, names, project/environment/server
-identity, domain summaries, source metadata, and environment key names/counts.
-It must not return raw provider payloads or environment values. The manual
-`Dokploy Target Inspect` workflow is the supported shared and production caller
-when operators need provider evidence without mutating Dokploy or Launchplane
-records.
+Dokploy target inspect uses the native FastAPI
+`GET /v1/dokploy-targets/inspect` route. The route is a read-only proof surface
+for provider identity before an adoption, creation, or repair: callers may pass
+either `context` and `instance` to inspect the current tracked target, or
+`target_type` and `target_id` to inspect an explicit provider target. It
+requires `dokploy_target.inspect` authz for product/context `launchplane`, reads
+Dokploy through Launchplane-managed secrets, and returns a redacted identity
+summary only: target ids, names, project/environment/server identity, domain
+summaries, source metadata, and environment key names/counts. It must not return
+raw provider payloads or environment values. The manual `Dokploy Target Inspect`
+workflow is the supported shared and production caller when operators need
+provider evidence without mutating Dokploy or Launchplane records.
 
 The manual `Product Environment Evidence` workflow is the supported read-only
 Phase Two caller for product environment read-model evidence. It uses GitHub
@@ -1358,6 +1362,8 @@ only after a passing plan and a matching stored preview record are present.
   human-session callers)
 - `GET /v1/ingress/route-audits/records/{record_id}` (native FastAPI for
   bearer-token and human-session callers)
+- `GET /v1/dokploy-targets/inspect` (native FastAPI for bearer-token and
+  human-session callers)
 - `GET /v1/every-code/summary` (native FastAPI for bearer-token,
   human-session, and Every Code worker-token callers)
 - `GET /v1/previews/readiness` (native FastAPI for bearer-token,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -3445,6 +3445,257 @@ class FastApiDriverContextViewTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FastApiDokployTargetInspectReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_dokploy_target_inspect_reads_redacted_provider_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_dokploy_target_inspect_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.http_app.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ) as read_dokploy_config,
+                patch(
+                    "control_plane.dokploy_target_inspect.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={
+                        "id": "compose-cm-prod",
+                        "name": "cm-prod",
+                        "serverId": "server-123",
+                        "environment": {
+                            "id": "env-prod",
+                            "name": "prod",
+                            "project": {"id": "project-odoo", "name": "odoo"},
+                        },
+                        "env": "ODOO_DB_PASSWORD=secret\nDISABLE_ODOO_ONLINE=true\n",
+                    },
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="dokploy_target.inspect",
+                        context="launchplane",
+                    ),
+                    database_url=database_url,
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+
+                response = await _get_dokploy_target_inspect(
+                    app,
+                    context="cm_website",
+                    instance="prod",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["inspect"]["target_id"], "compose-cm-prod")
+        self.assertEqual(payload["inspect"]["tracked_target"]["target_name"], "cm-prod")
+        self.assertEqual(payload["inspect"]["provider"]["environment"]["id"], "env-prod")
+        self.assertEqual(
+            payload["inspect"]["provider"]["env"]["keys"],
+            ["DISABLE_ODOO_ONLINE", "ODOO_DB_PASSWORD"],
+        )
+        self.assertTrue(payload["inspect"]["provider_payload_redacted"])
+        self.assertNotIn("secret", str(payload))
+        self.assertNotIn("provider_evidence", str(payload))
+        read_dokploy_config.assert_called_once_with(
+            control_plane_root=root,
+            database_url=database_url,
+        )
+
+    async def test_dokploy_target_inspect_rejects_without_authz(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                database_url=database_url,
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _get_dokploy_target_inspect(
+                app,
+                target_type="compose",
+                target_id="compose-123",
+            )
+            store.close()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_dokploy_target_inspect_requires_database_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="dokploy_target.inspect",
+                context="launchplane",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_dokploy_target_inspect(
+            app,
+            target_type="compose",
+            target_id="compose-123",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_required")
+
+    async def test_dokploy_target_inspect_rejects_invalid_query_mode(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="dokploy_target.inspect",
+                    context="launchplane",
+                ),
+                database_url=database_url,
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            response = await _get_dokploy_target_inspect(
+                app,
+                context="cm_website",
+                instance="prod",
+                target_type="compose",
+                target_id="compose-123",
+            )
+            store.close()
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_dokploy_target_inspect")
+
+    async def test_dokploy_target_inspect_returns_not_found_for_unknown_route(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch(
+                "control_plane.http_app.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example.invalid", "token"),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="dokploy_target.inspect",
+                        context="launchplane",
+                    ),
+                    database_url=database_url,
+                    record_store_factory=lambda: store,
+                    control_plane_root_path=root,
+                )
+
+                response = await _get_dokploy_target_inspect(
+                    app,
+                    context="missing",
+                    instance="prod",
+                )
+                store.close()
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_openapi_includes_dokploy_target_inspect_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="dokploy_target.inspect",
+                context="launchplane",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        inspect_route = openapi["paths"]["/v1/dokploy-targets/inspect"]["get"]
+        self.assertEqual(inspect_route["operationId"], "read_dokploy_target_inspect")
+        self.assertEqual(
+            inspect_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/DokployTargetInspectResponse",
+        )
+        self.assertIn("LaunchplaneErrorResponse", json.dumps(inspect_route))
+        self.assertEqual(
+            openapi["components"]["schemas"]["DokployTargetInspectResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
+
+    async def test_fastapi_dokploy_target_inspect_precedes_legacy_wsgi_fallback(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_dokploy_target_inspect_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.http_app.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.invalid", "token"),
+                ),
+                patch(
+                    "control_plane.dokploy_target_inspect.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"id": "compose-cm-prod", "name": "cm-prod"},
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="dokploy_target.inspect",
+                        context="launchplane",
+                    ),
+                    database_url=database_url,
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                legacy_app = create_launchplane_service_app(
+                    state_dir=root / "state",
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                    control_plane_root_path=root,
+                )
+                app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+                response = await _get_dokploy_target_inspect(
+                    app,
+                    context="cm_website",
+                    instance="prod",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+
+
 class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
     async def test_tracked_target_logs_returns_redacted_application_logs(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -9233,6 +9484,48 @@ def _seed_product_environment_read_records(database_url: str) -> None:
         store.close()
 
 
+def _seed_dokploy_target_inspect_records(database_url: str) -> None:
+    store = PostgresRecordStore(database_url=database_url)
+    store.ensure_schema()
+    try:
+        store.write_dokploy_target_record(
+            DokployTargetRecord(
+                context="cm_website",
+                instance="prod",
+                target_type="compose",
+                target_name="cm-prod",
+                project_name="odoo",
+                updated_at="2026-06-14T00:00:00Z",
+                source_label="test",
+            )
+        )
+        store.write_dokploy_target_id_record(
+            DokployTargetIdRecord(
+                context="cm_website",
+                instance="prod",
+                target_id="compose-cm-prod",
+                updated_at="2026-06-14T00:00:00Z",
+                source_label="test",
+            )
+        )
+        store.write_provider_target_record(
+            ProviderTargetRecord(
+                context="cm_website",
+                instance="prod",
+                provider_id="dokploy",
+                target_category="compose",
+                target_id="compose-cm-prod",
+                display_name="cm-prod",
+                provider_target_type="compose",
+                provider_evidence={"project_name": "odoo"},
+                updated_at="2026-06-14T00:00:00Z",
+                source_label="test",
+            )
+        )
+    finally:
+        store.close()
+
+
 def _seed_empty_agent_context_read_store(database_url: str) -> None:
     store = PostgresRecordStore(database_url=database_url)
     store.ensure_schema()
@@ -9882,6 +10175,29 @@ async def _get_preview_pr_feedback_notification_attempts(
 
 def _query_params(**values: str) -> dict[str, str]:
     return {key: value for key, value in values.items() if value != ""}
+
+
+async def _get_dokploy_target_inspect(
+    app: FastAPI,
+    *,
+    context: str = "",
+    instance: str = "",
+    target_type: str = "",
+    target_id: str = "",
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers.setdefault("Authorization", authorization)
+    params = _query_params(
+        context=context,
+        instance=instance,
+        target_type=target_type,
+        target_id=target_id,
+    )
+    suffix = f"?{urlencode(params)}" if params else ""
+    return await _asgi_get(app, f"/v1/dokploy-targets/inspect{suffix}", headers=request_headers)
 
 
 async def _get_products(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -14513,210 +14513,23 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(target_records, ())
 
-    def test_dokploy_target_inspect_endpoint_reads_redacted_provider_identity(self) -> None:
+    def test_dokploy_target_inspect_read_is_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            try:
-                store.ensure_schema()
-                store.write_dokploy_target_record(
-                    DokployTargetRecord(
-                        context="cm_website",
-                        instance="prod",
-                        target_type="compose",
-                        target_name="cm-prod",
-                        project_name="odoo",
-                        updated_at="2026-06-14T00:00:00Z",
-                        source_label="test",
-                    )
-                )
-                store.write_dokploy_target_id_record(
-                    DokployTargetIdRecord(
-                        context="cm_website",
-                        instance="prod",
-                        target_id="compose-cm-prod",
-                        updated_at="2026-06-14T00:00:00Z",
-                        source_label="test",
-                    )
-                )
-                store.write_provider_target_record(
-                    ProviderTargetRecord(
-                        context="cm_website",
-                        instance="prod",
-                        provider_id="dokploy",
-                        target_category="compose",
-                        target_id="compose-cm-prod",
-                        display_name="cm-prod",
-                        provider_target_type="compose",
-                        provider_evidence={"project_name": "odoo"},
-                        updated_at="2026-06-14T00:00:00Z",
-                        source_label="test",
-                    )
-                )
-            finally:
-                store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "workflow_refs": [
-                                "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["launchplane"],
-                            "contexts": ["launchplane"],
-                            "actions": ["dokploy_target.inspect"],
-                        }
-                    ]
-                }
-            )
             app = create_launchplane_service_app(
                 state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-            with (
-                patch(
-                    "control_plane.service.control_plane_dokploy.read_dokploy_config",
-                    return_value=("https://dokploy.example.invalid", "token"),
-                ) as read_dokploy_config,
-                patch(
-                    "control_plane.dokploy_target_inspect.control_plane_dokploy.fetch_dokploy_target_payload",
-                    return_value={
-                        "id": "compose-cm-prod",
-                        "name": "cm-prod",
-                        "serverId": "server-123",
-                        "environment": {
-                            "id": "env-prod",
-                            "name": "prod",
-                            "project": {"id": "project-odoo", "name": "odoo"},
-                        },
-                        "env": "ODOO_DB_PASSWORD=secret\nDISABLE_ODOO_ONLINE=true\n",
-                    },
-                ),
-            ):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/dokploy-targets/inspect",
-                    query_string="context=cm_website&instance=prod",
-                )
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["inspect"]["target_id"], "compose-cm-prod")
-        self.assertEqual(payload["inspect"]["tracked_target"]["target_name"], "cm-prod")
-        self.assertEqual(payload["inspect"]["provider"]["environment"]["id"], "env-prod")
-        self.assertEqual(
-            payload["inspect"]["provider"]["env"]["keys"],
-            ["DISABLE_ODOO_ONLINE", "ODOO_DB_PASSWORD"],
-        )
-        self.assertTrue(payload["inspect"]["provider_payload_redacted"])
-        self.assertNotIn("secret", str(payload))
-        self.assertNotIn("provider_evidence", str(payload))
-        read_dokploy_config.assert_called_once_with(
-            control_plane_root=root,
-            database_url=database_url,
-        )
-
-    def test_dokploy_target_inspect_endpoint_rejects_without_authz(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            try:
-                store.ensure_schema()
-            finally:
-                store.close()
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
+                verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
                 control_plane_root_path=root,
-                database_url=database_url,
+                local_record_store_for_tests=FilesystemRecordStore(root / "state"),
             )
 
             status_code, payload = _invoke_app(
                 app,
                 method="GET",
                 path="/v1/dokploy-targets/inspect",
-                query_string="target_type=compose&target_id=compose-123",
+                query_string="context=cm_website&instance=prod",
             )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_dokploy_target_inspect_endpoint_returns_not_found_for_unknown_route(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            store = PostgresRecordStore(database_url=database_url)
-            try:
-                store.ensure_schema()
-            finally:
-                store.close()
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "workflow_refs": [
-                                "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["launchplane"],
-                            "contexts": ["launchplane"],
-                            "actions": ["dokploy_target.inspect"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/dokploy-target-inspect.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-            with patch(
-                "control_plane.service.control_plane_dokploy.read_dokploy_config",
-                return_value=("https://dokploy.example.invalid", "token"),
-            ):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="GET",
-                    path="/v1/dokploy-targets/inspect",
-                    query_string="context=missing&instance=prod",
-                )
 
         self.assertEqual(status_code, 404)
         self.assertEqual(payload["error"]["code"], "not_found")


### PR DESCRIPTION
## Summary

- Move `GET /v1/dokploy-targets/inspect` from the legacy WSGI read dispatcher to native FastAPI.
- Delete the retired WSGI inspect matcher/handler path while keeping Dokploy target setup on the retained fallback.
- Add FastAPI route coverage for success, authz denial, DB-only storage requirement, invalid query mode, missing target, OpenAPI contract, and fallback precedence.
- Update service-boundary and compatibility-retirement docs for the native route ownership.

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiDokployTargetInspectReadTests tests.test_service.LaunchplaneServiceTests.test_dokploy_target_inspect_read_is_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py docs/compatibility-retirement.md docs/service-boundary.md`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `git diff --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (2748 tests)
- JetBrains changed-files inspection: clean
- Review agents: 2 green, no blockers
