### PR TITLE
Move public ingress monitor run-once to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 import secrets
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path as FilePath
 from typing import Annotated, Literal, Protocol, cast
@@ -95,6 +95,7 @@ from control_plane.contracts.preview_readiness_read_model import (
 )
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.work_graph_read_model import WorkGraphSnapshot
 from control_plane.contracts.protected_artifacts import (
     ProtectedArtifactStore,
@@ -141,6 +142,12 @@ from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
 )
+from control_plane.workflows.public_ingress_monitor import (
+    PublicIngressMonitorStore,
+    PublicIngressNotificationDriverSet,
+    build_github_issue_notifier,
+    run_public_ingress_monitor_once,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.work_graph_service import (
@@ -162,6 +169,7 @@ _PREVIEW_GENERATION_EVIDENCE_ROUTE = "/v1/evidence/previews/generations"
 _PREVIEW_DESTROYED_EVIDENCE_ROUTE = "/v1/evidence/previews/destroyed"
 _RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-host-hygiene/audits"
 _RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-lane-registration/audits"
+_PUBLIC_INGRESS_MONITOR_RUN_ONCE_ROUTE = "/v1/products/public-ingress-monitor/run-once"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 
 
@@ -942,6 +950,22 @@ class _RunnerLaneRegistrationAuditEvidenceStore(Protocol):
     ) -> object: ...
 
 
+class PublicIngressMonitorRunOnceRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str = "launchplane"
+    timeout_seconds: int = Field(default=10, ge=1, le=120)
+    notify: bool = True
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PublicIngressMonitorRunOnceRequest":
+        if self.product.strip() != "launchplane":
+            raise ValueError("public ingress monitor run requires product 'launchplane'")
+        self.product = "launchplane"
+        return self
+
+
 class _DeploymentReadStore(Protocol):
     def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
 
@@ -1446,6 +1470,87 @@ def require_secret_status_read_store(record_store: object) -> control_plane_secr
             f"Launchplane record store does not support secret status reads: {missing_summary}"
         )
     return cast(control_plane_secrets.SecretReadStore, record_store)
