### PR TITLE
Move Odoo worker reconcile to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -174,6 +174,10 @@ from control_plane.workflows.npmplus_ingress import (
     NpmplusIngressApplyResult,
     NpmplusIngressClient,
 )
+from control_plane.workflows.odoo_stable_operation_worker import (
+    DEFAULT_ODOO_STABLE_WORKER_MAX_ATTEMPTS,
+    reconcile_stale_odoo_stable_operation_records,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.work_graph_service import (
@@ -363,6 +367,22 @@ class OdooStableOperationWorkerStatusResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     worker_status: OdooStableOperationWorkerStatusResponseModel
+
+
+class OdooStableOperationWorkerReconcileResultResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reconciled_bootstrap_ids: tuple[str, ...]
+    reconciled_replacement_ids: tuple[str, ...]
+    reconciled_count: int
+
+
+class OdooStableOperationWorkerReconcileResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    reconcile_result: OdooStableOperationWorkerReconcileResultResponse
 
 
 class OdooStableBootstrapOperationStatusResponse(BaseModel):
@@ -2490,6 +2510,22 @@ def create_launchplane_fastapi_app(
                 message="Workflow cannot read Launchplane service runtime state.",
             )
 
+    def require_launchplane_service_reconcile_authorization(
+        *, identity: LaunchplaneIdentity, trace_id: str
+    ) -> None:
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="launchplane_service.reconcile_odoo_workers",
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot reconcile Launchplane Odoo workers.",
+            )
+
     def read_launchplane_runtime(
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
         record_store: Annotated[object, Depends(get_record_store)],
@@ -2544,6 +2580,53 @@ def create_launchplane_fastapi_app(
         return OdooStableOperationWorkerStatusResponse(
             trace_id=trace_id,
             worker_status=worker_status,
+        )
+
+    def reconcile_odoo_stable_operation_workers(
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        max_attempts: Annotated[str, Query()] = str(DEFAULT_ODOO_STABLE_WORKER_MAX_ATTEMPTS),
+    ) -> OdooStableOperationWorkerReconcileResponse:
+        trace_id = next_trace_id()
+        require_launchplane_service_reconcile_authorization(identity=identity, trace_id=trace_id)
+        try:
+            parsed_max_attempts = control_plane_service_status.query_int_value(
+                max_attempts,
+                "max_attempts",
+                default=DEFAULT_ODOO_STABLE_WORKER_MAX_ATTEMPTS,
+                minimum=1,
+                maximum=100,
+            )
+            assert parsed_max_attempts is not None
+            reconcile_result = reconcile_stale_odoo_stable_operation_records(
+                record_store=control_plane_service_status.require_odoo_stable_operation_worker_store(
+                    record_store
+                ),
+                max_attempts=parsed_max_attempts,
+            )
+        except click.ClickException as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="operation_record_storage_required",
+                message=str(error),
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        reconciled_bootstrap_ids = tuple(reconcile_result.reconciled_bootstrap_ids)
+        reconciled_replacement_ids = tuple(reconcile_result.reconciled_replacement_ids)
+        return OdooStableOperationWorkerReconcileResponse(
+            trace_id=trace_id,
+            reconcile_result=OdooStableOperationWorkerReconcileResultResponse(
+                reconciled_bootstrap_ids=reconciled_bootstrap_ids,
+                reconciled_replacement_ids=reconciled_replacement_ids,
+                reconciled_count=len(reconciled_bootstrap_ids) + len(reconciled_replacement_ids),
+            ),
         )
 
     def read_odoo_stable_bootstrap_operation_status(
@@ -7543,6 +7626,21 @@ def create_launchplane_fastapi_app(
         response_model=OdooStableOperationWorkerStatusResponse,
         operation_id="read_odoo_stable_operation_worker_status",
         summary="Read Odoo stable operation worker status",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        "/v1/service/odoo-workers/reconcile",
+        reconcile_odoo_stable_operation_workers,
+        methods=["POST"],
+        response_model=OdooStableOperationWorkerReconcileResponse,
+        operation_id="reconcile_odoo_stable_operation_workers",
+        summary="Reconcile stale Odoo stable operation workers",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -21,7 +21,6 @@ from starlette.types import ASGIApp
 
 from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import product_onboarding_service as control_plane_product_onboarding_service
-from control_plane import service_status as control_plane_service_status
 from control_plane.http_app import (
     LaunchplaneAuthzPolicyRuntime,
     create_launchplane_fastapi_app,
@@ -427,10 +426,6 @@ from control_plane.workflows.odoo_prod_rollback import (
 from control_plane.workflows.odoo_stable_target_replacement import (
     OdooStableTargetReplacementStore,
     build_odoo_stable_target_replacement_plan,
-)
-from control_plane.workflows.odoo_stable_operation_worker import (
-    DEFAULT_ODOO_STABLE_WORKER_MAX_ATTEMPTS,
-    reconcile_stale_odoo_stable_operation_records,
 )
 from control_plane.workflows.verireel_stable_deploy import (
     VeriReelStableDeployRequest,
@@ -3590,7 +3585,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/preview-gates",
         "/v1/work-graph/github/issues/reconcile",
         "/v1/work-graph/rank",
-        "/v1/service/odoo-workers/reconcile",
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-actions/removals",
         "/v1/authz-policies/github-humans/grants",
@@ -8448,86 +8442,6 @@ def create_launchplane_service_app(
                                 "Terminal agent credentials can only read redacted "
                                 "Launchplane context."
                             ),
-                        },
-                    },
-                )
-            if path == "/v1/service/odoo-workers/reconcile":
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="launchplane_service.reconcile_odoo_workers",
-                    product="launchplane",
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot reconcile Launchplane Odoo workers.",
-                            },
-                        },
-                    )
-                try:
-                    max_attempts = _query_int_value(
-                        query,
-                        "max_attempts",
-                        default=DEFAULT_ODOO_STABLE_WORKER_MAX_ATTEMPTS,
-                        minimum=1,
-                        maximum=100,
-                    )
-                    assert max_attempts is not None
-                    odoo_worker_reconcile_result = reconcile_stale_odoo_stable_operation_records(
-                        record_store=control_plane_service_status.require_odoo_stable_operation_worker_store(
-                            record_store
-                        ),
-                        max_attempts=max_attempts,
-                    )
-                except click.ClickException as error:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "operation_record_storage_required",
-                                "message": str(error),
-                            },
-                        },
-                    )
-                except ValueError as error:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "invalid_query",
-                                "message": str(error),
-                            },
-                        },
-                    )
-                reconciled_bootstrap_ids = list(
-                    odoo_worker_reconcile_result.reconciled_bootstrap_ids
-                )
-                reconciled_replacement_ids = list(
-                    odoo_worker_reconcile_result.reconciled_replacement_ids
-                )
-                return _json_response(
-                    start_response=start_response,
-                    status_code=200,
-                    payload={
-                        "status": "ok",
-                        "trace_id": request_trace_id,
-                        "reconcile_result": {
-                            "reconciled_bootstrap_ids": reconciled_bootstrap_ids,
-                            "reconciled_replacement_ids": reconciled_replacement_ids,
-                            "reconciled_count": len(reconciled_bootstrap_ids)
-                            + len(reconciled_replacement_ids),
                         },
                     },
                 )

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -57,7 +57,11 @@ Keep a compatibility surface only when it is one of these:
   Its legacy WSGI branch is deleted; direct fallback calls fail closed while
   the mounted fallback remains for retained non-native routes.
 - Launchplane service runtime and Odoo worker status reads use native FastAPI
