### PR TITLE
Migrate merge train policy import to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -91,6 +91,7 @@ from control_plane.contracts.ingress_route_audit_record import (
     IngressRouteAuditRecord,
     build_ingress_route_audit_record_id,
 )
+from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationRecord,
 )
@@ -274,6 +275,7 @@ _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/app
 _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
 _PRODUCT_CONFIG_APPLY_ROUTE = "/v1/product-config/apply"
 _PRODUCT_ONBOARDING_APPLY_ROUTE = "/v1/product-onboarding/apply"
+_MERGE_TRAIN_POLICY_IMPORT_ROUTE = "/v1/merge-train/policies/import"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _AGENT_WRITE_INTENT_EVALUATE_ROUTE = "/v1/agent/write-intents/evaluate"
 _EVERY_CODE_WORK_REQUEST_RERUN_ROUTE = "/v1/every-code/work-requests/rerun"
@@ -1126,6 +1128,26 @@ class ProductOnboardingApplyEnvelope(BaseModel):
         if self.product.strip() != "launchplane":
             raise ValueError("Product onboarding writes require product 'launchplane'.")
         self.product = "launchplane"
+        return self
+
+
+class MergeTrainPolicyImportEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str = "launchplane"
+    mode: Literal["dry_run", "apply"] = "dry_run"
+    reason: str = ""
+    record: MergeTrainPolicyRecord
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainPolicyImportEnvelope":
+        self.product = self.product.strip() or "launchplane"
+        if self.product != "launchplane":
+            raise ValueError("merge train policy import requires product 'launchplane'")
+        self.reason = self.reason.strip()
+        if self.mode == "apply" and not self.reason:
+            raise ValueError("merge train policy import apply requires reason")
         return self
 
 
@@ -6831,6 +6853,18 @@ def create_launchplane_fastapi_app(
             )
         return record_store
 
+    def require_merge_train_policy_database_store(
+        *, record_store: object, trace_id: str
+    ) -> PostgresRecordStore:
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message="Merge train policy writes require Launchplane database storage.",
+            )
+        return record_store
+
     def require_live_target_runtime_database_store(
         *, record_store: object, trace_id: str
     ) -> PostgresRecordStore:
@@ -7264,6 +7298,112 @@ def create_launchplane_fastapi_app(
             response=onboarding_response,
         )
         return onboarding_response
