### PR TITLE
Move Every Code feedback gates to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1426,6 +1426,10 @@ class _EveryCodePrFeedbackReadStore(Protocol):
     ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
 
 
+class _EveryCodePrFeedbackWriteStore(Protocol):
+    def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> object: ...
+
+
 class _EveryCodePreviewGateReadStore(Protocol):
     def list_every_code_preview_gate_records(
         self,
@@ -1437,6 +1441,12 @@ class _EveryCodePreviewGateReadStore(Protocol):
         limit: int | None = None,
         offset: int = 0,
     ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
+
+
+class _EveryCodePreviewGateWriteStore(Protocol):
+    def write_every_code_preview_gate_record(
+        self, record: EveryCodePreviewGateRecord
+    ) -> object: ...
 
 
 class _EveryCodeNotificationAttemptReadStore(Protocol):
@@ -2516,6 +2526,13 @@ def create_launchplane_fastapi_app(
             cookie=cookie,
         )
 
+    def require_every_code_worker_write_token(
+        authorization: Annotated[str, Header(alias="Authorization")] = "",
+    ) -> None:
+        if every_code_worker_token_authorized(authorization):
+            return
+        raise _authentication_required_error("Every Code worker token is required.")
+
     def read_write_identity(
         authorization: Annotated[str, Header(alias="Authorization")] = "",
     ) -> LaunchplaneIdentity:
@@ -3111,6 +3128,16 @@ def create_launchplane_fastapi_app(
         )
         return cast(_EveryCodePrFeedbackReadStore, record_store)
 
+    def require_every_code_pr_feedback_write_store(
+        record_store: object,
+    ) -> _EveryCodePrFeedbackWriteStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=("write_every_code_pr_feedback_record",),
+            capability="Every Code PR feedback writes",
+        )
+        return cast(_EveryCodePrFeedbackWriteStore, record_store)
+
     def require_every_code_preview_gate_read_store(
         record_store: object,
     ) -> _EveryCodePreviewGateReadStore:
@@ -3120,6 +3147,16 @@ def create_launchplane_fastapi_app(
             capability="Every Code preview gate reads",
         )
         return cast(_EveryCodePreviewGateReadStore, record_store)
