### PR TITLE
Retire sync live target apply mode

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -3133,7 +3133,6 @@ def _sync_live_target_from_tracked_contract(
     *,
     context_name: str,
     instance_name: str,
-    apply_changes: bool,
 ) -> dict[str, object]:
     control_plane_root = _control_plane_root()
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
@@ -3195,41 +3194,12 @@ def _sync_live_target_from_tracked_contract(
         if live_value != tracked_value:
             env_changes[env_key] = {"live": live_value, "tracked": tracked_value}
 
-    if apply_changes:
-        if source_changes:
-            control_plane_dokploy.update_dokploy_target_source(
-                host=host,
-                token=token,
-                target_definition=target_definition,
-                target_payload=target_payload,
-            )
-        if env_changes:
-            refreshed_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-                host=host,
-                token=token,
-                target_type=target_definition.target_type,
-                target_id=target_definition.target_id,
-            )
-            refreshed_env_map = control_plane_dokploy.parse_dokploy_env_text(
-                str(refreshed_payload.get("env") or "")
-            )
-            for env_key, env_value in target_definition.env.items():
-                refreshed_env_map[env_key] = env_value
-            control_plane_dokploy.update_dokploy_target_env(
-                host=host,
-                token=token,
-                target_type=target_definition.target_type,
-                target_id=target_definition.target_id,
-                target_payload=refreshed_payload,
-                env_text=control_plane_dokploy.serialize_dokploy_env_text(refreshed_env_map),
-            )
-
     payload = _build_live_target_runtime_contract_payload(
         context_name=context_name,
         instance_name=instance_name,
     )
     payload["sync_preview"] = {
-        "apply_changes": apply_changes,
+        "apply_changes": False,
         "source_changes": source_changes,
         "env_changes": env_changes,
     }

--- a/control_plane/cli_runtime_environments.py
+++ b/control_plane/cli_runtime_environments.py
@@ -437,15 +437,11 @@ def environments_logs(
 @environments.command("sync-live-target")
 @click.option("--context", "context_name", required=True)
 @click.option("--instance", "instance_name", required=True)
-@click.option("--apply", "apply_changes", is_flag=True, default=False)
-def environments_sync_live_target(
-    context_name: str, instance_name: str, apply_changes: bool
-) -> None:
+def environments_sync_live_target(context_name: str, instance_name: str) -> None:
     callbacks = _runtime_environment_callbacks()
     payload = callbacks.sync_live_target_from_tracked_contract(
         context_name=context_name,
         instance_name=instance_name,
-        apply_changes=apply_changes,
     )
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -135,8 +135,10 @@ Keep a compatibility surface only when it is one of these:
 - Live target runtime apply uses `POST /v1/live-target-runtime/apply` and the
   `live-target-runtime.yml` workflow for shared and production live changes.
   The local checkout `environments apply-live-target` mutation command is
-  deleted; operators use service/API identity so Launchplane resolves current
-  DB-backed target authority and records sanitized key/count evidence.
+  deleted, and `environments sync-live-target` is demoted to read-only drift
+  preview without a local `--apply` mutation mode. Operators use service/API
+  identity so Launchplane resolves current DB-backed target authority and
+  records sanitized key/count evidence.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -772,9 +772,10 @@ context only, and `context_instance` has both context and instance.
 - `environments show-live-target` reads the live Dokploy target payload for a
   tracked route and reports whether the target is ready for artifact-backed
   split-repo execution.
-- `environments sync-live-target --apply` pushes the tracked Dokploy source and
-  tracked env overlay for a route into the live target before re-reading the
-  artifact-readiness summary.
+- `environments sync-live-target` previews tracked Dokploy source/env drift for
+  a route without mutating the live target. Shared and production live target
+  runtime changes use `POST /v1/live-target-runtime/apply` or the
+  `live-target-runtime.yml` workflow instead of a local checkout command.
 - `ship execute` and `promote execute` can take an explicit `--env-file` overlay
   for the compose post-deploy update path.
 - The post-deploy overlay supports only `ODOO_DB_NAME`, `ODOO_FILESTORE_PATH`,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -1231,7 +1231,7 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
             payload["artifact_runtime_contract"]["mutable_addon_refs"],
         )
 
