### PR TITLE
Move runtime key-safety policy apply to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -122,6 +122,10 @@ from control_plane.contracts.secret_record import SecretScope
 from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationPolicyRecord
 from control_plane.drivers.registry import build_driver_context_view, list_driver_descriptors
 from control_plane.drivers.registry import read_driver_descriptor as read_driver_descriptor_record
+from control_plane.runtime_key_safety_http import (
+    RuntimeKeySafetyPolicyApplyEnvelope,
+    apply_runtime_key_safety_policy_route,
+)
 from control_plane.service_auth import (
     BearerIdentityConfig,
     GitHubActionsIdentity,
@@ -192,6 +196,7 @@ _EVERY_CODE_NOTIFICATION_POLICY_APPLY_ROUTE = "/v1/every-code/notification-polic
 _PREVIEW_PR_FEEDBACK_NOTIFICATION_POLICY_APPLY_ROUTE = (
     "/v1/previews/pr-feedback/notification-policies/apply"
 )
+_RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE = "/v1/runtime-key-safety/policies/apply"
 _EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
 _PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE = "/v1/private-health-endpoints/apply"
 _INGRESS_ROUTE_APPLY_ROUTE = "/v1/drivers/ingress/route-apply"
@@ -5172,6 +5177,18 @@ def create_launchplane_fastapi_app(
             )
         return record_store
 
+    def require_runtime_key_safety_policy_database_store(
+        *, record_store: object, trace_id: str
+    ) -> PostgresRecordStore:
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message="Runtime key-safety policy writes require Launchplane database storage.",
+            )
+        return record_store
+
     def require_local_operator_notification_policy_reason(
         *, identity: LaunchplaneIdentity, reason: str, trace_id: str, message: str
     ) -> None:
@@ -6129,6 +6146,71 @@ def create_launchplane_fastapi_app(
         )
         return response
 