+
+    async def import_merge_train_policy(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if isinstance(identity, TerminalAgentIdentity):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Terminal agent credentials can only read redacted Launchplane context.",
+            )
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            )
+        try:
+            policy_import_request = MergeTrainPolicyImportEnvelope.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="merge_train.policy_import",
+            product=policy_import_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot write Launchplane merge train policies.",
+            )
+        database_store = require_merge_train_policy_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        normalized_idempotency_key = idempotency_key.strip()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if policy_import_request.mode == "apply":
+            (
+                normalized_idempotency_key,
+                payload_fingerprint,
+                replay_response,
+            ) = await replay_apply_idempotency(
+                request=request,
+                record_store=database_store,
+                identity=identity,
+                route_path=_MERGE_TRAIN_POLICY_IMPORT_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                trace_id=trace_id,
+                check_replay=bool(normalized_idempotency_key),
+            )
+            if replay_response is not None:
+                return replay_response
+            database_store.write_merge_train_policy_record(policy_import_request.record)
+        result: dict[str, object] = {
+            "mode": policy_import_request.mode,
+            "record": {
+                "record_id": policy_import_request.record.record_id,
+                "status": policy_import_request.record.status,
+                "source": policy_import_request.record.source,
+                "updated_at": policy_import_request.record.updated_at,
+                "policy_sha256": policy_import_request.record.policy_sha256,
+                "repository_count": len(policy_import_request.record.policy.policies),
+                "policy_keys": [
+                    repository_policy.policy_key
+                    for repository_policy in policy_import_request.record.policy.policies
+                ],
+            },
+        }
+        policy_import_response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={},
+            result=result,
+        )
+        if policy_import_request.mode == "apply":
+            store_apply_idempotency(
+                record_store=database_store,
+                identity=identity,
+                route_path=_MERGE_TRAIN_POLICY_IMPORT_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=policy_import_response,
+            )
+        return policy_import_response
 
     async def apply_live_target_runtime(
         request: Request,
@@ -10617,6 +10757,34 @@ def create_launchplane_fastapi_app(
         },
         operation_id="apply_product_onboarding",
         summary="Apply product onboarding records",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _MERGE_TRAIN_POLICY_IMPORT_ROUTE,
+        import_merge_train_policy,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": MergeTrainPolicyImportEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="import_merge_train_policy",
+        summary="Import merge train policy records",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -69,7 +69,6 @@ from control_plane.contracts.merge_train_stack_collapse import (
 )
 from control_plane.contracts.merge_train_run_record import build_merge_train_run_record
 from control_plane.contracts.merge_train_policy import MergeTrainPolicy
-from control_plane.contracts.merge_train_policy import MergeTrainPolicyRecord
 from control_plane.contracts.merge_train_pr_feedback_record import (
     MergeTrainPrFeedbackEvent,
     MergeTrainPrFeedbackRecord,
@@ -990,26 +989,6 @@ class PreviewPrFeedbackEnvelope(BaseModel):
         return self
 
 
-class MergeTrainPolicyImportEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str = "launchplane"
-    mode: Literal["dry_run", "apply"] = "dry_run"
-    reason: str = ""
-    record: MergeTrainPolicyRecord
-
-    @model_validator(mode="after")
-    def _validate_envelope(self) -> "MergeTrainPolicyImportEnvelope":
-        self.product = self.product.strip() or "launchplane"
-        if self.product != "launchplane":
-            raise ValueError("merge train policy import requires product 'launchplane'")
-        self.reason = self.reason.strip()
-        if self.mode == "apply" and not self.reason:
-            raise ValueError("merge train policy import apply requires reason")
-        return self
-
-
 class OdooPostDeployEnvelope(_ProductRouteEnvelope):
     schema_version: int = Field(default=1, ge=1)
     post_deploy: OdooPostDeployRequest
@@ -1661,7 +1640,6 @@ _HUMAN_IDENTITY_MUTATION_ROUTES = frozenset(
         "/v1/authz-policies/terminal-agents/grants",
         "/v1/authz-policies/local-operators/grants",
         "/v1/authz-policies/local-admins/grants",
-        "/v1/merge-train/policies/import",
     }
 )
 _NON_IDEMPOTENT_DRIVER_RESULT_ROUTES = frozenset(
@@ -3382,7 +3360,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/authz-policies/terminal-agents/grants",
         "/v1/authz-policies/local-operators/grants",
         "/v1/authz-policies/local-admins/grants",
-        "/v1/merge-train/policies/import",
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
@@ -6072,12 +6049,6 @@ def _should_store_idempotency_record(
             "/v1/authz-policies/local-operators/grants",
             "/v1/authz-policies/local-admins/grants",
         }
-        and isinstance(driver_result, dict)
-        and driver_result.get("mode") == "dry_run"
-    ):
-        return False
-    if (
-        path == "/v1/merge-train/policies/import"
         and isinstance(driver_result, dict)
         and driver_result.get("mode") == "dry_run"
     ):
@@ -9409,68 +9380,6 @@ def create_launchplane_service_app(
                         audit=audit,
                     )
                 )
