### PR TITLE
Move product context writes to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -24,6 +24,7 @@ from control_plane.dokploy_target_setup_http import (
     execute_dokploy_target_setup,
 )
 from control_plane import product_context_audit as control_plane_product_context_audit
+from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import secrets as control_plane_secrets
 from control_plane import service_status as control_plane_service_status
@@ -208,6 +209,8 @@ _INGRESS_ROUTE_APPLY_ROUTE = "/v1/drivers/ingress/route-apply"
 _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE = "/v1/ingress/canary-routes/records/apply"
 _INGRESS_CANARY_ROUTE_APPLY_ROUTE = "/v1/ingress/canary-routes/apply"
 _PRODUCT_PROFILES_ROUTE = "/v1/product-profiles"
+_PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/apply"
+_PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 
 
@@ -5315,6 +5318,18 @@ def create_launchplane_fastapi_app(
             )
         return record_store
 
+    def require_product_context_apply_database_store(
+        *, record_store: object, trace_id: str, label: str
+    ) -> PostgresRecordStore:
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message=f"{label} requires Launchplane database storage.",
+            )
+        return record_store
+
     def require_local_operator_notification_policy_reason(
         *, identity: LaunchplaneIdentity, reason: str, trace_id: str, message: str
     ) -> None:
@@ -5462,6 +5477,233 @@ def create_launchplane_fastapi_app(
                 response_payload=response.model_dump(mode="json", exclude_none=True),
             )
         )
