### PR TITLE
Migrate product onboarding to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -28,6 +28,7 @@ from control_plane import product_config as control_plane_product_config
 from control_plane import product_config_service as control_plane_product_config_service
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_context_cutover as control_plane_product_context_cutover
+from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane import product_read_service as control_plane_product_read_service
 from control_plane import secrets as control_plane_secrets
 from control_plane import service_status as control_plane_service_status
@@ -114,6 +115,7 @@ from control_plane.contracts.product_environment_read_model import (
     ProductReadModelStore,
     ProductSiteOverview,
 )
+from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.repo_product_mapping_read_model import RepoProductMapping
 from control_plane.contracts.preview_evidence import (
@@ -206,6 +208,7 @@ from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
 )
+from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.public_ingress_monitor import (
     PublicIngressMonitorStore,
     public_ingress_notification_drivers,
@@ -270,6 +273,7 @@ _PRODUCT_PROFILES_ROUTE = "/v1/product-profiles"
 _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/apply"
 _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
 _PRODUCT_CONFIG_APPLY_ROUTE = "/v1/product-config/apply"
+_PRODUCT_ONBOARDING_APPLY_ROUTE = "/v1/product-onboarding/apply"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _AGENT_WRITE_INTENT_EVALUATE_ROUTE = "/v1/agent/write-intents/evaluate"
 _EVERY_CODE_WORK_REQUEST_RERUN_ROUTE = "/v1/every-code/work-requests/rerun"
@@ -1108,6 +1112,21 @@ class AcceptedEvidenceResponse(BaseModel):
     result: dict[str, object] | None = None
     replayed: bool | None = None
     original_trace_id: str | None = None
+
+
+class ProductOnboardingApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    manifest: ProductOnboardingManifest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "ProductOnboardingApplyEnvelope":
+        if self.product.strip() != "launchplane":
+            raise ValueError("Product onboarding writes require product 'launchplane'.")
+        self.product = "launchplane"
+        return self
 
 
 class PublicIngressNotificationPolicyApplyEnvelope(BaseModel):
@@ -6800,6 +6819,18 @@ def create_launchplane_fastapi_app(
             )
         return record_store
 
+    def require_product_onboarding_database_store(
+        *, record_store: object, trace_id: str
+    ) -> PostgresRecordStore:
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message="Product onboarding writes require Launchplane database storage.",
+            )
+        return record_store
+
     def require_live_target_runtime_database_store(
         *, record_store: object, trace_id: str
     ) -> PostgresRecordStore:
@@ -7131,6 +7162,108 @@ def create_launchplane_fastapi_app(
             response=product_config_response,
         )
         return product_config_response
