### PR TITLE
Accept runner name for registration lane validation

### DIFF
--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -232,7 +232,9 @@ def validate_local_executor_environment(
         for label in execution_env.get("RUNNER_LABELS", "").split(",")
         if label.strip()
     }
-    if request.execution_lane.lower() not in runner_labels:
+    runner_name = execution_env.get("RUNNER_NAME", "").strip().lower()
+    execution_lane = request.execution_lane.lower()
+    if execution_lane not in runner_labels and runner_name != execution_lane:
         raise ValueError(
             "runner lane registration executor is not running on the approved execution lane."
         )

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -373,11 +373,22 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
                 current_user="launchplane-runner-hygiene",
             )
 
-    def test_local_environment_fails_closed_without_execution_lane_label(self) -> None:
+    def test_local_environment_fails_closed_without_runner_identity(self) -> None:
         with self.assertRaisesRegex(ValueError, "approved execution lane"):
             validate_local_executor_environment(
                 request=_executor_request(mutate=True),
                 env={"GITHUB_REPOSITORY": "cbusillo/launchplane"},
+                current_user="launchplane-runner-hygiene",
+            )
+
+    def test_local_environment_fails_closed_without_execution_lane_label(self) -> None:
+        with self.assertRaisesRegex(ValueError, "approved execution lane"):
+            validate_local_executor_environment(
+                request=_executor_request(mutate=True),
+                env={
+                    "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                    "RUNNER_NAME": "chris-testing-launchplane",
+                },
                 current_user="launchplane-runner-hygiene",
             )
 
@@ -387,6 +398,16 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
             env={
                 "GITHUB_REPOSITORY": "cbusillo/launchplane",
                 "RUNNER_LABELS": "self-hosted,launchplane,chris-testing-ops-gate",
+            },
+            current_user="launchplane-runner-hygiene",
+        )
+
+    def test_local_environment_accepts_expected_runner_name(self) -> None:
+        validate_local_executor_environment(
+            request=_executor_request(mutate=True),
+            env={
+                "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                "RUNNER_NAME": "chris-testing-ops-gate",
             },
             current_user="launchplane-runner-hygiene",
         )


### PR DESCRIPTION
## Summary
- allow runner lane registration environment validation to accept `RUNNER_NAME == execution_lane` when GitHub does not expose `RUNNER_LABELS`
- keep the existing service-user and `GITHUB_REPOSITORY` checks unchanged
- add positive and negative tests for the runner-name fallback, including no runner identity and imposter runner name cases

## Why
After the workflow was routed to `chris-testing-ops-gate` and the pre-uv Python dependency was removed, the dry-run reached the Launchplane executor but failed because the job environment did not include `RUNNER_LABELS`. GitHub did expose the runner identity through the runner/job context, and the ops-gate runner name matches the approved execution lane.

Failed evidence run: https://github.com/cbusillo/launchplane/actions/runs/27883959744

## Validation
- `uv run python -m unittest tests.test_runner_lane_registration`
- `uv run --extra dev ruff format --check control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `uv run --extra dev ruff check control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `uv run --extra dev mypy control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `git diff --check`