-            elif path == "/v1/merge-train/policies/import":
-                merge_train_policy_request = MergeTrainPolicyImportEnvelope.model_validate(payload)
-                if not isinstance(record_store, PostgresRecordStore):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "database_required",
-                                "message": "Merge train policy writes require Launchplane database storage.",
-                            },
-                        },
-                    )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="merge_train.policy_import",
-                    product=merge_train_policy_request.product,
-                    context=_LAUNCHPLANE_SERVICE_CONTEXT,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot write Launchplane merge train policies.",
-                            },
-                        },
-                    )
-                if merge_train_policy_request.mode == "apply":
-                    idempotent_response = _check_idempotent_request(
-                        record_store=record_store,
-                        scope=request_scope,
-                        route_path=path,
-                        idempotency_key=request_idempotency_key,
-                        request_fingerprint=request_fingerprint,
-                        start_response=start_response,
-                        trace_id=request_trace_id,
-                    )
-                    if idempotent_response is not None:
-                        return idempotent_response
-                    record_store.write_merge_train_policy_record(merge_train_policy_request.record)
-                result = {
-                    "mode": merge_train_policy_request.mode,
-                    "record": {
-                        "record_id": merge_train_policy_request.record.record_id,
-                        "status": merge_train_policy_request.record.status,
-                        "source": merge_train_policy_request.record.source,
-                        "updated_at": merge_train_policy_request.record.updated_at,
-                        "policy_sha256": merge_train_policy_request.record.policy_sha256,
-                        "repository_count": len(merge_train_policy_request.record.policy.policies),
-                        "policy_keys": [
-                            repository_policy.policy_key
-                            for repository_policy in merge_train_policy_request.record.policy.policies
-                        ],
-                    },
-                }
-                driver_result = result
             elif path in descriptor_driver_dispatch_routes:
                 try:
                     dispatch_response = _dispatch_descriptor_driver_route(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -223,6 +223,14 @@ Keep a compatibility surface only when it is one of these:
   calls fail closed. Requests require DB-backed storage and
   `product_onboarding.apply` authz; `Idempotency-Key` replay/conflict handling
   remains available when callers provide a key.
+- Merge-train policy import uses native FastAPI
+  `POST /v1/merge-train/policies/import` for DB-backed policy record writes.
+  Its legacy WSGI write branch is deleted, and direct WSGI fallback calls fail
+  closed. Requests require `merge_train.policy_import` authz on
+  product/context `launchplane` for GitHub Actions OIDC, signed-in GitHub human
+  sessions, and local operator/admin bearer callers; apply requests preserve
+  optional `Idempotency-Key` replay/conflict handling while dry-runs remain
+  stateless.
 - Provider-target manifest input and product-onboarding service response aliases
   are retired. Product context audit/cutover responses are also retired from
   Dokploy-named target buckets. Manifests must use `provider_targets`;

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -658,12 +658,17 @@ The second batch service contract is
 creation and guarded PR-native landing, and writes
 `launchplane_merge_train_batch_landing_plans` records.
 
-`POST /v1/merge-train/policies/import` is the service-owned write path for merge
-train policy records. It requires database storage and
+`POST /v1/merge-train/policies/import` is the native FastAPI service-owned write
+path for merge train policy records. It requires database storage and
 `merge_train.policy_import` on product/context `launchplane`, accepts `dry_run`
-and `apply`, and writes the supplied typed record only in apply mode.
-Shared and production policy changes should use this route rather than direct DB
-CLI writes from an arbitrary checkout.
+and `apply`, and writes the supplied typed record only in apply mode. GitHub
+Actions OIDC callers, signed-in GitHub human sessions, and local operator/admin
+bearer callers may use the route when policy grants the action; terminal-agent
+credentials remain read-only. Apply requests preserve `Idempotency-Key`
+replay/conflict handling when callers provide a key; dry-runs remain stateless
+and repeatable. Shared and production policy changes should use this route rather
+than direct DB CLI writes from an arbitrary checkout, and the retired legacy WSGI
+fallback branch fails closed for direct calls.
 
 ## Host Assumption
 

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -2114,7 +2114,6 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     "/v1/authz-policies/terminal-agents/grants",
                     "/v1/authz-policies/local-operators/grants",
                     "/v1/authz-policies/local-admins/grants",
-                    "/v1/merge-train/policies/import",
                 }
             ),
         )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -150,6 +150,7 @@ from control_plane.service_human_auth import (
     GITHUB_USER_URL,
     GitHubOAuthClient,
     GitHubOAuthConfig,
+    HumanSessionManager,
     InMemoryHumanSessionStore,
     LaunchplaneHumanSession,
     load_github_oauth_config_from_env,
@@ -6923,7 +6924,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -6994,7 +6995,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -7042,6 +7043,71 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(records, ())
         self.assertIsNone(idempotency_record)
 
+    def test_merge_train_policy_import_endpoint_human_admin_session_can_apply(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            session_store = InMemoryHumanSessionStore()
+            session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=session_store,
+            )
+            human_session = session_manager.issue(_human_identity(role="admin"))
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_humans": [
+                        {
+                            "logins": ["alice"],
+                            "roles": ["admin"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["merge_train.policy_import"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                database_url=database_url,
+                human_session_manager=session_manager,
+            )
+            record = build_test_merge_train_policy_record(
+                repository="cbusillo/codex-skills",
+                record_id="merge-train-policy-codex-skills-human-import",
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/merge-train/policies/import",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Configure codex-skills merge train.",
+                    "record": record.model_dump(mode="json"),
+                },
+                authorization="",
+                headers={
+                    "Cookie": session_manager.session_cookie_header(human_session),
+                    "Idempotency-Key": "merge-train-policy:human-import",
+                },
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                records = store.list_merge_train_policy_records(status="active")
+            finally:
+                store.close()
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "apply")
+        self.assertEqual([stored.record_id for stored in records], [record.record_id])
+
     def test_merge_train_policy_import_endpoint_rejects_self_deploy_authority(
         self,
     ) -> None:
@@ -7064,7 +7130,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -7122,7 +7188,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -7158,6 +7224,167 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["error"]["code"], "invalid_request")
+
+    def test_merge_train_policy_import_endpoint_authorizes_before_storage_gate(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["launchplane_service_deploy.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+            record = build_test_merge_train_policy_record(
+                repository="cbusillo/codex-skills",
+                record_id="merge-train-policy-codex-skills-authz-before-storage",
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/merge-train/policies/import",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "record": record.model_dump(mode="json"),
+                },
+            )
+
+        self.assertEqual(status_code, 403)
+        self.assertEqual(payload["error"]["code"], "authorization_denied")
+
+    def test_merge_train_policy_import_endpoint_requires_database_storage(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/launchplane",
+                            "workflow_refs": [
+                                "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["launchplane"],
+                            "contexts": ["launchplane"],
+                            "actions": ["merge_train.policy_import"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+            record = build_test_merge_train_policy_record(
+                repository="cbusillo/codex-skills",
+                record_id="merge-train-policy-codex-skills-db-required",
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/merge-train/policies/import",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "apply",
+                    "reason": "Configure codex-skills merge train.",
+                    "record": record.model_dump(mode="json"),
+                },
+                headers={"Idempotency-Key": "merge-train-policy:db-required"},
+            )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "database_required")
+
+    def test_openapi_includes_merge_train_policy_import_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: FilesystemRecordStore(state_dir=Path("unused")),
+        )
+
+        payload = app.openapi()
+
+        route = payload["paths"]["/v1/merge-train/policies/import"]["post"]
+        self.assertEqual(route["operationId"], "import_merge_train_policy")
+        self.assertEqual(route["responses"]["202"]["description"], "Successful Response")
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(request_schema["title"], "MergeTrainPolicyImportEnvelope")
+        self.assertEqual(request_schema["additionalProperties"], False)
+
+    def test_merge_train_policy_import_endpoint_is_retired_from_legacy_wsgi_app(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=root,
+            )
+            record = build_test_merge_train_policy_record(
+                repository="cbusillo/codex-skills",
+                record_id="merge-train-policy-codex-skills-legacy-retired",
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/merge-train/policies/import",
+                payload={
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "record": record.model_dump(mode="json"),
+                },
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_every_code_github_webhook_creates_work_request(self) -> None:
         secret = "launchplane-every-code-webhook-secret"


### PR DESCRIPTION
## Summary
- Move `POST /v1/merge-train/policies/import` from the retained WSGI write handler to native FastAPI.
- Preserve DB-backed storage enforcement, `merge_train.policy_import` authorization, GitHub human-session/local operator/GitHub Actions identity compatibility, apply-only idempotency replay/conflict handling, and compact response shape.
- Delete the legacy WSGI branch/route metadata and document the compatibility retirement.

## Validation
- `uv run python -m unittest tests.test_driver_descriptors.DriverDescriptorRegistryTests.test_route_policy_sets_use_execution_metadata tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_import_endpoint_writes_active_record tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_import_endpoint_dry_run_does_not_write_record tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_import_endpoint_human_admin_session_can_apply tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_import_endpoint_rejects_self_deploy_authority tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_import_endpoint_rejects_non_launchplane_product tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_import_endpoint_authorizes_before_storage_gate tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_import_endpoint_requires_database_storage tests.test_service.LaunchplaneServiceTests.test_openapi_includes_merge_train_policy_import_contract tests.test_service.LaunchplaneServiceTests.test_merge_train_policy_import_endpoint_is_retired_from_legacy_wsgi_app`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff check --diff control_plane/http_app.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_service.py tests/test_driver_descriptors.py`
- `git diff --check`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest`
- JetBrains changed-file inspection: GREEN
- Agent review: GREEN/GREEN after preserving GitHub human-session compatibility

Refs #1322