### PR TITLE
Migrate live target runtime apply to FastAPI

### DIFF
--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -566,11 +566,12 @@ def read_control_plane_environment_values(
 def read_control_plane_dokploy_source_of_truth(
     *,
     control_plane_root: Path,
+    database_url: str | None = None,
     allow_incomplete_target_ids: bool = False,
     allowed_incomplete_target_routes: tuple[tuple[str, str], ...] = (),
 ) -> DokploySourceOfTruth:
     del control_plane_root
-    database_url = resolve_database_url()
+    database_url = resolve_database_url(database_url)
     if not database_url:
         raise click.ClickException(
             "Missing Launchplane tracked Dokploy target authority. Configure DB-backed tracked target records."

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -32,6 +32,7 @@ from control_plane import product_read_service as control_plane_product_read_ser
 from control_plane import secrets as control_plane_secrets
 from control_plane import service_status as control_plane_service_status
 from control_plane import tracked_target_logs as control_plane_tracked_target_logs
+from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane.agent_context_service import (
     AgentContextPayload,
     agent_context_action_allowed,
@@ -254,6 +255,7 @@ _PREVIEW_PR_FEEDBACK_NOTIFICATION_POLICY_APPLY_ROUTE = (
 _RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE = "/v1/runtime-key-safety/policies/apply"
 _EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
 _PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE = "/v1/private-health-endpoints/apply"
+_LIVE_TARGET_RUNTIME_APPLY_ROUTE = "/v1/live-target-runtime/apply"
 _INGRESS_ROUTE_APPLY_ROUTE = "/v1/drivers/ingress/route-apply"
 _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE = "/v1/ingress/canary-routes/records/apply"
 _INGRESS_CANARY_ROUTE_APPLY_ROUTE = "/v1/ingress/canary-routes/apply"
@@ -6791,6 +6793,18 @@ def create_launchplane_fastapi_app(
             )
         return record_store
 
+    def require_live_target_runtime_database_store(
+        *, record_store: object, trace_id: str
+    ) -> PostgresRecordStore:
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message="Live target runtime apply requires DB-backed Launchplane storage.",
+            )
+        return record_store
+
     def require_local_operator_notification_policy_reason(
         *, identity: LaunchplaneIdentity, reason: str, trace_id: str, message: str
     ) -> None:
@@ -7098,6 +7112,133 @@ def create_launchplane_fastapi_app(
             response=product_config_response,
         )
         return product_config_response
+
+    async def apply_live_target_runtime(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            )
+        try:
+            live_target_runtime_request = (
+                control_plane_live_target_runtime.LiveTargetRuntimeApplyEnvelope.model_validate(
+                    raw_payload
+                )
+            )
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        action = (
+            "live_target_runtime.apply"
+            if live_target_runtime_request.apply_changes
+            else "live_target_runtime.plan"
+        )
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=action,
+            product=live_target_runtime_request.product,
+            context=live_target_runtime_request.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot plan or apply live target runtime for the requested"
+                    " product/context."
+                ),
+            )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_LIVE_TARGET_RUNTIME_APPLY_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+        live_target_runtime_store = require_live_target_runtime_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        try:
+            driver_result = control_plane_live_target_runtime.apply_live_target_runtime_environment(
+                control_plane_root=resolved_control_plane_root,
+                database_url=live_target_runtime_store.database_url,
+                product_name=live_target_runtime_request.product,
+                context_name=live_target_runtime_request.context,
+                instance_name=live_target_runtime_request.instance,
+                apply_changes=live_target_runtime_request.apply_changes,
+                deploy=live_target_runtime_request.deploy,
+                no_cache=live_target_runtime_request.no_cache,
+                deploy_timeout_seconds=live_target_runtime_request.deploy_timeout_seconds,
+                deploy_trigger=(
+                    control_plane_live_target_runtime.trigger_and_wait_for_dokploy_target_deploy
+                ),
+            )
+        except control_plane_live_target_runtime.LiveTargetRuntimeError as error:
+            status_code = 400
+            if error.code in {
+                "runtime_key_safety_unavailable",
+                "runtime_environment_unavailable",
+                "dokploy_target_read_failed",
+            }:
+                status_code = 503
+            raise _launchplane_http_error(
+                status_code=status_code,
+                trace_id=trace_id,
+                code=error.code,
+                message=str(error),
+            ) from error
+        tracked_target = driver_result.get("tracked_target")
+        records: dict[str, str] = {}
+        if isinstance(tracked_target, dict):
+            records = {
+                "target_id": str(tracked_target.get("target_id", "")),
+                "target_type": str(tracked_target.get("target_type", "")),
+            }
+        live_target_runtime_response = accepted_evidence_response(
+            trace_id=trace_id,
+            records=records,
+            result=driver_result,
+        )
+        store_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_LIVE_TARGET_RUNTIME_APPLY_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=live_target_runtime_response,
+        )
+        return live_target_runtime_response
 
     async def apply_product_context_cutover(
         request: Request,
@@ -10191,6 +10332,34 @@ def create_launchplane_fastapi_app(
         },
         operation_id="apply_product_config",
         summary="Plan or apply product config",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _LIVE_TARGET_RUNTIME_APPLY_ROUTE,
+        apply_live_target_runtime,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": control_plane_live_target_runtime.LiveTargetRuntimeApplyEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="apply_live_target_runtime",
+        summary="Plan or apply live target runtime",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/live_target_runtime.py
+++ b/control_plane/live_target_runtime.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Protocol
 
 import click
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
@@ -34,6 +35,48 @@ class LiveTargetRuntimeError(Exception):
         super().__init__(message)
         self.code = code
         self.summary = summary or {}
+
+
+class LiveTargetRuntimeApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    mode: str
+    product: str
+    context: str
+    instance: str
+    deploy: bool = False
+    no_cache: bool = False
+    deploy_timeout_seconds: int | None = Field(default=None, gt=0)
+
+    @field_validator("mode")
+    @classmethod
+    def _validate_mode(cls, value: str) -> str:
+        normalized_value = value.strip().lower()
+        if normalized_value not in {"dry-run", "apply"}:
+            raise ValueError("Live target runtime mode must be 'dry-run' or 'apply'.")
+        return normalized_value
+
+    @model_validator(mode="after")
+    def _validate_route(self) -> "LiveTargetRuntimeApplyEnvelope":
+        self.product = self.product.strip()
+        self.context = self.context.strip()
+        self.instance = self.instance.strip()
+        if not self.product:
+            raise ValueError("Live target runtime apply requires product.")
+        if not self.context:
+            raise ValueError("Live target runtime apply requires context.")
+        if not self.instance:
+            raise ValueError("Live target runtime apply requires instance.")
+        if self.mode == "dry-run" and (
+            self.deploy or self.no_cache or self.deploy_timeout_seconds is not None
+        ):
+            raise ValueError("Deploy options require live target runtime mode 'apply'.")
+        return self
+
+    @property
+    def apply_changes(self) -> bool:
+        return self.mode == "apply"
 
 
 class DokployDeployTrigger(Protocol):
@@ -338,6 +381,7 @@ def require_dokploy_target_definition(
 def apply_live_target_runtime_environment(
     *,
     control_plane_root: Path,
+    database_url: str | None = None,
     product_name: str = "",
     context_name: str,
     instance_name: str,
@@ -349,6 +393,7 @@ def apply_live_target_runtime_environment(
 ) -> dict[str, object]:
     source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
         control_plane_root=control_plane_root,
+        database_url=database_url,
     )
     target_definition = require_dokploy_target_definition(
         source_of_truth=source_of_truth,
@@ -361,6 +406,7 @@ def apply_live_target_runtime_environment(
             control_plane_root=control_plane_root,
             context_name=context_name,
             instance_name=instance_name,
+            database_url=database_url,
         )
     except click.ClickException as error:
         raise LiveTargetRuntimeError(str(error), code="runtime_environment_unavailable") from error
@@ -370,7 +416,7 @@ def apply_live_target_runtime_environment(
             code="runtime_environment_empty",
         )
 
-    database_url = resolve_database_url(None)
+    database_url = resolve_database_url(database_url)
     runtime_secret_binding_keys: set[str] = set()
     if product_name.strip():
         if database_url is None:
@@ -410,7 +456,8 @@ def apply_live_target_runtime_environment(
 
     try:
         host, token = control_plane_dokploy.read_dokploy_config(
-            control_plane_root=control_plane_root
+            control_plane_root=control_plane_root,
+            database_url=database_url,
         )
         target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
             host=host,

--- a/control_plane/runtime_environments.py
+++ b/control_plane/runtime_environments.py
@@ -88,6 +88,7 @@ def resolve_runtime_environment_values(
             control_plane_root=control_plane_root,
             context_name=context_name,
             instance_name=instance_name,
+            database_url=database_url,
         )
     )
     return control_plane_secrets.overlay_runtime_environment_secret_values(
@@ -127,10 +128,12 @@ def resolve_tracked_target_environment_values(
     control_plane_root: Path,
     context_name: str,
     instance_name: str,
+    database_url: str | None = None,
 ) -> dict[str, str]:
     try:
         source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
-            control_plane_root=control_plane_root
+            control_plane_root=control_plane_root,
+            database_url=database_url,
         )
     except click.ClickException as error:
         error_message = str(error)

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -26,7 +26,6 @@ from control_plane.http_app import (
     create_launchplane_fastapi_app,
     resolve_launchplane_authz_policy,
 )
-from control_plane import live_target_runtime as control_plane_live_target_runtime
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.authz_policy_record import (
@@ -1721,48 +1720,6 @@ class ProductOnboardingApplyEnvelope(BaseModel):
         return self
 
 
-class LiveTargetRuntimeApplyEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    mode: str
-    product: str
-    context: str
-    instance: str
-    deploy: bool = False
-    no_cache: bool = False
-    deploy_timeout_seconds: int | None = Field(default=None, gt=0)
-
-    @field_validator("mode")
-    @classmethod
-    def _validate_mode(cls, value: str) -> str:
-        normalized_value = value.strip().lower()
-        if normalized_value not in {"dry-run", "apply"}:
-            raise ValueError("Live target runtime mode must be 'dry-run' or 'apply'.")
-        return normalized_value
-
-    @model_validator(mode="after")
-    def _validate_route(self) -> "LiveTargetRuntimeApplyEnvelope":
-        self.product = self.product.strip()
-        self.context = self.context.strip()
-        self.instance = self.instance.strip()
-        if not self.product:
-            raise ValueError("Live target runtime apply requires product.")
-        if not self.context:
-            raise ValueError("Live target runtime apply requires context.")
-        if not self.instance:
-            raise ValueError("Live target runtime apply requires instance.")
-        if self.mode == "dry-run" and (
-            self.deploy or self.no_cache or self.deploy_timeout_seconds is not None
-        ):
-            raise ValueError("Deploy options require live target runtime mode 'apply'.")
-        return self
-
-    @property
-    def apply_changes(self) -> bool:
-        return self.mode == "apply"
-
-
 def _redirect_response(
     *,
     start_response: _StartResponse,
@@ -3452,7 +3409,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/authz-policies/local-operators/grants",
         "/v1/authz-policies/local-admins/grants",
         "/v1/merge-train/policies/import",
-        "/v1/live-target-runtime/apply",
         "/v1/product-onboarding/apply",
         PROVIDER_TARGET_OPERATIONS_ROUTE,
         "/v1/previews/desired-state",
@@ -9549,102 +9505,6 @@ def create_launchplane_service_app(
                     },
                 }
                 driver_result = result
-            elif path == "/v1/live-target-runtime/apply":
-                live_target_runtime_request = LiveTargetRuntimeApplyEnvelope.model_validate(payload)
-                action = (
-                    "live_target_runtime.apply"
-                    if live_target_runtime_request.apply_changes
-                    else "live_target_runtime.plan"
-                )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action=action,
-                    product=live_target_runtime_request.product,
-                    context=live_target_runtime_request.context,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": (
-                                    "Workflow cannot plan or apply live target runtime for"
-                                    " the requested product/context."
-                                ),
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                if not isinstance(record_store, PostgresRecordStore):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "database_required",
-                                "message": (
-                                    "Live target runtime apply requires DB-backed Launchplane"
-                                    " storage."
-                                ),
-                            },
-                        },
-                    )
-                try:
-                    driver_result = control_plane_live_target_runtime.apply_live_target_runtime_environment(
-                        control_plane_root=resolved_root,
-                        product_name=live_target_runtime_request.product,
-                        context_name=live_target_runtime_request.context,
-                        instance_name=live_target_runtime_request.instance,
-                        apply_changes=live_target_runtime_request.apply_changes,
-                        deploy=live_target_runtime_request.deploy,
-                        no_cache=live_target_runtime_request.no_cache,
-                        deploy_timeout_seconds=(live_target_runtime_request.deploy_timeout_seconds),
-                        deploy_trigger=(
-                            control_plane_live_target_runtime.trigger_and_wait_for_dokploy_target_deploy
-                        ),
-                    )
-                except control_plane_live_target_runtime.LiveTargetRuntimeError as error:
-                    status_code = 400
-                    if error.code in {
-                        "runtime_key_safety_unavailable",
-                        "runtime_environment_unavailable",
-                        "dokploy_target_read_failed",
-                    }:
-                        status_code = 503
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=status_code,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": error.code,
-                                "message": str(error),
-                            },
-                        },
-                    )
-                tracked_target = driver_result.get("tracked_target")
-                result = {}
-                if isinstance(tracked_target, dict):
-                    result = {
-                        "target_id": str(tracked_target.get("target_id", "")),
-                        "target_type": str(tracked_target.get("target_type", "")),
-                    }
             elif path == "/v1/product-onboarding/apply":
                 onboarding_request = ProductOnboardingApplyEnvelope.model_validate(payload)
                 if not isinstance(record_store, PostgresRecordStore):

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -202,13 +202,14 @@ Keep a compatibility surface only when it is one of these:
   enforcement, metadata-only policy writes, and optional `Idempotency-Key`
   replay/conflict behavior. Its legacy WSGI write branch and WSGI-only helper
   code are deleted, and direct WSGI fallback calls fail closed.