+
+    async def apply_product_onboarding(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            )
+        try:
+            onboarding_request = ProductOnboardingApplyEnvelope.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="product_onboarding.apply",
+            product=onboarding_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot apply Launchplane product onboarding manifests.",
+            )
+        database_store = require_product_onboarding_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=database_store,
+            identity=identity,
+            route_path=_PRODUCT_ONBOARDING_APPLY_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+        try:
+            onboarding_result = apply_product_onboarding_manifest(
+                record_store=database_store,
+                manifest=onboarding_request.manifest,
+            )
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_product_onboarding_manifest",
+                message=str(error),
+            ) from error
+        result, driver_result = (
+            control_plane_product_onboarding_service.build_product_onboarding_service_result(
+                onboarding_result
+            )
+        )
+        onboarding_response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={
+                "product_profile": str(result["product_profile"]),
+                "provider_target_count": str(result["provider_target_count"]),
+                "provider_target_id_count": str(result["provider_target_id_count"]),
+                "runtime_environment_record_count": str(result["runtime_environment_record_count"]),
+                "secret_binding_count": str(result["secret_binding_count"]),
+            },
+            result=driver_result,
+        )
+        store_apply_idempotency(
+            record_store=database_store,
+            identity=identity,
+            route_path=_PRODUCT_ONBOARDING_APPLY_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=onboarding_response,
+        )
+        return onboarding_response
 
     async def apply_live_target_runtime(
         request: Request,
@@ -10456,6 +10589,34 @@ def create_launchplane_fastapi_app(
         },
         operation_id="apply_product_config",
         summary="Plan or apply product config",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PRODUCT_ONBOARDING_APPLY_ROUTE,
+        apply_product_onboarding,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": ProductOnboardingApplyEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="apply_product_onboarding",
+        summary="Apply product onboarding records",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/product_onboarding_service.py
+++ b/control_plane/product_onboarding_service.py
@@ -13,8 +13,20 @@ def build_product_onboarding_service_result(
         "runtime_environment_record_count": len(onboarding_result.runtime_environments),
         "secret_binding_count": len(onboarding_result.secret_bindings),
     }
+    target_ids_by_route = {
+        (record.context, record.instance): record
+        for record in onboarding_result.provider_target_ids
+    }
     provider_targets = [
-        record.model_dump(mode="json") for record in onboarding_result.provider_targets
+        {
+            "context": record.context,
+            "instance": record.instance,
+            "target_type": record.target_type,
+            "target_name": record.target_name,
+            "target_id_recorded": bool(target_ids_by_route.get((record.context, record.instance))),
+            "updated_at": record.updated_at,
+        }
+        for record in onboarding_result.provider_targets
     ]
     provider_target_ids = [
         {
@@ -22,37 +34,16 @@ def build_product_onboarding_service_result(
             "instance": record.instance,
             "target_id_recorded": bool(record.target_id.strip()),
             "updated_at": record.updated_at,
-            "source_label": record.source_label,
         }
         for record in onboarding_result.provider_target_ids
     ]
     driver_result: dict[str, object] = {
         "product": onboarding_result.product,
-        "product_profile": onboarding_result.product_profile.model_dump(mode="json"),
+        "product_profile": {
+            "product": onboarding_result.product_profile.product,
+            "updated_at": onboarding_result.product_profile.updated_at,
+        },
         "provider_targets": provider_targets,
         "provider_target_ids": provider_target_ids,
-        "runtime_environment_records": [
-            {
-                "scope": record.scope,
-                "context": record.context,
-                "instance": record.instance,
-                "env_keys": sorted(record.env),
-                "updated_at": record.updated_at,
-                "source_label": record.source_label,
-            }
-            for record in onboarding_result.runtime_environments
-        ],
-        "secret_bindings": [
-            {
-                "binding_id": binding.binding_id,
-                "integration": binding.integration,
-                "binding_key": binding.binding_key,
-                "context": binding.context,
-                "instance": binding.instance,
-                "status": binding.status,
-                "updated_at": binding.updated_at,
-            }
-            for binding in onboarding_result.secret_bindings
-        ],
     }
     return result, driver_result

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -20,7 +20,6 @@ from jwt import InvalidTokenError
 from starlette.types import ASGIApp
 
 from control_plane import authz_grant_service as control_plane_authz_grant_service
-from control_plane import product_onboarding_service as control_plane_product_onboarding_service
 from control_plane.http_app import (
     LaunchplaneAuthzPolicyRuntime,
     create_launchplane_fastapi_app,
@@ -127,7 +126,6 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
 )
-from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
 from control_plane.contracts.promotion_record import (
     HealthcheckEvidence,
     PostDeployUpdateEvidence,
@@ -312,7 +310,6 @@ from control_plane.workflows.odoo_preview_runtime import (
     build_odoo_preview_apply_inputs,
     execute_odoo_preview_dokploy_apply,
 )
-from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.preview_lifecycle_cleanup import (
@@ -1694,21 +1691,6 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
     def _validate_alignment(self) -> "LaunchplaneSelfDeployEnvelope":
         if self.product.strip() != "launchplane":
             raise ValueError("Launchplane self deploy requires product 'launchplane'.")
-        return self
-
-
-class ProductOnboardingApplyEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    manifest: ProductOnboardingManifest
-
-    @model_validator(mode="after")
-    def _validate_alignment(self) -> "ProductOnboardingApplyEnvelope":
-        if self.product.strip() != "launchplane":
-            raise ValueError("Product onboarding writes require product 'launchplane'.")
-        self.product = "launchplane"
         return self
 
 
@@ -3401,7 +3383,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/authz-policies/local-operators/grants",
         "/v1/authz-policies/local-admins/grants",
         "/v1/merge-train/policies/import",
-        "/v1/product-onboarding/apply",
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
@@ -9490,73 +9471,6 @@ def create_launchplane_service_app(
                     },
                 }
                 driver_result = result
-            elif path == "/v1/product-onboarding/apply":
-                onboarding_request = ProductOnboardingApplyEnvelope.model_validate(payload)
-                if not isinstance(record_store, PostgresRecordStore):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "database_required",
-                                "message": "Product onboarding writes require Launchplane database storage.",
-                            },
-                        },
-                    )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="product_onboarding.apply",
-                    product=onboarding_request.product,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot apply Launchplane product onboarding manifests.",
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                try:
-                    onboarding_result = apply_product_onboarding_manifest(
-                        record_store=record_store,
-                        manifest=onboarding_request.manifest,
-                    )
-                except ValueError as error:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=400,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "invalid_product_onboarding_manifest",
-                                "message": str(error),
-                            },
-                        },
-                    )
-                result, driver_result = (
-                    control_plane_product_onboarding_service.build_product_onboarding_service_result(
-                        onboarding_result
-                    )
-                )
             elif path in descriptor_driver_dispatch_routes:
                 try:
                     dispatch_response = _dispatch_descriptor_driver_route(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -217,6 +217,12 @@ Keep a compatibility surface only when it is one of these:
   and direct WSGI fallback calls fail closed. Audits and dry-runs remain
   repeatable; apply requests require DB-backed storage, backfill authz, and an
   `Idempotency-Key`.
+- Product onboarding uses native FastAPI `POST /v1/product-onboarding/apply`
+  and the Product Onboarding workflow for shared and production onboarding
+  writes. Its legacy WSGI write branch is deleted, and direct WSGI fallback
+  calls fail closed. Requests require DB-backed storage and
+  `product_onboarding.apply` authz; `Idempotency-Key` replay/conflict handling
+  remains available when callers provide a key.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -163,7 +163,9 @@ VeriReel product paths:
     bearer-token callers, DB-backed storage, metadata-only policy writes, and
     optional `Idempotency-Key` replay/conflict handling)
 - product onboarding route:
-  - `POST /v1/product-onboarding/apply`
+  - `POST /v1/product-onboarding/apply` (native FastAPI for bearer-token
+    callers, DB-backed onboarding records, optional `Idempotency-Key`
+    replay/conflict handling, and sanitized onboarding evidence)
 - Dokploy target setup route:
   - `POST /v1/dokploy-targets/setup` (native FastAPI for bearer-token
     callers, DB-backed setup records, apply-only `Idempotency-Key`
@@ -1303,18 +1305,20 @@ context/instance scope and explicit preview instance patterns for dynamic PR
 lanes; policy apply merges those scopes additively without making checked-in
 files runtime authority.
 
-Product onboarding uses `POST /v1/product-onboarding/apply`. The route accepts
-the same operator-approved manifest as `launchplane product-onboarding apply`
-and writes the full Launchplane-owned bundle: product profile, existing
-Dokploy-backed target records, target-id records, runtime-environment records,
-and managed secret binding placeholders. The manual `Product Onboarding`
-workflow is the supported shared and production caller: operators pass the
-manifest as runtime workflow input, and product-specific onboarding JSON stays
-out of checked-in catalogs. Manifests must use neutral `provider_targets`;
-obsolete `dokploy_targets` input is rejected with a clear validation error. The
-route is restricted to `product_onboarding.apply` authority for product/context
+Product onboarding uses the native FastAPI
+`POST /v1/product-onboarding/apply` route. The route accepts the same
+operator-approved manifest as `launchplane product-onboarding apply` and writes
+the full Launchplane-owned bundle: product profile, existing Dokploy-backed
+target records, target-id records, runtime-environment records, and managed
+secret binding placeholders. The manual `Product Onboarding` workflow is the
+supported shared and production caller: operators pass the manifest as runtime
+workflow input, and product-specific onboarding JSON stays out of checked-in
+catalogs. Manifests must use neutral `provider_targets`; obsolete
+`dokploy_targets` input is rejected with a clear validation error. The route is
+restricted to `product_onboarding.apply` authority for product/context
 `launchplane`, requires DB-backed storage, and returns only sanitized
-`provider_target*` summaries. Product records are not loaded from checked-in
+`provider_target*` summaries. Its legacy WSGI fallback branch is deleted; direct
+fallback calls fail closed. Product records are not loaded from checked-in
 catalogs or product repos.
 
 Product context audit, cutover, and legacy cleanup routes expose copied or

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -92,6 +92,9 @@ class ProductOnboardingServiceTests(unittest.TestCase):
                         "target_id": "app-discord-blue",
                         "target_type": "application",
                         "target_name": "discord-blue",
+                        "custom_git_url": "https://github.com/cbusillo/discord-blue.git",
+                        "env": {"DISCORD_BLUE_TARGET_ENV": "stored-only"},
+                        "domains": ["discord-blue.example.test"],
                         "healthcheck_enabled": False,
                     }
                 ],
