### PR TITLE
Move Every Code work request create to FastAPI

### DIFF
--- a/control_plane/every_code_work_request_write.py
+++ b/control_plane/every_code_work_request_write.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    build_every_code_work_request_id,
+    build_every_code_work_request_lifecycle_id,
+)
+
+
+class EveryCodeWorkRequestCreateEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+    issue_number: int = Field(ge=1)
+    issue_url: str
+    issue_title: str = ""
+    trigger_label: str = "every-code"
+    trigger_actor: str = ""
+    github_delivery_id: str = ""
+    source: Literal["github_issue_label", "manual", "reconciliation"] = "manual"
+    queued_at: str = ""
+
+
+def build_every_code_work_request_record(
+    request: EveryCodeWorkRequestCreateEnvelope, *, queued_at: str
+) -> EveryCodeWorkRequestRecord:
+    request_id = build_every_code_work_request_id(
+        repository=request.repository,
+        issue_number=request.issue_number,
+        trigger_label=request.trigger_label,
+    )
+    return EveryCodeWorkRequestRecord(
+        request_id=request_id,
+        lifecycle_id=build_every_code_work_request_lifecycle_id(
+            request_id=request_id,
+            queued_at=queued_at,
+        ),
+        source=request.source,
+        state="queued",
+        repository=request.repository.strip(),
+        issue_number=request.issue_number,
+        issue_url=request.issue_url.strip(),
+        issue_title=request.issue_title.strip(),
+        trigger_label=request.trigger_label.strip(),
+        trigger_actor=request.trigger_actor.strip(),
+        github_delivery_id=request.github_delivery_id.strip(),
+        queued_at=queued_at,
+        updated_at=queued_at,
+    )

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -127,6 +127,10 @@ from control_plane.contracts.secret_record import SecretScope
 from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationPolicyRecord
 from control_plane.drivers.registry import build_driver_context_view, list_driver_descriptors
 from control_plane.drivers.registry import read_driver_descriptor as read_driver_descriptor_record
+from control_plane.every_code_work_request_write import (
+    EveryCodeWorkRequestCreateEnvelope,
+    build_every_code_work_request_record,
+)
 from control_plane.runtime_key_safety_http import (
     RuntimeKeySafetyPolicyApplyEnvelope,
     apply_runtime_key_safety_policy_route,
@@ -1401,6 +1405,12 @@ class _EveryCodeWorkRequestRecordStore(Protocol):
     def read_every_code_work_request_record(
         self, request_id: str
     ) -> EveryCodeWorkRequestRecord: ...
+
+
+class _EveryCodeWorkRequestWriteStore(Protocol):
+    def write_every_code_work_request_record(
+        self, record: EveryCodeWorkRequestRecord
+    ) -> object: ...
 
 
 class _EveryCodePrFeedbackReadStore(Protocol):
@@ -3081,6 +3091,16 @@ def create_launchplane_fastapi_app(
         )
         return cast(_EveryCodeWorkRequestRecordStore, record_store)
 
+    def require_every_code_work_request_write_store(
+        record_store: object,
+    ) -> _EveryCodeWorkRequestWriteStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=("write_every_code_work_request_record",),
+            capability="Every Code work request writes",
+        )
+        return cast(_EveryCodeWorkRequestWriteStore, record_store)
+
     def require_every_code_pr_feedback_read_store(
         record_store: object,
     ) -> _EveryCodePrFeedbackReadStore:
@@ -3735,6 +3755,79 @@ def create_launchplane_fastapi_app(
                 message=str(error),
             ) from error
         return EveryCodeWorkRequestRecordResponse(trace_id=trace_id, request=record)
