### PR TITLE
Move Every Code feedback status to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -46,7 +46,11 @@ from control_plane.contracts.driver_descriptor import DriverContextView, DriverD
 from control_plane.contracts.edge_endpoint_record import EdgeEndpointRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
-from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
+from control_plane.contracts.every_code_pr_feedback_record import (
+    EveryCodePrFeedbackRecord,
+    EveryCodePrFeedbackStatus,
+    apply_every_code_pr_feedback_status,
+)
 from control_plane.contracts.every_code_notifications import (
     EveryCodeNotificationAttemptRecord,
     EveryCodeNotificationPolicyRecord,
@@ -740,6 +744,22 @@ class EveryCodePrFeedbackRecordsResponse(BaseModel):
     feedback: tuple[EveryCodePrFeedbackRecord, ...]
 
 
+class EveryCodePrFeedbackStatusEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    feedback_id: str
+    request_id: str
+    status: EveryCodePrFeedbackStatus
+
+    @model_validator(mode="after")
+    def _validate_status(self) -> "EveryCodePrFeedbackStatusEnvelope":
+        if not self.feedback_id.strip():
+            raise ValueError("Every Code PR feedback status requires feedback_id")
+        if not self.request_id.strip():
+            raise ValueError("Every Code PR feedback status requires request_id")
+        return self
+
+
 class EveryCodePreviewGateRecordsResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1428,6 +1448,12 @@ class _EveryCodePrFeedbackReadStore(Protocol):
 
 class _EveryCodePrFeedbackWriteStore(Protocol):
     def write_every_code_pr_feedback_record(self, record: EveryCodePrFeedbackRecord) -> object: ...
+
+
+class _EveryCodePrFeedbackStatusStore(
+    _EveryCodePrFeedbackReadStore, _EveryCodePrFeedbackWriteStore, Protocol
+):
+    pass
 
 
 class _EveryCodePreviewGateReadStore(Protocol):
@@ -3138,6 +3164,19 @@ def create_launchplane_fastapi_app(
         )
         return cast(_EveryCodePrFeedbackWriteStore, record_store)
 
+    def require_every_code_pr_feedback_status_store(
+        record_store: object,
+    ) -> _EveryCodePrFeedbackStatusStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=(
+                "list_every_code_pr_feedback_records",
+                "write_every_code_pr_feedback_record",
+            ),
+            capability="Every Code PR feedback status writes",
+        )
+        return cast(_EveryCodePrFeedbackStatusStore, record_store)
+
     def require_every_code_preview_gate_read_store(
         record_store: object,
     ) -> _EveryCodePreviewGateReadStore:
@@ -3942,6 +3981,71 @@ def create_launchplane_fastapi_app(
                 "status": feedback_record.status,
             },
             result={"feedback": feedback_record.model_dump(mode="json")},
