### PR TITLE
Move product profile writes to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -11,7 +11,7 @@ from fastapi import Depends, FastAPI, Header, HTTPException, Path, Query, Reques
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from jwt import InvalidTokenError
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.dokploy_target_inspect import (
@@ -207,6 +207,7 @@ _PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE = "/v1/private-health-endpoints/apply"
 _INGRESS_ROUTE_APPLY_ROUTE = "/v1/drivers/ingress/route-apply"
 _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE = "/v1/ingress/canary-routes/records/apply"
 _INGRESS_CANARY_ROUTE_APPLY_ROUTE = "/v1/ingress/canary-routes/apply"
+_PRODUCT_PROFILES_ROUTE = "/v1/product-profiles"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 
 
@@ -247,6 +248,10 @@ class AgentContextReadStore(ProductReadModelStore, Protocol):
         limit: int | None = None,
         offset: int = 0,
     ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
+
+
+class ProductProfileWriteStore(Protocol):
+    def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> object: ...
 
 
 class WorkGraphSnapshotReadStore(ProductReadModelStore, WorkGraphWorkRequestStore, Protocol):
@@ -1719,6 +1724,16 @@ def require_product_profile_read_store(record_store: object) -> ProductReadModel
             "read_product_profile_record"
         )
     return cast(ProductReadModelStore, record_store)
+
+
+def require_product_profile_write_store(record_store: object) -> ProductProfileWriteStore:
+    write_record = getattr(record_store, "write_product_profile_record", None)
+    if not callable(write_record):
+        raise TypeError(
+            "Launchplane record store does not support product profile writes: "
+            "write_product_profile_record"
+        )
+    return cast(ProductProfileWriteStore, record_store)
 
 
 def require_secret_status_read_store(record_store: object) -> control_plane_secrets.SecretReadStore:
@@ -4950,6 +4965,100 @@ def create_launchplane_fastapi_app(
             )
         return ProductProfileResponse(trace_id=trace_id, profile=profile)
 
+    async def write_product_profile(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            )
+        try:
+            profile = LaunchplaneProductProfileRecord.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="product_profile.write",
+            product=profile.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot write the requested product profile.",
+            )
+        try:
+            profile.validate_write_contract()
+        except ValueError as error:
+            message = str(error).strip() or "Product profile request failed validation."
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message=message,
+            ) from error
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_PRODUCT_PROFILES_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+        try:
+            profile_store = require_product_profile_write_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        profile_store.write_product_profile_record(profile)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"product_profile": profile.product},
+        )
+        store_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_PRODUCT_PROFILES_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
     def read_product_context_cutover_audit(
         product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
@@ -7966,6 +8075,34 @@ def create_launchplane_fastapi_app(
         responses={
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PRODUCT_PROFILES_ROUTE,
+        write_product_profile,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/LaunchplaneProductProfileRecord"}
+                    }
+                },
+            }
+        },
+        operation_id="write_product_profile",
+        summary="Write a Launchplane product profile",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -3610,7 +3610,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/previews/lifecycle-cleanup",
         "/v1/previews/lifecycle-plan",
         "/v1/previews/lifecycle-sweep",
-        "/v1/product-profiles",
         "/v1/drivers/launchplane/self-deploy",
     }
     return frozenset(launchplane_write_routes | set(_driver_write_routes_from_descriptors()))
@@ -11491,55 +11490,6 @@ def create_launchplane_service_app(
                         },
                     )
                 result = {"product_profile": legacy_cleanup_request.product}
