### PR TITLE
Move Every Code status writes to FastAPI

### DIFF
--- a/control_plane/every_code_notifications_delivery.py
+++ b/control_plane/every_code_notifications_delivery.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Protocol, cast
+
+from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.every_code_notifications import (
+    EveryCodeNotificationAttemptRecord,
+    EveryCodeNotificationDeliveryStatus,
+    EveryCodeNotificationDestination,
+    EveryCodeNotificationEvent,
+    EveryCodeNotificationPolicyRecord,
+    build_every_code_notification_attempt_id,
+)
+from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.notifications import post_discord_webhook, public_discord_url_error
+
+_LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+
+
+class EveryCodeNotificationStore(Protocol):
+    def write_every_code_notification_policy_record(
+        self, record: EveryCodeNotificationPolicyRecord
+    ) -> object: ...
+
+    def list_every_code_notification_policy_records(
+        self,
+        *,
+        repository: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodeNotificationPolicyRecord, ...]: ...
+
+    def write_every_code_notification_attempt_record(
+        self, record: EveryCodeNotificationAttemptRecord
+    ) -> object: ...
+
+    def list_every_code_notification_attempt_records(
+        self,
+        *,
+        request_id: str = "",
+        event: str = "",
+        destination_kind: str = "",
+        limit: int | None = None,
+    ) -> tuple[EveryCodeNotificationAttemptRecord, ...]: ...
+
+
+def deliver_every_code_blocked_notifications(
+    *,
+    record_store: object,
+    request: EveryCodeWorkRequestRecord,
+    attempted_at: str,
+    discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
+) -> tuple[EveryCodeNotificationAttemptRecord, ...]:
+    notification_store = _every_code_notification_store(record_store)
+    secret_store = _secret_capable_store(record_store)
+    if notification_store is None or secret_store is None:
+        return ()
+    policies = tuple(
+        policy
+        for policy in notification_store.list_every_code_notification_policy_records(
+            repository=request.repository,
+            status="enabled",
+            limit=None,
+        )
+        if policy.matches(request)
+    )
+    if not policies:
+        return ()
+    secret_resolver = _launchplane_managed_secret_resolver(
+        record_store=secret_store,
+        context_name=_LAUNCHPLANE_SERVICE_CONTEXT,
+        instance_name="every-code",
+    )
+    attempts: list[EveryCodeNotificationAttemptRecord] = []
+    for policy in policies:
+        for destination in policy.destinations:
+            if destination.status != "enabled":
+                attempt = _write_every_code_notification_attempt(
+                    notification_store=notification_store,
+                    request=request,
+                    event="work_request_blocked",
+                    policy=policy,
+                    destination=destination,
+                    attempted_at=attempted_at,
+                    delivery_status="skipped",
+                    action="destination_disabled",
+                )
+                attempts.append(attempt)
+                continue
+            if destination.kind == "discord":
+                attempt = deliver_every_code_discord_notification(
+                    notification_store=notification_store,
+                    secret_resolver=secret_resolver,
+                    discord_sender=discord_sender,
+                    request=request,
+                    policy=policy,
+                    destination=destination,
+                    attempted_at=attempted_at,
+                )
+                attempts.append(attempt)
+    return tuple(attempts)
+
+
+def deliver_every_code_discord_notification(
+    *,
+    notification_store: EveryCodeNotificationStore,
+    secret_resolver: Callable[[str], str],
+    discord_sender: Callable[[str, dict[str, object]], object],
+    request: EveryCodeWorkRequestRecord,
+    policy: EveryCodeNotificationPolicyRecord,
+    destination: EveryCodeNotificationDestination,
+    attempted_at: str,
+) -> EveryCodeNotificationAttemptRecord:
+    webhook_url = secret_resolver(destination.discord_webhook_secret).strip()
+    if not webhook_url:
+        return _write_every_code_notification_attempt(
+            notification_store=notification_store,
+            request=request,
+            event="work_request_blocked",
+            policy=policy,
+            destination=destination,
+            attempted_at=attempted_at,
+            delivery_status="failed",
+            action="missing_discord_webhook",
+            error_message="Discord webhook secret could not be resolved.",
+        )
+    public_url_error = public_discord_url_error(webhook_url)
+    if public_url_error:
+        return _write_every_code_notification_attempt(
+            notification_store=notification_store,
+            request=request,
+            event="work_request_blocked",
+            policy=policy,
+            destination=destination,
+            attempted_at=attempted_at,
+            delivery_status="failed",
+            action="invalid_discord_webhook",
+            error_message=f"Discord webhook URL is not public: {public_url_error}",
+        )
+    existing_attempt = _existing_every_code_notification_attempt(
+        notification_store=notification_store,
+        request=request,
+        event="work_request_blocked",
+        policy=policy,
+        destination=destination,
+    )
+    if existing_attempt is not None and existing_attempt.delivery_status in {
+        "pending",
+        "delivered",
+    }:
+        return existing_attempt
+    pending_attempt = _write_every_code_notification_attempt(
+        notification_store=notification_store,
+        request=request,
+        event="work_request_blocked",
+        policy=policy,
+        destination=destination,
+        attempted_at=attempted_at,
+        delivery_status="pending",
+        action="dispatching_discord",
+    )
+    try:
+        discord_sender(webhook_url, _every_code_blocked_discord_payload(request))
+    except Exception as error:  # noqa: BLE001 - delivery attempt records preserve failure detail.
+        return _write_every_code_notification_attempt(
+            notification_store=notification_store,
+            request=request,
+            event="work_request_blocked",
+            policy=policy,
+            destination=destination,
+            attempted_at=attempted_at,
+            delivery_status="failed",
+            action="discord_webhook_failed",
+            error_message=str(error) or error.__class__.__name__,
+        )
+    try:
+        return _write_every_code_notification_attempt(
+            notification_store=notification_store,
+            request=request,
+            event="work_request_blocked",
+            policy=policy,
+            destination=destination,
+            attempted_at=attempted_at,
+            delivery_status="delivered",
+            action="posted_discord",
+        )
+    except Exception:  # noqa: BLE001 - the pending attempt preserves dispatch evidence.
+        return pending_attempt
+
+
+def _secret_capable_store(record_store: object) -> control_plane_secrets.SecretReadStore | None:
+    if hasattr(record_store, "read_secret_record") and hasattr(record_store, "list_secret_records"):
+        return cast(control_plane_secrets.SecretReadStore, record_store)
+    return None
+
+
+def _every_code_notification_store(record_store: object) -> EveryCodeNotificationStore | None:
+    required_methods = (
+        "write_every_code_notification_policy_record",
+        "list_every_code_notification_policy_records",
+        "write_every_code_notification_attempt_record",
+        "list_every_code_notification_attempt_records",
+    )
+    if all(hasattr(record_store, method_name) for method_name in required_methods):
+        return cast(EveryCodeNotificationStore, record_store)
+    return None
+
+
+def _launchplane_managed_secret_resolver(
+    *,
+    record_store: control_plane_secrets.SecretReadStore,
+    context_name: str,
+    instance_name: str,
+) -> Callable[[str], str]:
+    def resolve(secret_id: str) -> str:
+        normalized_secret_id = secret_id.strip()
+        if not normalized_secret_id:
+            return ""
+        try:
+            record = record_store.read_secret_record(normalized_secret_id)
+        except Exception:  # noqa: BLE001 - notification attempts capture missing secrets.
+            return ""
+        if record.status != control_plane_secrets.SECRET_STATUS_CONFIGURED:
+            return ""
+        if not control_plane_secrets._scope_matches_record(
+            record,
+            context_name=context_name,
+            instance_name=instance_name,
+        ):
+            return ""
+        try:
+            version = record_store.read_secret_version(record.current_version_id)
+            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
+        except Exception:  # noqa: BLE001 - notification attempts capture unreadable secrets.
+            return ""
+
+    return resolve
+
+
+def _existing_every_code_notification_attempt(
+    *,
+    notification_store: EveryCodeNotificationStore,
+    request: EveryCodeWorkRequestRecord,
+    event: EveryCodeNotificationEvent,
+    policy: EveryCodeNotificationPolicyRecord,
+    destination: EveryCodeNotificationDestination,
+) -> EveryCodeNotificationAttemptRecord | None:
+    attempt_id = build_every_code_notification_attempt_id(
+        request_id=request.request_id,
+        event=event,
+        policy_id=policy.policy_id,
+        destination_id=destination.destination_id,
+        lifecycle_key=_every_code_notification_lifecycle_key(request),
+    )
+    return next(
+        (
+            attempt
+            for attempt in notification_store.list_every_code_notification_attempt_records(
+                request_id=request.request_id,
+                event=event,
+                limit=None,
+            )
+            if attempt.attempt_id == attempt_id
+        ),
+        None,
+    )
+
+
+def _write_every_code_notification_attempt(
+    *,
+    notification_store: EveryCodeNotificationStore,
+    request: EveryCodeWorkRequestRecord,
+    event: EveryCodeNotificationEvent,
+    policy: EveryCodeNotificationPolicyRecord,
+    destination: EveryCodeNotificationDestination,
+    attempted_at: str,
+    delivery_status: EveryCodeNotificationDeliveryStatus,
+    action: str,
+    error_message: str = "",
+) -> EveryCodeNotificationAttemptRecord:
+    attempt = EveryCodeNotificationAttemptRecord(
+        attempt_id=build_every_code_notification_attempt_id(
+            request_id=request.request_id,
+            event=event,
+            policy_id=policy.policy_id,
+            destination_id=destination.destination_id,
+            lifecycle_key=_every_code_notification_lifecycle_key(request),
+        ),
+        request_id=request.request_id,
+        event=event,
+        policy_id=policy.policy_id,
+        destination_id=destination.destination_id,
+        destination_kind=destination.kind,
+        delivery_status=delivery_status,
+        attempted_at=attempted_at,
+        action=action,
+        error_message=_bounded_text(error_message, max_length=500),
+    )
+    notification_store.write_every_code_notification_attempt_record(attempt)
+    return attempt
+
+
+def _every_code_notification_lifecycle_key(request: EveryCodeWorkRequestRecord) -> str:
+    return request.lifecycle_id
+
+
+def _every_code_blocked_discord_payload(
+    request: EveryCodeWorkRequestRecord,
+) -> dict[str, object]:
+    fields = [
+        {"name": "Repository", "value": request.repository, "inline": True},
+        {"name": "Issue", "value": str(request.issue_number), "inline": True},
+        {"name": "Host", "value": request.claimed_by_host, "inline": True},
+        {"name": "Request", "value": request.request_id, "inline": False},
+    ]
+    if request.issue_url:
+        fields.append({"name": "Issue URL", "value": request.issue_url, "inline": False})
+    return {
+        "embeds": [
+            {
+                "title": "Every Code work request blocked",
+                "description": _bounded_text(request.error_message, max_length=1500),
+                "color": 0xC62828,
+                "fields": fields,
+            }
+        ]
+    }
+
+
+def _bounded_text(value: str, *, max_length: int) -> str:
+    normalized_value = " ".join(value.strip().split())
+    if len(normalized_value) <= max_length:
+        return normalized_value
+    return f"{normalized_value[: max_length - 3]}..."

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1,7 +1,7 @@
 import hashlib
 import json
 import secrets
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path as FilePath
 from typing import Annotated, Literal, Protocol, cast