-- Live target runtime apply uses `POST /v1/live-target-runtime/apply` and the
-  `live-target-runtime.yml` workflow for shared and production live changes.
-  The local checkout `environments apply-live-target` mutation command is
-  deleted, and the local checkout `environments sync-live-target` drift-preview
-  compatibility command is deleted. Operators use service/API identity so
-  Launchplane resolves current DB-backed target authority and records sanitized
-  key/count evidence.
+- Live target runtime apply uses native FastAPI
+  `POST /v1/live-target-runtime/apply` and the `live-target-runtime.yml`
+  workflow for shared and production live changes. Its legacy WSGI write branch
+  is deleted, and direct WSGI fallback calls fail closed. The local checkout
+  `environments apply-live-target` mutation command is deleted, and the local
+  checkout `environments sync-live-target` drift-preview compatibility command
+  is deleted. Operators use service/API identity so Launchplane resolves current
+  DB-backed target authority and records sanitized key/count evidence.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1375,17 +1375,19 @@ environment responses because those responses can include provider target
 identifiers, runtime key names, managed-secret binding keys, and operational
 metadata.
 
-Live target runtime sync uses `POST /v1/live-target-runtime/apply`. The route
-accepts `mode: "dry-run"` or `mode: "apply"`, product/context/instance, and
-optional apply-only deploy controls. Dry-run requires `live_target_runtime.plan`;
-apply requires `live_target_runtime.apply`. The route resolves DB-backed runtime
-environment records, managed runtime secrets, and the tracked Dokploy target in
-the deployed Launchplane service, evaluates runtime key-safety policy, compares
-desired and live env by key, and returns sanitized key/count evidence without
-runtime values or secret plaintext. Apply updates only the product profile's
-expected runtime environment keys and runtime managed-secret binding keys for
-the selected lane, preserves unrelated live env, verifies persistence by key
-metadata, and can explicitly trigger a deploy when requested.
+Live target runtime sync uses the native FastAPI
+`POST /v1/live-target-runtime/apply` route. The route accepts `mode: "dry-run"`
+or `mode: "apply"`, product/context/instance, and optional apply-only deploy
+controls. Dry-run requires `live_target_runtime.plan`; apply requires
+`live_target_runtime.apply`. The route resolves DB-backed runtime environment
+records, managed runtime secrets, and the tracked Dokploy target in the deployed
+Launchplane service, evaluates runtime key-safety policy, compares desired and
+live env by key, and returns sanitized key/count evidence without runtime values
+or secret plaintext. Apply updates only the product profile's expected runtime
+environment keys and runtime managed-secret binding keys for the selected lane,
+preserves unrelated live env, verifies persistence by key metadata, and can
+explicitly trigger a deploy when requested. Its legacy WSGI fallback branch is
+deleted; direct WSGI fallback calls fail closed.
 
 Live target runtime applies are service-boundary work. Operators and agents must
 not run local CLI live-target mutation commands from arbitrary checkouts to make

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 from click import ClickException, Command
 from click.testing import CliRunner
