### PR TITLE
Add supervised runner lane registration slice

### DIFF
--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -17,6 +17,11 @@ name: Runner Lane Registration
         required: false
         default: auto
         type: string
+      runner_package_url:
+        description: GitHub Actions runner tarball URL for mutate=true.
+        required: false
+        default: ""
+        type: string
       labels:
         description: Comma-separated runner labels.
         required: true
@@ -122,6 +127,7 @@ jobs:
           TARGET_REPOSITORY: ${{ inputs.repository }}
           LANE_NAME: ${{ inputs.lane_name }}
           REGISTRATION_ROOT: ${{ inputs.registration_root }}
+          RUNNER_PACKAGE_URL: ${{ inputs.runner_package_url }}
           RUNNER_LABELS_INPUT: ${{ inputs.labels }}
           AUDIT_RECORD_KEY: ${{ inputs.audit_record_key }}
           GH_TOKEN: ${{ secrets.LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN }}
@@ -148,7 +154,8 @@ jobs:
             exit 1
           fi
           if [ -n "${RUNNER_REGISTRATION_ALLOWED_ROOT:-}" ] &&
-            [ "$REGISTRATION_ROOT" != "$RUNNER_REGISTRATION_ALLOWED_ROOT" ]; then
+            [ "$REGISTRATION_ROOT" != \
+              "$RUNNER_REGISTRATION_ALLOWED_ROOT" ]; then
             echo "registration_root must match Launchplane approved root." >&2
             exit 1
           fi
@@ -176,6 +183,7 @@ jobs:
             --service-user "$RUNNER_REGISTRATION_SERVICE_USER" \
             --lane-name "$LANE_NAME" \
             --registration-root "$REGISTRATION_ROOT" \
+            --runner-package-url "$RUNNER_PACKAGE_URL" \
             "${label_args[@]}" \
             --audit-record-key "$AUDIT_RECORD_KEY" \
             --allowed-repository "$TARGET_REPOSITORY" \
@@ -204,9 +212,15 @@ jobs:
 
       - name: Fail on unexpected registration result
         env:
+          MUTATE_REQUESTED: ${{ inputs.mutate }}
           REGISTRATION_STATUS: >-
             ${{ steps.registration.outputs.registration_status }}
         run: |
+          if [ "$MUTATE_REQUESTED" = "true" ] &&
+            [ "$REGISTRATION_STATUS" = "blocked" ]; then
+            jq . runner-lane-registration-result.json >&2
+            exit 1
+          fi
           if [ "$REGISTRATION_STATUS" != "blocked" ] &&
             [ "$REGISTRATION_STATUS" != "completed" ]; then
             jq . runner-lane-registration-result.json >&2

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -652,12 +652,17 @@ def runner_maintainer_plan(
     required=True,
     help="Absolute root directory where runner lanes may be registered.",
 )
