### PR TITLE
Remove public ingress alert issue URL routing

### DIFF
--- a/control_plane/cli_public_ingress_monitor.py
+++ b/control_plane/cli_public_ingress_monitor.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import click
 
 from control_plane.workflows.public_ingress_monitor import (
-    build_github_issue_notifier,
+    public_ingress_notification_drivers,
     run_public_ingress_monitor_once,
 )
 
@@ -33,11 +33,12 @@ def register_public_ingress_monitor_commands(
         if not callable(factory):
             raise click.ClickException("public ingress monitor requires a store factory.")
         record_store = factory(state_dir, database_url=database_url)
-        notifier = build_github_issue_notifier() if notify else None
         result = run_public_ingress_monitor_once(
             record_store=record_store,
             timeout_seconds=timeout_seconds,
             notify=notify,
-            notifier=notifier,
+            notification_drivers=(
+                public_ingress_notification_drivers(record_store=record_store) if notify else None
+            ),
         )
         click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))

--- a/control_plane/contracts/product_health_monitoring_migration.py
+++ b/control_plane/contracts/product_health_monitoring_migration.py
@@ -20,6 +20,7 @@ def migrate_product_profile_health_monitoring_payload(payload: object) -> object
             continue
         if "health_monitoring" in lane:
             lane.pop("public_ingress_monitoring", None)
+            _strip_legacy_alert_issue_urls(lane)
             continue
         old_policy = lane.pop("public_ingress_monitoring", None)
         if isinstance(old_policy, dict):
@@ -31,7 +32,6 @@ def migrate_product_profile_health_monitoring_payload(payload: object) -> object
                         require_runtime_identity=bool(
                             old_policy.get("require_runtime_identity", False)
                         ),
-                        alert_issue_url=str(old_policy.get("alert_issue_url") or ""),
                     )
                 ]
             }
@@ -74,7 +74,6 @@ def downgrade_product_profile_health_monitoring_payload(payload: object) -> obje
                 "require_runtime_identity": bool(
                     public_check.get("require_runtime_identity", False)
                 ),
-                "alert_issue_url": str(public_check.get("alert_issue_url") or ""),
             }
         else:
             lane["public_ingress_monitoring"] = {"enabled": False}
