### PR TITLE
Move Odoo operation status reads to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -55,6 +55,12 @@ from control_plane.contracts.idempotency_record import (
 from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
 from control_plane.contracts.ingress_canary_route_record import IngressCanaryRouteRecord
 from control_plane.contracts.ingress_route_audit_record import IngressRouteAuditRecord
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+)
+from control_plane.contracts.odoo_stable_target_replacement_operation import (
+    OdooStableTargetReplacementOperationRecord,
+)
 from control_plane.merge_train_admission import (
     MergeTrainRunHistoryStore,
     build_merge_train_controller_status_read_model,
@@ -202,6 +208,18 @@ class WorkGraphSnapshotReadStore(ProductReadModelStore, WorkGraphWorkRequestStor
     pass
 
 
+class OdooStableBootstrapOperationReadStore(Protocol):
+    def read_odoo_stable_bootstrap_operation_record(
+        self, operation_id: str
+    ) -> OdooStableBootstrapOperationRecord: ...
+
+
+class OdooStableTargetReplacementOperationReadStore(Protocol):
+    def read_odoo_stable_target_replacement_operation_record(
+        self, operation_id: str
+    ) -> OdooStableTargetReplacementOperationRecord: ...
+
+
 class LaunchplaneErrorDetail(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -292,6 +310,24 @@ class OdooStableOperationWorkerStatusResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     worker_status: OdooStableOperationWorkerStatusResponseModel
+
+
+class OdooStableBootstrapOperationStatusResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    operation: dict[str, object]
+    result: dict[str, object] | None = None
+
+
+class OdooStableTargetReplacementOperationStatusResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    operation: dict[str, object]
+    result: dict[str, object] | None = None
 
 
 class ProductEnvironmentConfigStatusResponse(BaseModel):
@@ -1322,6 +1358,54 @@ def require_recent_operations_read_store(record_store: object) -> _RecentOperati
     return cast(_RecentOperationsReadStore, record_store)
 
 
+def require_odoo_stable_bootstrap_operation_read_store(
+    record_store: object,
+) -> OdooStableBootstrapOperationReadStore:
+    read_record = getattr(record_store, "read_odoo_stable_bootstrap_operation_record", None)
+    if not callable(read_record):
+        raise TypeError(
+            "Launchplane record store does not support Odoo stable bootstrap operation "
+            "status reads: read_odoo_stable_bootstrap_operation_record"
+        )
+    return cast(OdooStableBootstrapOperationReadStore, record_store)
+
+
+def require_odoo_stable_target_replacement_operation_read_store(
+    record_store: object,
+) -> OdooStableTargetReplacementOperationReadStore:
+    read_record = getattr(
+        record_store,
+        "read_odoo_stable_target_replacement_operation_record",
+        None,
+    )
+    if not callable(read_record):
+        raise TypeError(
+            "Launchplane record store does not support Odoo target replacement operation "
+            "status reads: read_odoo_stable_target_replacement_operation_record"
+        )
+    return cast(OdooStableTargetReplacementOperationReadStore, record_store)
+
+
+def odoo_stable_bootstrap_operation_status_payload(
+    operation: OdooStableBootstrapOperationRecord,
+) -> dict[str, object]:
+    payload = operation.model_dump(mode="json")
+    payload["poll_url"] = (
+        f"/v1/drivers/odoo/stable-bootstrap/operations/{operation.operation_id.strip()}"
+    )
+    return payload
+
+
+def odoo_stable_target_replacement_operation_status_payload(
+    operation: OdooStableTargetReplacementOperationRecord,
+) -> dict[str, object]:
+    payload = operation.model_dump(mode="json")
+    payload["poll_url"] = (
+        f"/v1/drivers/odoo/target-replacement/operations/{operation.operation_id.strip()}"
+    )
+    return payload
+
+
 def require_product_profile_list_store(record_store: object) -> ProductReadModelStore:
     list_records = getattr(record_store, "list_product_profile_records", None)
     if not callable(list_records):
@@ -1945,6 +2029,100 @@ def create_launchplane_fastapi_app(
         return OdooStableOperationWorkerStatusResponse(
             trace_id=trace_id,
             worker_status=worker_status,
+        )
+
+    def read_odoo_stable_bootstrap_operation_status(
+        operation_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> OdooStableBootstrapOperationStatusResponse:
+        trace_id = next_trace_id()
+        try:
+            operation_store = require_odoo_stable_bootstrap_operation_read_store(record_store)
+            operation = operation_store.read_odoo_stable_bootstrap_operation_record(operation_id)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="odoo_stable_bootstrap.execute",
+            product=operation.product,
+            context=operation.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot read Odoo stable bootstrap operation status "
+                    "for the requested product/context."
+                ),
+            )
+        result = operation.result.model_dump(mode="json") if operation.result else None
+        return OdooStableBootstrapOperationStatusResponse(
+            trace_id=trace_id,
+            operation=odoo_stable_bootstrap_operation_status_payload(operation),
+            result=result,
+        )
+
+    def read_odoo_stable_target_replacement_operation_status(
+        operation_id: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> OdooStableTargetReplacementOperationStatusResponse:
+        trace_id = next_trace_id()
+        try:
+            operation_store = require_odoo_stable_target_replacement_operation_read_store(
+                record_store
+            )
+            operation = operation_store.read_odoo_stable_target_replacement_operation_record(
+                operation_id
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="odoo_target_replacement_apply.execute",
+            product=operation.product,
+            context=operation.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot read Odoo target replacement operation status "
+                    "for the requested product/context."
+                ),
+            )
+        result = operation.result.model_dump(mode="json") if operation.result else None
+        return OdooStableTargetReplacementOperationStatusResponse(
+            trace_id=trace_id,
+            operation=odoo_stable_target_replacement_operation_status_payload(operation),
+            result=result,
         )
 
     def read_product_environment_config_status(
@@ -5200,6 +5378,38 @@ def create_launchplane_fastapi_app(
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/drivers/odoo/stable-bootstrap/operations/{operation_id}",
+        read_odoo_stable_bootstrap_operation_status,
+        methods=["GET"],
+        response_model=OdooStableBootstrapOperationStatusResponse,
+        response_model_exclude_none=True,
+        operation_id="read_odoo_stable_bootstrap_operation_status",
+        summary="Read Odoo stable bootstrap operation status",
+        responses={
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/drivers/odoo/target-replacement/operations/{operation_id}",
+        read_odoo_stable_target_replacement_operation_status,
+        methods=["GET"],
+        response_model=OdooStableTargetReplacementOperationStatusResponse,
+        response_model_exclude_none=True,
+        operation_id="read_odoo_target_replacement_operation_status",
+        summary="Read Odoo target replacement operation status",
+        responses={
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4385,18 +4385,6 @@ def _not_found_response(
 
 def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
     segments = [segment for segment in path.split("/") if segment]
-    if (
-        len(segments) == 6
-        and segments[:4] == ["v1", "drivers", "odoo", "stable-bootstrap"]
-        and segments[4] == "operations"
-    ):
-        return "odoo_stable_bootstrap.execute", {"operation_id": segments[5]}
-    if (
-        len(segments) == 6
-        and segments[:4] == ["v1", "drivers", "odoo", "target-replacement"]
-        and segments[4] == "operations"
-    ):
-        return "odoo_target_replacement_apply.execute", {"operation_id": segments[5]}
     if len(segments) == 4 and segments == [
         "v1",
         "products",
@@ -9867,103 +9855,6 @@ def create_launchplane_service_app(
                         },
                     },
                 )
-            if method == "GET":
-                assert read_route is not None
-                action, params = read_route
-                if action == "odoo_stable_bootstrap.execute":
-                    operation_id = params["operation_id"]
-                    operation_store = _odoo_stable_bootstrap_operation_store(record_store)
-                    try:
-                        operation = operation_store.read_odoo_stable_bootstrap_operation_record(
-                            operation_id
-                        )
-                    except FileNotFoundError:
-                        return _not_found_response(
-                            start_response=start_response,
-                            trace_id=request_trace_id,
-                            path=path,
-                        )
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product=operation.product,
-                        context=operation.context,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read Odoo stable bootstrap operation status for the requested product/context.",
-                                },
-                            },
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "operation": _operation_payload(operation),
-                            **(
-                                {"result": operation.result.model_dump(mode="json")}
-                                if operation.result is not None
-                                else {}
-                            ),
-                        },
-                    )
-                if action == "odoo_target_replacement_apply.execute":
-                    replacement_operation_id = params["operation_id"]
-                    replacement_operation_store = _odoo_stable_target_replacement_operation_store(
-                        record_store
-                    )
-                    try:
-                        replacement_operation = replacement_operation_store.read_odoo_stable_target_replacement_operation_record(
-                            replacement_operation_id
-                        )
-                    except FileNotFoundError:
-                        return _not_found_response(
-                            start_response=start_response,
-                            trace_id=request_trace_id,
-                            path=path,
-                        )
-                    if not authz_policy.allows(
-                        identity=identity,
-                        action=action,
-                        product=replacement_operation.product,
-                        context=replacement_operation.context,
-                    ):
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=403,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "authorization_denied",
-                                    "message": "Workflow cannot read Odoo target replacement operation status for the requested product/context.",
-                                },
-                            },
-                        )
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=200,
-                        payload={
-                            "status": "ok",
-                            "trace_id": request_trace_id,
-                            "operation": _target_replacement_operation_payload(
-                                replacement_operation
-                            ),
-                            **(
-                                {"result": replacement_operation.result.model_dump(mode="json")}
-                                if replacement_operation.result is not None
-                                else {}
-                            ),
-                        },
-                    )
             if path == "/v1/service/odoo-workers/reconcile":
                 if not authz_policy.allows(
                     identity=identity,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -60,6 +60,10 @@ Keep a compatibility surface only when it is one of these:
   routes for bearer-token and human-session callers. Their legacy WSGI branch is
   deleted; direct fallback calls fail closed while the mounted fallback remains
   for retained non-native routes.
+- Odoo stable-bootstrap and target-replacement operation status reads use native
+  FastAPI routes for bearer-token and human-session callers. Their legacy WSGI
+  read branches are deleted; the POST enqueue routes still return the same poll
+  URLs while those write paths remain on the retained fallback.
 - Tracked target logs use the native FastAPI
   `GET /v1/contexts/{context}/instances/{instance}/logs` route. The legacy WSGI
   branch is deleted; direct fallback calls fail closed while the mounted fallback

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -47,6 +47,13 @@ VeriReel product paths:
   - `GET /v1/service/odoo-workers/status`, requiring
     `launchplane_service.read` for the Launchplane service context and returning
     Odoo operation worker queue counters without request payloads
+- native FastAPI Odoo operation status reads:
+  - `GET /v1/drivers/odoo/stable-bootstrap/operations/{operation_id}`,
+    requiring `odoo_stable_bootstrap.execute` for the stored operation product
+    and context
+  - `GET /v1/drivers/odoo/target-replacement/operations/{operation_id}`,
+    requiring `odoo_target_replacement_apply.execute` for the stored operation
+    product and context
 - native FastAPI protected artifact inventory route:
   - `GET /v1/artifacts/protected`, requiring `artifact_protection.read` for
     the requested product and either the requested context or whole-product
@@ -199,6 +206,10 @@ VeriReel product paths:
   - `POST /v1/drivers/generic-web/preview-destroy`
   - `POST /v1/drivers/odoo/artifact-publish-inputs`
   - `POST /v1/drivers/odoo/artifact-publish`
+  - `GET /v1/drivers/odoo/stable-bootstrap/operations/{operation_id}`
+    (native FastAPI)
+  - `GET /v1/drivers/odoo/target-replacement/operations/{operation_id}`
+    (native FastAPI)
   - `POST /v1/drivers/odoo/target-replacement-apply`
   - `POST /v1/drivers/odoo/post-deploy`
   - `POST /v1/drivers/odoo/config-parameter-override`
@@ -1348,6 +1359,10 @@ only after a passing plan and a matching stored preview record are present.
   callers)
 - `GET /v1/service/odoo-workers/status` (native FastAPI for bearer-token and
   human-session callers)