+        )
+
+    def write_every_code_pr_feedback_status(
+        payload: dict[str, object],
+        _worker_token: Annotated[None, Depends(require_every_code_worker_write_token)],
+        record_store: Annotated[object, Depends(get_record_store)],
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            every_code_store = require_every_code_pr_feedback_status_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        try:
+            feedback_status_request = EveryCodePrFeedbackStatusEnvelope.model_validate(payload)
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=str(error),
+            ) from error
+        feedback_matches = every_code_store.list_every_code_pr_feedback_records(
+            request_id=feedback_status_request.request_id.strip(),
+            limit=100,
+        )
+        existing_feedback_record = next(
+            (
+                record
+                for record in feedback_matches
+                if record.feedback_id == feedback_status_request.feedback_id.strip()
+            ),
+            None,
+        )
+        if existing_feedback_record is None:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message="Every Code PR feedback record was not found.",
+            )
+        updated_feedback_record = apply_every_code_pr_feedback_status(
+            existing_feedback_record,
+            status=feedback_status_request.status,
+        )
+        if updated_feedback_record is None:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="feedback_already_final",
+                message="Every Code PR feedback is already applied or ignored.",
+            )
+        every_code_store.write_every_code_pr_feedback_record(updated_feedback_record)
+        return accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "request_id": updated_feedback_record.request_id,
+                "feedback_id": updated_feedback_record.feedback_id,
+                "status": updated_feedback_record.status,
+            },
+            result={"feedback": updated_feedback_record.model_dump(mode="json")},
         )
 
     def list_every_code_preview_gates(
@@ -8451,6 +8555,14 @@ def create_launchplane_fastapi_app(
         403: {"model": LaunchplaneErrorResponse},
         503: {"model": LaunchplaneErrorResponse},
     }
+    every_code_worker_status_error_responses: dict[int | str, dict[str, object]] = {
+        400: {"model": LaunchplaneErrorResponse},
+        401: {"model": LaunchplaneErrorResponse},
+        403: {"model": LaunchplaneErrorResponse},
+        404: {"model": LaunchplaneErrorResponse},
+        409: {"model": LaunchplaneErrorResponse},
+        503: {"model": LaunchplaneErrorResponse},
+    }
 
     app.add_api_route(
         "/v1/previews/readiness",
@@ -8710,6 +8822,18 @@ def create_launchplane_fastapi_app(
         operation_id="write_every_code_pr_feedback",
         summary="Write Every Code PR feedback",
         responses=every_code_worker_write_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/pr-feedback/status",
+        write_every_code_pr_feedback_status,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_every_code_pr_feedback_status",
+        summary="Write Every Code PR feedback status",
+        responses=every_code_worker_status_error_responses,
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -65,8 +65,6 @@ from control_plane.contracts.every_code_preview_gate_record import (
 from control_plane.contracts.every_code_pr_feedback_record import (
     EveryCodePrFeedbackKind,
     EveryCodePrFeedbackRecord,
-    EveryCodePrFeedbackStatus,
-    apply_every_code_pr_feedback_status,
     build_every_code_pr_feedback_id,
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
@@ -1787,22 +1785,6 @@ class EveryCodeWorkRequestRerunEnvelope(BaseModel):
         self.trigger_actor = self.trigger_actor.strip()
         self.source_url = self.source_url.strip()
         self.agent_write_intent_record_id = self.agent_write_intent_record_id.strip()
-        return self
-
-
-class EveryCodePrFeedbackStatusEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    feedback_id: str
-    request_id: str
-    status: EveryCodePrFeedbackStatus
-
-    @model_validator(mode="after")
-    def _validate_status(self) -> "EveryCodePrFeedbackStatusEnvelope":
-        if not self.feedback_id.strip():
-            raise ValueError("Every Code PR feedback status requires feedback_id")
-        if not self.request_id.strip():
-            raise ValueError("Every Code PR feedback status requires request_id")
         return self
 
 
@@ -3549,7 +3531,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
-        "/v1/every-code/pr-feedback/status",
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-actions/removals",
         "/v1/authz-policies/github-humans/grants",
@@ -6781,7 +6762,6 @@ def _is_every_code_worker_route(*, method: str, path: str) -> bool:
         "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
-        "/v1/every-code/pr-feedback/status",
     }
 
 
@@ -6811,64 +6791,6 @@ def _handle_every_code_worker_write(
     every_code_discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
 ) -> list[bytes]:
     every_code_store = _every_code_work_request_store(record_store)
-    if path == "/v1/every-code/pr-feedback/status":
-        feedback_status_request = EveryCodePrFeedbackStatusEnvelope.model_validate(payload)
-        feedback_matches = every_code_store.list_every_code_pr_feedback_records(
-            request_id=feedback_status_request.request_id.strip(),
-            limit=100,
-        )
-        existing_feedback_record = next(
-            (
-                record
-                for record in feedback_matches
-                if record.feedback_id == feedback_status_request.feedback_id.strip()
-            ),
-            None,
-        )
-        if existing_feedback_record is None:
-            return _json_response(
-                start_response=start_response,
-                status_code=404,
-                payload={
-                    "status": "rejected",
-                    "trace_id": trace_id,
-                    "error": {
-                        "code": "not_found",
-                        "message": "Every Code PR feedback record was not found.",
-                    },
-                },
-            )
-        updated_feedback_record = apply_every_code_pr_feedback_status(
-            existing_feedback_record,
-            status=feedback_status_request.status,
-        )
-        if updated_feedback_record is None:
-            return _json_response(
-                start_response=start_response,
-                status_code=409,
-                payload={
-                    "status": "rejected",
-                    "trace_id": trace_id,
-                    "error": {
-                        "code": "feedback_already_final",
-                        "message": "Every Code PR feedback is already applied or ignored.",
-                    },
-                },
-            )
-        every_code_store.write_every_code_pr_feedback_record(updated_feedback_record)
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload=_accepted_payload(
-                trace_id=trace_id,
-                result={
-                    "request_id": updated_feedback_record.request_id,
-                    "feedback_id": updated_feedback_record.feedback_id,
-                    "status": updated_feedback_record.status,
-                },
-                driver_result={"feedback": updated_feedback_record.model_dump(mode="json")},
-            ),
-        )
     if path == "/v1/every-code/work-requests/claim":
         claim_request = EveryCodeWorkRequestClaimEnvelope.model_validate(payload)
         claimed_record = every_code_store.claim_every_code_work_request_record(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -141,11 +141,13 @@ Keep a compatibility surface only when it is one of these:
   deleted. Every Code work-request create uses native FastAPI, preserves
   `every_code_work_request.write` authorization, record-store write capability
   checks, and optional `Idempotency-Key` replay/conflict behavior. Every Code
-  PR-feedback write and preview-gate write routes use native FastAPI, preserve
-  the dedicated Every Code worker token, require only their direct record-store
-  write capabilities, and intentionally do not add idempotency state. Their
-  legacy WSGI write branches are deleted; direct WSGI fallback calls fail
-  closed. Every Code claim, status, rerun, webhook, and PR-feedback status
+  PR-feedback write, PR-feedback status, and preview-gate write routes use
+  native FastAPI, preserve the dedicated Every Code worker token, require only
+  their direct PR-feedback or preview-gate record-store capabilities, and
+  intentionally do not add idempotency state. The PR-feedback status route also
+  preserves the existing `404 not_found` and `409 feedback_already_final`
+  transition semantics. Their legacy WSGI write branches are deleted; direct
+  WSGI fallback calls fail closed. Every Code claim, status, rerun, and webhook
   routes remain on the mounted WSGI fallback until their native write
   replacements land.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -213,7 +213,10 @@ VeriReel product paths:
   - `POST /v1/every-code/pr-feedback` (native FastAPI for Every Code
     worker-token callers, direct PR-feedback record writes, and DB-backed
     storage capability enforcement without idempotency state)
-  - `POST /v1/every-code/pr-feedback/status`
+  - `POST /v1/every-code/pr-feedback/status` (native FastAPI for Every Code
+    worker-token callers, PR-feedback status transitions, `404 not_found` for
+    missing feedback, and `409 feedback_already_final` for already-final
+    feedback)
   - `POST /v1/every-code/preview-gates` (native FastAPI for Every Code
     worker-token callers, direct preview-gate record writes, and DB-backed
     storage capability enforcement without idempotency state)
@@ -438,11 +441,14 @@ reads use `every_code_work_request.read`; PR-feedback reads use
 reads use `preview_pr_feedback_notification_attempt.read`. The dedicated Every
 Code worker token is accepted only for the worker-facing Every Code read routes,
 not for the preview PR-feedback notification-attempt route. The legacy WSGI
-fallback no longer owns these read paths. Every Code PR-feedback and preview-gate
-record writes are also native FastAPI routes for the dedicated Every Code worker
-token. They require only the matching record-store write capability, preserve the
-direct worker signal payloads, do not create idempotency records, and fail closed
-when called through the direct WSGI fallback.
+fallback no longer owns these read paths. Every Code PR-feedback write,
+PR-feedback status, and preview-gate write routes are also native FastAPI routes
+for the dedicated Every Code worker token. They require only the matching
+PR-feedback or preview-gate record-store capabilities, preserve the direct worker
+signal payloads, do not create idempotency records, and fail closed when called
+through the direct WSGI fallback. PR-feedback status preserves the worker
+transition semantics: missing feedback returns `404 not_found`, and already
+applied or ignored feedback returns `409 feedback_already_final`.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4527,6 +4527,164 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.json()["error"]["code"], "database_storage_required")
 
+    async def test_every_code_pr_feedback_status_write_updates_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            feedback_record = EveryCodePrFeedbackRecord.model_validate(
+                _every_code_pr_feedback_payload()
+            )
+            store.write_every_code_pr_feedback_record(feedback_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_pr_feedback_status(
+                app,
+                {
+                    "feedback_id": feedback_record.feedback_id,
+                    "request_id": feedback_record.request_id,
+                    "status": "applied",
+                },
+                authorization="Bearer worker-token",
+            )
+            applied_records = store.list_every_code_pr_feedback_records(
+                request_id=feedback_record.request_id,
+                status="applied",
+            )
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["records"]["feedback_id"], feedback_record.feedback_id)
+        self.assertEqual(payload["records"]["status"], "applied")
+        self.assertEqual(payload["result"]["feedback"]["status"], "applied")
+        self.assertEqual(len(applied_records), 1)
+        self.assertEqual(applied_records[0].feedback_id, feedback_record.feedback_id)
+
+    async def test_every_code_pr_feedback_status_write_rejects_missing_worker_token(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            feedback_record = EveryCodePrFeedbackRecord.model_validate(
+                _every_code_pr_feedback_payload()
+            )
+            store.write_every_code_pr_feedback_record(feedback_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_read_policy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_pr_feedback_status(
+                app,
+                {
+                    "feedback_id": feedback_record.feedback_id,
+                    "request_id": feedback_record.request_id,
+                    "status": "applied",
+                },
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_every_code_pr_feedback_status_write_rejects_invalid_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_pr_feedback_status(
+                app,
+                {
+                    "feedback_id": "",
+                    "request_id": "every-code-cbusillo-code-123-test",
+                    "status": "applied",
+                },
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_payload")
+
+    async def test_every_code_pr_feedback_status_write_returns_not_found(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_pr_feedback_status(
+                app,
+                {
+                    "feedback_id": "missing-feedback",
+                    "request_id": "every-code-cbusillo-code-123-test",
+                    "status": "applied",
+                },
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_every_code_pr_feedback_status_write_rejects_final_feedback(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            feedback_record = EveryCodePrFeedbackRecord.model_validate(
+                {**_every_code_pr_feedback_payload(), "status": "applied"}
+            )
+            store.write_every_code_pr_feedback_record(feedback_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_pr_feedback_status(
+                app,
+                {
+                    "feedback_id": feedback_record.feedback_id,
+                    "request_id": feedback_record.request_id,
+                    "status": "ignored",
+                },
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "feedback_already_final")
+
+    async def test_every_code_pr_feedback_status_write_requires_store_capability(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+        )
+
+        response = await _post_every_code_pr_feedback_status(
+            app,
+            {
+                "feedback_id": "feedback-1",
+                "request_id": "every-code-cbusillo-code-123-test",
+                "status": "applied",
+            },
+            authorization="Bearer worker-token",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
     async def test_every_code_preview_gate_write_stores_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -4906,6 +5064,16 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
                     "LaunchplaneErrorResponse", json.dumps(route["responses"][status_code])
                 )
             self.assertNotIn("409", route["responses"])
+        status_route = openapi["paths"]["/v1/every-code/pr-feedback/status"]["post"]
+        self.assertEqual(status_route["operationId"], "write_every_code_pr_feedback_status")
+        self.assertEqual(
+            status_route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        for status_code in ("400", "401", "403", "404", "409", "503"):
+            self.assertIn(
+                "LaunchplaneErrorResponse", json.dumps(status_route["responses"][status_code])
+            )
 
     async def test_fastapi_every_code_reads_precede_legacy_wsgi_fallback(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -16183,6 +16351,22 @@ async def _post_every_code_pr_feedback(
         app,
         "POST",
         "/v1/every-code/pr-feedback",
+        headers=headers,
+        payload=payload,
+    )
+
+
+async def _post_every_code_pr_feedback_status(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/every-code/pr-feedback/status",
         headers=headers,
         payload=payload,
     )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9001,7 +9001,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertTrue(second_response["deduped"])
 
-    def test_every_code_worker_token_lists_and_marks_pr_feedback(self) -> None:
+    def test_every_code_worker_pr_feedback_status_is_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
         secret = "launchplane-every-code-webhook-secret"
         issue_payload = _every_code_github_issue_labeled_payload()
         comment_payload = _every_code_github_pr_comment_payload(comment_id=3003)
@@ -9084,23 +9086,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
                 authorization="Bearer dev-worker-token",
             )
-            second_status, second_response = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/pr-feedback/status",
-                payload={
-                    "feedback_id": feedback_id,
-                    "request_id": request_id,
-                    "status": "ignored",
-                },
-                authorization="Bearer dev-worker-token",
+            pending_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
+                request_id=request_id,
+                status="pending",
             )
 
         self.assertEqual(len(feedback_records), 1)
-        self.assertEqual(status_status, 202)
-        self.assertEqual(status_response["result"]["feedback"]["status"], "applied")
-        self.assertEqual(second_status, 409)
-        self.assertEqual(second_response["error"]["code"], "feedback_already_final")
+        self.assertEqual(status_status, 404, status_response)
+        self.assertEqual(status_response["error"]["code"], "not_found")
+        self.assertEqual(len(pending_records), 1)
+        self.assertEqual(pending_records[0].feedback_id, feedback_id)
 
     def test_every_code_worker_feedback_and_gate_writes_are_retired_from_legacy_wsgi_app(
         self,


### PR DESCRIPTION
## Summary

- Move `POST /v1/every-code/pr-feedback/status` to native FastAPI.
- Preserve Every Code worker-token write auth, payload validation, `404 not_found`, and `409 feedback_already_final` semantics.
- Gate storage narrowly on PR-feedback list/write capabilities and keep this route non-idempotent.
- Retire the direct WSGI fallback branch and document the FastAPI ownership boundary.

Refs #1322.

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiEveryCodeReadTests.test_every_code_pr_feedback_status_write_updates_record tests.test_http_app.FastApiEveryCodeReadTests.test_every_code_pr_feedback_status_write_rejects_missing_worker_token tests.test_http_app.FastApiEveryCodeReadTests.test_every_code_pr_feedback_status_write_rejects_invalid_payload tests.test_http_app.FastApiEveryCodeReadTests.test_every_code_pr_feedback_status_write_returns_not_found tests.test_http_app.FastApiEveryCodeReadTests.test_every_code_pr_feedback_status_write_rejects_final_feedback tests.test_http_app.FastApiEveryCodeReadTests.test_every_code_pr_feedback_status_write_requires_store_capability tests.test_http_app.FastApiEveryCodeReadTests.test_openapi_includes_every_code_read_contracts tests.test_service.LaunchplaneServiceTests.test_every_code_worker_pr_feedback_status_is_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `npx markdownlint-cli2 docs/compatibility-retirement.md docs/service-boundary.md`
- `uv run --extra dev ruff check .`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "$PWD" --scope changed_files`
- `uv run python -m unittest`

## Agent review

- Claude Sonnet review: green, no blocking findings.
- Antigravity review: green, no blocking findings.
- GPT-5.5 review: green, no blocking findings.