-  routes for bearer-token and human-session callers. Their legacy WSGI branch is
+  routes for bearer-token and human-session callers. Odoo worker reconcile uses
+  native FastAPI `POST /v1/service/odoo-workers/reconcile` on the bearer/OIDC
+  write identity path with the existing operation-record storage protocol,
+  `launchplane_service.reconcile_odoo_workers` authorization, `max_attempts`
+  validation, and `200` reconcile result payload. Their legacy WSGI branches are
   deleted; direct fallback calls fail closed while the mounted fallback remains
   for retained non-native routes.
 - Odoo stable-bootstrap and target-replacement operation status reads use native

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1431,6 +1431,8 @@ only after a passing plan and a matching stored preview record are present.
   callers)
 - `GET /v1/service/odoo-workers/status` (native FastAPI for bearer-token and
   human-session callers)
+- `POST /v1/service/odoo-workers/reconcile` (native FastAPI on the bearer/OIDC
+  write identity path with `launchplane_service.reconcile_odoo_workers`)
 - `GET /v1/drivers/odoo/stable-bootstrap/operations/{operation_id}` (native
   FastAPI for bearer-token and human-session callers)
 - `GET /v1/drivers/odoo/target-replacement/operations/{operation_id}` (native

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -272,6 +272,153 @@ class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(worker_status["operations"][0]["operation_id"], "bootstrap-cm-testing")
         self.assertNotIn("request", worker_status["operations"][0])
 
+    async def test_worker_reconcile_recovers_stale_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_odoo_stable_bootstrap_operation_record(
+                _stale_odoo_stable_bootstrap_record()
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_local_operator_launchplane_service_reconcile_policy(),
+                record_store_factory=lambda: record_store,
+                bearer_identity_config=_local_operator_bearer_config(
+                    token_label="local-owner-write"
+                ),
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/service/odoo-workers/reconcile",
+                headers={"Authorization": "Bearer local-operator-token"},
+                payload={},
+            )
+            operation = record_store.read_odoo_stable_bootstrap_operation_record(
+                "bootstrap-cm-testing"
+            )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(payload["trace_id"].startswith("launchplane_req_"))
+        self.assertEqual(
+            payload["reconcile_result"],
+            {
+                "reconciled_bootstrap_ids": ["bootstrap-cm-testing"],
+                "reconciled_replacement_ids": [],
+                "reconciled_count": 1,
+            },
+        )
+        self.assertEqual(operation.status, "pending")
+        self.assertEqual(operation.lease_owner, "")
+
+    async def test_worker_reconcile_accepts_github_actions_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_odoo_stable_bootstrap_operation_record(
+                _stale_odoo_stable_bootstrap_record()
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_github_actions_launchplane_service_reconcile_policy(),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/service/odoo-workers/reconcile",
+                headers={"Authorization": "Bearer valid-token"},
+                payload={},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json()["reconcile_result"]["reconciled_bootstrap_ids"],
+            ["bootstrap-cm-testing"],
+        )
+
+    async def test_worker_reconcile_requires_reconcile_authz(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=_local_operator_bearer_config(token_label="local-owner-write"),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/service/odoo-workers/reconcile",
+            headers={"Authorization": "Bearer local-operator-token"},
+            payload={},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_worker_reconcile_rejects_terminal_agent_mutation(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_terminal_agent_launchplane_service_reconcile_policy(),
+            record_store_factory=lambda: _EmptyStore(),
+            bearer_identity_config=BearerIdentityConfig(
+                terminal_agent_token="terminal-agent-token",
+                terminal_agent_subject="local-owner-agent",
+                terminal_agent_token_label="local-owner-read",
+            ),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/service/odoo-workers/reconcile",
+            headers={"Authorization": "Bearer terminal-agent-token"},
+            payload={},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_worker_reconcile_validates_max_attempts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_local_operator_launchplane_service_reconcile_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=_local_operator_bearer_config(token_label="local-owner-write"),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/service/odoo-workers/reconcile?max_attempts=0",
+            headers={"Authorization": "Bearer local-operator-token"},
+            payload={},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_query")
+
+    async def test_worker_reconcile_requires_operation_record_storage(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_local_operator_launchplane_service_reconcile_policy(),
+            record_store_factory=lambda: _EmptyStore(),
+            bearer_identity_config=_local_operator_bearer_config(token_label="local-owner-write"),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/service/odoo-workers/reconcile",
+            headers={"Authorization": "Bearer local-operator-token"},
+            payload={},
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "operation_record_storage_required")
+
     async def test_worker_status_requires_service_read_authz(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_identity()),
@@ -299,11 +446,19 @@ class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
 
         runtime_response = await _asgi_get(app, "/v1/service/runtime")
         worker_response = await _asgi_get(app, "/v1/service/odoo-workers/status")
+        reconcile_response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/service/odoo-workers/reconcile",
+            payload={},
+        )
 
         self.assertEqual(runtime_response.status_code, 401)
         self.assertEqual(worker_response.status_code, 401)
+        self.assertEqual(reconcile_response.status_code, 401)
         self.assertEqual(runtime_response.json()["error"]["code"], "authentication_required")
         self.assertEqual(worker_response.json()["error"]["code"], "authentication_required")
+        self.assertEqual(reconcile_response.json()["error"]["code"], "authentication_required")
 
     async def test_runtime_rejects_human_session_without_service_read_authz(self) -> None:
         oauth_config = _github_oauth_config()
@@ -388,6 +543,7 @@ class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
         openapi = response.json()
         runtime_route = openapi["paths"]["/v1/service/runtime"]["get"]
         worker_route = openapi["paths"]["/v1/service/odoo-workers/status"]["get"]
+        reconcile_route = openapi["paths"]["/v1/service/odoo-workers/reconcile"]["post"]
         self.assertEqual(runtime_route["operationId"], "read_launchplane_runtime")
         self.assertEqual(
             runtime_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
@@ -402,6 +558,14 @@ class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
             "#/components/schemas/OdooStableOperationWorkerStatusResponse",
         )
         self.assertEqual(
+            reconcile_route["operationId"],
+            "reconcile_odoo_stable_operation_workers",
+        )
+        self.assertEqual(
+            reconcile_route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/OdooStableOperationWorkerReconcileResponse",
+        )
+        self.assertEqual(
             openapi["components"]["schemas"]["LaunchplaneRuntimeResponse"]["additionalProperties"],
             False,
         )
@@ -411,8 +575,15 @@ class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
             ],
             False,
         )
