### PR TITLE
Migrate provider-target operations to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -161,6 +161,13 @@ from control_plane.product_config_http import (
     ProductConfigApplyEnvelope,
     product_config_live_target_next_actions,
 )
+from control_plane.provider_target_operations_http import (
+    PROVIDER_TARGET_OPERATIONS_ROUTE,
+    ProviderTargetOperationEnvelope,
+    execute_provider_target_operation_route,
+    provider_target_operation_authorized,
+    provider_target_operation_requires_reason,
+)
 from control_plane.runtime_key_safety_http import (
     RuntimeKeySafetyPolicyApplyEnvelope,
     apply_runtime_key_safety_policy_route,
@@ -6805,6 +6812,18 @@ def create_launchplane_fastapi_app(
             )
         return record_store
 
+    def require_provider_target_operation_database_store(
+        *, record_store: object, trace_id: str
+    ) -> PostgresRecordStore:
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message="Provider-target operations require Launchplane database storage.",
+            )
+        return record_store
+
     def require_local_operator_notification_policy_reason(
         *, identity: LaunchplaneIdentity, reason: str, trace_id: str, message: str
     ) -> None:
@@ -7239,6 +7258,111 @@ def create_launchplane_fastapi_app(
             response=live_target_runtime_response,
         )
         return live_target_runtime_response
