### PR TITLE
Route runner registration workflow to ops lane

### DIFF
--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -54,7 +54,7 @@ jobs:
   runner-lane-registration:
     runs-on:
       - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+      - ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE }}
     env:
       RUNNER_REGISTRATION_HOST: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_HOST }}
       RUNNER_REGISTRATION_EXECUTION_LANE: >-

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -508,6 +508,13 @@ class RunnerLaneRegistrationWorkflowTests(unittest.TestCase):
         self.assertIn("RUNNER_PACKAGE_URL: ${{ inputs.runner_package_url }}", workflow_text)
         self.assertIn('--runner-package-url "$RUNNER_PACKAGE_URL"', workflow_text)
         self.assertIn('[ "$MUTATE_REQUESTED" = "true" ]', workflow_text)
+        self.assertIn(
+            "    runs-on:\n"
+            "      - self-hosted\n"
+            "      - ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE }}\n",
+            workflow_text,
+        )
+        self.assertNotIn("${{ vars.LAUNCHPLANE_RUNNER_LABEL }}", workflow_text)
 
     def test_workflow_does_not_allowlist_user_registration_root(self) -> None:
         workflow_text = Path(".github/workflows/runner-lane-registration.yml").read_text(


### PR DESCRIPTION
## Summary
- route the manual Runner Lane Registration workflow to the configured hygiene execution lane instead of the broad shared runner label
- add a workflow regression assertion pinned to the `runs-on` block so the registration workflow cannot drift back to the broad pool unnoticed

## Why
A dry-run dispatch for `chris-testing-launchplane-3` failed in `Validate workflow configuration` because the workflow ran on the broad `chris-testing` pool as user `gha`, while the registration executor validates the ops-gate execution lane and `launchplane-runner-hygiene` service user.

Failed evidence run: https://github.com/cbusillo/launchplane/actions/runs/27882839930

## Validation
- `uv run python -m unittest tests.test_runner_lane_registration`
- `actionlint .github/workflows/runner-lane-registration.yml`
- `uv run --extra dev ruff format --check tests/test_runner_lane_registration.py`
- `uv run --extra dev ruff check tests/test_runner_lane_registration.py`
- `uv run --extra dev mypy tests/test_runner_lane_registration.py`
- `git diff --check`