@@ -98,7 +97,6 @@ def _public_http_check(
     *,
     enabled: bool = True,
     require_runtime_identity: bool = False,
-    alert_issue_url: str = "",
 ) -> dict[str, object]:
     return {
         "name": "public-ingress",
@@ -106,10 +104,21 @@ def _public_http_check(
         "enabled": enabled,
         "url": "",
         "require_runtime_identity": require_runtime_identity,
-        "alert_issue_url": alert_issue_url,
         "provider": "",
         "provider_check": "",
     }
+
+
+def _strip_legacy_alert_issue_urls(lane: dict[str, object]) -> None:
+    health_monitoring = lane.get("health_monitoring")
+    if not isinstance(health_monitoring, dict):
+        return
+    checks = health_monitoring.get("checks")
+    if not isinstance(checks, list):
+        return
+    for check in checks:
+        if isinstance(check, dict):
+            check.pop("alert_issue_url", None)
 
 
 def _lane_has_public_http_surface(*, lane: dict[str, object], profile: dict[str, object]) -> bool:

--- a/control_plane/contracts/product_profile_record.py
+++ b/control_plane/contracts/product_profile_record.py
@@ -163,7 +163,6 @@ class ProductLaneHealthCheck(BaseModel):
     url: str = ""
     private_endpoint_key: str = ""
     require_runtime_identity: bool = False
-    alert_issue_url: str = ""
     provider: str = ""
     provider_check: str = ""
 
@@ -171,7 +170,6 @@ class ProductLaneHealthCheck(BaseModel):
     def _validate_check(self) -> "ProductLaneHealthCheck":
         self.name = self.name.strip()
         self.url = self.url.strip()
-        self.alert_issue_url = self.alert_issue_url.strip()
         self.provider = self.provider.strip()
         self.provider_check = self.provider_check.strip()
         if not self.name:

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 import secrets
-from collections.abc import AsyncIterator, Callable
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from pathlib import Path as FilePath
 from typing import Annotated, Literal, Protocol, cast
@@ -95,7 +95,6 @@ from control_plane.contracts.preview_readiness_read_model import (
 )
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.promotion_record import PromotionRecord
-from control_plane.contracts.public_ingress_monitoring import PublicIngressIncidentRecord
 from control_plane.contracts.work_graph_read_model import WorkGraphSnapshot
 from control_plane.contracts.protected_artifacts import (
     ProtectedArtifactStore,
@@ -144,8 +143,7 @@ from control_plane.workflows.evidence_ingestion import (
 )
 from control_plane.workflows.public_ingress_monitor import (
     PublicIngressMonitorStore,
-    PublicIngressNotificationDriverSet,
-    build_github_issue_notifier,
+    public_ingress_notification_drivers,
     run_public_ingress_monitor_once,
 )
 from control_plane.workflows.ship import utc_now_timestamp
@@ -1502,55 +1500,6 @@ def require_public_ingress_monitor_store(
             f"{missing_summary}"
         )
     return cast(PublicIngressMonitorStore, record_store)
-
-
-def secret_read_store(record_store: object) -> control_plane_secrets.SecretReadStore | None:
-    if callable(getattr(record_store, "read_secret_record", None)) and callable(
-        getattr(record_store, "read_secret_version", None)
-    ):
-        return cast(control_plane_secrets.SecretReadStore, record_store)
-    return None
-
-
-def public_ingress_managed_secret_resolver(
-    *,
-    record_store: control_plane_secrets.SecretReadStore,
-) -> Callable[[str, PublicIngressIncidentRecord], str]:
-    def resolve(secret_id: str, incident: PublicIngressIncidentRecord) -> str:
-        normalized_secret_id = secret_id.strip()
-        if not normalized_secret_id:
-            return ""
-        try:
-            record = record_store.read_secret_record(normalized_secret_id)
-        except Exception:  # noqa: BLE001 - delivery records capture missing secrets per destination.
-            return ""
-        if record.status != control_plane_secrets.SECRET_STATUS_CONFIGURED:
-            return ""
-        if not control_plane_secrets._scope_matches_record(
-            record,
-            context_name=incident.context,
-            instance_name=incident.instance,
-        ):
-            return ""
-        try:
-            version = record_store.read_secret_version(record.current_version_id)
-            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
-        except Exception:  # noqa: BLE001 - delivery records capture unreadable secrets per destination.
-            return ""
-
-    return resolve
-
-
-def public_ingress_notification_drivers(
-    *,
-    record_store: object,
-) -> PublicIngressNotificationDriverSet:
-    secret_store = secret_read_store(record_store)
-    if secret_store is None:
-        return PublicIngressNotificationDriverSet()
-    return PublicIngressNotificationDriverSet(
-        incident_secret_resolver=public_ingress_managed_secret_resolver(record_store=secret_store)
-    )
 
 
 def require_product_context_audit_store(
@@ -4845,7 +4794,6 @@ def create_launchplane_fastapi_app(
             checked_at=recorded_at,
             timeout_seconds=monitor_request.timeout_seconds,
             notify=monitor_request.notify,
-            notifier=build_github_issue_notifier() if monitor_request.notify else None,
             notification_drivers=(
                 public_ingress_notification_drivers(record_store=record_store)
                 if monitor_request.notify

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -83,6 +83,7 @@ from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.contracts.private_health_endpoint_record import PrivateHealthEndpointRecord
 from control_plane.contracts.product_health_monitoring_migration import (
     canonical_health_check_record_token,
+    migrate_product_profile_health_monitoring_payload,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.public_ingress_monitoring import (
@@ -4253,12 +4254,27 @@ class PostgresRecordStore(HumanSessionStore):
             )
         )
 
-    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
-        return self._read_model(
-            model_type=LaunchplaneProductProfileRecord,
-            orm_model=LaunchplaneProductProfileRow,
-            filters=(LaunchplaneProductProfileRow.product == product,),
+    def _read_product_profile_payload(
+        self, payload: PayloadDict
+    ) -> LaunchplaneProductProfileRecord:
+        return LaunchplaneProductProfileRecord.model_validate(
+            migrate_product_profile_health_monitoring_payload(payload)
         )
+
+    def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        statement = (
+            select(LaunchplaneProductProfileRow)
+            .where(LaunchplaneProductProfileRow.product == product)
+            .limit(1)
+        )
+        with self._session_factory() as session:
+            row = session.scalar(statement)
+            if row is None:
+                raise FileNotFoundError(
+                    "No Launchplane record found in launchplane_product_profiles "
+                    f"for product={product!r}"
+                )
+            return self._read_product_profile_payload(row.payload)
 
     def list_product_profile_records(
         self,
@@ -4268,12 +4284,13 @@ class PostgresRecordStore(HumanSessionStore):
         filters: list[object] = []
         if driver_id:
             filters.append(LaunchplaneProductProfileRow.driver_id == driver_id)
-        return self._list_models(
-            model_type=LaunchplaneProductProfileRecord,
-            orm_model=LaunchplaneProductProfileRow,
-            filters=filters,
-            order_by=(LaunchplaneProductProfileRow.product.asc(),),
-        )
+        statement = select(LaunchplaneProductProfileRow)
+        if filters:
+            statement = statement.where(*cast(Any, filters))
+        statement = statement.order_by(LaunchplaneProductProfileRow.product.asc())
+        with self._session_factory() as session:
+            rows = session.scalars(statement).all()
+            return tuple(self._read_product_profile_payload(row.payload) for row in rows)
 
     def write_public_ingress_observation_record(
         self, record: PublicIngressObservationRecord

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from email.message import EmailMessage
 from http.client import HTTPMessage
-from typing import IO, Protocol
+from typing import IO, Protocol, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
 from urllib.request import HTTPRedirectHandler, OpenerDirector, Request, build_opener, urlopen
@@ -16,6 +16,7 @@ import ssl
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.product_health_monitoring_migration import (
     canonical_health_check_record_token,
@@ -143,7 +144,6 @@ class PublicIngressMonitorTarget:
     check_kind: ProductLaneHealthCheckKind
     expected_runtime_identity: RuntimeIdentity | None
     require_runtime_identity: bool
-    alert_issue_url: str
     provider: str = ""
     provider_check: str = ""
     private_endpoint_key: str = ""
@@ -188,7 +188,6 @@ class PublicIngressMonitorResult(BaseModel):
     pass_count: int = Field(default=0, ge=0)
     fail_count: int = Field(default=0, ge=0)
     skipped_count: int = Field(default=0, ge=0)
-    notification_count: int = Field(default=0, ge=0)
     open_incident_count: int = Field(default=0, ge=0)
     resolved_incident_count: int = Field(default=0, ge=0)
     delivery_attempt_count: int = Field(default=0, ge=0)
@@ -198,7 +197,6 @@ class PublicIngressMonitorResult(BaseModel):
 
 
 HttpGet = Callable[[str, int], HttpObservation]
-Notifier = Callable[[PublicIngressObservationRecord, PublicIngressObservationRecord | None], bool]
 
 
 class _RedirectTrackingHandler(HTTPRedirectHandler):
@@ -295,7 +293,6 @@ def _health_check_monitor_target(
             lane=lane,
         ),
         require_runtime_identity=check.require_runtime_identity,
-        alert_issue_url=check.alert_issue_url,
         provider=check.provider,
         provider_check=check.provider_check,
         private_endpoint_key=check.private_endpoint_key,
@@ -358,7 +355,6 @@ def run_public_ingress_monitor_once(
     timeout_seconds: int = 10,
     notify: bool = True,
     http_get: HttpGet | None = None,
-    notifier: Notifier | None = None,
     notification_drivers: PublicIngressNotificationDrivers | None = None,
 ) -> PublicIngressMonitorResult:
     observed_at = checked_at.strip() or utc_now_timestamp()
@@ -368,7 +364,6 @@ def run_public_ingress_monitor_once(
     delivery_attempts: list[PublicIngressNotificationAttemptRecord] = []
     open_incident_count = 0
     resolved_incident_count = 0
-    notification_count = 0
     for target in discover_public_ingress_monitor_targets(record_store):
         previous_record = _latest_observation(record_store=record_store, target=target)
         record = check_public_ingress_target(
@@ -377,11 +372,6 @@ def run_public_ingress_monitor_once(
             timeout_seconds=timeout_seconds,
             http_get=get,
         )
-        if notify and notifier is not None and _should_notify(record, previous_record):
-            notification_sent = notifier(record, previous_record)
-            record = record.model_copy(update={"notification_sent": notification_sent})
-            if notification_sent:
-                notification_count += 1
         record_store.write_public_ingress_observation_record(record)
         records.append(record)
         incident_records = reconcile_public_ingress_incident(
@@ -411,7 +401,6 @@ def run_public_ingress_monitor_once(
         pass_count=sum(1 for record in records if record.status == "pass"),
         fail_count=sum(1 for record in records if record.status == "fail"),
         skipped_count=sum(1 for record in records if record.status == "skipped"),
-        notification_count=notification_count,
         open_incident_count=open_incident_count,
         resolved_incident_count=resolved_incident_count,
         delivery_attempt_count=len(delivery_attempts),
@@ -634,7 +623,6 @@ def check_public_ingress_target(
         health_url=target.health_url,
         expected_runtime_identity=target.expected_runtime_identity,
         targets=tuple(target_observations),
-        notification_key=_notification_key(target),
         summary=summary,
     )
 
@@ -876,17 +864,6 @@ def _open_incidents(
     )
 
 
-def _should_notify(
-    record: PublicIngressObservationRecord, previous: PublicIngressObservationRecord | None
-) -> bool:
-    if not record.notification_key:
-        return False
-    previous_status = previous.status if previous is not None else "missing"
-    if record.status == "fail" and previous_status != "fail":
-        return True
-    return record.status == "pass" and previous_status == "fail"
-
-
 def _target_urls(
     target: PublicIngressMonitorTarget,
 ) -> tuple[tuple[PublicIngressTargetKind, str], ...]:
@@ -1033,21 +1010,15 @@ def _normalized_url(url: str) -> str:
     )
 
 
-def _notification_key(target: PublicIngressMonitorTarget) -> str:
-    return target.alert_issue_url or ""
-
-
 def public_http_health_check(
     *,
     name: str = "public-ingress",
     require_runtime_identity: bool = False,
-    alert_issue_url: str = "",
 ) -> ProductLaneHealthCheck:
     return ProductLaneHealthCheck(
         name=name,
         kind="public_http",
         require_runtime_identity=require_runtime_identity,
-        alert_issue_url=alert_issue_url,
     )
 
 
@@ -1121,6 +1092,57 @@ class PublicIngressNotificationDriverSet:
         if self.incident_secret_resolver is not None:
             return self.incident_secret_resolver(secret_name, incident)
         return self.secret_resolver(secret_name)
+
+
+def public_ingress_secret_read_store(
+    record_store: object,
+) -> control_plane_secrets.SecretReadStore | None:
+    if callable(getattr(record_store, "read_secret_record", None)) and callable(
+        getattr(record_store, "read_secret_version", None)
+    ):
+        return cast(control_plane_secrets.SecretReadStore, record_store)
+    return None
+
+
+def public_ingress_managed_secret_resolver(
+    *,
+    record_store: control_plane_secrets.SecretReadStore,
+) -> Callable[[str, PublicIngressIncidentRecord], str]:
+    def resolve(secret_id: str, incident: PublicIngressIncidentRecord) -> str:
+        normalized_secret_id = secret_id.strip()
+        if not normalized_secret_id:
+            return ""
+        try:
+            record = record_store.read_secret_record(normalized_secret_id)
+        except Exception:  # noqa: BLE001 - delivery records capture missing secrets per destination.
+            return ""
+        if record.status != control_plane_secrets.SECRET_STATUS_CONFIGURED:
+            return ""
+        if not control_plane_secrets._scope_matches_record(
+            record,
+            context_name=incident.context,
+            instance_name=incident.instance,
+        ):
+            return ""
+        try:
+            version = record_store.read_secret_version(record.current_version_id)
+            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
+        except Exception:  # noqa: BLE001 - delivery records capture unreadable secrets per destination.
+            return ""
+
+    return resolve
+
+
+def public_ingress_notification_drivers(
+    *,
+    record_store: object,
+) -> PublicIngressNotificationDriverSet:
+    secret_store = public_ingress_secret_read_store(record_store)
+    if secret_store is None:
+        return PublicIngressNotificationDriverSet()
+    return PublicIngressNotificationDriverSet(
+        incident_secret_resolver=public_ingress_managed_secret_resolver(record_store=secret_store)
+    )
 
 
 def _deliver_github_issue_notification(
@@ -1444,57 +1466,3 @@ def _send_email_message(
 
 def _post_discord_webhook(webhook_url: str, payload: dict[str, object]) -> None:
     post_discord_webhook(webhook_url, payload)
-
-
-def public_ingress_alert_body(
-    record: PublicIngressObservationRecord,
-    previous: PublicIngressObservationRecord | None,
-) -> str:
-    state = "RECOVERED" if record.status == "pass" else "FAILED"
-    previous_status = previous.status if previous is not None else "missing"
-    lines = [
-        f"Launchplane public ingress {state}: {record.product}/{record.instance}",
-        "",
-        f"- status: {record.status}",
-        f"- previous_status: {previous_status}",
-        f"- observed_at: {record.observed_at}",
-        f"- context: {record.context}",
-    ]
-    if record.failure_code:
-        lines.append(f"- failure_code: {record.failure_code}")
-    for target in record.targets:
-        lines.append(f"- {target.target}: {target.status} {target.summary}")
-    return "\n".join(lines)
-
-
-def build_github_issue_notifier(
-    *,
-    github_client: Callable[[str, dict[str, object]], dict[str, object]] | None = None,
-    token: str | None = None,
-) -> Notifier:
-    client = github_client or (
-        lambda action, payload: _gh_issue_client(action, payload, token=token)
-    )
-
-    def notify(
-        record: PublicIngressObservationRecord,
-        previous: PublicIngressObservationRecord | None,
-    ) -> bool:
-        issue_url = record.notification_key.strip()
-        if not issue_url:
-            return False
-        try:
-            repository, issue_number = _github_issue_url_reference(issue_url)
-            client(
-                "comment",
-                {
-                    "repository": repository,
-                    "issue_number": issue_number,
-                    "body": public_ingress_alert_body(record, previous),
-                },
-            )
-        except (RuntimeError, ValueError):
-            return False
-        return True
-
-    return notify

--- a/docs/records.md
+++ b/docs/records.md
@@ -316,8 +316,12 @@ fail closed until a provider-specific monitor implementation is wired. The
 monitor records HTTP reachability, redirect failures, private/internal URL skips
 for public checks, and runtime identity comparison when current lane inventory
 or deployment evidence provides an expected identity. Check policy may carry an
-`alert_issue_url`; Launchplane uses that issue for fail/recover transition
-comments, not as runtime configuration authority.
+enabled flag and provider-specific routing details, but alert destinations are
+not lane text fields. Public ingress incident notifications are routed through
+DB-backed notification policy records. Legacy product-profile payloads that
+still contain `alert_issue_url` are tolerated during record reads and stripped
+from the migrated health-monitoring shape instead of being treated as runtime
+authority.
 
 The product key is the durable workspace identity. For example,
 `sellyouroutboard` is the SellYourOutboard product workspace; `testing`, `prod`,

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -908,9 +908,12 @@ class FilesystemRecordStoreTests(unittest.TestCase):
         self.assertEqual(check.name, "public-ingress")
         self.assertEqual(check.kind, "public_http")
         self.assertTrue(check.require_runtime_identity)
-        self.assertEqual(check.alert_issue_url, "https://github.example.test/org/repo/issues/1")
         self.assertEqual([record.product for record in listed_records], ["example-site"])
         self.assertNotIn("public_ingress_monitoring", persisted_payload["lanes"][0])
+        self.assertNotIn(
+            "alert_issue_url",
+            persisted_payload["lanes"][0]["health_monitoring"]["checks"][0],
+        )
         self.assertEqual(
             persisted_payload["lanes"][0]["health_monitoring"]["checks"][0]["name"],
             "public-ingress",

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -17,7 +17,6 @@ from fastapi import FastAPI
 from jwt import InvalidTokenError
 from starlette.types import ASGIApp
 
-from control_plane import http_app as control_plane_http_app
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
@@ -96,7 +95,10 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.workflows.launchplane_self_deploy import LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY
-from control_plane.workflows.public_ingress_monitor import PublicIngressMonitorResult
+from control_plane.workflows.public_ingress_monitor import (
+    PublicIngressMonitorResult,
+    public_ingress_managed_secret_resolver,
+)
 from tests.test_service import create_launchplane_service_app
 from tests.test_service import (
     _generic_site_profile_payload,
@@ -7248,9 +7250,7 @@ class FastApiPublicIngressMonitorTests(unittest.IsolatedAsyncioTestCase):
                         actor="test",
                         source_label="test",
                     )
-                    resolver = control_plane_http_app.public_ingress_managed_secret_resolver(
-                        record_store=store
-                    )
+                    resolver = public_ingress_managed_secret_resolver(record_store=store)
                     incident = _public_ingress_incident(context="example-site", instance="prod")
                     other_incident = _public_ingress_incident(
                         context="example-site", instance="preview"

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -9,7 +9,7 @@ from unittest.mock import Mock, patch
 from alembic import command as alembic_command
 from alembic.config import Config as AlembicConfig
 from click.testing import CliRunner
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import create_engine, inspect, text, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.sql.schema import Index
 
@@ -157,7 +157,7 @@ from control_plane.service_auth import (
 from control_plane.service_human_auth import LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.factory import build_shared_record_store
-from control_plane.storage.postgres import Base, PostgresRecordStore
+from control_plane.storage.postgres import Base, LaunchplaneProductProfileRow, PostgresRecordStore
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
 
@@ -2519,6 +2519,45 @@ env_var = "GH_TOKEN"
         self.assertEqual(
             [record.product for record in listed_records], ["internal-tool", "sellyouroutboard"]
         )
+
+    def test_product_profile_reads_migrate_legacy_alert_issue_url(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            record = _product_profile_record()
+            store.write_product_profile_record(record)
+            payload = store._payload_dict(record)
+            lanes = payload["lanes"]
+            assert isinstance(lanes, list)
+            first_lane = lanes[0]
+            assert isinstance(first_lane, dict)
+            first_lane["health_monitoring"] = {
+                "checks": [
+                    {
+                        "name": "public-ingress",
+                        "kind": "public_http",
+                        "enabled": True,
+                        "alert_issue_url": "https://github.example.test/org/repo/issues/1",
+                    }
+                ]
+            }
+            with store._session_factory() as session:
+                session.execute(
+                    update(LaunchplaneProductProfileRow)
+                    .where(LaunchplaneProductProfileRow.product == record.product)
+                    .values(payload=payload)
+                )
+                session.commit()
+
+            loaded_record = store.read_product_profile_record("sellyouroutboard")
+            listed_records = store.list_product_profile_records(driver_id="generic-web")
+            store.close()
+
+        self.assertEqual(loaded_record.lanes[0].health_monitoring.checks[0].name, "public-ingress")
+        self.assertEqual([record.product for record in listed_records], ["sellyouroutboard"])
 
     def test_product_profiles_cli_upserts_lists_and_shows_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -90,7 +90,6 @@ def _manifest_payload() -> dict[str, object]:
                         {
                             "name": "public-ingress",
                             "kind": "public_http",
-                            "alert_issue_url": "https://github.com/cbusillo/launchplane/issues/929",
                         }
                     ]
                 },
@@ -1865,10 +1864,6 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertTrue(health_check.enabled)
         self.assertFalse(health_check.require_runtime_identity)
         self.assertEqual(
-            health_check.alert_issue_url,
-            "https://github.com/cbusillo/launchplane/issues/929",
-        )
-        self.assertEqual(
             profile.lanes[0].odoo_stable_bootstrap.approval_issue_url,
             "https://github.com/cbusillo/launchplane/issues/573",
         )
@@ -2451,7 +2446,6 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                             {
                                 "name": "public-ingress",
                                 "kind": "public_http",
-                                "alert_issue_url": "https://github.com/example/ops/issues/123",
                             }
                         ]
                     },
@@ -2491,10 +2485,25 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             "https://repairshopr-sync.example.test/health",
         )
         self.assertTrue(profile.lanes[0].health_monitoring.checks[0].enabled)
-        self.assertEqual(
-            profile.lanes[0].health_monitoring.checks[0].alert_issue_url,
-            "https://github.com/example/ops/issues/123",
-        )
+
+    def test_product_onboarding_manifest_rejects_health_check_alert_issue_url(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+        lanes = payload["lanes"]
+        assert isinstance(lanes, list)
+        first_lane = lanes[0]
+        assert isinstance(first_lane, dict)
+        health_monitoring = first_lane["health_monitoring"]
+        assert isinstance(health_monitoring, dict)
+        checks = health_monitoring["checks"]
+        assert isinstance(checks, list)
+        first_check = checks[0]
+        assert isinstance(first_check, dict)
+        first_check["alert_issue_url"] = "https://github.com/example/ops/issues/123"
+
+        with self.assertRaisesRegex(ValueError, "alert_issue_url"):
+            ProductOnboardingManifest.model_validate(payload)
 
     def test_product_onboarding_manifest_rejects_image_less_health_monitoring_without_url(
         self,
@@ -2800,7 +2809,6 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                     "enabled": True,
                     "url": "",
                     "require_runtime_identity": False,
-                    "alert_issue_url": "",
                     "provider": "",
                     "provider_check": "",
                 }
@@ -2856,7 +2864,6 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             {
                 "enabled": True,
                 "require_runtime_identity": True,
-                "alert_issue_url": "https://github.example.test/org/repo/issues/1",
             },
         )
         self.assertEqual(lanes[1]["public_ingress_monitoring"], {"enabled": False})

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -6,6 +6,10 @@ from typing import Literal
 from unittest.mock import patch
 from urllib.request import Request
 
+import click
+from click.testing import CliRunner
+
+from control_plane.cli_public_ingress_monitor import register_public_ingress_monitor_commands
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
 from control_plane.contracts.product_health_monitoring_migration import (
@@ -27,27 +31,25 @@ from control_plane.contracts.public_ingress_monitoring import (
 )
 from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationDestination
 from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationPolicyRecord
-from control_plane.contracts.public_ingress_monitoring import PublicIngressTargetObservation
 from control_plane.contracts.public_ingress_monitoring import build_public_ingress_lane_incident_id
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.workflows.public_ingress_monitor import (
     HttpObservation,
+    PublicIngressMonitorResult,
     PublicIngressNotificationDriverSet,
-    build_github_issue_notifier,
     discover_public_ingress_monitor_targets,
     run_public_ingress_monitor_once,
 )
 
 
 def _public_health_monitoring(
-    *, require_runtime_identity: bool = False, alert_issue_url: str = ""
+    *, require_runtime_identity: bool = False
 ) -> ProductLaneHealthMonitoringPolicy:
     return ProductLaneHealthMonitoringPolicy(
         checks=(
             ProductLaneHealthCheck(
                 name="public-ingress",
                 require_runtime_identity=require_runtime_identity,
-                alert_issue_url=alert_issue_url,
             ),
         )
     )
@@ -196,9 +198,7 @@ class _Store:
         ]
         self.notification_attempts.append(record)
 
-    def read_private_health_endpoint_record(
-        self, endpoint_key: str
-    ) -> PrivateHealthEndpointRecord:
+    def read_private_health_endpoint_record(self, endpoint_key: str) -> PrivateHealthEndpointRecord:
         try:
             return self.private_health_endpoints[endpoint_key]
         except KeyError as error:
@@ -222,9 +222,7 @@ def _profile(
                 instance="prod",
                 context="example-site",
                 base_url="https://example.test",
-                health_monitoring=_public_health_monitoring(
-                    alert_issue_url="https://github.com/cbusillo/launchplane/issues/929"
-                ),
+                health_monitoring=_public_health_monitoring(),
             ),
         ),
         updated_at="2026-05-29T12:00:00Z",
@@ -257,15 +255,6 @@ def _notification_policy(
         updated_at="2026-05-29T12:00:00Z",
         source="test",
     )
-
-
-def _record_notification(
-    notifications: list[tuple[str, str]],
-    record: PublicIngressObservationRecord,
-    previous: PublicIngressObservationRecord | None,
-) -> bool:
-    notifications.append((record.status, previous.status if previous else "missing"))
-    return True
 
 
 def _capture_github_call(
@@ -316,6 +305,42 @@ def _add_private_endpoint(
         status=status,
         updated_at="2026-05-29T12:00:00Z",
     )
+
+
+class PublicIngressMonitorCliTests(unittest.TestCase):
+    def test_run_once_wires_policy_backed_notification_drivers(self) -> None:
+        command_group = click.Group()
+        record_store = object()
+        notification_drivers = object()
+        register_public_ingress_monitor_commands(
+            command_group,
+            store_factory=lambda _state_dir, database_url="": record_store,
+        )
+
+        with patch(
+            "control_plane.cli_public_ingress_monitor.public_ingress_notification_drivers",
+            return_value=notification_drivers,
+        ) as build_drivers:
+            with patch(
+                "control_plane.cli_public_ingress_monitor.run_public_ingress_monitor_once"
+            ) as run_monitor:
+                run_monitor.return_value = PublicIngressMonitorResult(
+                    checked_at="2026-06-18T11:00:00Z",
+                    target_count=0,
+                    records=(),
+                )
+
+                result = CliRunner().invoke(
+                    command_group,
+                    ["public-ingress-monitor", "run-once", "--database-url", "sqlite:///test.db"],
+                )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        build_drivers.assert_called_once_with(record_store=record_store)
+        run_monitor.assert_called_once()
+        self.assertIs(run_monitor.call_args.kwargs["record_store"], record_store)
+        self.assertTrue(run_monitor.call_args.kwargs["notify"])
+        self.assertIs(run_monitor.call_args.kwargs["notification_drivers"], notification_drivers)
 
 
 class PublicIngressMonitorTests(unittest.TestCase):
@@ -841,9 +866,8 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(health.status, "fail")
         self.assertIn("deployment_record_id", health.runtime_identity_detail)
 
-    def test_notifies_on_failure_and_recovery_transitions(self) -> None:
+    def test_observations_do_not_use_standing_issue_notification_keys(self) -> None:
         store = _Store((_profile(),))
-        notifications: list[tuple[str, str]] = []
 
         run_public_ingress_monitor_once(
             record_store=store,
@@ -853,7 +877,6 @@ class PublicIngressMonitorTests(unittest.TestCase):
                 final_url=url,
                 redirect_count=0,
             ),
-            notifier=lambda record, previous: _record_notification(notifications, record, previous),
         )
         run_public_ingress_monitor_once(
             record_store=store,
@@ -863,7 +886,6 @@ class PublicIngressMonitorTests(unittest.TestCase):
                 final_url=url,
                 redirect_count=0,
             ),
-            notifier=lambda record, previous: _record_notification(notifications, record, previous),
         )
         run_public_ingress_monitor_once(
             record_store=store,
@@ -873,12 +895,11 @@ class PublicIngressMonitorTests(unittest.TestCase):
                 final_url=url,
                 redirect_count=0,
             ),
-            notifier=lambda record, previous: _record_notification(notifications, record, previous),
         )
 
-        self.assertEqual(notifications, [("fail", "pass"), ("pass", "fail")])
-        self.assertTrue(store.records[1].notification_sent)
-        self.assertTrue(store.records[2].notification_sent)
+        self.assertEqual([record.status for record in store.records], ["pass", "fail", "pass"])
+        self.assertTrue(all(record.notification_key == "" for record in store.records))
+        self.assertTrue(all(not record.notification_sent for record in store.records))
 
     def test_opens_updates_and_resolves_public_ingress_incident(self) -> None:
         store = _Store((_profile(),))
@@ -1281,116 +1302,6 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(
             github_calls[1][1]["issue_url"],
             "https://github.com/cbusillo/launchplane/issues/123",
-        )
-
-    def test_github_issue_notifier_comments_on_alert_issue(self) -> None:
-        calls: list[tuple[str, dict[str, object]]] = []
-        notifier = build_github_issue_notifier(
-            github_client=lambda action, payload: _capture_github_call(calls, action, payload)
-        )
-        record = PublicIngressObservationRecord(
-            record_id="public-ingress-example-site-prod-20260529t122500z",
-            product="example-site",
-            context="example-site",
-            instance="prod",
-            observed_at="2026-05-29T12:25:00Z",
-            status="fail",
-            failure_code="http_error",
-            base_url="https://example.test",
-            targets=(
-                PublicIngressTargetObservation(
-                    target="base_url",
-                    url="https://example.test",
-                    status="fail",
-                    failure_code="http_error",
-                    summary="HTTP 503",
-                ),
-            ),
-            notification_key="https://github.com/cbusillo/launchplane/issues/929",
-            summary="Public ingress failed.",
-        )
-
-        self.assertTrue(notifier(record, None))
-        self.assertEqual(calls[0][0], "comment")
-        self.assertEqual(calls[0][1]["repository"], "cbusillo/launchplane")
-        self.assertEqual(calls[0][1]["issue_number"], 929)
-
-    def test_github_issue_notifier_fails_closed_without_managed_token(self) -> None:
-        notifier = build_github_issue_notifier()
-        record = PublicIngressObservationRecord(
-            record_id="public-ingress-example-site-prod-20260529t122500z",
-            product="example-site",
-            context="example-site",
-            instance="prod",
-            observed_at="2026-05-29T12:25:00Z",
-            status="fail",
-            failure_code="http_error",
-            base_url="https://example.test",
-            targets=(
-                PublicIngressTargetObservation(
-                    target="base_url",
-                    url="https://example.test",
-                    status="fail",
-                    failure_code="http_error",
-                    summary="HTTP 503",
-                ),
-            ),
-            notification_key="https://github.com/cbusillo/launchplane/issues/929",
-            summary="Public ingress failed.",
-        )
-
-        with patch.dict("os.environ", {}, clear=True):
-            self.assertFalse(notifier(record, None))
-
-    def test_github_issue_notifier_uses_managed_token_api(self) -> None:
-        requests: list[Request] = []
-
-        def fake_urlopen(request: Request, timeout: int) -> _GitHubResponse:
-            requests.append(request)
-            self.assertEqual(timeout, 15)
-            return _GitHubResponse(
-                {
-                    "html_url": "https://github.com/cbusillo/launchplane/issues/929#issuecomment-1",
-                    "id": 1,
-                }
-            )
-
-        notifier = build_github_issue_notifier(token="managed-token")
-        record = PublicIngressObservationRecord(
-            record_id="public-ingress-example-site-prod-20260529t122500z",
-            product="example-site",
-            context="example-site",
-            instance="prod",
-            observed_at="2026-05-29T12:25:00Z",
-            status="fail",
-            failure_code="http_error",
-            base_url="https://example.test",
-            targets=(
-                PublicIngressTargetObservation(
-                    target="base_url",
-                    url="https://example.test",
-                    status="fail",
-                    failure_code="http_error",
-                    summary="HTTP 503",
-                ),
-            ),
-            notification_key="https://github.com/cbusillo/launchplane/issues/929",
-            summary="Public ingress failed.",
-        )
-
-        with patch("control_plane.workflows.public_ingress_monitor.urlopen", fake_urlopen):
-            self.assertTrue(notifier(record, None))
-
-        request = requests[0]
-        self.assertEqual(
-            getattr(request, "full_url"),
-            "https://api.github.com/repos/cbusillo/launchplane/issues/929/comments",
-        )
-        self.assertEqual(request.get_method(), "POST")
-        self.assertEqual(request.get_header("Authorization"), "Bearer managed-token")
-        self.assertEqual(
-            json.loads(getattr(request, "data").decode("utf-8"))["body"].splitlines()[0],
-            "Launchplane public ingress FAILED: example-site/prod",
         )
 
     def test_default_github_incident_driver_uses_managed_token_api(self) -> None:


### PR DESCRIPTION
## Summary
- Remove lane health-check `alert_issue_url` as a current public-ingress notification authority.
- Keep historical product profile payloads readable by stripping legacy `alert_issue_url` during filesystem/Postgres profile read migration.
- Route CLI and FastAPI public-ingress monitor notifications through DB-backed notification drivers instead of legacy standing issue comments.
- Update records docs and tests for the v2 cleanup boundary.

Refs #985
Refs #1322

## Verification
- Final review agents: green, no blocking findings.
- `uv run python -m unittest` (2,764 tests): passed.
- `uv run --extra dev ruff check .`: passed.
- `uv run --extra dev ruff format --check <changed files>`: passed.
- `uv run --extra dev mypy control_plane tests`: passed.
- `uv run launchplane service audit-config-authority --control-plane-root .`: status ok; existing broad scanner findings unchanged/outside this slice.
- JetBrains changed-files closeout: clean, 0 problems.

## Notes
- Repo-wide `ruff format --check .` still reports pre-existing unrelated formatting drift in 55 files; changed files are formatted.