### PR TITLE
Move work graph rank to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -183,8 +183,10 @@ from control_plane.work_graph_issue_inbox import GitHubIssueInboxReadModel
 from control_plane.work_graph_service import (
     WorkGraphIssueInboxProvider,
     WorkGraphPlanningFactsProvider,
+    WorkGraphRankEnvelope,
     WorkGraphWorkRequestStore,
     build_repo_product_mapping_service_payload,
+    build_work_graph_rank_result,
     build_work_graph_snapshot_service_payload,
 )
 
@@ -2417,6 +2419,45 @@ def create_launchplane_fastapi_app(
             return human_identity
         raise _authentication_required_error("Authorization header is required.")
 
+    def read_work_graph_rank_identity(
+        request: Request,
+        response: Response,
+        authorization: Annotated[str, Header(alias="Authorization")] = "",
+        cookie: Annotated[str, Header(alias="Cookie")] = "",
+    ) -> GitHubActionsIdentity | GitHubHumanIdentity:
+        human_identity = read_human_session_identity(
+            cookie_header=cookie,
+            request=request,
+            response=response,
+        )
+        if human_identity is not None:
+            return human_identity
+        header = authorization.strip()
+        if not header:
+            raise _authentication_required_error("Authorization header is required.")
+        scheme, _, token = header.partition(" ")
+        bearer_token = token.strip()
+        if scheme.lower() != "bearer" or not bearer_token:
+            raise _authentication_required_error("Bearer token is required.")
+        try:
+            owner_agent_identity = bearer_identity_from_token(
+                token=bearer_token,
+                config=bearer_identity_config or BearerIdentityConfig(),
+            )
+        except PermissionError as error:
+            raise _authentication_required_error(str(error)) from error
+        if owner_agent_identity is not None:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=next_trace_id(),
+                code="authorization_denied",
+                message=("Work graph rank requires GitHub Actions OIDC or a GitHub human session."),
+            )
+        try:
+            return verifier.verify(bearer_token)
+        except (InvalidTokenError, ValueError) as error:
+            raise _authentication_required_error(str(error)) from error
+
     def every_code_worker_token_authorized(authorization: str) -> bool:
         if bearer_identity_config is None:
             return False