+        self.assertEqual(
+            openapi["components"]["schemas"]["OdooStableOperationWorkerReconcileResponse"][
+                "additionalProperties"
+            ],
+            False,
+        )
         self.assertTrue(set(runtime_route["responses"]) >= {"200", "401", "403"})
         self.assertTrue(set(worker_route["responses"]) >= {"200", "400", "401", "403", "503"})
+        self.assertTrue(set(reconcile_route["responses"]) >= {"200", "400", "401", "403", "503"})
 
     async def test_fastapi_service_runtime_precedes_legacy_wsgi_fallback(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -14695,6 +14866,41 @@ def _local_operator_launchplane_service_read_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
+def _local_operator_launchplane_service_reconcile_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "local_operators": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-write"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["launchplane_service.reconcile_odoo_workers"],
+                }
+            ]
+        }
+    )
+
+
+def _github_actions_launchplane_service_reconcile_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["launchplane_service.reconcile_odoo_workers"],
+                }
+            ]
+        }
+    )
+
+
 def _pending_odoo_stable_bootstrap_record() -> OdooStableBootstrapOperationRecord:
     return OdooStableBootstrapOperationRecord.model_validate(
         {
@@ -14715,6 +14921,35 @@ def _pending_odoo_stable_bootstrap_record() -> OdooStableBootstrapOperationRecor
             "phase": "created",
             "created_at": "2026-05-17T00:00:00Z",
             "updated_at": "2026-05-17T00:00:00Z",
+        }
+    )
+
+
+def _stale_odoo_stable_bootstrap_record() -> OdooStableBootstrapOperationRecord:
+    return OdooStableBootstrapOperationRecord.model_validate(
+        {
+            "operation_id": "bootstrap-cm-testing",
+            "product": "odoo-tenant-cm",
+            "context": "cm",
+            "instance": "testing",
+            "idempotency_key": "bootstrap-cm-testing",
+            "request_fingerprint": "fingerprint-123",
+            "request": {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm",
+                "context": "cm",
+                "instance": "testing",
+                "confirmation": "bootstrap cm testing",
+            },
+            "status": "running",
+            "phase": "created",
+            "created_at": "2026-05-17T00:00:00Z",
+            "updated_at": "2026-05-17T00:01:00Z",
+            "started_at": "2026-05-17T00:01:00Z",
+            "lease_owner": "old-worker",
+            "lease_expires_at": "2000-01-01T00:00:00Z",
+            "heartbeat_at": "2000-01-01T00:00:00Z",
+            "attempt": 1,
         }
     )
 