-    def test_environments_sync_live_target_applies_tracked_source_and_env_contract(self) -> None:
+    def test_environments_sync_live_target_reports_tracked_source_and_env_drift(self) -> None:
         runner = CliRunner()
         source_of_truth = control_plane_dokploy.DokploySourceOfTruth.model_validate(
             {
@@ -1273,8 +1273,8 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
                 "name": "opw-testing",
                 "appName": "compose-opw-testing",
                 "sourceType": "git",
-                "customGitUrl": "git@github.com:cbusillo/odoo-devkit.git",
-                "customGitBranch": "main",
+                "customGitUrl": "git@github.com:cbusillo/odoo-ai.git",
+                "customGitBranch": "opw-testing",
                 "customGitSSHKeyId": "ssh-key-123",
                 "composePath": "./docker-compose.yml",
                 "environmentId": "env-123",
@@ -1283,23 +1283,7 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
                 "watchPaths": [],
                 "env": "ODOO_ADDON_REPOSITORIES=cbusillo/disable_odoo_online@main\n",
             },
-            {
-                "name": "opw-testing",
-                "appName": "compose-opw-testing",
-                "sourceType": "git",
-                "customGitUrl": "git@github.com:cbusillo/odoo-devkit.git",
-                "customGitBranch": "main",
-                "customGitSSHKeyId": "ssh-key-123",
-                "composePath": "./docker-compose.yml",
-                "environmentId": "env-123",
-                "triggerType": "push",
-                "enableSubmodules": False,
-                "watchPaths": [],
-                "env": "ODOO_ADDON_REPOSITORIES=cbusillo/disable_odoo_online@411f6b8e85cac72dc7aa2e2dc5540001043c327d\n",
-            },
         ]
-        captured_source_updates: list[dict[str, object]] = []
-        captured_env_updates: list[dict[str, object]] = []
 
         with (
             patch(
@@ -1314,14 +1298,8 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
                 "control_plane.dokploy.fetch_dokploy_target_payload",
                 side_effect=fetch_payloads,
             ),
-            patch(
-                "control_plane.dokploy.update_dokploy_target_source",
-                side_effect=lambda **kwargs: captured_source_updates.append(kwargs),
-            ),
-            patch(
-                "control_plane.dokploy.update_dokploy_target_env",
-                side_effect=lambda **kwargs: captured_env_updates.append(kwargs),
-            ),
+            patch("control_plane.dokploy.update_dokploy_target_source") as update_target_source,
+            patch("control_plane.dokploy.update_dokploy_target_env") as update_target_env,
         ):
             result = runner.invoke(
                 main,
@@ -1332,25 +1310,43 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
                     "opw",
                     "--instance",
                     "testing",
-                    "--apply",
                 ],
             )
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
-        self.assertEqual(len(captured_source_updates), 1)
-        self.assertEqual(len(captured_env_updates), 1)
-        self.assertIn(
-            "411f6b8e85cac72dc7aa2e2dc5540001043c327d", str(captured_env_updates[0]["env_text"])
-        )
+        update_target_source.assert_not_called()
+        update_target_env.assert_not_called()
         payload = json.loads(result.output)
-        self.assertTrue(payload["artifact_runtime_contract"]["artifact_ready"])
+        self.assertFalse(payload["artifact_runtime_contract"]["artifact_ready"])
         self.assertEqual(
-            payload["live_target"]["custom_git_url"], "git@github.com:cbusillo/odoo-devkit.git"
+            payload["live_target"]["custom_git_url"], "git@github.com:cbusillo/odoo-ai.git"
         )
+        self.assertFalse(payload["sync_preview"]["apply_changes"])
         self.assertEqual(
             payload["sync_preview"]["source_changes"]["custom_git_url"]["tracked"],
             "git@github.com:cbusillo/odoo-devkit.git",
         )
+        self.assertEqual(
+            payload["sync_preview"]["env_changes"]["ODOO_ADDON_REPOSITORIES"]["tracked"],
+            "cbusillo/disable_odoo_online@411f6b8e85cac72dc7aa2e2dc5540001043c327d",
+        )
+
+    def test_environments_sync_live_target_apply_option_is_retired(self) -> None:
+        result = CliRunner().invoke(
+            main,
+            [
+                "environments",
+                "sync-live-target",
+                "--context",
+                "opw",
+                "--instance",
+                "testing",
+                "--apply",
+            ],
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No such option '--apply'", result.output)
 
     def test_read_control_plane_dokploy_source_of_truth_prefers_postgres_target_ids_without_file_fallback(
         self,


### PR DESCRIPTION
# Retire Sync Live Target Apply Mode

## Summary

- retire the local `environments sync-live-target --apply` mutation mode
- keep `environments sync-live-target` as a read-only tracked source/env drift preview
- update tests and docs to point shared/production mutation at the
  `POST /v1/live-target-runtime/apply` service route and workflow

Refs #1322

## Validation

- focused sync-live-target retirement tests
- `uv run python -m unittest tests.test_dokploy`
- `uv run python -m unittest tests.test_runtime_environments`
- `uv run python -m unittest`
- `uv run --extra dev ruff check` on changed Python files
- `uv run --extra dev ruff format --check` on changed Python files
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains changed-files closeout through the route-safe helper
- Review agents: antigravity, claude-sonnet-4.6, code-gpt-5.5 all green;
  merge recommended