@@ -3241,6 +3282,26 @@ def create_launchplane_fastapi_app(
             trace_id=trace_id,
             snapshot=WorkGraphSnapshot.model_validate(payload["snapshot"]),
             source=cast(dict[str, object], payload["source"]),
+        )
+
+    def rank_work_graph_snapshot(
+        payload: WorkGraphRankEnvelope,
+        identity: Annotated[
+            GitHubActionsIdentity | GitHubHumanIdentity,
+            Depends(read_work_graph_rank_identity),
+        ],
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        require_work_graph_rank_authorization(
+            identity=identity,
+            trace_id=trace_id,
+            message="Workflow cannot rank the Launchplane work graph.",
+        )
+        _summary, driver_result = build_work_graph_rank_result(payload)
+        return AcceptedEvidenceResponse(
+            trace_id=trace_id,
+            records={},
+            result=driver_result,
         )
 
     def read_work_graph_issue_inbox(
@@ -8236,6 +8297,22 @@ def create_launchplane_fastapi_app(
         operation_id="read_work_graph_snapshot",
         summary="Read Launchplane work graph snapshot",
         responses=agent_context_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/work-graph/rank",
+        rank_work_graph_snapshot,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="rank_work_graph_snapshot",
+        summary="Rank Launchplane work graph snapshot",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+        },
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -314,10 +314,8 @@ from control_plane.work_graph_service import (
     WorkGraphIssueInboxReconcileProvider,
 )
 from control_plane.work_graph_http import (
-    rank_work_graph_snapshot,
     reconcile_work_graph_issue_inbox,
     work_graph_issue_inbox_reconcile_denied_response,
-    work_graph_rank_denied_response,
 )
 from control_plane.workflows.launchplane_self_deploy import (
     LaunchplaneSelfDeployRequest,
@@ -1721,7 +1719,6 @@ _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
         "/v1/merge-train/policies/import",
     }
 )
-_HUMAN_IDENTITY_READ_MODEL_POST_ROUTES = frozenset({"/v1/work-graph/rank"})
 _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES = frozenset(
     {
         _GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path,
@@ -3584,7 +3581,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/pr-feedback/status",
         "/v1/every-code/preview-gates",
         "/v1/work-graph/github/issues/reconcile",
-        "/v1/work-graph/rank",
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-actions/removals",
         "/v1/authz-policies/github-humans/grants",
@@ -8403,10 +8399,7 @@ def create_launchplane_service_app(
                     on_renewed_session=record_renewed_session,
                 )
             else:
-                if (
-                    path in _HUMAN_IDENTITY_MUTATION_ROUTES
-                    or path in _HUMAN_IDENTITY_READ_MODEL_POST_ROUTES
-                ):
+                if path in _HUMAN_IDENTITY_MUTATION_ROUTES:
                     identity = _read_identity(
                         environ=environ,
                         verifier=verifier,
@@ -10017,20 +10010,6 @@ def create_launchplane_service_app(
                     idempotency_key=request_idempotency_key,
                     every_code_discord_sender=every_code_discord_sender,
                 )
-            elif path == "/v1/work-graph/rank":
-                work_graph_rank_result = rank_work_graph_snapshot(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    payload=payload,
-                )
-                if work_graph_rank_result is None:
-                    return work_graph_rank_denied_response(
-                        trace_id=request_trace_id,
-                        json_response=_json_response,
-                        start_response=start_response,
-                    )
-                result = work_graph_rank_result.result
-                driver_result = work_graph_rank_result.driver_result
             elif path == "/v1/work-graph/github/issues/reconcile":
                 reconcile_result = reconcile_work_graph_issue_inbox(
                     authz_policy=authz_policy,

--- a/control_plane/work_graph_http.py
+++ b/control_plane/work_graph_http.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from dataclasses import dataclass
 from typing import TypeAlias
 from control_plane.service_auth import (
     GitHubActionsIdentity,
@@ -13,8 +12,6 @@ from control_plane.service_auth import (
 )
 from control_plane.work_graph_service import (
     WorkGraphIssueInboxReconcileProvider,
-    WorkGraphRankEnvelope,
-    build_work_graph_rank_result,
 )
 from control_plane.work_graph_issue_inbox import (
     GitHubIssueInboxReconcileRequest,
@@ -33,12 +30,6 @@ ResolvedLaunchplaneIdentity: TypeAlias = (
 )
 
 LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
-
-
-@dataclass(frozen=True)
-class WorkGraphRankResult:
-    result: dict[str, object]
-    driver_result: dict[str, object]
 
 
 def reconcile_work_graph_issue_inbox(
@@ -62,44 +53,6 @@ def reconcile_work_graph_issue_inbox(
     if issue_inbox_reconcile_provider is None:
         raise ValueError("GitHub issue inbox reconciliation is not configured.")
     return issue_inbox_reconcile_provider(request)
-
-
-def rank_work_graph_snapshot(
-    *,
-    authz_policy: LaunchplaneAuthzPolicy,
-    identity: ResolvedLaunchplaneIdentity,
-    payload: dict[str, object],
-) -> WorkGraphRankResult | None:
-    rank_request = WorkGraphRankEnvelope.model_validate(payload)
-    if not authz_policy.allows(
-        identity=identity,
-        action="work_graph.rank",
-        product="launchplane",
-        context=LAUNCHPLANE_SERVICE_CONTEXT,
-    ):
-        return None
-    result, driver_result = build_work_graph_rank_result(rank_request)
-    return WorkGraphRankResult(result=result, driver_result=driver_result)
-
-
-def work_graph_rank_denied_response(
-    *,
-    trace_id: str,
-    json_response: JsonResponse,
-    start_response: StartResponse,
-) -> list[bytes]:
-    return json_response(
-        start_response=start_response,
-        status_code=403,
-        payload={
-            "status": "rejected",
-            "trace_id": trace_id,
-            "error": {
-                "code": "authorization_denied",
-                "message": "Workflow cannot rank Launchplane work graph snapshots.",
-            },
-        },
-    )
 
 
 def work_graph_issue_inbox_reconcile_denied_response(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -108,10 +108,10 @@ Keep a compatibility surface only when it is one of these:
   FastAPI routes. Their legacy WSGI read branches are deleted; merge-train
   worker, controller mutation, feedback, and phase runner routes remain on the
   retained fallback until their native write replacements land.
-- Work graph snapshot and GitHub issue-inbox reads use native FastAPI routes.
-  Their legacy WSGI read branches and WSGI-only read helpers are deleted;
-  work-graph rank and GitHub issue-inbox reconcile writes remain on the retained
-  fallback until their native write replacements land.
+- Work graph snapshot, work-graph rank, and GitHub issue-inbox reads use native
+  FastAPI routes. Their legacy WSGI read/rank branches and WSGI-only read/rank
+  helpers are deleted; GitHub issue-inbox reconcile remains on the retained
+  fallback until its native write replacement lands.
 - Protected artifact inventory and product environment config-status reads use
   native FastAPI routes for bearer-token and human-session callers. Their legacy
   WSGI branches are deleted; cleanup callers use the service route instead of a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -223,7 +223,7 @@ VeriReel product paths:
   - `GET /v1/work-graph/merge-train/policy-targets` (native FastAPI)
   - `GET /v1/work-graph/merge-train/admission` (native FastAPI)
   - `GET /v1/work-graph/merge-train/controller/status` (native FastAPI)
-  - `POST /v1/work-graph/rank`
+  - `POST /v1/work-graph/rank` (native FastAPI)
   - `POST /v1/work-graph/merge-train/run-once`
   - `POST /v1/work-graph/merge-train/pr-feedback`
   - `POST /v1/work-graph/merge-train/controller/run-once`
@@ -434,9 +434,11 @@ fallback no longer owns these read paths.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the
-`work_graph.rank` action for product/context `launchplane`, performs no storage
-writes, and does not make Launchplane authoritative for copied GitHub or Code
-Plans state.
+`work_graph.rank` action for product/context `launchplane`, accepts GitHub
+Actions OIDC and GitHub human-session callers, rejects owner-agent bearer tokens
+at the identity boundary even if a policy grant is too broad, performs no
+storage writes, and does not make Launchplane authoritative for copied GitHub or
+Code Plans state.
 
 `POST /v1/work-graph/merge-train/run-once` executes one policy-backed Level 1
 ordered-queue pass for a requested repository/base branch. It requires the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -138,6 +138,7 @@ from tests.test_service import (
     _seed_tracked_target_records,
     _sqlite_database_url,
     _write_runtime_key_safety_policy,
+    _work_graph_snapshot_payload,
 )
 from tests.test_service import _StubVerifier
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy_with_codex_skills
@@ -3102,6 +3103,128 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.json()["error"]["code"], "database_storage_required")
 
+    async def test_work_graph_rank_returns_ranked_queue(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_work_graph_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_work_graph_rank(
+            app,
+            payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+        )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(payload["records"], {})
+        queue = payload["result"]["queue"]
+        self.assertEqual(len(queue["items"]), 1)
+        self.assertEqual(queue["hidden_count"], 1)
+        self.assertEqual(queue["items"][0]["number"], 190)
+        self.assertEqual(queue["items"][0]["recommendation"], "deep_work")
+
+    async def test_work_graph_rank_rejects_unauthorized_identity(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_work_graph_rank(
+            app,
+            payload={"snapshot": _work_graph_snapshot_payload()},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_work_graph_rank_rejects_owner_agent_bearer_identities(
+        self,
+    ) -> None:
+        cases = (
+            (
+                "terminal_agent",
+                _terminal_agent_work_graph_rank_policy(),
+                BearerIdentityConfig(
+                    terminal_agent_token="terminal-read-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+                "terminal-read-token",
+            ),
+            (
+                "local_operator",
+                _local_operator_work_graph_rank_policy(),
+                _local_operator_bearer_config(),
+                "local-operator-token",
+            ),
+            (
+                "local_admin",
+                _local_admin_work_graph_rank_policy(),
+                BearerIdentityConfig(
+                    local_admin_token="local-admin-token",
+                    local_admin_subject="local-owner-agent",
+                    local_admin_token_label="local-owner-admin",
+                ),
+                "local-admin-token",
+            ),
+        )
+        for label, policy, bearer_config, token in cases:
+            with self.subTest(identity=label):
+                app = create_launchplane_fastapi_app(
+                    verifier=_RejectingVerifier(),
+                    authz_policy=policy,
+                    bearer_identity_config=bearer_config,
+                    record_store_factory=lambda: _MissingProductReadStore(),
+                )
+
+                response = await _post_work_graph_rank(
+                    app,
+                    payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+                    authorization=f"Bearer {token}",
+                )
+
+                self.assertEqual(response.status_code, 403)
+                self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_work_graph_rank_rejects_unclassified_issue(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_work_graph_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+        snapshot = _work_graph_snapshot_payload()
+        snapshot["repos"] = []
+
+        response = await _post_work_graph_rank(app, payload={"snapshot": snapshot})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    async def test_human_session_can_rank_work_graph_snapshot(self) -> None:
+        oauth_config = _github_oauth_config()
+        session_store = InMemoryHumanSessionStore()
+        session_manager = HumanSessionManager(config=oauth_config, session_store=session_store)
+        human_session = session_manager.issue(_github_human_identity())
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_github_human_work_graph_rank_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+
+        response = await _post_work_graph_rank(
+            app,
+            payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+            authorization="",
+            headers={"Cookie": session_manager.session_cookie_header(human_session)},
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["result"]["queue"]["items"][0]["number"], 190)
+
     async def test_work_graph_issue_inbox_returns_provider_payload(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_identity()),
@@ -3210,6 +3333,11 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
             await _get_repo_product_mapping(app, authorization=""),
             await _get_agent_context(app, authorization=""),
             await _get_work_graph_snapshot(app, authorization=""),
+            await _post_work_graph_rank(
+                app,
+                payload={"snapshot": _work_graph_snapshot_payload()},
+                authorization="",
+            ),
             await _get_work_graph_issue_inbox(app, authorization=""),
         ]
 
@@ -3350,6 +3478,16 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
                 )
             self.assertFalse(
                 openapi["components"]["schemas"][response_model_name]["additionalProperties"]
+            )
+        rank_route = openapi["paths"]["/v1/work-graph/rank"]["post"]
+        self.assertEqual(rank_route["operationId"], "rank_work_graph_snapshot")
+        self.assertEqual(
+            rank_route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        for status_code in ("400", "401", "403"):
+            self.assertIn(
+                "LaunchplaneErrorResponse", json.dumps(rank_route["responses"][status_code])
             )
 
     async def test_fastapi_agent_context_reads_precede_legacy_wsgi_fallback(self) -> None:
@@ -13206,6 +13344,70 @@ def _work_graph_read_policy(
     )
 
 
+def _github_human_work_graph_rank_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_humans": [
+                {
+                    "logins": ["example-operator"],
+                    "roles": ["admin"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["work_graph.rank"],
+                }
+            ]
+        }
+    )
+
+
+def _terminal_agent_work_graph_rank_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "terminal_agents": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["work_graph.rank"],
+                }
+            ]
+        }
+    )
+
+
+def _local_operator_work_graph_rank_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "local_operators": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["work_graph.rank"],
+                }
+            ]
+        }
+    )
+
+
+def _local_admin_work_graph_rank_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "local_admins": [
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-admin"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["work_graph.rank"],
+                }
+            ]
+        }
+    )
+
+
 def _driver_read_policy(*, context: str = "launchplane") -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -15210,6 +15412,25 @@ async def _get_work_graph_snapshot(
 ) -> _AsgiResponse:
     headers = {"Authorization": authorization} if authorization else {}
     return await _asgi_get(app, "/v1/work-graph/snapshot", headers=headers)