+- `GET /v1/drivers/odoo/stable-bootstrap/operations/{operation_id}` (native
+  FastAPI for bearer-token and human-session callers)
+- `GET /v1/drivers/odoo/target-replacement/operations/{operation_id}` (native
+  FastAPI for bearer-token and human-session callers)
 - `GET /v1/edge-endpoints/records` (native FastAPI for bearer-token and
   human-session callers)
 - `GET /v1/edge-endpoints/records/{endpoint_key}` (native FastAPI for

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -41,6 +41,9 @@ from control_plane.contracts.merge_train_policy import (
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
 )
+from control_plane.contracts.odoo_stable_target_replacement_operation import (
+    OdooStableTargetReplacementOperationRecord,
+)
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationState,
@@ -412,6 +415,230 @@ class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "ok")
+
+
+class FastApiOdooOperationStatusReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_stable_bootstrap_operation_status_returns_native_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_odoo_stable_bootstrap_operation_record(
+                _running_odoo_stable_bootstrap_record()
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_odoo_operation_status_identity()),
+                authz_policy=_odoo_operation_status_policy(action="odoo_stable_bootstrap.execute"),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _asgi_get(
+                app,
+                "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(payload["operation"]["operation_id"], "operation-cm-testing")
+        self.assertEqual(payload["operation"]["status"], "running")
+        self.assertEqual(
+            payload["operation"]["poll_url"],
+            "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+        )
+        self.assertNotIn("result", payload)
+
+    async def test_target_replacement_operation_status_returns_native_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_odoo_stable_target_replacement_operation_record(
+                _running_odoo_target_replacement_record()
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_odoo_operation_status_identity()),
+                authz_policy=_odoo_operation_status_policy(
+                    action="odoo_target_replacement_apply.execute"
+                ),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _asgi_get(
+                app,
+                "/v1/drivers/odoo/target-replacement/operations/operation-cm-testing",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(payload["operation"]["operation_id"], "operation-cm-testing")
+        self.assertEqual(payload["operation"]["status"], "running")
+        self.assertEqual(
+            payload["operation"]["poll_url"],
+            "/v1/drivers/odoo/target-replacement/operations/operation-cm-testing",
+        )
+        self.assertNotIn("result", payload)
+
+    async def test_operation_status_routes_require_authentication(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_odoo_operation_status_identity()),
+            authz_policy=_odoo_operation_status_policy(action="odoo_stable_bootstrap.execute"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(
+            app,
+            "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_operation_status_authorizes_against_stored_operation_context(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_odoo_stable_bootstrap_operation_record(
+                _running_odoo_stable_bootstrap_record()
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_odoo_operation_status_identity()),
+                authz_policy=_odoo_operation_status_policy(
+                    action="odoo_stable_bootstrap.execute",
+                    contexts=("prod",),
+                ),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _asgi_get(
+                app,
+                "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_operation_status_missing_record_returns_not_found(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_odoo_operation_status_identity()),
+                authz_policy=_odoo_operation_status_policy(action="odoo_stable_bootstrap.execute"),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _asgi_get(
+                app,
+                "/v1/drivers/odoo/stable-bootstrap/operations/missing-operation",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_operation_status_requires_only_read_operation_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_odoo_operation_status_identity()),
+            authz_policy=_odoo_operation_status_policy(action="odoo_stable_bootstrap.execute"),
+            record_store_factory=lambda: _EmptyStore(),
+        )
+
+        response = await _asgi_get(
+            app,
+            "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("read_odoo_stable_bootstrap_operation_record", payload["error"]["message"])
+
+    async def test_openapi_includes_odoo_operation_status_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_odoo_operation_status_identity()),
+            authz_policy=_odoo_operation_status_policy(action="odoo_stable_bootstrap.execute"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        bootstrap_route = openapi["paths"][
+            "/v1/drivers/odoo/stable-bootstrap/operations/{operation_id}"
+        ]["get"]
+        replacement_route = openapi["paths"][
+            "/v1/drivers/odoo/target-replacement/operations/{operation_id}"
+        ]["get"]
+        self.assertEqual(
+            bootstrap_route["operationId"],
+            "read_odoo_stable_bootstrap_operation_status",
+        )
+        self.assertEqual(
+            replacement_route["operationId"],
+            "read_odoo_target_replacement_operation_status",
+        )
+        self.assertEqual(
+            bootstrap_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/OdooStableBootstrapOperationStatusResponse",
+        )
+        self.assertEqual(
+            replacement_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/OdooStableTargetReplacementOperationStatusResponse",
+        )
+        self.assertTrue(set(bootstrap_route["responses"]) >= {"200", "401", "403", "404", "503"})
+        self.assertTrue(set(replacement_route["responses"]) >= {"200", "401", "403", "404", "503"})
+
+    async def test_fastapi_operation_status_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            record_store = FilesystemRecordStore(state_dir=state_dir)
+            record_store.write_odoo_stable_bootstrap_operation_record(
+                _running_odoo_stable_bootstrap_record()
+            )
+            record_store.write_odoo_stable_target_replacement_operation_record(
+                _running_odoo_target_replacement_record()
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_odoo_operation_status_identity()),
+                authz_policy=_odoo_operation_status_policy(
+                    action="odoo_stable_bootstrap.execute",
+                    actions=(
+                        "odoo_stable_bootstrap.execute",
+                        "odoo_target_replacement_apply.execute",
+                    ),
+                ),
+                record_store_factory=lambda: record_store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+                local_record_store_for_tests=record_store,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            bootstrap_response = await _asgi_get(
+                app,
+                "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+            replacement_response = await _asgi_get(
+                app,
+                "/v1/drivers/odoo/target-replacement/operations/operation-cm-testing",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(bootstrap_response.status_code, 200)
+        self.assertEqual(replacement_response.status_code, 200)
+        self.assertEqual(bootstrap_response.json()["status"], "ok")
+        self.assertEqual(replacement_response.json()["status"], "ok")
 
 
 class FastApiDeploymentEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
@@ -10316,6 +10543,92 @@ def _pending_odoo_stable_bootstrap_record() -> OdooStableBootstrapOperationRecor
             "phase": "created",
             "created_at": "2026-05-17T00:00:00Z",
             "updated_at": "2026-05-17T00:00:00Z",
+        }
+    )
+
+
+def _running_odoo_stable_bootstrap_record() -> OdooStableBootstrapOperationRecord:
+    return OdooStableBootstrapOperationRecord.model_validate(
+        {
+            "operation_id": "operation-cm-testing",
+            "product": "odoo-tenant-cm",
+            "context": "cm",
+            "instance": "testing",
+            "idempotency_key": "bootstrap-cm-testing",
+            "request_fingerprint": "fingerprint-123",
+            "request": {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm",
+                "context": "cm",
+                "instance": "testing",
+                "confirmation": "bootstrap cm testing",
+            },
+            "status": "running",
+            "phase": "running",
+            "created_at": "2026-05-17T00:00:00Z",
+            "updated_at": "2026-05-17T00:01:00Z",
+            "started_at": "2026-05-17T00:01:00Z",
+        }
+    )
+
+
+def _running_odoo_target_replacement_record() -> OdooStableTargetReplacementOperationRecord:
+    return OdooStableTargetReplacementOperationRecord.model_validate(
+        {
+            "operation_id": "operation-cm-testing",
+            "product": "odoo-tenant-cm",
+            "context": "cm",
+            "instance": "testing",
+            "idempotency_key": "apply-cm-testing",
+            "request_fingerprint": "fingerprint-123",
+            "request": {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm",
+                "instance": "testing",
+                "strategy": "recreate-in-place",
+                "allow_empty_data": False,
+            },
+            "status": "running",
+            "phase": "running",
+            "created_at": "2026-05-17T00:00:00Z",
+            "updated_at": "2026-05-17T00:01:00Z",
+            "started_at": "2026-05-17T00:01:00Z",
+        }
+    )
+
+
+def _odoo_operation_status_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="cbusillo/launchplane",
+        workflow_ref=(
+            "cbusillo/launchplane/.github/workflows/odoo-operation-status.yml@refs/heads/main"
+        ),
+        event_name="workflow_dispatch",
+    )
+
+
+def _odoo_operation_status_policy(
+    *,
+    action: str = "",
+    actions: tuple[str, ...] = (),
+    products: tuple[str, ...] = ("odoo-tenant-cm",),
+    contexts: tuple[str, ...] = ("cm",),
+) -> LaunchplaneAuthzPolicy:
+    resolved_actions = actions or (action,)
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "cbusillo/launchplane",
+                    "workflow_refs": [
+                        "cbusillo/launchplane/.github/workflows/odoo-operation-status.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": list(products),
+                    "contexts": list(contexts),
+                    "actions": list(resolved_actions),
+                }
+            ]
         }
     )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -68,9 +68,6 @@ from control_plane.contracts.odoo_instance_override_record import OdooOverrideVa
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
 )