@@ -59,7 +59,11 @@ from control_plane.contracts.every_code_summary_read_model import (
     EveryCodeSummaryReadModel,
     build_every_code_summary_read_model,
 )
-from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    EveryCodeWorkRequestStatusUpdate,
+    apply_every_code_work_request_status,
+)
 from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
     build_launchplane_idempotency_record_id,
@@ -135,6 +139,8 @@ from control_plane.every_code_work_request_write import (
     EveryCodeWorkRequestCreateEnvelope,
     build_every_code_work_request_record,
 )
+from control_plane.every_code_notifications_delivery import deliver_every_code_blocked_notifications
+from control_plane.notifications import post_discord_webhook
 from control_plane.runtime_key_safety_http import (
     RuntimeKeySafetyPolicyApplyEnvelope,
     apply_runtime_key_safety_policy_route,
@@ -729,6 +735,26 @@ class EveryCodeWorkRequestClaimEnvelope(BaseModel):
             raise ValueError("Every Code work request claim requires request_id")
         if not self.host.strip():
             raise ValueError("Every Code work request claim requires host")
+        return self
+
+
+class EveryCodeWorkRequestStatusEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str
+    host: str
+    state: Literal["running", "done", "blocked"]
+    result_pr_url: str = ""
+    result_summary: str = ""
+    error_message: str = ""
+    updated_at: str = ""
+
+    @model_validator(mode="after")
+    def _validate_status(self) -> "EveryCodeWorkRequestStatusEnvelope":
+        if not self.request_id.strip():
+            raise ValueError("Every Code work request status requires request_id")
+        if not self.host.strip():
+            raise ValueError("Every Code work request status requires host")
         return self
 
 
@@ -1456,6 +1482,16 @@ class _EveryCodeWorkRequestClaimStore(Protocol):
         host: str,
         claimed_at: str,
     ) -> EveryCodeWorkRequestRecord | None: ...
+
+
+class _EveryCodeWorkRequestStatusStore(Protocol):
+    def read_every_code_work_request_record(
+        self, request_id: str
+    ) -> EveryCodeWorkRequestRecord: ...
+
+    def write_every_code_work_request_record(
+        self, record: EveryCodeWorkRequestRecord
+    ) -> object: ...
 
 
 class _EveryCodePrFeedbackReadStore(Protocol):
