### PR TITLE
Defer runner package validation until create

### DIFF
--- a/control_plane/workflows/runner_lane_registration_executor.py
+++ b/control_plane/workflows/runner_lane_registration_executor.py
@@ -81,14 +81,6 @@ class RunnerLaneRegistrationExecutorRequest(BaseModel):
         )
         self.registration_root = _normalized_path(self.registration_root)
         self.runner_package_url = self.runner_package_url.strip()
-        if self.mutate and not self.runner_package_url:
-            raise ValueError(
-                "runner lane registration executor requires runner_package_url when mutate=true"
-            )
-        if self.runner_package_url and not _is_allowed_runner_package_url(self.runner_package_url):
-            raise ValueError(
-                "runner lane registration executor runner_package_url must be an actions/runner tarball URL"
-            )
         self.labels = tuple(
             sorted({label.strip().lower() for label in self.labels if label.strip()})
         )
@@ -159,6 +151,7 @@ def execute_runner_lane_registration_executor(
     token_record: RunnerLaneRegistrationTokenRecord | None = None
     post_inventory: RunnerLaneInventory | None = None
     try:
+        _validate_runner_package_url_for_create(request)
         token, token_record = token_fetcher.fetch_registration_token(repository=request.repository)
         _prepare_runner_directory(request=request, remote_runner=remote_runner)
         _configure_runner(request=request, token=token, remote_runner=remote_runner)
@@ -422,6 +415,20 @@ def _runner_directory(request: RunnerLaneRegistrationExecutorRequest) -> str:
 
 def _systemd_unit_name(request: RunnerLaneRegistrationExecutorRequest) -> str:
     return f"launchplane-runner@{request.lane_name}.service"
+
+
+def _validate_runner_package_url_for_create(
+    request: RunnerLaneRegistrationExecutorRequest,
+) -> None:
+    assert request.mutate
+    if not request.runner_package_url:
+        raise ValueError(
+            "runner lane registration executor requires runner_package_url when mutate=true"
+        )
+    if not _is_allowed_runner_package_url(request.runner_package_url):
+        raise ValueError(
+            "runner lane registration executor runner_package_url must be an actions/runner tarball URL"
+        )
 
 
 def _is_allowed_runner_package_url(value: str) -> bool:

--- a/tests/test_runner_lane_registration.py
+++ b/tests/test_runner_lane_registration.py
@@ -197,16 +197,6 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "execution_lane must use"):
             _executor_request(mutate=True, execution_lane="ops-gate;touch bad")
 
-    def test_executor_request_rejects_runner_package_path_traversal(self) -> None:
-        with self.assertRaisesRegex(ValueError, "actions/runner tarball URL"):
-            _executor_request(
-                mutate=True,
-                runner_package_url=(
-                    "https://github.com/actions/runner/releases/download/"
-                    "../download/actions-runner-linux-x64-2.327.1.tar.gz"
-                ),
-            )
-
     def test_blocked_plan_posts_planned_audit_without_token_or_command(self) -> None:
         token_fetcher = _TokenFetcher()
         command_runner = _CommandRunner()
@@ -226,6 +216,82 @@ class RunnerLaneRegistrationExecutorTests(unittest.TestCase):
         self.assertEqual(token_fetcher.calls, [])
         self.assertEqual(command_runner.commands, [])
         self.assertEqual(audit_poster.records[0][0], "planned")
+
+    def test_blocked_plan_allows_invalid_runner_package_url_without_token_or_command(
+        self,
+    ) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner()
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_lane_registration_executor(
+            request=_executor_request(
+                mutate=True,
+                runner_package_url=(
+                    "https://github.com/actions/runner/releases/download/"
+                    "../download/actions-runner-linux-x64-2.327.1.tar.gz"
+                ),
+            ),
+            policy=_policy(),
+            pre_inventory=_inventory(lanes=(_lane(),)),
+            inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
+            token_fetcher=token_fetcher,  # type: ignore[arg-type]
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(token_fetcher.calls, [])
+        self.assertEqual(command_runner.commands, [])
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned"])
+
+    def test_ready_executor_posts_failed_audit_without_runner_package_url(self) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner()
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_lane_registration_executor(
+            request=_executor_request(mutate=True, runner_package_url=""),
+            policy=_policy(),
+            pre_inventory=_inventory(lanes=()),
+            inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
+            token_fetcher=token_fetcher,  # type: ignore[arg-type]
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("requires runner_package_url", result.message)
+        self.assertEqual(token_fetcher.calls, [])
+        self.assertEqual(command_runner.commands, [])
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned", "failed"])
+
+    def test_ready_executor_posts_failed_audit_for_unsafe_runner_package_url(self) -> None:
+        token_fetcher = _TokenFetcher()
+        command_runner = _CommandRunner()
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_lane_registration_executor(
+            request=_executor_request(
+                mutate=True,
+                runner_package_url=(
+                    "https://github.com/actions/runner/releases/download/"
+                    "../download/actions-runner-linux-x64-2.327.1.tar.gz"
+                ),
+            ),
+            policy=_policy(),
+            pre_inventory=_inventory(lanes=()),
+            inventory_reader=lambda _repo: _inventory(lanes=(_lane(),)),
+            token_fetcher=token_fetcher,  # type: ignore[arg-type]
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("actions/runner tarball URL", result.message)
+        self.assertEqual(token_fetcher.calls, [])
+        self.assertEqual(command_runner.commands, [])
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned", "failed"])
 
     def test_ready_executor_completes_supervised_registration(self) -> None:
         token_fetcher = _TokenFetcher()


### PR DESCRIPTION
## Summary
- defer runner package URL validation until the registration plan is ready to create
- preserve normal planned/blocked audit output for policy-blocked mutate requests even when the optional package URL input is blank or malformed
- keep missing/unsafe package URLs fail-closed before token fetch or host commands when the create path is actually reached

## Why
Auto-review found that `RunnerLaneRegistrationExecutorRequest` validated `runner_package_url` before plan evaluation. That meant otherwise-blocked mutate requests could fail before the executor wrote the usual planned/blocked evidence.

## Validation
- `uv run python -m unittest tests.test_runner_lane_registration tests.test_runner_lane_maintainer tests.test_runner_lane_baseline tests.test_runner_lane_inventory`
- `uv run --extra dev ruff format --check control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `uv run --extra dev ruff check control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `uv run --extra dev mypy control_plane/workflows/runner_lane_registration_executor.py tests/test_runner_lane_registration.py`
- `actionlint .github/workflows/runner-lane-registration.yml`
- `git diff --check`