-            elif path == "/v1/product-profiles":
-                product_profile_request = LaunchplaneProductProfileRecord.model_validate(payload)
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="product_profile.write",
-                    product=product_profile_request.product,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot write the requested product profile.",
-                            },
-                        },
-                    )
-                try:
-                    product_profile_request.validate_write_contract()
-                except ValueError as error:
-                    message = str(error).strip() or "Product profile request failed validation."
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "invalid_request",
-                                "message": message,
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                record_store.write_product_profile_record(product_profile_request)
-                result = {"product_profile": product_profile_request.product}
             elif path == "/v1/previews/lifecycle-plan":
                 preview_lifecycle_plan_request = PreviewLifecyclePlanEnvelope.model_validate(
                     payload

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -119,6 +119,10 @@ Keep a compatibility surface only when it is one of these:
   product-profile collection also preserves the dedicated Every Code worker
   token. Their legacy WSGI branches are deleted; direct fallback calls fail
   closed while the mounted fallback remains for retained non-native routes.
+- Product profile writes use native FastAPI `POST /v1/product-profiles` for
+  bearer-token callers and preserve product-profile write-contract validation,
+  record storage, and optional `Idempotency-Key` replay/conflict behavior. The
+  legacy WSGI write branch is deleted; direct WSGI fallback calls fail closed.
 - Every Code work-request, summary, PR-feedback, preview-gate,
   notification-attempt, and preview-readiness reads use native FastAPI routes.
   The worker-facing read routes preserve the dedicated Every Code worker token;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -150,7 +150,9 @@ VeriReel product paths:
     human-session, and Every Code worker-token callers)
   - `GET /v1/product-profiles/{product}` (native FastAPI for bearer-token and
     human-session callers)
-  - `POST /v1/product-profiles`
+  - `POST /v1/product-profiles` (native FastAPI for bearer-token callers,
+    product-profile write-contract validation, record storage, and optional
+    `Idempotency-Key` replay/conflict handling)
 - product config write route:
   - `POST /v1/product-config/apply`
 - runtime key-safety policy route:
@@ -1048,8 +1050,13 @@ refresh/destroy flow.
 - `POST /v1/product-profiles`
 
 Product profiles are Launchplane-owned product/driver bindings. They are written
-through authenticated service ingress and stored in Launchplane records; product
-repos do not carry repo-local Launchplane lifecycle manifests.
+through native FastAPI authenticated service ingress and stored in Launchplane
+records; product repos do not carry repo-local Launchplane lifecycle manifests.
+Writes require `product_profile.write` for the profile product in the
+Launchplane service context, validate the profile write contract before storage,
+and preserve optional `Idempotency-Key` replay/conflict behavior. The legacy WSGI
+write branch is deleted; direct fallback calls fail closed while the mounted
+fallback remains for retained non-native routes.
 
 Public ingress notification policy writes use
 `POST /v1/public-ingress/notification-policies/apply`. The request carries

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4096,7 +4096,7 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(notification_response.status_code, 200)
 
 
-class FastApiProductProfileReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiProductProfileTests(unittest.IsolatedAsyncioTestCase):
     async def test_list_product_profiles_returns_profiles_for_driver(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -4147,6 +4147,210 @@ class FastApiProductProfileReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["profile"]["product"], "sellyouroutboard")
         self.assertEqual(payload["profile"]["driver_id"], "generic-web")
         self.assertEqual(payload["profile"]["preview"]["slug_template"], "pr-{number}")