@@ -128,11 +131,38 @@ class ProductOnboardingServiceTests(unittest.TestCase):
         self.assertEqual(result["secret_binding_count"], 1)
         self.assertEqual(len(store.provider_targets), 1)
         self.assertEqual(driver_result["product"], "discord-blue")
+        self.assertEqual(
+            driver_result["product_profile"],
+            {
+                "product": "discord-blue",
+                "updated_at": "2026-05-04T18:00:00Z",
+            },
+        )
+        self.assertEqual(
+            driver_result["provider_targets"],
+            [
+                {
+                    "context": "discord-blue",
+                    "instance": "prod",
+                    "target_type": "application",
+                    "target_name": "discord-blue",
+                    "target_id_recorded": True,
+                    "updated_at": "2026-05-04T18:00:00Z",
+                }
+            ],
+        )
         self.assertIn("provider_targets", driver_result)
         self.assertIn("provider_target_ids", driver_result)
         self.assertNotIn("dokploy_targets", driver_result)
         self.assertNotIn("dokploy_target_ids", driver_result)
+        self.assertNotIn("runtime_environment_records", driver_result)
+        self.assertNotIn("secret_bindings", driver_result)
         self.assertNotIn("secret_id", str(driver_result))
+        self.assertNotIn("app-discord-blue", str(driver_result))
+        self.assertNotIn("custom_git_url", str(driver_result))
+        self.assertNotIn("DISCORD_BLUE_TARGET_ENV", str(driver_result))
+        self.assertNotIn("discord-blue.example.test", str(driver_result))
+        self.assertNotIn("test:discord-blue-onboarding", str(driver_result))
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10593,7 +10593,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -10690,6 +10690,12 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         self.assertEqual(secret_bindings[0].binding_key, "DISCORD_TOKEN")
         self.assertNotIn("secret_id", json.dumps(payload, sort_keys=True))