+
+    async def create_every_code_work_request(
+        request: Request,
+        every_code_request: EveryCodeWorkRequestCreateEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="every_code_work_request.write",
+            product="launchplane",
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot create Every Code work requests.",
+            )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path="/v1/every-code/work-requests/create",
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=True,
+        )
+        if replayed_response is not None:
+            return replayed_response
+        try:
+            every_code_store = require_every_code_work_request_write_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        try:
+            record = build_every_code_work_request_record(
+                every_code_request,
+                queued_at=every_code_request.queued_at.strip() or utc_now_timestamp(),
+            )
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message=str(error) or "Request could not be completed.",
+            ) from error
+        every_code_store.write_every_code_work_request_record(record)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"request_id": record.request_id, "state": record.state},
+            result={"request": record.model_dump(mode="json")},
+        )
+        store_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path="/v1/every-code/work-requests/create",
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
 
     def list_every_code_pr_feedback(
         identity: Annotated[
@@ -8238,6 +8331,13 @@ def create_launchplane_fastapi_app(
         404: {"model": LaunchplaneErrorResponse},
         503: {"model": LaunchplaneErrorResponse},
     }
+    every_code_work_request_write_error_responses: dict[int | str, dict[str, object]] = {
+        400: {"model": LaunchplaneErrorResponse},
+        401: {"model": LaunchplaneErrorResponse},
+        403: {"model": LaunchplaneErrorResponse},
+        409: {"model": LaunchplaneErrorResponse},
+        503: {"model": LaunchplaneErrorResponse},
+    }
 
     app.add_api_route(
         "/v1/previews/readiness",
@@ -8463,6 +8563,18 @@ def create_launchplane_fastapi_app(
         operation_id="read_every_code_work_request",
         summary="Read one Every Code work request",
         responses=every_code_read_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/work-requests/create",
+        create_every_code_work_request,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="create_every_code_work_request",
+        summary="Create Every Code work request",
+        responses=every_code_work_request_write_error_responses,
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -47,8 +47,6 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
     apply_every_code_work_request_status,
-    build_every_code_work_request_id,
-    build_every_code_work_request_lifecycle_id,
     close_every_code_work_request_for_issue,
     close_every_code_work_request_for_pull_request,
     requeue_every_code_work_request,
@@ -166,6 +164,10 @@ from control_plane.runtime_key_safety import (
     runtime_key_safety_environment_class,
 )
 from control_plane.drivers.registry import list_driver_descriptors, read_driver_descriptor
+from control_plane.every_code_work_request_write import (
+    EveryCodeWorkRequestCreateEnvelope,
+    build_every_code_work_request_record,
+)
 from control_plane.notifications import post_discord_webhook, public_discord_url_error
 from control_plane.drivers.dispatch import (
     _DescriptorDriverDispatchContext as _DescriptorDriverDispatchContext,
@@ -1740,20 +1742,6 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
         if self.product.strip() != "launchplane":
             raise ValueError("Launchplane self deploy requires product 'launchplane'.")
         return self
-
-
-class EveryCodeWorkRequestCreateEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    repository: str
-    issue_number: int = Field(ge=1)
-    issue_url: str
-    issue_title: str = ""
-    trigger_label: str = "every-code"
-    trigger_actor: str = ""
-    github_delivery_id: str = ""
-    source: Literal["github_issue_label", "manual", "reconciliation"] = "manual"
-    queued_at: str = ""
 
 
 class EveryCodeWorkRequestClaimEnvelope(BaseModel):
@@ -3566,7 +3554,6 @@ def _build_write_routes() -> frozenset[str]:
         _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
-        "/v1/every-code/work-requests/create",
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
@@ -4847,7 +4834,7 @@ def _handle_every_code_github_webhook(
         source="github_issue_label",
         queued_at=_utc_now_timestamp(),
     )
-    record = _build_every_code_work_request_record(request, queued_at=request.queued_at)
+    record = build_every_code_work_request_record(request, queued_at=request.queued_at)
     every_code_store = _every_code_work_request_store(record_store)
     stored_record, created = every_code_store.create_every_code_work_request_record_if_absent(
         record
@@ -7534,34 +7521,6 @@ def _record_slug(value: str) -> str:
     return normalized or "launchplane-record"
 
 
-def _build_every_code_work_request_record(
-    request: EveryCodeWorkRequestCreateEnvelope, *, queued_at: str
-) -> EveryCodeWorkRequestRecord:
-    request_id = build_every_code_work_request_id(
-        repository=request.repository,
-        issue_number=request.issue_number,
-        trigger_label=request.trigger_label,
-    )
-    return EveryCodeWorkRequestRecord(
-        request_id=request_id,
-        lifecycle_id=build_every_code_work_request_lifecycle_id(
-            request_id=request_id,
-            queued_at=queued_at,
-        ),
-        source=request.source,
-        state="queued",
-        repository=request.repository.strip(),
-        issue_number=request.issue_number,
-        issue_url=request.issue_url.strip(),
-        issue_title=request.issue_title.strip(),
-        trigger_label=request.trigger_label.strip(),
-        trigger_actor=request.trigger_actor.strip(),
-        github_delivery_id=request.github_delivery_id.strip(),
-        queued_at=queued_at,
-        updated_at=queued_at,
-    )
-
-
 def _bootstrap_policy_source_from_env() -> str:
     if os.environ.get("LAUNCHPLANE_POLICY_TOML", "").strip():
         return "bootstrap-env:LAUNCHPLANE_POLICY_TOML"
@@ -8436,46 +8395,7 @@ def create_launchplane_service_app(
             effective_idempotency_route_path = path
             driver_result: BaseModel | dict[str, object] | None = None
             result: dict[str, object] = {}
-            if path == "/v1/every-code/work-requests/create":
-                every_code_request = EveryCodeWorkRequestCreateEnvelope.model_validate(payload)
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="every_code_work_request.write",
-                    product="launchplane",
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot create Every Code work requests.",
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                every_code_store = _every_code_work_request_store(record_store)
-                record = _build_every_code_work_request_record(
-                    every_code_request,
-                    queued_at=every_code_request.queued_at.strip() or _utc_now_timestamp(),
-                )
-                every_code_store.write_every_code_work_request_record(record)
-                result = {"request_id": record.request_id, "state": record.state}
-                driver_result = {"request": record.model_dump(mode="json")}
-            elif path == _MERGE_TRAIN_RUN_ONCE_ROUTE:
+            if path == _MERGE_TRAIN_RUN_ONCE_ROUTE:
                 merge_train_request = MergeTrainRunOnceEnvelope.model_validate(payload)
                 policy_record = resolve_merge_train_policy_record(record_store)
                 policy = policy_record.policy

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -138,9 +138,12 @@ Keep a compatibility surface only when it is one of these:
   The worker-facing read routes preserve the dedicated Every Code worker token;
   preview PR-feedback notification-attempt reads stay bearer/human authorized.
   The legacy WSGI read map, read payload helper, and worker-token GET bypass are
-  deleted; Every Code write, claim, status, rerun, webhook, notification-policy,
-  PR-feedback write/status, and preview-gate write routes remain on the mounted
-  WSGI fallback until their native write replacements land.
+  deleted. Every Code work-request create uses native FastAPI, preserves
+  `every_code_work_request.write` authorization, record-store write capability
+  checks, and optional `Idempotency-Key` replay/conflict behavior. Every Code
+  claim, status, rerun, webhook, PR-feedback write/status, and preview-gate
+  write routes remain on the mounted WSGI fallback until their native write
+  replacements land.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -203,7 +203,10 @@ VeriReel product paths:
     bearer-token callers, DB-backed storage, local-operator reason enforcement,
     and optional `Idempotency-Key` replay/conflict handling)
   - `POST /v1/every-code/github-webhook`
-  - `POST /v1/every-code/work-requests/create`
+  - `POST /v1/every-code/work-requests/create` (native FastAPI for
+    bearer-token callers, `every_code_work_request.write` authorization on
+    `launchplane`/`launchplane`, record-store write capability checks, and
+    optional `Idempotency-Key` replay/conflict handling)
   - `POST /v1/every-code/work-requests/claim`
   - `POST /v1/every-code/work-requests/rerun`
   - `POST /v1/every-code/work-requests/status`

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4292,6 +4292,161 @@ class FastApiMergeTrainReadTests(unittest.IsolatedAsyncioTestCase):
 
 
 class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_every_code_work_request_create_queues_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_work_request_write_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_every_code_work_request_create(
+                app,
+                _every_code_work_request_create_payload(),
+                idempotency_key="every-code-create-code-123",
+            )
+            stored_requests = store.list_every_code_work_request_records(state="queued")
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["records"]["state"], "queued")
+        self.assertEqual(payload["result"]["request"]["state"], "queued")
+        self.assertEqual(payload["records"]["request_id"], stored_requests[0].request_id)
+        self.assertEqual(stored_requests[0].repository, "cbusillo/code")
+
+    async def test_every_code_work_request_create_replays_idempotency(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_work_request_write_policy(),
+                record_store_factory=lambda: store,
+            )
+            payload = _every_code_work_request_create_payload()
+
+            first_response = await _post_every_code_work_request_create(
+                app,
+                payload,
+                idempotency_key="every-code-create-code-123",
+            )
+            second_response = await _post_every_code_work_request_create(
+                app,
+                payload,
+                idempotency_key="every-code-create-code-123",
+            )
+            stored_requests = store.list_every_code_work_request_records(state="queued")
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        self.assertTrue(second_response.json()["replayed"])
+        self.assertEqual(
+            second_response.json()["original_trace_id"],
+            first_response.json()["trace_id"],
+        )
+        self.assertEqual(len(stored_requests), 1)
+
+    async def test_every_code_work_request_create_rejects_reused_idempotency_key(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_work_request_write_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            first_response = await _post_every_code_work_request_create(
+                app,
+                _every_code_work_request_create_payload(),
+                idempotency_key="every-code-create-code-123",
+            )
+            conflict_response = await _post_every_code_work_request_create(
+                app,
+                _every_code_work_request_create_payload(issue_number=124),
+                idempotency_key="every-code-create-code-123",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(conflict_response.status_code, 409)
+        self.assertEqual(conflict_response.json()["error"]["code"], "idempotency_key_reused")
+
+    async def test_every_code_work_request_create_rejects_unauthorized_identity(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_every_code_work_request_create(
+                app,
+                _every_code_work_request_create_payload(),
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_every_code_work_request_create_rejects_invalid_record_payload(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_work_request_write_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_every_code_work_request_create(
+                app,
+                {
+                    **_every_code_work_request_create_payload(),
+                    "repository": "cbusillo-code",
+                },
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    async def test_every_code_work_request_create_rejects_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_every_code_work_request_write_policy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_create(
+                app,
+                _every_code_work_request_create_payload(),
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_every_code_work_request_create_requires_store_capability(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_every_code_work_request_write_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_every_code_work_request_create(
+            app,
+            _every_code_work_request_create_payload(),
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
     async def test_every_code_read_routes_return_native_payloads(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -4565,6 +4720,16 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
                 self.assertIn(
                     "LaunchplaneErrorResponse", json.dumps(route["responses"][status_code])
                 )
+        create_route = openapi["paths"]["/v1/every-code/work-requests/create"]["post"]
+        self.assertEqual(create_route["operationId"], "create_every_code_work_request")
+        self.assertEqual(
+            create_route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        for status_code in ("400", "401", "403", "409", "503"):
+            self.assertIn(
+                "LaunchplaneErrorResponse", json.dumps(create_route["responses"][status_code])
+            )
 
     async def test_fastapi_every_code_reads_precede_legacy_wsgi_fallback(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -14968,6 +15133,26 @@ def _every_code_read_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
+def _every_code_work_request_write_policy() -> LaunchplaneAuthzPolicy:
+    return _record_read_policy(
+        action="every_code_work_request.write",
+        context="launchplane",
+    )
+
+
+def _every_code_work_request_create_payload(*, issue_number: int = 123) -> dict[str, object]:
+    return {
+        "repository": "cbusillo/code",
+        "issue_number": issue_number,
+        "issue_url": f"https://github.com/cbusillo/code/issues/{issue_number}",
+        "issue_title": "Wire local automation",
+        "trigger_label": "every-code",
+        "trigger_actor": "cbusillo",
+        "source": "manual",
+        "queued_at": "2026-05-05T22:00:00Z",
+    }
+
+
 def _notification_policy_apply_policy(
     *, action: str, product: str, context: str
 ) -> LaunchplaneAuthzPolicy:
@@ -15725,6 +15910,28 @@ async def _get_every_code_work_request(
         app,
         f"/v1/every-code/work-requests/{request_id}",
         headers=headers,
+    )
+
+
+async def _post_every_code_work_request_create(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/every-code/work-requests/create",
+        headers=request_headers,
+        payload=payload,
     )
 
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1793,6 +1793,28 @@ def _every_code_github_pull_request_closed_payload(
     }
 
 
+def _seed_every_code_work_request_record(
+    state_dir: Path,
+    *,
+    request_id: str = "every-code-cbusillo-code-123-test",
+) -> EveryCodeWorkRequestRecord:
+    record = EveryCodeWorkRequestRecord(
+        request_id=request_id,
+        source="manual",
+        state="queued",
+        repository="cbusillo/code",
+        issue_number=123,
+        issue_url="https://github.com/cbusillo/code/issues/123",
+        issue_title="Wire local automation",
+        trigger_label="every-code",
+        trigger_actor="cbusillo",
+        queued_at="2026-05-05T22:00:00Z",
+        updated_at="2026-05-05T22:00:00Z",
+    )
+    FilesystemRecordStore(state_dir).write_every_code_work_request_record(record)
+    return record
+
+
 def _every_code_github_pr_comment_payload(
     *,
     repository: str = "cbusillo/code",
@@ -9445,23 +9467,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            create_status, create_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "cbusillo/code",
-                    "issue_number": 123,
-                    "issue_url": "https://github.com/cbusillo/code/issues/123",
-                    "issue_title": "Wire local automation",
-                    "trigger_label": "every-code",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-05T22:00:00Z",
-                },
-                headers={"Idempotency-Key": "every-code-create-code-123"},
-            )
-            request_id = str(create_payload["records"]["request_id"])
+            seeded_request = _seed_every_code_work_request_record(state_dir)
+            request_id = seeded_request.request_id
             queued_requests = FilesystemRecordStore(state_dir).list_every_code_work_request_records(
                 state="queued"
             )
@@ -9496,8 +9503,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 request_id
             )
 
-        self.assertEqual(create_status, 202)
-        self.assertEqual(create_payload["records"]["state"], "queued")
         self.assertEqual(len(queued_requests), 1)
         self.assertEqual(claim_status, 202)
         self.assertEqual(claim_payload["records"]["state"], "claimed")
@@ -9550,22 +9555,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            create_status, create_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "cbusillo/code",
-                    "issue_number": 123,
-                    "issue_url": "https://github.com/cbusillo/code/issues/123",
-                    "issue_title": "Wire local automation",
-                    "trigger_label": "every-code",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-05T22:00:00Z",
-                },
-            )
-            request_id = str(create_payload["records"]["request_id"])
+            seeded_request = _seed_every_code_work_request_record(state_dir)
+            request_id = seeded_request.request_id
             queued_requests = FilesystemRecordStore(state_dir).list_every_code_work_request_records(
                 state="queued"
             )
@@ -9590,7 +9581,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authorization="Bearer worker-token",
             )
 
-        self.assertEqual(create_status, 202)
         self.assertEqual(queued_requests[0].request_id, request_id)
         self.assertEqual(claim_status, 202)
         self.assertEqual(claim_payload["result"]["request"]["claimed_by_host"], "Chris-Studio")
@@ -9674,28 +9664,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            create_status, create_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "cbusillo/code",
-                    "issue_number": 123,
-                    "issue_url": "https://github.com/cbusillo/code/issues/123",
-                    "issue_title": "Wire local automation",
-                    "trigger_label": "every-code",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-05T22:00:00Z",
-                },
-            )
-            request_id = str(create_payload["records"]["request_id"])
+            request_id = _seed_every_code_work_request_record(state_dir).request_id
             _invoke_app(
                 app,
                 method="POST",
@@ -9747,7 +9723,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 headers={"Idempotency-Key": "every-code-rerun-intent:123"},
             )
 
-        self.assertEqual(create_status, 202)
         self.assertEqual(intent_status, 202)
         self.assertEqual(rerun_status, 202)
         self.assertEqual(rerun_payload["records"]["agent_write_intent_record_id"], intent_record_id)
@@ -9789,27 +9764,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            _create_status, create_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "cbusillo/code",
-                    "issue_number": 123,
-                    "issue_url": "https://github.com/cbusillo/code/issues/123",
-                    "issue_title": "Wire local automation",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-05T22:00:00Z",
-                },
-            )
-            request_id = str(create_payload["records"]["request_id"])
+            request_id = _seed_every_code_work_request_record(state_dir).request_id
             _invoke_app(
                 app,
                 method="POST",
@@ -9910,21 +9872,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            _create_status, create_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/create",
-                payload={
-                    "repository": "cbusillo/code",
-                    "issue_number": 123,
-                    "issue_url": "https://github.com/cbusillo/code/issues/123",
-                    "issue_title": "Wire local automation",
-                    "trigger_actor": "cbusillo",
-                    "source": "manual",
-                    "queued_at": "2026-05-05T22:00:00Z",
-                },
-            )
-            request_id = str(create_payload["records"]["request_id"])
+            request_id = _seed_every_code_work_request_record(state_dir).request_id
             _invoke_app(
                 app,
                 method="POST",
@@ -10068,12 +10016,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(feedback_status, 405)
         self.assertEqual(feedback_payload["error"]["code"], "method_not_allowed")
 
-    def test_every_code_work_request_create_rejects_unauthorized_identity(self) -> None:
+    def test_every_code_work_request_create_is_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(_identity(repository="cbusillo/launchplane")),
-                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                authz_policy=_every_code_worker_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
             status_code, payload = _invoke_app(
@@ -10087,8 +10035,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
 
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_work_graph_reads_are_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- Add native FastAPI handling for POST /v1/every-code/work-requests/create with write identity, authz, idempotency replay/conflict handling, and store capability checks.
- Share the Every Code work-request create envelope/builder with the GitHub webhook path and retire the legacy WSGI create branch.
- Add FastAPI create coverage for success, replay, conflict, auth failures, invalid payloads, worker-token rejection, store capability errors, OpenAPI docs, and WSGI retirement.

## Validation
- Review agents: initial finding fixed; focused re-review green.
- uv run python -m unittest tests.test_http_app.FastApiProductEnvironmentReadTests.test_openapi_includes_agent_context_read_contracts tests.test_http_app.FastApiEveryCodeReadTests tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_create_is_retired_from_legacy_wsgi_app
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/every_code_work_request_write.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff check --diff control_plane/http_app.py control_plane/service.py control_plane/every_code_work_request_write.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/every_code_work_request_write.py tests/test_http_app.py tests/test_service.py
- npx markdownlint-cli2 docs/compatibility-retirement.md docs/service-boundary.md
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest
- JetBrains changed_files inspection green

Refs #1322