### PR TITLE
Move Every Code rerun writes to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -3,6 +3,7 @@ import json
 import secrets
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
 from pathlib import Path as FilePath
 from typing import Annotated, Literal, Protocol, cast
 from uuid import uuid4
@@ -40,6 +41,7 @@ from control_plane.contracts.authz_policy_record import (
     authz_policy_sha256,
     build_authz_policy_record_id,
 )
+from control_plane.contracts.agent_write_intent import AgentWriteIntentRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.driver_descriptor import DriverContextView, DriverDescriptor
@@ -63,6 +65,7 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
     apply_every_code_work_request_status,
+    requeue_every_code_work_request,
 )
 from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
@@ -236,6 +239,8 @@ _PRODUCT_PROFILES_ROUTE = "/v1/product-profiles"
 _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/apply"
 _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
+_EVERY_CODE_WORK_REQUEST_RERUN_ROUTE = "/v1/every-code/work-requests/rerun"
+_AGENT_WRITE_INTENT_MAX_AGE = timedelta(hours=24)
 
 
 class RepoProductMappingReadStore(Protocol):
@@ -310,6 +315,7 @@ class LaunchplaneErrorResponse(BaseModel):
     status: str = "rejected"
     trace_id: str
     error: LaunchplaneErrorDetail
+    records: dict[str, str] | None = None
 
 
 class HealthResponse(BaseModel):
@@ -755,6 +761,25 @@ class EveryCodeWorkRequestStatusEnvelope(BaseModel):
             raise ValueError("Every Code work request status requires request_id")
         if not self.host.strip():
             raise ValueError("Every Code work request status requires host")
+        return self
+
+
+class EveryCodeWorkRequestRerunEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request_id: str
+    trigger_actor: str = ""
+    source_url: str = ""
+    agent_write_intent_record_id: str = ""
+
+    @model_validator(mode="after")
+    def _validate_rerun(self) -> "EveryCodeWorkRequestRerunEnvelope":
+        if not self.request_id.strip():
+            raise ValueError("Every Code work request rerun requires request_id")
+        self.request_id = self.request_id.strip()
+        self.trigger_actor = self.trigger_actor.strip()
+        self.source_url = self.source_url.strip()
+        self.agent_write_intent_record_id = self.agent_write_intent_record_id.strip()
         return self
 
 
@@ -1492,6 +1517,30 @@ class _EveryCodeWorkRequestStatusStore(Protocol):
     def write_every_code_work_request_record(
         self, record: EveryCodeWorkRequestRecord
     ) -> object: ...
+
+
+class _EveryCodeWorkRequestRerunStore(Protocol):
+    def read_every_code_work_request_record(
+        self, request_id: str
+    ) -> EveryCodeWorkRequestRecord: ...
+
+    def write_every_code_work_request_record(
+        self, record: EveryCodeWorkRequestRecord
+    ) -> object: ...
+
+
+class _AgentWriteIntentRecordReadStore(Protocol):
+    def read_agent_write_intent_record(self, record_id: str) -> AgentWriteIntentRecord: ...
+
+    def list_agent_write_intent_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[AgentWriteIntentRecord, ...]: ...
 
 
 class _EveryCodePrFeedbackReadStore(Protocol):
@@ -2268,6 +2317,16 @@ def idempotency_scope(identity: LaunchplaneIdentity) -> str:
 def request_fingerprint(payload: dict[str, object]) -> str:
     canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def parse_utc_timestamp(value: str) -> datetime:
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    parsed = datetime.fromisoformat(normalized)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 def _public_ingress_notification_policy_summary(
@@ -3236,6 +3295,161 @@ def create_launchplane_fastapi_app(
         )
         return cast(_EveryCodeWorkRequestStatusStore, record_store)
 
+    def require_every_code_work_request_rerun_store(
+        record_store: object,
+    ) -> _EveryCodeWorkRequestRerunStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=(
+                "read_every_code_work_request_record",
+                "write_every_code_work_request_record",
+            ),
+            capability="Every Code work request rerun writes",
+        )
+        return cast(_EveryCodeWorkRequestRerunStore, record_store)
+
+    def require_agent_write_intent_read_store(
+        record_store: object,
+    ) -> _AgentWriteIntentRecordReadStore:
+        require_every_code_read_methods(
+            record_store,
+            required_methods=(
+                "read_agent_write_intent_record",
+                "list_agent_write_intent_records",
+            ),
+            capability="agent write-intent evidence reads",
+        )
+        return cast(_AgentWriteIntentRecordReadStore, record_store)
+
+    def reject_agent_write_intent(
+        *, trace_id: str, code: str, message: str, record_id: str = ""
+    ) -> HTTPException:
+        detail: dict[str, object] = {"trace_id": trace_id, "code": code, "message": message}
+        if record_id:
+            detail["records"] = {"agent_write_intent_record_id": record_id}
+        return HTTPException(
+            status_code=404 if code == "agent_write_intent_not_found" else 409,
+            detail=detail,
+        )
+
+    def validate_every_code_rerun_write_intent(
+        *,
+        record_store: object,
+        rerun_request: EveryCodeWorkRequestRerunEnvelope,
+        idempotency_key: str,
+        now: datetime,
+        trace_id: str,
+    ) -> AgentWriteIntentRecord | None:
+        record_id = rerun_request.agent_write_intent_record_id.strip()
+        if not record_id:
+            return None
+        try:
+            record = require_agent_write_intent_read_store(
+                record_store
+            ).read_agent_write_intent_record(record_id)
+        except FileNotFoundError as error:
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_not_found",
+                message="Agent write-intent evidence record was not found.",
+                record_id=record_id,
+            ) from error
+        if (
+            record.evaluation.status != "allowed"
+            or record.evaluation.intent != "every_code_rerun"
+            or record.evaluation.mode != "apply"
+            or not record.evaluation.safe_to_execute
+        ):
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_not_executable",
+                message=(
+                    "Every Code rerun requires an allowed apply-mode "
+                    "every_code_rerun intent record."
+                ),
+                record_id=record.record_id,
+            )
+        if (
+            record.evaluation.product != "launchplane"
+            or record.evaluation.context != _LAUNCHPLANE_SERVICE_CONTEXT
+        ):
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_scope_mismatch",
+                message=(
+                    "Agent write-intent evidence does not match the Every Code "
+                    "rerun product/context."
+                ),
+                record_id=record.record_id,
+            )
+        if record.evaluation.authz_action != "every_code_work_request.rerun":
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_action_mismatch",
+                message="Agent write-intent evidence was evaluated for a different route action.",
+                record_id=record.record_id,
+            )
+        if rerun_request.source_url and rerun_request.source_url != record.request.source_url:
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_source_mismatch",
+                message="Every Code rerun source_url does not match the write-intent source_url.",
+                record_id=record.record_id,
+            )
+        if idempotency_key and record.idempotency_key and idempotency_key != record.idempotency_key:
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_idempotency_mismatch",
+                message=(
+                    "Every Code rerun idempotency key does not match the write-intent evidence."
+                ),
+                record_id=record.record_id,
+            )
+        try:
+            recorded_at = parse_utc_timestamp(record.recorded_at)
+        except ValueError as error:
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_stale",
+                message="Agent write-intent evidence timestamp is invalid or stale.",
+                record_id=record.record_id,
+            ) from error
+        if recorded_at > now or now - recorded_at > _AGENT_WRITE_INTENT_MAX_AGE:
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_stale",
+                message="Agent write-intent evidence is too old for Every Code rerun execution.",
+                record_id=record.record_id,
+            )
+        return record
+
+    def matching_every_code_rerun_intent_record(
+        *, record_store: object, source_url: str, now: datetime
+    ) -> AgentWriteIntentRecord | None:
+        for record in require_agent_write_intent_read_store(
+            record_store
+        ).list_agent_write_intent_records(
+            product="launchplane",
+            context_name=_LAUNCHPLANE_SERVICE_CONTEXT,
+            status="allowed",
+            limit=50,
+        ):
+            if record.evaluation.intent != "every_code_rerun":
+                continue
+            if record.evaluation.mode != "apply" or not record.evaluation.safe_to_execute:
+                continue
+            if record.evaluation.authz_action != "every_code_work_request.rerun":
+                continue
+            if record.request.source_url != source_url:
+                continue
+            try:
+                recorded_at = parse_utc_timestamp(record.recorded_at)
+            except ValueError:
+                continue
+            if recorded_at <= now and now - recorded_at <= _AGENT_WRITE_INTENT_MAX_AGE:
+                return record
+        return None
+
     def require_every_code_pr_feedback_read_store(
         record_store: object,
     ) -> _EveryCodePrFeedbackReadStore:
@@ -4202,6 +4416,148 @@ def create_launchplane_fastapi_app(
                 record_store=record_store,
                 identity=idempotency_identity,
                 route_path="/v1/every-code/work-requests/status",
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=response,
+            )
+        return response
+
+    async def rerun_every_code_work_request(
+        request: Request,
+        payload: dict[str, object],
+        identity: Annotated[
+            LaunchplaneIdentity | None,
+            Depends(read_every_code_work_request_worker_write_identity),
+        ],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        normalized_idempotency_key = ""
+        intent_idempotency_key = idempotency_key.strip()
+        payload_fingerprint = ""
+        if identity is not None:
+            if not resolved_authz_policy_runtime.policy.allows(
+                identity=identity,
+                action="every_code_work_request.rerun",
+                product="launchplane",
+                context=_LAUNCHPLANE_SERVICE_CONTEXT,
+            ):
+                raise _launchplane_http_error(
+                    status_code=403,
+                    trace_id=trace_id,
+                    code="authorization_denied",
+                    message="Workflow cannot rerun Every Code work requests.",
+                )
+            (
+                normalized_idempotency_key,
+                payload_fingerprint,
+                replayed_response,
+            ) = await replay_apply_idempotency(
+                request=request,
+                record_store=record_store,
+                identity=identity,
+                route_path=_EVERY_CODE_WORK_REQUEST_RERUN_ROUTE,
+                idempotency_key=idempotency_key,
+                trace_id=trace_id,
+                check_replay=True,
+            )
+            if replayed_response is not None:
+                return replayed_response
+            intent_idempotency_key = normalized_idempotency_key
+        try:
+            rerun_request = EveryCodeWorkRequestRerunEnvelope.model_validate(payload)
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=str(error),
+            ) from error
+        try:
+            every_code_store = require_every_code_work_request_rerun_store(record_store)
+            require_agent_write_intent_read_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        rerun_checked_at = datetime.now(timezone.utc)
+        intent_record = validate_every_code_rerun_write_intent(
+            record_store=record_store,
+            rerun_request=rerun_request,
+            idempotency_key=intent_idempotency_key,
+            now=rerun_checked_at,
+            trace_id=trace_id,
+        )
+        try:
+            existing_record = every_code_store.read_every_code_work_request_record(
+                rerun_request.request_id
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        if intent_record is None:
+            intent_record = matching_every_code_rerun_intent_record(
+                record_store=record_store,
+                source_url=existing_record.issue_url,
+                now=rerun_checked_at,
+            )
+            if intent_record is None:
+                raise reject_agent_write_intent(
+                    trace_id=trace_id,
+                    code="agent_write_intent_required",
+                    message="Every Code rerun requires matching approved write-intent evidence.",
+                )
+        if intent_record.request.source_url != existing_record.issue_url:
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_source_mismatch",
+                message="Every Code rerun write-intent source_url does not match the work-request issue URL.",
+                record_id=intent_record.record_id,
+            )
+        if rerun_request.source_url and rerun_request.source_url != existing_record.issue_url:
+            raise reject_agent_write_intent(
+                trace_id=trace_id,
+                code="agent_write_intent_source_mismatch",
+                message="Every Code rerun source_url does not match the work-request issue URL.",
+                record_id=intent_record.record_id,
+            )
+        try:
+            requeued_record = requeue_every_code_work_request(
+                existing_record,
+                queued_at=utc_now_timestamp(),
+                trigger_actor=rerun_request.trigger_actor,
+            )
+        except (ValueError, ValidationError) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_payload",
+                message=str(error),
+            ) from error
+        every_code_store.write_every_code_work_request_record(requeued_record)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "request_id": requeued_record.request_id,
+                "state": requeued_record.state,
+                "agent_write_intent_record_id": intent_record.record_id,
+            },
+            result={"request": requeued_record.model_dump(mode="json")},
+        )
+        if identity is not None:
+            store_apply_idempotency(
+                record_store=record_store,
+                identity=identity,
+                route_path=_EVERY_CODE_WORK_REQUEST_RERUN_ROUTE,
                 idempotency_key=normalized_idempotency_key,
                 request_fingerprint_value=payload_fingerprint,
                 trace_id=trace_id,
@@ -9141,6 +9497,28 @@ def create_launchplane_fastapi_app(
     )
 
     app.add_api_route(
+        _EVERY_CODE_WORK_REQUEST_RERUN_ROUTE,
+        rerun_every_code_work_request,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="rerun_every_code_work_request",
+        summary="Rerun Every Code work request",
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": EveryCodeWorkRequestRerunEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        responses=every_code_worker_status_error_responses,
+    )
+
+    app.add_api_route(
         "/v1/every-code/pr-feedback",
         list_every_code_pr_feedback,
         methods=["GET"],
@@ -9600,15 +9978,18 @@ def create_launchplane_fastapi_app(
             trace_id = str(detail.get("trace_id", trace_id))
             code = str(detail.get("code", code))
             message = str(detail.get("message", "Launchplane request failed."))
+            records = detail.get("records")
         else:
             message = str(http_error.detail)
+            records = None
         payload = LaunchplaneErrorResponse(
             trace_id=trace_id,
             error=LaunchplaneErrorDetail(code=code, message=message),
+            records=records if isinstance(records, dict) else None,
         )
         response = JSONResponse(
             status_code=http_error.status_code,
-            content=payload.model_dump(mode="json"),
+            content=payload.model_dump(mode="json", exclude_none=True),
             headers=http_error.headers,
         )
         preserve_renewed_session_cookie(request, response)
@@ -9628,7 +10009,7 @@ def create_launchplane_fastapi_app(
         )
         response = JSONResponse(
             status_code=400,
-            content=payload.model_dump(mode="json"),
+            content=payload.model_dump(mode="json", exclude_none=True),
         )
         preserve_renewed_session_cookie(request, response)
         return response

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 import hashlib
 import json
 import logging
@@ -47,7 +47,6 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     close_every_code_work_request_for_issue,
     close_every_code_work_request_for_pull_request,
-    requeue_every_code_work_request,
 )
 from control_plane.contracts.every_code_preview_gate_record import (
     EveryCodePreviewGateRecord,
@@ -638,7 +637,6 @@ _GITHUB_ISSUE_REFERENCE_PATTERN = re.compile(
     re.IGNORECASE,
 )
 _EVERY_CODE_TRIGGER_LABEL = "every-code"
-_AGENT_WRITE_INTENT_MAX_AGE = timedelta(hours=24)
 
 
 @dataclass(frozen=True)
@@ -1729,25 +1727,6 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
     def _validate_alignment(self) -> "LaunchplaneSelfDeployEnvelope":
         if self.product.strip() != "launchplane":
             raise ValueError("Launchplane self deploy requires product 'launchplane'.")
-        return self
-
-
-class EveryCodeWorkRequestRerunEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    request_id: str
-    trigger_actor: str = ""
-    source_url: str = ""
-    agent_write_intent_record_id: str = ""
-
-    @model_validator(mode="after")
-    def _validate_rerun(self) -> "EveryCodeWorkRequestRerunEnvelope":
-        if not self.request_id.strip():
-            raise ValueError("Every Code work request rerun requires request_id")
-        self.request_id = self.request_id.strip()
-        self.trigger_actor = self.trigger_actor.strip()
-        self.source_url = self.source_url.strip()
-        self.agent_write_intent_record_id = self.agent_write_intent_record_id.strip()
         return self
 
 
@@ -3491,7 +3470,6 @@ def _build_write_routes() -> frozenset[str]:
         _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
         "/v1/agent/write-intents/evaluate",
-        "/v1/every-code/work-requests/rerun",
         "/v1/authz-policies/github-actions/grants",
         "/v1/authz-policies/github-actions/removals",
         "/v1/authz-policies/github-humans/grants",
@@ -6445,267 +6423,6 @@ def _owner_agent_identity_from_bearer(environ: dict[str, object]) -> Launchplane
     )
 
 
-def _is_every_code_worker_route(*, method: str, path: str) -> bool:
-    return method == "POST" and path in {
-        "/v1/every-code/work-requests/rerun",
-    }
-
-
-def _every_code_worker_token_authorized(
-    *, environ: dict[str, object], method: str, path: str
-) -> bool:
-    if not _is_every_code_worker_route(method=method, path=path):
-        return False
-    expected_token = _every_code_worker_token_from_env()
-    if not expected_token:
-        return False
-    try:
-        provided_token = _bearer_token(environ)
-    except PermissionError:
-        return False
-    return secrets.compare_digest(provided_token, expected_token)
-
-
-def _handle_every_code_worker_write(
-    *,
-    start_response: _StartResponse,
-    trace_id: str,
-    record_store: object,
-    path: str,
-    payload: dict[str, object],
-    idempotency_key: str = "",
-) -> list[bytes]:
-    every_code_store = _every_code_work_request_store(record_store)
-    if path == "/v1/every-code/work-requests/rerun":
-        rerun_request = EveryCodeWorkRequestRerunEnvelope.model_validate(payload)
-        rerun_checked_at = datetime.now(timezone.utc)
-        intent_record, intent_response = _validate_every_code_rerun_write_intent(
-            record_store=record_store,
-            rerun_request=rerun_request,
-            idempotency_key=idempotency_key,
-            now=rerun_checked_at,
-            trace_id=trace_id,
-            start_response=start_response,
-        )
-        if intent_response is not None:
-            return intent_response
-        existing_record = every_code_store.read_every_code_work_request_record(
-            rerun_request.request_id.strip()
-        )
-        if intent_record is None:
-            intent_record = _matching_every_code_rerun_intent_record(
-                record_store=record_store,
-                source_url=existing_record.issue_url,
-                now=rerun_checked_at,
-            )
-            if intent_record is None:
-                return _reject_agent_write_intent(
-                    start_response=start_response,
-                    trace_id=trace_id,
-                    code="agent_write_intent_required",
-                    message="Every Code rerun requires matching approved write-intent evidence.",
-                )
-        if rerun_request.source_url and rerun_request.source_url != existing_record.issue_url:
-            return _reject_agent_write_intent(
-                start_response=start_response,
-                trace_id=trace_id,
-                code="agent_write_intent_source_mismatch",
-                message="Every Code rerun source_url does not match the work-request issue URL.",
-                record_id=intent_record.record_id,
-            )
-        requeued_record = requeue_every_code_work_request(
-            existing_record,
-            queued_at=_utc_now_timestamp(),
-            trigger_actor=rerun_request.trigger_actor,
-        )
-        every_code_store.write_every_code_work_request_record(requeued_record)
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload=_accepted_payload(
-                trace_id=trace_id,
-                result={
-                    "request_id": requeued_record.request_id,
-                    "state": requeued_record.state,
-                    **(
-                        {"agent_write_intent_record_id": intent_record.record_id}
-                        if intent_record is not None
-                        else {}
-                    ),
-                },
-                driver_result={"request": requeued_record.model_dump(mode="json")},
-            ),
-        )
-    return _json_response(
-        start_response=start_response,
-        status_code=404,
-        payload={
-            "status": "rejected",
-            "trace_id": trace_id,
-            "error": {
-                "code": "not_found",
-                "message": "Launchplane route was not found.",
-            },
-        },
-    )
-
-
-def _agent_write_intent_rejection_payload(
-    *, trace_id: str, code: str, message: str, record_id: str = ""
-) -> dict[str, object]:
-    payload: dict[str, object] = {
-        "status": "rejected",
-        "trace_id": trace_id,
-        "error": {"code": code, "message": message},
-    }
-    if record_id:
-        payload["records"] = {"agent_write_intent_record_id": record_id}
-    return payload
-
-
-def _reject_agent_write_intent(
-    *,
-    start_response: _StartResponse,
-    trace_id: str,
-    code: str,
-    message: str,
-    record_id: str = "",
-) -> list[bytes]:
-    status_code = 404 if code == "agent_write_intent_not_found" else 409
-    return _json_response(
-        start_response=start_response,
-        status_code=status_code,
-        payload=_agent_write_intent_rejection_payload(
-            trace_id=trace_id,
-            code=code,
-            message=message,
-            record_id=record_id,
-        ),
-    )
-
-
-def _validate_every_code_rerun_write_intent(
-    *,
-    record_store: object,
-    rerun_request: EveryCodeWorkRequestRerunEnvelope,
-    idempotency_key: str,
-    now: datetime,
-    trace_id: str,
-    start_response: _StartResponse,
-) -> tuple[AgentWriteIntentRecord | None, list[bytes] | None]:
-    record_id = rerun_request.agent_write_intent_record_id.strip()
-    if not record_id:
-        return None, None
-    try:
-        record = _agent_write_intent_record_store(record_store).read_agent_write_intent_record(
-            record_id
-        )
-    except FileNotFoundError:
-        return None, _reject_agent_write_intent(
-            start_response=start_response,
-            trace_id=trace_id,
-            code="agent_write_intent_not_found",
-            message="Agent write-intent evidence record was not found.",
-            record_id=record_id,
-        )
-    if (
-        record.evaluation.status != "allowed"
-        or record.evaluation.intent != "every_code_rerun"
-        or record.evaluation.mode != "apply"
-        or not record.evaluation.safe_to_execute
-    ):
-        return record, _reject_agent_write_intent(
-            start_response=start_response,
-            trace_id=trace_id,
-            code="agent_write_intent_not_executable",
-            message="Every Code rerun requires an allowed apply-mode every_code_rerun intent record.",
-            record_id=record.record_id,
-        )
-    if (
-        record.evaluation.product != "launchplane"
-        or record.evaluation.context != _LAUNCHPLANE_SERVICE_CONTEXT
-    ):
-        return record, _reject_agent_write_intent(
-            start_response=start_response,
-            trace_id=trace_id,
-            code="agent_write_intent_scope_mismatch",
-            message="Agent write-intent evidence does not match the Every Code rerun product/context.",
-            record_id=record.record_id,
-        )
-    if record.evaluation.authz_action != "every_code_work_request.rerun":
-        return record, _reject_agent_write_intent(
-            start_response=start_response,
-            trace_id=trace_id,
-            code="agent_write_intent_action_mismatch",
-            message="Agent write-intent evidence was evaluated for a different route action.",
-            record_id=record.record_id,
-        )
-    if rerun_request.source_url and rerun_request.source_url != record.request.source_url:
-        return record, _reject_agent_write_intent(
-            start_response=start_response,
-            trace_id=trace_id,
-            code="agent_write_intent_source_mismatch",
-            message="Every Code rerun source_url does not match the write-intent source_url.",
-            record_id=record.record_id,
-        )
-    if idempotency_key and record.idempotency_key and idempotency_key != record.idempotency_key:
-        return record, _reject_agent_write_intent(
-            start_response=start_response,
-            trace_id=trace_id,
-            code="agent_write_intent_idempotency_mismatch",
-            message="Every Code rerun idempotency key does not match the write-intent evidence.",
-            record_id=record.record_id,
-        )
-    try:
-        recorded_at = _parse_utc_timestamp(record.recorded_at)
-    except ValueError:
-        return record, _reject_agent_write_intent(
-            start_response=start_response,
-            trace_id=trace_id,
-            code="agent_write_intent_stale",
-            message="Agent write-intent evidence timestamp is invalid or stale.",
-            record_id=record.record_id,
-        )
-    if recorded_at > now or now - recorded_at > _AGENT_WRITE_INTENT_MAX_AGE:
-        return record, _reject_agent_write_intent(
-            start_response=start_response,
-            trace_id=trace_id,
-            code="agent_write_intent_stale",
-            message="Agent write-intent evidence is too old for Every Code rerun execution.",
-            record_id=record.record_id,
-        )
-    return record, None
-
-
-def _matching_every_code_rerun_intent_record(
-    *,
-    record_store: object,
-    source_url: str,
-    now: datetime,
-) -> AgentWriteIntentRecord | None:
-    for record in _agent_write_intent_record_store(record_store).list_agent_write_intent_records(
-        product="launchplane",
-        context_name=_LAUNCHPLANE_SERVICE_CONTEXT,
-        status="allowed",
-        limit=50,
-    ):
-        if record.evaluation.intent != "every_code_rerun":
-            continue
-        if record.evaluation.mode != "apply" or not record.evaluation.safe_to_execute:
-            continue
-        if record.evaluation.authz_action != "every_code_work_request.rerun":
-            continue
-        if record.request.source_url != source_url:
-            continue
-        try:
-            recorded_at = _parse_utc_timestamp(record.recorded_at)
-        except ValueError:
-            continue
-        if recorded_at <= now and now - recorded_at <= _AGENT_WRITE_INTENT_MAX_AGE:
-            return record
-    return None
-
-
 def _session(
     *,
     environ: dict[str, object],
@@ -7815,30 +7532,6 @@ def create_launchplane_service_app(
                         "error": {
                             "code": "invalid_request",
                             "message": "GitHub webhook payload is invalid.",
-                        },
-                    },
-                )
-        if _every_code_worker_token_authorized(environ=environ, method=method, path=path):
-            payload = _read_json_request(environ)
-            try:
-                return _handle_every_code_worker_write(
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                    record_store=record_store,
-                    path=path,
-                    payload=payload,
-                    idempotency_key=_idempotency_key(environ),
-                )
-            except ValueError as error:
-                return _json_response(
-                    start_response=start_response,
-                    status_code=400,
-                    payload={
-                        "status": "rejected",
-                        "trace_id": request_trace_id,
-                        "error": {
-                            "code": "invalid_payload",
-                            "message": str(error),
                         },
                     },
                 )
@@ -9306,44 +8999,6 @@ def create_launchplane_service_app(
                     },
                 }
                 driver_result = result
