### PR TITLE
Migrate Every Code GitHub webhook to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -2930,13 +2930,13 @@ def create_launchplane_fastapi_app(
                 resolved_control_plane_root,
                 trace_id,
             )
-        except ValueError as error:
+        except ValueError:
             raise _launchplane_http_error(
                 status_code=400,
                 trace_id=trace_id,
                 code="invalid_request",
                 message="GitHub webhook payload is invalid.",
-            ) from error
+            )
         return JSONResponse(status_code=status_code, content=payload)
 
     def read_every_code_work_request_worker_write_identity(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -2936,7 +2936,7 @@ def create_launchplane_fastapi_app(
                 trace_id=trace_id,
                 code="invalid_request",
                 message="GitHub webhook payload is invalid.",
-            )
+            ) from None
         return JSONResponse(status_code=status_code, content=payload)
 
     def read_every_code_work_request_worker_write_identity(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -246,6 +246,10 @@ from control_plane.work_graph_service import (
     build_work_graph_snapshot_service_payload,
 )
 
+EveryCodeGitHubWebhookHandler = Callable[
+    [bytes, str, str, str, object, FilePath, str], tuple[int, dict[str, object]]
+]
+
 
 _BEARER_CHALLENGE_HEADER = {"WWW-Authenticate": 'Bearer realm="Launchplane API"'}
 _LAUNCHPLANE_DRIVER_READ_PRODUCT = "launchplane"
@@ -286,6 +290,7 @@ _AUTHZ_POLICY_LOCAL_ADMINS_GRANTS_ROUTE = "/v1/authz-policies/local-admins/grant
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _AGENT_WRITE_INTENT_EVALUATE_ROUTE = "/v1/agent/write-intents/evaluate"
 _EVERY_CODE_WORK_REQUEST_RERUN_ROUTE = "/v1/every-code/work-requests/rerun"
+_EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _AGENT_WRITE_INTENT_MAX_AGE = timedelta(hours=24)
 
 AuthzPolicyRouteEnvelope = (
@@ -2691,6 +2696,7 @@ def create_launchplane_fastapi_app(
     work_graph_issue_inbox_provider: WorkGraphIssueInboxProvider | None = None,
     work_graph_issue_inbox_reconcile_provider: WorkGraphIssueInboxReconcileProvider | None = None,
     every_code_discord_sender: Callable[[str, dict[str, object]], object] = post_discord_webhook,
+    every_code_github_webhook_handler: EveryCodeGitHubWebhookHandler | None = None,
 ) -> FastAPI:
     resolved_control_plane_root = (
         control_plane_root_path or FilePath(__file__).resolve().parent.parent
@@ -2898,6 +2904,40 @@ def create_launchplane_fastapi_app(
         if every_code_worker_token_authorized(authorization):
             return
         raise _authentication_required_error("Every Code worker token is required.")
+
+    async def handle_every_code_github_webhook(
+        request: Request,
+        x_github_event: Annotated[str, Header(alias="X-GitHub-Event")] = "",
+        x_github_delivery: Annotated[str, Header(alias="X-GitHub-Delivery")] = "",
+        x_hub_signature_256: Annotated[str, Header(alias="X-Hub-Signature-256")] = "",
+        record_store: object = Depends(get_record_store),
+    ) -> JSONResponse:
+        trace_id = next_trace_id()
+        if every_code_github_webhook_handler is None:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=f"No Launchplane route for {_EVERY_CODE_GITHUB_WEBHOOK_ROUTE}.",
+            )
+        try:
+            status_code, payload = every_code_github_webhook_handler(
+                await request.body(),
+                x_github_event,
+                x_github_delivery,
+                x_hub_signature_256,
+                record_store,
+                resolved_control_plane_root,
+                trace_id,
+            )
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="GitHub webhook payload is invalid.",
+            ) from error
+        return JSONResponse(status_code=status_code, content=payload)
 
     def read_every_code_work_request_worker_write_identity(
         authorization: Annotated[str, Header(alias="Authorization")] = "",
@@ -10502,6 +10542,21 @@ def create_launchplane_fastapi_app(
         409: {"model": LaunchplaneErrorResponse},
         503: {"model": LaunchplaneErrorResponse},
     }
+
+    app.add_api_route(
+        _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
+        handle_every_code_github_webhook,
+        methods=["POST"],
+        status_code=202,
+        operation_id="handle_every_code_github_webhook",
+        summary="Handle Every Code GitHub webhook",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
 
     app.add_api_route(
         "/v1/previews/readiness",

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -2920,23 +2920,15 @@ def create_launchplane_fastapi_app(
                 code="not_found",
                 message=f"No Launchplane route for {_EVERY_CODE_GITHUB_WEBHOOK_ROUTE}.",
             )
-        try:
-            status_code, payload = every_code_github_webhook_handler(
-                await request.body(),
-                x_github_event,
-                x_github_delivery,
-                x_hub_signature_256,
-                record_store,
-                resolved_control_plane_root,
-                trace_id,
-            )
-        except ValueError:
-            raise _launchplane_http_error(
-                status_code=400,
-                trace_id=trace_id,
-                code="invalid_request",
-                message="GitHub webhook payload is invalid.",
-            ) from None
+        status_code, payload = every_code_github_webhook_handler(
+            await request.body(),
+            x_github_event,
+            x_github_delivery,
+            x_hub_signature_256,
+            record_store,
+            resolved_control_plane_root,
+            trace_id,
+        )
         return JSONResponse(status_code=status_code, content=payload)
 
     def read_every_code_work_request_worker_write_identity(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -415,7 +415,6 @@ from control_plane.workflows.verireel_preview_driver import (
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _WHOLE_PRODUCT_CONTEXT = "*"
-_EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
 _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
@@ -681,6 +680,7 @@ class _OdooStableTargetReplacementOperationStore(Protocol):
 
 _StartResponse = Callable[[str, list[tuple[str, str]]], None]
 _WsgiApp = Callable[[dict[str, object], _StartResponse], list[bytes]]
+_EveryCodeWebhookResponse = tuple[int, dict[str, object]]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -3337,7 +3337,6 @@ def _driver_write_routes_from_descriptors() -> frozenset[str]:
 
 def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
-        _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
         _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE,
@@ -4295,10 +4294,6 @@ def _supports_every_code_work_requests(record_store: object) -> bool:
     return hasattr(record_store, "list_every_code_work_request_records")
 
 
-def _github_webhook_header(environ: dict[str, object], name: str) -> str:
-    return str(environ.get(f"HTTP_{name.upper().replace('-', '_')}", "")).strip()
-
-
 def _github_webhook_mapping(payload: dict[str, object], key: str) -> dict[str, object] | None:
     value = payload.get(key)
     if isinstance(value, dict):
@@ -4377,14 +4372,12 @@ def _every_code_feedback_actor_is_trusted(
 
 def _every_code_untrusted_feedback_response(
     *,
-    start_response: _StartResponse,
     trace_id: str,
     delivery_id: str,
-) -> list[bytes]:
-    return _json_response(
-        start_response=start_response,
-        status_code=202,
-        payload={
+) -> _EveryCodeWebhookResponse:
+    return (
+        202,
+        {
             "status": "accepted",
             "trace_id": trace_id,
             "skipped": True,
@@ -4394,20 +4387,20 @@ def _every_code_untrusted_feedback_response(
     )
 
 
-def _handle_every_code_github_webhook(
-    *,
-    environ: dict[str, object],
-    start_response: _StartResponse,
-    trace_id: str,
+def handle_every_code_github_webhook_request(
+    body_bytes: bytes,
+    event_name: str,
+    delivery_id: str,
+    signature_header: str,
     record_store: object,
     control_plane_root_path: Path,
-) -> list[bytes]:
+    trace_id: str,
+) -> _EveryCodeWebhookResponse:
     secret = os.environ.get(_EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY, "").strip()
     if not secret:
-        return _json_response(
-            start_response=start_response,
-            status_code=503,
-            payload={
+        return (
+            503,
+            {
                 "status": "rejected",
                 "trace_id": trace_id,
                 "error": {
@@ -4417,18 +4410,16 @@ def _handle_every_code_github_webhook(
             },
         )
 
-    body_bytes = _read_request_body(environ)
     try:
         verify_github_webhook_signature(
             payload_bytes=body_bytes,
-            signature_header=_github_webhook_header(environ, "X-Hub-Signature-256"),
+            signature_header=signature_header,
             secret=secret,
         )
     except click.ClickException:
-        return _json_response(
-            start_response=start_response,
-            status_code=401,
-            payload={
+        return (
+            401,
+            {
                 "status": "rejected",
                 "trace_id": trace_id,
                 "error": {
@@ -4438,12 +4429,10 @@ def _handle_every_code_github_webhook(
             },
         )
 
-    delivery_id = _github_webhook_header(environ, "X-GitHub-Delivery")
-    if not delivery_id:
-        return _json_response(
-            start_response=start_response,
-            status_code=400,
-            payload={
+    if not delivery_id.strip():
+        return (
+            400,
+            {
                 "status": "rejected",
                 "trace_id": trace_id,
                 "error": {
@@ -4453,41 +4442,42 @@ def _handle_every_code_github_webhook(
             },
         )
 
+    normalized_delivery_id = delivery_id.strip()
+    normalized_event_name = event_name.strip()
     payload = _decode_json_request_body(body_bytes)
-    event_name = _github_webhook_header(environ, "X-GitHub-Event")
-    if event_name == "issue_comment":
+    if normalized_event_name == "issue_comment":
         preview_validation_response = _handle_every_code_preview_validation_webhook(
-            start_response=start_response,
             trace_id=trace_id,
-            delivery_id=delivery_id,
+            delivery_id=normalized_delivery_id,
             payload=payload,
             record_store=record_store,
             control_plane_root_path=control_plane_root_path,
         )
         if preview_validation_response is not None:
             return preview_validation_response
-    if event_name in {"issue_comment", "pull_request_review", "pull_request_review_comment"}:
+    if normalized_event_name in {
+        "issue_comment",
+        "pull_request_review",
+        "pull_request_review_comment",
+    }:
         return _handle_every_code_pr_feedback_webhook(
-            start_response=start_response,
             trace_id=trace_id,
-            delivery_id=delivery_id,
-            event_name=event_name,
+            delivery_id=normalized_delivery_id,
+            event_name=normalized_event_name,
             payload=payload,
             record_store=record_store,
         )
-    if event_name == "pull_request":
+    if normalized_event_name == "pull_request":
         return _handle_every_code_pull_request_webhook(
-            start_response=start_response,
             trace_id=trace_id,
-            delivery_id=delivery_id,
+            delivery_id=normalized_delivery_id,
             payload=payload,
             record_store=record_store,
         )
-    if event_name != "issues":
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+    if normalized_event_name != "issues":
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -4496,17 +4486,15 @@ def _handle_every_code_github_webhook(
         )
     if payload.get("action") == "closed":
         return _handle_every_code_issue_closed_webhook(
-            start_response=start_response,
             trace_id=trace_id,
-            delivery_id=delivery_id,
+            delivery_id=normalized_delivery_id,
             payload=payload,
             record_store=record_store,
         )
     if payload.get("action") != "labeled":
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -4517,10 +4505,9 @@ def _handle_every_code_github_webhook(
     label = _github_webhook_mapping(payload, "label")
     label_name = _github_webhook_string(label, "name")
     if label_name.strip().lower() != _EVERY_CODE_TRIGGER_LABEL:
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -4542,7 +4529,7 @@ def _handle_every_code_github_webhook(
         issue_title=_github_webhook_string(issue_payload, "title"),
         trigger_label=_EVERY_CODE_TRIGGER_LABEL,
         trigger_actor=_github_webhook_string(sender_payload, "login"),
-        github_delivery_id=delivery_id,
+        github_delivery_id=normalized_delivery_id,
         source="github_issue_label",
         queued_at=_utc_now_timestamp(),
     )
@@ -4559,18 +4546,17 @@ def _handle_every_code_github_webhook(
         driver_result={"request": stored_record.model_dump(mode="json")},
     )
     accepted_payload["deduped"] = deduped
-    accepted_payload["github_delivery_id"] = delivery_id
-    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+    accepted_payload["github_delivery_id"] = normalized_delivery_id
+    return 202, accepted_payload
 
 
 def _handle_every_code_issue_closed_webhook(
     *,
-    start_response: _StartResponse,
     trace_id: str,
     delivery_id: str,
     payload: dict[str, object],
     record_store: object,
-) -> list[bytes]:
+) -> _EveryCodeWebhookResponse:
     repository_payload = _github_webhook_mapping(payload, "repository")
     issue_payload = _github_webhook_mapping(payload, "issue")
     repository = _github_webhook_string(repository_payload, "full_name")
@@ -4618,11 +4604,7 @@ def _handle_every_code_issue_closed_webhook(
                 "request_id": terminal_record.request_id,
                 "state": terminal_record.state,
             }
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload=response_payload,
-        )
+        return 202, response_payload
 
     updated_record = updated_records[0]
     accepted_payload = _accepted_payload(
@@ -4639,22 +4621,20 @@ def _handle_every_code_issue_closed_webhook(
         },
     )
     accepted_payload["github_delivery_id"] = delivery_id
-    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+    return 202, accepted_payload
 
 
 def _handle_every_code_pull_request_webhook(
     *,
-    start_response: _StartResponse,
     trace_id: str,
     delivery_id: str,
     payload: dict[str, object],
     record_store: object,
-) -> list[bytes]:
+) -> _EveryCodeWebhookResponse:
     if payload.get("action") != "closed":
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -4706,10 +4686,9 @@ def _handle_every_code_pull_request_webhook(
             candidate_records[record.request_id] = record
 
     if not candidate_records:
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -4735,10 +4714,9 @@ def _handle_every_code_pull_request_webhook(
 
     if not updated_records:
         terminal_record = terminal_records[0]
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -4766,7 +4744,7 @@ def _handle_every_code_pull_request_webhook(
         },
     )
     accepted_payload["github_delivery_id"] = delivery_id
-    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+    return 202, accepted_payload
 
 
 def _every_code_issue_url_matches_pull_request(
@@ -4793,13 +4771,12 @@ def _every_code_issue_url_matches_pull_request(
 
 def _handle_every_code_preview_validation_webhook(
     *,
-    start_response: _StartResponse,
     trace_id: str,
     delivery_id: str,
     payload: dict[str, object],
     record_store: object,
     control_plane_root_path: Path,
-) -> list[bytes] | None:
+) -> _EveryCodeWebhookResponse | None:
     if payload.get("action") != "created":
         return None
     issue_payload = _github_webhook_mapping(payload, "issue")
@@ -4828,7 +4805,6 @@ def _handle_every_code_preview_validation_webhook(
         source_issue_author=issue_author,
     ):
         return _every_code_untrusted_feedback_response(
-            start_response=start_response,
             trace_id=trace_id,
             delivery_id=delivery_id,
         )
@@ -4860,10 +4836,9 @@ def _handle_every_code_preview_validation_webhook(
             received_at=_utc_now_timestamp(),
         )
     except click.ClickException as exc:
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -4889,7 +4864,7 @@ def _handle_every_code_preview_validation_webhook(
     if bool(result.get("deduped")):
         accepted_payload["deduped"] = True
     accepted_payload["github_delivery_id"] = delivery_id
-    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+    return 202, accepted_payload
 
 
 def _github_issue_numbers_referenced_by_pull_request(
@@ -4982,21 +4957,19 @@ def _iter_every_code_pr_feedback_records(
 
 def _handle_every_code_pr_feedback_webhook(
     *,
-    start_response: _StartResponse,
     trace_id: str,
     delivery_id: str,
     event_name: str,
     payload: dict[str, object],
     record_store: object,
-) -> list[bytes]:
+) -> _EveryCodeWebhookResponse:
     if not _every_code_pr_feedback_action_supported(
         event_name=event_name,
         action=str(payload.get("action", "")),
     ):
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -5011,10 +4984,9 @@ def _handle_every_code_pr_feedback_webhook(
         sender_payload=sender_payload,
         body_payload=body_payload,
     ):
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -5028,7 +5000,6 @@ def _handle_every_code_pr_feedback_webhook(
     actor = _github_webhook_string(sender_payload, "login")
     if not _every_code_feedback_actor_is_trusted(repository=repository, actor=actor):
         return _every_code_untrusted_feedback_response(
-            start_response=start_response,
             trace_id=trace_id,
             delivery_id=delivery_id,
         )
@@ -5039,10 +5010,9 @@ def _handle_every_code_pr_feedback_webhook(
     )
     body = _github_webhook_string(body_payload, "body")
     if not body.strip():
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -5092,10 +5062,9 @@ def _handle_every_code_pr_feedback_webhook(
                 matched_record = record
                 break
     if matched_record is None:
-        return _json_response(
-            start_response=start_response,
-            status_code=202,
-            payload={
+        return (
+            202,
+            {
                 "status": "accepted",
                 "trace_id": trace_id,
                 "skipped": True,
@@ -5122,10 +5091,9 @@ def _handle_every_code_pr_feedback_webhook(
     )
     for existing_feedback in existing_feedback_records:
         if existing_feedback.feedback_id == feedback_id:
-            return _json_response(
-                start_response=start_response,
-                status_code=202,
-                payload={
+            return (
+                202,
+                {
                     "status": "accepted",
                     "trace_id": trace_id,
                     "deduped": True,
@@ -5166,7 +5134,7 @@ def _handle_every_code_pr_feedback_webhook(
         driver_result={"feedback": feedback_record.model_dump(mode="json")},
     )
     accepted_payload["github_delivery_id"] = delivery_id
-    return _json_response(start_response=start_response, status_code=202, payload=accepted_payload)
+    return 202, accepted_payload
 
 
 def _every_code_pr_feedback_action_supported(*, event_name: str, action: str) -> bool:
@@ -7181,28 +7149,6 @@ def create_launchplane_service_app(
                     },
                 },
             )
-        if method == "POST" and path == _EVERY_CODE_GITHUB_WEBHOOK_ROUTE:
-            try:
-                return _handle_every_code_github_webhook(
-                    environ=environ,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                    record_store=record_store,
-                    control_plane_root_path=resolved_root,
-                )
-            except ValueError:
-                return _json_response(
-                    start_response=start_response,
-                    status_code=400,
-                    payload={
-                        "status": "rejected",
-                        "trace_id": request_trace_id,
-                        "error": {
-                            "code": "invalid_request",
-                            "message": "GitHub webhook payload is invalid.",
-                        },
-                    },
-                )
         try:
             if method == "GET":
                 identity = _read_identity(
@@ -9384,6 +9330,7 @@ def serve_launchplane_service(
         work_graph_planning_facts_provider=work_graph_planning_facts_provider,
         work_graph_issue_inbox_provider=work_graph_issue_inbox_provider,
         work_graph_issue_inbox_reconcile_provider=work_graph_issue_inbox_reconcile_provider,
+        every_code_github_webhook_handler=handle_every_code_github_webhook_request,
     )
     fastapi_application.mount(
         "/",

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4908,7 +4908,7 @@ def _handle_every_code_preview_validation_webhook(
             token=token,
             received_at=_utc_now_timestamp(),
         )
-    except click.ClickException as exc:
+    except click.ClickException:
         return (
             202,
             {
@@ -4916,7 +4916,6 @@ def _handle_every_code_preview_validation_webhook(
                 "trace_id": trace_id,
                 "skipped": True,
                 "reason": "preview_validation_failed",
-                "message": str(exc),
                 "github_delivery_id": delivery_id,
             },
         )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4387,6 +4387,22 @@ def _every_code_untrusted_feedback_response(
     )
 
 
+def _every_code_github_webhook_invalid_payload_response(
+    trace_id: str,
+) -> _EveryCodeWebhookResponse:
+    return (
+        400,
+        {
+            "status": "rejected",
+            "trace_id": trace_id,
+            "error": {
+                "code": "invalid_request",
+                "message": "GitHub webhook payload is invalid.",
+            },
+        },
+    )
+
+
 def handle_every_code_github_webhook_request(
     body_bytes: bytes,
     event_name: str,
@@ -4444,7 +4460,32 @@ def handle_every_code_github_webhook_request(
 
     normalized_delivery_id = delivery_id.strip()
     normalized_event_name = event_name.strip()
-    payload = _decode_json_request_body(body_bytes)
+    try:
+        payload = _decode_json_request_body(body_bytes)
+    except ValueError:
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
+    try:
+        return _handle_decoded_every_code_github_webhook_request(
+            trace_id=trace_id,
+            normalized_delivery_id=normalized_delivery_id,
+            normalized_event_name=normalized_event_name,
+            payload=payload,
+            record_store=record_store,
+            control_plane_root_path=control_plane_root_path,
+        )
+    except ValueError:
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
+
+
+def _handle_decoded_every_code_github_webhook_request(
+    *,
+    trace_id: str,
+    normalized_delivery_id: str,
+    normalized_event_name: str,
+    payload: dict[str, object],
+    record_store: object,
+    control_plane_root_path: Path,
+) -> _EveryCodeWebhookResponse:
     if normalized_event_name == "issue_comment":
         preview_validation_response = _handle_every_code_preview_validation_webhook(
             trace_id=trace_id,

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -4301,18 +4301,44 @@ def _github_webhook_mapping(payload: dict[str, object], key: str) -> dict[str, o
     return None
 
 
-def _github_webhook_required_mapping(payload: dict[str, object], key: str) -> dict[str, object]:
-    value = _github_webhook_mapping(payload, key)
-    if value is None:
-        raise ValueError(f"GitHub webhook requires object field {key!r}")
-    return value
-
-
 def _github_webhook_string(mapping: dict[str, object] | None, key: str) -> str:
     if mapping is None:
         return ""
     value = mapping.get(key)
     return value.strip() if isinstance(value, str) else ""
+
+
+def _github_webhook_raw_string(mapping: dict[str, object] | None, key: str) -> str:
+    if mapping is None:
+        return ""
+    value = mapping.get(key)
+    return value if isinstance(value, str) else ""
+
+
+def _github_webhook_positive_int(mapping: dict[str, object] | None, key: str) -> int | None:
+    if mapping is None:
+        return None
+    value = mapping.get(key)
+    if type(value) is int and value >= 1:
+        return value
+    return None
+
+
+def _github_repository_full_name_is_valid(repository: str) -> bool:
+    if repository.strip() != repository:
+        return False
+    owner, separator, name = repository.partition("/")
+    if not (owner and separator and name) or "/" in name:
+        return False
+    return all(_github_repository_component_is_valid(part) for part in (owner, name))
+
+
+def _github_repository_component_is_valid(value: str) -> bool:
+    return bool(
+        value
+        and value.strip() == value
+        and all(character.isalnum() or character in {".", "_", "-"} for character in value)
+    )
 
 
 def _github_login_normalized(login: str) -> str:
@@ -4460,21 +4486,17 @@ def handle_every_code_github_webhook_request(
 
     normalized_delivery_id = delivery_id.strip()
     normalized_event_name = event_name.strip()
-    try:
-        payload = _decode_json_request_body(body_bytes)
-    except ValueError:
+    payload = _decode_json_request_body_or_none(body_bytes)
+    if payload is None:
         return _every_code_github_webhook_invalid_payload_response(trace_id)
-    try:
-        return _handle_decoded_every_code_github_webhook_request(
-            trace_id=trace_id,
-            normalized_delivery_id=normalized_delivery_id,
-            normalized_event_name=normalized_event_name,
-            payload=payload,
-            record_store=record_store,
-            control_plane_root_path=control_plane_root_path,
-        )
-    except ValueError:
-        return _every_code_github_webhook_invalid_payload_response(trace_id)
+    return _handle_decoded_every_code_github_webhook_request(
+        trace_id=trace_id,
+        normalized_delivery_id=normalized_delivery_id,
+        normalized_event_name=normalized_event_name,
+        payload=payload,
+        record_store=record_store,
+        control_plane_root_path=control_plane_root_path,
+    )
 
 
 def _handle_decoded_every_code_github_webhook_request(
@@ -4559,14 +4581,20 @@ def _handle_decoded_every_code_github_webhook_request(
     repository_payload = _github_webhook_mapping(payload, "repository")
     issue_payload = _github_webhook_mapping(payload, "issue")
     sender_payload = _github_webhook_mapping(payload, "sender")
-    issue_number_value = issue_payload.get("number") if issue_payload is not None else None
-    if not isinstance(issue_number_value, int):
-        raise ValueError("GitHub issue webhook requires integer issue.number")
+    repository = _github_webhook_raw_string(repository_payload, "full_name")
+    issue_url = _github_webhook_string(issue_payload, "html_url")
+    issue_number_value = _github_webhook_positive_int(issue_payload, "number")
+    if (
+        issue_number_value is None
+        or not _github_repository_full_name_is_valid(repository)
+        or not issue_url.strip()
+    ):
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
 
     request = EveryCodeWorkRequestCreateEnvelope(
-        repository=_github_webhook_string(repository_payload, "full_name"),
+        repository=repository,
         issue_number=issue_number_value,
-        issue_url=_github_webhook_string(issue_payload, "html_url"),
+        issue_url=issue_url,
         issue_title=_github_webhook_string(issue_payload, "title"),
         trigger_label=_EVERY_CODE_TRIGGER_LABEL,
         trigger_actor=_github_webhook_string(sender_payload, "login"),
@@ -4600,10 +4628,10 @@ def _handle_every_code_issue_closed_webhook(
 ) -> _EveryCodeWebhookResponse:
     repository_payload = _github_webhook_mapping(payload, "repository")
     issue_payload = _github_webhook_mapping(payload, "issue")
-    repository = _github_webhook_string(repository_payload, "full_name")
-    issue_number_value = issue_payload.get("number") if issue_payload is not None else None
-    if not isinstance(issue_number_value, int):
-        raise ValueError("GitHub issue webhook requires integer issue.number")
+    repository = _github_webhook_raw_string(repository_payload, "full_name")
+    issue_number_value = _github_webhook_positive_int(issue_payload, "number")
+    if issue_number_value is None or not _github_repository_full_name_is_valid(repository):
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
     issue_url = _github_webhook_string(issue_payload, "html_url")
     closed_at = _github_webhook_string(issue_payload, "closed_at") or _utc_now_timestamp()
     state_reason = _github_webhook_string(issue_payload, "state_reason")
@@ -4685,8 +4713,12 @@ def _handle_every_code_pull_request_webhook(
 
     repository_payload = _github_webhook_mapping(payload, "repository")
     pull_request_payload = _github_webhook_mapping(payload, "pull_request")
-    repository = _github_webhook_string(repository_payload, "full_name")
-    pr_url = _github_webhook_string(pull_request_payload, "html_url")
+    repository = _github_webhook_raw_string(repository_payload, "full_name")
+    if not _github_repository_full_name_is_valid(repository):
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
+    pr_url = _github_webhook_raw_string(pull_request_payload, "html_url")
+    if not pr_url.strip() or pr_url.strip() != pr_url:
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
     linked_issue_numbers = (
         _github_issue_numbers_referenced_by_pull_request(
             pull_request_payload,
@@ -5021,6 +5053,8 @@ def _handle_every_code_pr_feedback_webhook(
 
     sender_payload = _github_webhook_mapping(payload, "sender")
     body_payload = _every_code_feedback_body_payload(event_name=event_name, payload=payload)
+    if body_payload is None:
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
     if _every_code_feedback_actor_is_automation(
         sender_payload=sender_payload,
         body_payload=body_payload,
@@ -5037,18 +5071,23 @@ def _handle_every_code_pr_feedback_webhook(
         )
 
     repository_payload = _github_webhook_mapping(payload, "repository")
-    repository = _github_webhook_string(repository_payload, "full_name")
+    repository = _github_webhook_raw_string(repository_payload, "full_name")
+    if not _github_repository_full_name_is_valid(repository):
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
     actor = _github_webhook_string(sender_payload, "login")
     if not _every_code_feedback_actor_is_trusted(repository=repository, actor=actor):
         return _every_code_untrusted_feedback_response(
             trace_id=trace_id,
             delivery_id=delivery_id,
         )
-    pr_number, pr_url = _every_code_feedback_pr_reference(
+    pr_reference = _every_code_feedback_pr_reference(
         event_name=event_name,
         payload=payload,
         repository=repository,
     )
+    if pr_reference is None:
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
+    pr_number, pr_url = pr_reference
     body = _github_webhook_string(body_payload, "body")
     if not body.strip():
         return (
@@ -5115,8 +5154,13 @@ def _handle_every_code_pr_feedback_webhook(
         )
 
     github_node_id = _github_webhook_string(body_payload, "node_id")
-    github_id_value = body_payload.get("id") if body_payload is not None else ""
+    github_id_value = body_payload.get("id")
     github_id = str(github_id_value) if github_id_value is not None else ""
+    github_feedback_identity = github_node_id.strip() or github_id.strip()
+    if not github_feedback_identity or not any(
+        character.isalnum() for character in github_feedback_identity
+    ):
+        return _every_code_github_webhook_invalid_payload_response(trace_id)
     feedback_id = build_every_code_pr_feedback_id(
         repository=repository,
         pr_number=pr_number,
@@ -5219,9 +5263,9 @@ def _every_code_feedback_kind(event_name: str) -> EveryCodePrFeedbackKind:
 
 def _every_code_feedback_body_payload(
     *, event_name: str, payload: dict[str, object]
-) -> dict[str, object]:
+) -> dict[str, object] | None:
     key = "review" if event_name == "pull_request_review" else "comment"
-    return _github_webhook_required_mapping(payload, key)
+    return _github_webhook_mapping(payload, key)
 
 
 def _every_code_feedback_pr_reference(
@@ -5229,18 +5273,22 @@ def _every_code_feedback_pr_reference(
     event_name: str,
     payload: dict[str, object],
     repository: str,
-) -> tuple[int, str]:
+) -> tuple[int, str] | None:
     if event_name == "issue_comment":
-        issue_payload = _github_webhook_required_mapping(payload, "issue")
+        issue_payload = _github_webhook_mapping(payload, "issue")
+        if issue_payload is None:
+            return None
         pull_request_marker = issue_payload.get("pull_request")
         if not isinstance(pull_request_marker, dict):
-            raise ValueError("Every Code PR feedback issue_comment requires pull_request issue")
-        pr_number_value = issue_payload.get("number")
+            return None
+        pr_number_value = _github_webhook_positive_int(issue_payload, "number")
     else:
-        pull_request_payload = _github_webhook_required_mapping(payload, "pull_request")
-        pr_number_value = pull_request_payload.get("number")
-    if not isinstance(pr_number_value, int):
-        raise ValueError("Every Code PR feedback requires integer pull request number")
+        pull_request_payload = _github_webhook_mapping(payload, "pull_request")
+        if pull_request_payload is None:
+            return None
+        pr_number_value = _github_webhook_positive_int(pull_request_payload, "number")
+    if pr_number_value is None:
+        return None
     return pr_number_value, f"https://github.com/{repository}/pull/{pr_number_value}"
 
 
@@ -6083,6 +6131,16 @@ def _decode_json_request_body(body_bytes: bytes) -> dict[str, object]:
     if not isinstance(payload, dict):
         raise ValueError("Request body must decode to a JSON object.")
     return payload
+
+
+def _decode_json_request_body_or_none(body_bytes: bytes) -> dict[str, object] | None:
+    try:
+        payload = json.loads(body_bytes.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return cast(dict[str, object], payload)
 
 
 def _bearer_token(environ: dict[str, object]) -> str:

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -167,8 +167,11 @@ Keep a compatibility surface only when it is one of these:
   idempotency state. The PR-feedback status route also preserves the existing
   `404 not_found` and `409 feedback_already_final` transition semantics. Their
   legacy WSGI write branches are deleted; direct WSGI fallback calls fail closed.
-  The Every Code GitHub webhook route remains on the mounted WSGI fallback until
-  its native replacement lands.
+  The Every Code GitHub webhook uses native FastAPI, preserves unauthenticated
+  GitHub HMAC verification, delivery/event/signature validation, signed-event
+  skip semantics, work-request creation/dedupe, issue and pull-request close
+  handling, preview validation comments, and PR-feedback ingestion. Its legacy
+  WSGI write branch is deleted; direct WSGI fallback calls fail closed.
 - Agent write-intent evaluation uses native FastAPI
   `POST /v1/agent/write-intents/evaluate`, preserves terminal-agent scoped
   preflight access, returns denied intents as successful `202 accepted` preflight

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -212,7 +212,10 @@ VeriReel product paths:
   - `POST /v1/every-code/notification-policies/apply` (native FastAPI for
     bearer-token callers, DB-backed storage, local-operator reason enforcement,
     and optional `Idempotency-Key` replay/conflict handling)
-  - `POST /v1/every-code/github-webhook`
+  - `POST /v1/every-code/github-webhook` (native FastAPI,
+    unauthenticated GitHub HMAC verification, signed-event skip semantics,
+    Every Code work-request creation/dedupe, issue and pull-request close
+    handling, preview validation comments, and PR-feedback ingestion)
   - `POST /v1/every-code/work-requests/create` (native FastAPI for
     bearer-token callers, `every_code_work_request.write` authorization on
     `launchplane`/`launchplane`, record-store write capability checks, and
@@ -376,7 +379,8 @@ requests. Other signed events, actions, or labels return `202` with
 Every Code work request and include `deduped` plus the delivery id in the
 response. Matching pull-request close deliveries can close every linked request
 referenced by the PR, including still-queued requests that never stored a result
-PR URL.
+PR URL. The route is native FastAPI; the legacy WSGI branch is deleted, and
+direct WSGI fallback calls fail closed.
 
 The Every Code worker read, native claim, and status routes also accept a
 dedicated local-worker bearer token. Configure

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1800,10 +1800,14 @@ def _meta_product_config_payload(
     return payload
 
 
-def _github_webhook_signature(payload: Mapping[str, object], secret: str) -> str:
-    body_bytes = json.dumps(payload).encode("utf-8")
+def _github_webhook_body_signature(body_bytes: bytes, secret: str) -> str:
     signature = hmac.new(secret.encode("utf-8"), body_bytes, hashlib.sha256).hexdigest()
     return f"sha256={signature}"
+
+
+def _github_webhook_signature(payload: Mapping[str, object], secret: str) -> str:
+    body_bytes = json.dumps(payload).encode("utf-8")
+    return _github_webhook_body_signature(body_bytes, secret)
 
 
 def _every_code_github_issue_labeled_payload(
@@ -2199,21 +2203,29 @@ def _invoke_raw_app(
     authorization: str = "",
     query_string: str = "",
     headers: dict[str, str] | None = None,
+    body_bytes: bytes = b"",
 ) -> tuple[int, dict[str, str], bytes]:
     environ = {
         "REQUEST_METHOD": method,
         "PATH_INFO": path,
         "QUERY_STRING": query_string,
-        "CONTENT_LENGTH": "0",
-        "wsgi.input": io.BytesIO(b""),
+        "CONTENT_LENGTH": str(len(body_bytes)),
+        "wsgi.input": io.BytesIO(body_bytes),
         "HTTP_AUTHORIZATION": authorization,
+        "SERVER_NAME": "testserver",
+        "SERVER_PORT": "80",
+        "wsgi.url_scheme": "http",
     }
     for header_name, header_value in (headers or {}).items():
         environ[f"HTTP_{header_name.upper().replace('-', '_')}"] = header_value
     captured_status = ""
     captured_headers: list[tuple[str, str]] = []
 
-    def start_response(status: str, response_headers: list[tuple[str, str]]) -> None:
+    def start_response(
+        status: str,
+        response_headers: list[tuple[str, str]],
+        _exc_info: object | None = None,
+    ) -> None:
         nonlocal captured_status, captured_headers
         captured_status = status
         captured_headers = response_headers
@@ -9605,6 +9617,44 @@ class LaunchplaneServiceTests(unittest.TestCase):
 
         self.assertEqual(status_code, 401)
         self.assertEqual(payload["error"]["code"], "webhook_signature_invalid")
+
+    def test_every_code_github_webhook_rejects_invalid_json_payload(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        body_bytes = b'{"action":'
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_every_code_github_webhook_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, _headers, response_body = _invoke_raw_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                authorization="",
+                body_bytes=body_bytes,
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-invalid-json",
+                    "X-Hub-Signature-256": _github_webhook_body_signature(
+                        body_bytes,
+                        secret,
+                    ),
+                },
+            )
+            payload = json.loads(response_body.decode("utf-8"))
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "GitHub webhook payload is invalid.")
 
     def test_every_code_github_webhook_ignores_other_labels(self) -> None:
         secret = "launchplane-every-code-webhook-secret"

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9656,6 +9656,403 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "invalid_request")
         self.assertEqual(payload["error"]["message"], "GitHub webhook payload is invalid.")
 
+    def test_every_code_github_webhook_rejects_malformed_issue_payload(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        webhook_payload = _every_code_github_issue_labeled_payload()
+        webhook_payload["repository"] = {}
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_every_code_github_webhook_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-malformed-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "GitHub webhook payload is invalid.")
+
+    def test_every_code_github_webhook_rejects_bool_issue_number(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        webhook_payload = _every_code_github_issue_labeled_payload()
+        issue = cast(dict[str, object], webhook_payload["issue"])
+        issue["number"] = True
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_every_code_github_webhook_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-bool-issue-number",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "GitHub webhook payload is invalid.")
+
+    def test_every_code_github_webhook_rejects_malformed_repository_name(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        webhook_payload = _every_code_github_issue_labeled_payload()
+        repository = cast(dict[str, object], webhook_payload["repository"])
+        repository["full_name"] = " cbusillo/code"
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_every_code_github_webhook_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-malformed-repository",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "GitHub webhook payload is invalid.")
+
+    def test_every_code_github_webhook_rejects_malformed_pull_request_repository(
+        self,
+    ) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        webhook_payload = _every_code_github_pull_request_closed_payload()
+        repository = cast(dict[str, object], webhook_payload["repository"])
+        repository["full_name"] = " cbusillo/code"
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_every_code_github_webhook_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-malformed-pr-repository",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "GitHub webhook payload is invalid.")
+
+    def test_every_code_github_webhook_rejects_malformed_pull_request_url(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        webhook_payload = _every_code_github_pull_request_closed_payload()
+        pull_request = cast(dict[str, object], webhook_payload["pull_request"])
+        pull_request["html_url"] = ""
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_every_code_github_webhook_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "delivery-malformed-pr-url",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 400)
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "GitHub webhook payload is invalid.")
+
+    def test_every_code_github_webhook_rejects_malformed_feedback_payload(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload()
+        comment_payload = _every_code_github_pr_comment_payload()
+        comment = cast(dict[str, object], comment_payload["comment"])
+        comment.pop("node_id")
+        comment.pop("id")
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_every_code_github_webhook_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = str(issue_response["records"]["request_id"])
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="done",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
+                result_summary="Opened PR.",
+                updated_at="2026-05-06T16:00:00Z",
+            )
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-malformed-feedback",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+            feedback_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
+                request_id=request_id
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(feedback_status, 400)
+        self.assertEqual(feedback_response["status"], "rejected")
+        self.assertEqual(feedback_response["error"]["code"], "invalid_request")
+        self.assertEqual(
+            feedback_response["error"]["message"], "GitHub webhook payload is invalid."
+        )
+        self.assertEqual(feedback_records, ())
+
+    def test_every_code_github_webhook_rejects_malformed_feedback_repository(
+        self,
+    ) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload()
+        comment_payload = _every_code_github_pr_comment_payload()
+        repository = cast(dict[str, object], comment_payload["repository"])
+        repository["full_name"] = " cbusillo/code"
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_every_code_github_webhook_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = str(issue_response["records"]["request_id"])
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="done",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
+                result_summary="Opened PR.",
+                updated_at="2026-05-06T16:00:00Z",
+            )
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-malformed-feedback-repository",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+            feedback_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
+                request_id=request_id
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(feedback_status, 400)
+        self.assertEqual(feedback_response["status"], "rejected")
+        self.assertEqual(feedback_response["error"]["code"], "invalid_request")
+        self.assertEqual(
+            feedback_response["error"]["message"], "GitHub webhook payload is invalid."
+        )
+        self.assertEqual(feedback_records, ())
+
+    def test_every_code_github_webhook_rejects_slug_unsafe_feedback_identity(
+        self,
+    ) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        issue_payload = _every_code_github_issue_labeled_payload()
+        comment_payload = _every_code_github_pr_comment_payload()
+        comment = cast(dict[str, object], comment_payload["comment"])
+        comment["node_id"] = "---"
+        comment.pop("id")
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret,
+                    "LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN": "dev-worker-token",
+                },
+            ),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            app = create_every_code_github_webhook_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            issue_status, issue_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=issue_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-issue",
+                    "X-Hub-Signature-256": _github_webhook_signature(issue_payload, secret),
+                },
+            )
+            request_id = str(issue_response["records"]["request_id"])
+            _claim_every_code_work_request_in_filesystem(state_dir, request_id)
+            _update_every_code_work_request_status_in_filesystem(
+                state_dir,
+                request_id,
+                state="done",
+                result_pr_url="https://github.com/cbusillo/code/pull/26",
+                result_summary="Opened PR.",
+                updated_at="2026-05-06T16:00:00Z",
+            )
+            feedback_status, feedback_response = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-slug-unsafe-feedback",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+            feedback_records = FilesystemRecordStore(state_dir).list_every_code_pr_feedback_records(
+                request_id=request_id
+            )
+
+        self.assertEqual(issue_status, 202)
+        self.assertEqual(feedback_status, 400)
+        self.assertEqual(feedback_response["status"], "rejected")
+        self.assertEqual(feedback_response["error"]["code"], "invalid_request")
+        self.assertEqual(
+            feedback_response["error"]["message"], "GitHub webhook payload is invalid."
+        )
+        self.assertEqual(feedback_records, ())
+
     def test_every_code_github_webhook_ignores_other_labels(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         webhook_payload = _every_code_github_issue_labeled_payload(label="bug")

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -131,6 +131,7 @@ from control_plane.merge_train import discover_merge_train_stack
 from control_plane.service import (
     GenericWebPreviewVerificationRequest,
     create_launchplane_service_app as _create_launchplane_service_app,
+    handle_every_code_github_webhook_request,
 )
 from control_plane.http_app import LaunchplaneAuthzPolicyRuntime
 from control_plane.http_app import create_launchplane_fastapi_app
@@ -1423,6 +1424,19 @@ def create_launchplane_fastapi_wsgi_app(
         Callable[[dict[str, object], Callable[[str, list[tuple[str, str]]], None]], list[bytes]],
         ASGIMiddleware(app),
     )
+
+
+def create_every_code_github_webhook_app(
+    **kwargs: object,
+) -> Callable[[dict[str, object], Callable[[str, list[tuple[str, str]]], None]], list[bytes]]:
+    state_dir = kwargs.pop("state_dir", None)
+    local_record_store = kwargs.pop("local_record_store_for_tests", None)
+    if local_record_store is None and "database_url" not in kwargs and isinstance(state_dir, Path):
+        local_record_store = FilesystemRecordStore(state_dir=state_dir)
+    if local_record_store is not None:
+        kwargs["record_store_factory"] = lambda: local_record_store
+    kwargs["every_code_github_webhook_handler"] = handle_every_code_github_webhook_request
+    return create_launchplane_fastapi_wsgi_app(**kwargs)
 
 
 def create_launchplane_dokploy_target_setup_app(**kwargs: object) -> Any:
@@ -2787,7 +2801,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         ):
             root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_every_code_worker_identity()),
                 authz_policy=_every_code_worker_policy(
@@ -2900,7 +2914,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         ):
             root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=root / "state",
                 verifier=_StubVerifier(_every_code_worker_identity()),
                 authz_policy=_every_code_worker_policy(
@@ -7448,7 +7462,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -7521,7 +7535,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -7567,6 +7581,38 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(second_payload["records"]["state"], "claimed")
         self.assertEqual(stored_request.state, "claimed")
         self.assertEqual(stored_request.github_delivery_id, "delivery-1")
+
+    def test_every_code_github_webhook_is_retired_from_legacy_wsgi_app(self) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        webhook_payload = _every_code_github_issue_labeled_payload()
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+        ):
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=webhook_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-GitHub-Delivery": "delivery-1",
+                    "X-Hub-Signature-256": _github_webhook_signature(webhook_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_every_code_summary_read_route_is_retired_from_legacy_wsgi_app(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -7704,7 +7750,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -7801,7 +7847,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -7892,7 +7938,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -7979,7 +8025,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -8064,7 +8110,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -8148,7 +8194,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -8238,7 +8284,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -8317,7 +8363,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -8381,7 +8427,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
             ),
         ):
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(identity),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -8419,7 +8465,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -8519,7 +8565,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ) as create_comment,
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -8626,7 +8672,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -8695,7 +8741,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -8765,7 +8811,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -8836,7 +8882,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -8919,7 +8965,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 repo_managers={"cbusillo/sellyouroutboard": "@Mbanks89"},
             )
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -8995,7 +9041,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 repo_managers={"cbusillo/sellyouroutboard": "@Mbanks89"},
             )
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -9063,7 +9109,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
         ):
             state_dir = Path(temporary_directory_name) / "state"
             _write_github_planning_config(Path(home_directory_name), repo_managers={})
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -9125,7 +9171,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -9194,7 +9240,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
@@ -9273,14 +9319,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
             ),
         ):
             state_dir = Path(temporary_directory_name) / "state"
-            app = create_launchplane_service_app(
+            webhook_app = create_every_code_github_webhook_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
             _issue_status, issue_response = _invoke_app(
-                app,
+                webhook_app,
                 method="POST",
                 path="/v1/every-code/github-webhook",
                 payload=issue_payload,
@@ -9302,7 +9348,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 updated_at="2026-05-06T16:00:00Z",
             )
             _invoke_app(
-                app,
+                webhook_app,
                 method="POST",
                 path="/v1/every-code/github-webhook",
                 payload=comment_payload,
@@ -9318,8 +9364,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 status="pending",
             )
             feedback_id = feedback_records[0].feedback_id
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
             status_status, status_response = _invoke_app(
-                app,
+                legacy_app,
                 method="POST",
                 path="/v1/every-code/pr-feedback/status",
                 payload={
@@ -9532,7 +9584,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
             ),
         ):
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
@@ -9564,7 +9616,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
             ),
         ):
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
@@ -9596,7 +9648,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": ""},
             ),
         ):
-            app = create_launchplane_service_app(
+            app = create_every_code_github_webhook_app(
                 state_dir=Path(temporary_directory_name) / "state",
                 verifier=_StubVerifier(_identity()),
                 authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -8637,6 +8637,54 @@ class LaunchplaneServiceTests(unittest.TestCase):
         create_comment.assert_called_once()
         self.assertIn("@cbusillo", create_comment.call_args.kwargs["body"])
 
+    def test_every_code_preview_validation_failure_returns_generic_webhook_response(
+        self,
+    ) -> None:
+        secret = "launchplane-every-code-webhook-secret"
+        comment_payload = _every_code_github_issue_comment_payload(
+            repository="cbusillo/sellyouroutboard",
+            issue_number=82,
+            body="/preview ok",
+        )
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET": secret},
+            ),
+            patch(
+                "control_plane.service.resolve_launchplane_github_token",
+                side_effect=ClickException(
+                    "Traceback (most recent call last): secret token leaked"
+                ),
+            ),
+        ):
+            app = create_every_code_github_webhook_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/every-code/github-webhook",
+                payload=comment_payload,
+                authorization="",
+                headers={
+                    "X-GitHub-Event": "issue_comment",
+                    "X-GitHub-Delivery": "delivery-preview-validation-failed",
+                    "X-Hub-Signature-256": _github_webhook_signature(comment_payload, secret),
+                },
+            )
+
+        self.assertEqual(status_code, 202)
+        self.assertEqual(payload["status"], "accepted")
+        self.assertIs(payload["skipped"], True)
+        self.assertEqual(payload["reason"], "preview_validation_failed")
+        self.assertNotIn("message", payload)
+        self.assertNotIn("Traceback", json.dumps(payload, sort_keys=True))
+
     def test_every_code_preview_ok_allows_repo_owner_override(self) -> None:
         secret = "launchplane-every-code-webhook-secret"
         issue_payload = _every_code_github_issue_labeled_payload(


### PR DESCRIPTION
## Summary
- move `POST /v1/every-code/github-webhook` onto native FastAPI while preserving unauthenticated GitHub HMAC verification
- delete the legacy WSGI webhook dispatcher path and assert direct WSGI fallback calls fail closed
- keep webhook creation/dedupe, issue and pull-request close handling, preview validation, and PR-feedback ingestion covered on the native path
- update v2 compatibility/service-boundary docs for the webhook migration

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests -k every_code_github_webhook`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests -k every_code`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest` (2,903 tests)
- JetBrains changed-files inspection: GREEN, no actionable findings
- Review agents: two read-only agents, no blocking findings; one housekeeping note fixed before push
