### PR TITLE
Move endpoint apply routes to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -178,6 +178,8 @@ _EVERY_CODE_NOTIFICATION_POLICY_APPLY_ROUTE = "/v1/every-code/notification-polic
 _PREVIEW_PR_FEEDBACK_NOTIFICATION_POLICY_APPLY_ROUTE = (
     "/v1/previews/pr-feedback/notification-policies/apply"
 )
+_EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
+_PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE = "/v1/private-health-endpoints/apply"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 
 
@@ -970,6 +972,52 @@ class PreviewPrFeedbackNotificationPolicyApplyEnvelope(BaseModel):
         return self
 
 
+class EdgeEndpointApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: Literal["dry-run", "apply"] = "dry-run"
+    endpoint: EdgeEndpointRecord
+    reason: str = ""
+    confirmation: str = ""
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "EdgeEndpointApplyEnvelope":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported edge endpoint apply schema version")
+        self.reason = self.reason.strip()
+        self.confirmation = self.confirmation.strip()
+        if self.mode == "apply":
+            if not self.reason:
+                raise ValueError("Edge endpoint apply requires a reason")
+            if self.confirmation != "APPLY LAUNCHPLANE EDGE ENDPOINT":
+                raise ValueError("Edge endpoint apply requires exact confirmation text")
+        return self
+
+
+class PrivateHealthEndpointApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: Literal["dry-run", "apply"] = "dry-run"
+    endpoint: PrivateHealthEndpointRecord
+    reason: str = ""
+    confirmation: str = ""
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "PrivateHealthEndpointApplyEnvelope":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported private health endpoint apply schema version")
+        self.reason = self.reason.strip()
+        self.confirmation = self.confirmation.strip()
+        if self.mode == "apply":
+            if not self.reason:
+                raise ValueError("Private health endpoint apply requires a reason")
+            if self.confirmation != "APPLY LAUNCHPLANE PRIVATE HEALTH ENDPOINT":
+                raise ValueError("Private health endpoint apply requires exact confirmation text")
+        return self
+
+
 class _RecordStoreFactory(Protocol):
     def __call__(self) -> object: ...
 
@@ -1023,6 +1071,24 @@ class _PreviewPrFeedbackNotificationPolicyApplyStore(Protocol):
         self,
         record: PreviewPrFeedbackNotificationPolicyRecord,
     ) -> object: ...
+
+
+class _EdgeEndpointApplyStore(Protocol):
+    def write_edge_endpoint_record(self, record: EdgeEndpointRecord) -> object: ...
+
+    def read_edge_endpoint_record(self, endpoint_key: str) -> EdgeEndpointRecord: ...
+
+
+class _PrivateHealthEndpointApplyStore(Protocol):
+    def write_private_health_endpoint_record(
+        self,
+        record: PrivateHealthEndpointRecord,
+    ) -> object: ...
+
+    def read_private_health_endpoint_record(
+        self,
+        endpoint_key: str,
+    ) -> PrivateHealthEndpointRecord: ...
 
 
 class PublicIngressMonitorRunOnceRequest(BaseModel):
@@ -1682,6 +1748,45 @@ def require_private_health_endpoint_read_store(
             f"{missing_summary}"
         )
     return cast(_PrivateHealthEndpointReadStore, record_store)
+
+
+def require_edge_endpoint_apply_store(record_store: object) -> _EdgeEndpointApplyStore:
+    required_methods = (
+        "write_edge_endpoint_record",
+        "read_edge_endpoint_record",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            f"Launchplane record store does not support edge endpoint applies: {missing_summary}"
+        )
+    return cast(_EdgeEndpointApplyStore, record_store)
+
+
+def require_private_health_endpoint_apply_store(
+    record_store: object,
+) -> _PrivateHealthEndpointApplyStore:
+    required_methods = (
+        "write_private_health_endpoint_record",
+        "read_private_health_endpoint_record",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support private health endpoint applies: "
+            f"{missing_summary}"
+        )
+    return cast(_PrivateHealthEndpointApplyStore, record_store)
 
 
 def require_ingress_canary_route_read_store(
@@ -4944,6 +5049,251 @@ def create_launchplane_fastapi_app(
             )
         )
 