+        self.assertNotIn("app-discord-blue", json.dumps(payload, sort_keys=True))
+        self.assertNotIn("/var/lib/discord-blue", json.dumps(payload, sort_keys=True))
+        self.assertNotIn("https://discord-blue.example.test", json.dumps(payload, sort_keys=True))
+        self.assertNotIn("DISCORD_BLUE_STATE_DIR", json.dumps(payload, sort_keys=True))
+        self.assertNotIn("DISCORD_TOKEN", json.dumps(payload, sort_keys=True))
+        self.assertNotIn("test:discord-blue-onboarding", json.dumps(payload, sort_keys=True))
 
     def test_product_onboarding_endpoint_rejects_provider_target_conflict(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -10730,7 +10736,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -10810,7 +10816,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -10857,6 +10863,191 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_product_onboarding_endpoint_requires_database_storage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/product-onboarding.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["product_onboarding.apply"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/product-onboarding.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-onboarding/apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "manifest": {
+                        "product": "discord-blue",
+                        "display_name": "Discord Blue",
+                        "repository": "cbusillo/discord-blue",
+                        "driver_id": "generic-web",
+                        "image_repository": "ghcr.io/cbusillo/discord-blue",
+                        "runtime_port": 8787,
+                        "health_path": "/health",
+                        "lanes": [
+                            {
+                                "instance": "prod",
+                                "context": "discord-blue",
+                                "base_url": "https://discord-blue.example.test",
+                            }
+                        ],
+                        "updated_at": "2026-05-04T18:00:00Z",
+                        "source_label": "test:discord-blue-onboarding",
+                    },
+                },
+                headers={"Idempotency-Key": "product-onboarding-filesystem-denied"},
+            )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "database_required")
+
+    def test_product_onboarding_endpoint_checks_authz_before_database_storage(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/product-onboarding.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/product-onboarding.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-onboarding/apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "manifest": {
+                        "product": "discord-blue",
+                        "display_name": "Discord Blue",
+                        "repository": "cbusillo/discord-blue",
+                        "driver_id": "generic-web",
+                        "image_repository": "ghcr.io/cbusillo/discord-blue",
+                        "runtime_port": 8787,
+                        "health_path": "/health",
+                        "lanes": [
+                            {
+                                "instance": "prod",
+                                "context": "discord-blue",
+                                "base_url": "https://discord-blue.example.test",
+                            }
+                        ],
+                        "updated_at": "2026-05-04T18:00:00Z",
+                        "source_label": "test:discord-blue-onboarding",
+                    },
+                },
+                headers={"Idempotency-Key": "product-onboarding-authz-denied"},
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_openapi_includes_product_onboarding_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: FilesystemRecordStore(state_dir=Path("unused")),
+        )
+
+        payload = app.openapi()
+
+        route = payload["paths"]["/v1/product-onboarding/apply"]["post"]
+        self.assertEqual(route["operationId"], "apply_product_onboarding")
+        self.assertEqual(route["responses"]["202"]["description"], "Successful Response")
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(request_schema["title"], "ProductOnboardingApplyEnvelope")
+        self.assertEqual(request_schema["additionalProperties"], False)
+
+    def test_product_onboarding_endpoint_is_retired_from_legacy_wsgi_app(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/product-onboarding/apply",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "manifest": {
+                        "product": "discord-blue",
+                        "display_name": "Discord Blue",
+                        "repository": "cbusillo/discord-blue",
+                        "driver_id": "generic-web",
+                        "lanes": [
+                            {
+                                "instance": "prod",
+                                "context": "discord-blue",
+                            }
+                        ],
+                    },
+                },
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_provider_target_operation_endpoint_backfills_route(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- migrate `POST /v1/product-onboarding/apply` to the native FastAPI app
- retire the legacy WSGI write branch and verify direct WSGI fallback calls fail closed
- enforce authz, DB-backed storage, idempotency, and sanitized onboarding evidence on the FastAPI route
- narrow product-onboarding service results to neutral `provider_target*` summaries without target IDs, env/domain/source/secret/runtime details
- update service-boundary and compatibility-retirement docs for the v2 ownership boundary

Refs #1322

## Validation

- `uv run python -m unittest tests.test_product_onboarding_service.ProductOnboardingServiceTests.test_service_result_summarizes_records_without_secret_ids tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_writes_full_launchplane_owned_bundle tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_rejects_provider_target_conflict tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_rejects_self_deploy_authority tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_requires_database_storage tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_checks_authz_before_database_storage tests.test_service.LaunchplaneServiceTests.test_openapi_includes_product_onboarding_contract tests.test_service.LaunchplaneServiceTests.test_product_onboarding_endpoint_is_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/product_onboarding_service.py control_plane/service.py tests/test_product_onboarding_service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/product_onboarding_service.py control_plane/service.py tests/test_product_onboarding_service.py tests/test_service.py`
- `git diff --check`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py closeout --repo "$PWD" --scope changed_files`
- two-agent final merge review: green / green
