### PR TITLE
Move work graph reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -65,6 +65,7 @@ from control_plane.merge_train_policy_source import (
     resolve_merge_train_policy_record,
 )
 from control_plane.contracts.product_environment_read_model import (
+    ActionAllowed,
     ProductActivityReadModel,
     ProductEnvironmentConfigStatus,
     ProductEnvironmentDetail,
@@ -88,6 +89,7 @@ from control_plane.contracts.preview_readiness_read_model import (
 )
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
+from control_plane.contracts.work_graph_read_model import WorkGraphSnapshot
 from control_plane.contracts.protected_artifacts import (
     ProtectedArtifactStore,
     ProtectedArtifactSet,
@@ -134,9 +136,13 @@ from control_plane.workflows.evidence_ingestion import (
     apply_promotion_evidence,
 )
 from control_plane.workflows.ship import utc_now_timestamp
+from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.work_graph_service import (
+    WorkGraphIssueInboxProvider,
     WorkGraphPlanningFactsProvider,
+    WorkGraphWorkRequestStore,
     build_repo_product_mapping_service_payload,
+    build_work_graph_snapshot_service_payload,
 )
 
 
@@ -190,6 +196,10 @@ class AgentContextReadStore(ProductReadModelStore, Protocol):
         limit: int | None = None,
         offset: int = 0,
     ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
+
+
+class WorkGraphSnapshotReadStore(ProductReadModelStore, WorkGraphWorkRequestStore, Protocol):
+    pass
 
 
 class LaunchplaneErrorDetail(BaseModel):
@@ -354,6 +364,24 @@ class AgentContextResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     context: AgentContextPayload
+
+
+class WorkGraphSnapshotResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    snapshot: WorkGraphSnapshot
+    source: dict[str, object]
+
+
+class WorkGraphIssueInboxResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    configured: bool
+    inbox: GitHubIssueInboxReadModel
 
 
 class DriverDescriptorsResponse(BaseModel):
@@ -1673,6 +1701,7 @@ def create_launchplane_fastapi_app(
     human_session_manager: HumanSessionManager | None = None,
     control_plane_root_path: FilePath | None = None,
     work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
+    work_graph_issue_inbox_provider: WorkGraphIssueInboxProvider | None = None,
 ) -> FastAPI:
     resolved_authz_policy_runtime = authz_policy_runtime or LaunchplaneAuthzPolicyRuntime(
         authz_policy
@@ -2093,6 +2122,23 @@ def create_launchplane_fastapi_app(
             message=message,
         )
 
+    def require_work_graph_rank_authorization(
+        *, identity: LaunchplaneIdentity, trace_id: str, message: str
+    ) -> None:
+        if resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="work_graph.rank",
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            return
+        raise _launchplane_http_error(
+            status_code=403,
+            trace_id=trace_id,
+            code="authorization_denied",
+            message=message,
+        )
+
     def require_read_store_methods(
         record_store: object,
         *,
@@ -2146,6 +2192,20 @@ def create_launchplane_fastapi_app(
             message="Agent context reads require a database-backed record store.",
         )
         return cast(AgentContextReadStore, record_store)
+
+    def require_work_graph_snapshot_read_store(
+        record_store: object, *, trace_id: str
+    ) -> WorkGraphSnapshotReadStore:
+        require_read_store_methods(
+            record_store,
+            trace_id=trace_id,
+            method_names=(
+                "list_product_profile_records",
+                "list_every_code_work_request_records",
+            ),
+            message="Work graph snapshot reads require a database-backed record store.",
+        )
+        return cast(WorkGraphSnapshotReadStore, record_store)
 
     def require_every_code_read_methods(
         record_store: object,
@@ -2364,6 +2424,73 @@ def create_launchplane_fastapi_app(
             planning_facts_provider=work_graph_planning_facts_provider,
         )
         return AgentContextResponse(trace_id=trace_id, context=context)
+
+    def work_graph_product_action_allowed(*, identity: LaunchplaneIdentity) -> ActionAllowed:
+        def action_allowed(
+            requested_action: str,
+            requested_product: str,
+            requested_context: str,
+        ) -> bool:
+            return resolved_authz_policy_runtime.policy.allows(
+                identity=identity,
+                action=requested_action,
+                product=requested_product,
+                context=requested_context,
+            )
+
+        return action_allowed
+
+    def read_work_graph_snapshot(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> WorkGraphSnapshotResponse:
+        trace_id = next_trace_id()
+        require_work_graph_rank_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            message="Workflow cannot read the Launchplane work graph snapshot.",
+        )
+        snapshot_store = require_work_graph_snapshot_read_store(
+            record_store,
+            trace_id=trace_id,
+        )
+        payload = build_work_graph_snapshot_service_payload(
+            generated_at=utc_now_timestamp(),
+            product_store=snapshot_store,
+            work_request_store=snapshot_store,
+            action_allowed=work_graph_product_action_allowed(identity=identity),
+            planning_facts_provider=work_graph_planning_facts_provider,
+        )
+        return WorkGraphSnapshotResponse(
+            trace_id=trace_id,
+            snapshot=WorkGraphSnapshot.model_validate(payload["snapshot"]),
+            source=cast(dict[str, object], payload["source"]),
+        )
+
+    def read_work_graph_issue_inbox(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+    ) -> WorkGraphIssueInboxResponse:
+        trace_id = next_trace_id()
+        require_work_graph_rank_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            message="Workflow cannot read the Launchplane GitHub issue inbox.",
+        )
+        if work_graph_issue_inbox_provider is None:
+            return WorkGraphIssueInboxResponse(
+                trace_id=trace_id,
+                configured=False,
+                inbox=GitHubIssueInboxReadModel(
+                    generated_at="",
+                    repository_count=0,
+                    issue_count=0,
+                ),
+            )
+        return WorkGraphIssueInboxResponse(
+            trace_id=trace_id,
+            configured=True,
+            inbox=work_graph_issue_inbox_provider(),
+        )
 
     def merge_train_policy_not_configured_error(
         *, trace_id: str, error: MergeTrainPolicyStoreMissingError
@@ -5443,6 +5570,26 @@ def create_launchplane_fastapi_app(
         response_model=AgentContextResponse,
         operation_id="read_agent_context",
         summary="Read Launchplane agent context",
+        responses=agent_context_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/work-graph/snapshot",
+        read_work_graph_snapshot,
+        methods=["GET"],
+        response_model=WorkGraphSnapshotResponse,
+        operation_id="read_work_graph_snapshot",
+        summary="Read Launchplane work graph snapshot",
+        responses=agent_context_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/work-graph/github/issues",
+        read_work_graph_issue_inbox,
+        methods=["GET"],
+        response_model=WorkGraphIssueInboxResponse,
+        operation_id="read_work_graph_issue_inbox",
+        summary="Read Launchplane GitHub issue inbox",
         responses=agent_context_error_responses,
     )
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -335,13 +335,9 @@ from control_plane.work_graph_issue_inbox import (
     reconcile_github_issue_inbox,
 )
 from control_plane.work_graph_service import (
-    WorkGraphIssueInboxProvider,
     WorkGraphIssueInboxReconcileProvider,
-    WorkGraphPlanningFactsProvider,
 )
 from control_plane.work_graph_http import (
-    handle_work_graph_issue_inbox_read,
-    handle_work_graph_snapshot_read,
     rank_work_graph_snapshot,
     reconcile_work_graph_issue_inbox,
     work_graph_issue_inbox_reconcile_denied_response,
@@ -4401,10 +4397,6 @@ def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
         and segments[4] == "operations"
     ):
         return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
-    if len(segments) == 3 and segments == ["v1", "work-graph", "snapshot"]:
-        return "work_graph.rank", {}
-    if len(segments) == 4 and segments == ["v1", "work-graph", "github", "issues"]:
-        return "work_graph.issue_inbox", {}
     if len(segments) == 4 and segments == [
         "v1",
         "products",
@@ -9480,8 +9472,6 @@ def create_launchplane_service_app(
     github_oauth_config: GitHubOAuthConfig | None = None,
     github_oauth_client: GitHubOAuthClient | None = None,
     human_session_store: HumanSessionStore | None = None,
-    work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
-    work_graph_issue_inbox_provider: WorkGraphIssueInboxProvider | None = None,
     work_graph_issue_inbox_reconcile_provider: WorkGraphIssueInboxReconcileProvider | None = None,
     ingress_provider_factory: _IngressProviderFactory | None = None,
     npmplus_ingress_client_factory: _NpmplusIngressClientFactory | None = None,
@@ -9973,27 +9963,6 @@ def create_launchplane_service_app(
                                 else {}
                             ),
                         },
-                    )
-                if action == "work_graph.rank":
-                    return handle_work_graph_snapshot_read(
-                        authz_policy=authz_policy,
-                        identity=identity,
-                        trace_id=request_trace_id,
-                        product_store=record_store,
-                        work_request_store=_every_code_work_request_store(record_store),
-                        planning_facts_provider=work_graph_planning_facts_provider,
-                        utc_now=_utc_now_timestamp,
-                        json_response=_json_response,
-                        start_response=start_response,
-                    )
-                if action == "work_graph.issue_inbox":
-                    return handle_work_graph_issue_inbox_read(
-                        authz_policy=authz_policy,
-                        identity=identity,
-                        trace_id=request_trace_id,
-                        issue_inbox_provider=work_graph_issue_inbox_provider,
-                        json_response=_json_response,
-                        start_response=start_response,
                     )
             if path == "/v1/service/odoo-workers/reconcile":
                 if not authz_policy.allows(
@@ -14474,8 +14443,6 @@ def serve_launchplane_service(
         verifier=verifier,
         authz_policy=bootstrap_authz_policy,
         database_url=database_url,
-        work_graph_planning_facts_provider=work_graph_planning_facts_provider,
-        work_graph_issue_inbox_provider=work_graph_issue_inbox_provider,
         work_graph_issue_inbox_reconcile_provider=work_graph_issue_inbox_reconcile_provider,
         authz_policy_runtime=authz_policy_runtime,
         record_store_for_service=service_record_store,
@@ -14498,6 +14465,7 @@ def serve_launchplane_service(
         human_session_manager=human_session_manager,
         control_plane_root_path=control_plane_root(),
         work_graph_planning_facts_provider=work_graph_planning_facts_provider,
+        work_graph_issue_inbox_provider=work_graph_issue_inbox_provider,
     )
     fastapi_application.mount(
         "/",

--- a/control_plane/work_graph_http.py
+++ b/control_plane/work_graph_http.py
@@ -3,10 +3,6 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TypeAlias
-from control_plane.contracts.product_environment_read_model import (
-    ActionAllowed,
-    ProductReadModelStore,
-)
 from control_plane.service_auth import (
     GitHubActionsIdentity,
     GitHubHumanIdentity,
@@ -16,13 +12,9 @@ from control_plane.service_auth import (
     TerminalAgentIdentity,
 )
 from control_plane.work_graph_service import (
-    WorkGraphIssueInboxProvider,
     WorkGraphIssueInboxReconcileProvider,
-    WorkGraphPlanningFactsProvider,
     WorkGraphRankEnvelope,
-    WorkGraphWorkRequestStore,
     build_work_graph_rank_result,
-    build_work_graph_snapshot_service_payload,
 )
 from control_plane.work_graph_issue_inbox import (
     GitHubIssueInboxReconcileRequest,
@@ -32,7 +24,6 @@ from control_plane.work_graph_issue_inbox import (
 
 JsonResponse = Callable[..., list[bytes]]
 StartResponse = Callable[[str, list[tuple[str, str]]], None]
-UtcNow = Callable[[], str]
 ResolvedLaunchplaneIdentity: TypeAlias = (
     GitHubActionsIdentity
     | GitHubHumanIdentity
@@ -48,115 +39,6 @@ LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 class WorkGraphRankResult:
     result: dict[str, object]
     driver_result: dict[str, object]
-
-
-def handle_work_graph_snapshot_read(
-    *,
-    authz_policy: LaunchplaneAuthzPolicy,
-    identity: ResolvedLaunchplaneIdentity,
-    trace_id: str,
-    product_store: ProductReadModelStore,
-    work_request_store: WorkGraphWorkRequestStore,
-    planning_facts_provider: WorkGraphPlanningFactsProvider | None,
-    utc_now: UtcNow,
-    json_response: JsonResponse,
-    start_response: StartResponse,
-) -> list[bytes]:
-    if not authz_policy.allows(
-        identity=identity,
-        action="work_graph.rank",
-        product="launchplane",
-        context=LAUNCHPLANE_SERVICE_CONTEXT,
-    ):
-        return json_response(
-            start_response=start_response,
-            status_code=403,
-            payload={
-                "status": "rejected",
-                "trace_id": trace_id,
-                "error": {
-                    "code": "authorization_denied",
-                    "message": "Workflow cannot read the Launchplane work graph snapshot.",
-                },
-            },
-        )
-
-    work_graph_payload = build_work_graph_snapshot_service_payload(
-        generated_at=utc_now(),
-        product_store=product_store,
-        work_request_store=work_request_store,
-        action_allowed=_work_graph_product_action_allowed(
-            authz_policy=authz_policy,
-            identity=identity,
-        ),
-        planning_facts_provider=planning_facts_provider,
-    )
-    return json_response(
-        start_response=start_response,
-        status_code=200,
-        payload={
-            "status": "ok",
-            "trace_id": trace_id,
-            **work_graph_payload,
-        },
-    )
-
-
-def handle_work_graph_issue_inbox_read(
-    *,
-    authz_policy: LaunchplaneAuthzPolicy,
-    identity: ResolvedLaunchplaneIdentity,
-    trace_id: str,
-    issue_inbox_provider: WorkGraphIssueInboxProvider | None,
-    json_response: JsonResponse,
-    start_response: StartResponse,
-) -> list[bytes]:
-    if not authz_policy.allows(
-        identity=identity,
-        action="work_graph.rank",
-        product="launchplane",
-        context=LAUNCHPLANE_SERVICE_CONTEXT,
-    ):
-        return json_response(
-            start_response=start_response,
-            status_code=403,
-            payload={
-                "status": "rejected",
-                "trace_id": trace_id,
-                "error": {
-                    "code": "authorization_denied",
-                    "message": "Workflow cannot read the Launchplane GitHub issue inbox.",
-                },
-            },
-        )
-    if issue_inbox_provider is None:
-        return json_response(
-            start_response=start_response,
-            status_code=200,
-            payload={
-                "status": "ok",
-                "trace_id": trace_id,
-                "configured": False,
-                "inbox": {
-                    "schema_version": 1,
-                    "generated_at": "",
-                    "project_configured": False,
-                    "repository_count": 0,
-                    "issue_count": 0,
-                    "repositories": [],
-                },
-            },
-        )
-    return json_response(
-        start_response=start_response,
-        status_code=200,
-        payload={
-            "status": "ok",
-            "trace_id": trace_id,
-            "configured": True,
-            "inbox": issue_inbox_provider().model_dump(mode="json"),
-        },
-    )
 
 
 def reconcile_work_graph_issue_inbox(
@@ -238,21 +120,3 @@ def work_graph_issue_inbox_reconcile_denied_response(
             },
         },
     )
-
-
-def _work_graph_product_action_allowed(
-    *,
-    authz_policy: LaunchplaneAuthzPolicy,
-    identity: ResolvedLaunchplaneIdentity,
-) -> ActionAllowed:
-    def action_allowed(
-        requested_action: str, requested_product: str, requested_context: str
-    ) -> bool:
-        return authz_policy.allows(
-            identity=identity,
-            action=requested_action,
-            product=requested_product,
-            context=requested_context,
-        )
-
-    return action_allowed

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -91,6 +91,10 @@ Keep a compatibility surface only when it is one of these:
   FastAPI routes. Their legacy WSGI read branches are deleted; merge-train
   worker, controller mutation, feedback, and phase runner routes remain on the
   retained fallback until their native write replacements land.
+- Work graph snapshot and GitHub issue-inbox reads use native FastAPI routes.
+  Their legacy WSGI read branches and WSGI-only read helpers are deleted;
+  work-graph rank and GitHub issue-inbox reconcile writes remain on the retained
+  fallback until their native write replacements land.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -175,7 +175,8 @@ VeriReel product paths:
 - work graph chooser route:
   - `GET /v1/agent/context`
   - `GET /v1/repo-product-mapping`
-  - `GET /v1/work-graph/snapshot`
+  - `GET /v1/work-graph/snapshot` (native FastAPI)
+  - `GET /v1/work-graph/github/issues` (native FastAPI)
   - `GET /v1/work-graph/merge-train/policy-targets` (native FastAPI)
   - `GET /v1/work-graph/merge-train/admission` (native FastAPI)
   - `GET /v1/work-graph/merge-train/controller/status` (native FastAPI)
@@ -498,9 +499,10 @@ Every Code work-request repos. Managed runtime entries come from product profile
 records and include product, contexts, stable environments, driver id, and
 preview context; awareness entries do not imply Launchplane runtime ownership.
 
-`GET /v1/work-graph/snapshot` returns the current Launchplane-assembled work
-graph snapshot for the same authorization boundary. It composes product
-overviews and Every Code work-request records into the typed snapshot contract.
+`GET /v1/work-graph/snapshot` is a native FastAPI route that returns the
+current Launchplane-assembled work graph snapshot for the same authorization
+boundary. It composes product overviews and Every Code work-request records into
+the typed snapshot contract.
 When a caller-owned planning ingestion provider is configured, the route can
 overlay compact GitHub/Code Plans facts. The first provider is opt-in via
 `LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER` and

--- a/docs/work-graph-read-model.md
+++ b/docs/work-graph-read-model.md
@@ -87,8 +87,9 @@ Authenticated callers can also read the current Launchplane-assembled snapshot:
 GET /v1/work-graph/snapshot
 ```
 
-The snapshot route uses the same `work_graph.rank` authorization. It composes
-current product overviews with durable Every Code work-request records,
+The native FastAPI snapshot route uses the same `work_graph.rank`
+authorization. It composes current product overviews with durable Every Code
+work-request records,
 classifies product repositories as `managed_runtime`, classifies other request
 repositories as `active_awareness`, and returns source counts with the snapshot.
 The route can also apply compact planning facts from a caller-owned ingestion
@@ -155,8 +156,8 @@ repository inventory:
 GET /v1/work-graph/github/issues
 ```
 
-The route uses the same `work_graph.rank` authorization as the snapshot route
-and never writes GitHub or Launchplane state. Enable it with
+The native FastAPI route uses the same `work_graph.rank` authorization as the
+snapshot route and never writes GitHub or Launchplane state. Enable it with
 `LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES`, a comma or newline separated
 list of `owner/repo` values. `LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT` bounds
 the open issue reads per repository and defaults to `100`. The provider shells

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -89,6 +89,7 @@ from control_plane.service_human_auth import (
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.workflows.launchplane_self_deploy import LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY
 from tests.test_service import create_launchplane_service_app
 from tests.test_service import (
@@ -1326,6 +1327,205 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(sections["every_code_summary"]["status"], "available")
         self.assertEqual(sections["preview_readiness"]["status"], "available")
 
+    async def test_work_graph_snapshot_returns_launchplane_assembled_snapshot(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_agent_context_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_work_graph_read_policy(),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _get_work_graph_snapshot(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(set(payload), {"status", "trace_id", "snapshot", "source"})
+        self.assertEqual(payload["source"]["product_count"], 1)
+        self.assertEqual(payload["source"]["work_request_count"], 2)
+        self.assertEqual(payload["source"]["planning_fact_count"], 0)
+        snapshot = payload["snapshot"]
+        self.assertEqual(snapshot["schema_version"], 1)
+        repos_by_name = {repo["repository"]: repo for repo in snapshot["repos"]}
+        self.assertEqual(repos_by_name["every/example-site"]["classification"], "managed_runtime")
+        self.assertEqual(repos_by_name["every/example-site"]["product"], "example-site")
+        self.assertEqual(repos_by_name["cbusillo/tooling"]["classification"], "active_awareness")
+        issues_by_key = {
+            (issue["repository"], issue["number"]): issue for issue in snapshot["issues"]
+        }
+        self.assertEqual(issues_by_key[("every/example-site", 190)]["focus"], "Next")
+
+    async def test_work_graph_snapshot_uses_compact_planning_facts_when_available(
+        self,
+    ) -> None:
+        def planning_facts() -> tuple[WorkGraphPlanningIssueFacts, ...]:
+            return (
+                WorkGraphPlanningIssueFacts.model_validate(
+                    {
+                        "repository": "every/example-site",
+                        "number": 190,
+                        "focus": "Now",
+                        "manager": "Chris",
+                        "finish_line": "Project fields are visible in the cockpit.",
+                        "labels": ("plan", "plan:active"),
+                        "blocking": 1,
+                        "updated_at": "2026-05-06T03:54:00Z",
+                    }
+                ),
+            )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_agent_context_read_records(database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_work_graph_read_policy(),
+                record_store_factory=lambda: app_store,
+                work_graph_planning_facts_provider=planning_facts,
+            )
+
+            response = await _get_work_graph_snapshot(app)
+            app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["source"]["planning_fact_count"], 1)
+        issues_by_key = {
+            (issue["repository"], issue["number"]): issue for issue in payload["snapshot"]["issues"]
+        }
+        issue = issues_by_key[("every/example-site", 190)]
+        self.assertEqual(issue["focus"], "Now")
+        self.assertEqual(issue["manager"], "Chris")
+        self.assertEqual(issue["finish_line"], "Project fields are visible in the cockpit.")
+        self.assertEqual(issue["labels"], ["every-code", "plan", "plan:active"])
+        self.assertEqual(issue["blocking"], 1)
+        self.assertEqual(issue["updated_at"], "2026-05-06T03:54:00Z")
+
+    async def test_work_graph_snapshot_rejects_unauthorized_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_work_graph_snapshot(app)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_work_graph_snapshot_requires_database_backed_store(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_work_graph_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_work_graph_snapshot(app)
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
+    async def test_work_graph_issue_inbox_returns_provider_payload(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_work_graph_read_policy(products=("launchplane",)),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            work_graph_issue_inbox_provider=lambda: GitHubIssueInboxReadModel.model_validate(
+                {
+                    "generated_at": "2026-05-21T12:00:00Z",
+                    "project_configured": True,
+                    "repository_count": 1,
+                    "issue_count": 2,
+                    "stale_project_item_count": 1,
+                    "repositories": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "issue_count": 2,
+                            "present_in_project_count": 1,
+                            "missing_from_project_count": 1,
+                            "issues": [
+                                {
+                                    "key": "cbusillo/launchplane#697",
+                                    "repository": "cbusillo/launchplane",
+                                    "number": 697,
+                                    "title": "Add read-only grouped GitHub issue inbox",
+                                    "url": "https://github.com/cbusillo/launchplane/issues/697",
+                                    "state": "OPEN",
+                                    "project_status": "missing",
+                                    "present_in_project": False,
+                                },
+                                {
+                                    "key": "cbusillo/launchplane#601",
+                                    "repository": "cbusillo/launchplane",
+                                    "number": 601,
+                                    "title": "Closed Project item",
+                                    "url": "https://github.com/cbusillo/launchplane/issues/601",
+                                    "state": "closed",
+                                    "project_status": "closed",
+                                    "present_in_project": True,
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ),
+        )
+
+        response = await _get_work_graph_issue_inbox(app)
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertTrue(payload["configured"])
+        inbox = payload["inbox"]
+        self.assertEqual(inbox["repository_count"], 1)
+        self.assertEqual(inbox["stale_project_item_count"], 1)
+        self.assertEqual(inbox["repositories"][0]["issues"][0]["key"], "cbusillo/launchplane#697")
+        self.assertIs(inbox["repositories"][0]["issues"][0]["present_in_project"], False)
+        self.assertEqual(inbox["repositories"][0]["issues"][1]["project_status"], "closed")
+
+    async def test_work_graph_issue_inbox_returns_empty_payload_without_provider(
+        self,
+    ) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_work_graph_read_policy(products=("launchplane",)),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_work_graph_issue_inbox(app)
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertFalse(payload["configured"])
+        self.assertEqual(payload["inbox"]["generated_at"], "")
+        self.assertFalse(payload["inbox"]["project_configured"])
+        self.assertEqual(payload["inbox"]["repository_count"], 0)
+        self.assertEqual(payload["inbox"]["issue_count"], 0)
+        self.assertEqual(payload["inbox"]["repositories"], [])
+
+    async def test_work_graph_issue_inbox_rejects_unauthorized_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            work_graph_issue_inbox_provider=lambda: GitHubIssueInboxReadModel(
+                generated_at="2026-05-21T12:00:00Z",
+                repository_count=0,
+                issue_count=0,
+            ),
+        )
+
+        response = await _get_work_graph_issue_inbox(app)
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
     async def test_agent_context_reads_require_identity(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_identity()),
@@ -1338,6 +1538,8 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
         responses = [
             await _get_repo_product_mapping(app, authorization=""),
             await _get_agent_context(app, authorization=""),
+            await _get_work_graph_snapshot(app, authorization=""),
+            await _get_work_graph_issue_inbox(app, authorization=""),
         ]
 
         for response in responses:
@@ -1455,6 +1657,14 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
                 "RepoProductMappingResponse",
             ),
             "/v1/agent/context": ("read_agent_context", "AgentContextResponse"),
+            "/v1/work-graph/snapshot": (
+                "read_work_graph_snapshot",
+                "WorkGraphSnapshotResponse",
+            ),
+            "/v1/work-graph/github/issues": (
+                "read_work_graph_issue_inbox",
+                "WorkGraphIssueInboxResponse",
+            ),
         }
         for path, (operation_id, response_model_name) in expected_routes.items():
             route = openapi["paths"][path]["get"]
@@ -1477,10 +1687,7 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
             _seed_agent_context_read_records(database_url)
             app_store = PostgresRecordStore(database_url=database_url)
-            policy = _product_environment_read_policy(
-                contexts=("launchplane", "example-site"),
-                products=("launchplane", "example-site"),
-            )
+            policy = _work_graph_read_policy()
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
@@ -1496,10 +1703,14 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
 
             mapping_response = await _get_repo_product_mapping(app)
             context_response = await _get_agent_context(app, repository="every/example-site")
+            snapshot_response = await _get_work_graph_snapshot(app)
+            issue_inbox_response = await _get_work_graph_issue_inbox(app)
             app_store.close()
 
         self.assertEqual(mapping_response.status_code, 200)
         self.assertEqual(context_response.status_code, 200)
+        self.assertEqual(snapshot_response.status_code, 200)
+        self.assertEqual(issue_inbox_response.status_code, 200)
 
     async def test_list_products_returns_db_backed_overviews(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -8629,6 +8840,29 @@ def _product_environment_read_policy(
     )
 
 
+def _work_graph_read_policy(
+    *,
+    products: tuple[str, ...] = ("launchplane", "example-site"),
+    contexts: tuple[str, ...] = ("launchplane", "example-site"),
+) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": list(products),
+                    "contexts": list(contexts),
+                    "actions": ["work_graph.rank", "product_environment.read"],
+                }
+            ]
+        }
+    )
+
+
 def _driver_read_policy(*, context: str = "launchplane") -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -10231,6 +10465,24 @@ async def _get_agent_context(
     headers = {"Authorization": authorization} if authorization else {}
     suffix = f"?{urlencode({'repository': repository})}" if repository else ""
     return await _asgi_get(app, f"/v1/agent/context{suffix}", headers=headers)
+
+
+async def _get_work_graph_snapshot(
+    app: FastAPI,
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(app, "/v1/work-graph/snapshot", headers=headers)
+
+
+async def _get_work_graph_issue_inbox(
+    app: FastAPI,
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_get(app, "/v1/work-graph/github/issues", headers=headers)
 
 
 async def _get_every_code_summary(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -124,8 +124,6 @@ from control_plane.contracts.runner_lane_registration import (
     plan_runner_lane_registration,
 )
 from control_plane.contracts.secret_record import SecretBinding
-from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
-from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReconcileResult
 from control_plane.merge_train import MergeTrainDryRunSnapshot, MergeTrainPullRequestSnapshot
 from control_plane.merge_train import MergeTrainCheckStatus
@@ -11987,276 +11985,35 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["queue"]["items"][0]["number"], 190)
 
-    def test_work_graph_snapshot_returns_launchplane_assembled_snapshot(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane", "example-site"],
-                        "contexts": ["launchplane", "example-site"],
-                        "actions": [
-                            "work_graph.rank",
-                            "product_environment.read",
-                            "every_code_work_request.write",
-                        ],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-            status_code, create_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "every/example-site",
-                    "issue_number": 190,
-                    "issue_url": "https://github.com/every/example-site/issues/190",
-                    "issue_title": "Build operator chooser",
-                    "trigger_label": "every-code",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-06T02:00:00Z",
-                },
-                headers={"Idempotency-Key": "every-code-create-example-site-190"},
-            )
-            self.assertEqual(status_code, 202)
-            self.assertEqual(create_payload["result"]["request"]["state"], "queued")
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/work-graph/snapshot",
-            )
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["status"], "ok")
-        self.assertEqual(payload["source"]["product_count"], 1)
-        self.assertEqual(payload["source"]["work_request_count"], 1)
-        snapshot = payload["snapshot"]
-        self.assertEqual(snapshot["schema_version"], 1)
-        self.assertEqual(snapshot["repos"][0]["classification"], "managed_runtime")
-        self.assertEqual(snapshot["repos"][0]["product"], "example-site")
-        self.assertEqual(snapshot["issues"][0]["repository"], "every/example-site")
-        self.assertEqual(snapshot["issues"][0]["focus"], "Next")
-        self.assertEqual(payload["source"]["planning_fact_count"], 0)
-
-    def test_work_graph_snapshot_uses_compact_planning_facts_when_available(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane", "example-site"],
-                        "contexts": ["launchplane", "example-site"],
-                        "actions": [
-                            "work_graph.rank",
-                            "product_environment.read",
-                            "every_code_work_request.write",
-                        ],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                work_graph_planning_facts_provider=lambda: (
-                    WorkGraphPlanningIssueFacts.model_validate(
-                        {
-                            "repository": "every/example-site",
-                            "number": 190,
-                            "focus": "Now",
-                            "manager": "Chris",
-                            "finish_line": "Project fields are visible in the cockpit.",
-                            "labels": ("plan", "plan:active"),
-                            "blocking": 1,
-                            "updated_at": "2026-05-06T03:54:00Z",
-                        }
-                    ),
-                ),
-            )
-            create_status, _ = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "every/example-site",
-                    "issue_number": 190,
-                    "issue_url": "https://github.com/every/example-site/issues/190",
-                    "issue_title": "Build operator chooser",
-                    "trigger_label": "every-code",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-06T02:00:00Z",
-                },
-                headers={"Idempotency-Key": "every-code-create-example-site-190"},
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/work-graph/snapshot",
-            )
-
-        self.assertEqual(create_status, 202)
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["source"]["planning_fact_count"], 1)
-        issue = payload["snapshot"]["issues"][0]
-        self.assertEqual(issue["focus"], "Now")
-        self.assertEqual(issue["manager"], "Chris")
-        self.assertEqual(issue["finish_line"], "Project fields are visible in the cockpit.")
-        self.assertEqual(issue["labels"], ["every-code", "plan", "plan:active"])
-        self.assertEqual(issue["blocking"], 1)
-        self.assertEqual(issue["updated_at"], "2026-05-06T03:54:00Z")
-
-    def test_work_graph_snapshot_rejects_unauthorized_identity(self) -> None:
+    def test_work_graph_reads_are_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/work-graph/snapshot",
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_work_graph_issue_inbox_returns_provider_payload(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
                     {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["work_graph.rank"],
-                    }
-                ]
-            }
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(
-                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
-                ),
-                authz_policy=policy,
-                control_plane_root_path=Path(temporary_directory_name),
-                work_graph_issue_inbox_provider=lambda: GitHubIssueInboxReadModel.model_validate(
-                    {
-                        "generated_at": "2026-05-21T12:00:00Z",
-                        "project_configured": True,
-                        "repository_count": 1,
-                        "issue_count": 2,
-                        "stale_project_item_count": 1,
-                        "repositories": [
+                        "github_actions": [
                             {
                                 "repository": "cbusillo/launchplane",
-                                "issue_count": 2,
-                                "present_in_project_count": 1,
-                                "missing_from_project_count": 1,
-                                "issues": [
-                                    {
-                                        "key": "cbusillo/launchplane#697",
-                                        "repository": "cbusillo/launchplane",
-                                        "number": 697,
-                                        "title": "Add read-only grouped GitHub issue inbox",
-                                        "url": "https://github.com/cbusillo/launchplane/issues/697",
-                                        "state": "OPEN",
-                                        "project_status": "missing",
-                                        "present_in_project": False,
-                                    },
-                                    {
-                                        "key": "cbusillo/launchplane#601",
-                                        "repository": "cbusillo/launchplane",
-                                        "number": 601,
-                                        "title": "Closed Project item",
-                                        "url": "https://github.com/cbusillo/launchplane/issues/601",
-                                        "state": "closed",
-                                        "project_status": "closed",
-                                        "present_in_project": True,
-                                    },
-                                ],
+                                "workflow_refs": ["*"],
+                                "event_names": ["workflow_dispatch"],
+                                "products": ["launchplane", "example-site"],
+                                "contexts": ["launchplane", "example-site"],
+                                "actions": ["work_graph.rank", "product_environment.read"],
                             }
-                        ],
+                        ]
                     }
                 ),
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/work-graph/github/issues",
-            )
-
-        self.assertEqual(status_code, 200)
-        self.assertTrue(payload["configured"])
-        inbox = payload["inbox"]
-        self.assertEqual(inbox["repository_count"], 1)
-        self.assertEqual(inbox["stale_project_item_count"], 1)
-        self.assertEqual(inbox["repositories"][0]["issues"][0]["key"], "cbusillo/launchplane#697")
-        self.assertIs(inbox["repositories"][0]["issues"][0]["present_in_project"], False)
-        self.assertEqual(inbox["repositories"][0]["issues"][1]["project_status"], "closed")
-
-    def test_work_graph_issue_inbox_rejects_unauthorized_identity(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
                 control_plane_root_path=Path(temporary_directory_name),
-                work_graph_issue_inbox_provider=lambda: GitHubIssueInboxReadModel.model_validate(
-                    {
-                        "generated_at": "2026-05-21T12:00:00Z",
-                        "repository_count": 0,
-                        "issue_count": 0,
-                    }
-                ),
             )
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/work-graph/github/issues",
-            )
+            responses = [
+                _invoke_app(app, method="GET", path="/v1/work-graph/snapshot"),
+                _invoke_app(app, method="GET", path="/v1/work-graph/github/issues"),
+            ]
 
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        for status_code, payload in responses:
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_work_graph_issue_inbox_reconcile_dry_run_returns_missing_items(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(


### PR DESCRIPTION
## Summary

- Move `GET /v1/work-graph/snapshot` and `GET /v1/work-graph/github/issues` to native FastAPI routes.
- Retire the matching legacy WSGI read-route branches and WSGI-only work-graph GET helpers.
- Preserve POST rank/reconcile on the mounted WSGI fallback and update docs/tests for the new ownership boundary.

## Verification

- `uv run python -m unittest tests.test_http_app.FastApiProductEnvironmentReadTests tests.test_service.LaunchplaneServiceTests.test_work_graph_reads_are_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/work_graph_http.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/work_graph_http.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/http_app.py control_plane/service.py control_plane/work_graph_http.py tests/test_http_app.py tests/test_service.py`
- `git diff --check`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (`2748` tests)
- JetBrains changed-files closeout: clean

Repo-wide `uv run --extra dev ruff format --check .` still reports pre-existing formatting drift in untouched files; changed files are formatted cleanly.

## Review

- Multi-agent review batch green after one low-severity stale WSGI wiring cleanup.
- Final post-cleanup review green.