+    async def replay_endpoint_apply_idempotency(
+        *,
+        request: Request,
+        record_store: object,
+        identity: LaunchplaneIdentity,
+        route_path: str,
+        idempotency_key: str,
+        trace_id: str,
+        check_replay: bool,
+    ) -> tuple[str, str, AcceptedEvidenceResponse | None]:
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_scope = idempotency_scope(identity)
+        raw_payload = await request.json()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        idempotency_store = idempotency_capable_store(record_store)
+        if idempotency_store is not None and normalized_idempotency_key and check_replay:
+            stored_record = idempotency_store.read_idempotency_record(
+                scope=normalized_scope,
+                route_path=route_path,
+                idempotency_key=normalized_idempotency_key,
+            )
+            if stored_record is not None:
+                if stored_record.request_fingerprint != payload_fingerprint:
+                    raise _launchplane_http_error(
+                        status_code=409,
+                        trace_id=trace_id,
+                        code="idempotency_key_reused",
+                        message=(
+                            "Idempotency-Key was already used for a different "
+                            "Launchplane request payload on this route."
+                        ),
+                    )
+                return (
+                    normalized_idempotency_key,
+                    payload_fingerprint,
+                    replay_idempotent_response(
+                        trace_id=trace_id,
+                        stored_record=stored_record,
+                    ),
+                )
+        return normalized_idempotency_key, payload_fingerprint, None
+
+    def store_endpoint_apply_idempotency(
+        *,
+        record_store: object,
+        identity: LaunchplaneIdentity,
+        route_path: str,
+        idempotency_key: str,
+        request_fingerprint_value: str,
+        trace_id: str,
+        response: AcceptedEvidenceResponse,
+    ) -> None:
+        idempotency_store = idempotency_capable_store(record_store)
+        if idempotency_store is None or not idempotency_key:
+            return
+        idempotency_store.write_idempotency_record(
+            LaunchplaneIdempotencyRecord(
+                record_id=build_launchplane_idempotency_record_id(response_trace_id=trace_id),
+                scope=idempotency_scope(identity),
+                route_path=route_path,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint_value,
+                response_status_code=202,
+                response_trace_id=trace_id,
+                recorded_at=utc_now_timestamp(),
+                response_payload=response.model_dump(mode="json", exclude_none=True),
+            )
+        )
+
+    async def apply_edge_endpoint(
+        request: Request,
+        endpoint_request: EdgeEndpointApplyEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="edge_endpoint.apply",
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot apply Launchplane edge endpoint records.",
+            )
+        if endpoint_request.mode == "apply" and not idempotency_key.strip():
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Edge endpoint apply requests require an Idempotency-Key header.",
+            )
+        (
+            normalized_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_endpoint_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_EDGE_ENDPOINT_APPLY_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=endpoint_request.mode == "apply",
+        )
+        if replayed_response is not None:
+            return replayed_response
+        try:
+            endpoint_store = require_edge_endpoint_apply_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        endpoint_status = "applied" if endpoint_request.mode == "apply" else "planned"
+        if endpoint_request.mode == "apply":
+            endpoint_store.write_edge_endpoint_record(endpoint_request.endpoint)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "edge_endpoint_key": endpoint_request.endpoint.endpoint_key,
+                "edge_endpoint_status": endpoint_status,
+            },
+            result={
+                "mode": endpoint_request.mode,
+                "endpoint_key": endpoint_request.endpoint.endpoint_key,
+                "endpoint_status": endpoint_status,
+                "record": endpoint_request.endpoint.model_dump(mode="json"),
+            },
+        )
+        store_endpoint_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_EDGE_ENDPOINT_APPLY_ROUTE,
+            idempotency_key=normalized_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
+    async def apply_private_health_endpoint(
+        request: Request,
+        endpoint_request: PrivateHealthEndpointApplyEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="private_health_endpoint.apply",
+            product=endpoint_request.endpoint.product,
+            context=endpoint_request.endpoint.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot apply private health endpoint records "
+                    "for the requested product/context."
+                ),
+            )
+        if endpoint_request.mode == "apply" and not idempotency_key.strip():
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Private health endpoint apply requests require an Idempotency-Key header.",
+            )
+        (
+            normalized_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_endpoint_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=endpoint_request.mode == "apply",
+        )
+        if replayed_response is not None:
+            return replayed_response
+        try:
+            endpoint_store = require_private_health_endpoint_apply_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        try:
+            existing_endpoint = endpoint_store.read_private_health_endpoint_record(
+                endpoint_request.endpoint.endpoint_key
+            )
+        except FileNotFoundError:
+            existing_endpoint = None
+        if existing_endpoint is not None and (
+            existing_endpoint.product != endpoint_request.endpoint.product
+            or existing_endpoint.context != endpoint_request.endpoint.context
+            or existing_endpoint.instance != endpoint_request.endpoint.instance
+        ):
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="conflicting_private_health_endpoint",
+                message=(
+                    "Private health endpoint key already belongs to another "
+                    "product/context/instance."
+                ),
+            )
+        endpoint_status = "applied" if endpoint_request.mode == "apply" else "planned"
+        if endpoint_request.mode == "apply":
+            endpoint_store.write_private_health_endpoint_record(endpoint_request.endpoint)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={},
+            result={
+                "mode": endpoint_request.mode,
+                "endpoint_key": endpoint_request.endpoint.endpoint_key,
+                "endpoint_status": endpoint_status,
+                "record": endpoint_request.endpoint.model_dump(mode="json"),
+            },
+        )
+        store_endpoint_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE,
+            idempotency_key=normalized_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
     async def apply_public_ingress_notification_policy(
         request: Request,
         policy_request: PublicIngressNotificationPolicyApplyEnvelope,
@@ -6147,6 +6497,40 @@ def create_launchplane_fastapi_app(
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _EDGE_ENDPOINT_APPLY_ROUTE,
+        apply_edge_endpoint,
+        methods=["POST"],
+        response_model=AcceptedEvidenceResponse,
+        status_code=202,
+        operation_id="apply_edge_endpoint",
+        summary="Plan or apply one Launchplane edge endpoint record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE,
+        apply_private_health_endpoint,
+        methods=["POST"],
+        response_model=AcceptedEvidenceResponse,
+        status_code=202,
+        operation_id="apply_private_health_endpoint",
+        summary="Plan or apply one private health endpoint record",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -50,7 +50,6 @@ from control_plane.contracts.deploy_target import DeployedTargetReference
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
-from control_plane.contracts.private_health_endpoint_record import PrivateHealthEndpointRecord
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
@@ -521,8 +520,6 @@ _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
 _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
 _NPMPLUS_INGRESS_APPLY_ROUTE_PATH = "/v1/drivers/ingress/route-apply"
-_EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
-_PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE = "/v1/private-health-endpoints/apply"
 _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE = "/v1/ingress/canary-routes/records/apply"
 _INGRESS_CANARY_ROUTE_APPLY_ROUTE = "/v1/ingress/canary-routes/apply"
 _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/controller/run-once"
@@ -794,19 +791,7 @@ class _OdooStableTargetReplacementOperationStore(Protocol):
 
 
 class _EdgeEndpointRecordStore(Protocol):
-    def write_edge_endpoint_record(self, record: EdgeEndpointRecord) -> object: ...
-
     def read_edge_endpoint_record(self, endpoint_key: str) -> EdgeEndpointRecord: ...
-
-
-class _PrivateHealthEndpointRecordStore(Protocol):
-    def write_private_health_endpoint_record(
-        self, record: PrivateHealthEndpointRecord
-    ) -> object: ...
-
-    def read_private_health_endpoint_record(
-        self, endpoint_key: str
-    ) -> PrivateHealthEndpointRecord: ...
 
 
 class _IngressCanaryRouteRecordStore(Protocol):
@@ -1141,52 +1126,6 @@ _NPMPLUS_INGRESS_APPLY_ROUTE = _DriverRouteExecutionMetadata(
         "Workflow cannot plan or apply the ingress route for the requested product/context."
     ),
 )
-
-
-class EdgeEndpointApplyEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    mode: Literal["dry-run", "apply"] = "dry-run"
-    endpoint: EdgeEndpointRecord
-    reason: str = ""
-    confirmation: str = ""
-
-    @model_validator(mode="after")
-    def _validate_envelope(self) -> "EdgeEndpointApplyEnvelope":
-        if self.schema_version != 1:
-            raise ValueError("Unsupported edge endpoint apply schema version")
-        self.reason = self.reason.strip()
-        self.confirmation = self.confirmation.strip()
-        if self.mode == "apply":
-            if not self.reason:
-                raise ValueError("Edge endpoint apply requires a reason")
-            if self.confirmation != "APPLY LAUNCHPLANE EDGE ENDPOINT":
-                raise ValueError("Edge endpoint apply requires exact confirmation text")
-        return self
-
-
-class PrivateHealthEndpointApplyEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    mode: Literal["dry-run", "apply"] = "dry-run"
-    endpoint: PrivateHealthEndpointRecord
-    reason: str = ""
-    confirmation: str = ""
-
-    @model_validator(mode="after")
-    def _validate_envelope(self) -> "PrivateHealthEndpointApplyEnvelope":
-        if self.schema_version != 1:
-            raise ValueError("Unsupported private health endpoint apply schema version")
-        self.reason = self.reason.strip()
-        self.confirmation = self.confirmation.strip()
-        if self.mode == "apply":
-            if not self.reason:
-                raise ValueError("Private health endpoint apply requires a reason")
-            if self.confirmation != "APPLY LAUNCHPLANE PRIVATE HEALTH ENDPOINT":
-                raise ValueError("Private health endpoint apply requires exact confirmation text")
-        return self
 
 
 class IngressCanaryRouteRecordApplyEnvelope(BaseModel):
@@ -4448,8 +4387,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/product-onboarding/apply",
         "/v1/dokploy-targets/setup",
         PROVIDER_TARGET_OPERATIONS_ROUTE,
-        _EDGE_ENDPOINT_APPLY_ROUTE,
-        _PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE,
         _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE,
         _INGRESS_CANARY_ROUTE_APPLY_ROUTE,
         "/v1/product-config/apply",
@@ -6595,8 +6532,6 @@ def _accepted_payload_extra_record_keys(*, route_path: str) -> frozenset[str]:
         return frozenset({"ingress_provider"})
     if route_path == _INGRESS_CANARY_ROUTE_APPLY_ROUTE:
         return frozenset({"ingress_provider"})
-    if route_path == _EDGE_ENDPOINT_APPLY_ROUTE:
-        return frozenset({"edge_endpoint_status"})
     if route_path == _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE:
         return frozenset({"ingress_canary_route_status"})
     return frozenset()
@@ -6675,27 +6610,10 @@ def _odoo_stable_target_replacement_operation_store(
 
 
 def _edge_endpoint_record_store(record_store: object) -> _EdgeEndpointRecordStore:
-    required_methods = (
-        "write_edge_endpoint_record",
-        "read_edge_endpoint_record",
-    )
+    required_methods = ("read_edge_endpoint_record",)
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_EdgeEndpointRecordStore, record_store)
     raise click.ClickException("Edge endpoint operations require Launchplane record storage.")
-
-
-def _private_health_endpoint_record_store(
-    record_store: object,
-) -> _PrivateHealthEndpointRecordStore:
-    required_methods = (
-        "write_private_health_endpoint_record",
-        "read_private_health_endpoint_record",
-    )
-    if all(hasattr(record_store, method_name) for method_name in required_methods):
-        return cast(_PrivateHealthEndpointRecordStore, record_store)
-    raise click.ClickException(
-        "Private health endpoint operations require Launchplane record storage."
-    )
 
 
 def _ingress_canary_route_record_store(
@@ -7743,68 +7661,6 @@ def _write_ingress_route_audit_record(
     )
     write_record(record)
     return record
-
-
-def _edge_endpoint_apply_result(
-    *,
-    record_store: object,
-    request: EdgeEndpointApplyEnvelope,
-) -> tuple[dict[str, object], dict[str, object]]:
-    endpoint_store = _edge_endpoint_record_store(record_store)
-    if request.mode == "apply":
-        endpoint_store.write_edge_endpoint_record(request.endpoint)
-        status = "applied"
-    else:
-        status = "planned"
-    return {
-        "edge_endpoint_key": request.endpoint.endpoint_key,
-        "edge_endpoint_status": status,
-        "mode": request.mode,
-        "reason": request.reason,
-    }, {
-        "mode": request.mode,
-        "endpoint_key": request.endpoint.endpoint_key,
-        "endpoint_status": status,
-        "record": request.endpoint.model_dump(mode="json"),
-    }
-
-
-def _private_health_endpoint_apply_result(
-    *,
-    record_store: object,
-    request: PrivateHealthEndpointApplyEnvelope,
-) -> tuple[dict[str, object], dict[str, object]]:
-    endpoint_store = _private_health_endpoint_record_store(record_store)
-    try:
-        existing_endpoint = endpoint_store.read_private_health_endpoint_record(
-            request.endpoint.endpoint_key
-        )
-    except FileNotFoundError:
-        existing_endpoint = None
-    if existing_endpoint is not None and (
-        existing_endpoint.product != request.endpoint.product
-        or existing_endpoint.context != request.endpoint.context
-        or existing_endpoint.instance != request.endpoint.instance
-    ):
-        raise ValueError(
-            "Private health endpoint key already belongs to another product/context/instance."
-        )
-    if request.mode == "apply":
-        endpoint_store.write_private_health_endpoint_record(request.endpoint)
-        status = "applied"
-    else:
-        status = "planned"
-    return {
-        "private_health_endpoint_key": request.endpoint.endpoint_key,
-        "private_health_endpoint_status": status,
-        "mode": request.mode,
-        "reason": request.reason,
-    }, {
-        "mode": request.mode,
-        "endpoint_key": request.endpoint.endpoint_key,
-        "endpoint_status": status,
-        "record": request.endpoint.model_dump(mode="json"),
-    }
 
 
 def _ingress_canary_route_record_apply_result(
@@ -12579,126 +12435,6 @@ def create_launchplane_service_app(
                 assert isinstance(provider_target_result, ProviderTargetOperationRouteResult)
                 result = provider_target_result.result
                 driver_result = provider_target_result.driver_result
-            elif path == _EDGE_ENDPOINT_APPLY_ROUTE:
-                edge_endpoint_request = EdgeEndpointApplyEnvelope.model_validate(payload)
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="edge_endpoint.apply",
-                    product="launchplane",
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot apply Launchplane edge endpoint records.",
-                            },
-                        },
-                    )
-                if edge_endpoint_request.mode == "apply":
-                    if not request_idempotency_key:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=400,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "idempotency_key_required",
-                                    "message": "Edge endpoint apply requests require an Idempotency-Key header.",
-                                },
-                            },
-                        )
-                    idempotent_response = _check_idempotent_request(
-                        record_store=record_store,
-                        scope=request_scope,
-                        route_path=path,
-                        idempotency_key=request_idempotency_key,
-                        request_fingerprint=request_fingerprint,
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                    )
-                    if idempotent_response is not None:
-                        return idempotent_response
-                result, driver_result = _edge_endpoint_apply_result(
-                    record_store=record_store,
-                    request=edge_endpoint_request,
-                )
-            elif path == _PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE:
-                private_endpoint_request = PrivateHealthEndpointApplyEnvelope.model_validate(
-                    payload
-                )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="private_health_endpoint.apply",
-                    product=private_endpoint_request.endpoint.product,
-                    context=private_endpoint_request.endpoint.context,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": (
-                                    "Workflow cannot apply private health endpoint records "
-                                    "for the requested product/context."
-                                ),
-                            },
-                        },
-                    )
-                if private_endpoint_request.mode == "apply":
-                    if not request_idempotency_key:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=400,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "idempotency_key_required",
-                                    "message": (
-                                        "Private health endpoint apply requests require "
-                                        "an Idempotency-Key header."
-                                    ),
-                                },
-                            },
-                        )
-                    idempotent_response = _check_idempotent_request(
-                        record_store=record_store,
-                        scope=request_scope,
-                        route_path=path,
-                        idempotency_key=request_idempotency_key,
-                        request_fingerprint=request_fingerprint,
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                    )
-                    if idempotent_response is not None:
-                        return idempotent_response
-                try:
-                    result, driver_result = _private_health_endpoint_apply_result(
-                        record_store=record_store,
-                        request=private_endpoint_request,
-                    )
-                except ValueError as error:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=409,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "conflicting_private_health_endpoint",
-                                "message": str(error),
-                            },
-                        },
-                    )
             elif path == _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE:
                 canary_record_request = IngressCanaryRouteRecordApplyEnvelope.model_validate(
                     payload

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -70,13 +70,15 @@ Keep a compatibility surface only when it is one of these:
   remains for retained non-native routes.
 - Edge endpoint record reads use native FastAPI `GET /v1/edge-endpoints/records`
   and `GET /v1/edge-endpoints/records/{endpoint_key}` routes. Their legacy WSGI
-  read branch is deleted; edge endpoint apply remains on the retained fallback
-  until that write path has its own native replacement.
+  read branch is deleted. Edge endpoint apply uses native FastAPI
+  `POST /v1/edge-endpoints/apply`; its legacy WSGI write branch is deleted, and
+  direct fallback calls fail closed.
 - Private health endpoint record reads use native FastAPI
   `GET /v1/private-health-endpoints/records` and
   `GET /v1/private-health-endpoints/records/{endpoint_key}` routes. Their
-  legacy WSGI read branch is deleted; private health endpoint apply remains on
-  the retained fallback until that write path has its own native replacement.
+  legacy WSGI read branch is deleted. Private health endpoint apply uses native
+  FastAPI `POST /v1/private-health-endpoints/apply`; its legacy WSGI write
+  branch is deleted, and direct fallback calls fail closed.
 - Ingress canary route record reads use native FastAPI
   `GET /v1/ingress/canary-routes/records` and
   `GET /v1/ingress/canary-routes/records/{canary_key}` routes. Their legacy

--- a/docs/records.md
+++ b/docs/records.md
@@ -212,8 +212,11 @@ an ORM column/table or remains only in the evidence payload.
   authority for a lane: `endpoint_key`, `product`, `context`, `instance`,
   `url`, `status`, `updated_at`, and payload-only provenance such as
   `source_label`. The service applies them through
-  `POST /v1/private-health-endpoints/apply` with product/context-scoped
-  `private_health_endpoint.apply` authorization, and reads them through
+  native FastAPI `POST /v1/private-health-endpoints/apply` with
+  product/context-scoped `private_health_endpoint.apply` authorization, exact
+  apply-mode confirmation, retry-safe idempotency for mutations, private URL
+  validation, and cross-scope endpoint-key conflict protection. The service
+  reads them through
   `GET /v1/private-health-endpoints/records` with
   `private_health_endpoint.read`. The stored URL must be private/internal;
   product profiles reference it by `private_endpoint_key` and do not own the
@@ -268,8 +271,11 @@ an ORM column/table or remains only in the evidence payload.
   `updated_at`. `endpoint_key` and `server_name` are human-facing operator
   identity. `upstream_host` is the provider data-plane value and must be an IP
   address for NPMplus-backed routes so a bad hostname cannot become a runtime
-  Nginx startup dependency. Product repositories must not own provider topology,
-  edge IPs, NPMplus host ids, or Dokploy server routing facts.
+  Nginx startup dependency. Native FastAPI `POST /v1/edge-endpoints/apply`
+  writes this Launchplane-owned authority with `edge_endpoint.apply`, exact
+  apply-mode confirmation, and retry-safe idempotency for mutations. Product
+  repositories must not own provider topology, edge IPs, NPMplus host ids, or
+  Dokploy server routing facts.
 - Ingress canary route: modeled fields are `canary_key`, `product`, `context`,
   `domain_name`, `expected_host_id`, `edge_endpoint_key`, `certificate_id`,
   `status`, and `updated_at`. The record is Launchplane-owned route authority

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1074,6 +1074,27 @@ delivered or failed attempts under
 `launchplane_preview_pr_feedback_notification_attempts`; operators can read
 those attempts with `GET /v1/previews/pr-feedback/notification-attempts`.
 
+Edge endpoint writes use `POST /v1/edge-endpoints/apply`. The request carries
+`mode: "dry-run"` or `mode: "apply"`, a complete `EdgeEndpointRecord`, a reason,
+and exact confirmation text for apply mode. The route is native FastAPI and its
+legacy WSGI fallback branch is deleted. Apply authorizes with
+`edge_endpoint.apply` against product/context `launchplane`/`launchplane`,
+requires an `Idempotency-Key` header before mutation, and continues to support
+Launchplane record stores that implement the edge endpoint read/write methods.
+Dry-runs plan the accepted response without writing the record.
+
+Private health endpoint writes use `POST /v1/private-health-endpoints/apply`.
+The request carries `mode: "dry-run"` or `mode: "apply"`, a complete
+`PrivateHealthEndpointRecord`, a reason, and exact confirmation text for apply
+mode. The route is native FastAPI and its legacy WSGI fallback branch is
+deleted. Apply authorizes with `private_health_endpoint.apply` against the
+request endpoint's product/context, requires an `Idempotency-Key` header before
+mutation, rejects public URLs through the private endpoint contract validator,
+and rejects cross-product/context/instance overwrites for an existing endpoint
+key. The accepted response preserves the legacy private-health apply envelope:
+the endpoint key/status remain in `result`, while `records` stays empty for
+compatibility with existing replays.
+
 Product config writes use `POST /v1/product-config/apply`. The request carries
 `mode: "dry-run"` or `mode: "apply"`, product/context/instance, non-secret
 runtime values, and write-only managed secret values. Dry-run requires the
@@ -1452,8 +1473,10 @@ against the requested query product/context before storage access, require those
 scope query parameters for list and single-record reads, preserve optional
 `status`, `mode`, `provider_host_id`, `trace_id`, `idempotency_key`, and `limit`
 list filters, and return `404 not_found` when a record exists outside the
-requested scope. Their legacy WSGI branches are deleted; direct fallback calls
-fail closed while the mounted fallback remains for retained non-native routes.
+requested scope. Endpoint apply routes use native FastAPI write handlers with
+the apply contracts above. Their legacy WSGI branches are deleted; direct
+fallback calls fail closed while the mounted fallback remains for retained
+non-native routes.
 
 Product/site reads use action `product_environment.read`. They are native
 FastAPI routes backed by DB-owned product environment read-model composition.

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -112,6 +112,7 @@ from control_plane.workflows.public_ingress_monitor import (
 from tests.test_service import create_launchplane_service_app
 from tests.test_service import (
     _generic_site_profile_payload,
+    _edge_endpoint_apply_payload,
     _edge_endpoint_record,
     _identity,
     _ingress_canary_route_record,
@@ -121,6 +122,7 @@ from tests.test_service import (
     _merge_train_service_identity,
     _merge_train_service_policy,
     _private_health_endpoint_record,
+    _private_health_endpoint_apply_payload,
     _product_profile_payload,
     _product_profile_payload_with_prod,
     _seed_merge_train_policy,
@@ -6359,6 +6361,497 @@ class FastApiPrivateHealthEndpointReadTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["status"], "ok")
+
+
+class FastApiEndpointApplyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_edge_endpoint_apply_writes_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="edge_endpoint.apply",
+                    product="launchplane",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/edge-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "edge-endpoint-apply-test",
+                },
+                payload=_edge_endpoint_apply_payload(mode="apply"),
+            )
+            stored_record = store.read_edge_endpoint_record("cm-prod-dokploy")
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"]["edge_endpoint_key"], "cm-prod-dokploy")
+        self.assertEqual(payload["records"]["edge_endpoint_status"], "applied")
+        self.assertEqual(payload["result"]["mode"], "apply")
+        self.assertEqual(payload["result"]["endpoint_status"], "applied")
+        self.assertEqual(stored_record.server_name, "docker-cm-prod")
+
+    async def test_edge_endpoint_dry_run_does_not_write_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="edge_endpoint.apply",
+                    product="launchplane",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/edge-endpoints/apply",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=_edge_endpoint_apply_payload(mode="dry-run"),
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["records"]["edge_endpoint_status"], "planned")
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        with self.assertRaises(FileNotFoundError):
+            store.read_edge_endpoint_record("cm-prod-dokploy")
+
+    async def test_edge_endpoint_apply_requires_idempotency_key_before_store_gate(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_notification_policy_apply_policy(
+                action="edge_endpoint.apply",
+                product="launchplane",
+                context="launchplane",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/edge-endpoints/apply",
+            headers={"Authorization": "Bearer valid-token"},
+            payload=_edge_endpoint_apply_payload(mode="apply"),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "idempotency_key_required")
+
+    async def test_edge_endpoint_apply_replays_and_rejects_conflicting_idempotency_key(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="edge_endpoint.apply",
+                    product="launchplane",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+            payload = _edge_endpoint_apply_payload(mode="apply")
+            conflicting_payload = _edge_endpoint_apply_payload(mode="apply")
+            endpoint = cast(dict[str, object], conflicting_payload["endpoint"])
+            endpoint["upstream_port"] = 8443
+
+            first_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/edge-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "edge-endpoint-replay-test",
+                },
+                payload=payload,
+            )
+            replay_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/edge-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "edge-endpoint-replay-test",
+                },
+                payload=payload,
+            )
+            conflict_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/edge-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "edge-endpoint-replay-test",
+                },
+                payload=conflicting_payload,
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        first_payload = first_response.json()
+        replay_payload = replay_response.json()
+        self.assertTrue(replay_payload["replayed"])
+        self.assertEqual(replay_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(replay_payload["records"], first_payload["records"])
+        self.assertEqual(conflict_response.status_code, 409)
+        self.assertEqual(conflict_response.json()["error"]["code"], "idempotency_key_reused")
+
+    async def test_private_health_endpoint_apply_writes_record_with_legacy_records_shape(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="private_health_endpoint.apply",
+                    product="repairshopr-sync",
+                    context="repairshopr-sync",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "private-health-endpoint-apply-test",
+                },
+                payload=_private_health_endpoint_apply_payload(mode="apply"),
+            )
+            stored_record = store.read_private_health_endpoint_record(
+                "repairshopr-sync-prod-runtime"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["records"], {})
+        self.assertEqual(payload["result"]["endpoint_key"], "repairshopr-sync-prod-runtime")
+        self.assertEqual(payload["result"]["endpoint_status"], "applied")
+        self.assertEqual(stored_record.url, "http://10.0.0.5:8000/health")
+
+    async def test_private_health_endpoint_dry_run_does_not_write_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="private_health_endpoint.apply",
+                    product="repairshopr-sync",
+                    context="repairshopr-sync",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=_private_health_endpoint_apply_payload(mode="dry-run"),
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["records"], {})
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertEqual(payload["result"]["endpoint_status"], "planned")
+        with self.assertRaises(FileNotFoundError):
+            store.read_private_health_endpoint_record("repairshopr-sync-prod-runtime")
+
+    async def test_private_health_endpoint_apply_requires_idempotency_key_before_store_gate(
+        self,
+    ) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_notification_policy_apply_policy(
+                action="private_health_endpoint.apply",
+                product="repairshopr-sync",
+                context="repairshopr-sync",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/private-health-endpoints/apply",
+            headers={"Authorization": "Bearer valid-token"},
+            payload=_private_health_endpoint_apply_payload(mode="apply"),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "idempotency_key_required")
+
+    async def test_private_health_endpoint_apply_rejects_public_url(self) -> None:
+        payload = _private_health_endpoint_apply_payload(mode="apply")
+        endpoint = cast(dict[str, object], payload["endpoint"])
+        endpoint["url"] = "https://repairshopr-sync.example.test/health"
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="private_health_endpoint.apply",
+                    product="repairshopr-sync",
+                    context="repairshopr-sync",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "private-health-public-url-test",
+                },
+                payload=payload,
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    async def test_private_health_endpoint_apply_rejects_cross_scope_overwrite(self) -> None:
+        existing_record = _private_health_endpoint_record().model_copy(
+            update={
+                "endpoint_key": "shared-runtime",
+                "product": "other-product",
+                "context": "other-product",
+            }
+        )
+        payload = _private_health_endpoint_apply_payload(mode="apply")
+        endpoint = cast(dict[str, object], payload["endpoint"])
+        endpoint["endpoint_key"] = "shared-runtime"
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            store.write_private_health_endpoint_record(existing_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="private_health_endpoint.apply",
+                    product="repairshopr-sync",
+                    context="repairshopr-sync",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "private-health-cross-scope-test",
+                },
+                payload=payload,
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "conflicting_private_health_endpoint")
+
+    async def test_private_health_endpoint_apply_replays_and_rejects_conflicting_idempotency_key(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="private_health_endpoint.apply",
+                    product="repairshopr-sync",
+                    context="repairshopr-sync",
+                ),
+                record_store_factory=lambda: store,
+            )
+            payload = _private_health_endpoint_apply_payload(mode="apply")
+            conflicting_payload = _private_health_endpoint_apply_payload(mode="apply")
+            endpoint = cast(dict[str, object], conflicting_payload["endpoint"])
+            endpoint["url"] = "http://10.0.0.6:8000/health"
+
+            first_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "private-health-replay-test",
+                },
+                payload=payload,
+            )
+            replay_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "private-health-replay-test",
+                },
+                payload=payload,
+            )
+            conflict_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "private-health-replay-test",
+                },
+                payload=conflicting_payload,
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        first_payload = first_response.json()
+        replay_payload = replay_response.json()
+        self.assertTrue(replay_payload["replayed"])
+        self.assertEqual(replay_payload["original_trace_id"], first_payload["trace_id"])
+        self.assertEqual(replay_payload["result"], first_payload["result"])
+        self.assertEqual(conflict_response.status_code, 409)
+        self.assertEqual(conflict_response.json()["error"]["code"], "idempotency_key_reused")
+
+    async def test_endpoint_apply_routes_require_exact_authz_scope(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            edge_app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="edge_endpoint.apply",
+                    product="repairshopr-sync",
+                    context="repairshopr-sync",
+                ),
+                record_store_factory=lambda: store,
+            )
+            private_app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="private_health_endpoint.apply",
+                    product="launchplane",
+                    context="launchplane",
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            edge_response = await _asgi_request(
+                edge_app,
+                "POST",
+                "/v1/edge-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "edge-authz-test",
+                },
+                payload=_edge_endpoint_apply_payload(mode="apply"),
+            )
+            private_response = await _asgi_request(
+                private_app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Idempotency-Key": "private-health-authz-test",
+                },
+                payload=_private_health_endpoint_apply_payload(mode="apply"),
+            )
+
+        self.assertEqual(edge_response.status_code, 403)
+        self.assertEqual(private_response.status_code, 403)
+        self.assertEqual(edge_response.json()["error"]["code"], "authorization_denied")
+        self.assertEqual(private_response.json()["error"]["code"], "authorization_denied")
+
+    async def test_endpoint_apply_routes_precede_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "every/verireel",
+                                "workflow_refs": [
+                                    "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                                ],
+                                "event_names": ["pull_request"],
+                                "products": ["launchplane", "repairshopr-sync"],
+                                "contexts": ["launchplane", "repairshopr-sync"],
+                                "actions": [
+                                    "edge_endpoint.apply",
+                                    "private_health_endpoint.apply",
+                                ],
+                            }
+                        ]
+                    }
+                ),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+                local_record_store_for_tests=store,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            edge_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/edge-endpoints/apply",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=_edge_endpoint_apply_payload(mode="dry-run"),
+            )
+            private_response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/private-health-endpoints/apply",
+                headers={"Authorization": "Bearer valid-token"},
+                payload=_private_health_endpoint_apply_payload(mode="dry-run"),
+            )
+
+        self.assertEqual(edge_response.status_code, 202)
+        self.assertEqual(private_response.status_code, 202)
+        self.assertEqual(edge_response.json()["result"]["mode"], "dry-run")
+        self.assertEqual(private_response.json()["result"]["mode"], "dry-run")
+
+    async def test_openapi_includes_endpoint_apply_routes(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        edge_route = openapi["paths"]["/v1/edge-endpoints/apply"]["post"]
+        private_route = openapi["paths"]["/v1/private-health-endpoints/apply"]["post"]
+        self.assertEqual(edge_route["operationId"], "apply_edge_endpoint")
+        self.assertEqual(private_route["operationId"], "apply_private_health_endpoint")
+        self.assertEqual(
+            edge_route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        self.assertEqual(
+            private_route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
 
 
 class FastApiIngressCanaryRouteReadTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2386,228 +2386,27 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(records[0].trace_id, payload["trace_id"])
 
-    def test_edge_endpoint_apply_route_stores_db_backed_upstream(self) -> None:
-        policy = _local_operator_policy(
-            actions=("edge_endpoint.apply",),
-            products=("launchplane",),
-            contexts=("launchplane",),
-        )
-        endpoint_payload = _edge_endpoint_apply_payload(mode="apply")
+    def test_endpoint_apply_legacy_wsgi_fallback_is_removed(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            record_store = FilesystemRecordStore(root / "state")
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=root / "state",
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=record_store,
-                )
-                apply_status_code, apply_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/edge-endpoints/apply",
-                    payload=endpoint_payload,
-                    authorization="Bearer local-operator-token",
-                    headers={"Idempotency-Key": "edge-endpoint-apply"},
-                )
-                stored_record = record_store.read_edge_endpoint_record("cm-prod-dokploy")
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
 
-        self.assertEqual(apply_status_code, 202)
-        self.assertEqual(apply_payload["records"]["edge_endpoint_key"], "cm-prod-dokploy")
-        self.assertEqual(apply_payload["records"]["edge_endpoint_status"], "applied")
-        self.assertEqual(stored_record.server_name, "docker-cm-prod")
-        self.assertEqual(stored_record.upstream_host, "100.73.170.113")
+            responses = tuple(
+                _invoke_app(app, method=method, path=path, payload={"schema_version": 1})
+                for method in ("GET", "POST")
+                for path in (
+                    "/v1/edge-endpoints/apply",
+                    "/v1/private-health-endpoints/apply",
+                )
+            )
 
-    def test_edge_endpoint_dry_run_does_not_store_upstream(self) -> None:
-        policy = _local_operator_policy(
-            actions=("edge_endpoint.apply",),
-            products=("launchplane",),
-            contexts=("launchplane",),
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            record_store = FilesystemRecordStore(root / "state")
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=root / "state",
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=record_store,
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/edge-endpoints/apply",
-                    payload=_edge_endpoint_apply_payload(mode="dry-run"),
-                    authorization="Bearer local-operator-token",
-                )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["records"]["edge_endpoint_status"], "planned")
-        self.assertEqual(payload["result"]["mode"], "dry-run")
-        self.assertEqual(payload["result"]["endpoint_key"], "cm-prod-dokploy")
-        with self.assertRaises(FileNotFoundError):
-            record_store.read_edge_endpoint_record("cm-prod-dokploy")
-
-    def test_private_health_endpoint_apply_route_stores_db_backed_url(
-        self,
-    ) -> None:
-        policy = _local_operator_policy(
-            actions=("private_health_endpoint.apply",),
-            products=("repairshopr-sync",),
-            contexts=("repairshopr-sync",),
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            record_store = FilesystemRecordStore(root / "state")
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=root / "state",
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=record_store,
-                )
-                apply_status_code, apply_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/private-health-endpoints/apply",
-                    payload=_private_health_endpoint_apply_payload(mode="apply"),
-                    authorization="Bearer local-operator-token",
-                    headers={"Idempotency-Key": "private-health-endpoint-apply"},
-                )
-                stored_record = record_store.read_private_health_endpoint_record(
-                    "repairshopr-sync-prod-runtime"
-                )
-
-        self.assertEqual(apply_status_code, 202)
-        self.assertEqual(
-            apply_payload["result"]["endpoint_key"],
-            "repairshopr-sync-prod-runtime",
-        )
-        self.assertEqual(
-            apply_payload["result"]["endpoint_status"],
-            "applied",
-        )
-        self.assertEqual(stored_record.product, "repairshopr-sync")
-        self.assertEqual(stored_record.url, "http://10.0.0.5:8000/health")
-
-    def test_private_health_endpoint_apply_rejects_public_url(self) -> None:
-        policy = _local_operator_policy(
-            actions=("private_health_endpoint.apply",),
-            products=("repairshopr-sync",),
-            contexts=("repairshopr-sync",),
-        )
-        payload = _private_health_endpoint_apply_payload(mode="apply")
-        endpoint = cast(dict[str, object], payload["endpoint"])
-        endpoint["url"] = "https://repairshopr-sync.example.test/health"
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            record_store = FilesystemRecordStore(root / "state")
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=root / "state",
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=record_store,
-                )
-                status_code, response_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/private-health-endpoints/apply",
-                    payload=payload,
-                    authorization="Bearer local-operator-token",
-                    headers={"Idempotency-Key": "private-health-endpoint-apply"},
-                )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(response_payload["status"], "rejected")
-
-    def test_private_health_endpoint_apply_rejects_cross_product_overwrite(
-        self,
-    ) -> None:
-        policy = _local_operator_policy(
-            actions=("private_health_endpoint.apply",),
-            products=("repairshopr-sync",),
-            contexts=("repairshopr-sync",),
-        )
-        existing_record = _private_health_endpoint_record().model_copy(
-            update={
-                "endpoint_key": "shared-runtime",
-                "product": "other-product",
-                "context": "other-product",
-                "instance": "prod",
-            }
-        )
-        payload = _private_health_endpoint_apply_payload(mode="apply")
-        endpoint = cast(dict[str, object], payload["endpoint"])
-        endpoint["endpoint_key"] = "shared-runtime"
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            record_store = FilesystemRecordStore(root / "state")
-            record_store.write_private_health_endpoint_record(existing_record)
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=root / "state",
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=record_store,
-                )
-                status_code, response_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/private-health-endpoints/apply",
-                    payload=payload,
-                    authorization="Bearer local-operator-token",
-                    headers={"Idempotency-Key": "private-health-endpoint-conflict"},
-                )
-
-        self.assertEqual(status_code, 409)
-        self.assertEqual(response_payload["status"], "rejected")
-        self.assertEqual(
-            response_payload["error"]["code"],
-            "conflicting_private_health_endpoint",
-        )
+        for status_code, payload in responses:
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_ingress_canary_route_record_apply_stores_route_authority(
         self,


### PR DESCRIPTION
## Summary
- move edge endpoint and private health endpoint apply routes onto native FastAPI handlers
- delete the legacy WSGI apply branches and stale endpoint write support from `service.py`
- preserve idempotency, authz, response-shape, fallback, and OpenAPI coverage with focused tests
- update v2 compatibility retirement and record/service-boundary docs

## Verification
- `uv run python -m unittest`
- `uv run python -m unittest tests.test_http_app.FastApiEndpointApplyTests tests.test_service.LaunchplaneServiceTests.test_endpoint_apply_legacy_wsgi_fallback_is_removed`
- `uv run python -m unittest tests.test_http_app tests.test_service`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains changed-files inspection: clean

Note: repo-wide `uv run --extra dev ruff format --check .` still reports pre-existing unrelated formatting debt outside this slice; the changed Python files pass format check.

Refs #1322