+
+
+async def _post_work_graph_rank(
+    app: FastAPI,
+    *,
+    payload: dict[str, object],
+    authorization: str = "Bearer valid-token",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/work-graph/rank",
+        headers=request_headers,
+        payload=payload,
+    )
 
 
 async def _get_work_graph_issue_inbox(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10091,139 +10091,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
 
-    def test_work_graph_rank_returns_ranked_queue(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": [
-                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
-                        ],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["work_graph.rank"],
-                    }
-                ]
-            }
-        )
-        identity = _identity(
-            repository="cbusillo/launchplane",
-            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
-            event_name="workflow_dispatch",
-        )
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(identity),
-                authz_policy=policy,
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/work-graph/rank",
-                payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["status"], "accepted")
-        queue = payload["result"]["queue"]
-        self.assertEqual(len(queue["items"]), 1)
-        self.assertEqual(queue["hidden_count"], 1)
-        self.assertEqual(queue["items"][0]["number"], 190)
-        self.assertEqual(queue["items"][0]["recommendation"], "deep_work")
-
-    def test_work_graph_rank_rejects_unauthorized_identity(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/work-graph/rank",
-                payload={"snapshot": _work_graph_snapshot_payload()},
-            )
-
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_work_graph_rank_rejects_unclassified_issue(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": ["*"],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["work_graph.rank"],
-                    }
-                ]
-            }
-        )
-        snapshot = _work_graph_snapshot_payload()
-        snapshot["repos"] = []
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=policy,
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/work-graph/rank",
-                payload={"snapshot": snapshot},
-            )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_request")
-
-    def test_human_session_can_rank_work_graph_snapshot(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_humans": [
-                    {
-                        "logins": ["alice"],
-                        "roles": ["read_only"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["work_graph.rank"],
-                    }
-                ]
-            }
-        )
-        oauth_client = _StubGitHubOAuthClient(_human_identity())
-        with TemporaryDirectory() as temporary_directory_name:
-            app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
-                verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=policy,
-                github_oauth_config=_github_oauth_config(),
-                github_oauth_client=oauth_client,
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            cookie = _signed_in_cookie(app)
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/work-graph/rank",
-                payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
-                authorization="",
-                headers={"Cookie": cookie},
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["queue"]["items"][0]["number"], 190)
-
     def test_work_graph_reads_are_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(
@@ -10248,6 +10115,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
             responses = [
                 _invoke_app(app, method="GET", path="/v1/work-graph/snapshot"),
                 _invoke_app(app, method="GET", path="/v1/work-graph/github/issues"),
+                _invoke_app(
+                    app,
+                    method="POST",
+                    path="/v1/work-graph/rank",
+                    payload={"snapshot": _work_graph_snapshot_payload(), "limit": 1},
+                ),
             ]
 
         for status_code, payload in responses:


### PR DESCRIPTION
## Summary
- move `POST /v1/work-graph/rank` to native FastAPI with the existing accepted queue response contract
- retire the legacy WSGI rank branch/helper and assert direct fallback calls fail closed
- preserve the intended caller boundary: GitHub Actions OIDC and GitHub human sessions only, rejecting owner-agent bearer tokens even with broad `work_graph.rank` grants
- update service-boundary and compatibility-retirement docs

## Local verification
- `uv run python -m unittest tests.test_http_app.FastApiProductEnvironmentReadTests tests.test_service.LaunchplaneServiceTests.test_work_graph_reads_are_retired_from_legacy_wsgi_app`
- `uv run python -m unittest tests.test_http_app.FastApiProductEnvironmentReadTests.test_work_graph_rank_returns_ranked_queue tests.test_http_app.FastApiProductEnvironmentReadTests.test_work_graph_rank_rejects_unauthorized_identity tests.test_http_app.FastApiProductEnvironmentReadTests.test_work_graph_rank_rejects_owner_agent_bearer_identities tests.test_http_app.FastApiProductEnvironmentReadTests.test_work_graph_rank_rejects_unclassified_issue tests.test_http_app.FastApiProductEnvironmentReadTests.test_human_session_can_rank_work_graph_snapshot tests.test_http_app.FastApiProductEnvironmentReadTests.test_agent_context_reads_require_identity tests.test_service.LaunchplaneServiceTests.test_work_graph_reads_are_retired_from_legacy_wsgi_app`
- `uv run python -m unittest`
- `uv run python -m py_compile control_plane/http_app.py control_plane/service.py control_plane/work_graph_http.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/work_graph_http.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/work_graph_http.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev markdownlint-cli2 docs/service-boundary.md docs/compatibility-retirement.md`
- JetBrains changed-file inspection: GREEN

## Review
- multi-agent review caught the owner-agent bearer boundary edge
- follow-up targeted re-review after fix: green

## Notes
- Full `ruff format --check .` still reports existing formatting drift in untouched files; touched-file format check is clean.