@@ -14837,6 +15072,22 @@ def _terminal_agent_launchplane_read_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
+def _terminal_agent_launchplane_service_reconcile_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["launchplane_service.reconcile_odoo_workers"],
+                }
+            ]
+        }
+    )
+
+
 def _local_operator_artifact_protection_policy(
     *,
     products: tuple[str, ...] = ("*",),
@@ -14899,11 +15150,11 @@ def _github_human_identity(*, role: Literal["read_only", "admin"] = "admin") -> 
     )
 
 
-def _local_operator_bearer_config() -> BearerIdentityConfig:
+def _local_operator_bearer_config(*, token_label: str = "local-owner-read") -> BearerIdentityConfig:
     return BearerIdentityConfig(
         local_operator_token="local-operator-token",
         local_operator_subject="local-owner-agent",
-        local_operator_token_label="local-owner-read",
+        local_operator_token_label=token_label,
     )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10489,11 +10489,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 path="/v1/service/odoo-workers/status",
                 authorization="",
             )
+            reconcile_status, reconcile_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/service/odoo-workers/reconcile",
+                payload={},
+                authorization="",
+            )
 
         self.assertEqual(runtime_status, 404)
         self.assertEqual(worker_status, 404)
+        self.assertEqual(reconcile_status, 404)
         self.assertEqual(runtime_payload["error"]["code"], "not_found")
         self.assertEqual(worker_payload["error"]["code"], "not_found")