+
+    async def run_provider_target_operations(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            )
+        try:
+            provider_target_request = ProviderTargetOperationEnvelope.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        provider_target_store = require_provider_target_operation_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        if provider_target_operation_requires_reason(
+            identity=identity,
+            request=provider_target_request,
+        ):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="reason_required",
+                message="Local operator provider-target backfill apply requires a reason.",
+            )
+        if not provider_target_operation_authorized(
+            authz_policy=resolved_authz_policy_runtime.policy,
+            identity=identity,
+            request=provider_target_request,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot run Launchplane provider-target operations.",
+            )
+        normalized_idempotency_key = idempotency_key.strip()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if provider_target_request.mode == "backfill-apply":
+            if not normalized_idempotency_key:
+                raise _launchplane_http_error(
+                    status_code=400,
+                    trace_id=trace_id,
+                    code="idempotency_key_required",
+                    message=(
+                        "Provider-target backfill apply requests require an Idempotency-Key header."
+                    ),
+                )
+            (
+                normalized_idempotency_key,
+                payload_fingerprint,
+                replay_response,
+            ) = await replay_apply_idempotency(
+                request=request,
+                record_store=provider_target_store,
+                identity=identity,
+                route_path=PROVIDER_TARGET_OPERATIONS_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                trace_id=trace_id,
+                check_replay=True,
+            )
+            if replay_response is not None:
+                return replay_response
+        provider_target_result = execute_provider_target_operation_route(
+            record_store=provider_target_store,
+            request=provider_target_request,
+        )
+        provider_target_response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={},
+            result=provider_target_result.driver_result,
+        )
+        if provider_target_request.mode == "backfill-apply":
+            store_apply_idempotency(
+                record_store=provider_target_store,
+                identity=identity,
+                route_path=PROVIDER_TARGET_OPERATIONS_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=provider_target_response,
+            )
+        return provider_target_response
 
     async def apply_product_context_cutover(
         request: Request,
@@ -10360,6 +10484,34 @@ def create_launchplane_fastapi_app(
         },
         operation_id="apply_live_target_runtime",
         summary="Plan or apply live target runtime",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        PROVIDER_TARGET_OPERATIONS_ROUTE,
+        run_provider_target_operations,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": ProviderTargetOperationEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="run_provider_target_operations",
+        summary="Audit or backfill provider-target records",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -259,14 +259,6 @@ from control_plane.service_human_auth import (
 from control_plane.storage.factory import build_shared_record_store
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.ui_static_http import serve_ui_route
-from control_plane.provider_target_operations_http import (
-    PROVIDER_TARGET_OPERATIONS_ROUTE,
-    ProviderTargetOperationEnvelope,
-    ProviderTargetOperationRouteResult,
-    execute_provider_target_operation_route,
-    provider_target_operation_authorized,
-    provider_target_operation_requires_reason,
-)
 from control_plane.work_graph_github_projects import (
     build_github_project_planning_facts,
     load_github_project_planning_facts_config_from_env,
@@ -3410,7 +3402,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/authz-policies/local-admins/grants",
         "/v1/merge-train/policies/import",
         "/v1/product-onboarding/apply",
-        PROVIDER_TARGET_OPERATIONS_ROUTE,
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
@@ -6108,12 +6099,6 @@ def _should_store_idempotency_record(
         path == "/v1/merge-train/policies/import"
         and isinstance(driver_result, dict)
         and driver_result.get("mode") == "dry_run"
-    ):
-        return False
-    if (
-        path == PROVIDER_TARGET_OPERATIONS_ROUTE
-        and isinstance(driver_result, dict)
-        and driver_result.get("mode") != "backfill-apply"
     ):
         return False
     if driver_result is None:
@@ -9572,97 +9557,6 @@ def create_launchplane_service_app(
                         onboarding_result
                     )
                 )
-            elif path == PROVIDER_TARGET_OPERATIONS_ROUTE:
-                provider_target_request = ProviderTargetOperationEnvelope.model_validate(payload)
-                if not isinstance(record_store, PostgresRecordStore):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "database_required",
-                                "message": (
-                                    "Provider-target operations require Launchplane"
-                                    " database storage."
-                                ),
-                            },
-                        },
-                    )
-                if provider_target_operation_requires_reason(
-                    identity=identity,
-                    request=provider_target_request,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "reason_required",
-                                "message": (
-                                    "Local operator provider-target backfill apply"
-                                    " requires a reason."
-                                ),
-                            },
-                        },
-                    )
-                if not provider_target_operation_authorized(
-                    authz_policy=authz_policy,
-                    identity=identity,
-                    request=provider_target_request,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": (
-                                    "Workflow cannot run Launchplane provider-target operations."
-                                ),
-                            },
-                        },
-                    )
-                if provider_target_request.mode == "backfill-apply":
-                    if not request_idempotency_key:
-                        return _json_response(
-                            start_response=start_response,
-                            status_code=400,
-                            payload={
-                                "status": "rejected",
-                                "trace_id": request_trace_id,
-                                "error": {
-                                    "code": "idempotency_key_required",
-                                    "message": (
-                                        "Provider-target backfill apply requests require"
-                                        " an Idempotency-Key header."
-                                    ),
-                                },
-                            },
-                        )
-                    idempotent_response = _check_idempotent_request(
-                        record_store=record_store,
-                        scope=request_scope,
-                        route_path=path,
-                        idempotency_key=request_idempotency_key,
-                        request_fingerprint=request_fingerprint,
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                    )
-                    if idempotent_response is not None:
-                        return idempotent_response
-                provider_target_result = execute_provider_target_operation_route(
-                    record_store=record_store,
-                    request=provider_target_request,
-                )
-                assert isinstance(provider_target_result, ProviderTargetOperationRouteResult)
-                result = provider_target_result.result
-                driver_result = provider_target_result.driver_result
             elif path in descriptor_driver_dispatch_routes:
                 try:
                     dispatch_response = _dispatch_descriptor_driver_route(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -210,6 +210,13 @@ Keep a compatibility surface only when it is one of these:
   checkout `environments sync-live-target` drift-preview compatibility command
   is deleted. Operators use service/API identity so Launchplane resolves current
   DB-backed target authority and records sanitized key/count evidence.
+- Provider-target operations use native FastAPI
+  `POST /v1/provider-targets/operations` and the Provider Target Operations
+  workflow for shared and production provider-target audits/backfills. Its
+  legacy WSGI write branch and WSGI-only idempotency special-case are deleted,
+  and direct WSGI fallback calls fail closed. Audits and dry-runs remain
+  repeatable; apply requests require DB-backed storage, backfill authz, and an
+  `Idempotency-Key`.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -169,7 +169,9 @@ VeriReel product paths:
     callers, DB-backed setup records, apply-only `Idempotency-Key`
     replay/conflict handling, and repeatable dry-runs)
 - provider-target operation route:
-  - `POST /v1/provider-targets/operations`
+  - `POST /v1/provider-targets/operations` (native FastAPI for bearer-token
+    callers, DB-backed audit/backfill records, apply-only `Idempotency-Key`
+    replay/conflict handling, and repeatable audits/dry-runs)
 - product context cutover route:
   - `POST /v1/product-profiles/context-cutover/apply`
 - product legacy context cleanup route:
@@ -1321,14 +1323,16 @@ deleted runtime identity records under neutral `provider_targets` and
 provider-specific execution/config storage where needed, but service responses
 must not reintroduce Dokploy-named target buckets for these workflows.
 
-Provider-target Phase Two operations use `POST /v1/provider-targets/operations`.
-The route accepts one Launchplane-owned route at a time with mode `audit`,
-`backfill-dry-run`, or `backfill-apply`, `provider_id`, `context`, `instance`,
-and an apply-only `reason`. It requires DB-backed storage and authorizes through
+Provider-target Phase Two operations use the native FastAPI
+`POST /v1/provider-targets/operations` route. The route accepts one
+Launchplane-owned route at a time with mode `audit`, `backfill-dry-run`, or
+`backfill-apply`, `provider_id`, `context`, `instance`, and an apply-only
+`reason`. It requires DB-backed storage and authorizes through
 `provider_target.audit` for audit/dry-run or `provider_target.backfill` for
 apply, always scoped to product/context `launchplane`. Apply requests are
 idempotency-keyed and write only complete non-conflicting Dokploy target/id
 projections; existing rows and conflicts are reported rather than overwritten.
+Its legacy WSGI fallback branch is deleted; direct fallback calls fail closed.
 The manual `Provider Target Operations` workflow is the supported shared and
 production caller for Phase Two backfill evidence.
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10889,7 +10889,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -12490,7 +12490,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -12558,7 +12558,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -12597,6 +12597,103 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["error"]["code"], "idempotency_key_required")
         self.assertEqual(provider_targets, ())
+
+    def test_provider_target_operation_endpoint_requires_database_storage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/provider-target-operations.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["provider_target.audit"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/provider-target-operations.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/provider-targets/operations",
+                payload={
+                    "schema_version": 1,
+                    "mode": "audit",
+                    "product": "launchplane",
+                    "provider_id": "dokploy",
+                    "context": "verireel",
+                    "instance": "testing",
+                },
+            )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "database_required")
+
+    def test_openapi_includes_provider_target_operation_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: FilesystemRecordStore(state_dir=Path("unused")),
+        )
+
+        payload = app.openapi()
+
+        route = payload["paths"]["/v1/provider-targets/operations"]["post"]
+        self.assertEqual(route["operationId"], "run_provider_target_operations")
+        self.assertEqual(route["responses"]["202"]["description"], "Successful Response")
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(request_schema["title"], "ProviderTargetOperationEnvelope")
+        self.assertEqual(request_schema["additionalProperties"], False)
+
+    def test_provider_target_operation_endpoint_is_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/provider-targets/operations",
+                payload={
+                    "schema_version": 1,
+                    "mode": "audit",
+                    "product": "launchplane",
+                    "provider_id": "dokploy",
+                    "context": "verireel",
+                    "instance": "testing",
+                },
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_product_environment_read_legacy_wsgi_routes_are_retired(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- migrate `POST /v1/provider-targets/operations` to native FastAPI
- remove the retained WSGI route branch, write-route registration, and WSGI-only idempotency special-case
- keep provider-target audits/dry-runs repeatable while storing/replaying idempotency only for `backfill-apply`
- update service-boundary and compatibility-retirement docs plus FastAPI/OpenAPI/retired-WSGI coverage

Refs #1322

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_provider_target_operation_endpoint_backfills_route tests.test_service.LaunchplaneServiceTests.test_provider_target_operation_endpoint_rejects_apply_without_authz tests.test_service.LaunchplaneServiceTests.test_provider_target_operation_endpoint_rejects_apply_without_idempotency_key tests.test_service.LaunchplaneServiceTests.test_provider_target_operation_endpoint_requires_database_storage tests.test_service.LaunchplaneServiceTests.test_openapi_includes_provider_target_operation_contract tests.test_service.LaunchplaneServiceTests.test_provider_target_operation_endpoint_is_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
- JetBrains changed-files inspection: green
- Review agents: code-gpt-5.5 green; antigravity green