+    async def apply_runtime_key_safety_policy(
+        request: Request,
+        policy_request: RuntimeKeySafetyPolicyApplyEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="runtime_key_safety.write",
+            product=policy_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot write Launchplane runtime key-safety policy records.",
+            )
+        database_store = require_runtime_key_safety_policy_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        (
+            normalized_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=database_store,
+            identity=identity,
+            route_path=_RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=True,
+        )
+        if replayed_response is not None:
+            return replayed_response
+        route_result = apply_runtime_key_safety_policy_route(
+            record_store=database_store,
+            request=policy_request,
+            now_timestamp=utc_now_timestamp,
+            record_slug=_record_slug,
+        )
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "runtime_key_safety_policy_record_id": str(
+                    route_result.result["runtime_key_safety_policy_record_id"]
+                ),
+            },
+            result=route_result.driver_result,
+        )
+        store_apply_idempotency(
+            record_store=database_store,
+            identity=identity,
+            route_path=_RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE,
+            idempotency_key=normalized_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
     async def apply_preview_pr_feedback_notification_policy(
         request: Request,
         policy_request: PreviewPrFeedbackNotificationPolicyApplyEnvelope,
@@ -7055,6 +7137,24 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="apply_preview_pr_feedback_notification_policy",
         summary="Apply preview PR feedback notification policy",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE,
+        apply_runtime_key_safety_policy,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="apply_runtime_key_safety_policy",
+        summary="Apply runtime key-safety policy records",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
@@ -8040,6 +8140,14 @@ def _launchplane_http_error(
         status_code=status_code,
         detail={"trace_id": trace_id, "code": code, "message": message},
     )
+
+
+def _record_slug(value: str) -> str:
+    compact = "".join(
+        character.lower() if character.isalnum() else "-" for character in value.strip()
+    )
+    normalized = "-".join(part for part in compact.split("-") if part)
+    return normalized or "launchplane-record"
 
 
 def _authentication_required_error(message: str) -> HTTPException:

--- a/control_plane/runtime_key_safety_http.py
+++ b/control_plane/runtime_key_safety_http.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from dataclasses import dataclass
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import runtime_key_safety_service as control_plane_runtime_key_safety_service
 from control_plane.contracts.runtime_key_safety_policy import RuntimeSecretSafetyRule
-from control_plane.runtime_key_safety_service import RuntimeKeySafetyPolicyStore
-from control_plane.service_auth import LaunchplaneAuthzPolicy, LaunchplaneIdentity
-
-
-JsonResponse = Callable[..., list[bytes]]
-RecordSlugProvider = Callable[[str], str]
-StartResponse = Callable[[str, list[tuple[str, str]]], None]
-TimestampProvider = Callable[[], str]
-
-LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+from control_plane.runtime_key_safety_service import (
+    RecordSlugProvider,
+    RuntimeKeySafetyPolicyStore,
+    TimestampProvider,
+)
 
 
 class RuntimeKeySafetyPolicyApplyEnvelope(BaseModel):
@@ -42,36 +36,6 @@ class RuntimeKeySafetyPolicyApplyEnvelope(BaseModel):
 class RuntimeKeySafetyPolicyRouteResult:
     result: dict[str, object]
     driver_result: dict[str, object]
-
-
-def validate_runtime_key_safety_policy_request(
-    *,
-    authz_policy: LaunchplaneAuthzPolicy,
-    identity: LaunchplaneIdentity,
-    payload: dict[str, object],
-    trace_id: str,
-    json_response: JsonResponse,
-    start_response: StartResponse,
-) -> tuple[RuntimeKeySafetyPolicyApplyEnvelope | None, list[bytes] | None]:
-    request = RuntimeKeySafetyPolicyApplyEnvelope.model_validate(payload)
-    if _runtime_key_safety_policy_authorized(
-        authz_policy=authz_policy,
-        identity=identity,
-        product=request.product,
-    ):
-        return request, None
-    return None, json_response(
-        start_response=start_response,
-        status_code=403,
-        payload={
-            "status": "rejected",
-            "trace_id": trace_id,
-            "error": {
-                "code": "authorization_denied",
-                "message": "Workflow cannot write Launchplane runtime key-safety policy records.",
-            },
-        },
-    )
 
 
 def apply_runtime_key_safety_policy_route(
@@ -101,38 +65,4 @@ def apply_runtime_key_safety_policy_route(
             ),
             "changed": changed,
         },
-    )
-
-
-def runtime_key_safety_database_required_response(
-    *,
-    trace_id: str,
-    json_response: JsonResponse,
-    start_response: StartResponse,
-) -> list[bytes]:
-    return json_response(
-        start_response=start_response,
-        status_code=503,
-        payload={
-            "status": "rejected",
-            "trace_id": trace_id,
-            "error": {
-                "code": "database_required",
-                "message": "Runtime key-safety policy writes require Launchplane database storage.",
-            },
-        },
-    )
-
-
-def _runtime_key_safety_policy_authorized(
-    *,
-    authz_policy: LaunchplaneAuthzPolicy,
-    identity: LaunchplaneIdentity,
-    product: str,
-) -> bool:
-    return authz_policy.allows(
-        identity=identity,
-        action="runtime_key_safety.write",
-        product=product,
-        context=LAUNCHPLANE_SERVICE_CONTEXT,
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -171,12 +171,6 @@ from control_plane.runtime_key_safety import (
     latest_active_runtime_key_safety_policy,
     runtime_key_safety_environment_class,
 )
-from control_plane.runtime_key_safety_http import (
-    RuntimeKeySafetyPolicyRouteResult,
-    apply_runtime_key_safety_policy_route,
-    runtime_key_safety_database_required_response,
-    validate_runtime_key_safety_policy_request,
-)
 from control_plane.drivers.registry import list_driver_descriptors, read_driver_descriptor
 from control_plane.notifications import post_discord_webhook, public_discord_url_error
 from control_plane.drivers.dispatch import (
@@ -4133,7 +4127,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/authz-policies/local-operators/grants",
         "/v1/authz-policies/local-admins/grants",
         "/v1/merge-train/policies/import",
-        "/v1/runtime-key-safety/policies/apply",
         "/v1/live-target-runtime/apply",
         "/v1/product-onboarding/apply",
         "/v1/dokploy-targets/setup",
@@ -11533,46 +11526,6 @@ def create_launchplane_service_app(
                     },
                 }
                 driver_result = result
-            elif path == "/v1/runtime-key-safety/policies/apply":
-                runtime_policy_request, runtime_policy_response = (
-                    validate_runtime_key_safety_policy_request(
-                        authz_policy=authz_policy,
-                        identity=identity,
-                        payload=payload,
-                        trace_id=request_trace_id,
-                        json_response=_json_response,
-                        start_response=start_response,
-                    )
-                )
-                if runtime_policy_response is not None:
-                    return runtime_policy_response
-                assert runtime_policy_request is not None
-                if not isinstance(record_store, PostgresRecordStore):
-                    return runtime_key_safety_database_required_response(
-                        trace_id=request_trace_id,
-                        json_response=_json_response,
-                        start_response=start_response,
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                runtime_policy_result = apply_runtime_key_safety_policy_route(
-                    record_store=record_store,
-                    request=runtime_policy_request,
-                    now_timestamp=_now_timestamp,
-                    record_slug=_record_slug,
-                )
-                assert isinstance(runtime_policy_result, RuntimeKeySafetyPolicyRouteResult)
-                result = runtime_policy_result.result
-                driver_result = runtime_policy_result.driver_result
             elif path == "/v1/live-target-runtime/apply":
                 live_target_runtime_request = LiveTargetRuntimeApplyEnvelope.model_validate(payload)
                 action = (

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -146,6 +146,12 @@ Keep a compatibility surface only when it is one of these:
   scope validation, and optional `Idempotency-Key` replay/conflict behavior.
   Their legacy WSGI write branches are deleted, and direct WSGI fallback calls
   to these policy-apply paths fail closed.
+- Runtime key-safety policy apply uses native FastAPI
+  `POST /v1/runtime-key-safety/policies/apply` for bearer-token callers and
+  preserves `runtime_key_safety.write` authorization, DB-backed storage
+  enforcement, metadata-only policy writes, and optional `Idempotency-Key`
+  replay/conflict behavior. Its legacy WSGI write branch and WSGI-only helper
+  code are deleted, and direct WSGI fallback calls fail closed.
 - Live target runtime apply uses `POST /v1/live-target-runtime/apply` and the
   `live-target-runtime.yml` workflow for shared and production live changes.
   The local checkout `environments apply-live-target` mutation command is

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -153,6 +153,10 @@ VeriReel product paths:
   - `POST /v1/product-profiles`
 - product config write route:
   - `POST /v1/product-config/apply`
+- runtime key-safety policy route:
+  - `POST /v1/runtime-key-safety/policies/apply` (native FastAPI for
+    bearer-token callers, DB-backed storage, metadata-only policy writes, and
+    optional `Idempotency-Key` replay/conflict handling)
 - product onboarding route:
   - `POST /v1/product-onboarding/apply`
 - Dokploy target setup route:
@@ -1213,15 +1217,18 @@ should surface that action and stop. Applying product-config records does not by
 itself guarantee the live target process has been synchronized.
 
 Runtime key-safety policy reconciliation uses
-`POST /v1/runtime-key-safety/policies/apply`. The route is restricted to
-workflows with `runtime_key_safety.write` for product/context `launchplane`,
-requires DB-backed storage, and writes metadata-only policy records for managed
-runtime secret binding keys. It merges requested rules into the latest active
-policy by binding key so deploy-time bootstrap can add required classifications
-without dropping existing policy coverage. Request and response payloads must
-not include secret plaintext. Rules can carry exact context/instance scope and
-explicit preview instance patterns for dynamic PR lanes; policy apply merges
-those scopes additively without making checked-in files runtime authority.
+`POST /v1/runtime-key-safety/policies/apply`. The route is native FastAPI and
+its legacy WSGI fallback branch is deleted. It is restricted to workflows with
+`runtime_key_safety.write` for product/context `launchplane`, requires DB-backed
+storage, and writes metadata-only policy records for managed runtime secret
+binding keys. Optional `Idempotency-Key` headers preserve replay/conflict
+semantics for retry-safe service calls. It merges requested rules into the
+latest active policy by binding key so deploy-time bootstrap can add required
+classifications without dropping existing policy coverage. Request and response
+payloads must not include secret plaintext. Rules can carry exact
+context/instance scope and explicit preview instance patterns for dynamic PR
+lanes; policy apply merges those scopes additively without making checked-in
+files runtime authority.
 
 Product onboarding uses `POST /v1/product-onboarding/apply`. The route accepts
 the same operator-approved manifest as `launchplane product-onboarding apply`

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -137,6 +137,7 @@ from tests.test_service import (
     _seed_merge_train_policy,
     _seed_tracked_target_records,
     _sqlite_database_url,
+    _write_runtime_key_safety_policy,
 )
 from tests.test_service import _StubVerifier
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
@@ -1703,6 +1704,272 @@ class FastApiNotificationPolicyApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("/v1/public-ingress/notification-policies/apply", paths)
         self.assertIn("/v1/every-code/notification-policies/apply", paths)
         self.assertIn("/v1/previews/pr-feedback/notification-policies/apply", paths)
+
+
+class FastApiRuntimeKeySafetyPolicyApplyTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runtime_key_safety_policy_apply_reconciles_rules_and_replays(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                _write_runtime_key_safety_policy(database_url=database_url)
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_runtime_key_safety_policy_apply_policy(
+                        action="runtime_key_safety.write"
+                    ),
+                    record_store_factory=lambda: store,
+                )
+                payload = _runtime_key_safety_policy_apply_payload()
+
+                first_response = await _post_runtime_key_safety_policy_apply(
+                    app,
+                    payload,
+                    idempotency_key="runtime-key-safety-policy:test",
+                )
+                active_policy = store.list_runtime_key_safety_policy_records(
+                    status="active", limit=1
+                )[0]
+                replay_response = await _post_runtime_key_safety_policy_apply(
+                    app,
+                    payload,
+                    idempotency_key="runtime-key-safety-policy:test",
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(first_response.status_code, 202)
+        first_payload = first_response.json()
+        self.assertEqual(first_payload["status"], "accepted")
+        self.assertEqual(
+            set(first_payload["records"]),
+            {"runtime_key_safety_policy_record_id"},
+        )
+        self.assertEqual(
+            first_payload["records"]["runtime_key_safety_policy_record_id"],
+            active_policy.record_id,
+        )
+        self.assertEqual(first_payload["result"]["changed"], True)
+        self.assertEqual(
+            first_payload["result"]["runtime_key_safety_policy"]["binding_keys"],
+            ["RESEND_API_KEY", "SMTP_PASSWORD"],
+        )
+        self.assertEqual(
+            [rule.binding_key for rule in active_policy.rules],
+            ["RESEND_API_KEY", "SMTP_PASSWORD"],
+        )
+        self.assertEqual(replay_response.status_code, 202)
+        replay_payload = replay_response.json()
+        self.assertEqual(replay_payload["records"], first_payload["records"])
+        self.assertEqual(replay_payload["result"], first_payload["result"])
+        self.assertTrue(replay_payload["replayed"])
+        self.assertEqual(replay_payload["original_trace_id"], first_payload["trace_id"])
+
+    async def test_runtime_key_safety_policy_apply_rejects_conflicting_idempotency_key(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_runtime_key_safety_policy_apply_policy(
+                        action="runtime_key_safety.write"
+                    ),
+                    record_store_factory=lambda: store,
+                )
+                first_payload = _runtime_key_safety_policy_apply_payload()
+                conflicting_payload = _runtime_key_safety_policy_apply_payload()
+                conflicting_rules = cast(list[dict[str, object]], conflicting_payload["rules"])
+                conflicting_rules[1] = {
+                    "binding_key": "MAILGUN_API_KEY",
+                    "secret_class": "prod_only",
+                    "allowed_contexts": ["sellyouroutboard"],
+                    "allowed_instances": ["prod"],
+                }
+
+                first_response = await _post_runtime_key_safety_policy_apply(
+                    app,
+                    first_payload,
+                    idempotency_key="runtime-key-safety-policy:conflict",
+                )
+                second_response = await _post_runtime_key_safety_policy_apply(
+                    app,
+                    conflicting_payload,
+                    idempotency_key="runtime-key-safety-policy:conflict",
+                )
+                active_policy = store.list_runtime_key_safety_policy_records(
+                    status="active", limit=1
+                )[0]
+            finally:
+                store.close()
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        payload = second_response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+        self.assertEqual(
+            [rule.binding_key for rule in active_policy.rules],
+            ["RESEND_API_KEY", "SMTP_PASSWORD"],
+        )
+
+    async def test_runtime_key_safety_policy_apply_rejects_without_permission(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_runtime_key_safety_policy_apply_policy(
+                        action="product_profile.read"
+                    ),
+                    record_store_factory=lambda: store,
+                )
+
+                response = await _post_runtime_key_safety_policy_apply(
+                    app,
+                    _runtime_key_safety_policy_apply_payload(),
+                    idempotency_key="runtime-key-safety-policy:unauthorized",
+                )
+                active_records = store.list_runtime_key_safety_policy_records(status="active")
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(active_records, ())
+
+    async def test_runtime_key_safety_policy_apply_rejects_human_session_mutation(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            oauth_config = _github_oauth_config()
+            session_manager = HumanSessionManager(
+                config=oauth_config,
+                session_store=InMemoryHumanSessionStore(),
+            )
+            human_session = session_manager.issue(_github_human_identity())
+            try:
+                app = create_launchplane_fastapi_app(
+                    verifier=_RejectingVerifier(),
+                    authz_policy=_github_human_runtime_key_safety_policy_apply_policy(),
+                    record_store_factory=lambda: store,
+                    human_session_manager=session_manager,
+                )
+
+                response = await _post_runtime_key_safety_policy_apply(
+                    app,
+                    _runtime_key_safety_policy_apply_payload(),
+                    authorization="",
+                    headers={"Cookie": session_manager.session_cookie_header(human_session)},
+                )
+                active_records = store.list_runtime_key_safety_policy_records(status="active")
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+        self.assertEqual(active_records, ())
+
+    async def test_runtime_key_safety_policy_apply_requires_database_storage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_runtime_key_safety_policy_apply_policy(
+                    action="runtime_key_safety.write"
+                ),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_runtime_key_safety_policy_apply(
+                app,
+                _runtime_key_safety_policy_apply_payload(),
+            )
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_required")
+
+    async def test_runtime_key_safety_policy_apply_native_route_precedes_wsgi_fallback(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                policy = _runtime_key_safety_policy_apply_policy(action="runtime_key_safety.write")
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=policy,
+                    record_store_factory=lambda: store,
+                )
+                legacy_app = create_launchplane_service_app(
+                    state_dir=root / "state",
+                    verifier=_RejectingVerifier(),
+                    authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                    local_record_store_for_tests=store,
+                )
+                app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+                response = await _post_runtime_key_safety_policy_apply(
+                    app,
+                    _runtime_key_safety_policy_apply_payload(),
+                )
+            finally:
+                store.close()
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["status"], "accepted")
+
+    async def test_openapi_includes_runtime_key_safety_policy_apply_route(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/runtime-key-safety/policies/apply"]["post"]
+        self.assertEqual(route["operationId"], "apply_runtime_key_safety_policy")
+        self.assertEqual(
+            route["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/RuntimeKeySafetyPolicyApplyEnvelope",
+        )
+        self.assertEqual(
+            route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        for status_code in ("400", "401", "403", "409", "503"):
+            self.assertIn("LaunchplaneErrorResponse", json.dumps(route["responses"][status_code]))
 
 
 class FastApiBackupGateEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
@@ -13443,6 +13710,63 @@ def _notification_policy_apply_policy(
     )
 
 
+def _runtime_key_safety_policy_apply_policy(*, action: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": [action],
+                }
+            ]
+        }
+    )
+
+
+def _github_human_runtime_key_safety_policy_apply_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_humans": [
+                {
+                    "logins": ["example-operator"],
+                    "roles": ["admin"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["runtime_key_safety.write"],
+                }
+            ]
+        }
+    )
+
+
+def _runtime_key_safety_policy_apply_payload() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": "launchplane",
+        "source_label": "test:runtime-key-safety-policy",
+        "rules": [
+            {
+                "binding_key": "SMTP_PASSWORD",
+                "secret_class": "prod_only",
+                "allowed_contexts": ["sellyouroutboard"],
+                "allowed_instances": ["prod"],
+            },
+            {
+                "binding_key": "RESEND_API_KEY",
+                "secret_class": "prod_only",
+                "allowed_contexts": ["sellyouroutboard"],
+                "allowed_instances": ["prod"],
+            },
+        ],
+    }
+
+
 def _github_human_ingress_route_policy(
     *, action: str, product: str, context: str
 ) -> LaunchplaneAuthzPolicy:
@@ -14760,6 +15084,28 @@ async def _post_promotion_evidence(
         app,
         "POST",
         "/v1/evidence/promotions",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
+async def _post_runtime_key_safety_policy_apply(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/runtime-key-safety/policies/apply",
         headers=request_headers,
         payload=payload,
     )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2464,6 +2464,31 @@ class LaunchplaneServiceTests(unittest.TestCase):
             self.assertEqual(status_code, 404)
             self.assertEqual(payload["error"]["code"], "not_found")
 
+    def test_runtime_key_safety_policy_apply_legacy_wsgi_fallback_is_removed(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+
+            responses = tuple(
+                _invoke_app(
+                    app,
+                    method=method,
+                    path="/v1/runtime-key-safety/policies/apply",
+                    payload={"schema_version": 1},
+                )
+                for method in ("GET", "POST")
+            )
+
+        for status_code, payload in responses:
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
+
     def test_every_code_blocked_status_posts_discord_notification(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         sent_payloads: list[tuple[str, dict[str, object]]] = []
@@ -22078,233 +22103,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     },
                 },
                 headers={"Idempotency-Key": "authz-removal:self-deploy-denied"},
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_runtime_key_safety_policy_endpoint_reconciles_rules(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "workflow_refs": [
-                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["launchplane"],
-                            "contexts": ["launchplane"],
-                            "actions": ["runtime_key_safety.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-            _write_runtime_key_safety_policy(database_url=database_url)
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/runtime-key-safety/policies/apply",
-                payload={
-                    "schema_version": 1,
-                    "product": "launchplane",
-                    "source_label": "test:runtime-key-safety-policy",
-                    "rules": [
-                        {
-                            "binding_key": "SMTP_PASSWORD",
-                            "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard"],
-                            "allowed_instances": ["prod"],
-                        },
-                        {
-                            "binding_key": "RESEND_API_KEY",
-                            "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard"],
-                            "allowed_instances": ["prod"],
-                        },
-                    ],
-                },
-                headers={"Idempotency-Key": "runtime-key-safety-policy:test"},
-            )
-            store = PostgresRecordStore(database_url=database_url)
-            try:
-                active_policy = store.list_runtime_key_safety_policy_records(
-                    status="active", limit=1
-                )[0]
-            finally:
-                store.close()
-            repeat_status_code, repeat_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/runtime-key-safety/policies/apply",
-                payload={
-                    "schema_version": 1,
-                    "product": "launchplane",
-                    "source_label": "test:runtime-key-safety-policy",
-                    "rules": [
-                        {
-                            "binding_key": "SMTP_PASSWORD",
-                            "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard"],
-                            "allowed_instances": ["prod"],
-                        },
-                        {
-                            "binding_key": "RESEND_API_KEY",
-                            "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard"],
-                            "allowed_instances": ["prod"],
-                        },
-                    ],
-                },
-                headers={"Idempotency-Key": "runtime-key-safety-policy:test-repeat"},
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(
-            payload["records"]["runtime_key_safety_policy_record_id"], active_policy.record_id
-        )
-        self.assertEqual(payload["result"]["changed"], True)
-        self.assertEqual(
-            payload["result"]["runtime_key_safety_policy"]["binding_keys"],
-            ["RESEND_API_KEY", "SMTP_PASSWORD"],
-        )
-        self.assertEqual(
-            [rule.binding_key for rule in active_policy.rules],
-            ["RESEND_API_KEY", "SMTP_PASSWORD"],
-        )
-        self.assertEqual(repeat_status_code, 202)
-        self.assertEqual(
-            repeat_payload["records"]["runtime_key_safety_policy_record_id"],
-            active_policy.record_id,
-        )
-        self.assertEqual(repeat_payload["result"]["changed"], False)
-
-    def test_runtime_key_safety_policy_endpoint_rejects_without_permission(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "actions": ["product_profile.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/runtime-key-safety/policies/apply",
-                payload={
-                    "schema_version": 1,
-                    "product": "launchplane",
-                    "rules": [
-                        {
-                            "binding_key": "RESEND_API_KEY",
-                            "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard-prod"],
-                            "allowed_instances": ["prod"],
-                        }
-                    ],
-                },
-                headers={"Idempotency-Key": "runtime-key-safety-policy:unauthorized"},
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_runtime_key_safety_policy_endpoint_rejects_self_deploy_authority(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/launchplane",
-                            "workflow_refs": [
-                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["launchplane"],
-                            "contexts": ["launchplane"],
-                            "actions": ["launchplane_service_deploy.execute"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/runtime-key-safety/policies/apply",
-                payload={
-                    "schema_version": 1,
-                    "product": "launchplane",
-                    "rules": [
-                        {
-                            "binding_key": "RESEND_API_KEY",
-                            "secret_class": "prod_only",
-                            "allowed_contexts": ["sellyouroutboard-prod"],
-                            "allowed_instances": ["prod"],
-                        }
-                    ],
-                },
-                headers={"Idempotency-Key": "runtime-key-safety-policy:self-deploy-denied"},
             )
 
         self.assertEqual(status_code, 403)


### PR DESCRIPTION
## Summary
- move POST /v1/runtime-key-safety/policies/apply to the native FastAPI app
- preserve bearer-only auth, runtime_key_safety.write authorization, Postgres gating, accepted response shape, and Idempotency-Key replay/conflict behavior
- remove the legacy WSGI fallback branch and stale runtime-key-safety HTTP helpers
- update compatibility/service-boundary docs for the native route

## Validation
- uv run python -m py_compile control_plane/http_app.py control_plane/service.py control_plane/runtime_key_safety_http.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/runtime_key_safety_http.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/runtime_key_safety_http.py tests/test_http_app.py tests/test_service.py
- markdownlint-cli2 docs/compatibility-retirement.md docs/service-boundary.md
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest tests.test_http_app.FastApiRuntimeKeySafetyPolicyApplyTests tests.test_service.LaunchplaneServiceTests.test_runtime_key_safety_policy_apply_legacy_wsgi_fallback_is_removed
- uv run python -m unittest

## Review
- Fresh read-only agent review batch ce3106b5: green from antigravity and Claude; GPT review found one low stale-code cleanup, fixed before commit

## Notes
- JetBrains inspection was attempted, but PyCharm did not open this exact worktree, so the inspection verdict remained UNKNOWN.