-from control_plane.contracts.odoo_stable_target_replacement_operation import (
-    OdooStableTargetReplacementOperationRecord,
-)
 from control_plane.contracts.merge_train_run_record import MergeTrainRunRecord
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
@@ -30456,83 +30453,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 second_payload["error"]["code"], "odoo_stable_bootstrap_operation_active"
             )
 
-    def test_odoo_stable_bootstrap_operation_status_reads_for_authorized_workflow(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            request = {
-                "schema_version": 1,
-                "product": "odoo-tenant-cm",
-                "context": "cm",
-                "instance": "testing",
-                "confirmation": "bootstrap cm testing",
-            }
-            store.write_odoo_stable_bootstrap_operation_record(
-                OdooStableBootstrapOperationRecord.model_validate(
-                    {
-                        "operation_id": "operation-cm-testing",
-                        "product": "odoo-tenant-cm",
-                        "context": "cm",
-                        "instance": "testing",
-                        "idempotency_key": "bootstrap-cm-testing",
-                        "request_fingerprint": "abc123",
-                        "request": request,
-                        "status": "running",
-                        "phase": "running",
-                        "created_at": "2026-05-17T00:00:00Z",
-                        "updated_at": "2026-05-17T00:01:00Z",
-                        "started_at": "2026-05-17T00:01:00Z",
-                    }
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "workflow_refs": [
-                                "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["odoo_stable_bootstrap.execute"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-stable-bootstrap.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
-            )
-
-            self.assertEqual(status_code, 200)
-            self.assertEqual(payload["status"], "ok")
-            self.assertEqual(payload["operation"]["status"], "running")
-            self.assertEqual(
-                payload["operation"]["poll_url"],
-                "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
-            )
-
     def test_odoo_stable_bootstrap_driver_rejects_unauthorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -31281,82 +31201,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(
                 second_payload["error"]["code"],
                 "odoo_stable_target_replacement_operation_active",
-            )
-
-    def test_odoo_target_replacement_operation_status_reads_for_authorized_workflow(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_odoo_stable_target_replacement_operation_record(
-                OdooStableTargetReplacementOperationRecord.model_validate(
-                    {
-                        "operation_id": "operation-cm-testing",
-                        "product": "odoo-tenant-cm",
-                        "context": "cm",
-                        "instance": "testing",
-                        "idempotency_key": "apply-cm-testing",
-                        "request_fingerprint": "abc123",
-                        "request": {
-                            "schema_version": 1,
-                            "product": "odoo-tenant-cm",
-                            "instance": "testing",
-                            "strategy": "recreate-in-place",
-                            "allow_empty_data": False,
-                        },
-                        "status": "running",
-                        "phase": "running",
-                        "created_at": "2026-05-17T00:00:00Z",
-                        "updated_at": "2026-05-17T00:01:00Z",
-                        "started_at": "2026-05-17T00:01:00Z",
-                    }
-                )
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "workflow_refs": [
-                                "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["odoo-tenant-cm"],
-                            "contexts": ["cm"],
-                            "actions": ["odoo_target_replacement_apply.execute"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-target-replacement-apply.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/drivers/odoo/target-replacement/operations/operation-cm-testing",
-            )
-
-            self.assertEqual(status_code, 200)
-            self.assertEqual(payload["status"], "ok")
-            self.assertEqual(payload["operation"]["status"], "running")
-            self.assertEqual(
-                payload["operation"]["poll_url"],
-                "/v1/drivers/odoo/target-replacement/operations/operation-cm-testing",
             )
 
     def test_odoo_target_replacement_apply_driver_rejects_unauthorized_workflow(


### PR DESCRIPTION
## Summary

- Move Odoo stable-bootstrap and target-replacement operation status GET reads to native FastAPI routes.
- Remove the corresponding legacy WSGI read matcher/handler branches while keeping POST enqueue poll URLs unchanged.
- Add native FastAPI coverage for response shape, auth/authz, missing records, read-only store gates, OpenAPI, and fallback precedence.
- Update service-boundary and compatibility-retirement docs.

Refs #1322

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiOdooOperationStatusReadTests tests.test_service.LaunchplaneServiceTests`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (2754 tests)
- JetBrains changed-files inspection: clean
- Review agents: 2 green final reviews
