### PR TITLE
Migrate preview lifecycle plan to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -125,6 +125,11 @@ from control_plane.contracts.preview_evidence import (
     PreviewGenerationEvidenceEnvelope,
 )
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
+from control_plane.contracts.preview_lifecycle_plan_record import (
+    PreviewLifecycleDesiredPreview,
+    PreviewLifecyclePlanRecord,
+)
 from control_plane.contracts.preview_pr_feedback_notifications import (
     PreviewPrFeedbackNotificationAttemptRecord,
     PreviewPrFeedbackNotificationPolicyRecord,
@@ -230,6 +235,7 @@ from control_plane.workflows.odoo_stable_operation_worker import (
     DEFAULT_ODOO_STABLE_WORKER_MAX_ATTEMPTS,
     reconcile_stale_odoo_stable_operation_records,
 )
+from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.work_graph_issue_inbox import (
     GitHubIssueInboxReadModel,
@@ -268,6 +274,7 @@ _EVERY_CODE_NOTIFICATION_POLICY_APPLY_ROUTE = "/v1/every-code/notification-polic
 _PREVIEW_PR_FEEDBACK_NOTIFICATION_POLICY_APPLY_ROUTE = (
     "/v1/previews/pr-feedback/notification-policies/apply"
 )
+_PREVIEW_LIFECYCLE_PLAN_ROUTE = "/v1/previews/lifecycle-plan"
 _RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE = "/v1/runtime-key-safety/policies/apply"
 _EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
 _PRIVATE_HEALTH_ENDPOINT_APPLY_ROUTE = "/v1/private-health-endpoints/apply"
@@ -1218,6 +1225,27 @@ class PreviewPrFeedbackNotificationPolicyApplyEnvelope(BaseModel):
         return self
 
 
+class PreviewLifecyclePlanEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    desired_previews: tuple[PreviewLifecycleDesiredPreview, ...] = ()
+    desired_state_id: str = ""
+    source: str = "workflow"
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PreviewLifecyclePlanEnvelope":
+        if not self.product.strip():
+            raise ValueError("preview lifecycle plan requires product")
+        if not self.context.strip():
+            raise ValueError("preview lifecycle plan requires context")
+        if not self.source.strip():
+            raise ValueError("preview lifecycle plan requires source")
+        return self
+
+
 class EdgeEndpointApplyEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1396,6 +1424,21 @@ class _PreviewPrFeedbackNotificationPolicyApplyStore(Protocol):
     def write_preview_pr_feedback_notification_policy_record(
         self,
         record: PreviewPrFeedbackNotificationPolicyRecord,
+    ) -> object: ...
+
+
+class _PreviewLifecyclePlanApplyStore(Protocol):
+    def list_preview_inventory_scan_records(
+        self,
+        *,
+        context_name: str | None = None,
+        limit: int | None = 50,
+        offset: int = 0,
+    ) -> tuple[PreviewInventoryScanRecord, ...]: ...
+
+    def write_preview_lifecycle_plan_record(
+        self,
+        record: PreviewLifecyclePlanRecord,
     ) -> object: ...
 
 
@@ -2271,6 +2314,27 @@ def require_ingress_route_apply_store(record_store: object) -> _IngressRouteAppl
             f"Launchplane record store does not support ingress route applies: {missing_summary}"
         )
     return cast(_IngressRouteApplyStore, record_store)
+
+
+def require_preview_lifecycle_plan_apply_store(
+    record_store: object,
+) -> _PreviewLifecyclePlanApplyStore:
+    required_methods = (
+        "list_preview_inventory_scan_records",
+        "write_preview_lifecycle_plan_record",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support preview lifecycle plan applies: "
+            f"{missing_summary}"
+        )
+    return cast(_PreviewLifecyclePlanApplyStore, record_store)
 
 
 def require_ingress_edge_endpoint_read_store(record_store: object) -> _IngressEdgeEndpointReadStore:
@@ -8731,6 +8795,82 @@ def create_launchplane_fastapi_app(
             )
         return response
 
+    async def apply_preview_lifecycle_plan(
+        request: Request,
+        plan_request: PreviewLifecyclePlanEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="preview_lifecycle.plan",
+            product=plan_request.product,
+            context=plan_request.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot plan preview lifecycle for the requested product/context."
+                ),
+            )
+        (
+            normalized_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_PREVIEW_LIFECYCLE_PLAN_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=True,
+        )
+        if replayed_response is not None:
+            return replayed_response
+        try:
+            plan_store = require_preview_lifecycle_plan_apply_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        inventory_scans = plan_store.list_preview_inventory_scan_records(
+            context_name=plan_request.context,
+            limit=1,
+        )
+        plan_record = build_preview_lifecycle_plan(
+            product=plan_request.product,
+            context=plan_request.context,
+            planned_at=utc_now_timestamp(),
+            source=plan_request.source,
+            desired_previews=plan_request.desired_previews,
+            desired_state_id=plan_request.desired_state_id,
+            latest_inventory_scan=next(iter(inventory_scans), None),
+        )
+        plan_store.write_preview_lifecycle_plan_record(plan_record)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"preview_lifecycle_plan_id": plan_record.plan_id},
+            result=plan_record.model_dump(mode="json"),
+        )
+        store_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_PREVIEW_LIFECYCLE_PLAN_ROUTE,
+            idempotency_key=normalized_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
     async def apply_ingress_canary_route(
         request: Request,
         canary_request: IngressCanaryRouteApplyEnvelope,
@@ -10087,6 +10227,24 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="apply_preview_pr_feedback_notification_policy",
         summary="Apply preview PR feedback notification policy",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PREVIEW_LIFECYCLE_PLAN_ROUTE,
+        apply_preview_lifecycle_plan,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="apply_preview_lifecycle_plan",
+        summary="Plan preview lifecycle",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -100,7 +100,6 @@ from control_plane.contracts.preview_mutation_request import (
 )
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_lifecycle_plan_record import (
-    PreviewLifecycleDesiredPreview,
     PreviewLifecyclePlanRecord,
 )
 from control_plane.contracts.preview_lifecycle_cleanup_record import PreviewLifecycleCleanupRecord
@@ -843,27 +842,6 @@ _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS = frozenset(
 _GENERIC_WEB_BASE_DRIVER_ROUTE_PATHS = frozenset(
     _GENERIC_WEB_BASE_DRIVER_SHARED_ROUTE_PATHS | _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS
 )
-
-
-class PreviewLifecyclePlanEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    context: str
-    desired_previews: tuple[PreviewLifecycleDesiredPreview, ...] = ()
-    desired_state_id: str = ""
-    source: str = "workflow"
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "PreviewLifecyclePlanEnvelope":
-        if not self.product.strip():
-            raise ValueError("preview lifecycle plan requires product")
-        if not self.context.strip():
-            raise ValueError("preview lifecycle plan requires context")
-        if not self.source.strip():
-            raise ValueError("preview lifecycle plan requires source")
-        return self
 
 
 class PreviewDesiredStateEnvelope(BaseModel):
@@ -3346,7 +3324,6 @@ def _build_write_routes() -> frozenset[str]:
         "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
-        "/v1/previews/lifecycle-plan",
         "/v1/previews/lifecycle-sweep",
         "/v1/drivers/launchplane/self-deploy",
     }
@@ -8719,59 +8696,6 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     request=self_deploy_request.deploy,
                 ).model_dump(mode="json")