+
+
+def require_public_ingress_monitor_store(
+    record_store: object, *, notify: bool
+) -> PublicIngressMonitorStore:
+    required_methods = [
+        "list_product_profile_records",
+        "list_public_ingress_observation_records",
+        "write_public_ingress_observation_record",
+        "list_public_ingress_incident_records",
+        "write_public_ingress_incident_record",
+    ]
+    if notify:
+        required_methods.extend(
+            [
+                "list_public_ingress_notification_policy_records",
+                "list_public_ingress_notification_attempt_records",
+                "write_public_ingress_notification_attempt_record",
+            ]
+        )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support public ingress monitor runs: "
+            f"{missing_summary}"
+        )
+    return cast(PublicIngressMonitorStore, record_store)
+
+
+def secret_read_store(record_store: object) -> control_plane_secrets.SecretReadStore | None:
+    if callable(getattr(record_store, "read_secret_record", None)) and callable(
+        getattr(record_store, "read_secret_version", None)
+    ):
+        return cast(control_plane_secrets.SecretReadStore, record_store)
+    return None
+
+
+def public_ingress_managed_secret_resolver(
+    *,
+    record_store: control_plane_secrets.SecretReadStore,
+) -> Callable[[str, PublicIngressIncidentRecord], str]:
+    def resolve(secret_id: str, incident: PublicIngressIncidentRecord) -> str:
+        normalized_secret_id = secret_id.strip()
+        if not normalized_secret_id:
+            return ""
+        try:
+            record = record_store.read_secret_record(normalized_secret_id)
+        except Exception:  # noqa: BLE001 - delivery records capture missing secrets per destination.
+            return ""
+        if record.status != control_plane_secrets.SECRET_STATUS_CONFIGURED:
+            return ""
+        if not control_plane_secrets._scope_matches_record(
+            record,
+            context_name=incident.context,
+            instance_name=incident.instance,
+        ):
+            return ""
+        try:
+            version = record_store.read_secret_version(record.current_version_id)
+            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
+        except Exception:  # noqa: BLE001 - delivery records capture unreadable secrets per destination.
+            return ""
+
+    return resolve
+
+
+def public_ingress_notification_drivers(
+    *,
+    record_store: object,
+) -> PublicIngressNotificationDriverSet:
+    secret_store = secret_read_store(record_store)
+    if secret_store is None:
+        return PublicIngressNotificationDriverSet()
+    return PublicIngressNotificationDriverSet(
+        incident_secret_resolver=public_ingress_managed_secret_resolver(record_store=secret_store)
+    )
 
 
 def require_product_context_audit_store(
@@ -4673,6 +4778,100 @@ def create_launchplane_fastapi_app(
             original_trace_id=stored_record.response_trace_id,
         )
 
+    async def run_public_ingress_monitor(
+        request: Request,
+        monitor_request: PublicIngressMonitorRunOnceRequest,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="public_ingress_monitor.run_once",
+            product=monitor_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot run public ingress monitoring.",
+            )
+
+        idempotency_store = idempotency_capable_store(record_store)
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_scope = idempotency_scope(identity)
+        raw_payload = await request.json()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if idempotency_store is not None and normalized_idempotency_key:
+            stored_record = idempotency_store.read_idempotency_record(
+                scope=normalized_scope,
+                route_path=_PUBLIC_INGRESS_MONITOR_RUN_ONCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+            )
+            if stored_record is not None:
+                if stored_record.request_fingerprint != payload_fingerprint:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different "
+                            "Launchplane request payload on this route."
+                        ),
+                    )
+                return replay_idempotent_response(
+                    trace_id=trace_id,
+                    stored_record=stored_record,
+                )
+
+        try:
+            monitor_store = require_public_ingress_monitor_store(
+                record_store,
+                notify=monitor_request.notify,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+
+        recorded_at = utc_now_timestamp()
+        monitor_result = run_public_ingress_monitor_once(
+            record_store=monitor_store,
+            checked_at=recorded_at,
+            timeout_seconds=monitor_request.timeout_seconds,
+            notify=monitor_request.notify,
+            notifier=build_github_issue_notifier() if monitor_request.notify else None,
+            notification_drivers=(
+                public_ingress_notification_drivers(record_store=record_store)
+                if monitor_request.notify
+                else None
+            ),
+        )
+        result = monitor_result.model_dump(mode="json")
+        response = accepted_evidence_response(trace_id=trace_id, records={}, result=result)
+        if idempotency_store is not None and normalized_idempotency_key:
+            idempotency_store.write_idempotency_record(
+                LaunchplaneIdempotencyRecord(
+                    record_id=build_launchplane_idempotency_record_id(
+                        response_trace_id=trace_id,
+                    ),
+                    scope=normalized_scope,
+                    route_path=_PUBLIC_INGRESS_MONITOR_RUN_ONCE_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint=payload_fingerprint,
+                    response_status_code=202,
+                    response_trace_id=trace_id,
+                    recorded_at=recorded_at,
+                    response_payload=response.model_dump(mode="json", exclude_none=True),
+                )
+            )
+        return response
+
     async def write_deployment_evidence(
         request: Request,
         deployment_request: DeploymentEvidenceRequest,
@@ -6049,6 +6248,24 @@ def create_launchplane_fastapi_app(
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
             404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PUBLIC_INGRESS_MONITOR_RUN_ONCE_ROUTE,
+        run_public_ingress_monitor,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="run_public_ingress_monitor",
+        summary="Run public ingress monitoring once",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -174,7 +174,6 @@ from control_plane.contracts.promotion_record import (
     ReleaseStatus,
 )
 from control_plane.contracts.public_ingress_monitoring import (
-    PublicIngressIncidentRecord,
     PublicIngressNotificationPolicyRecord,
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
@@ -406,11 +405,6 @@ from control_plane.workflows.dokploy_target_adoption import (
     create_dokploy_compose_target,
 )
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
-from control_plane.workflows.public_ingress_monitor import (
-    PublicIngressNotificationDriverSet,
-    build_github_issue_notifier,
-    run_public_ingress_monitor_once,
-)
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.preview_lifecycle_cleanup import (
@@ -829,22 +823,6 @@ _WsgiApp = Callable[[dict[str, object], _StartResponse], list[bytes]]
 
 
 _LOGGER = logging.getLogger(__name__)
-
-
-class PublicIngressMonitorRunOnceEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str = "launchplane"
-    timeout_seconds: int = Field(default=10, ge=1, le=120)
-    notify: bool = True
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "PublicIngressMonitorRunOnceEnvelope":
-        if self.product.strip() != "launchplane":
-            raise ValueError("public ingress monitor run requires product 'launchplane'")
-        self.product = "launchplane"
-        return self
 
 
 class PublicIngressNotificationPolicyApplyEnvelope(BaseModel):
@@ -4383,18 +4361,6 @@ def _not_found_response(
     )
 
 
-def _match_read_route(path: str) -> tuple[str, dict[str, str]] | None:
-    segments = [segment for segment in path.split("/") if segment]
-    if len(segments) == 4 and segments == [
-        "v1",
-        "products",
-        "public-ingress-monitor",
-        "run-once",
-    ]:
-        return "public_ingress_monitor.run_once", {}
-    return None
-
-
 def _driver_route_metadata_from_descriptors() -> dict[str, _DriverRouteMetadata]:
     route_metadata: dict[str, _DriverRouteMetadata] = {}
     for descriptor in list_driver_descriptors():
@@ -4518,7 +4484,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/preview-gates",
         "/v1/work-graph/github/issues/reconcile",
         "/v1/work-graph/rank",
-        "/v1/products/public-ingress-monitor/run-once",
         "/v1/service/odoo-workers/reconcile",
         "/v1/public-ingress/notification-policies/apply",
         "/v1/every-code/notification-policies/apply",
@@ -7448,35 +7413,6 @@ def _preview_pr_feedback_discord_payload(
     }
 
 
-def _public_ingress_managed_secret_resolver(
-    *,
-    record_store: control_plane_secrets.SecretReadStore,
-) -> Callable[[str, PublicIngressIncidentRecord], str]:
-    def resolve(secret_id: str, incident: PublicIngressIncidentRecord) -> str:
-        normalized_secret_id = secret_id.strip()
-        if not normalized_secret_id:
-            return ""
-        try:
-            record = record_store.read_secret_record(normalized_secret_id)
-        except Exception:  # noqa: BLE001 - delivery records capture missing secrets per destination.
-            return ""
-        if record.status != control_plane_secrets.SECRET_STATUS_CONFIGURED:
-            return ""
-        if not control_plane_secrets._scope_matches_record(
-            record,
-            context_name=incident.context,
-            instance_name=incident.instance,
-        ):
-            return ""
-        try:
-            version = record_store.read_secret_version(record.current_version_id)
-            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
-        except Exception:  # noqa: BLE001 - delivery records capture unreadable secrets per destination.
-            return ""
-
-    return resolve
-
-
 def _launchplane_managed_secret_resolver(
     *,
     record_store: control_plane_secrets.SecretReadStore,
@@ -7506,18 +7442,6 @@ def _launchplane_managed_secret_resolver(
             return ""
 
     return resolve
-
-
-def _public_ingress_notification_drivers(
-    *,
-    record_store: object,
-) -> PublicIngressNotificationDriverSet:
-    secret_store = _secret_capable_store(record_store)
-    if secret_store is None:
-        return PublicIngressNotificationDriverSet()
-    return PublicIngressNotificationDriverSet(
-        incident_secret_resolver=_public_ingress_managed_secret_resolver(record_store=secret_store)
-    )
 
 
 def _deliver_every_code_blocked_notifications(
@@ -9711,8 +9635,7 @@ def create_launchplane_service_app(
                 json_response=_json_response,
                 http_status_text=_http_status_text,
             )
-        read_route = _match_read_route(path)
-        if path not in write_routes and read_route is None:
+        if path not in write_routes:
             return _not_found_response(
                 start_response=start_response,
                 trace_id=request_trace_id,
@@ -9731,7 +9654,7 @@ def create_launchplane_service_app(
                     },
                 },
             )
-        if method == "GET" and read_route is None:
+        if method == "GET":
             return _json_response(
                 start_response=start_response,
                 status_code=405,
@@ -9741,19 +9664,6 @@ def create_launchplane_service_app(
                     "error": {
                         "code": "method_not_allowed",
                         "message": "Only POST is allowed for this Launchplane route.",
-                    },
-                },
-            )
-        if method == "POST" and path not in write_routes:
-            return _json_response(
-                start_response=start_response,
-                status_code=405,
-                payload={
-                    "status": "rejected",
-                    "trace_id": request_trace_id,
-                    "error": {
-                        "code": "method_not_allowed",
-                        "message": "Only GET is allowed for this Launchplane route.",
                     },
                 },
             )
@@ -11389,53 +11299,6 @@ def create_launchplane_service_app(
                         "recorded_at": intent_record.recorded_at,
                     },
                 }
-                driver_result = result
-            elif path == "/v1/products/public-ingress-monitor/run-once":
-                monitor_request = PublicIngressMonitorRunOnceEnvelope.model_validate(payload)
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="public_ingress_monitor.run_once",
-                    product=monitor_request.product,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot run public ingress monitoring.",
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                recorded_at = _utc_now_timestamp()
-                notifier = build_github_issue_notifier() if monitor_request.notify else None
-                monitor_result = run_public_ingress_monitor_once(
-                    record_store=record_store,
-                    checked_at=recorded_at,
-                    timeout_seconds=monitor_request.timeout_seconds,
-                    notify=monitor_request.notify,
-                    notifier=notifier,
-                    notification_drivers=(
-                        _public_ingress_notification_drivers(record_store=record_store)
-                        if monitor_request.notify
-                        else None
-                    ),
-                )
-                result = monitor_result.model_dump(mode="json")
                 driver_result = result
             elif path == "/v1/public-ingress/notification-policies/apply":
                 policy_request = PublicIngressNotificationPolicyApplyEnvelope.model_validate(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -125,6 +125,12 @@ Keep a compatibility surface only when it is one of these:
   branches are deleted; the mounted fallback remains only for retained
   non-native routes, and direct WSGI calls to these evidence-ingress paths fail
   closed.
+- Public ingress monitor run-once uses native FastAPI
+  `POST /v1/products/public-ingress-monitor/run-once` for bearer-token callers
+  and preserves the existing optional `Idempotency-Key` replay/conflict
+  contract. The stale legacy WSGI write branch and old read-route matcher are
+  deleted; the route has no `GET` API, and direct WSGI fallback calls fail
+  closed.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -110,6 +110,9 @@ VeriReel product paths:
     `product_profile.read` for the stored product profile in the Launchplane
     service context and returning redacted current-authority metadata only
 - authenticated evidence routes:
+  - `POST /v1/products/public-ingress-monitor/run-once` (native FastAPI for
+    bearer-token callers, with Pydantic/OpenAPI contract coverage,
+    idempotency replay preservation, and no legacy `GET` route)
   - `POST /v1/evidence/backup-gates` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
   - `POST /v1/evidence/deployments` (native FastAPI for bearer-token callers,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -17,6 +17,7 @@ from fastapi import FastAPI
 from jwt import InvalidTokenError
 from starlette.types import ASGIApp
 
+from control_plane import http_app as control_plane_http_app
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
@@ -54,6 +55,7 @@ from control_plane.contracts.preview_pr_feedback_notifications import (
     PreviewPrFeedbackNotificationAttemptRecord,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     DeploymentEvidence,
@@ -94,6 +96,7 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.workflows.launchplane_self_deploy import LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY
+from control_plane.workflows.public_ingress_monitor import PublicIngressMonitorResult
 from tests.test_service import create_launchplane_service_app
 from tests.test_service import (
     _generic_site_profile_payload,
@@ -7157,6 +7160,344 @@ class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FastApiPublicIngressMonitorTests(unittest.IsolatedAsyncioTestCase):
+    async def test_public_ingress_monitor_runs_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_public_ingress_monitor_identity()),
+                authz_policy=_public_ingress_monitor_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+                run_monitor.return_value = PublicIngressMonitorResult(
+                    checked_at="2026-05-29T12:00:00Z",
+                    target_count=1,
+                    pass_count=1,
+                    records=(),
+                )
+
+                response = await _post_public_ingress_monitor(
+                    app,
+                    {"schema_version": 1, "product": "launchplane", "notify": False},
+                    idempotency_key="public-ingress-monitor-test",
+                )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"], {})
+        self.assertEqual(payload["result"]["target_count"], 1)
+        run_monitor.assert_called_once()
+        self.assertIsNone(run_monitor.call_args.kwargs["notification_drivers"])
+
+    async def test_public_ingress_monitor_wires_notification_drivers(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_public_ingress_monitor_identity()),
+                authz_policy=_public_ingress_monitor_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+                run_monitor.return_value = PublicIngressMonitorResult(
+                    checked_at="2026-05-29T12:00:00Z",
+                    target_count=1,
+                    pass_count=1,
+                    records=(),
+                )
+
+                response = await _post_public_ingress_monitor(
+                    app,
+                    {"schema_version": 1, "product": "launchplane", "notify": True},
+                    idempotency_key="public-ingress-monitor-notify-test",
+                )
+
+        self.assertEqual(response.status_code, 202)
+        run_monitor.assert_called_once()
+        self.assertIsNotNone(run_monitor.call_args.kwargs["notification_drivers"])
+
+    async def test_public_ingress_notification_drivers_resolve_lane_scoped_secrets(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                with patch.dict(
+                    "os.environ",
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: (
+                            "test-master-key"
+                        )
+                    },
+                    clear=True,
+                ):
+                    secret_result = control_plane_secrets.write_secret_value(
+                        record_store=store,
+                        scope="context_instance",
+                        integration="public-ingress-notifications",
+                        name="discord webhook",
+                        plaintext_value="https://discord.com/api/webhooks/test/webhook",
+                        binding_key="DISCORD_WEBHOOK",
+                        context_name="example-site",
+                        instance_name="prod",
+                        actor="test",
+                        source_label="test",
+                    )
+                    resolver = control_plane_http_app.public_ingress_managed_secret_resolver(
+                        record_store=store
+                    )
+                    incident = _public_ingress_incident(context="example-site", instance="prod")
+                    other_incident = _public_ingress_incident(
+                        context="example-site", instance="preview"
+                    )
+                    resolved_value = resolver(str(secret_result["secret_id"]), incident)
+                    unresolved_value = resolver(str(secret_result["secret_id"]), other_incident)
+            finally:
+                store.close()
+
+        self.assertEqual(resolved_value, "https://discord.com/api/webhooks/test/webhook")
+        self.assertEqual(unresolved_value, "")
+
+    async def test_public_ingress_monitor_rejects_unauthorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_public_ingress_monitor_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                record_store_factory=lambda: store,
+            )
+            with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+                response = await _post_public_ingress_monitor(
+                    app,
+                    {"schema_version": 1, "product": "launchplane"},
+                )
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        run_monitor.assert_not_called()
+
+    async def test_public_ingress_monitor_rejects_invalid_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_public_ingress_monitor_identity()),
+                authz_policy=_public_ingress_monitor_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+                response = await _post_public_ingress_monitor(
+                    app,
+                    {"schema_version": 1, "product": "other-product"},
+                )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        run_monitor.assert_not_called()
+
+    async def test_public_ingress_monitor_requires_monitor_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_public_ingress_monitor_identity()),
+            authz_policy=_public_ingress_monitor_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+        with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+            response = await _post_public_ingress_monitor(
+                app,
+                {"schema_version": 1, "product": "launchplane"},
+            )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        run_monitor.assert_not_called()
+
+    async def test_public_ingress_monitor_replays_idempotent_run(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_public_ingress_monitor_identity()),
+                authz_policy=_public_ingress_monitor_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+                run_monitor.return_value = PublicIngressMonitorResult(
+                    checked_at="2026-05-29T12:00:00Z",
+                    target_count=1,
+                    pass_count=1,
+                    records=(),
+                )
+                request_payload = {"schema_version": 1, "product": "launchplane"}
+
+                first_response = await _post_public_ingress_monitor(
+                    app,
+                    request_payload,
+                    idempotency_key="public-ingress-monitor-replay",
+                )
+                second_response = await _post_public_ingress_monitor(
+                    app,
+                    request_payload,
+                    idempotency_key="public-ingress-monitor-replay",
+                )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertNotEqual(second_payload["trace_id"], first_payload["trace_id"])
+        run_monitor.assert_called_once()
+
+    async def test_public_ingress_monitor_replays_before_requiring_monitor_store(
+        self,
+    ) -> None:
+        request_payload = {"schema_version": 1, "product": "launchplane"}
+        replay_store = _PublicIngressMonitorIdempotencyReplayStore(
+            payload=request_payload,
+            idempotency_key="public-ingress-monitor-replay-only",
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_public_ingress_monitor_identity()),
+            authz_policy=_public_ingress_monitor_policy(),
+            record_store_factory=lambda: replay_store,
+        )
+        with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+            response = await _post_public_ingress_monitor(
+                app,
+                request_payload,
+                idempotency_key="public-ingress-monitor-replay-only",
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertTrue(payload["replayed"])
+        self.assertEqual(payload["original_trace_id"], "launchplane_req_original")
+        self.assertEqual(replay_store.read_idempotency_calls, 1)
+        run_monitor.assert_not_called()
+
+    async def test_public_ingress_monitor_rejects_idempotency_key_reuse(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_public_ingress_monitor_identity()),
+                authz_policy=_public_ingress_monitor_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+                run_monitor.return_value = PublicIngressMonitorResult(
+                    checked_at="2026-05-29T12:00:00Z",
+                    target_count=1,
+                    pass_count=1,
+                    records=(),
+                )
+
+                first_response = await _post_public_ingress_monitor(
+                    app,
+                    {"schema_version": 1, "product": "launchplane", "notify": False},
+                    idempotency_key="public-ingress-monitor-reuse",
+                )
+                second_response = await _post_public_ingress_monitor(
+                    app,
+                    {"schema_version": 1, "product": "launchplane", "notify": True},
+                    idempotency_key="public-ingress-monitor-reuse",
+                )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        payload = second_response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+        run_monitor.assert_called_once()
+
+    async def test_public_ingress_monitor_get_is_not_registered(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_public_ingress_monitor_identity()),
+            authz_policy=_public_ingress_monitor_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+        with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+            response = await _asgi_get(
+                app,
+                "/v1/products/public-ingress-monitor/run-once",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 405)
+        run_monitor.assert_not_called()
+
+    async def test_openapi_includes_public_ingress_monitor_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_public_ingress_monitor_identity()),
+            authz_policy=_public_ingress_monitor_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/products/public-ingress-monitor/run-once"]
+        self.assertEqual(set(route.keys()), {"post"})
+        self.assertEqual(route["post"]["operationId"], "run_public_ingress_monitor")
+        self.assertEqual(
+            route["post"]["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/PublicIngressMonitorRunOnceRequest",
+        )
+        self.assertEqual(
+            route["post"]["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["PublicIngressMonitorRunOnceRequest"][
+                "additionalProperties"
+            ],
+            False,
+        )
+
+    async def test_public_ingress_monitor_native_route_precedes_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_public_ingress_monitor_identity()),
+                authz_policy=_public_ingress_monitor_policy(),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+            with patch("control_plane.http_app.run_public_ingress_monitor_once") as run_monitor:
+                run_monitor.return_value = PublicIngressMonitorResult(
+                    checked_at="2026-05-29T12:00:00Z",
+                    target_count=1,
+                    pass_count=1,
+                    records=(),
+                )
+
+                response = await _post_public_ingress_monitor(
+                    app,
+                    {"schema_version": 1, "product": "launchplane", "notify": False},
+                )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["status"], "accepted")
+        run_monitor.assert_called_once()
+
+
 class FastApiPromotionEvidenceTests(unittest.IsolatedAsyncioTestCase):
     async def test_promotion_evidence_writes_record_and_inventory_for_authorized_workflow(
         self,
@@ -9210,6 +9551,51 @@ def _promotion_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
                 }
             ]
         }
+    )
+
+
+def _public_ingress_monitor_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="cbusillo/launchplane",
+        workflow_ref="cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main",
+        event_name="schedule",
+    )
+
+
+def _public_ingress_monitor_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "cbusillo/launchplane",
+                    "workflow_refs": [
+                        "cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main"
+                    ],
+                    "event_names": ["schedule"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["public_ingress_monitor.run_once"],
+                }
+            ]
+        }
+    )
+
+
+def _public_ingress_incident(
+    *, context: str = "launchplane", instance: str = "prod"
+) -> PublicIngressIncidentRecord:
+    return PublicIngressIncidentRecord(
+        incident_id=f"public-ingress-incident-{context}-{instance}",
+        product="launchplane",
+        context=context,
+        instance=instance,
+        status="open",
+        opened_at="2026-05-29T12:00:00Z",
+        opened_observation_id="public-ingress-observation-opened",
+        latest_observation_id="public-ingress-observation-latest",
+        latest_observed_at="2026-05-29T12:00:00Z",
+        failure_code="http_error",
+        summary="Public ingress failed.",
     )
 
 