+from a2wsgi import ASGIMiddleware
 from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane.cli import main
@@ -1379,6 +1380,23 @@ def create_launchplane_service_app(
     )
 
 
+def create_launchplane_fastapi_wsgi_app(
+    **kwargs: object,
+) -> Callable[[dict[str, object], Callable[[str, list[tuple[str, str]]], None]], list[bytes]]:
+    kwargs.pop("state_dir", None)
+    database_url = kwargs.get("database_url")
+    if isinstance(database_url, str) and database_url.startswith("sqlite"):
+        store = PostgresRecordStore(database_url=database_url)
+        store.ensure_schema()
+        store.close()
+    factory = cast(Any, create_launchplane_fastapi_app)
+    app = factory(**kwargs)
+    return cast(
+        Callable[[dict[str, object], Callable[[str, list[tuple[str, str]]], None]], list[bytes]],
+        ASGIMiddleware(app),
+    )
+
+
 def create_launchplane_dokploy_target_setup_app(**kwargs: object) -> Any:
     state_dir = kwargs.pop("state_dir", None)
     local_record_store = kwargs.pop("local_record_store_for_tests", None)
@@ -2086,12 +2104,19 @@ def _invoke_app(
         "CONTENT_LENGTH": str(len(body_bytes)),
         "wsgi.input": io.BytesIO(body_bytes),
         "HTTP_AUTHORIZATION": authorization,
+        "SERVER_NAME": "testserver",
+        "SERVER_PORT": "80",
+        "wsgi.url_scheme": "http",
     }
     for header_name, header_value in (headers or {}).items():
         environ[f"HTTP_{header_name.upper().replace('-', '_')}"] = header_value
     captured_status = ""
 