+
+    async def test_write_product_profile_persists_authorized_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            record_store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _post_product_profile(
+                app,
+                _product_profile_payload(),
+                idempotency_key="profile-sellyouroutboard",
+            )
+            stored_profile = record_store.read_product_profile_record("sellyouroutboard")
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["records"], {"product_profile": "sellyouroutboard"})
+        self.assertNotIn("result", payload)
+        self.assertEqual(stored_profile.driver_id, "generic-web")
+        self.assertEqual(stored_profile.preview.slug_template, "pr-{number}")
+
+    async def test_write_product_profile_replays_idempotent_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: record_store,
+            )
+            payload = _product_profile_payload()
+
+            first_response = await _post_product_profile(
+                app,
+                payload,
+                idempotency_key="profile-sellyouroutboard",
+            )
+            second_response = await _post_product_profile(
+                app,
+                payload,
+                idempotency_key="profile-sellyouroutboard",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
+
+    async def test_write_product_profile_replays_before_write_store_check(self) -> None:
+        payload = _product_profile_payload()
+        record_store = _ProductProfileReplayOnlyStore(
+            payload=payload,
+            idempotency_key="profile-sellyouroutboard",
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: record_store,
+        )
+
+        response = await _post_product_profile(
+            app,
+            payload,
+            idempotency_key="profile-sellyouroutboard",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        response_payload = response.json()
+        self.assertTrue(response_payload["replayed"])
+        self.assertEqual(response_payload["records"], {"product_profile": "sellyouroutboard"})
+        self.assertEqual(response_payload["original_trace_id"], "launchplane_req_original")
+        self.assertEqual(record_store.read_idempotency_calls, 1)
+
+    async def test_write_product_profile_rejects_reused_idempotency_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: record_store,
+            )
+            changed_payload = {
+                **_product_profile_payload(),
+                "display_name": "Changed Product Name",
+            }
+
+            await _post_product_profile(
+                app,
+                _product_profile_payload(),
+                idempotency_key="profile-sellyouroutboard",
+            )
+            response = await _post_product_profile(
+                app,
+                changed_payload,
+                idempotency_key="profile-sellyouroutboard",
+            )
+
+        self.assertEqual(response.status_code, 409)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "idempotency_key_reused")
+
+    async def test_write_product_profile_authenticates_before_malformed_body(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/product-profiles",
+            raw_body=b"{",
+            headers={"Content-Type": "application/json"},
+        )
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+
+    async def test_write_product_profile_reports_schema_validation_message(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_product_profile(app, {"schema_version": 1})
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Request payload failed validation.")
+
+    async def test_write_product_profile_rejects_inert_health_monitoring(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: record_store,
+            )
+            profile_payload = _product_profile_payload()
+            profile_payload["lanes"] = (
+                {
+                    "instance": "testing",
+                    "context": "sellyouroutboard-testing",
+                    "health_monitoring": {
+                        "checks": [{"name": "public-ingress", "kind": "public_http"}]
+                    },
+                },
+            )
+
+            response = await _post_product_profile(
+                app,
+                profile_payload,
+                idempotency_key="profile-sellyouroutboard",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "public HTTP health check requires base_url or explicit health_url",
+        )
+
+    async def test_write_product_profile_rejects_unauthorized_product(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="verireel"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_product_profile(app, _product_profile_payload())
+
+        self.assertEqual(response.status_code, 403)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    async def test_write_product_profile_requires_matching_store_method(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_product_profile(app, _product_profile_payload())
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("write_product_profile_record", payload["error"]["message"])
 
     async def test_list_product_profiles_accepts_every_code_worker_token(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -4286,7 +4490,7 @@ class FastApiProductProfileReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("list_product_profile_records", list_response.json()["error"]["message"])
         self.assertIn("read_product_profile_record", show_response.json()["error"]["message"])
 
-    async def test_openapi_includes_product_profile_read_contracts(self) -> None:
+    async def test_openapi_includes_product_profile_contracts(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_identity()),
             authz_policy=_product_profile_read_policy(product="launchplane"),
@@ -4298,17 +4502,29 @@ class FastApiProductProfileReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         openapi = response.json()
         list_route = openapi["paths"]["/v1/product-profiles"]["get"]
+        write_route = openapi["paths"]["/v1/product-profiles"]["post"]
         show_route = openapi["paths"]["/v1/product-profiles/{product}"]["get"]
         self.assertEqual(list_route["operationId"], "list_product_profiles")
+        self.assertEqual(write_route["operationId"], "write_product_profile")
         self.assertEqual(show_route["operationId"], "read_product_profile")
         self.assertEqual(
             list_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
             "#/components/schemas/ProductProfileListResponse",
         )
         self.assertEqual(
+            write_route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        self.assertEqual(
+            write_route["requestBody"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/LaunchplaneProductProfileRecord",
+        )
+        self.assertEqual(
             show_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
             "#/components/schemas/ProductProfileResponse",
         )
+        for status_code in ("400", "401", "403", "409", "503"):
+            self.assertIn(status_code, write_route["responses"])
         self.assertEqual(
             openapi["components"]["schemas"]["ProductProfileListResponse"]["additionalProperties"],
             False,
@@ -4361,6 +4577,30 @@ class FastApiProductProfileReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(show_response.status_code, 200)
         self.assertEqual(list_response.json()["profiles"][0]["product"], "sellyouroutboard")
         self.assertEqual(show_response.json()["profile"]["product"], "sellyouroutboard")
+
+    async def test_fastapi_product_profile_write_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            record_store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: record_store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "legacy-state",
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _post_product_profile(app, _product_profile_payload())
+            stored_profile = record_store.read_product_profile_record("sellyouroutboard")
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["records"]["product_profile"], "sellyouroutboard")
+        self.assertEqual(stored_profile.driver_id, "generic-web")
 
 
 class FastApiProductContextCutoverAuditReadTests(unittest.IsolatedAsyncioTestCase):
@@ -14056,6 +14296,25 @@ def _product_profile_read_policy(*, product: str) -> LaunchplaneAuthzPolicy:
     )
 
 
+def _product_profile_write_policy(*, product: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": [product],
+                    "contexts": ["launchplane"],
+                    "actions": ["product_profile.write"],
+                }
+            ]
+        }
+    )
+
+
 def _local_operator_product_environment_read_policy(*, context: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -15045,6 +15304,28 @@ async def _get_product_profile(
     )
 
 
+async def _post_product_profile(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/product-profiles",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _get_context_cutover_audit(
     app: FastAPI,
     *,
@@ -15360,11 +15641,14 @@ async def _asgi_request(
     *,
     headers: dict[str, str] | None = None,
     payload: dict[str, object] | None = None,
+    raw_body: bytes | None = None,
 ) -> _AsgiResponse:
     request_path, separator, raw_query_string = path.partition("?")
     request_headers_dict = dict(headers or {})
     body = b""
-    if payload is not None:
+    if raw_body is not None:
+        body = raw_body
+    elif payload is not None:
         body = json.dumps(payload).encode("utf-8")
         request_headers_dict.setdefault("Content-Type", "application/json")
     request_headers_dict.setdefault("Content-Length", str(len(body)))
@@ -15630,6 +15914,44 @@ class _PublicIngressMonitorIdempotencyReplayStore:
                 "trace_id": "launchplane_req_original",
                 "records": {},
                 "result": {"target_count": 1},
+            },
+        )
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> None:
+        raise AssertionError("idempotent replay must not write a new record")
+
+
+class _ProductProfileReplayOnlyStore:
+    def __init__(self, *, payload: dict[str, object], idempotency_key: str) -> None:
+        self.read_idempotency_calls = 0
+        self._payload = payload
+        self._idempotency_key = idempotency_key
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> LaunchplaneIdempotencyRecord | None:
+        self.read_idempotency_calls += 1
+        if route_path != "/v1/product-profiles" or idempotency_key != self._idempotency_key:
+            return None
+        return LaunchplaneIdempotencyRecord(
+            record_id="idempotency-launchplane_req_original",
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=hashlib.sha256(
+                json.dumps(self._payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest(),
+            response_status_code=202,
+            response_trace_id="launchplane_req_original",
+            recorded_at="2026-05-29T12:00:00Z",
+            response_payload={
+                "status": "accepted",
+                "trace_id": "launchplane_req_original",
+                "records": {"product_profile": "sellyouroutboard"},
             },
         )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9598,7 +9598,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_status, 202)
         self.assertEqual(status_payload["result"]["request"]["state"], "done")
 
-    def test_product_profile_reads_are_retired_from_legacy_wsgi_app(self) -> None:
+    def test_product_profile_routes_are_retired_from_legacy_wsgi_app(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
@@ -9629,11 +9629,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 path="/v1/product-profiles/sellyouroutboard",
                 authorization="Bearer worker-token",
             )
+            write_status, write_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles",
+                payload=_product_profile_payload(),
+            )
 
-        self.assertEqual(list_status, 405)
-        self.assertEqual(list_payload["error"]["code"], "method_not_allowed")
+        self.assertEqual(list_status, 404)
+        self.assertEqual(list_payload["error"]["code"], "not_found")
         self.assertEqual(show_status, 404)
         self.assertEqual(show_payload["error"]["code"], "not_found")
+        self.assertEqual(write_status, 404)
+        self.assertEqual(write_payload["error"]["code"], "not_found")
 
     def test_every_code_worker_token_can_rerun_terminal_request(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
@@ -11430,101 +11438,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 500)
         self.assertEqual(payload["error"]["code"], "driver_route_not_registered")
-
-    def test_product_profile_write_endpoint_persists_authorized_record(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane", "sellyouroutboard"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.write", "product_profile.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            write_status_code, write_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/product-profiles",
-                payload=_product_profile_payload(),
-                headers={"Idempotency-Key": "profile-sellyouroutboard"},
-            )
-            stored_profile = FilesystemRecordStore(
-                state_dir=root / "state"
-            ).read_product_profile_record("sellyouroutboard")
-
-        self.assertEqual(write_status_code, 202)
-        self.assertEqual(write_payload["records"], {"product_profile": "sellyouroutboard"})
-        self.assertEqual(stored_profile.driver_id, "generic-web")
-        self.assertEqual(stored_profile.preview.slug_template, "pr-{number}")
-
-    def test_product_profile_endpoint_rejects_inert_health_monitoring(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["launchplane", "sellyouroutboard"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-            profile_payload = _product_profile_payload()
-            profile_payload["lanes"] = (
-                {
-                    "instance": "testing",
-                    "context": "sellyouroutboard-testing",
-                    "health_monitoring": {
-                        "checks": [{"name": "public-ingress", "kind": "public_http"}]
-                    },
-                },
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/product-profiles",
-                payload=profile_payload,
-                headers={"Idempotency-Key": "profile-sellyouroutboard"},
-            )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_request")
-        self.assertEqual(
-            payload["error"]["message"],
-            "public HTTP health check requires base_url or explicit health_url",
-        )
 
     def test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -14384,42 +14297,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
             intent["secret_evidence"]["findings"][0]["code"],
             "secret_class_not_allowed",
         )
-
-    def test_product_profile_write_rejects_unauthorized_product(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["verireel"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/product-profiles",
-                payload=_product_profile_payload(),
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
 
     def test_product_config_api_dry_run_returns_redacted_plan_without_writes(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add native FastAPI `POST /v1/product-profiles` with auth-first body parsing, write-contract validation, idempotency replay/conflict handling, and explicit OpenAPI request-body schema
- remove the retained WSGI product-profile write branch so direct fallback calls fail closed
- move write coverage into FastAPI tests and update v2 compatibility/service-boundary docs

## Validation
- `uv run python -m unittest tests.test_http_app.FastApiProductProfileTests tests.test_service.LaunchplaneServiceTests.test_product_profile_routes_are_retired_from_legacy_wsgi_app`
- `uv run python -m py_compile control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `npx markdownlint-cli2 docs/service-boundary.md docs/compatibility-retirement.md`
- `uv run --extra dev ruff check .`
- `uv run python -m unittest`
- `uv run launchplane service audit-config-authority --control-plane-root .` (`status: ok`; existing scanner coverage/finding noise)
- JetBrains changed-files inspection: GREEN

## Notes
- Full-repo `uv run --extra dev ruff format --check .` still reports pre-existing unrelated formatting drift outside this slice; touched files are format-clean.