@@ -11590,6 +11976,28 @@ async def _post_backup_gate_evidence(
     )
 
 
+async def _post_public_ingress_monitor(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/products/public-ingress-monitor/run-once",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _post_promotion_evidence(
     app: FastAPI,
     payload: dict[str, object],
@@ -11968,6 +12376,48 @@ class _IdempotencyOnlyBackupGateReplayStore:
 
     def _write_backup_gate_record(self, record: BackupGateRecord) -> None:
         self.write_backup_gate_calls += 1
+
+
+class _PublicIngressMonitorIdempotencyReplayStore:
+    def __init__(self, *, payload: dict[str, object], idempotency_key: str) -> None:
+        self.read_idempotency_calls = 0
+        self._payload = payload
+        self._idempotency_key = idempotency_key
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> LaunchplaneIdempotencyRecord | None:
+        self.read_idempotency_calls += 1
+        if (
+            route_path != "/v1/products/public-ingress-monitor/run-once"
+            or idempotency_key != self._idempotency_key
+        ):
+            return None
+        return LaunchplaneIdempotencyRecord(
+            record_id="idempotency-launchplane_req_original",
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=hashlib.sha256(
+                json.dumps(self._payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest(),
+            response_status_code=202,
+            response_trace_id="launchplane_req_original",
+            recorded_at="2026-05-29T12:00:00Z",
+            response_payload={
+                "status": "accepted",
+                "trace_id": "launchplane_req_original",
+                "records": {},
+                "result": {"target_count": 1},
+            },
+        )
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> None:
+        raise AssertionError("idempotent replay must not write a new record")
 
 
 class _IdempotencyOnlyRunnerHostHygieneAuditReplayStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -94,7 +94,6 @@ from control_plane.contracts.promotion_record import (
     PromotionRecord,
 )
 from control_plane.contracts.public_ingress_monitoring import (
-    PublicIngressIncidentRecord,
     PublicIngressNotificationDestination,
     PublicIngressNotificationPolicyRecord,
 )
@@ -201,7 +200,6 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewRefreshResult,
 )
 from control_plane.workflows.odoo_preview_runtime import OdooPreviewDokployApplyResult
-from control_plane.workflows.public_ingress_monitor import PublicIngressMonitorResult
 from control_plane.npmplus import NpmplusProxyHost, NpmplusProxyHostPayload
 from control_plane.workflows.ingress_provider import NpmplusIngressProvider
 from control_plane.workflows.npmplus_ingress import (
@@ -1363,24 +1361,6 @@ def _generic_site_profile_payload(product: str = "example-site") -> dict[str, ob
 
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
-
-
-def _public_ingress_incident(
-    *, context: str = "launchplane", instance: str = "prod"
-) -> PublicIngressIncidentRecord:
-    return PublicIngressIncidentRecord(
-        incident_id=f"public-ingress-incident-{context}-{instance}",
-        product="launchplane",
-        context=context,
-        instance=instance,
-        status="open",
-        opened_at="2026-05-29T12:00:00Z",
-        opened_observation_id="public-ingress-observation-opened",
-        latest_observation_id="public-ingress-observation-latest",
-        latest_observed_at="2026-05-29T12:00:00Z",
-        failure_code="http_error",
-        summary="Public ingress failed.",
-    )
 
 
 def create_launchplane_service_app(
@@ -3458,165 +3438,26 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "authorization_denied")
         self.assertEqual(client.calls, [])
 
-    def test_public_ingress_monitor_run_once_service_writes_observation(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": [
-                            "cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main"
-                        ],
-                        "event_names": ["schedule"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["public_ingress_monitor.run_once"],
-                    }
-                ]
-            }
-        )
-        identity = _identity(
-            repository="cbusillo/launchplane",
-            workflow_ref="cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main",
-            event_name="schedule",
-        )
-
+    def test_public_ingress_monitor_run_once_legacy_wsgi_fallback_is_removed(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            state_dir = Path(temporary_directory_name) / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
             app = create_launchplane_service_app(
-                state_dir=state_dir,
-                local_record_store_for_tests=store,
-                verifier=_StubVerifier(identity),
-                authz_policy=policy,
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch("control_plane.service.run_public_ingress_monitor_once") as run_monitor:
-                run_monitor.return_value = PublicIngressMonitorResult(
-                    checked_at="2026-05-29T12:00:00Z",
-                    target_count=1,
-                    pass_count=1,
-                    records=(),
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/products/public-ingress-monitor/run-once",
-                    payload={"schema_version": 1, "product": "launchplane", "notify": False},
-                    headers={"Idempotency-Key": "public-ingress-monitor-test"},
-                )
 
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["status"], "accepted")
-        run_monitor.assert_called_once()
-        self.assertIsNone(run_monitor.call_args.kwargs["notification_drivers"])
-
-    def test_public_ingress_monitor_run_once_service_wires_notification_drivers(
-        self,
-    ) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": [
-                            "cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main"
-                        ],
-                        "event_names": ["schedule"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["public_ingress_monitor.run_once"],
-                    }
-                ]
-            }
-        )
-        identity = _identity(
-            repository="cbusillo/launchplane",
-            workflow_ref="cbusillo/launchplane/.github/workflows/public-ingress-monitor.yml@refs/heads/main",
-            event_name="schedule",
-        )
-
-        with TemporaryDirectory() as temporary_directory_name:
-            state_dir = Path(temporary_directory_name) / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                local_record_store_for_tests=store,
-                verifier=_StubVerifier(identity),
-                authz_policy=policy,
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            with patch("control_plane.service.run_public_ingress_monitor_once") as run_monitor:
-                run_monitor.return_value = PublicIngressMonitorResult(
-                    checked_at="2026-05-29T12:00:00Z",
-                    target_count=1,
-                    pass_count=1,
-                    records=(),
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/products/public-ingress-monitor/run-once",
-                    payload={"schema_version": 1, "product": "launchplane", "notify": True},
-                    headers={"Idempotency-Key": "public-ingress-monitor-notify-test"},
-                )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["status"], "accepted")
-        run_monitor.assert_called_once()
-        self.assertIsNotNone(run_monitor.call_args.kwargs["notification_drivers"])
-
-    def test_public_ingress_notification_drivers_resolve_lane_scoped_secrets(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            database_url = _sqlite_database_url(
-                Path(temporary_directory_name) / "launchplane.sqlite3"
-            )
-            store = PostgresRecordStore(database_url=database_url)
-            store.ensure_schema()
-            try:
-                with patch.dict(
-                    os.environ,
-                    {
-                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: (
-                            "test-master-key"
-                        )
-                    },
-                    clear=True,
-                ):
-                    secret_result = control_plane_secrets.write_secret_value(
-                        record_store=store,
-                        scope="context_instance",
-                        integration="public-ingress-notifications",
-                        name="discord webhook",
-                        plaintext_value="https://discord.com/api/webhooks/test/webhook",
-                        binding_key="DISCORD_WEBHOOK",
-                        context_name="example-site",
-                        instance_name="prod",
-                        actor="test",
-                        source_label="test",
+            for method in ("GET", "POST"):
+                with self.subTest(method=method):
+                    status_code, payload = _invoke_app(
+                        app,
+                        method=method,
+                        path="/v1/products/public-ingress-monitor/run-once",
+                        payload={"schema_version": 1, "product": "launchplane"},
                     )
-                    resolver = control_plane_service._public_ingress_managed_secret_resolver(
-                        record_store=store
-                    )
-                    incident = _public_ingress_incident(context="example-site", instance="prod")
-                    other_incident = _public_ingress_incident(
-                        context="example-site", instance="preview"
-                    )
-                    resolved_value = resolver(str(secret_result["secret_id"]), incident)
-                    unresolved_value = resolver(str(secret_result["secret_id"]), other_incident)
-            finally:
-                store.close()
 
-        self.assertEqual(resolved_value, "https://discord.com/api/webhooks/test/webhook")
-        self.assertEqual(unresolved_value, "")
+                    self.assertEqual(status_code, 404)
+                    self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_public_ingress_notification_policy_apply_writes_db_policy(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- Move `POST /v1/products/public-ingress-monitor/run-once` to the native FastAPI app.
- Remove the stale legacy WSGI read-route matcher and public-ingress monitor fallback branch.
- Preserve authz, optional notification wiring, idempotency replay/conflict behavior, and fail-closed store checks.
- Update service-boundary and compatibility-retirement docs for the native route ownership.

Refs #1322

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiPublicIngressMonitorTests tests.test_service.LaunchplaneServiceTests.test_public_ingress_monitor_run_once_legacy_wsgi_fallback_is_removed`
- `git diff --check`
- `uv run --extra dev ruff check --fix --diff control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
- JetBrains/PyCharm closeout, changed files: clean, 0 problems

## Review
- Read-only scout confirmed the legacy `_match_read_route` entry was stale classification, not a real GET read API.
- Three review agents reported no blocking findings.
- Non-blocking review notes about store-capability test coverage and test colocation were addressed before commit.