@@ -2389,6 +2425,7 @@ def create_launchplane_fastapi_app(
     work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
     work_graph_issue_inbox_provider: WorkGraphIssueInboxProvider | None = None,
     work_graph_issue_inbox_reconcile_provider: WorkGraphIssueInboxReconcileProvider | None = None,
+    every_code_discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
 ) -> FastAPI:
     resolved_authz_policy_runtime = authz_policy_runtime or LaunchplaneAuthzPolicyRuntime(
         authz_policy
@@ -2584,7 +2621,7 @@ def create_launchplane_fastapi_app(
             return
         raise _authentication_required_error("Every Code worker token is required.")
 
-    def read_every_code_work_request_claim_identity(
+    def read_every_code_work_request_worker_write_identity(
         authorization: Annotated[str, Header(alias="Authorization")] = "",
     ) -> LaunchplaneIdentity | None:
         if every_code_worker_token_authorized(authorization):
@@ -3185,6 +3222,19 @@ def create_launchplane_fastapi_app(
             capability="Every Code work request claim writes",
         )
         return cast(_EveryCodeWorkRequestClaimStore, record_store)
+
+    def require_every_code_work_request_status_store(
+        record_store: object,
+    ) -> _EveryCodeWorkRequestStatusStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=(
+                "read_every_code_work_request_record",
+                "write_every_code_work_request_record",
+            ),
+            capability="Every Code work request status writes",
+        )
+        return cast(_EveryCodeWorkRequestStatusStore, record_store)
 
     def require_every_code_pr_feedback_read_store(
         record_store: object,
@@ -3951,7 +4001,8 @@ def create_launchplane_fastapi_app(
         request: Request,
         payload: dict[str, object],
         identity: Annotated[
-            LaunchplaneIdentity | None, Depends(read_every_code_work_request_claim_identity)
+            LaunchplaneIdentity | None,
+            Depends(read_every_code_work_request_worker_write_identity),
         ],
         record_store: Annotated[object, Depends(get_record_store)],
         idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
@@ -4024,6 +4075,139 @@ def create_launchplane_fastapi_app(
             records={"request_id": claimed_record.request_id, "state": claimed_record.state},
             result={"request": claimed_record.model_dump(mode="json")},
         )
+
+    async def write_every_code_work_request_status(
+        request: Request,
+        payload: dict[str, object],
+        identity: Annotated[
+            LaunchplaneIdentity | None,
+            Depends(read_every_code_work_request_worker_write_identity),
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        normalized_idempotency_key = ""
+        payload_fingerprint = ""
+        worker_token_authorized = every_code_worker_token_authorized(
+            request.headers.get("Authorization", "")
+        )
+        idempotency_identity = identity or (
+            TerminalAgentIdentity(
+                subject="every-code-worker",
+                token_label="every-code-worker-token",
+            )
+            if worker_token_authorized
+            else None
+        )
+        if identity is not None:
+            if not resolved_authz_policy_runtime.policy.allows(
+                identity=identity,
+                action="every_code_work_request.update",
+                product="launchplane",
+                context=_LAUNCHPLANE_SERVICE_CONTEXT,
+            ):
+                raise _launchplane_http_error(
+                    status_code=403,
+                    trace_id=trace_id,
+                    code="authorization_denied",
+                    message="Workflow cannot update Every Code work requests.",
+                )
+        if idempotency_identity is not None:
+            (
+                normalized_idempotency_key,
+                payload_fingerprint,
+                replayed_response,
+            ) = await replay_apply_idempotency(
+                request=request,
+                record_store=record_store,
+                identity=idempotency_identity,
+                route_path="/v1/every-code/work-requests/status",
+                idempotency_key=idempotency_key,
+                trace_id=trace_id,
+                check_replay=True,
+            )
+            if replayed_response is not None:
+                return replayed_response
+        try:
+            every_code_store = require_every_code_work_request_status_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        try:
+            status_request = EveryCodeWorkRequestStatusEnvelope.model_validate(payload)
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=str(error),
+            ) from error
+        try:
+            existing_record = every_code_store.read_every_code_work_request_record(
+                status_request.request_id.strip()
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        try:
+            updated_record = apply_every_code_work_request_status(
+                existing_record,
+                EveryCodeWorkRequestStatusUpdate(
+                    state=status_request.state,
+                    host=status_request.host,
+                    updated_at=status_request.updated_at.strip() or utc_now_timestamp(),
+                    result_pr_url=status_request.result_pr_url,
+                    result_summary=status_request.result_summary,
+                    error_message=status_request.error_message,
+                ),
+            )
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=str(error),
+            ) from error
+        every_code_store.write_every_code_work_request_record(updated_record)
+        notification_attempts: tuple[EveryCodeNotificationAttemptRecord, ...] = ()
+        if updated_record.state == "blocked":
+            notification_attempts = deliver_every_code_blocked_notifications(
+                record_store=record_store,
+                request=updated_record,
+                attempted_at=utc_now_timestamp(),
+                discord_sender=every_code_discord_sender,
+            )
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"request_id": updated_record.request_id, "state": updated_record.state},
+            result={
+                "request": updated_record.model_dump(mode="json"),
+                "notifications": [
+                    notification_attempt.model_dump(mode="json")
+                    for notification_attempt in notification_attempts
+                ],
+            },
+        )
+        if idempotency_identity is not None:
+            store_apply_idempotency(
+                record_store=record_store,
+                identity=idempotency_identity,
+                route_path="/v1/every-code/work-requests/status",
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=response,
+            )
+        return response
 
     def list_every_code_pr_feedback(
         identity: Annotated[
@@ -8931,6 +9115,28 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="claim_every_code_work_request",
         summary="Claim Every Code work request",
+        responses=every_code_worker_status_error_responses,
+    )
+
+    app.add_api_route(
+        "/v1/every-code/work-requests/status",
+        write_every_code_work_request_status,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="write_every_code_work_request_status",
+        summary="Write Every Code work request status",
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": EveryCodeWorkRequestStatusEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
         responses=every_code_worker_status_error_responses,
     )
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -45,19 +45,9 @@ from control_plane.contracts.agent_write_intent import (
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
-    EveryCodeWorkRequestStatusUpdate,
-    apply_every_code_work_request_status,
     close_every_code_work_request_for_issue,
     close_every_code_work_request_for_pull_request,
     requeue_every_code_work_request,
-)
-from control_plane.contracts.every_code_notifications import (
-    EveryCodeNotificationAttemptRecord,
-    EveryCodeNotificationDeliveryStatus,
-    EveryCodeNotificationDestination,
-    EveryCodeNotificationEvent,
-    EveryCodeNotificationPolicyRecord,
-    build_every_code_notification_attempt_id,
 )
 from control_plane.contracts.every_code_preview_gate_record import (
     EveryCodePreviewGateRecord,
@@ -1740,18 +1730,6 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
         if self.product.strip() != "launchplane":
             raise ValueError("Launchplane self deploy requires product 'launchplane'.")
         return self
-
-
-class EveryCodeWorkRequestStatusEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    request_id: str
-    host: str
-    state: Literal["running", "done", "blocked"]
-    result_pr_url: str = ""
-    result_summary: str = ""
-    error_message: str = ""
-    updated_at: str = ""
 
 
 class EveryCodeWorkRequestRerunEnvelope(BaseModel):
@@ -3514,7 +3492,6 @@ def _build_write_routes() -> frozenset[str]:
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
         "/v1/every-code/work-requests/rerun",
-        "/v1/every-code/work-requests/status",
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-actions/removals",
         "/v1/authz-policies/github-humans/grants",
@@ -3688,33 +3665,6 @@ class _EveryCodeWorkRequestStore(Protocol):
     ) -> tuple[EveryCodePreviewGateRecord, ...]: ...
 
 
-class _EveryCodeNotificationStore(Protocol):
-    def write_every_code_notification_policy_record(
-        self, record: EveryCodeNotificationPolicyRecord
-    ) -> object: ...
-
-    def list_every_code_notification_policy_records(
-        self,
-        *,
-        repository: str = "",
-        status: str = "",
-        limit: int | None = None,
-    ) -> tuple[EveryCodeNotificationPolicyRecord, ...]: ...
-
-    def write_every_code_notification_attempt_record(
-        self, record: EveryCodeNotificationAttemptRecord
-    ) -> object: ...
-
-    def list_every_code_notification_attempt_records(
-        self,
-        *,
-        request_id: str = "",
-        event: str = "",
-        destination_kind: str = "",
-        limit: int | None = None,
-    ) -> tuple[EveryCodeNotificationAttemptRecord, ...]: ...
-
-
 class _PreviewPrFeedbackNotificationStore(Protocol):
     def write_preview_pr_feedback_notification_policy_record(
         self, record: PreviewPrFeedbackNotificationPolicyRecord
@@ -3775,18 +3725,6 @@ def _every_code_work_request_store(record_store: object) -> _EveryCodeWorkReques
     if all(hasattr(record_store, method_name) for method_name in required_methods):
         return cast(_EveryCodeWorkRequestStore, record_store)
     raise TypeError("record store does not support Every Code work requests")
-
-
-def _every_code_notification_store(record_store: object) -> _EveryCodeNotificationStore | None:
-    required_methods = (
-        "write_every_code_notification_policy_record",
-        "list_every_code_notification_policy_records",
-        "write_every_code_notification_attempt_record",
-        "list_every_code_notification_attempt_records",
-    )
-    if all(hasattr(record_store, method_name) for method_name in required_methods):
-        return cast(_EveryCodeNotificationStore, record_store)
-    return None
 
 
 def _preview_pr_feedback_notification_store(
@@ -6284,240 +6222,6 @@ def _launchplane_managed_secret_resolver(
     return resolve
 
 
-def _deliver_every_code_blocked_notifications(
-    *,
-    record_store: object,
-    request: EveryCodeWorkRequestRecord,
-    attempted_at: str,
-    discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
-) -> tuple[EveryCodeNotificationAttemptRecord, ...]:
-    notification_store = _every_code_notification_store(record_store)
-    secret_store = _secret_capable_store(record_store)
-    if notification_store is None or secret_store is None:
-        return ()
-    policies = tuple(
-        policy
-        for policy in notification_store.list_every_code_notification_policy_records(
-            repository=request.repository,
-            status="enabled",
-            limit=None,
-        )
-        if policy.matches(request)
-    )
-    if not policies:
-        return ()
-    secret_resolver = _launchplane_managed_secret_resolver(
-        record_store=secret_store,
-        context_name=_LAUNCHPLANE_SERVICE_CONTEXT,
-        instance_name="every-code",
-    )
-    attempts: list[EveryCodeNotificationAttemptRecord] = []
-    for policy in policies:
-        for destination in policy.destinations:
-            if destination.status != "enabled":
-                attempt = _write_every_code_notification_attempt(
-                    notification_store=notification_store,
-                    request=request,
-                    event="work_request_blocked",
-                    policy=policy,
-                    destination=destination,
-                    attempted_at=attempted_at,
-                    delivery_status="skipped",
-                    action="destination_disabled",
-                )
-                attempts.append(attempt)
-                continue
-            if destination.kind == "discord":
-                attempt = _deliver_every_code_discord_notification(
-                    notification_store=notification_store,
-                    secret_resolver=secret_resolver,
-                    discord_sender=discord_sender,
-                    request=request,
-                    policy=policy,
-                    destination=destination,
-                    attempted_at=attempted_at,
-                )
-                attempts.append(attempt)
-    return tuple(attempts)
-
-
-def _deliver_every_code_discord_notification(
-    *,
-    notification_store: _EveryCodeNotificationStore,
-    secret_resolver: Callable[[str], str],
-    discord_sender: Callable[[str, dict[str, object]], object],
-    request: EveryCodeWorkRequestRecord,
-    policy: EveryCodeNotificationPolicyRecord,
-    destination: EveryCodeNotificationDestination,
-    attempted_at: str,
-) -> EveryCodeNotificationAttemptRecord:
-    webhook_url = secret_resolver(destination.discord_webhook_secret).strip()
-    if not webhook_url:
-        return _write_every_code_notification_attempt(
-            notification_store=notification_store,
-            request=request,
-            event="work_request_blocked",
-            policy=policy,
-            destination=destination,
-            attempted_at=attempted_at,
-            delivery_status="failed",
-            action="missing_discord_webhook",
-            error_message="Discord webhook secret could not be resolved.",
-        )
-    public_url_error = public_discord_url_error(webhook_url)
-    if public_url_error:
-        return _write_every_code_notification_attempt(
-            notification_store=notification_store,
-            request=request,
-            event="work_request_blocked",
-            policy=policy,
-            destination=destination,
-            attempted_at=attempted_at,
-            delivery_status="failed",
-            action="invalid_discord_webhook",
-            error_message=f"Discord webhook URL is not public: {public_url_error}",
-        )
-    existing_attempt = _existing_every_code_notification_attempt(
-        notification_store=notification_store,
-        request=request,
-        event="work_request_blocked",
-        policy=policy,
-        destination=destination,
-    )
-    if existing_attempt is not None and existing_attempt.delivery_status in {
-        "pending",
-        "delivered",
-    }:
-        return existing_attempt
-    pending_attempt = _write_every_code_notification_attempt(
-        notification_store=notification_store,
-        request=request,
-        event="work_request_blocked",
-        policy=policy,
-        destination=destination,
-        attempted_at=attempted_at,
-        delivery_status="pending",
-        action="dispatching_discord",
-    )
-    try:
-        discord_sender(webhook_url, _every_code_blocked_discord_payload(request))
-    except Exception as error:  # noqa: BLE001 - delivery attempt records preserve failure detail.
-        return _write_every_code_notification_attempt(
-            notification_store=notification_store,
-            request=request,
-            event="work_request_blocked",
-            policy=policy,
-            destination=destination,
-            attempted_at=attempted_at,
-            delivery_status="failed",
-            action="discord_webhook_failed",
-            error_message=str(error) or error.__class__.__name__,
-        )
-    try:
-        return _write_every_code_notification_attempt(
-            notification_store=notification_store,
-            request=request,
-            event="work_request_blocked",
-            policy=policy,
-            destination=destination,
-            attempted_at=attempted_at,
-            delivery_status="delivered",
-            action="posted_discord",
-        )
-    except Exception:  # noqa: BLE001 - the pending attempt preserves dispatch evidence.
-        return pending_attempt
-
-
-def _existing_every_code_notification_attempt(
-    *,
-    notification_store: _EveryCodeNotificationStore,
-    request: EveryCodeWorkRequestRecord,
-    event: EveryCodeNotificationEvent,
-    policy: EveryCodeNotificationPolicyRecord,
-    destination: EveryCodeNotificationDestination,
-) -> EveryCodeNotificationAttemptRecord | None:
-    attempt_id = build_every_code_notification_attempt_id(
-        request_id=request.request_id,
-        event=event,
-        policy_id=policy.policy_id,
-        destination_id=destination.destination_id,
-        lifecycle_key=_every_code_notification_lifecycle_key(request),
-    )
-    return next(
-        (
-            attempt
-            for attempt in notification_store.list_every_code_notification_attempt_records(
-                request_id=request.request_id,
-                event=event,
-                limit=None,
-            )
-            if attempt.attempt_id == attempt_id
-        ),
-        None,
-    )
-
-
-def _write_every_code_notification_attempt(
-    *,
-    notification_store: _EveryCodeNotificationStore,
-    request: EveryCodeWorkRequestRecord,
-    event: EveryCodeNotificationEvent,
-    policy: EveryCodeNotificationPolicyRecord,
-    destination: EveryCodeNotificationDestination,
-    attempted_at: str,
-    delivery_status: EveryCodeNotificationDeliveryStatus,
-    action: str,
-    error_message: str = "",
-) -> EveryCodeNotificationAttemptRecord:
-    attempt = EveryCodeNotificationAttemptRecord(
-        attempt_id=build_every_code_notification_attempt_id(
-            request_id=request.request_id,
-            event=event,
-            policy_id=policy.policy_id,
-            destination_id=destination.destination_id,
-            lifecycle_key=_every_code_notification_lifecycle_key(request),
-        ),
-        request_id=request.request_id,
-        event=event,
-        policy_id=policy.policy_id,
-        destination_id=destination.destination_id,
-        destination_kind=destination.kind,
-        delivery_status=delivery_status,
-        attempted_at=attempted_at,
-        action=action,
-        error_message=_bounded_text(error_message, max_length=500),
-    )
-    notification_store.write_every_code_notification_attempt_record(attempt)
-    return attempt
-
-
-def _every_code_notification_lifecycle_key(request: EveryCodeWorkRequestRecord) -> str:
-    return request.lifecycle_id
-
-
-def _every_code_blocked_discord_payload(
-    request: EveryCodeWorkRequestRecord,
-) -> dict[str, object]:
-    fields = [
-        {"name": "Repository", "value": request.repository, "inline": True},
-        {"name": "Issue", "value": str(request.issue_number), "inline": True},
-        {"name": "Host", "value": request.claimed_by_host, "inline": True},
-        {"name": "Request", "value": request.request_id, "inline": False},
-    ]
-    if request.issue_url:
-        fields.append({"name": "Issue URL", "value": request.issue_url, "inline": False})
-    return {
-        "embeds": [
-            {
-                "title": "Every Code work request blocked",
-                "description": _bounded_text(request.error_message, max_length=1500),
-                "color": 0xC62828,
-                "fields": fields,
-            }
-        ]
-    }
-
-
 def _bounded_text(value: str, *, max_length: int) -> str:
     normalized_value = " ".join(value.strip().split())
     if len(normalized_value) <= max_length:
@@ -6744,7 +6448,6 @@ def _owner_agent_identity_from_bearer(environ: dict[str, object]) -> Launchplane
 def _is_every_code_worker_route(*, method: str, path: str) -> bool:
     return method == "POST" and path in {
         "/v1/every-code/work-requests/rerun",
-        "/v1/every-code/work-requests/status",
     }
 
 
@@ -6771,7 +6474,6 @@ def _handle_every_code_worker_write(
     path: str,
     payload: dict[str, object],
     idempotency_key: str = "",
-    every_code_discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
 ) -> list[bytes]:
     every_code_store = _every_code_work_request_store(record_store)
     if path == "/v1/every-code/work-requests/rerun":
@@ -6834,47 +6536,17 @@ def _handle_every_code_worker_write(
                 driver_result={"request": requeued_record.model_dump(mode="json")},
             ),
         )
-    work_request_status_request = EveryCodeWorkRequestStatusEnvelope.model_validate(payload)
-    existing_work_request_record = every_code_store.read_every_code_work_request_record(
-        work_request_status_request.request_id.strip()
-    )
-    updated_work_request_record = apply_every_code_work_request_status(
-        existing_work_request_record,
-        EveryCodeWorkRequestStatusUpdate(
-            state=work_request_status_request.state,
-            host=work_request_status_request.host,
-            updated_at=work_request_status_request.updated_at.strip() or _utc_now_timestamp(),
-            result_pr_url=work_request_status_request.result_pr_url,
-            result_summary=work_request_status_request.result_summary,
-            error_message=work_request_status_request.error_message,
-        ),
-    )
-    every_code_store.write_every_code_work_request_record(updated_work_request_record)
-    notification_attempts: tuple[EveryCodeNotificationAttemptRecord, ...] = ()
-    if updated_work_request_record.state == "blocked":
-        notification_attempts = _deliver_every_code_blocked_notifications(
-            record_store=record_store,
-            request=updated_work_request_record,
-            attempted_at=_utc_now_timestamp(),
-            discord_sender=every_code_discord_sender,
-        )
     return _json_response(
         start_response=start_response,
-        status_code=202,
-        payload=_accepted_payload(
-            trace_id=trace_id,
-            result={
-                "request_id": updated_work_request_record.request_id,
-                "state": updated_work_request_record.state,
+        status_code=404,
+        payload={
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {
+                "code": "not_found",
+                "message": "Launchplane route was not found.",
             },
-            driver_result={
-                "request": updated_work_request_record.model_dump(mode="json"),
-                "notifications": [
-                    notification_attempt.model_dump(mode="json")
-                    for notification_attempt in notification_attempts
-                ],
-            },
-        ),
+        },
     )
 
 
@@ -7857,7 +7529,6 @@ def create_launchplane_service_app(
     github_oauth_config: GitHubOAuthConfig | None = None,
     github_oauth_client: GitHubOAuthClient | None = None,
     human_session_store: HumanSessionStore | None = None,
-    every_code_discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
     preview_pr_feedback_discord_sender: Callable[
         [str, dict[str, object]], object
     ] = post_discord_webhook,
@@ -8157,7 +7828,6 @@ def create_launchplane_service_app(
                     path=path,
                     payload=payload,
                     idempotency_key=_idempotency_key(environ),
-                    every_code_discord_sender=every_code_discord_sender,
                 )
             except ValueError as error:
                 return _json_response(
@@ -9673,46 +9343,6 @@ def create_launchplane_service_app(
                     path=path,
                     payload=payload,
                     idempotency_key=request_idempotency_key,
-                    every_code_discord_sender=every_code_discord_sender,
-                )
-            elif path == "/v1/every-code/work-requests/status":
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="every_code_work_request.update",
-                    product="launchplane",
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot update Every Code work requests.",
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                return _handle_every_code_worker_write(
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                    record_store=record_store,
-                    path=path,
-                    payload=payload,
-                    idempotency_key=request_idempotency_key,
-                    every_code_discord_sender=every_code_discord_sender,
                 )
             elif path == "/v1/product-config/apply":
                 product_config_request, product_config_response = (

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -145,15 +145,19 @@ Keep a compatibility surface only when it is one of these:
   claims and `every_code_work_request.claim` workflow authorization, keeps the
   `404 not_found` and `409 work_request_already_claimed` transition semantics,
   and honors existing workflow idempotency replays without adding worker-token
-  idempotency state. Every Code PR-feedback write, PR-feedback status, and
-  preview-gate write routes use native FastAPI, preserve the dedicated Every
-  Code worker token, require only their direct PR-feedback or preview-gate
-  record-store capabilities, and intentionally do not add idempotency state. The
-  PR-feedback status route also preserves the existing `404 not_found` and
-  `409 feedback_already_final` transition semantics. Their legacy WSGI write
-  branches are deleted; direct WSGI fallback calls fail closed. Every Code
-  status, rerun, and webhook routes remain on the mounted WSGI fallback until
-  their native write replacements land.
+  idempotency state. Every Code work-request status uses native FastAPI,
+  preserves the dedicated Every Code worker token and
+  `every_code_work_request.update` workflow authorization, checks idempotency
+  before requiring write-store capabilities, preserves blocked-notification
+  delivery, and keeps the existing `404 not_found` transition semantics. Every
+  Code PR-feedback write, PR-feedback status, and preview-gate write routes use
+  native FastAPI, preserve the dedicated Every Code worker token, require only
+  their direct PR-feedback or preview-gate record-store capabilities, and
+  intentionally do not add idempotency state. The PR-feedback status route also
+  preserves the existing `404 not_found` and `409 feedback_already_final`
+  transition semantics. Their legacy WSGI write branches are deleted; direct
+  WSGI fallback calls fail closed. Every Code rerun and webhook routes remain on
+  the mounted WSGI fallback until their native write replacements land.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -213,8 +213,12 @@ VeriReel product paths:
     `404 not_found` for missing requests, `409 work_request_already_claimed`
     for non-queued requests, and workflow `Idempotency-Key` replay/conflict
     handling)
+  - `POST /v1/every-code/work-requests/status` (native FastAPI for Every Code
+    worker-token callers and bearer-token callers with
+    `every_code_work_request.update`, replay-before-write idempotency handling,
+    record-store status capability checks, `404 not_found` for missing requests,
+    and blocked-notification delivery)
   - `POST /v1/every-code/work-requests/rerun`
-  - `POST /v1/every-code/work-requests/status`
   - `POST /v1/every-code/pr-feedback` (native FastAPI for Every Code
     worker-token callers, direct PR-feedback record writes, and DB-backed
     storage capability enforcement without idempotency state)
@@ -447,14 +451,19 @@ reads use `every_code_work_request.read`; PR-feedback reads use
 reads use `preview_pr_feedback_notification_attempt.read`. The dedicated Every
 Code worker token is accepted only for the worker-facing Every Code read routes,
 not for the preview PR-feedback notification-attempt route. The legacy WSGI
-fallback no longer owns these read paths. Every Code PR-feedback write,
-PR-feedback status, and preview-gate write routes are also native FastAPI routes
-for the dedicated Every Code worker token. They require only the matching
-PR-feedback or preview-gate record-store capabilities, preserve the direct worker
-signal payloads, do not create idempotency records, and fail closed when called
-through the direct WSGI fallback. PR-feedback status preserves the worker
-transition semantics: missing feedback returns `404 not_found`, and already
-applied or ignored feedback returns `409 feedback_already_final`.
+fallback no longer owns these read paths. Every Code work-request status is also
+a native FastAPI route for the dedicated Every Code worker token and workflows
+authorized for `every_code_work_request.update`. It checks idempotency replay
+before requiring status-write store capabilities, writes successful idempotency
+records, preserves missing-request `404 not_found`, and delivers configured
+blocked notifications when a request transitions to `blocked`. Every Code
+PR-feedback write, PR-feedback status, and preview-gate write routes are also
+native FastAPI routes for the dedicated Every Code worker token. They require
+only the matching PR-feedback or preview-gate record-store capabilities, preserve
+the direct worker signal payloads, do not create idempotency records, and fail
+closed when called through the direct WSGI fallback. PR-feedback status preserves
+the worker transition semantics: missing feedback returns `404 not_found`, and
+already applied or ignored feedback returns `409 feedback_already_final`.
 
 `POST /v1/work-graph/rank` ranks a caller-supplied work graph snapshot and
 returns the queue payload under `result.queue`. The route requires the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -4643,6 +4643,317 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.json()["error"]["code"], "database_storage_required")
 
+    async def test_every_code_work_request_status_accepts_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            claimed = store.claim_every_code_work_request_record(
+                request_id=seeded.request_id,
+                host="Chris-Studio",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            if claimed is None:
+                raise AssertionError("expected seeded request to be claimable")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_status(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "host": "Chris-Studio",
+                    "state": "running",
+                    "updated_at": "2026-05-05T22:02:00Z",
+                },
+                authorization="Bearer worker-token",
+            )
+            stored_request = store.read_every_code_work_request_record(seeded.request_id)
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["records"]["request_id"], seeded.request_id)
+        self.assertEqual(payload["records"]["state"], "running")
+        self.assertEqual(payload["result"]["request"]["state"], "running")
+        self.assertEqual(payload["result"]["request"]["started_at"], "2026-05-05T22:02:00Z")
+        self.assertEqual(stored_request.state, "running")
+
+    async def test_every_code_work_request_status_accepts_authorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            claimed = store.claim_every_code_work_request_record(
+                request_id=seeded.request_id,
+                host="Runner-Host",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            if claimed is None:
+                raise AssertionError("expected seeded request to be claimable")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_work_request_status_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_every_code_work_request_status(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "host": "Runner-Host",
+                    "state": "done",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "result_summary": "Opened a PR with the requested fix.",
+                },
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["records"]["state"], "done")
+        self.assertEqual(
+            response.json()["result"]["request"]["result_pr_url"],
+            "https://github.com/cbusillo/code/pull/26",
+        )
+
+    async def test_every_code_work_request_status_replays_authorized_idempotency(self) -> None:
+        payload: dict[str, object] = {
+            "request_id": "every-code-cbusillo-code-123-test",
+            "host": "Runner-Host",
+            "state": "done",
+            "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+        }
+        store = _EveryCodeStatusReplayOnlyStore(
+            payload=payload,
+            idempotency_key="every-code-status-replay",
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_every_code_work_request_status_policy(),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_every_code_work_request_status(
+            app,
+            payload,
+            idempotency_key="every-code-status-replay",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertTrue(response.json()["replayed"])
+        self.assertEqual(response.json()["original_trace_id"], "launchplane_req_original")
+        self.assertEqual(store.read_idempotency_calls, 1)
+        self.assertEqual(store.read_calls, 0)
+        self.assertEqual(store.write_calls, 0)
+
+    async def test_every_code_work_request_status_rejects_missing_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_status(
+                app,
+                {"request_id": seeded.request_id, "host": "Chris-Studio", "state": "running"},
+                authorization="",
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.json()["error"]["code"], "authentication_required")
+
+    async def test_every_code_work_request_status_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_every_code_work_request_status(
+                app,
+                {"request_id": seeded.request_id, "host": "Chris-Studio", "state": "running"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_every_code_work_request_status_rejects_invalid_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            claimed = store.claim_every_code_work_request_record(
+                request_id=seeded.request_id,
+                host="Chris-Studio",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            if claimed is None:
+                raise AssertionError("expected seeded request to be claimable")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_status(
+                app,
+                {"request_id": seeded.request_id, "host": "Other-Host", "state": "running"},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_payload")
+
+    async def test_every_code_work_request_status_returns_not_found(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_status(
+                app,
+                {
+                    "request_id": "every-code-cbusillo-code-123-test",
+                    "host": "Chris-Studio",
+                    "state": "running",
+                },
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_every_code_work_request_status_requires_store_capability(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+        )
+
+        response = await _post_every_code_work_request_status(
+            app,
+            {
+                "request_id": "every-code-cbusillo-code-123-test",
+                "host": "Chris-Studio",
+                "state": "running",
+            },
+            authorization="Bearer worker-token",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
+    async def test_every_code_work_request_status_sends_blocked_notifications(self) -> None:
+        sent_payloads: list[tuple[str, dict[str, object]]] = []
+
+        def send_discord(webhook_url: str, payload: dict[str, object]) -> None:
+            sent_payloads.append((webhook_url, payload))
+
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                "os.environ",
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: (
+                        "test-master-key"
+                    ),
+                },
+                clear=True,
+            ),
+        ):
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            try:
+                store.ensure_schema()
+                seeded = _seed_every_code_claim_request(store)
+                claimed = store.claim_every_code_work_request_record(
+                    request_id=seeded.request_id,
+                    host="Chris-Studio",
+                    claimed_at="2026-05-05T22:01:00Z",
+                )
+                if claimed is None:
+                    raise AssertionError("expected seeded request to be claimable")
+                secret_result = control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="context_instance",
+                    integration="every-code-notifications",
+                    name="discord webhook",
+                    plaintext_value="https://discord.com/api/webhooks/test/webhook",
+                    binding_key="DISCORD_WEBHOOK",
+                    context_name="launchplane",
+                    instance_name="every-code",
+                    actor="test",
+                    source_label="test",
+                )
+                store.write_every_code_notification_policy_record(
+                    EveryCodeNotificationPolicyRecord(
+                        policy_id="every-code-notification-discord",
+                        repository="cbusillo/code",
+                        status="enabled",
+                        created_at="2026-06-14T18:10:00Z",
+                        updated_at="2026-06-14T18:10:00Z",
+                        source="test",
+                        destinations=(
+                            EveryCodeNotificationDestination(
+                                destination_id="discord",
+                                kind="discord",
+                                discord_webhook_secret=str(secret_result["secret_id"]),
+                            ),
+                        ),
+                    )
+                )
+                app = create_launchplane_fastapi_app(
+                    verifier=_RejectingVerifier(),
+                    authz_policy=LaunchplaneAuthzPolicy(),
+                    record_store_factory=lambda: store,
+                    bearer_identity_config=BearerIdentityConfig(
+                        every_code_worker_token="worker-token"
+                    ),
+                    every_code_discord_sender=send_discord,
+                )
+
+                response = await _post_every_code_work_request_status(
+                    app,
+                    {
+                        "request_id": seeded.request_id,
+                        "host": "Chris-Studio",
+                        "state": "blocked",
+                        "error_message": "Every Code bot auth actor mismatch.",
+                    },
+                    authorization="Bearer worker-token",
+                )
+                attempts = store.list_every_code_notification_attempt_records(
+                    request_id=seeded.request_id,
+                    event="work_request_blocked",
+                )
+            finally:
+                store.close()
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["records"]["state"], "blocked")
+        self.assertEqual(len(sent_payloads), 1)
+        webhook_url, discord_payload = sent_payloads[0]
+        self.assertEqual(webhook_url, "https://discord.com/api/webhooks/test/webhook")
+        self.assertIn("embeds", discord_payload)
+        self.assertEqual(payload["result"]["notifications"][0]["delivery_status"], "delivered")
+        self.assertEqual(attempts[0].delivery_status, "delivered")
+
     async def test_every_code_pr_feedback_write_stores_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -5243,6 +5554,41 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
         for status_code in ("400", "401", "403", "409", "503"):
             self.assertIn(
                 "LaunchplaneErrorResponse", json.dumps(create_route["responses"][status_code])
+            )
+        work_request_status_route = openapi["paths"]["/v1/every-code/work-requests/status"]["post"]
+        self.assertEqual(
+            work_request_status_route["operationId"],
+            "write_every_code_work_request_status",
+        )
+        self.assertEqual(
+            work_request_status_route["requestBody"]["content"]["application/json"]["schema"][
+                "title"
+            ],
+            "EveryCodeWorkRequestStatusEnvelope",
+        )
+        self.assertFalse(
+            work_request_status_route["requestBody"]["content"]["application/json"]["schema"][
+                "additionalProperties"
+            ]
+        )
+        self.assertEqual(
+            set(
+                work_request_status_route["requestBody"]["content"]["application/json"]["schema"][
+                    "required"
+                ]
+            ),
+            {"request_id", "host", "state"},
+        )
+        self.assertEqual(
+            work_request_status_route["responses"]["202"]["content"]["application/json"]["schema"][
+                "$ref"
+            ],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        for status_code in ("400", "401", "403", "404", "409", "503"):
+            self.assertIn(
+                "LaunchplaneErrorResponse",
+                json.dumps(work_request_status_route["responses"][status_code]),
             )
         worker_write_routes = {
             "/v1/every-code/pr-feedback": "write_every_code_pr_feedback",
@@ -15705,6 +16051,13 @@ def _every_code_work_request_claim_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
+def _every_code_work_request_status_policy() -> LaunchplaneAuthzPolicy:
+    return _record_read_policy(
+        action="every_code_work_request.update",
+        context="launchplane",
+    )
+
+
 def _every_code_work_request_create_payload(*, issue_number: int = 123) -> dict[str, object]:
     return {
         "repository": "cbusillo/code",
@@ -16554,6 +16907,28 @@ async def _post_every_code_work_request_claim(
         app,
         "POST",
         "/v1/every-code/work-requests/claim",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
+async def _post_every_code_work_request_status(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/every-code/work-requests/status",
         headers=request_headers,
         payload=payload,
     )
@@ -17975,6 +18350,70 @@ class _EveryCodeClaimReplayOnlyStore:
         del request_id, host, claimed_at
         self.claim_calls += 1
         raise AssertionError("idempotent replay must not claim a record")
+
+
+class _EveryCodeStatusReplayOnlyStore:
+    def __init__(self, *, payload: dict[str, object], idempotency_key: str) -> None:
+        self.read_idempotency_calls = 0
+        self.read_calls = 0
+        self.write_calls = 0
+        self._payload = payload
+        self._idempotency_key = idempotency_key
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> LaunchplaneIdempotencyRecord | None:
+        self.read_idempotency_calls += 1
+        if (
+            route_path != "/v1/every-code/work-requests/status"
+            or idempotency_key != self._idempotency_key
+        ):
+            return None
+        return LaunchplaneIdempotencyRecord(
+            record_id="idempotency-launchplane_req_original",
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=hashlib.sha256(
+                json.dumps(self._payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest(),
+            response_status_code=202,
+            response_trace_id="launchplane_req_original",
+            recorded_at="2026-05-29T12:00:00Z",
+            response_payload={
+                "status": "accepted",
+                "trace_id": "launchplane_req_original",
+                "records": {
+                    "request_id": "every-code-cbusillo-code-123-test",
+                    "state": "done",
+                },
+                "result": {
+                    "request": {
+                        "request_id": "every-code-cbusillo-code-123-test",
+                        "state": "done",
+                        "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    },
+                    "notifications": [],
+                },
+            },
+        )
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> None:
+        raise AssertionError("idempotent replay must not write a new record")
+
+    def read_every_code_work_request_record(self, request_id: str) -> EveryCodeWorkRequestRecord:
+        del request_id
+        self.read_calls += 1
+        raise AssertionError("idempotent replay must not read a work request")
+
+    def write_every_code_work_request_record(self, record: EveryCodeWorkRequestRecord) -> None:
+        del record
+        self.write_calls += 1
+        raise AssertionError("idempotent replay must not write a work request")
 
 
 class _ProductContextApplyReplayOnlyStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -36,7 +36,13 @@ from control_plane.contracts.every_code_preview_gate_record import EveryCodePrev
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
 from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
+    EveryCodeWorkRequestStatusUpdate,
+    apply_every_code_work_request_status,
     requeue_every_code_work_request,
+)
+from control_plane.every_code_notifications_delivery import (
+    deliver_every_code_blocked_notifications,
+    deliver_every_code_discord_notification,
 )
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.deploy_target import ProviderTargetRecord
@@ -1872,6 +1878,97 @@ def _claim_every_code_work_request_in_postgres(
     return _every_code_claim_fixture_response(record)
 
 
+def _update_every_code_work_request_status_record(
+    record_store: Any,
+    request_id: str,
+    *,
+    state: Literal["running", "done", "blocked"] = "running",
+    host: str = "Chris-Studio",
+    updated_at: str = "2026-05-05T22:02:00Z",
+    result_pr_url: str = "",
+    result_summary: str = "",
+    error_message: str = "",
+) -> EveryCodeWorkRequestRecord:
+    record = record_store.read_every_code_work_request_record(request_id)
+    updated = apply_every_code_work_request_status(
+        record,
+        EveryCodeWorkRequestStatusUpdate(
+            state=state,
+            host=host,
+            updated_at=updated_at,
+            result_pr_url=result_pr_url,
+            result_summary=result_summary,
+            error_message=error_message,
+        ),
+    )
+    record_store.write_every_code_work_request_record(updated)
+    return updated
+
+
+def _every_code_status_fixture_response(
+    record: EveryCodeWorkRequestRecord,
+) -> tuple[int, dict[str, Any]]:
+    return (
+        202,
+        {
+            "records": {"request_id": record.request_id, "state": record.state},
+            "result": {"request": record.model_dump(mode="json"), "notifications": []},
+        },
+    )
+
+
+def _update_every_code_work_request_status_in_filesystem(
+    state_dir: Path,
+    request_id: str,
+    *,
+    state: Literal["running", "done", "blocked"] = "running",
+    host: str = "Chris-Studio",
+    updated_at: str = "2026-05-05T22:02:00Z",
+    result_pr_url: str = "",
+    result_summary: str = "",
+    error_message: str = "",
+) -> tuple[int, dict[str, Any]]:
+    record = _update_every_code_work_request_status_record(
+        FilesystemRecordStore(state_dir),
+        request_id,
+        state=state,
+        host=host,
+        updated_at=updated_at,
+        result_pr_url=result_pr_url,
+        result_summary=result_summary,
+        error_message=error_message,
+    )
+    return _every_code_status_fixture_response(record)
+
+
+def _update_every_code_work_request_status_in_postgres(
+    database_url: str,
+    request_id: str,
+    *,
+    state: Literal["running", "done", "blocked"] = "running",
+    host: str = "Chris-Studio",
+    updated_at: str = "2026-05-05T22:02:00Z",
+    result_pr_url: str = "",
+    result_summary: str = "",
+    error_message: str = "",
+) -> tuple[int, dict[str, Any]]:
+    store = PostgresRecordStore(database_url=database_url)
+    try:
+        record = _update_every_code_work_request_status_record(
+            store,
+            request_id,
+            state=state,
+            host=host,
+            updated_at=updated_at,
+            result_pr_url=result_pr_url,
+            result_summary=result_summary,
+            error_message=error_message,
+        )
+    finally:
+        store.close()
+    return _every_code_status_fixture_response(record)
+
+
 def _every_code_github_pr_comment_payload(
     *,
     repository: str = "cbusillo/code",
@@ -2646,7 +2743,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
                 control_plane_root_path=root,
                 database_url=database_url,
-                every_code_discord_sender=send_discord,
             )
             store = PostgresRecordStore(database_url=database_url)
             try:
@@ -2700,20 +2796,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 database_url,
                 request_id,
             )
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "blocked",
-                    "error_message": "Every Code bot auth actor mismatch.",
-                },
-                headers={"Idempotency-Key": "every-code-blocked-notify-status"},
-            )
             store = PostgresRecordStore(database_url=database_url)
             try:
+                blocked_record = _update_every_code_work_request_status_record(
+                    store,
+                    request_id,
+                    state="blocked",
+                    error_message="Every Code bot auth actor mismatch.",
+                )
+                notification_attempts = deliver_every_code_blocked_notifications(
+                    record_store=store,
+                    request=blocked_record,
+                    attempted_at="2026-05-05T22:03:00Z",
+                    discord_sender=send_discord,
+                )
                 attempts = store.list_every_code_notification_attempt_records(
                     request_id=request_id,
                     event="work_request_blocked",
@@ -2723,13 +2819,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(create_status, 202)
         self.assertEqual(claim_status, 202)
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["records"]["state"], "blocked")
+        self.assertEqual(blocked_record.state, "blocked")
         self.assertEqual(len(sent_payloads), 1)
         webhook_url, discord_payload = sent_payloads[0]
         self.assertEqual(webhook_url, "https://discord.com/api/webhooks/test/webhook")
         self.assertIn("embeds", discord_payload)
-        self.assertEqual(payload["result"]["notifications"][0]["delivery_status"], "delivered")
+        self.assertEqual(notification_attempts[0].delivery_status, "delivered")
         self.assertEqual(attempts[0].delivery_status, "delivered")
 
     def test_every_code_blocked_status_records_discord_failure(self) -> None:
@@ -2761,7 +2856,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
                 control_plane_root_path=root,
                 database_url=database_url,
-                every_code_discord_sender=send_discord,
             )
             store = PostgresRecordStore(database_url=database_url)
             try:
@@ -2815,20 +2909,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 database_url,
                 request_id,
             )
-            status_code, payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "blocked",
-                    "error_message": "Every Code bot claim comment failed.",
-                },
-                headers={"Idempotency-Key": "every-code-blocked-notify-failed-status"},
-            )
             store = PostgresRecordStore(database_url=database_url)
             try:
+                blocked_record = _update_every_code_work_request_status_record(
+                    store,
+                    request_id,
+                    state="blocked",
+                    error_message="Every Code bot claim comment failed.",
+                )
+                notification_attempts = deliver_every_code_blocked_notifications(
+                    record_store=store,
+                    request=blocked_record,
+                    attempted_at="2026-05-05T22:03:00Z",
+                    discord_sender=send_discord,
+                )
                 attempts = store.list_every_code_notification_attempt_records(
                     request_id=request_id,
                     event="work_request_blocked",
@@ -2838,11 +2932,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(create_status, 202)
         self.assertEqual(claim_status, 202)
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["records"]["state"], "blocked")
-        self.assertEqual(payload["result"]["request"]["state"], "blocked")
-        self.assertEqual(payload["result"]["notifications"][0]["delivery_status"], "failed")
-        self.assertIn("discord unavailable", payload["result"]["notifications"][0]["error_message"])
+        self.assertEqual(blocked_record.state, "blocked")
+        self.assertEqual(notification_attempts[0].delivery_status, "failed")
+        self.assertIn("discord unavailable", notification_attempts[0].error_message)
         self.assertEqual(attempts[0].delivery_status, "failed")
         self.assertIn("discord unavailable", attempts[0].error_message)
 
@@ -2888,7 +2980,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             sent_payloads.append((webhook_url, payload))
 
         store.fail_delivered_write = True
-        first_attempt = control_plane_service._deliver_every_code_discord_notification(
+        first_attempt = deliver_every_code_discord_notification(
             notification_store=store,
             secret_resolver=lambda _secret_id: "https://discord.com/api/webhooks/test/webhook",
             request=request_record,
@@ -2897,7 +2989,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             attempted_at="2026-06-14T18:11:00Z",
             discord_sender=send_discord,
         )
-        second_attempt = control_plane_service._deliver_every_code_discord_notification(
+        second_attempt = deliver_every_code_discord_notification(
             notification_store=store,
             secret_resolver=lambda _secret_id: "https://discord.com/api/webhooks/test/webhook",
             request=request_record,
@@ -2966,7 +3058,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         def send_discord(webhook_url: str, payload: dict[str, object]) -> None:
             sent_payloads.append((webhook_url, payload))
 
-        first_attempt = control_plane_service._deliver_every_code_discord_notification(
+        first_attempt = deliver_every_code_discord_notification(
             notification_store=store,
             secret_resolver=lambda _secret_id: "https://discord.com/api/webhooks/test/webhook",
             request=first_blocked_request,
@@ -2975,7 +3067,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             attempted_at="2026-06-14T18:11:00Z",
             discord_sender=send_discord,
         )
-        repeated_attempt = control_plane_service._deliver_every_code_discord_notification(
+        repeated_attempt = deliver_every_code_discord_notification(
             notification_store=store,
             secret_resolver=lambda _secret_id: "https://discord.com/api/webhooks/test/webhook",
             request=first_blocked_request,
@@ -2984,7 +3076,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             attempted_at="2026-06-14T18:12:00Z",
             discord_sender=send_discord,
         )
-        second_attempt = control_plane_service._deliver_every_code_discord_notification(
+        second_attempt = deliver_every_code_discord_notification(
             notification_store=store,
             secret_resolver=lambda _secret_id: "https://discord.com/api/webhooks/test/webhook",
             request=second_blocked_request,
@@ -7357,17 +7449,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 state_dir,
                 request_id,
             )
-            done_status, _done_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                },
-                headers={"Idempotency-Key": "every-code-finished-done"},
+            done_status, _done_payload = _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="done",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
             )
             second_status, second_payload = _invoke_app(
                 app,
@@ -7457,16 +7543,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = str(create_payload["records"]["request_id"])
             _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "running",
-                },
-                headers={"Idempotency-Key": "every-code-issue-close-running"},
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="running",
             )
 
             close_status, closed_response = _invoke_app(
@@ -7554,17 +7634,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = str(create_payload["records"]["request_id"])
             _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "running",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                },
-                headers={"Idempotency-Key": "every-code-close-running"},
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="running",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
             )
 
             close_status, close_payload = _invoke_app(
@@ -7647,17 +7721,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = str(create_payload["records"]["request_id"])
             _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "running",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                },
-                headers={"Idempotency-Key": "every-code-unmerged-close-running"},
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="running",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
             )
 
             close_status, close_payload = _invoke_app(
@@ -7738,16 +7806,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = str(create_payload["records"]["request_id"])
             _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "running",
-                },
-                headers={"Idempotency-Key": "every-code-feedback-close-running"},
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="running",
             )
             close_status, close_payload = _invoke_app(
                 app,
@@ -7918,16 +7980,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = str(create_payload["records"]["request_id"])
             _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "running",
-                },
-                headers={"Idempotency-Key": "every-code-pr-number-running"},
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="running",
             )
             close_status, close_payload = _invoke_app(
                 app,
@@ -8005,17 +8061,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 )
                 request_id = str(create_payload["records"]["request_id"])
                 _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-                _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/every-code/work-requests/status",
-                    payload={
-                        "request_id": request_id,
-                        "host": "Chris-Studio",
-                        "state": "running",
-                        "result_pr_url": f"https://github.com/cbusillo/code/pull/{issue_number}",
-                    },
-                    headers={"Idempotency-Key": f"every-code-page-running-{issue_number}"},
+                _update_every_code_work_request_status_in_filesystem(
+                    state_dir,
+                    request_id,
+                    state="running",
+                    result_pr_url=f"https://github.com/cbusillo/code/pull/{issue_number}",
                 )
 
             close_status, close_payload = _invoke_app(
@@ -8114,19 +8164,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 state_dir,
                 str(request_id),
             )
-            status_status, _status_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                    "result_summary": "Opened PR.",
-                    "updated_at": "2026-05-06T16:00:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            status_status, _status_payload = _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="done",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
+                result_summary="Opened PR.",
+                updated_at="2026-05-06T16:00:00Z",
             )
             feedback_status, feedback_response = _invoke_app(
                 app,
@@ -8220,19 +8264,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 state_dir,
                 str(request_id),
             )
-            status_status, _status_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/88",
-                    "result_summary": "Opened PR.",
-                    "updated_at": "2026-05-07T12:40:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            status_status, _status_payload = _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="done",
+                result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/88",
+                result_summary="Opened PR.",
+                updated_at="2026-05-07T12:40:00Z",
             )
             ok_status, ok_response = _invoke_app(
                 app,
@@ -8330,19 +8368,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = issue_response["records"]["request_id"]
             _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/88",
-                    "result_summary": "Opened PR.",
-                    "updated_at": "2026-05-07T12:40:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="done",
+                result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/88",
+                result_summary="Opened PR.",
+                updated_at="2026-05-07T12:40:00Z",
             )
             ok_status, ok_response = _invoke_app(
                 app,
@@ -8478,19 +8510,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 state_dir,
                 str(request_id),
             )
-            status_status, _status_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/88",
-                    "result_summary": "Opened PR.",
-                    "updated_at": "2026-05-07T12:40:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            status_status, _status_payload = _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="done",
+                result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/88",
+                result_summary="Opened PR.",
+                updated_at="2026-05-07T12:40:00Z",
             )
             changes_status, changes_response = _invoke_app(
                 app,
@@ -8555,18 +8581,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 state_dir,
                 str(request_id),
             )
-            running_status, _running_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "running",
-                    "result_summary": "Visible tmux session.",
-                    "updated_at": "2026-05-06T16:00:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            running_status, _running_payload = _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="running",
+                result_summary="Visible tmux session.",
+                updated_at="2026-05-06T16:00:00Z",
             )
             feedback_status, feedback_response = _invoke_app(
                 app,
@@ -8641,18 +8661,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = issue_response["records"]["request_id"]
             _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "running",
-                    "result_summary": "Visible tmux session.",
-                    "updated_at": "2026-05-06T16:00:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="running",
+                result_summary="Visible tmux session.",
+                updated_at="2026-05-06T16:00:00Z",
             )
             feedback_status, feedback_response = _invoke_app(
                 app,
@@ -8723,19 +8737,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = issue_response["records"]["request_id"]
             _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/75",
-                    "result_summary": "Opened PR.",
-                    "updated_at": "2026-05-07T12:40:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="done",
+                result_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/75",
+                result_summary="Opened PR.",
+                updated_at="2026-05-07T12:40:00Z",
             )
             feedback_status, feedback_response = _invoke_app(
                 app,
@@ -8862,18 +8870,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 state_dir,
                 str(request_id),
             )
-            _running_status, _running_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "running",
-                    "result_summary": "Visible tmux session.",
-                    "updated_at": "2026-05-06T16:00:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            _running_status, _running_payload = (
+                _update_every_code_work_request_status_in_filesystem(
+                    state_dir,
+                    str(request_id),
+                    state="running",
+                    result_summary="Visible tmux session.",
+                    updated_at="2026-05-06T16:00:00Z",
+                )
             )
             feedback_status, feedback_response = _invoke_app(
                 app,
@@ -8932,19 +8936,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = issue_response["records"]["request_id"]
             _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                    "result_summary": "Opened PR.",
-                    "updated_at": "2026-05-06T16:00:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="done",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
+                result_summary="Opened PR.",
+                updated_at="2026-05-06T16:00:00Z",
             )
             first_status, first_response = _invoke_app(
                 app,
@@ -9017,19 +9015,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = issue_response["records"]["request_id"]
             _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "done",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                    "result_summary": "Opened PR.",
-                    "updated_at": "2026-05-06T16:00:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="done",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
+                result_summary="Opened PR.",
+                updated_at="2026-05-06T16:00:00Z",
             )
             _invoke_app(
                 app,
@@ -9198,18 +9190,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = issue_response["records"]["request_id"]
             _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "blocked",
-                    "error_message": "Needs another pass.",
-                    "updated_at": "2026-05-06T16:00:00Z",
-                },
-                authorization="Bearer dev-worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                str(request_id),
+                state="blocked",
+                error_message="Needs another pass.",
+                updated_at="2026-05-06T16:00:00Z",
             )
             intent_status, intent_payload = _invoke_app(
                 app,
@@ -9517,6 +9503,105 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(claim_payload["error"]["code"], "not_found")
         self.assertEqual(stored_request.state, "queued")
 
+    def test_every_code_work_request_status_is_retired_from_legacy_wsgi_app(self) -> None:
+        policy = LaunchplaneAuthzPolicy.model_validate(
+            {
+                "github_actions": [
+                    {
+                        "repository": "cbusillo/launchplane",
+                        "workflow_refs": [
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
+                        ],
+                        "event_names": ["workflow_dispatch"],
+                        "products": ["launchplane"],
+                        "contexts": ["launchplane"],
+                        "actions": ["every_code_work_request.update"],
+                    }
+                ]
+            }
+        )
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(identity),
+                authz_policy=policy,
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            seeded_request = _seed_every_code_work_request_record(state_dir)
+            request_id = seeded_request.request_id
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "done",
+                    "result_summary": "Opened PR.",
+                    "updated_at": "2026-05-05T22:03:00Z",
+                },
+                headers={"Idempotency-Key": "every-code-status-code-123"},
+            )
+            stored_request = FilesystemRecordStore(state_dir).read_every_code_work_request_record(
+                request_id
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
+        self.assertEqual(stored_request.state, "claimed")
+        self.assertEqual(stored_request.result_summary, "")
+
+    def test_every_code_work_request_status_worker_token_is_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
+            ),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            seeded_request = _seed_every_code_work_request_record(state_dir)
+            request_id = seeded_request.request_id
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/work-requests/status",
+                payload={
+                    "request_id": request_id,
+                    "host": "Chris-Studio",
+                    "state": "blocked",
+                    "error_message": "Needs another pass.",
+                    "updated_at": "2026-05-05T22:03:00Z",
+                },
+                authorization="Bearer worker-token",
+            )
+            stored_request = FilesystemRecordStore(state_dir).read_every_code_work_request_record(
+                request_id
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
+        self.assertEqual(stored_request.state, "claimed")
+        self.assertEqual(stored_request.error_message, "")
+
     def test_product_profile_routes_are_retired_from_legacy_wsgi_app(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -9603,20 +9688,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = _seed_every_code_work_request_record(state_dir).request_id
             _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "blocked",
-                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
-                    "result_summary": "Detached session went stale.",
-                    "error_message": "Detached session went stale.",
-                    "updated_at": "2026-05-05T22:05:00Z",
-                },
-                authorization="Bearer worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="blocked",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
+                result_summary="Detached session went stale.",
+                error_message="Detached session went stale.",
+                updated_at="2026-05-05T22:05:00Z",
             )
             intent_status, intent_payload = _invoke_app(
                 app,
@@ -9697,18 +9776,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = _seed_every_code_work_request_record(state_dir).request_id
             _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "blocked",
-                    "error_message": "Needs another pass.",
-                    "updated_at": "2026-05-05T22:05:00Z",
-                },
-                authorization="Bearer worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="blocked",
+                error_message="Needs another pass.",
+                updated_at="2026-05-05T22:05:00Z",
             )
 
             missing_status, missing_payload = _invoke_app(
@@ -9792,18 +9865,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             request_id = _seed_every_code_work_request_record(state_dir).request_id
             _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/status",
-                payload={
-                    "request_id": request_id,
-                    "host": "Chris-Studio",
-                    "state": "blocked",
-                    "error_message": "Needs another pass.",
-                    "updated_at": "2026-05-05T22:05:00Z",
-                },
-                authorization="Bearer worker-token",
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="blocked",
+                error_message="Needs another pass.",
+                updated_at="2026-05-05T22:05:00Z",
             )
             _wrong_context_status, wrong_context_payload = _invoke_app(
                 app,


### PR DESCRIPTION
## Summary
- Move POST /v1/every-code/work-requests/status from the legacy WSGI fallback into native FastAPI
- Preserve worker-token and workflow auth, replay-before-write idempotency, blocked notification delivery, and status transition behavior
- Extract Every Code notification delivery helpers out of service.py and document the compatibility retirement

## Validation
- uv run python -m unittest tests.test_http_app.FastApiEveryCodeReadTests
- uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_status_is_retired_from_legacy_wsgi_app tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_status_worker_token_is_retired_from_legacy_wsgi_app tests.test_service.LaunchplaneServiceTests.test_every_code_worker_token_reruns_terminal_request tests.test_service.LaunchplaneServiceTests.test_every_code_worker_token_can_rerun_terminal_request tests.test_service.LaunchplaneServiceTests.test_every_code_rerun_requires_matching_write_intent_evidence tests.test_service.LaunchplaneServiceTests.test_every_code_rerun_rejects_stale_and_wrong_context_write_intents tests.test_service.LaunchplaneServiceTests.test_every_code_blocked_status_posts_discord_notification tests.test_service.LaunchplaneServiceTests.test_every_code_blocked_status_records_discord_failure
- uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/every_code_notifications_delivery.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/every_code_notifications_delivery.py tests/test_http_app.py tests/test_service.py
- uv run --extra dev mypy control_plane tests
- uv run python -m unittest
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "/Users/cbusillo/Developer/launchplane" --scope changed_files
- Review agents: initial batch green after OpenAPI contract fix; follow-up batch GREEN

Note: repo-wide ruff check passed; repo-wide ruff format --check still reports pre-existing formatting drift outside this slice, so this branch kept formatting surgical to touched Python files.

Refs #1322