### PR TITLE
Remove Python dependency from runner registration workflow

### DIFF
--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -159,18 +159,15 @@ jobs:
             echo "registration_root must match Launchplane approved root." >&2
             exit 1
           fi
-          python - <<'PY' > runner-lane-registration-label-args.bin
-          import os
-          import sys
-
-          labels = os.environ["RUNNER_LABELS_INPUT"].split(",")
-          for label in labels:
-              trimmed = label.strip()
-              if trimmed:
-                  sys.stdout.write("--label\0")
-                  sys.stdout.write(f"{trimmed}\0")
-          PY
-          mapfile -d '' -t label_args < runner-lane-registration-label-args.bin
+          IFS=',' read -r -a raw_labels <<<"$RUNNER_LABELS_INPUT"
+          label_args=()
+          for label in "${raw_labels[@]}"; do
+            trimmed="${label#"${label%%[![:space:]]*}"}"
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+            if [ -n "$trimmed" ]; then
+              label_args+=(--label "$trimmed")
+            fi
+          done
           mutate_flag=--dry-run
           if [ "$MUTATE_REQUESTED" = "true" ]; then
             mutate_flag=--mutate

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -508,6 +508,8 @@ class RunnerLaneRegistrationWorkflowTests(unittest.TestCase):
         self.assertIn("RUNNER_PACKAGE_URL: ${{ inputs.runner_package_url }}", workflow_text)
         self.assertIn('--runner-package-url "$RUNNER_PACKAGE_URL"', workflow_text)
         self.assertIn('[ "$MUTATE_REQUESTED" = "true" ]', workflow_text)
+        self.assertIn("IFS=',' read -r -a raw_labels", workflow_text)
+        self.assertNotIn("python - <<'PY'", workflow_text)
         self.assertIn(
             "    runs-on:\n"
             "      - self-hosted\n"


### PR DESCRIPTION
## Summary
- remove the pre-uv `python` heredoc from the Runner Lane Registration workflow
- split and trim comma-separated labels using Bash arrays instead
- add a regression assertion that the Python heredoc stays out of the workflow

## Why
After routing the workflow to the ops-gate lane, the dry-run reached the executor step but failed because that constrained lane does not have `python` on PATH. This code ran before `uv`, so relying on system Python was brittle.

Failed evidence run: https://github.com/cbusillo/launchplane/actions/runs/27883420968

## Validation
- `uv run python -m unittest tests.test_runner_lane_registration`
- `actionlint .github/workflows/runner-lane-registration.yml`
- `uv run --extra dev ruff format --check tests/test_runner_lane_registration.py`
- `uv run --extra dev ruff check tests/test_runner_lane_registration.py`
- `uv run --extra dev mypy tests/test_runner_lane_registration.py`
- `git diff --check`