+
+    def require_every_code_preview_gate_write_store(
+        record_store: object,
+    ) -> _EveryCodePreviewGateWriteStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=("write_every_code_preview_gate_record",),
+            capability="Every Code preview gate writes",
+        )
+        return cast(_EveryCodePreviewGateWriteStore, record_store)
 
     def require_every_code_notification_attempt_read_store(
         record_store: object,
@@ -3872,6 +3909,41 @@ def create_launchplane_fastapi_app(
             feedback=records,
         )
 
+    def write_every_code_pr_feedback(
+        payload: dict[str, object],
+        _worker_token: Annotated[None, Depends(require_every_code_worker_write_token)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            every_code_store = require_every_code_pr_feedback_write_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        try:
+            feedback_record = EveryCodePrFeedbackRecord.model_validate(payload)
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=str(error),
+            ) from error
+        every_code_store.write_every_code_pr_feedback_record(feedback_record)
+        return accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "request_id": feedback_record.request_id,
+                "feedback_id": feedback_record.feedback_id,
+                "status": feedback_record.status,
+            },
+            result={"feedback": feedback_record.model_dump(mode="json")},
+        )
+
     def list_every_code_preview_gates(
         identity: Annotated[
             LaunchplaneIdentity | None, Depends(read_every_code_worker_read_identity)
@@ -3913,6 +3985,41 @@ def create_launchplane_fastapi_app(
             repository=repository.strip(),
             status_filter=status.strip(),
             gates=records,
+        )
+
+    def write_every_code_preview_gate(
+        payload: dict[str, object],
+        _worker_token: Annotated[None, Depends(require_every_code_worker_write_token)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            every_code_store = require_every_code_preview_gate_write_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        try:
+            gate_record = EveryCodePreviewGateRecord.model_validate(payload)
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=str(error),
+            ) from error
+        every_code_store.write_every_code_preview_gate_record(gate_record)
+        return accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "gate_id": gate_record.gate_id,
+                "request_id": gate_record.request_id,
+                "status": gate_record.status,
+            },
+            result={"gate": gate_record.model_dump(mode="json")},
         )
 
     def list_every_code_notification_attempts(
@@ -8338,6 +8445,12 @@ def create_launchplane_fastapi_app(
         409: {"model": LaunchplaneErrorResponse},
         503: {"model": LaunchplaneErrorResponse},
     }
+    every_code_worker_write_error_responses: dict[int | str, dict[str, object]] = {
+        400: {"model": LaunchplaneErrorResponse},
+        401: {"model": LaunchplaneErrorResponse},
+        403: {"model": LaunchplaneErrorResponse},
+        503: {"model": LaunchplaneErrorResponse},
+    }
 
     app.add_api_route(
         "/v1/previews/readiness",
@@ -8588,6 +8701,18 @@ def create_launchplane_fastapi_app(
     )
 
     app.add_api_route(
+        "/v1/every-code/pr-feedback",
+        write_every_code_pr_feedback,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_every_code_pr_feedback",
+        summary="Write Every Code PR feedback",
+        responses=every_code_worker_write_error_responses,
+    )
+
+    app.add_api_route(
         "/v1/every-code/preview-gates",
         list_every_code_preview_gates,
         methods=["GET"],
@@ -8595,6 +8720,18 @@ def create_launchplane_fastapi_app(
         operation_id="list_every_code_preview_gates",
         summary="List Every Code preview gates",
         responses=every_code_read_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/preview-gates",
+        write_every_code_preview_gate,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_every_code_preview_gate",
+        summary="Write Every Code preview gate",
+        responses=every_code_worker_write_error_responses,
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1806,14 +1806,6 @@ class EveryCodePrFeedbackStatusEnvelope(BaseModel):
         return self
 
 
-class EveryCodePrFeedbackEnvelope(EveryCodePrFeedbackRecord):
-    pass
-
-
-class EveryCodePreviewGateEnvelope(EveryCodePreviewGateRecord):
-    pass
-
-
 class ProductOnboardingApplyEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -3557,9 +3549,7 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
-        "/v1/every-code/pr-feedback",
         "/v1/every-code/pr-feedback/status",
-        "/v1/every-code/preview-gates",
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-actions/removals",
         "/v1/authz-policies/github-humans/grants",
@@ -6791,9 +6781,7 @@ def _is_every_code_worker_route(*, method: str, path: str) -> bool:
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
-        "/v1/every-code/pr-feedback",
         "/v1/every-code/pr-feedback/status",
-        "/v1/every-code/preview-gates",
     }
 
 
@@ -6823,38 +6811,6 @@ def _handle_every_code_worker_write(
     every_code_discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
 ) -> list[bytes]:
     every_code_store = _every_code_work_request_store(record_store)
-    if path == "/v1/every-code/preview-gates":
-        gate_record = EveryCodePreviewGateEnvelope.model_validate(payload)
-        every_code_store.write_every_code_preview_gate_record(gate_record)
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload=_accepted_payload(
-                trace_id=trace_id,
-                result={
-                    "gate_id": gate_record.gate_id,
-                    "request_id": gate_record.request_id,
-                    "status": gate_record.status,
-                },
-                driver_result={"gate": gate_record.model_dump(mode="json")},
-            ),
-        )
-    if path == "/v1/every-code/pr-feedback":
-        feedback_record = EveryCodePrFeedbackEnvelope.model_validate(payload)
-        every_code_store.write_every_code_pr_feedback_record(feedback_record)
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload=_accepted_payload(
-                trace_id=trace_id,
-                result={
-                    "request_id": feedback_record.request_id,
-                    "feedback_id": feedback_record.feedback_id,
-                    "status": feedback_record.status,
-                },
-                driver_result={"feedback": feedback_record.model_dump(mode="json")},
-            ),
-        )
     if path == "/v1/every-code/pr-feedback/status":
         feedback_status_request = EveryCodePrFeedbackStatusEnvelope.model_validate(payload)
         feedback_matches = every_code_store.list_every_code_pr_feedback_records(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -141,8 +141,12 @@ Keep a compatibility surface only when it is one of these:
   deleted. Every Code work-request create uses native FastAPI, preserves
   `every_code_work_request.write` authorization, record-store write capability
   checks, and optional `Idempotency-Key` replay/conflict behavior. Every Code
-  claim, status, rerun, webhook, PR-feedback write/status, and preview-gate
-  write routes remain on the mounted WSGI fallback until their native write
+  PR-feedback write and preview-gate write routes use native FastAPI, preserve
+  the dedicated Every Code worker token, require only their direct record-store
+  write capabilities, and intentionally do not add idempotency state. Their
+  legacy WSGI write branches are deleted; direct WSGI fallback calls fail
+  closed. Every Code claim, status, rerun, webhook, and PR-feedback status
+  routes remain on the mounted WSGI fallback until their native write
   replacements land.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -210,9 +210,13 @@ VeriReel product paths:
   - `POST /v1/every-code/work-requests/claim`
   - `POST /v1/every-code/work-requests/rerun`
   - `POST /v1/every-code/work-requests/status`
-  - `POST /v1/every-code/pr-feedback`
+  - `POST /v1/every-code/pr-feedback` (native FastAPI for Every Code
+    worker-token callers, direct PR-feedback record writes, and DB-backed
+    storage capability enforcement without idempotency state)
   - `POST /v1/every-code/pr-feedback/status`
-  - `POST /v1/every-code/preview-gates`
+  - `POST /v1/every-code/preview-gates` (native FastAPI for Every Code
+    worker-token callers, direct preview-gate record writes, and DB-backed
+    storage capability enforcement without idempotency state)
 - preview PR feedback notification policy route:
   - `POST /v1/previews/pr-feedback/notification-policies/apply` (native FastAPI
     for bearer-token callers, DB-backed storage, explicit product/context scope,
@@ -434,7 +438,11 @@ reads use `every_code_work_request.read`; PR-feedback reads use
 reads use `preview_pr_feedback_notification_attempt.read`. The dedicated Every
 Code worker token is accepted only for the worker-facing Every Code read routes,
 not for the preview PR-feedback notification-attempt route. The legacy WSGI
-fallback no longer owns these read paths.
+fallback no longer owns these read paths. Every Code PR-feedback and preview-gate
+record writes are also native FastAPI routes for the dedicated Every Code worker
+token. They require only the matching record-store write capability, preserve the
+direct worker signal payloads, do not create idempotency records, and fail closed
+when called through the direct WSGI fallback.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4447,6 +4447,166 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.json()["error"]["code"], "database_storage_required")
 
+    async def test_every_code_pr_feedback_write_stores_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_pr_feedback(
+                app,
+                _every_code_pr_feedback_payload(),
+                authorization="Bearer worker-token",
+            )
+            records = store.list_every_code_pr_feedback_records(
+                request_id="every-code-cbusillo-code-123-test",
+                status="pending",
+            )
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["records"]["feedback_id"], records[0].feedback_id)
+        self.assertEqual(payload["result"]["feedback"]["feedback_id"], records[0].feedback_id)
+        self.assertEqual(len(records), 1)
+
+    async def test_every_code_pr_feedback_write_rejects_missing_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_read_policy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_pr_feedback(
+                app,
+                _every_code_pr_feedback_payload(),
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_every_code_pr_feedback_write_rejects_invalid_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_pr_feedback(
+                app,
+                {**_every_code_pr_feedback_payload(), "repository": "cbusillo-code"},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_payload")
+
+    async def test_every_code_pr_feedback_write_requires_store_capability(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+        )
+
+        response = await _post_every_code_pr_feedback(
+            app,
+            _every_code_pr_feedback_payload(),
+            authorization="Bearer worker-token",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
+    async def test_every_code_preview_gate_write_stores_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_preview_gate(
+                app,
+                _every_code_preview_gate_payload(),
+                authorization="Bearer worker-token",
+            )
+            records = store.list_every_code_preview_gate_records(
+                request_id="every-code-cbusillo-code-123-test",
+                status="ready",
+            )
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["records"]["gate_id"], records[0].gate_id)
+        self.assertEqual(payload["result"]["gate"]["gate_id"], records[0].gate_id)
+        self.assertEqual(len(records), 1)
+
+    async def test_every_code_preview_gate_write_rejects_missing_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_read_policy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_preview_gate(
+                app,
+                _every_code_preview_gate_payload(),
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_every_code_preview_gate_write_rejects_invalid_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_preview_gate(
+                app,
+                {**_every_code_preview_gate_payload(), "repository": "cbusillo-code"},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_payload")
+
+    async def test_every_code_preview_gate_write_requires_store_capability(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+        )
+
+        response = await _post_every_code_preview_gate(
+            app,
+            _every_code_preview_gate_payload(),
+            authorization="Bearer worker-token",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
     async def test_every_code_read_routes_return_native_payloads(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -4730,6 +4890,22 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn(
                 "LaunchplaneErrorResponse", json.dumps(create_route["responses"][status_code])
             )
+        worker_write_routes = {
+            "/v1/every-code/pr-feedback": "write_every_code_pr_feedback",
+            "/v1/every-code/preview-gates": "write_every_code_preview_gate",
+        }
+        for path, operation_id in worker_write_routes.items():
+            route = openapi["paths"][path]["post"]
+            self.assertEqual(route["operationId"], operation_id)
+            self.assertEqual(
+                route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+                "#/components/schemas/AcceptedEvidenceResponse",
+            )
+            for status_code in ("400", "401", "403", "503"):
+                self.assertIn(
+                    "LaunchplaneErrorResponse", json.dumps(route["responses"][status_code])
+                )
+            self.assertNotIn("409", route["responses"])
 
     async def test_fastapi_every_code_reads_precede_legacy_wsgi_fallback(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -15153,6 +15329,43 @@ def _every_code_work_request_create_payload(*, issue_number: int = 123) -> dict[
     }
 
 
+def _every_code_pr_feedback_payload() -> dict[str, object]:
+    return {
+        "feedback_id": "every-code-pr-feedback-cbusillo-code-31-review-1",
+        "request_id": "every-code-cbusillo-code-123-test",
+        "repository": "cbusillo/code",
+        "pr_number": 31,
+        "pr_url": "https://github.com/cbusillo/code/pull/31",
+        "feedback_kind": "pull_request_review_comment",
+        "github_delivery_id": "delivery-feedback-1",
+        "github_node_id": "PRRC_kwDOTest123",
+        "actor": "reviewer",
+        "author_association": "MEMBER",
+        "body": "Please tighten the FastAPI write route coverage.",
+        "html_url": "https://github.com/cbusillo/code/pull/31#discussion_r1",
+        "received_at": "2026-06-18T12:07:00Z",
+        "status": "pending",
+    }
+
+
+def _every_code_preview_gate_payload() -> dict[str, object]:
+    return {
+        "gate_id": "every-code-preview-gate-cbusillo-code-31-test",
+        "request_id": "every-code-cbusillo-code-123-test",
+        "repository": "cbusillo/code",
+        "issue_number": 123,
+        "issue_url": "https://github.com/cbusillo/code/issues/123",
+        "pr_number": 31,
+        "pr_url": "https://github.com/cbusillo/code/pull/31",
+        "head_sha": "abcdef1234567890",
+        "status": "ready",
+        "created_at": "2026-06-18T12:05:00Z",
+        "updated_at": "2026-06-18T12:06:00Z",
+        "ready_at": "2026-06-18T12:06:00Z",
+        "last_checked_at": "2026-06-18T12:06:00Z",
+    }
+
+
 def _notification_policy_apply_policy(
     *, action: str, product: str, context: str
 ) -> LaunchplaneAuthzPolicy:
@@ -15959,6 +16172,22 @@ async def _get_every_code_pr_feedback(
     return await _asgi_get(app, f"/v1/every-code/pr-feedback{suffix}", headers=headers)
 
 
+async def _post_every_code_pr_feedback(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/every-code/pr-feedback",
+        headers=headers,
+        payload=payload,
+    )
+
+
 async def _get_every_code_preview_gates(
     app: FastAPI,
     *,
@@ -15981,6 +16210,22 @@ async def _get_every_code_preview_gates(
     )
     suffix = f"?{urlencode(params)}" if params else ""
     return await _asgi_get(app, f"/v1/every-code/preview-gates{suffix}", headers=headers)
+
+
+async def _post_every_code_preview_gate(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/every-code/preview-gates",
+        headers=headers,
+        payload=payload,
+    )
 
 
 async def _get_every_code_notification_attempts(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -32,6 +32,7 @@ from control_plane.contracts.every_code_notifications import (
     EveryCodeNotificationDestination,
     EveryCodeNotificationPolicyRecord,
 )
+from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
@@ -7239,8 +7240,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 )
             }
 
-        self.assertEqual(responses["/v1/every-code/pr-feedback"][0], 405)
-        self.assertEqual(responses["/v1/every-code/preview-gates"][0], 405)
+        self.assertEqual(responses["/v1/every-code/pr-feedback"][0], 404)
+        self.assertEqual(responses["/v1/every-code/preview-gates"][0], 404)
         self.assertEqual(responses["/v1/every-code/notification-attempts"][0], 404)
         self.assertEqual(
             responses["/v1/previews/pr-feedback/notification-attempts"][0],
@@ -9101,7 +9102,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(second_status, 409)
         self.assertEqual(second_response["error"]["code"], "feedback_already_final")
 
-    def test_every_code_worker_token_writes_pr_feedback_record(self) -> None:
+    def test_every_code_worker_feedback_and_gate_writes_are_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
         feedback_record = EveryCodePrFeedbackRecord(
             feedback_id="every-code-pr-feedback-cbusillo-code-26-check-failure-build",
             request_id="every-code-cbusillo-code-123-test",
@@ -9115,6 +9118,21 @@ class LaunchplaneServiceTests(unittest.TestCase):
             body="GitHub check build failed on the Every Code PR branch.",
             html_url="https://github.com/cbusillo/code/actions/runs/1001/job/2002",
             received_at="2026-05-06T19:00:00Z",
+        )
+        gate_record = EveryCodePreviewGateRecord(
+            gate_id="every-code-preview-gate-cbusillo-code-26-checks",
+            request_id="every-code-cbusillo-code-123-test",
+            repository="cbusillo/code",
+            issue_number=123,
+            issue_url="https://github.com/cbusillo/code/issues/123",
+            pr_number=26,
+            pr_url="https://github.com/cbusillo/code/pull/26",
+            head_sha="abcdef1234567890",
+            status="ready",
+            created_at="2026-05-06T18:00:00Z",
+            updated_at="2026-05-06T18:01:00Z",
+            ready_at="2026-05-06T18:01:00Z",
+            last_checked_at="2026-05-06T18:01:00Z",
         )
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -9132,25 +9150,35 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
             )
-            write_status, write_response = _invoke_app(
+            feedback_status, feedback_response = _invoke_app(
                 app,
                 method="POST",
                 path="/v1/every-code/pr-feedback",
                 payload=feedback_record.model_dump(mode="json"),
                 authorization="Bearer dev-worker-token",
             )
+            gate_status, gate_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/preview-gates",
+                payload=gate_record.model_dump(mode="json"),
+                authorization="Bearer dev-worker-token",
+            )
             feedback_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
                 request_id=feedback_record.request_id,
                 status="pending",
             )
+            gate_records = FilesystemRecordStore(state_dir).list_every_code_preview_gate_records(
+                request_id=gate_record.request_id,
+                status="ready",
+            )
 
-        self.assertEqual(write_status, 202, write_response)
-        self.assertEqual(write_response["records"]["feedback_id"], feedback_record.feedback_id)
-        self.assertEqual(
-            write_response["result"]["feedback"]["feedback_id"], feedback_record.feedback_id
-        )
-        self.assertEqual(len(feedback_records), 1)
-        self.assertEqual(feedback_records[0].feedback_id, feedback_record.feedback_id)
+        self.assertEqual(feedback_status, 404, feedback_response)
+        self.assertEqual(feedback_response["error"]["code"], "not_found")
+        self.assertEqual(gate_status, 404, gate_response)
+        self.assertEqual(gate_response["error"]["code"], "not_found")
+        self.assertEqual(feedback_records, ())
+        self.assertEqual(gate_records, ())
 
     def test_every_code_worker_token_reruns_terminal_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
@@ -10013,8 +10041,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(work_status, 404)
         self.assertEqual(work_payload["error"]["code"], "not_found")
-        self.assertEqual(feedback_status, 405)
-        self.assertEqual(feedback_payload["error"]["code"], "method_not_allowed")
+        self.assertEqual(feedback_status, 404)
+        self.assertEqual(feedback_payload["error"]["code"], "not_found")
 
     def test_every_code_work_request_create_is_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- Move `POST /v1/every-code/pr-feedback` and `POST /v1/every-code/preview-gates` to native FastAPI worker-token write handlers.
- Remove the retired legacy WSGI worker-write branches and fail closed for direct WSGI fallback calls.
- Add FastAPI tests for success, worker-token auth, invalid payloads, store capability failures, OpenAPI contracts, and legacy fallback retirement.
- Update v2 compatibility/service-boundary docs for the new ownership boundary.

Refs #1322

## Validation

- `uv run python -m unittest` (2842 tests)
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `npx markdownlint-cli2 docs/compatibility-retirement.md docs/service-boundary.md`
- JetBrains changed-files inspection: GREEN
- Review agents: 4 green/no blocking findings

## Notes

Repo-wide `ruff format --check .` still reports pre-existing formatting drift outside this PR's touched files, so this slice keeps formatting scoped to changed files.