+@click.option(
+    "--runner-package-url",
+    default="",
+    help="GitHub Actions runner tarball URL used when --mutate creates a lane.",
+)
 @click.option("--label", "labels", multiple=True, required=True, help="Runner label.")
 @click.option(
     "--mutate/--dry-run",
     default=False,
     show_default=True,
-    help="Record apply intent. Live registration is disabled until a supervised maintainer exists.",
+    help="Register a new lane through the supervised create-only executor.",
 )
 @click.option(
     "--audit-record-key",
@@ -738,6 +743,7 @@ def runner_lane_registration_executor(
     service_user: str,
     lane_name: str,
     registration_root: str,
+    runner_package_url: str,
     labels: tuple[str, ...],
     mutate: bool,
     audit_record_key: str,
@@ -786,6 +792,7 @@ def runner_lane_registration_executor(
             service_user=service_user,
             lane_name=lane_name,
             registration_root=registration_root,
+            runner_package_url=runner_package_url,
             labels=labels,
             mutate=mutate,
             audit_record_key=audit_record_key,

--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -6,7 +6,10 @@ import json
 import os
 import pwd
 import re
+from shlex import quote
+from time import sleep
 from urllib.error import HTTPError
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 from control_plane.contracts.runner_lane_inventory import RunnerLaneInventory
@@ -25,6 +28,8 @@ AuditPoster = Callable[[RunnerLaneRegistrationAuditRecord, str], dict[str, objec
 InventoryReader = Callable[[str], RunnerLaneInventory]
 BearerTokenProvider = Callable[[], str]
 AUDIT_ROUTE_PATH = "/v1/evidence/runner-lane-registration/audits"
+POST_REGISTRATION_INVENTORY_ATTEMPTS = 6
+POST_REGISTRATION_INVENTORY_INTERVAL_SECONDS = 5
 
 
 class RunnerLaneRegistrationExecutorRequest(BaseModel):
@@ -37,6 +42,7 @@ class RunnerLaneRegistrationExecutorRequest(BaseModel):
     service_user: str
     lane_name: str
     registration_root: str
+    runner_package_url: str = ""
     labels: tuple[str, ...]
     mutate: bool = False
     audit_record_key: str
@@ -72,10 +78,16 @@ class RunnerLaneRegistrationExecutorRequest(BaseModel):
         self.registration_root = _required_text(
             self.registration_root,
             "runner lane registration executor requires registration_root",
-        ).rstrip("/")
-        if not self.registration_root.startswith("/"):
+        )
+        self.registration_root = _normalized_path(self.registration_root)
+        self.runner_package_url = self.runner_package_url.strip()
+        if self.mutate and not self.runner_package_url:
             raise ValueError(
-                "runner lane registration executor requires absolute registration_root"
+                "runner lane registration executor requires runner_package_url when mutate=true"
+            )
+        if self.runner_package_url and not _is_allowed_runner_package_url(self.runner_package_url):
+            raise ValueError(
+                "runner lane registration executor runner_package_url must be an actions/runner tarball URL"
             )
         self.labels = tuple(
             sorted({label.strip().lower() for label in self.labels if label.strip()})
@@ -110,7 +122,6 @@ def execute_runner_lane_registration_executor(
     remote_runner: RemoteCommandRunner,
     audit_poster: AuditPoster,
 ) -> RunnerLaneRegistrationExecutorResult:
-    del inventory_reader, token_fetcher, remote_runner
     registration_request = RunnerLaneRegistrationRequest(
         repository=request.repository,
         host_name=request.host_name,
@@ -145,26 +156,60 @@ def execute_runner_lane_registration_executor(
             message=plan.summary,
         )
 
+    token_record: RunnerLaneRegistrationTokenRecord | None = None
+    post_inventory: RunnerLaneInventory | None = None
+    try:
+        token, token_record = token_fetcher.fetch_registration_token(repository=request.repository)
+        _prepare_runner_directory(request=request, remote_runner=remote_runner)
+        _configure_runner(request=request, token=token, remote_runner=remote_runner)
+        _start_supervised_runner(request=request, remote_runner=remote_runner)
+        post_inventory = _read_verified_post_inventory(
+            request=request,
+            inventory_reader=inventory_reader,
+        )
+    except Exception as error:  # noqa: BLE001 - convert any adapter failure into audit evidence.
+        failure_message = _failure_message(error)
+        terminal_audit = RunnerLaneRegistrationAuditRecord(
+            audit_record_key=request.audit_record_key,
+            status="failed",
+            request=registration_request,
+            plan=plan,
+            pre_inventory=pre_inventory,
+            post_inventory=post_inventory,
+            message=failure_message,
+        )
+        terminal_response = audit_poster(
+            terminal_audit,
+            f"runner-lane-registration:{request.audit_record_key}:failed",
+        )
+        return RunnerLaneRegistrationExecutorResult(
+            status="failed",
+            audit_record_key=request.audit_record_key,
+            planned_response=planned_response,
+            terminal_response=terminal_response,
+            token_record=token_record,
+            message=failure_message,
+        )
+
     terminal_audit = RunnerLaneRegistrationAuditRecord(
         audit_record_key=request.audit_record_key,
-        status="failed",
+        status="completed",
         request=registration_request,
         plan=plan,
         pre_inventory=pre_inventory,
-        message=(
-            "runner lane registration requires a supervised host maintainer; "
-            "starting run.sh from an Actions job is disabled"
-        ),
+        post_inventory=post_inventory,
+        message="runner lane registration completed with supervised systemd service",
     )
     terminal_response = audit_poster(
         terminal_audit,
-        f"runner-lane-registration:{request.audit_record_key}:supervisor-required",
+        f"runner-lane-registration:{request.audit_record_key}:completed",
     )
     return RunnerLaneRegistrationExecutorResult(
-        status="failed",
+        status="completed",
         audit_record_key=request.audit_record_key,
         planned_response=planned_response,
         terminal_response=terminal_response,
+        token_record=token_record,
         message=terminal_audit.message,
     )
 
@@ -191,6 +236,225 @@ def validate_local_executor_environment(
         raise ValueError(
             "runner lane registration executor is not running on the approved execution lane."
         )
+
+
+class RunnerLaneRegistrationCommandError(ValueError):
+    pass
+
+
+def _prepare_runner_directory(
+    *,
+    request: RunnerLaneRegistrationExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+) -> None:
+    runner_directory = _runner_directory(request)
+    command = (
+        "sh",
+        "-eu",
+        "-c",
+        "\n".join(
+            (
+                f"runner_dir={quote(runner_directory)}",
+                f"runner_package_url={quote(request.runner_package_url)}",
+                f"registration_root={quote(request.registration_root)}",
+                'mkdir -p "$registration_root"',
+                'if [ -e "$runner_dir" ]; then',
+                '  echo "runner directory already exists" >&2',
+                "  exit 1",
+                "fi",
+                'mkdir "$runner_dir"',
+                'temp_dir="$(mktemp -d)"',
+                "trap 'rm -rf \"$temp_dir\"' EXIT",
+                'curl --fail --silent --show-error --location "$runner_package_url" --output "$temp_dir/actions-runner.tar.gz"',
+                'tar -xzf "$temp_dir/actions-runner.tar.gz" -C "$runner_dir"',
+                'test -x "$runner_dir/config.sh"',
+            )
+        ),
+    )
+    _run_registration_command(
+        step="prepare runner directory",
+        command=command,
+        request=request,
+        remote_runner=remote_runner,
+    )
+
+
+def _configure_runner(
+    *,
+    request: RunnerLaneRegistrationExecutorRequest,
+    token: str,
+    remote_runner: RemoteCommandRunner,
+) -> None:
+    command = (
+        "sh",
+        "-eu",
+        "-c",
+        "\n".join(
+            (
+                'cd "$RUNNER_DIRECTORY"',
+                './config.sh --unattended --url "$RUNNER_REPOSITORY_URL" --token "$RUNNER_REGISTRATION_TOKEN" --name "$RUNNER_NAME" --labels "$RUNNER_LABELS"',
+            )
+        ),
+    )
+    _run_registration_command(
+        step="configure runner",
+        command=command,
+        request=request,
+        remote_runner=remote_runner,
+        extra_env={"RUNNER_REGISTRATION_TOKEN": token},
+    )
+
+
+def _start_supervised_runner(
+    *,
+    request: RunnerLaneRegistrationExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+) -> None:
+    unit_name = _systemd_unit_name(request)
+    command = (
+        "sudo",
+        "-n",
+        "systemctl",
+        "enable",
+        "--now",
+        unit_name,
+    )
+    _run_registration_command(
+        step="start supervised runner service",
+        command=command,
+        request=request,
+        remote_runner=remote_runner,
+    )
+    _run_registration_command(
+        step="verify supervised runner service",
+        command=("sudo", "-n", "systemctl", "is-active", "--quiet", unit_name),
+        request=request,
+        remote_runner=remote_runner,
+    )
+
+
+def _verify_registered_lane(
+    *,
+    request: RunnerLaneRegistrationExecutorRequest,
+    post_inventory: RunnerLaneInventory,
+) -> None:
+    matching_lanes = tuple(
+        lane for lane in post_inventory.lanes if lane.name.strip().lower() == request.lane_name
+    )
+    if len(matching_lanes) != 1:
+        raise ValueError(
+            "runner lane registration post-inventory must include exactly one matching lane"
+        )
+    lane = matching_lanes[0]
+    if lane.repository != request.repository:
+        raise ValueError("runner lane registration post-inventory lane repository mismatch")
+    if lane.status != "online":
+        raise ValueError("runner lane registration post-inventory lane is not online")
+    observed_labels = {label.strip().lower() for label in lane.labels if label.strip()}
+    expected_labels = set(request.labels)
+    missing_labels = sorted(expected_labels - observed_labels)
+    if missing_labels:
+        raise ValueError(
+            "runner lane registration post-inventory lane is missing expected labels: "
+            + ", ".join(missing_labels)
+        )
+
+
+def _read_verified_post_inventory(
+    *,
+    request: RunnerLaneRegistrationExecutorRequest,
+    inventory_reader: InventoryReader,
+) -> RunnerLaneInventory:
+    latest_error: ValueError | None = None
+    for attempt in range(POST_REGISTRATION_INVENTORY_ATTEMPTS):
+        post_inventory = inventory_reader(request.repository)
+        try:
+            _verify_registered_lane(request=request, post_inventory=post_inventory)
+            return post_inventory
+        except ValueError as error:
+            latest_error = error
+            if attempt < POST_REGISTRATION_INVENTORY_ATTEMPTS - 1:
+                sleep(POST_REGISTRATION_INVENTORY_INTERVAL_SECONDS)
+    if latest_error is not None:
+        raise latest_error
+    raise ValueError("runner lane registration post-inventory could not be verified")
+
+
+def _run_registration_command(
+    *,
+    step: str,
+    command: Sequence[str],
+    request: RunnerLaneRegistrationExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+    extra_env: Mapping[str, str] | None = None,
+) -> None:
+    result = remote_runner(
+        command,
+        request.timeout_seconds,
+        {
+            "RUNNER_DIRECTORY": _runner_directory(request),
+            "RUNNER_LABELS": ",".join(request.labels),
+            "RUNNER_NAME": request.lane_name,
+            "RUNNER_REPOSITORY_URL": f"https://github.com/{request.repository}",
+            **(extra_env or {}),
+        },
+    )
+    if result.returncode != 0:
+        message = f"runner lane registration command failed during {step}: exit {result.returncode}"
+        stderr = result.stderr.strip()
+        if stderr:
+            message = f"{message}: {_redacted_command_output(stderr)}"
+        raise RunnerLaneRegistrationCommandError(message)
+
+
+def _failure_message(error: Exception) -> str:
+    message = str(error).strip()
+    if not message:
+        message = "runner lane registration failed"
+    return message
+
+
+def _runner_directory(request: RunnerLaneRegistrationExecutorRequest) -> str:
+    return f"{request.registration_root}/{request.lane_name}"
+
+
+def _systemd_unit_name(request: RunnerLaneRegistrationExecutorRequest) -> str:
+    return f"launchplane-runner@{request.lane_name}.service"
+
+
+def _is_allowed_runner_package_url(value: str) -> bool:
+    parsed = urlparse(value)
+    if parsed.scheme != "https" or parsed.netloc != "github.com":
+        return False
+    if parsed.params or parsed.query or parsed.fragment:
+        return False
+    if any(segment in {".", ".."} for segment in parsed.path.split("/")):
+        return False
+    pattern = re.compile(
+        r"^/actions/runner/releases/download/v[0-9][0-9A-Za-z._-]*/"
+        r"actions-runner-[A-Za-z0-9._-]+-[0-9][0-9A-Za-z._-]*\.tar\.gz$"
+    )
+    return bool(pattern.fullmatch(parsed.path))
+
+
+def _redacted_command_output(value: str) -> str:
+    return value.replace("\n", " ")[:500]
+
+
+def _normalized_path(value: str) -> str:
+    normalized = value.strip().rstrip("/")
+    if not normalized.startswith("/"):
+        raise ValueError("runner lane registration executor requires absolute registration_root")
+    segments: list[str] = []
+    for segment in normalized.split("/"):
+        if segment in {"", "."}:
+            continue
+        if segment == "..":
+            if segments:
+                segments.pop()
+            continue
+        segments.append(segment)
+    return "/" + "/".join(segments)
 
 
 def build_local_command_runner() -> RemoteCommandRunner:

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -189,10 +189,12 @@ captured image and volume inventory to decide any later phase-two cleanup lane.
 Runner lane registration uses a separate manual ops-lane workflow,
 `.github/workflows/runner-lane-registration.yml`. It shares the same approved
 host, execution-lane, and service-user variables, but it does not prune Docker
-state or restart existing services. Its first slice registers a repo-scoped
-Actions runner lane under an allowlisted registration root and verifies the lane
-through GitHub inventory. Treat the registration artifact as evidence until the
-service-backed runner-registration audit record is accepted.
+state or restart existing services. Its first slice creates a new repo-scoped
+Actions runner lane under an allowlisted registration root, starts only the
+matching `launchplane-runner@<lane>.service` supervisor, and verifies the lane
+through GitHub inventory before writing a completed registration audit.
+Existing-lane adoption, stale-lane removal, and generic runner service restarts
+remain outside this slice.
 
 ## Host Replacement Runbook
 

--- a/docs/runner-lane-baseline.md
+++ b/docs/runner-lane-baseline.md
@@ -224,6 +224,7 @@ uv run launchplane work-graph runner-lane-registration-executor \
   --service-user launchplane-runner-hygiene \
   --lane-name product-runner-1 \
   --registration-root /home/launchplane-runner-hygiene/actions-runners \
+  --runner-package-url "$ACTIONS_RUNNER_TARBALL_URL" \
   --label self-hosted \
   --label launchplane \
   --label launchplane-managed \
@@ -235,14 +236,26 @@ uv run launchplane work-graph runner-lane-registration-executor \
 ```
 
 The command is dry-run by default. A dry-run writes only local JSON evidence and
-does not request a GitHub registration token. `--mutate` records apply intent
-and writes a failed audit explaining that runner registration requires a
-supervised host maintainer. The earlier proof path briefly started `run.sh` from
-inside the GitHub Actions job, but that can produce transient online evidence
-and leave the runner offline after job cleanup. That shortcut is disabled. Until
-the supervised maintainer exists, mutate runs do not request a GitHub
-registration token. The token itself must never be written to the audit record,
-command output, or JSON result.
+does not request a GitHub registration token. When `--mutate` is explicitly set
+and the registration plan is ready, the executor performs a create-only
+supervised registration: it requests a short-lived GitHub registration token,
+prepares a new lane directory below the approved registration root, downloads
+the operator-supplied GitHub Actions runner package, runs `config.sh`, starts the
+root-owned `launchplane-runner@<lane>.service` unit through the reviewed narrow
+privilege boundary, and verifies that GitHub inventory reports exactly one
+online lane with the expected labels before writing a `completed` audit. If any
+step fails, the executor writes a `failed` audit. The raw registration token must
+never be written to the audit record, command output, or JSON result.
+GitHub's runner `config.sh` still requires the token as a command-line option,
+so the ops lane must treat same-user process inspection on the host as privileged
+and keep unrelated workloads off the constrained service user during mutation.
+
+This slice only creates a new lane. Existing-lane adoption, stale-lane removal,
+remove/recreate, runner work-directory pruning, and service restarts remain
+future maintainer capabilities. The earlier proof path briefly started `run.sh`
+from inside the GitHub Actions job, but that can produce transient online
+evidence and leave the runner offline after job cleanup. That shortcut remains
+disabled; the runner must be supervised outside the Actions job process tree.
 
 The manual workflow defaults `registration_root` to `auto`, which resolves to
 `$HOME/actions-runners` for the constrained service user. Operators may pass an
@@ -255,8 +268,12 @@ inventory and registration-token requests. The default `GITHUB_TOKEN` from the
 Launchplane workflow is not sufficient authority for product repository runner
 administration.
 
-This executor is the proving-ground adapter for #1231. Durable service-backed
-audit persistence is available through
+This executor is the proving-ground adapter for #1231. Mutating runs require an
+`ACTIONS_RUNNER_TARBALL_URL` value that points to an `actions/runner` release
+tarball on GitHub, plus a preinstalled `launchplane-runner@.service` template
+and a narrow sudo rule or equivalent root helper for `systemctl enable --now`
+and `systemctl is-active` on that template. Durable service-backed audit
+persistence is available through
 `POST /v1/evidence/runner-lane-registration/audits` under
 `runner_lane_registration_audit.write`; descriptor-backed operator routing for
 registration planning remains a later slice. The workflow still uploads the JSON
@@ -265,9 +282,9 @@ any other product proof.
 
 ## Supervised Runner Maintainer Plan
 
-The durable runner maintainer must replace the disabled apply shortcut before a
-product repository can rely on a Launchplane-managed runner lane. The maintainer
-should reconcile desired runner state rather than simply start `run.sh`:
+The durable runner maintainer grows from the create-only executor into full
+desired-state reconciliation. It must keep reconciling runner state rather than
+simply start `run.sh`:
 
 1. Read GitHub runner inventory and local service state for the requested lane.
 2. If registration is required, request a short-lived GitHub registration token

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 from typing import Any
+from unittest.mock import patch
 from click import Command
 from click.testing import CliRunner
 import getpass
@@ -61,8 +62,14 @@ class _TokenFetcher:
 
 
 class _CommandRunner:
-    def __init__(self, *, returncode: int = 0) -> None:
+    def __init__(
+        self,
+        *,
+        returncode: int = 0,
+        returncodes: Sequence[int] | None = None,
+    ) -> None:
         self.returncode = returncode
+        self.returncodes = list(returncodes or ())
         self.commands: list[tuple[str, ...]] = []
         self.envs: list[dict[str, str]] = []
 
@@ -71,7 +78,20 @@ class _CommandRunner:
     ) -> RemoteCommandResult:
         self.commands.append(tuple(command))
         self.envs.append(dict(env))
-        return RemoteCommandResult(returncode=self.returncode, stderr="registration failed")
+        returncode = self.returncodes.pop(0) if self.returncodes else self.returncode
+        return RemoteCommandResult(returncode=returncode, stderr="registration failed")
+
+
+class _InventoryReader:
+    def __init__(self, inventories: Sequence[RunnerLaneInventory]) -> None:
+        self.inventories = list(inventories)
+        self.calls: list[str] = []
+
+    def __call__(self, repository: str) -> RunnerLaneInventory:
+        self.calls.append(repository)
+        if len(self.inventories) > 1:
+            return self.inventories.pop(0)
+        return self.inventories[0]
 
 
 class _AuditPoster:
@@ -177,6 +197,16 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "execution_lane must use"):
             _executor_request(mutate=True, execution_lane="ops-gate;touch bad")
 
+    def test_executor_request_rejects_runner_package_path_traversal(self) -> None:
+        with self.assertRaisesRegex(ValueError, "actions/runner tarball URL"):
+            _executor_request(
+                mutate=True,
+                runner_package_url=(
+                    "https://github.com/actions/runner/releases/download/"
+                    "../download/actions-runner-linux-x64-2.327.1.tar.gz"
+                ),
+            )
+
     def test_blocked_plan_posts_planned_audit_without_token_or_command(self) -> None:
         token_fetcher = _TokenFetcher()
         command_runner = _CommandRunner()
@@ -197,7 +227,7 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
         self.assertEqual(command_runner.commands, [])
         self.assertEqual(audit_poster.records[0][0], "planned")
 
-    def test_ready_executor_requires_supervised_host_maintainer(self) -> None:
+    def test_ready_executor_completes_supervised_registration(self) -> None:
         token_fetcher = _TokenFetcher()
         command_runner = _CommandRunner()
         audit_poster = _AuditPoster()
@@ -212,13 +242,128 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
             audit_poster=audit_poster,
         )
 
-        self.assertEqual(result.status, "failed")
-        self.assertIn("supervised host maintainer", result.message)
-        self.assertEqual(token_fetcher.calls, [])
-        self.assertEqual(command_runner.commands, [])
-        self.assertEqual(result.token_record, None)
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(token_fetcher.calls, ["cbusillo/odoo-tenant-cm-website"])
+        self.assertEqual(len(command_runner.commands), 4)
+        self.assertEqual(command_runner.commands[0][:3], ("sh", "-eu", "-c"))
+        self.assertIn("config.sh", command_runner.commands[1][3])
+        self.assertEqual(
+            command_runner.commands[2],
+            (
+                "sudo",
+                "-n",
+                "systemctl",
+                "enable",
+                "--now",
+                "launchplane-runner@cm-website-runner-1.service",
+            ),
+        )
+        self.assertEqual(
+            command_runner.commands[3],
+            (
+                "sudo",
+                "-n",
+                "systemctl",
+                "is-active",
+                "--quiet",
+                "launchplane-runner@cm-website-runner-1.service",
+            ),
+        )
+        self.assertEqual(
+            command_runner.envs[1]["RUNNER_DIRECTORY"],
+            "/home/launchplane-runner-hygiene/actions-runners/cm-website-runner-1",
+        )
+        self.assertEqual(command_runner.envs[1]["RUNNER_REGISTRATION_TOKEN"], "secret-token")
+        self.assertNotIn("secret-token", " ".join(command_runner.commands[1]))
+        self.assertIsNotNone(result.token_record)
+        if result.token_record is not None:
+            self.assertEqual(result.token_record.repository, "cbusillo/odoo-tenant-cm-website")
         self.assertNotIn("secret-token", result.model_dump_json())
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned", "completed"])
+
+    def test_ready_executor_posts_failed_audit_when_config_fails(self) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner(returncodes=[0, 1])
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_lane_registration_executor(
+            request=_executor_request(mutate=True),
+            policy=_policy(),
+            pre_inventory=_inventory(lanes=()),
+            inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
+            token_fetcher=token_fetcher,  # type: ignore[arg-type]
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("configure runner", result.message)
         self.assertEqual([record[0] for record in audit_poster.records], ["planned", "failed"])
+        self.assertNotIn("secret-token", result.model_dump_json())
+
+    def test_ready_executor_reports_command_stderr_in_failed_audit(self) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner(returncodes=[1])
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_lane_registration_executor(
+            request=_executor_request(mutate=True),
+            policy=_policy(),
+            pre_inventory=_inventory(lanes=()),
+            inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
+            token_fetcher=token_fetcher,  # type: ignore[arg-type]
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("prepare runner directory", result.message)
+        self.assertIn("registration failed", result.message)
+
+    def test_ready_executor_posts_failed_audit_when_post_inventory_is_missing_lane(self) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner()
+        audit_poster = _AuditPoster()
+
+        with patch("control_plane.workflows.runner_lane_registration_executor.sleep"):
+            result = execute_runner_lane_registration_executor(
+                request=_executor_request(mutate=True),
+                policy=_policy(),
+                pre_inventory=_inventory(lanes=()),
+                inventory_reader=lambda _repo: _inventory(lanes=()),
+                token_fetcher=token_fetcher,  # type: ignore[arg-type]
+                remote_runner=command_runner,
+                audit_poster=audit_poster,
+            )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("exactly one matching lane", result.message)
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned", "failed"])
+
+    def test_ready_executor_polls_until_post_inventory_reports_online_lane(self) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner()
+        audit_poster = _AuditPoster()
+        inventory_reader = _InventoryReader(
+            (
+                _inventory(lanes=()),
+                _inventory(lanes=(_lane(),)),
+            )
+        )
+
+        with patch("control_plane.workflows.runner_lane_registration_executor.sleep"):
+            result = execute_runner_lane_registration_executor(
+                request=_executor_request(mutate=True),
+                policy=_policy(),
+                pre_inventory=_inventory(lanes=()),
+                inventory_reader=inventory_reader,
+                token_fetcher=token_fetcher,  # type: ignore[arg-type]
+                remote_runner=command_runner,
+                audit_poster=audit_poster,
+            )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(len(inventory_reader.calls), 2)
 
     def test_local_environment_fails_closed_without_actions_repository(self) -> None:
         with self.assertRaisesRegex(ValueError, "must run from cbusillo/launchplane"):
@@ -360,6 +505,9 @@ class RunnerLaneRegistrationWorkflowTests(unittest.TestCase):
         self.assertIn("if: always()", workflow_text)
         self.assertIn("if-no-files-found: warn", workflow_text)
         self.assertIn("runner lane registration executor did not produce a result", workflow_text)
+        self.assertIn("RUNNER_PACKAGE_URL: ${{ inputs.runner_package_url }}", workflow_text)
+        self.assertIn('--runner-package-url "$RUNNER_PACKAGE_URL"', workflow_text)
+        self.assertIn('[ "$MUTATE_REQUESTED" = "true" ]', workflow_text)
 
     def test_workflow_does_not_allowlist_user_registration_root(self) -> None:
         workflow_text = Path(".github/workflows/runner-lane-registration.yml").read_text(
@@ -399,7 +547,14 @@ def _request(
 
 
 def _executor_request(
-    *, mutate: bool, execution_lane: str = "chris-testing-ops-gate"
+    *,
+    mutate: bool,
+    execution_lane: str = "chris-testing-ops-gate",
+    runner_package_url: str = (
+        "https://github.com/actions/runner/releases/download/"
+        "v2.327.1/actions-runner-linux-x64-2.327.1.tar.gz"
+    ),
+    timeout_seconds: int = 120,
 ) -> RunnerLaneRegistrationExecutorRequest:
     return RunnerLaneRegistrationExecutorRequest(
         repository="cbusillo/odoo-tenant-cm-website",
@@ -408,9 +563,11 @@ def _executor_request(
         service_user="launchplane-runner-hygiene",
         lane_name="cm-website-runner-1",
         registration_root="/home/launchplane-runner-hygiene/actions-runners",
+        runner_package_url=runner_package_url,
         labels=("self-hosted", "launchplane", "launchplane-managed"),
         mutate=mutate,
         audit_record_key="runner-lane-registration/2026-06-08/cm-website/test",
+        timeout_seconds=timeout_seconds,
     )
 
 


### PR DESCRIPTION
## Summary
- add create-only supervised runner registration to the existing runner-lane registration executor
- require an operator-supplied actions/runner tarball URL for mutate=true, then prepare a new lane directory, run config.sh, start launchplane-runner@<lane>.service, and verify GitHub inventory before completed audit
- keep dry-run planning, failed-audit behavior, and v2 boundaries explicit: no adoption, removal, recreate, generic restarts, or checked-in live lane topology

## V2 boundary
This deliberately avoids manual SSH drift and does not hard-code the desired third lane. Live lane identity, labels, repo, host, root, and runner package URL remain operator/workflow input or Launchplane records. The executor is create-only; broader desired-state reconciliation remains future maintainer work.

## Validation
- `uv run python -m unittest tests.test_runner_lane_registration tests.test_runner_lane_maintainer tests.test_runner_lane_baseline tests.test_runner_lane_inventory tests.test_runner_queue_wait tests.test_runner_host_hygiene tests.test_runner_host_hygiene_executor`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `actionlint .github/workflows/runner-lane-registration.yml`
- `npx --yes markdownlint-cli2 docs/runner-lane-baseline.md docs/runner-host-hygiene.md`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- `ulimit -n 4096; uv run python -m unittest`

Note: the first full-unit run hit the local workstation file-descriptor limit during unrelated work-graph temp cleanup; the same suite passed after raising the limit.