-            elif path == "/v1/every-code/work-requests/rerun":
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="every_code_work_request.rerun",
-                    product="launchplane",
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot rerun Every Code work requests.",
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                return _handle_every_code_worker_write(
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                    record_store=record_store,
-                    path=path,
-                    payload=payload,
-                    idempotency_key=request_idempotency_key,
-                )
             elif path == "/v1/product-config/apply":
                 product_config_request, product_config_response = (
                     validate_product_config_apply_request(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -150,14 +150,19 @@ Keep a compatibility surface only when it is one of these:
   `every_code_work_request.update` workflow authorization, checks idempotency
   before requiring write-store capabilities, preserves blocked-notification
   delivery, and keeps the existing `404 not_found` transition semantics. Every
-  Code PR-feedback write, PR-feedback status, and preview-gate write routes use
-  native FastAPI, preserve the dedicated Every Code worker token, require only
-  their direct PR-feedback or preview-gate record-store capabilities, and
-  intentionally do not add idempotency state. The PR-feedback status route also
-  preserves the existing `404 not_found` and `409 feedback_already_final`
-  transition semantics. Their legacy WSGI write branches are deleted; direct
-  WSGI fallback calls fail closed. Every Code rerun and webhook routes remain on
-  the mounted WSGI fallback until their native write replacements land.
+  Code work-request rerun uses native FastAPI, preserves the dedicated Every Code
+  worker token and `every_code_work_request.rerun` workflow authorization,
+  requires approved `every_code_rerun` write-intent evidence, checks workflow
+  idempotency replay before requiring write-store capabilities, and keeps the
+  terminal-only requeue semantics. Every Code PR-feedback write, PR-feedback
+  status, and preview-gate write routes use native FastAPI, preserve the
+  dedicated Every Code worker token, require only their direct PR-feedback or
+  preview-gate record-store capabilities, and intentionally do not add
+  idempotency state. The PR-feedback status route also preserves the existing
+  `404 not_found` and `409 feedback_already_final` transition semantics. Their
+  legacy WSGI write branches are deleted; direct WSGI fallback calls fail closed.
+  The Every Code GitHub webhook route remains on the mounted WSGI fallback until
+  its native replacement lands.
 - Deployment, backup-gate, promotion, preview generation, preview destroyed,
   runner-host hygiene audit, and runner-lane registration audit evidence
   ingestion use native FastAPI routes for bearer-token callers and preserve the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -218,7 +218,12 @@ VeriReel product paths:
     `every_code_work_request.update`, replay-before-write idempotency handling,
     record-store status capability checks, `404 not_found` for missing requests,
     and blocked-notification delivery)
-  - `POST /v1/every-code/work-requests/rerun`
+  - `POST /v1/every-code/work-requests/rerun` (native FastAPI for Every Code
+    worker-token callers and bearer-token callers with
+    `every_code_work_request.rerun`, approved `every_code_rerun` write-intent
+    evidence, workflow replay-before-write idempotency handling, record-store
+    rerun capability checks, `404 not_found` for missing requests, and
+    terminal-only requeue semantics)
   - `POST /v1/every-code/pr-feedback` (native FastAPI for Every Code
     worker-token callers, direct PR-feedback record writes, and DB-backed
     storage capability enforcement without idempotency state)

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -18,6 +18,12 @@ from jwt import InvalidTokenError
 from starlette.types import ASGIApp
 
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.agent_write_intent import (
+    AgentWriteIntentRecord,
+    AgentWriteIntentRequest,
+    build_agent_write_intent_record_id,
+    evaluate_agent_write_intent,
+)
 from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
@@ -32,7 +38,11 @@ from control_plane.contracts.every_code_notifications import (
 )
 from control_plane.contracts.every_code_preview_gate_record import EveryCodePreviewGateRecord
 from control_plane.contracts.every_code_pr_feedback_record import EveryCodePrFeedbackRecord
-from control_plane.contracts.every_code_work_request import EveryCodeWorkRequestRecord
+from control_plane.contracts.every_code_work_request import (
+    EveryCodeWorkRequestRecord,
+    EveryCodeWorkRequestStatusUpdate,
+    apply_every_code_work_request_status,
+)
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.ingress_route_audit_record import (
     IngressRouteAuditOperation,
@@ -94,6 +104,7 @@ from control_plane.service_auth import (
     GitHubHumanIdentity,
     GitHubActionsIdentity,
     LaunchplaneAuthzPolicy,
+    agent_authz_audit,
 )
 from control_plane.service_human_auth import (
     GitHubOAuthConfig,
@@ -4953,6 +4964,428 @@ class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("embeds", discord_payload)
         self.assertEqual(payload["result"]["notifications"][0]["delivery_status"], "delivered")
         self.assertEqual(attempts[0].delivery_status, "delivered")
+
+    async def test_every_code_work_request_rerun_accepts_worker_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            claimed = store.claim_every_code_work_request_record(
+                request_id=seeded.request_id,
+                host="Chris-Studio",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            if claimed is None:
+                raise AssertionError("expected seeded request to be claimable")
+            blocked = apply_every_code_work_request_status(
+                claimed,
+                EveryCodeWorkRequestStatusUpdate(
+                    state="blocked",
+                    host="Chris-Studio",
+                    updated_at="2026-05-05T22:05:00Z",
+                    result_pr_url="https://github.com/cbusillo/code/pull/26",
+                    result_summary="Detached session went stale.",
+                    error_message="Detached session went stale.",
+                ),
+            )
+            store.write_every_code_work_request_record(blocked)
+            intent = _seed_every_code_rerun_intent(
+                store,
+                idempotency_key="every-code-rerun-intent:123",
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "trigger_actor": "cbusillo",
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "agent_write_intent_record_id": intent.record_id,
+                },
+                authorization="Bearer worker-token",
+                idempotency_key="every-code-rerun-intent:123",
+            )
+            stored_request = store.read_every_code_work_request_record(seeded.request_id)
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["records"]["request_id"], seeded.request_id)
+        self.assertEqual(payload["records"]["state"], "queued")
+        self.assertEqual(payload["records"]["agent_write_intent_record_id"], intent.record_id)
+        self.assertEqual(payload["result"]["request"]["trigger_actor"], "cbusillo")
+        self.assertEqual(stored_request.state, "queued")
+        self.assertEqual(stored_request.claimed_by_host, "")
+        self.assertEqual(stored_request.result_pr_url, "")
+        self.assertEqual(stored_request.error_message, "")
+
+    async def test_every_code_work_request_rerun_accepts_authorized_identity(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            claimed = store.claim_every_code_work_request_record(
+                request_id=seeded.request_id,
+                host="Runner-Host",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            if claimed is None:
+                raise AssertionError("expected seeded request to be claimable")
+            done = apply_every_code_work_request_status(
+                claimed,
+                EveryCodeWorkRequestStatusUpdate(
+                    state="done",
+                    host="Runner-Host",
+                    updated_at="2026-05-05T22:05:00Z",
+                    result_pr_url="https://github.com/cbusillo/code/pull/26",
+                ),
+            )
+            store.write_every_code_work_request_record(done)
+            intent = _seed_every_code_rerun_intent(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_every_code_work_request_rerun_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "trigger_actor": "ops",
+                    "agent_write_intent_record_id": intent.record_id,
+                },
+                idempotency_key="every-code-rerun-code-123",
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["records"]["state"], "queued")
+        self.assertEqual(response.json()["result"]["request"]["trigger_actor"], "ops")
+
+    async def test_every_code_work_request_rerun_uses_matching_intent_evidence(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            claimed = store.claim_every_code_work_request_record(
+                request_id=seeded.request_id,
+                host="Chris-Studio",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            if claimed is None:
+                raise AssertionError("expected seeded request to be claimable")
+            blocked = apply_every_code_work_request_status(
+                claimed,
+                EveryCodeWorkRequestStatusUpdate(
+                    state="blocked",
+                    host="Chris-Studio",
+                    updated_at="2026-05-05T22:05:00Z",
+                    error_message="Needs another pass.",
+                ),
+            )
+            store.write_every_code_work_request_record(blocked)
+            intent = _seed_every_code_rerun_intent(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_rerun(
+                app,
+                {"request_id": seeded.request_id, "trigger_actor": "ops"},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(
+            response.json()["records"]["agent_write_intent_record_id"],
+            intent.record_id,
+        )
+        self.assertEqual(response.json()["records"]["state"], "queued")
+
+    async def test_every_code_work_request_rerun_replays_authorized_idempotency(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "request_id": "every-code-cbusillo-code-123-test",
+            "agent_write_intent_record_id": "agent-write-intent-test",
+        }
+        store = _EveryCodeRerunReplayOnlyStore(
+            payload=payload,
+            idempotency_key="every-code-rerun-replay",
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_every_code_work_request_rerun_policy(),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_every_code_work_request_rerun(
+            app,
+            payload,
+            idempotency_key="every-code-rerun-replay",
+        )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertTrue(response.json()["replayed"])
+        self.assertEqual(response.json()["original_trace_id"], "launchplane_req_original")
+        self.assertEqual(store.read_idempotency_calls, 1)
+        self.assertEqual(store.read_calls, 0)
+        self.assertEqual(store.write_calls, 0)
+
+    async def test_every_code_work_request_rerun_rejects_invalid_inputs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            claimed = store.claim_every_code_work_request_record(
+                request_id=seeded.request_id,
+                host="Chris-Studio",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            if claimed is None:
+                raise AssertionError("expected seeded request to be claimable")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            active_response = await _post_every_code_work_request_rerun(
+                app,
+                {"request_id": seeded.request_id},
+                authorization="Bearer worker-token",
+            )
+            invalid_response = await _post_every_code_work_request_rerun(
+                app,
+                {"request_id": ""},
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(active_response.status_code, 409)
+        self.assertEqual(active_response.json()["error"]["code"], "agent_write_intent_required")
+        self.assertEqual(invalid_response.status_code, 400)
+        self.assertEqual(invalid_response.json()["error"]["code"], "invalid_payload")
+
+    async def test_every_code_work_request_rerun_validation_error_omits_records(
+        self,
+    ) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/every-code/work-requests/rerun",
+            headers={
+                "Authorization": "Bearer worker-token",
+                "Content-Type": "application/json",
+            },
+            raw_body=b'{"request_id":',
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        self.assertNotIn("records", response.json())
+
+    async def test_every_code_work_request_rerun_rejects_non_terminal_request(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            intent = _seed_every_code_rerun_intent(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "agent_write_intent_record_id": intent.record_id,
+                },
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_payload")
+
+    async def test_every_code_work_request_rerun_requires_write_intent_evidence(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            seeded = _seed_every_code_claim_request(store)
+            claimed = store.claim_every_code_work_request_record(
+                request_id=seeded.request_id,
+                host="Chris-Studio",
+                claimed_at="2026-05-05T22:01:00Z",
+            )
+            if claimed is None:
+                raise AssertionError("expected seeded request to be claimable")
+            blocked = apply_every_code_work_request_status(
+                claimed,
+                EveryCodeWorkRequestStatusUpdate(
+                    state="blocked",
+                    host="Chris-Studio",
+                    updated_at="2026-05-05T22:05:00Z",
+                    error_message="Needs another pass.",
+                ),
+            )
+            store.write_every_code_work_request_record(blocked)
+            wrong_source_intent = _seed_every_code_rerun_intent(
+                store,
+                source_url="https://github.com/cbusillo/code/issues/999",
+            )
+            wrong_context_intent = _seed_every_code_rerun_intent(
+                store,
+                context="other-context",
+            )
+            stale_intent = _seed_every_code_rerun_intent(
+                store,
+                recorded_at="2026-01-01T00:00:00Z",
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            missing_response = await _post_every_code_work_request_rerun(
+                app,
+                {"request_id": seeded.request_id},
+                authorization="Bearer worker-token",
+            )
+            mismatch_response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "source_url": "https://github.com/cbusillo/code/issues/123",
+                    "agent_write_intent_record_id": wrong_source_intent.record_id,
+                },
+                authorization="Bearer worker-token",
+            )
+            mismatch_without_source_response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "agent_write_intent_record_id": wrong_source_intent.record_id,
+                },
+                authorization="Bearer worker-token",
+            )
+            wrong_context_response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "agent_write_intent_record_id": wrong_context_intent.record_id,
+                },
+                authorization="Bearer worker-token",
+            )
+            stale_response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "agent_write_intent_record_id": stale_intent.record_id,
+                },
+                authorization="Bearer worker-token",
+            )
+            not_found_response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": seeded.request_id,
+                    "agent_write_intent_record_id": "agent-write-intent-missing",
+                },
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(missing_response.status_code, 409)
+        self.assertEqual(missing_response.json()["error"]["code"], "agent_write_intent_required")
+        self.assertEqual(mismatch_response.status_code, 409)
+        self.assertEqual(
+            mismatch_response.json()["error"]["code"],
+            "agent_write_intent_source_mismatch",
+        )
+        self.assertEqual(
+            mismatch_response.json()["records"]["agent_write_intent_record_id"],
+            wrong_source_intent.record_id,
+        )
+        self.assertEqual(mismatch_without_source_response.status_code, 409)
+        self.assertEqual(
+            mismatch_without_source_response.json()["error"]["code"],
+            "agent_write_intent_source_mismatch",
+        )
+        self.assertEqual(wrong_context_response.status_code, 409)
+        self.assertEqual(
+            wrong_context_response.json()["error"]["code"],
+            "agent_write_intent_scope_mismatch",
+        )
+        self.assertEqual(stale_response.status_code, 409)
+        self.assertEqual(stale_response.json()["error"]["code"], "agent_write_intent_stale")
+        self.assertEqual(not_found_response.status_code, 404)
+        self.assertEqual(
+            not_found_response.json()["error"]["code"],
+            "agent_write_intent_not_found",
+        )
+
+    async def test_every_code_work_request_rerun_returns_not_found_for_missing_request(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            intent = _seed_every_code_rerun_intent(store)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+            )
+
+            response = await _post_every_code_work_request_rerun(
+                app,
+                {
+                    "request_id": "every-code-cbusillo-code-123-missing",
+                    "agent_write_intent_record_id": intent.record_id,
+                },
+                authorization="Bearer worker-token",
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_every_code_work_request_rerun_requires_store_capability(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            bearer_identity_config=BearerIdentityConfig(every_code_worker_token="worker-token"),
+        )
+
+        response = await _post_every_code_work_request_rerun(
+            app,
+            {"request_id": "every-code-cbusillo-code-123-test"},
+            authorization="Bearer worker-token",
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+        self.assertNotIn("records", response.json())
 
     async def test_every_code_pr_feedback_write_stores_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -16058,6 +16491,66 @@ def _every_code_work_request_status_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
+def _every_code_work_request_rerun_policy() -> LaunchplaneAuthzPolicy:
+    return _record_read_policy(
+        action="every_code_work_request.rerun",
+        context="launchplane",
+    )
+
+
+def _seed_every_code_rerun_intent(
+    store: Any,
+    *,
+    source_url: str = "https://github.com/cbusillo/code/issues/123",
+    context: str = "launchplane",
+    idempotency_key: str = "",
+    recorded_at: str = "",
+    authorized: bool = True,
+) -> AgentWriteIntentRecord:
+    resolved_recorded_at = recorded_at or datetime.now(timezone.utc).replace(
+        microsecond=0
+    ).isoformat().replace("+00:00", "Z")
+    request = AgentWriteIntentRequest(
+        intent="every_code_rerun",
+        mode="apply",
+        product="launchplane",
+        context=context,
+        source_url=source_url,
+        idempotency_key=idempotency_key,
+        reason="Approved rerun for blocked Every Code request.",
+    )
+    audit = agent_authz_audit(
+        identity=_identity(),
+        action="every_code_work_request.rerun",
+        product="launchplane",
+        context=context,
+        decision="allowed" if authorized else "denied",
+        reason_code="authorized" if authorized else "authorization_denied",
+        policy_source="test",
+        policy_sha256="test-policy-sha256",
+    )
+    evaluation = evaluate_agent_write_intent(
+        request=request,
+        authorized=authorized,
+        audit=audit,
+    )
+    record = AgentWriteIntentRecord(
+        record_id=build_agent_write_intent_record_id(
+            recorded_at=resolved_recorded_at,
+            trace_id="launchplane_req_every_code_rerun_test",
+            request=request,
+            evaluation=evaluation,
+        ),
+        recorded_at=resolved_recorded_at,
+        trace_id="launchplane_req_every_code_rerun_test",
+        idempotency_key=idempotency_key,
+        request=request,
+        evaluation=evaluation,
+    )
+    store.write_agent_write_intent_record(record)
+    return record
+
+
 def _every_code_work_request_create_payload(*, issue_number: int = 123) -> dict[str, object]:
     return {
         "repository": "cbusillo/code",
@@ -16929,6 +17422,28 @@ async def _post_every_code_work_request_status(
         app,
         "POST",
         "/v1/every-code/work-requests/status",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
+async def _post_every_code_work_request_rerun(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/every-code/work-requests/rerun",
         headers=request_headers,
         payload=payload,
     )
@@ -18414,6 +18929,87 @@ class _EveryCodeStatusReplayOnlyStore:
         del record
         self.write_calls += 1
         raise AssertionError("idempotent replay must not write a work request")
+
+
+class _EveryCodeRerunReplayOnlyStore:
+    def __init__(self, *, payload: dict[str, object], idempotency_key: str) -> None:
+        self.read_idempotency_calls = 0
+        self.read_calls = 0
+        self.write_calls = 0
+        self._payload = payload
+        self._idempotency_key = idempotency_key
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> LaunchplaneIdempotencyRecord | None:
+        self.read_idempotency_calls += 1
+        if (
+            route_path != "/v1/every-code/work-requests/rerun"
+            or idempotency_key != self._idempotency_key
+        ):
+            return None
+        return LaunchplaneIdempotencyRecord(
+            record_id="idempotency-launchplane_req_original",
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=hashlib.sha256(
+                json.dumps(self._payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest(),
+            response_status_code=202,
+            response_trace_id="launchplane_req_original",
+            recorded_at="2026-05-29T12:00:00Z",
+            response_payload={
+                "status": "accepted",
+                "trace_id": "launchplane_req_original",
+                "records": {
+                    "request_id": "every-code-cbusillo-code-123-test",
+                    "state": "queued",
+                    "agent_write_intent_record_id": "agent-write-intent-test",
+                },
+                "result": {
+                    "request": {
+                        "request_id": "every-code-cbusillo-code-123-test",
+                        "state": "queued",
+                        "trigger_actor": "cbusillo",
+                    }
+                },
+            },
+        )
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> None:
+        del record
+        raise AssertionError("idempotent replay must not write a new record")
+
+    def read_every_code_work_request_record(self, request_id: str) -> EveryCodeWorkRequestRecord:
+        del request_id
+        self.read_calls += 1
+        raise AssertionError("idempotent replay must not read a work request")
+
+    def write_every_code_work_request_record(self, record: EveryCodeWorkRequestRecord) -> None:
+        del record
+        self.write_calls += 1
+        raise AssertionError("idempotent replay must not write a work request")
+
+    def read_agent_write_intent_record(self, record_id: str) -> AgentWriteIntentRecord:
+        del record_id
+        raise AssertionError("idempotent replay must not read write-intent evidence")
+
+    def list_agent_write_intent_records(
+        self,
+        *,
+        product: str = "",
+        context_name: str = "",
+        status: str = "",
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> tuple[AgentWriteIntentRecord, ...]:
+        del product, context_name, status, limit, offset
+        raise AssertionError("idempotent replay must not list write-intent evidence")
 
 
 class _ProductContextApplyReplayOnlyStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9140,18 +9140,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(feedback_records, ())
         self.assertEqual(gate_records, ())
 
-    def test_every_code_worker_token_reruns_terminal_request(self) -> None:
-        secret = "launchplane-every-code-webhook-secret"
-        issue_payload = _every_code_github_issue_labeled_payload()
+    def test_every_code_work_request_rerun_is_retired_from_legacy_wsgi_app(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {
                 "github_actions": [
                     {
-                        "repository": "every/verireel",
+                        "repository": "cbusillo/launchplane",
                         "workflow_refs": [
-                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
                         ],
-                        "event_names": ["pull_request"],
+                        "event_names": ["workflow_dispatch"],
                         "products": ["launchplane"],
                         "contexts": ["launchplane"],
                         "actions": ["every_code_work_request.rerun"],
@@ -9159,36 +9157,20 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ]
             }
         )
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict(
-                os.environ,
-                {
-                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
-                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
-                },
-            ),
-        ):
+        identity = _identity(
+            repository="cbusillo/launchplane",
+            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
+            event_name="workflow_dispatch",
+        )
+        with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
             app = create_launchplane_service_app(
                 state_dir=state_dir,
-                verifier=_StubVerifier(_identity()),
+                verifier=_StubVerifier(identity),
                 authz_policy=policy,
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            _issue_status, issue_response = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/github-webhook",
-                payload=issue_payload,
-                authorization="",
-                headers={
-                    "X-GitHub-Event": "issues",
-                    "X-GitHub-Delivery": "delivery-issue",
-                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
-                },
-            )
-            request_id = issue_response["records"]["request_id"]
+            request_id = _seed_every_code_work_request_record(state_dir).request_id
             _claim_every_code_work_request_in_filesystem(state_dir, str(request_id))
             _update_every_code_work_request_status_in_filesystem(
                 state_dir,
@@ -9197,21 +9179,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 error_message="Needs another pass.",
                 updated_at="2026-05-06T16:00:00Z",
             )
-            intent_status, intent_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/agent/write-intents/evaluate",
-                payload={
-                    "intent": "every_code_rerun",
-                    "mode": "apply",
-                    "product": "launchplane",
-                    "context": "launchplane",
-                    "source_url": "https://github.com/cbusillo/code/issues/123",
-                    "reason": "Approved rerun for blocked Every Code request.",
-                },
-            )
-            intent_record_id = intent_payload["result"]["record"]["record_id"]
-
             rerun_status, rerun_response = _invoke_app(
                 app,
                 method="POST",
@@ -9219,81 +9186,44 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload={
                     "request_id": request_id,
                     "trigger_actor": "ops",
-                    "agent_write_intent_record_id": intent_record_id,
                 },
-                authorization="Bearer dev-worker-token",
+                headers={"Idempotency-Key": "every-code-rerun-code-123"},
+            )
+            stored_request = FilesystemRecordStore(state_dir).read_every_code_work_request_record(
+                request_id
             )
 
-        self.assertEqual(intent_status, 202)
-        self.assertEqual(rerun_status, 202)
-        request = rerun_response["result"]["request"]
-        self.assertEqual(request["state"], "queued")
-        self.assertEqual(request["trigger_actor"], "ops")
-        self.assertEqual(request["claimed_by_host"], "")
-        self.assertEqual(request["error_message"], "")
+        self.assertEqual(rerun_status, 404)
+        self.assertEqual(rerun_response["error"]["code"], "not_found")
+        self.assertEqual(stored_request.state, "blocked")
+        self.assertEqual(stored_request.error_message, "Needs another pass.")
 
-    def test_every_code_worker_token_cannot_rerun_active_request(self) -> None:
-        secret = "launchplane-every-code-webhook-secret"
-        issue_payload = _every_code_github_issue_labeled_payload()
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "every/verireel",
-                        "workflow_refs": [
-                            "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                        ],
-                        "event_names": ["pull_request"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": ["every_code_work_request.rerun"],
-                    }
-                ]
-            }
-        )
+    def test_every_code_work_request_rerun_worker_token_is_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
             patch.dict(
                 os.environ,
-                {
-                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
-                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
-                },
+                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token"},
             ),
         ):
             app = create_launchplane_service_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            _issue_status, issue_response = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/github-webhook",
-                payload=issue_payload,
-                authorization="",
-                headers={
-                    "X-GitHub-Event": "issues",
-                    "X-GitHub-Delivery": "delivery-issue",
-                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
-                },
+            state_dir = Path(temporary_directory_name) / "state"
+            request_id = _seed_every_code_work_request_record(state_dir).request_id
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="blocked",
+                error_message="Needs another pass.",
+                updated_at="2026-05-05T22:05:00Z",
             )
-            request_id = issue_response["records"]["request_id"]
-            intent_status, intent_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/agent/write-intents/evaluate",
-                payload={
-                    "intent": "every_code_rerun",
-                    "mode": "apply",
-                    "product": "launchplane",
-                    "context": "launchplane",
-                    "source_url": "https://github.com/cbusillo/code/issues/123",
-                    "reason": "Approved rerun for active Every Code request.",
-                },
-            )
-            intent_record_id = intent_payload["result"]["record"]["record_id"]
 
             rerun_status, rerun_response = _invoke_app(
                 app,
@@ -9302,14 +9232,17 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 payload={
                     "request_id": request_id,
                     "trigger_actor": "ops",
-                    "agent_write_intent_record_id": intent_record_id,
                 },
                 authorization="Bearer dev-worker-token",
             )
+            stored_request = FilesystemRecordStore(state_dir).read_every_code_work_request_record(
+                request_id
+            )
 
-        self.assertEqual(intent_status, 202)
-        self.assertEqual(rerun_status, 400)
-        self.assertEqual(rerun_response["error"]["code"], "invalid_payload")
+        self.assertEqual(rerun_status, 404)
+        self.assertEqual(rerun_response["error"]["code"], "not_found")
+        self.assertEqual(stored_request.state, "blocked")
+        self.assertEqual(stored_request.error_message, "Needs another pass.")
 
     def test_every_code_github_webhook_rejects_invalid_signature(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
@@ -9646,294 +9579,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(show_payload["error"]["code"], "not_found")
         self.assertEqual(write_status, 404)
         self.assertEqual(write_payload["error"]["code"], "not_found")
-
-    def test_every_code_worker_token_can_rerun_terminal_request(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": [
-                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
-                        ],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": [
-                            "every_code_work_request.write",
-                            "every_code_work_request.rerun",
-                        ],
-                    }
-                ]
-            }
-        )
-        identity = _identity(
-            repository="cbusillo/launchplane",
-            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
-            event_name="workflow_dispatch",
-        )
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict(
-                os.environ,
-                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
-            ),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(identity),
-                authz_policy=policy,
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            request_id = _seed_every_code_work_request_record(state_dir).request_id
-            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _update_every_code_work_request_status_in_filesystem(
-                state_dir,
-                request_id,
-                state="blocked",
-                result_pr_url="https://github.com/cbusillo/code/pull/26",
-                result_summary="Detached session went stale.",
-                error_message="Detached session went stale.",
-                updated_at="2026-05-05T22:05:00Z",
-            )
-            intent_status, intent_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/agent/write-intents/evaluate",
-                payload={
-                    "intent": "every_code_rerun",
-                    "mode": "apply",
-                    "product": "launchplane",
-                    "context": "launchplane",
-                    "source_url": "https://github.com/cbusillo/code/issues/123",
-                    "reason": "Approved rerun for blocked Every Code request.",
-                },
-                headers={"Idempotency-Key": "every-code-rerun-intent:123"},
-            )
-            intent_record_id = intent_payload["result"]["record"]["record_id"]
-            rerun_status, rerun_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/rerun",
-                payload={
-                    "request_id": request_id,
-                    "trigger_actor": "cbusillo",
-                    "source_url": "https://github.com/cbusillo/code/issues/123",
-                    "agent_write_intent_record_id": intent_record_id,
-                },
-                authorization="Bearer worker-token",
-                headers={"Idempotency-Key": "every-code-rerun-intent:123"},
-            )
-
-        self.assertEqual(intent_status, 202)
-        self.assertEqual(rerun_status, 202)
-        self.assertEqual(rerun_payload["records"]["agent_write_intent_record_id"], intent_record_id)
-        self.assertEqual(rerun_payload["records"]["state"], "queued")
-        self.assertEqual(rerun_payload["result"]["request"]["trigger_actor"], "cbusillo")
-        self.assertEqual(rerun_payload["result"]["request"]["claimed_by_host"], "")
-        self.assertEqual(rerun_payload["result"]["request"]["result_pr_url"], "")
-        self.assertEqual(rerun_payload["result"]["request"]["error_message"], "")
-
-    def test_every_code_rerun_requires_matching_write_intent_evidence(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": [
-                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
-                        ],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane"],
-                        "actions": [
-                            "every_code_work_request.write",
-                            "every_code_work_request.rerun",
-                        ],
-                    }
-                ]
-            }
-        )
-        identity = _identity(
-            repository="cbusillo/launchplane",
-            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
-            event_name="workflow_dispatch",
-        )
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict(
-                os.environ,
-                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
-            ),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(identity),
-                authz_policy=policy,
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            request_id = _seed_every_code_work_request_record(state_dir).request_id
-            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _update_every_code_work_request_status_in_filesystem(
-                state_dir,
-                request_id,
-                state="blocked",
-                error_message="Needs another pass.",
-                updated_at="2026-05-05T22:05:00Z",
-            )
-
-            missing_status, missing_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/rerun",
-                payload={"request_id": request_id, "trigger_actor": "cbusillo"},
-                authorization="Bearer worker-token",
-            )
-            wrong_source_status, wrong_source_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/agent/write-intents/evaluate",
-                payload={
-                    "intent": "every_code_rerun",
-                    "mode": "apply",
-                    "product": "launchplane",
-                    "context": "launchplane",
-                    "source_url": "https://github.com/cbusillo/code/issues/999",
-                    "reason": "Approved rerun for a different Every Code request.",
-                },
-            )
-            wrong_source_record_id = wrong_source_payload["result"]["record"]["record_id"]
-            mismatched_status, mismatched_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/rerun",
-                payload={
-                    "request_id": request_id,
-                    "trigger_actor": "cbusillo",
-                    "source_url": "https://github.com/cbusillo/code/issues/123",
-                    "agent_write_intent_record_id": wrong_source_record_id,
-                },
-                authorization="Bearer worker-token",
-            )
-
-        self.assertEqual(missing_status, 409)
-        self.assertEqual(missing_payload["error"]["code"], "agent_write_intent_required")
-        self.assertEqual(wrong_source_status, 202)
-        self.assertEqual(mismatched_status, 409)
-        self.assertEqual(mismatched_payload["error"]["code"], "agent_write_intent_source_mismatch")
-
-    def test_every_code_rerun_rejects_stale_and_wrong_context_write_intents(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {
-                "github_actions": [
-                    {
-                        "repository": "cbusillo/launchplane",
-                        "workflow_refs": [
-                            "cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main"
-                        ],
-                        "event_names": ["workflow_dispatch"],
-                        "products": ["launchplane"],
-                        "contexts": ["launchplane", "other-context"],
-                        "actions": [
-                            "every_code_work_request.write",
-                            "every_code_work_request.rerun",
-                        ],
-                    }
-                ]
-            }
-        )
-        identity = _identity(
-            repository="cbusillo/launchplane",
-            workflow_ref="cbusillo/launchplane/.github/workflows/every-code-worker.yml@refs/heads/main",
-            event_name="workflow_dispatch",
-        )
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict(
-                os.environ,
-                {"LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "worker-token"},
-            ),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(identity),
-                authz_policy=policy,
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            request_id = _seed_every_code_work_request_record(state_dir).request_id
-            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
-            _update_every_code_work_request_status_in_filesystem(
-                state_dir,
-                request_id,
-                state="blocked",
-                error_message="Needs another pass.",
-                updated_at="2026-05-05T22:05:00Z",
-            )
-            _wrong_context_status, wrong_context_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/agent/write-intents/evaluate",
-                payload={
-                    "intent": "every_code_rerun",
-                    "mode": "apply",
-                    "product": "launchplane",
-                    "context": "other-context",
-                    "source_url": "https://github.com/cbusillo/code/issues/123",
-                    "reason": "Approved rerun in the wrong context.",
-                },
-            )
-            wrong_context_record_id = wrong_context_payload["result"]["record"]["record_id"]
-            wrong_context_status, wrong_context_rerun_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/rerun",
-                payload={
-                    "request_id": request_id,
-                    "agent_write_intent_record_id": wrong_context_record_id,
-                },
-                authorization="Bearer worker-token",
-            )
-
-            _intent_status, intent_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/agent/write-intents/evaluate",
-                payload={
-                    "intent": "every_code_rerun",
-                    "mode": "apply",
-                    "product": "launchplane",
-                    "context": "launchplane",
-                    "source_url": "https://github.com/cbusillo/code/issues/123",
-                    "reason": "Approved rerun for a blocked Every Code request.",
-                },
-            )
-            stale_record_id = intent_payload["result"]["record"]["record_id"]
-            store = FilesystemRecordStore(state_dir)
-            stale_record = store.read_agent_write_intent_record(stale_record_id)
-            store.write_agent_write_intent_record(
-                stale_record.model_copy(update={"recorded_at": "2026-01-01T00:00:00Z"})
-            )
-            stale_status, stale_payload = _invoke_app(
-                app,
-                method="POST",
-                path="/v1/every-code/work-requests/rerun",
-                payload={
-                    "request_id": request_id,
-                    "agent_write_intent_record_id": stale_record_id,
-                },
-                authorization="Bearer worker-token",
-            )
-
-        self.assertEqual(wrong_context_status, 409)
-        self.assertEqual(
-            wrong_context_rerun_payload["error"]["code"],
-            "agent_write_intent_scope_mismatch",
-        )
-        self.assertEqual(stale_status, 409)
-        self.assertEqual(stale_payload["error"]["code"], "agent_write_intent_stale")
 
     def test_every_code_worker_read_route_is_retired_before_authentication(self) -> None:
         with (


### PR DESCRIPTION
## Summary

- Move `POST /v1/every-code/work-requests/rerun` from the legacy WSGI fallback into the native FastAPI service.
- Require approved `every_code_rerun` write-intent evidence and bind it to the stored work-request issue URL before requeueing.
- Preserve workflow idempotency replay before write-store capability checks, while keeping worker-token reruns out of idempotency state writes.
- Retire the stale WSGI rerun branch and update boundary/compatibility docs.

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiEveryCodeReadTests tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_rerun_is_retired_from_legacy_wsgi_app tests.test_service.LaunchplaneServiceTests.test_every_code_work_request_rerun_worker_token_is_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
- JetBrains changed-files inspection: green
- Review agents: final focused rerun/write-intent/error-serialization review returned no findings