+        self.assertEqual(reconcile_payload["error"]["code"], "not_found")
 
     def test_target_logs_route_is_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -10792,200 +10801,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(
             authorized_config_response.json()["config_status"]["product"], "example-site"
         )
-
-    def test_service_odoo_workers_reconcile_endpoint_recovers_stale_records(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            record_store = FilesystemRecordStore(state_dir)
-            record_store.write_odoo_stable_bootstrap_operation_record(
-                OdooStableBootstrapOperationRecord.model_validate(
-                    {
-                        "operation_id": "bootstrap-cm-testing",
-                        "product": "odoo-tenant-cm",
-                        "context": "cm",
-                        "instance": "testing",
-                        "idempotency_key": "bootstrap-cm-testing",
-                        "request_fingerprint": "fingerprint-123",
-                        "request": {
-                            "schema_version": 1,
-                            "product": "odoo-tenant-cm",
-                            "context": "cm",
-                            "instance": "testing",
-                            "confirmation": "bootstrap cm testing",
-                        },
-                        "status": "running",
-                        "phase": "created",
-                        "created_at": "2026-05-17T00:00:00Z",
-                        "updated_at": "2026-05-17T00:01:00Z",
-                        "started_at": "2026-05-17T00:01:00Z",
-                        "lease_owner": "old-worker",
-                        "lease_expires_at": "2000-01-01T00:00:00Z",
-                        "heartbeat_at": "2000-01-01T00:00:00Z",
-                        "attempt": 1,
-                    }
-                )
-            )
-            policy = _local_operator_policy(
-                actions=("launchplane_service.reconcile_odoo_workers",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=state_dir,
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=record_store,
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/service/odoo-workers/reconcile",
-                    payload={},
-                    authorization="Bearer local-operator-token",
-                )
-
-            self.assertEqual(status_code, 200)
-            reconcile_result = payload["reconcile_result"]
-            self.assertEqual(payload["status"], "ok")
-            self.assertEqual(reconcile_result["reconciled_count"], 1)
-            self.assertEqual(
-                reconcile_result["reconciled_bootstrap_ids"],
-                ["bootstrap-cm-testing"],
-            )
-            self.assertEqual(reconcile_result["reconciled_replacement_ids"], [])
-            operation = record_store.read_odoo_stable_bootstrap_operation_record(
-                "bootstrap-cm-testing"
-            )
-            self.assertEqual(operation.status, "pending")
-            self.assertEqual(operation.lease_owner, "")
-
-    def test_service_odoo_workers_reconcile_endpoint_requires_reconcile_authz(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            policy = _local_operator_policy(
-                actions=("launchplane_service.read",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=state_dir,
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=FilesystemRecordStore(state_dir),
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/service/odoo-workers/reconcile",
-                    payload={},
-                    authorization="Bearer local-operator-token",
-                )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_service_odoo_workers_reconcile_endpoint_validates_max_attempts(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            policy = _local_operator_policy(
-                actions=("launchplane_service.reconcile_odoo_workers",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=state_dir,
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=FilesystemRecordStore(state_dir),
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/service/odoo-workers/reconcile",
-                    query_string="max_attempts=0",
-                    payload={},
-                    authorization="Bearer local-operator-token",
-                )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_query")
-
-    def test_service_odoo_workers_reconcile_endpoint_requires_operation_record_storage(
-        self,
-    ) -> None:
-        class _EmptyStore:
-            backend_name = "test-empty"
-
-            def close(self) -> None:
-                return None
-
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            policy = _local_operator_policy(
-                actions=("launchplane_service.reconcile_odoo_workers",),
-                products=("launchplane",),
-                contexts=("launchplane",),
-            )
-            with patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN": "local-operator-token",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT": "local-owner-agent",
-                    "LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL": "local-owner-write",
-                },
-            ):
-                app = create_launchplane_service_app(
-                    state_dir=state_dir,
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=policy,
-                    control_plane_root_path=root,
-                    local_record_store_for_tests=cast(Any, _EmptyStore()),
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/service/odoo-workers/reconcile",
-                    payload={},
-                    authorization="Bearer local-operator-token",
-                )
-
-        self.assertEqual(status_code, 503)
-        self.assertEqual(payload["error"]["code"], "operation_record_storage_required")
 
     def test_ui_route_serves_static_shell_without_authentication(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- move `POST /v1/service/odoo-workers/reconcile` from the legacy WSGI dispatcher to native FastAPI
- preserve the bearer/OIDC write identity path, `launchplane_service.reconcile_odoo_workers` authz, `max_attempts` validation, operation-store protocol gating, and 200 reconcile payload
- retire the legacy WSGI branch/write-route ownership and update docs/tests for the native contract

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiServiceRuntimeReadTests tests.test_service.LaunchplaneServiceTests.test_service_runtime_routes_are_retired_from_legacy_wsgi_app` (16 tests)
- `uv run python -m py_compile control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `npx markdownlint-cli2 docs/service-boundary.md docs/compatibility-retirement.md`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (2824 tests)
- JetBrains inspection closeout: GREEN, changed-files scope, PyCharm route
- Review agents: GREEN from `code-gpt-5.5`, `claude-sonnet-4.6`, and `antigravity`

Refs #1322