-            elif path == "/v1/previews/lifecycle-plan":
-                preview_lifecycle_plan_request = PreviewLifecyclePlanEnvelope.model_validate(
-                    payload
-                )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="preview_lifecycle.plan",
-                    product=preview_lifecycle_plan_request.product,
-                    context=preview_lifecycle_plan_request.context,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": (
-                                    "Workflow cannot plan preview lifecycle for the requested"
-                                    " product/context."
-                                ),
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = build_preview_lifecycle_plan(
-                    product=preview_lifecycle_plan_request.product,
-                    context=preview_lifecycle_plan_request.context,
-                    planned_at=_utc_now_timestamp(),
-                    source=preview_lifecycle_plan_request.source,
-                    desired_previews=preview_lifecycle_plan_request.desired_previews,
-                    desired_state_id=preview_lifecycle_plan_request.desired_state_id,
-                    latest_inventory_scan=_latest_preview_inventory_scan(
-                        record_store=record_store,
-                        context_name=preview_lifecycle_plan_request.context,
-                    ),
-                )
-                preview_lifecycle_plan_id = _write_preview_lifecycle_plan_if_supported(
-                    record_store=record_store,
-                    record=driver_result,
-                )
-                result = {"preview_lifecycle_plan_id": preview_lifecycle_plan_id}
             elif path == "/v1/previews/desired-state":
                 preview_desired_state_request = PreviewDesiredStateEnvelope.model_validate(payload)
                 if not authz_policy.allows(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -193,6 +193,12 @@ Keep a compatibility surface only when it is one of these:
   local checkout `public-ingress-monitor run-once` CLI mutation command are
   deleted; the route has no `GET` API, manual reruns go through the GitHub
   workflow, and direct WSGI fallback calls fail closed.
+- Preview lifecycle plan uses native FastAPI
+  `POST /v1/previews/lifecycle-plan`, preserves
+  `preview_lifecycle.plan` authorization and optional `Idempotency-Key`
+  replay/conflict behavior, writes the typed lifecycle plan record, and returns
+  the stored plan as accepted evidence. Its legacy WSGI write branch is deleted,
+  and direct WSGI fallback calls fail closed.
 - Public ingress, Every Code, and preview PR feedback notification policy apply
   use native FastAPI routes for bearer-token callers and preserve DB-backed
   storage enforcement, local operator reason requirements, explicit preview

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1103,6 +1103,12 @@ report-only behavior and records the cleanup request/result next to the plan.
 Destructive provider cleanup is only attempted when `apply=true` is explicitly
 supplied by an authorized GitHub Actions workflow.
 
+`POST /v1/previews/lifecycle-plan` is a native FastAPI route. It requires
+`preview_lifecycle.plan` authorization for the requested product/context,
+preserves optional `Idempotency-Key` replay/conflict behavior, writes the typed
+preview lifecycle plan record, and has its legacy WSGI fallback branch deleted;
+direct fallback calls fail closed.
+
 PR feedback delivery is part of the same preview lifecycle boundary. Product
 repos submit thin preview outcome facts to `POST /v1/previews/pr-feedback`;
 Launchplane renders the review comment, upserts the anchored GitHub PR comment

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -2143,11 +2143,12 @@ def _invoke_app(
     headers: dict[str, str] | None = None,
 ) -> tuple[int, dict[str, Any]]:
     body_bytes = json.dumps(payload).encode("utf-8") if payload is not None else b""
-    environ = {
+    environ: dict[str, object] = {
         "REQUEST_METHOD": method,
         "PATH_INFO": path,
         "QUERY_STRING": query_string,
         "CONTENT_LENGTH": str(len(body_bytes)),
+        "CONTENT_TYPE": "application/json" if payload is not None else "",
         "wsgi.input": io.BytesIO(body_bytes),
         "HTTP_AUTHORIZATION": authorization,
         "SERVER_NAME": "testserver",
@@ -2760,6 +2761,29 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     "/v1/every-code/notification-policies/apply",
                     "/v1/previews/pr-feedback/notification-policies/apply",
                 )
+            )
+
+        for status_code, payload in responses:
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
+
+    def test_preview_lifecycle_plan_legacy_wsgi_fallback_is_removed(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            app = create_launchplane_service_app(
+                state_dir=Path(temporary_directory_name) / "state",
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+
+            responses = tuple(
+                _invoke_app(
+                    app,
+                    method=method,
+                    path="/v1/previews/lifecycle-plan",
+                    payload={"schema_version": 1},
+                )
+                for method in ("GET", "POST")
             )
 
         for status_code, payload in responses:
@@ -23713,8 +23737,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
+            app = create_launchplane_fastapi_wsgi_app(
                 verifier=_StubVerifier(
                     _identity(
                         workflow_ref=(
@@ -23725,6 +23748,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
                 authz_policy=policy,
                 control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
             )
 
             status_code, payload = _invoke_app(
@@ -23791,8 +23815,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
+            app = create_launchplane_fastapi_wsgi_app(
                 verifier=_StubVerifier(
                     _identity(
                         workflow_ref=(
@@ -23803,6 +23826,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
                 authz_policy=policy,
                 control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
             )
 
             status_code, payload = _invoke_app(
@@ -23838,8 +23862,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
+            app = create_launchplane_fastapi_wsgi_app(
                 verifier=_StubVerifier(
                     _identity(
                         workflow_ref=(
@@ -23850,6 +23873,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
                 authz_policy=policy,
                 control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
             )
 
             status_code, payload = _invoke_app(
@@ -23867,6 +23891,184 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["result"]["status"], "missing_inventory")
         self.assertEqual(payload["result"]["orphaned_slugs"], [])
         self.assertIn("has not recorded", payload["result"]["error_message"])
+
+    def test_preview_lifecycle_plan_endpoint_replays_idempotent_request(self) -> None:
+        request_payload = {
+            "product": "verireel",
+            "context": "verireel-testing",
+            "source": "preview-janitor",
+            "desired_previews": [{"preview_slug": "pr-42"}],
+        }
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_lifecycle.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+
+            first_status, first_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-plan",
+                payload=request_payload,
+                headers={"Idempotency-Key": "preview-lifecycle-plan:42"},
+            )
+            replay_status, replay_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-plan",
+                payload=request_payload,
+                headers={"Idempotency-Key": "preview-lifecycle-plan:42"},
+            )
+            plan_records = FilesystemRecordStore(
+                state_dir=root / "state"
+            ).list_preview_lifecycle_plan_records(context_name="verireel-testing")
+
+        self.assertEqual(first_status, 202)
+        self.assertEqual(replay_status, 202)
+        self.assertTrue(replay_payload["replayed"])
+        self.assertEqual(
+            replay_payload["records"]["preview_lifecycle_plan_id"],
+            first_payload["records"]["preview_lifecycle_plan_id"],
+        )
+        self.assertEqual(replay_payload["result"], first_payload["result"])
+        self.assertEqual(len(plan_records), 1)
+
+    def test_preview_lifecycle_plan_endpoint_rejects_idempotency_key_reuse(
+        self,
+    ) -> None:
+        request_payload = {
+            "product": "verireel",
+            "context": "verireel-testing",
+            "source": "preview-janitor",
+            "desired_previews": [{"preview_slug": "pr-42"}],
+        }
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_lifecycle.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=lambda: FilesystemRecordStore(state_dir=root / "state"),
+            )
+
+            first_status, _first_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-plan",
+                payload=request_payload,
+                headers={"Idempotency-Key": "preview-lifecycle-plan:reuse"},
+            )
+            conflict_status, conflict_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-plan",
+                payload={
+                    **request_payload,
+                    "desired_previews": [{"preview_slug": "pr-43"}],
+                },
+                headers={"Idempotency-Key": "preview-lifecycle-plan:reuse"},
+            )
+
+        self.assertEqual(first_status, 202)
+        self.assertEqual(conflict_status, 409)
+        self.assertEqual(conflict_payload["error"]["code"], "idempotency_key_reused")
+
+    def test_preview_lifecycle_plan_endpoint_requires_plan_store(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "every/verireel",
+                            "workflow_refs": [
+                                "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                            ],
+                            "event_names": ["workflow_dispatch"],
+                            "products": ["verireel"],
+                            "contexts": ["verireel-testing"],
+                            "actions": ["preview_lifecycle.plan"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_wsgi_app(
+                verifier=_StubVerifier(
+                    _identity(
+                        workflow_ref=(
+                            "every/verireel/.github/workflows/preview-janitor.yml@refs/heads/main"
+                        ),
+                        event_name="workflow_dispatch",
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+                record_store_factory=object,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/lifecycle-plan",
+                payload={
+                    "product": "verireel",
+                    "context": "verireel-testing",
+                    "desired_previews": [{"preview_slug": "pr-42"}],
+                },
+            )
+
+        self.assertEqual(status_code, 503)
+        self.assertEqual(payload["error"]["code"], "database_storage_required")
+        self.assertIn("preview lifecycle plan applies", payload["error"]["message"])
 
     def test_preview_desired_state_endpoint_discovers_and_records_labeled_prs(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- Migrate `POST /v1/previews/lifecycle-plan` from the legacy WSGI dispatcher to native FastAPI.
- Preserve `preview_lifecycle.plan` authorization, optional `Idempotency-Key` replay/conflict behavior, accepted-evidence response shape, and typed lifecycle plan persistence.
- Remove direct legacy WSGI ownership for the route and document the v2 retirement boundary.

## Validation
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests -k preview_lifecycle_plan`
- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `ulimit -n 4096 && uv run python -m unittest`
- JetBrains changed-file inspection: GREEN
- Fresh read-only agent review: no blocking findings