-    def start_response(status: str, _response_headers: list[tuple[str, str]]) -> None:
+    def start_response(
+        status: str,
+        _response_headers: list[tuple[str, str]],
+        _exc_info: object | None = None,
+    ) -> None:
         nonlocal captured_status
         captured_status = status
 
@@ -19614,7 +19639,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -19634,7 +19659,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 patch.dict(
                     os.environ,
                     {
-                        "LAUNCHPLANE_DATABASE_URL": database_url,
                         control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
                     },
                     clear=True,
@@ -19729,7 +19753,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -19834,7 +19858,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -19960,7 +19984,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -20119,7 +20143,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -20136,7 +20160,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.service.control_plane_live_target_runtime.apply_live_target_runtime_environment",
+                "control_plane.http_app.control_plane_live_target_runtime.apply_live_target_runtime_environment",
                 side_effect=control_plane_live_target_runtime.LiveTargetRuntimeError(
                     "Live target runtime apply requires LAUNCHPLANE_DATABASE_URL for DB-backed runtime key-safety evaluation.",
                     code="runtime_key_safety_unavailable",
@@ -20176,7 +20200,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
@@ -20202,6 +20226,113 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_live_target_runtime_apply_requires_database_storage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard"],
+                            "actions": ["live_target_runtime.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(repository="cbusillo/launchplane", event_name="workflow_dispatch")
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/live-target-runtime/apply",
+                payload={
+                    "schema_version": 1,
+                    "mode": "dry-run",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard",
+                    "instance": "prod",
+                },
+                headers={"Idempotency-Key": "live-target-runtime:filesystem-store"},
+            )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "database_required")
+
+    def test_openapi_includes_live_target_runtime_apply_contract(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_fastapi_wsgi_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+
+            status_code, payload = _invoke_app(app, method="GET", path="/openapi.json")
+
+        self.assertEqual(status_code, 200)
+        route = payload["paths"]["/v1/live-target-runtime/apply"]["post"]
+        self.assertEqual(route["operationId"], "apply_live_target_runtime")
+        self.assertEqual(
+            route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
+            "#/components/schemas/AcceptedEvidenceResponse",
+        )
+        self.assertEqual(
+            route["requestBody"]["content"]["application/json"]["schema"]["title"],
+            "LiveTargetRuntimeApplyEnvelope",
+        )
+        for response_status in ("400", "401", "403", "409", "503"):
+            self.assertIn(response_status, route["responses"])
+
+    def test_live_target_runtime_apply_is_retired_from_legacy_wsgi_app(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate(
+                    {
+                        "github_actions": [
+                            {
+                                "repository": "cbusillo/launchplane",
+                                "products": ["sellyouroutboard"],
+                                "contexts": ["sellyouroutboard"],
+                                "actions": ["live_target_runtime.apply"],
+                            }
+                        ]
+                    }
+                ),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/live-target-runtime/apply",
+                payload={
+                    "schema_version": 1,
+                    "mode": "apply",
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard",
+                    "instance": "prod",
+                },
+                headers={"Idempotency-Key": "live-target-runtime:retired-wsgi"},
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_evidence_ingress_routes_are_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- migrate `POST /v1/live-target-runtime/apply` to native FastAPI with request validation, OpenAPI contract, authz, idempotency, and accepted evidence response handling
- retire the legacy WSGI write branch/list entry so direct fallback calls fail closed
- thread the validated Postgres database URL through live target runtime, Dokploy, and runtime environment helpers so service `--database-url` works without `LAUNCHPLANE_DATABASE_URL`
- update tests and docs for the v2 ownership boundary

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_dry_run_returns_redacted_delta tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_requires_expected_managed_secret_values tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_apply_updates_env_and_verifies tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_apply_can_trigger_deploy tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_apply_requires_database_for_key_safety tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_maps_runtime_key_safety_database_error tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_api_apply_requires_apply_authorization tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_apply_requires_database_storage tests.test_service.LaunchplaneServiceTests.test_openapi_includes_live_target_runtime_apply_contract tests.test_service.LaunchplaneServiceTests.test_live_target_runtime_apply_is_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/live_target_runtime.py control_plane/service.py control_plane/dokploy.py control_plane/runtime_environments.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/live_target_runtime.py control_plane/service.py control_plane/dokploy.py control_plane/runtime_environments.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
- JetBrains changed-files inspection: green

Refs #1322