### PR TITLE
Move Every Code claim route to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -717,6 +717,21 @@ class EveryCodeWorkRequestRecordResponse(BaseModel):
     request: EveryCodeWorkRequestRecord
 
 
+class EveryCodeWorkRequestClaimEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str
+    host: str
+
+    @model_validator(mode="after")
+    def _validate_claim(self) -> "EveryCodeWorkRequestClaimEnvelope":
+        if not self.request_id.strip():
+            raise ValueError("Every Code work request claim requires request_id")
+        if not self.host.strip():
+            raise ValueError("Every Code work request claim requires host")
+        return self
+
+
 class EveryCodeSummaryResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1431,6 +1446,16 @@ class _EveryCodeWorkRequestWriteStore(Protocol):
     def write_every_code_work_request_record(
         self, record: EveryCodeWorkRequestRecord
     ) -> object: ...
+
+
+class _EveryCodeWorkRequestClaimStore(Protocol):
+    def claim_every_code_work_request_record(
+        self,
+        *,
+        request_id: str,
+        host: str,
+        claimed_at: str,
+    ) -> EveryCodeWorkRequestRecord | None: ...
 
 
 class _EveryCodePrFeedbackReadStore(Protocol):
@@ -2559,6 +2584,13 @@ def create_launchplane_fastapi_app(
             return
         raise _authentication_required_error("Every Code worker token is required.")
 
+    def read_every_code_work_request_claim_identity(
+        authorization: Annotated[str, Header(alias="Authorization")] = "",
+    ) -> LaunchplaneIdentity | None:
+        if every_code_worker_token_authorized(authorization):
+            return None
+        return read_write_identity(authorization=authorization)
+
     def read_write_identity(
         authorization: Annotated[str, Header(alias="Authorization")] = "",
     ) -> LaunchplaneIdentity:
@@ -3143,6 +3175,16 @@ def create_launchplane_fastapi_app(
             capability="Every Code work request writes",
         )
         return cast(_EveryCodeWorkRequestWriteStore, record_store)
+
+    def require_every_code_work_request_claim_store(
+        record_store: object,
+    ) -> _EveryCodeWorkRequestClaimStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=("claim_every_code_work_request_record",),
+            capability="Every Code work request claim writes",
+        )
+        return cast(_EveryCodeWorkRequestClaimStore, record_store)
 
     def require_every_code_pr_feedback_read_store(
         record_store: object,
@@ -3904,6 +3946,84 @@ def create_launchplane_fastapi_app(
             response=response,
         )
         return response
+
+    async def claim_every_code_work_request(
+        request: Request,
+        payload: dict[str, object],
+        identity: Annotated[
+            LaunchplaneIdentity | None, Depends(read_every_code_work_request_claim_identity)
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if identity is not None:
+            if not resolved_authz_policy_runtime.policy.allows(
+                identity=identity,
+                action="every_code_work_request.claim",
+                product="launchplane",
+                context=_LAUNCHPLANE_SERVICE_CONTEXT,
+            ):
+                raise _launchplane_http_error(
+                    status_code=403,
+                    trace_id=trace_id,
+                    code="authorization_denied",
+                    message="Workflow cannot claim Every Code work requests.",
+                )
+            _, _, replayed_response = await replay_apply_idempotency(
+                request=request,
+                record_store=record_store,
+                identity=identity,
+                route_path="/v1/every-code/work-requests/claim",
+                idempotency_key=idempotency_key,
+                trace_id=trace_id,
+                check_replay=True,
+            )
+            if replayed_response is not None:
+                return replayed_response
+        try:
+            every_code_store = require_every_code_work_request_claim_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        try:
+            claim_request = EveryCodeWorkRequestClaimEnvelope.model_validate(payload)
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=str(error),
+            ) from error
+        try:
+            claimed_record = every_code_store.claim_every_code_work_request_record(
+                request_id=claim_request.request_id.strip(),
+                host=claim_request.host.strip(),
+                claimed_at=utc_now_timestamp(),
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if claimed_record is None:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="work_request_already_claimed",
+                message="Every Code work request is not queued for claim.",
+            )
+        return accepted_evidence_response(
+            trace_id=trace_id,
+            records={"request_id": claimed_record.request_id, "state": claimed_record.state},
+            result={"request": claimed_record.model_dump(mode="json")},
+        )
 
     def list_every_code_pr_feedback(
         identity: Annotated[
@@ -8800,6 +8920,18 @@ def create_launchplane_fastapi_app(
         operation_id="create_every_code_work_request",
         summary="Create Every Code work request",
         responses=every_code_work_request_write_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/work-requests/claim",
+        claim_every_code_work_request,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="claim_every_code_work_request",
+        summary="Claim Every Code work request",
+        responses=every_code_worker_status_error_responses,
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1742,21 +1742,6 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
         return self
 
 
-class EveryCodeWorkRequestClaimEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    request_id: str
-    host: str
-
-    @model_validator(mode="after")
-    def _validate_claim(self) -> "EveryCodeWorkRequestClaimEnvelope":
-        if not self.request_id.strip():
-            raise ValueError("Every Code work request claim requires request_id")
-        if not self.host.strip():
-            raise ValueError("Every Code work request claim requires host")
-        return self
-
-
 class EveryCodeWorkRequestStatusEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -3528,7 +3513,6 @@ def _build_write_routes() -> frozenset[str]:
         _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
-        "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
         "/v1/authz-policies/github-actions/grants",
@@ -6759,7 +6743,6 @@ def _owner_agent_identity_from_bearer(environ: dict[str, object]) -> Launchplane
 
 def _is_every_code_worker_route(*, method: str, path: str) -> bool:
     return method == "POST" and path in {
-        "/v1/every-code/work-requests/claim",
         "/v1/every-code/work-requests/rerun",
         "/v1/every-code/work-requests/status",
     }
@@ -6791,35 +6774,6 @@ def _handle_every_code_worker_write(
     every_code_discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
 ) -> list[bytes]:
     every_code_store = _every_code_work_request_store(record_store)
-    if path == "/v1/every-code/work-requests/claim":
-        claim_request = EveryCodeWorkRequestClaimEnvelope.model_validate(payload)
-        claimed_record = every_code_store.claim_every_code_work_request_record(
-            request_id=claim_request.request_id.strip(),
-            host=claim_request.host.strip(),
-            claimed_at=_utc_now_timestamp(),
-        )
-        if claimed_record is None:
-            return _json_response(
-                start_response=start_response,
-                status_code=409,
-                payload={
-                    "status": "rejected",
-                    "trace_id": trace_id,
-                    "error": {
-                        "code": "work_request_already_claimed",
-                        "message": "Every Code work request is not queued for claim.",
-                    },
-                },
-            )
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload=_accepted_payload(
-                trace_id=trace_id,
-                result={"request_id": claimed_record.request_id, "state": claimed_record.state},
-                driver_result={"request": claimed_record.model_dump(mode="json")},
-            ),
-        )
     if path == "/v1/every-code/work-requests/rerun":
         rerun_request = EveryCodeWorkRequestRerunEnvelope.model_validate(payload)
         rerun_checked_at = datetime.now(timezone.utc)
@@ -9682,45 +9636,6 @@ def create_launchplane_service_app(
                     },
                 }
                 driver_result = result
-            elif path == "/v1/every-code/work-requests/claim":
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="every_code_work_request.claim",
-                    product="launchplane",
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot claim Every Code work requests.",
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                return _handle_every_code_worker_write(
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                    record_store=record_store,
-                    path=path,
-                    payload=payload,
-                    idempotency_key=request_idempotency_key,
-                    every_code_discord_sender=every_code_discord_sender,
-                )
             elif path == "/v1/every-code/work-requests/rerun":
                 if not authz_policy.allows(
                     identity=identity,

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -141,15 +141,19 @@ Keep a compatibility surface only when it is one of these:
   deleted. Every Code work-request create uses native FastAPI, preserves
   `every_code_work_request.write` authorization, record-store write capability
   checks, and optional `Idempotency-Key` replay/conflict behavior. Every Code
-  PR-feedback write, PR-feedback status, and preview-gate write routes use
-  native FastAPI, preserve the dedicated Every Code worker token, require only
-  their direct PR-feedback or preview-gate record-store capabilities, and
-  intentionally do not add idempotency state. The PR-feedback status route also
-  preserves the existing `404 not_found` and `409 feedback_already_final`
-  transition semantics. Their legacy WSGI write branches are deleted; direct
-  WSGI fallback calls fail closed. Every Code claim, status, rerun, and webhook
-  routes remain on the mounted WSGI fallback until their native write
-  replacements land.
+  work-request claim uses native FastAPI, preserves both dedicated worker-token
+  claims and `every_code_work_request.claim` workflow authorization, keeps the
+  `404 not_found` and `409 work_request_already_claimed` transition semantics,
+  and honors existing workflow idempotency replays without adding worker-token
+  idempotency state. Every Code PR-feedback write, PR-feedback status, and
+  preview-gate write routes use native FastAPI, preserve the dedicated Every
+  Code worker token, require only their direct PR-feedback or preview-gate
+  record-store capabilities, and intentionally do not add idempotency state. The
+  PR-feedback status route also preserves the existing `404 not_found` and
+  `409 feedback_already_final` transition semantics. Their legacy WSGI write
+  branches are deleted; direct WSGI fallback calls fail closed. Every Code
+  status, rerun, and webhook routes remain on the mounted WSGI fallback until
+  their native write replacements land.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -207,7 +207,12 @@ VeriReel product paths:
     bearer-token callers, `every_code_work_request.write` authorization on
     `launchplane`/`launchplane`, record-store write capability checks, and
     optional `Idempotency-Key` replay/conflict handling)
-  - `POST /v1/every-code/work-requests/claim`
+  - `POST /v1/every-code/work-requests/claim` (native FastAPI for Every Code
+    worker-token callers and bearer-token callers with
+    `every_code_work_request.claim`, record-store claim capability checks,
+    `404 not_found` for missing requests, `409 work_request_already_claimed`
+    for non-queued requests, and workflow `Idempotency-Key` replay/conflict
+    handling)
   - `POST /v1/every-code/work-requests/rerun`
   - `POST /v1/every-code/work-requests/status`
   - `POST /v1/every-code/pr-feedback` (native FastAPI for Every Code
@@ -354,9 +359,10 @@ response. Matching pull-request close deliveries can close every linked request
 referenced by the PR, including still-queued requests that never stored a result
 PR URL.
 
-The Every Code worker read, claim, and status routes also accept a dedicated
-local-worker bearer token. Configure `LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN` on
-the Launchplane service and on the Mac worker host, then run the worker with
+The Every Code worker read, native claim, and status routes also accept a
+dedicated local-worker bearer token. Configure
+`LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN` on the Launchplane service and on the Mac
+worker host, then run the worker with
 `uv run launchplane every-code start --service-url https://...`. That token is
 scoped in code to Every Code work-request, PR-feedback, preview-gate, preview
 readiness routes, plus read-only `GET /v1/product-profiles` for preview

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4447,6 +4447,202 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.json()["error"]["code"], "database_storage_required")
 
+    async def test_every_code_work_request_claim_accepts_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_claim(
+                app,
+                {"request_id": seeded.request_id, "host": "Chris-Studio"},
+                authorization="Bearer worker-token",
+                idempotency_key="every-code-worker-claim",
+            )
+            stored_request = store.read_every_code_work_request_record(seeded.request_id)
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["records"]["request_id"], seeded.request_id)
+        self.assertEqual(payload["records"]["state"], "claimed")
+        self.assertEqual(payload["result"]["request"]["state"], "claimed")
+        self.assertEqual(payload["result"]["request"]["claimed_by_host"], "Chris-Studio")
+        self.assertEqual(stored_request.state, "claimed")
+        self.assertEqual(stored_request.claimed_by_host, "Chris-Studio")
+
+    async def test_every_code_work_request_claim_accepts_authorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_work_request_claim_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_every_code_work_request_claim(
+                app,
+                {"request_id": seeded.request_id, "host": "Runner-Host"},
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["result"]["request"]["claimed_by_host"], "Runner-Host")
+
+    async def test_every_code_work_request_claim_replays_authorized_idempotency(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "request_id": "every-code-cbusillo-code-123-test",
+            "host": "Runner-Host",
+        }
+        store = _EveryCodeClaimReplayOnlyStore(
+            payload=payload,
+            idempotency_key="every-code-claim-replay",
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_every_code_work_request_claim_policy(),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_every_code_work_request_claim(
+            app,
+            payload,
+            idempotency_key="every-code-claim-replay",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertTrue(response.json()["replayed"])
+        self.assertEqual(response.json()["original_trace_id"], "launchplane_req_original")
+        self.assertEqual(store.read_idempotency_calls, 1)
+        self.assertEqual(store.claim_calls, 0)
+
+    async def test_every_code_work_request_claim_rejects_missing_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_claim(
+                app,
+                {"request_id": seeded.request_id, "host": "Chris-Studio"},
+                authorization="",
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_every_code_work_request_claim_rejects_unauthorized_identity(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_every_code_work_request_claim(
+                app,
+                {"request_id": seeded.request_id, "host": "Chris-Studio"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_every_code_work_request_claim_rejects_invalid_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_claim(
+                app,
+                {"request_id": "", "host": "Chris-Studio"},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_payload")
+
+    async def test_every_code_work_request_claim_returns_not_found(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_claim(
+                app,
+                {"request_id": "every-code-cbusillo-code-123-test", "host": "Chris-Studio"},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_every_code_work_request_claim_rejects_already_claimed(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            first_response = await _post_every_code_work_request_claim(
+                app,
+                {"request_id": seeded.request_id, "host": "Chris-Studio"},
+                authorization="Bearer worker-token",
+            )
+            second_response = await _post_every_code_work_request_claim(
+                app,
+                {"request_id": seeded.request_id, "host": "Other-Host"},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 409)
+        self.assertEqual(second_response.json()["error"]["code"], "work_request_already_claimed")
+
+    async def test_every_code_work_request_claim_requires_store_capability(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+        )
+
+        response = await _post_every_code_work_request_claim(
+            app,
+            {"request_id": "every-code-cbusillo-code-123-test", "host": "Chris-Studio"},
+            authorization="Bearer worker-token",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
     async def test_every_code_pr_feedback_write_stores_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -15464,6 +15660,24 @@ def _seed_every_code_read_records(store: Any) -> dict[str, str]:
     }
 
 
+def _seed_every_code_claim_request(store: Any) -> EveryCodeWorkRequestRecord:
+    record = EveryCodeWorkRequestRecord(
+        request_id="every-code-cbusillo-code-123-test",
+        source="manual",
+        state="queued",
+        repository="cbusillo/code",
+        issue_number=123,
+        issue_url="https://github.com/cbusillo/code/issues/123",
+        issue_title="Wire local automation",
+        trigger_label="every-code",
+        trigger_actor="cbusillo",
+        queued_at="2026-05-05T22:00:00Z",
+        updated_at="2026-05-05T22:00:00Z",
+    )
+    store.write_every_code_work_request_record(record)
+    return record
+
+
 def _every_code_read_policy() -> LaunchplaneAuthzPolicy:
     return _record_read_policy(
         action="every_code_work_request.read",
@@ -15480,6 +15694,13 @@ def _every_code_read_policy() -> LaunchplaneAuthzPolicy:
 def _every_code_work_request_write_policy() -> LaunchplaneAuthzPolicy:
     return _record_read_policy(
         action="every_code_work_request.write",
+        context="launchplane",
+    )
+
+
+def _every_code_work_request_claim_policy() -> LaunchplaneAuthzPolicy:
+    return _record_read_policy(
+        action="every_code_work_request.claim",
         context="launchplane",
     )
 
@@ -16311,6 +16532,28 @@ async def _post_every_code_work_request_create(
         app,
         "POST",
         "/v1/every-code/work-requests/create",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
+async def _post_every_code_work_request_claim(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/every-code/work-requests/claim",
         headers=request_headers,
         payload=payload,
     )
@@ -17669,6 +17912,69 @@ class _ProductProfileReplayOnlyStore:
 
     def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> None:
         raise AssertionError("idempotent replay must not write a new record")
+
+
+class _EveryCodeClaimReplayOnlyStore:
+    def __init__(self, *, payload: dict[str, object], idempotency_key: str) -> None:
+        self.read_idempotency_calls = 0
+        self.claim_calls = 0
+        self._payload = payload
+        self._idempotency_key = idempotency_key
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> LaunchplaneIdempotencyRecord | None:
+        self.read_idempotency_calls += 1
+        if (
+            route_path != "/v1/every-code/work-requests/claim"
+            or idempotency_key != self._idempotency_key
+        ):
+            return None
+        return LaunchplaneIdempotencyRecord(
+            record_id="idempotency-launchplane_req_original",
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=hashlib.sha256(
+                json.dumps(self._payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest(),
+            response_status_code=202,
+            response_trace_id="launchplane_req_original",
+            recorded_at="2026-05-29T12:00:00Z",
+            response_payload={
+                "status": "accepted",
+                "trace_id": "launchplane_req_original",
+                "records": {
+                    "request_id": "every-code-cbusillo-code-123-test",
+                    "state": "claimed",
+                },
+                "result": {
+                    "request": {
+                        "request_id": "every-code-cbusillo-code-123-test",
+                        "state": "claimed",
+                        "claimed_by_host": "Runner-Host",
+                    }
+                },
+            },
+        )
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> None:
+        raise AssertionError("idempotent replay must not write a new record")
+
+    def claim_every_code_work_request_record(
+        self,
+        *,
+        request_id: str,
+        host: str,
+        claimed_at: str,
+    ) -> EveryCodeWorkRequestRecord | None:
+        del request_id, host, claimed_at
+        self.claim_calls += 1
+        raise AssertionError("idempotent replay must not claim a record")
 
 
 class _ProductContextApplyReplayOnlyStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1816,6 +1816,62 @@ def _seed_every_code_work_request_record(
     return record
 
 
+def _claim_every_code_work_request_record(
+    record_store: Any,
+    request_id: str,
+    *,
+    host: str = "Chris-Studio",
+) -> EveryCodeWorkRequestRecord:
+    record = record_store.claim_every_code_work_request_record(
+        request_id=request_id,
+        host=host,
+        claimed_at="2026-05-05T22:01:00Z",
+    )
+    if record is None:
+        raise AssertionError(f"Every Code work request {request_id} was not queued")
+    return cast(EveryCodeWorkRequestRecord, record)
+
+
+def _every_code_claim_fixture_response(
+    record: EveryCodeWorkRequestRecord,
+) -> tuple[int, dict[str, Any]]:
+    return (
+        202,
+        {
+            "records": {"request_id": record.request_id, "state": record.state},
+            "result": {"request": record.model_dump(mode="json")},
+        },
+    )
+
+
+def _claim_every_code_work_request_in_filesystem(
+    state_dir: Path,
+    request_id: str,
+    *,
+    host: str = "Chris-Studio",
+) -> tuple[int, dict[str, Any]]:
+    record = _claim_every_code_work_request_record(
+        FilesystemRecordStore(state_dir),
+        request_id,
+        host=host,
+    )
+    return _every_code_claim_fixture_response(record)
+
+
+def _claim_every_code_work_request_in_postgres(
+    database_url: str,
+    request_id: str,
+    *,
+    host: str = "Chris-Studio",
+) -> tuple[int, dict[str, Any]]:
+    store = PostgresRecordStore(database_url=database_url)
+    try:
+        record = _claim_every_code_work_request_record(store, request_id, host=host)
+    finally:
+        store.close()
+    return _every_code_claim_fixture_response(record)
+
+
 def _every_code_github_pr_comment_payload(
     *,
     repository: str = "cbusillo/code",
@@ -2640,12 +2696,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(create_payload["records"]["request_id"])
-            claim_status, _claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-blocked-notify-claim"},
+            claim_status, _claim_payload = _claim_every_code_work_request_in_postgres(
+                database_url,
+                request_id,
             )
             status_code, payload = _invoke_app(
                 app,
@@ -2758,12 +2811,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(create_payload["records"]["request_id"])
-            claim_status, _claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-blocked-notify-failed-claim"},
+            claim_status, _claim_payload = _claim_every_code_work_request_in_postgres(
+                database_url,
+                request_id,
             )
             status_code, payload = _invoke_app(
                 app,
@@ -7120,12 +7170,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(first_payload["records"]["request_id"])
-            claim_status, _claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-webhook-claim"},
+            claim_status, _claim_payload = _claim_every_code_work_request_in_filesystem(
+                state_dir,
+                request_id,
             )
             second_status, second_payload = _invoke_app(
                 app,
@@ -7306,12 +7353,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(first_payload["records"]["request_id"])
-            claim_status, _claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-finished-claim"},
+            claim_status, _claim_payload = _claim_every_code_work_request_in_filesystem(
+                state_dir,
+                request_id,
             )
             done_status, _done_payload = _invoke_app(
                 app,
@@ -7412,13 +7456,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(create_payload["records"]["request_id"])
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-issue-close-claim"},
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
             _invoke_app(
                 app,
                 method="POST",
@@ -7515,13 +7553,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(create_payload["records"]["request_id"])
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-close-claim"},
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
             _invoke_app(
                 app,
                 method="POST",
@@ -7594,8 +7626,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -7613,13 +7646,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(create_payload["records"]["request_id"])
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-unmerged-close-claim"},
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
             _invoke_app(
                 app,
                 method="POST",
@@ -7690,8 +7717,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -7709,13 +7737,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(create_payload["records"]["request_id"])
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-feedback-close-claim"},
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
             _invoke_app(
                 app,
                 method="POST",
@@ -7875,8 +7897,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -7894,13 +7917,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = str(create_payload["records"]["request_id"])
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                headers={"Idempotency-Key": "every-code-pr-number-claim"},
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
             _invoke_app(
                 app,
                 method="POST",
@@ -7965,8 +7982,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -7986,13 +8004,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     },
                 )
                 request_id = str(create_payload["records"]["request_id"])
-                _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/every-code/work-requests/claim",
-                    payload={"request_id": request_id, "host": "Chris-Studio"},
-                    headers={"Idempotency-Key": f"every-code-page-claim-{issue_number}"},
-                )
+                _claim_every_code_work_request_in_filesystem(state_dir, request_id)
                 _invoke_app(
                     app,
                     method="POST",
@@ -8098,12 +8110,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            claim_status, claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
+            claim_status, claim_payload = _claim_every_code_work_request_in_filesystem(
+                state_dir,
+                str(request_id),
             )
             status_status, _status_payload = _invoke_app(
                 app,
@@ -8187,8 +8196,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 return_value={"id": 987},
             ) as create_comment,
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -8206,12 +8216,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            claim_status, _claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
+            claim_status, _claim_payload = _claim_every_code_work_request_in_filesystem(
+                state_dir,
+                str(request_id),
             )
             status_status, _status_payload = _invoke_app(
                 app,
@@ -8322,13 +8329,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
             _invoke_app(
                 app,
                 method="POST",
@@ -8453,8 +8454,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ],
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -8472,12 +8474,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            claim_status, _claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
+            claim_status, _claim_payload = _claim_every_code_work_request_in_filesystem(
+                state_dir,
+                str(request_id),
             )
             status_status, _status_payload = _invoke_app(
                 app,
@@ -8532,8 +8531,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -8551,12 +8551,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            claim_status, _claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
+            claim_status, _claim_payload = _claim_every_code_work_request_in_filesystem(
+                state_dir,
+                str(request_id),
             )
             running_status, _running_payload = _invoke_app(
                 app,
@@ -8623,8 +8620,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 Path(home_directory_name),
                 repo_managers={"cbusillo/sellyouroutboard": "@Mbanks89"},
             )
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -8642,13 +8640,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
             _invoke_app(
                 app,
                 method="POST",
@@ -8710,8 +8702,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 path=".codex/github-planning.json",
                 repo_managers={"cbusillo/sellyouroutboard": "@Mbanks89"},
             )
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -8729,13 +8722,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
             _invoke_app(
                 app,
                 method="POST",
@@ -8871,12 +8858,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            _claim_status, _claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
+            _claim_status, _claim_payload = _claim_every_code_work_request_in_filesystem(
+                state_dir,
+                str(request_id),
             )
             _running_status, _running_payload = _invoke_app(
                 app,
@@ -8927,8 +8911,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
@@ -8946,13 +8931,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
             _invoke_app(
                 app,
                 method="POST",
@@ -9037,13 +9016,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
             _invoke_app(
                 app,
                 method="POST",
@@ -9204,8 +9177,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
         ):
+            state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
-                state_dir=Path(temporary_directory_name) / "state",
+                state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
@@ -9223,13 +9197,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
             request_id = issue_response["records"]["request_id"]
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer dev-worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
             _invoke_app(
                 app,
                 method="POST",
@@ -9455,7 +9423,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 503)
         self.assertEqual(payload["error"]["code"], "webhook_secret_not_configured")
 
-    def test_every_code_work_request_create_list_claim_and_status_flow(self) -> None:
+    def test_every_code_work_request_claim_is_retired_from_legacy_wsgi_app(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {
                 "github_actions": [
@@ -9502,68 +9470,18 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload={"request_id": request_id, "host": "Chris-Studio"},
                 headers={"Idempotency-Key": "every-code-claim-code-123"},
             )
-            second_claim_status, second_claim_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Other-Host"},
-                headers={"Idempotency-Key": "every-code-claim-code-123-other"},
-            )
-            status_status, status_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                    "updated_at": "2026-05-05T22:05:00Z",
-                },
-                headers={"Idempotency-Key": "every-code-status-code-123-done"},
-            )
             stored_request = FilesystemRecordStore(state_dir).read_every_code_work_request_record(
                 request_id
             )
 
         self.assertEqual(len(queued_requests), 1)
-        self.assertEqual(claim_status, 202)
-        self.assertEqual(claim_payload["records"]["state"], "claimed")
-        self.assertEqual(second_claim_status, 409)
-        self.assertEqual(second_claim_payload["error"]["code"], "work_request_already_claimed")
-        self.assertEqual(status_status, 202)
-        self.assertEqual(status_payload["records"]["state"], "done")
-        self.assertEqual(stored_request.state, "done")
-        self.assertEqual(
-            stored_request.result_pr_url,
-            "https://github.com/cbusillo/code/pull/26",
-        )
+        self.assertEqual(claim_status, 404)
+        self.assertEqual(claim_payload["error"]["code"], "not_found")
+        self.assertEqual(stored_request.state, "queued")
 
-    def test_every_code_worker_token_can_claim_and_update_requests(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": [
-                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
-                        ],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": [
-                            "every_code_work_request.write",
-                            "every_code_work_request.rerun",
-                        ],
-                    }
-                ]
-            }
-        )
-        identity = _identity(
-            repository="cbusillo/launchplane",
-            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
-            event_name="workflow_dispatch",
-        )
+    def test_every_code_work_request_claim_worker_token_is_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
@@ -9574,8 +9492,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
             state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
                 state_dir=state_dir,
-                verifier=_StubVerifier(identity),
-                authz_policy=policy,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
                 control_plane_root_path=Path(temporary_directory_name),
             )
             seeded_request = _seed_every_code_work_request_record(state_dir)
@@ -9590,25 +9508,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload={"request_id": request_id, "host": "Chris-Studio"},
                 authorization="Bearer worker-token",
             )
-            status_status, status_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                    "updated_at": "2026-05-05T22:05:00Z",
-                },
-                authorization="Bearer worker-token",
+            stored_request = FilesystemRecordStore(state_dir).read_every_code_work_request_record(
+                request_id
             )
 
-        self.assertEqual(queued_requests[0].request_id, request_id)
-        self.assertEqual(claim_status, 202)
-        self.assertEqual(claim_payload["result"]["request"]["claimed_by_host"], "Chris-Studio")
-        self.assertEqual(status_status, 202)
-        self.assertEqual(status_payload["result"]["request"]["state"], "done")
+        self.assertEqual(len(queued_requests), 1)
+        self.assertEqual(claim_status, 404)
+        self.assertEqual(claim_payload["error"]["code"], "not_found")
+        self.assertEqual(stored_request.state, "queued")
 
     def test_product_profile_routes_are_retired_from_legacy_wsgi_app(self) -> None:
         with (
@@ -9695,13 +9602,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=Path(temporary_directory_name),
             )
             request_id = _seed_every_code_work_request_record(state_dir).request_id
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
             _invoke_app(
                 app,
                 method="POST",
@@ -9795,13 +9696,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=Path(temporary_directory_name),
             )
             request_id = _seed_every_code_work_request_record(state_dir).request_id
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
             _invoke_app(
                 app,
                 method="POST",
@@ -9896,13 +9791,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=Path(temporary_directory_name),
             )
             request_id = _seed_every_code_work_request_record(state_dir).request_id
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/claim",
-                payload={"request_id": request_id, "host": "Chris-Studio"},
-                authorization="Bearer worker-token",
-            )
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
             _invoke_app(
                 app,
                 method="POST",


### PR DESCRIPTION
## Summary

- Move `POST /v1/every-code/work-requests/claim` to the native FastAPI app.
- Retire the stale legacy WSGI claim route so direct fallback calls now fail closed.
- Preserve worker-token claim auth, workflow-identity claim authorization, existing idempotency replay behavior, and `404`/`409` claim-state semantics.
- Update service-boundary and compatibility-retirement docs for the cutover.

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiEveryCodeReadTests`
- `uv run python -m unittest tests.test_http_app.FastApiEveryCodeReadTests tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_claim_is_retired_from_legacy_wsgi_app tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_claim_worker_token_is_retired_from_legacy_wsgi_app tests.test_service.LaunchplaneServiceTests.test_every_code_worker_token_reruns_terminal_request tests.test_service.LaunchplaneServiceTests.test_every_code_worker_token_can_rerun_terminal_request tests.test_service.LaunchplaneServiceTests.test_every_code_rerun_requires_matching_write_intent_evidence tests.test_service.LaunchplaneServiceTests.test_every_code_rerun_rejects_stale_and_wrong_context_write_intents`
- `uv run python -m unittest` (`2857` tests)
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `npx markdownlint-cli2 docs/compatibility-retirement.md docs/service-boundary.md`
- JetBrains PyCharm inspection closeout, scope `changed_files`: GREEN, no actionable findings.
- Final read-only review agents: no blockers; one clean/no-findings review, one low-severity schema/test-helper/idempotency-note review with covered/non-blocking observations.