+
+    async def apply_product_context_cutover(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            )
+        try:
+            context_cutover_request = (
+                control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(
+                    raw_payload
+                )
+            )
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="product_profile.write",
+            product=context_cutover_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot cut over the requested product profile context.",
+            )
+        database_store = require_product_context_apply_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            label="Product context cutover",
+        )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=database_store,
+            identity=identity,
+            route_path=_PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+        try:
+            profile = database_store.read_product_profile_record(context_cutover_request.product)
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if not product_profile_context_cutover_contexts_allowed(
+            profile=profile,
+            source_context=context_cutover_request.source_context,
+            target_context=context_cutover_request.target_context,
+            preview_context="",
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="context_not_in_product_boundary",
+                message="Requested cutover contexts are not owned by the product profile.",
+            )
+        try:
+            result = control_plane_product_context_cutover.apply_product_context_cutover(
+                record_store=database_store,
+                request=context_cutover_request,
+            )
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_context_cutover_request",
+                message="Product context cutover context_cutover_request is invalid.",
+            ) from error
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"product_profile": context_cutover_request.product},
+            result=result,
+        )
+        store_apply_idempotency(
+            record_store=database_store,
+            identity=identity,
+            route_path=_PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
+    async def apply_product_legacy_context_cleanup(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            )
+        try:
+            legacy_cleanup_request = (
+                control_plane_product_context_cutover.LegacyContextCleanupRequest.model_validate(
+                    raw_payload
+                )
+            )
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="product_profile.write",
+            product=legacy_cleanup_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot clean up the requested legacy product context.",
+            )
+        database_store = require_product_context_apply_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+            label="Legacy context cleanup",
+        )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=database_store,
+            identity=identity,
+            route_path=_PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+        try:
+            result = control_plane_product_context_cutover.apply_legacy_context_cleanup(
+                record_store=database_store,
+                request=legacy_cleanup_request,
+            )
+        except control_plane_product_context_cutover.LegacyContextCleanupBoundaryError as error:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="context_not_in_product_boundary",
+                message="Requested cleanup contexts are not in the product cleanup boundary.",
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_legacy_context_cleanup_request",
+                message="Legacy context cleanup legacy_cleanup_request is invalid.",
+            ) from error
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"product_profile": legacy_cleanup_request.product},
+            result=result,
+        )
+        store_apply_idempotency(
+            record_store=database_store,
+            identity=identity,
+            route_path=_PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
 
     def resolve_ingress_edge_endpoint(
         *,
@@ -8118,6 +8360,64 @@ def create_launchplane_fastapi_app(
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
             404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE,
+        apply_product_context_cutover,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": control_plane_product_context_cutover.ProductContextCutoverRequest.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="apply_product_context_cutover",
+        summary="Plan or apply product context cutover",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE,
+        apply_product_legacy_context_cleanup,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": control_plane_product_context_cutover.LegacyContextCleanupRequest.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="apply_product_legacy_context_cleanup",
+        summary="Plan or apply legacy product context cleanup",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -20,7 +20,6 @@ from jwt import InvalidTokenError
 from starlette.types import ASGIApp
 
 from control_plane import authz_grant_service as control_plane_authz_grant_service
-from control_plane import product_context_cutover as control_plane_product_context_cutover
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane import service_status as control_plane_service_status
 from control_plane.http_app import (
@@ -3603,8 +3602,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/product-onboarding/apply",
         PROVIDER_TARGET_OPERATIONS_ROUTE,
         "/v1/product-config/apply",
-        "/v1/product-profiles/context-cutover/apply",
-        "/v1/product-profiles/legacy-context-cleanup/apply",
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
@@ -7435,31 +7432,6 @@ def _authz_policy_unavailable_response(
             },
         },
     )
-
-
-def _product_profile_context_cutover_allowed_contexts(
-    profile: LaunchplaneProductProfileRecord,
-) -> frozenset[str]:
-    contexts = {profile.product.strip()}
-    contexts.update(lane.context.strip() for lane in profile.lanes if lane.context.strip())
-    if profile.preview.enabled and profile.preview.context.strip():
-        contexts.add(profile.preview.context.strip())
-    return frozenset(context for context in contexts if context)
-
-
-def _product_profile_context_cutover_contexts_allowed(
-    *,
-    profile: LaunchplaneProductProfileRecord,
-    source_context: str,
-    target_context: str,
-    preview_context: str,
-) -> bool:
-    allowed_contexts = _product_profile_context_cutover_allowed_contexts(profile)
-    requested_contexts = {source_context.strip(), target_context.strip()}
-    if preview_context.strip():
-        requested_contexts.add(preview_context.strip())
-    requested_contexts.discard("")
-    return requested_contexts.issubset(allowed_contexts)
 
 
 def _product_driver_compatible(
@@ -11324,172 +11296,6 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     request=self_deploy_request.deploy,
                 ).model_dump(mode="json")
-            elif path == "/v1/product-profiles/context-cutover/apply":
-                context_cutover_request = control_plane_product_context_cutover.ProductContextCutoverRequest.model_validate(
-                    payload
-                )
-                if not isinstance(record_store, PostgresRecordStore):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "database_required",
-                                "message": "Product context cutover requires Launchplane database storage.",
-                            },
-                        },
-                    )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="product_profile.write",
-                    product=context_cutover_request.product,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot cut over the requested product profile context.",
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                profile = record_store.read_product_profile_record(context_cutover_request.product)
-                if not _product_profile_context_cutover_contexts_allowed(
-                    profile=profile,
-                    source_context=context_cutover_request.source_context,
-                    target_context=context_cutover_request.target_context,
-                    preview_context="",
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "context_not_in_product_boundary",
-                                "message": "Requested cutover contexts are not owned by the product profile.",
-                            },
-                        },
-                    )
-                try:
-                    driver_result = (
-                        control_plane_product_context_cutover.apply_product_context_cutover(
-                            record_store=record_store,
-                            request=context_cutover_request,
-                        )
-                    )
-                except ValueError:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "invalid_context_cutover_request",
-                                "message": "Product context cutover context_cutover_request is invalid.",
-                            },
-                        },
-                    )
-                result = {"product_profile": context_cutover_request.product}
-            elif path == "/v1/product-profiles/legacy-context-cleanup/apply":
-                legacy_cleanup_request = control_plane_product_context_cutover.LegacyContextCleanupRequest.model_validate(
-                    payload
-                )
-                if not isinstance(record_store, PostgresRecordStore):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "database_required",
-                                "message": "Legacy context cleanup requires Launchplane database storage.",
-                            },
-                        },
-                    )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="product_profile.write",
-                    product=legacy_cleanup_request.product,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot clean up the requested legacy product context.",
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                try:
-                    driver_result = (
-                        control_plane_product_context_cutover.apply_legacy_context_cleanup(
-                            record_store=record_store,
-                            request=legacy_cleanup_request,
-                        )
-                    )
-                except control_plane_product_context_cutover.LegacyContextCleanupBoundaryError:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "context_not_in_product_boundary",
-                                "message": "Requested cleanup contexts are not in the product cleanup boundary.",
-                            },
-                        },
-                    )
-                except ValueError:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "invalid_legacy_context_cleanup_request",
-                                "message": "Legacy context cleanup legacy_cleanup_request is invalid.",
-                            },
-                        },
-                    )
-                result = {"product_profile": legacy_cleanup_request.product}
             elif path == "/v1/previews/lifecycle-plan":
                 preview_lifecycle_plan_request = PreviewLifecyclePlanEnvelope.model_validate(
                     payload

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -123,6 +123,13 @@ Keep a compatibility surface only when it is one of these:
   bearer-token callers and preserve product-profile write-contract validation,
   record storage, and optional `Idempotency-Key` replay/conflict behavior. The
   legacy WSGI write branch is deleted; direct WSGI fallback calls fail closed.
+- Product context cutover and legacy context cleanup apply writes use native
+  FastAPI `POST /v1/product-profiles/context-cutover/apply` and
+  `POST /v1/product-profiles/legacy-context-cleanup/apply` for bearer-token
+  callers. They preserve `product_profile.write` authorization, DB-backed
+  storage gating, redacted result payloads, and optional `Idempotency-Key`
+  replay/conflict behavior. Their legacy WSGI write branches are deleted;
+  direct WSGI fallback calls fail closed.
 - Every Code work-request, summary, PR-feedback, preview-gate,
   notification-attempt, and preview-readiness reads use native FastAPI routes.
   The worker-facing read routes preserve the dedicated Every Code worker token;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1563,23 +1563,30 @@ inventory and release tuple pointers, and append-only evidence counts. It does
 not return runtime values, secret plaintext, secret ciphertext, or full provider
 environment text.
 
-Product context cutover apply uses `product_profile.write` for the requested
-product in the Launchplane service context. It supports `dry-run` and `apply`
-modes, copies only current-authority records into the target context, updates
-lane/preview product profile context fields, and returns key names/counts only.
-It does not copy append-only deployments, promotions, backup gates, or preview
-history.
+Product context cutover apply uses native FastAPI
+`POST /v1/product-profiles/context-cutover/apply` and `product_profile.write`
+for the requested product in the Launchplane service context. It supports
+`dry-run` and `apply` modes, copies only current-authority records into the
+target context, updates lane/preview product profile context fields, returns key
+names/counts only, and preserves optional `Idempotency-Key` replay/conflict
+behavior. Its legacy WSGI fallback branch is deleted; direct fallback calls fail
+closed. It does not copy append-only deployments, promotions, backup gates, or
+preview history.
 
-Product legacy context cleanup uses `product_profile.write` for the requested
-product in the Launchplane service context. It supports `dry-run` and `apply`
-modes after a context cutover has moved the product profile to the target
-context. Cleanup refuses to run while the source context is still owned by this
-or another product profile. It deletes legacy runtime environment records and
-Dokploy target lookup records only when matching target-context records already
-exist, disables legacy managed secret records and bindings, and preserves
-inventory, release tuple, deployment, promotion, backup gate, and preview
-history records as evidence. Responses remain redacted to key names, counts,
-target metadata, secret IDs, and binding keys/status.
+Product legacy context cleanup uses native FastAPI
+`POST /v1/product-profiles/legacy-context-cleanup/apply` and
+`product_profile.write` for the requested product in the Launchplane service
+context. It supports `dry-run` and `apply` modes after a context cutover has
+moved the product profile to the target context, preserves optional
+`Idempotency-Key` replay/conflict behavior, and has its legacy WSGI fallback
+branch deleted. Direct fallback calls fail closed. Cleanup refuses to run while
+the source context is still owned by this or another product profile. It deletes
+legacy runtime environment records and Dokploy target lookup records only when
+matching target-context records already exist, disables legacy managed secret
+records and bindings, and preserves inventory, release tuple, deployment,
+promotion, backup gate, and preview history records as evidence. Responses
+remain redacted to key names, counts, target metadata, secret IDs, and binding
+keys/status.
 
 ### Driver execution endpoints
 

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4603,7 +4603,355 @@ class FastApiProductProfileTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(stored_profile.driver_id, "generic-web")
 
 
-class FastApiProductContextCutoverAuditReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiProductContextCutoverTests(unittest.IsolatedAsyncioTestCase):
+    async def test_context_cutover_apply_updates_profile_for_authorized_workflow(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+
+            payload: dict[str, object] = {
+                "product": "sellyouroutboard",
+                "source_context": "sellyouroutboard-testing",
+                "target_context": "sellyouroutboard",
+                "mode": "apply",
+                "display_name": "SellYourOutboard",
+                "source_label": "test:context-cutover",
+            }
+            response = await _post_context_cutover_apply(
+                app,
+                payload,
+                idempotency_key="profile-context-cutover",
+            )
+            replay_response = await _post_context_cutover_apply(
+                app,
+                payload,
+                idempotency_key="profile-context-cutover",
+            )
+            stored_profile = app_store.read_product_profile_record("sellyouroutboard")
+            app_store.close()
+
+        self.assertEqual(response.status_code, 202)
+        body = response.json()
+        replay_body = replay_response.json()
+        self.assertEqual(body["records"], {"product_profile": "sellyouroutboard"})
+        self.assertEqual(replay_response.status_code, 202)
+        self.assertEqual(replay_body["records"], {"product_profile": "sellyouroutboard"})
+        self.assertEqual(replay_body["result"], body["result"])
+        self.assertEqual(body["result"]["profile"]["display_name"], "SellYourOutboard")
+        self.assertEqual(stored_profile.display_name, "SellYourOutboard")
+        self.assertEqual({lane.context for lane in stored_profile.lanes}, {"sellyouroutboard"})
+        self.assertEqual(stored_profile.preview.context, "sellyouroutboard")
+
+    async def test_context_cutover_apply_rejects_contexts_outside_product_boundary(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _post_context_cutover_apply(
+                app,
+                {
+                    "product": "sellyouroutboard",
+                    "source_context": "verireel-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "dry-run",
+                    "display_name": "SellYourOutboard",
+                },
+                idempotency_key="profile-context-cutover-cross-product",
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "context_not_in_product_boundary")
+
+    async def test_legacy_context_cleanup_apply_returns_redacted_dry_run(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            profile_payload = _product_profile_payload_with_prod()
+            profile_lanes = cast(tuple[dict[str, object], ...], profile_payload["lanes"])
+            profile_payload["lanes"] = tuple(
+                {**lane, "context": "sellyouroutboard"} for lane in profile_lanes
+            )
+            profile_preview = cast(dict[str, object], profile_payload["preview"])
+            profile_payload["preview"] = {
+                **profile_preview,
+                "context": "sellyouroutboard",
+            }
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(profile_payload)
+                )
+            finally:
+                store.close()
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+
+            response = await _post_legacy_context_cleanup_apply(
+                app,
+                {
+                    "product": "sellyouroutboard",
+                    "source_context": "sellyouroutboard-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "dry-run",
+                },
+                idempotency_key="legacy-context-cleanup-dry-run",
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 202)
+        body = response.json()
+        self.assertEqual(body["records"], {"product_profile": "sellyouroutboard"})
+        self.assertFalse(body["result"]["blocked"])
+        self.assertEqual(body["result"]["groups"]["runtime_environment_records"], [])
+
+    async def test_context_apply_authenticates_before_malformed_body(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_context_cutover_apply(
+            app,
+            {},
+            authorization="",
+            raw_body=b"{",
+        )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_context_apply_rejects_malformed_body_after_authentication(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_context_cutover_apply(
+            app,
+            {},
+            raw_body=b"\xff",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    async def test_context_cutover_apply_reports_schema_validation_message(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_context_cutover_apply(app, {"product": "sellyouroutboard"})
+
+        self.assertEqual(response.status_code, 400)
+        body = response.json()
+        self.assertEqual(body["error"]["code"], "invalid_request")
+        self.assertEqual(body["error"]["message"], "Request payload failed validation.")
+
+    async def test_context_cutover_apply_requires_database_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_context_cutover_apply(
+            app,
+            {
+                "product": "sellyouroutboard",
+                "source_context": "sellyouroutboard-testing",
+                "target_context": "sellyouroutboard",
+            },
+        )
+
+        self.assertEqual(response.status_code, 503)
+        body = response.json()
+        self.assertEqual(body["error"]["code"], "database_required")
+        self.assertEqual(
+            body["error"]["message"],
+            "Product context cutover requires Launchplane database storage.",
+        )
+
+    async def test_context_cutover_apply_requires_database_before_idempotency_replay(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "product": "sellyouroutboard",
+            "source_context": "sellyouroutboard-testing",
+            "target_context": "sellyouroutboard",
+        }
+        store = _ProductContextApplyReplayOnlyStore(
+            route_path="/v1/product-profiles/context-cutover/apply",
+            payload=payload,
+            idempotency_key="context-cutover-replay",
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_context_cutover_apply(
+            app,
+            payload,
+            idempotency_key="context-cutover-replay",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_required")
+        self.assertEqual(store.read_idempotency_calls, 0)
+
+    async def test_legacy_context_cleanup_apply_requires_database_before_idempotency_replay(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "product": "sellyouroutboard",
+            "source_context": "sellyouroutboard-testing",
+            "target_context": "sellyouroutboard",
+            "mode": "dry-run",
+        }
+        store = _ProductContextApplyReplayOnlyStore(
+            route_path="/v1/product-profiles/legacy-context-cleanup/apply",
+            payload=payload,
+            idempotency_key="legacy-context-cleanup-replay",
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_legacy_context_cleanup_apply(
+            app,
+            payload,
+            idempotency_key="legacy-context-cleanup-replay",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_required")
+        self.assertEqual(store.read_idempotency_calls, 0)
+
+    async def test_openapi_includes_context_apply_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        cutover_route = openapi["paths"]["/v1/product-profiles/context-cutover/apply"]["post"]
+        cleanup_route = openapi["paths"]["/v1/product-profiles/legacy-context-cleanup/apply"][
+            "post"
+        ]
+        self.assertEqual(cutover_route["operationId"], "apply_product_context_cutover")
+        self.assertEqual(
+            cleanup_route["operationId"],
+            "apply_product_legacy_context_cleanup",
+        )
+        self.assertEqual(
+            cutover_route["requestBody"]["content"]["application/json"]["schema"]["title"],
+            "ProductContextCutoverRequest",
+        )
+        self.assertEqual(
+            cleanup_route["requestBody"]["content"]["application/json"]["schema"]["title"],
+            "LegacyContextCleanupRequest",
+        )
+        for route in (cutover_route, cleanup_route):
+            self.assertEqual(
+                route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+                "#/components/schemas/AcceptedEvidenceResponse",
+            )
+            for status_code in ("400", "401", "403", "404", "409", "503"):
+                self.assertIn(status_code, route["responses"])
+
+    async def test_fastapi_context_apply_precedes_legacy_wsgi_fallback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                store.write_product_profile_record(
+                    LaunchplaneProductProfileRecord.model_validate(
+                        _product_profile_payload_with_prod()
+                    )
+                )
+            finally:
+                store.close()
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+                record_store_factory=lambda: app_store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({}),
+                control_plane_root_path=root,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+
+            response = await _post_context_cutover_apply(
+                app,
+                {
+                    "product": "sellyouroutboard",
+                    "source_context": "sellyouroutboard-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "dry-run",
+                },
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["records"], {"product_profile": "sellyouroutboard"})
+
     async def test_context_cutover_audit_returns_redacted_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -15326,6 +15674,54 @@ async def _post_product_profile(
     )
 
 
+async def _post_context_cutover_apply(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+    raw_body: bytes | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/product-profiles/context-cutover/apply",
+        headers=request_headers,
+        payload=payload,
+        raw_body=raw_body,
+    )
+
+
+async def _post_legacy_context_cleanup_apply(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+    raw_body: bytes | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/product-profiles/legacy-context-cleanup/apply",
+        headers=request_headers,
+        payload=payload,
+        raw_body=raw_body,
+    )
+
+
 async def _get_context_cutover_audit(
     app: FastAPI,
     *,
@@ -15936,6 +16332,51 @@ class _ProductProfileReplayOnlyStore:
     ) -> LaunchplaneIdempotencyRecord | None:
         self.read_idempotency_calls += 1
         if route_path != "/v1/product-profiles" or idempotency_key != self._idempotency_key:
+            return None
+        return LaunchplaneIdempotencyRecord(
+            record_id="idempotency-launchplane_req_original",
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=hashlib.sha256(
+                json.dumps(self._payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest(),
+            response_status_code=202,
+            response_trace_id="launchplane_req_original",
+            recorded_at="2026-05-29T12:00:00Z",
+            response_payload={
+                "status": "accepted",
+                "trace_id": "launchplane_req_original",
+                "records": {"product_profile": "sellyouroutboard"},
+            },
+        )
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> None:
+        raise AssertionError("idempotent replay must not write a new record")
+
+
+class _ProductContextApplyReplayOnlyStore:
+    def __init__(
+        self,
+        *,
+        route_path: str,
+        payload: dict[str, object],
+        idempotency_key: str,
+    ) -> None:
+        self.read_idempotency_calls = 0
+        self._route_path = route_path
+        self._payload = payload
+        self._idempotency_key = idempotency_key
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> LaunchplaneIdempotencyRecord | None:
+        self.read_idempotency_calls += 1
+        if route_path != self._route_path or idempotency_key != self._idempotency_key:
             return None
         return LaunchplaneIdempotencyRecord(
             record_id="idempotency-launchplane_req_original",

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -13568,210 +13568,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "authorization_denied")
         self.assertIn("can only read", payload["error"]["message"])
 
-    def test_product_context_cutover_endpoint_updates_profile_for_authorized_workflow(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["sellyouroutboard"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.write", "product_profile.read"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-            store = PostgresRecordStore(database_url=database_url)
-            try:
-                store.write_product_profile_record(
-                    LaunchplaneProductProfileRecord.model_validate(
-                        _product_profile_payload_with_prod()
-                    )
-                )
-            finally:
-                store.close()
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/product-profiles/context-cutover/apply",
-                payload={
-                    "product": "sellyouroutboard",
-                    "source_context": "sellyouroutboard-testing",
-                    "target_context": "sellyouroutboard",
-                    "mode": "apply",
-                    "display_name": "SellYourOutboard",
-                    "source_label": "test:context-cutover",
-                },
-                headers={"Idempotency-Key": "profile-context-cutover"},
-            )
-            replay_status_code, replay_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/product-profiles/context-cutover/apply",
-                payload={
-                    "product": "sellyouroutboard",
-                    "source_context": "sellyouroutboard-testing",
-                    "target_context": "sellyouroutboard",
-                    "mode": "apply",
-                    "display_name": "SellYourOutboard",
-                    "source_label": "test:context-cutover",
-                },
-                headers={"Idempotency-Key": "profile-context-cutover"},
-            )
-            store = PostgresRecordStore(database_url=database_url)
-            try:
-                stored_profile = store.read_product_profile_record("sellyouroutboard")
-            finally:
-                store.close()
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["records"], {"product_profile": "sellyouroutboard"})
-        self.assertEqual(replay_status_code, 202)
-        self.assertEqual(replay_payload["records"], {"product_profile": "sellyouroutboard"})
-        self.assertEqual(replay_payload["result"], payload["result"])
-        self.assertEqual(payload["result"]["profile"]["display_name"], "SellYourOutboard")
-        self.assertEqual(stored_profile.display_name, "SellYourOutboard")
-        self.assertEqual(
-            {lane.context for lane in stored_profile.lanes},
-            {"sellyouroutboard"},
-        )
-        self.assertEqual(stored_profile.preview.context, "sellyouroutboard")
-
-    def test_product_context_cutover_endpoint_rejects_contexts_outside_product_boundary(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["sellyouroutboard"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-            store = PostgresRecordStore(database_url=database_url)
-            try:
-                store.write_product_profile_record(
-                    LaunchplaneProductProfileRecord.model_validate(
-                        _product_profile_payload_with_prod()
-                    )
-                )
-            finally:
-                store.close()
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/product-profiles/context-cutover/apply",
-                payload={
-                    "product": "sellyouroutboard",
-                    "source_context": "verireel-testing",
-                    "target_context": "sellyouroutboard",
-                    "mode": "dry-run",
-                    "display_name": "SellYourOutboard",
-                },
-                headers={"Idempotency-Key": "profile-context-cutover-cross-product"},
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "context_not_in_product_boundary")
-
-    def test_legacy_context_cleanup_endpoint_returns_redacted_dry_run(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/verireel",
-                            "workflow_refs": [
-                                "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["sellyouroutboard"],
-                            "contexts": ["launchplane"],
-                            "actions": ["product_profile.write"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                control_plane_root_path=root,
-                database_url=database_url,
-            )
-            profile_payload = _product_profile_payload_with_prod()
-            profile_lanes = cast(tuple[dict[str, object], ...], profile_payload["lanes"])
-            profile_payload["lanes"] = tuple(
-                {**lane, "context": "sellyouroutboard"} for lane in profile_lanes
-            )
-            profile_preview = cast(dict[str, object], profile_payload["preview"])
-            profile_payload["preview"] = {
-                **profile_preview,
-                "context": "sellyouroutboard",
-            }
-            store = PostgresRecordStore(database_url=database_url)
-            try:
-                store.write_product_profile_record(
-                    LaunchplaneProductProfileRecord.model_validate(profile_payload)
-                )
-            finally:
-                store.close()
-
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/product-profiles/legacy-context-cleanup/apply",
-                payload={
-                    "product": "sellyouroutboard",
-                    "source_context": "sellyouroutboard-testing",
-                    "target_context": "sellyouroutboard",
-                    "mode": "dry-run",
-                },
-                headers={"Idempotency-Key": "legacy-context-cleanup-dry-run"},
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["records"], {"product_profile": "sellyouroutboard"})
-        self.assertFalse(payload["result"]["blocked"])
-        self.assertEqual(payload["result"]["groups"]["runtime_environment_records"], [])
-
-    def test_context_cutover_audit_route_is_retired_from_legacy_wsgi_app(self) -> None:
+    def test_product_context_routes_are_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
@@ -13809,7 +13606,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 database_url=database_url,
             )
 
-            status_code, payload = _invoke_app(
+            audit_status_code, audit_payload = _invoke_app(
                 app,
                 method="GET",
                 path="/v1/product-profiles/sellyouroutboard/context-cutover-audit",
@@ -13817,9 +13614,36 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "source_context=sellyouroutboard-testing&target_context=sellyouroutboard"
                 ),
             )
+            cutover_status_code, cutover_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles/context-cutover/apply",
+                payload={
+                    "product": "sellyouroutboard",
+                    "source_context": "sellyouroutboard-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "dry-run",
+                },
+            )
+            cleanup_status_code, cleanup_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-profiles/legacy-context-cleanup/apply",
+                payload={
+                    "product": "sellyouroutboard",
+                    "source_context": "sellyouroutboard-testing",
+                    "target_context": "sellyouroutboard",
+                    "mode": "dry-run",
+                },
+            )
 
-        self.assertEqual(status_code, 404)
-        self.assertEqual(payload["error"]["code"], "not_found")
+        for status_code, payload in (
+            (audit_status_code, audit_payload),
+            (cutover_status_code, cutover_payload),
+            (cleanup_status_code, cleanup_payload),
+        ):
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_agent_write_intent_evaluate_returns_allowed_dry_run_without_execution(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- move product context cutover and legacy cleanup apply writes to native FastAPI
- enforce auth-first parsing, product_profile.write authorization, Postgres-only DB gating before idempotency replay, and redacted accepted responses
- retire the legacy WSGI apply branches and update tests/docs for the v2 boundary

## Validation
- uv run python -m unittest tests.test_http_app.FastApiProductContextCutoverTests tests.test_service.LaunchplaneServiceTests.test_product_context_routes_are_retired_from_legacy_wsgi_app
- uv run python -m py_compile control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff check .
- uv run --extra dev mypy control_plane tests
- npx markdownlint-cli2 docs/service-boundary.md docs/compatibility-retirement.md
- uv run python -m unittest
- JetBrains inspect-closeout changed_files: GREEN
- Review agents: code-gpt-5.5 GREEN, claude-sonnet-4.6 GREEN

## Notes
- Repo-wide ruff format --check still reports pre-existing unrelated formatting drift outside this slice; touched-file format check is clean.