### PR TITLE
Route runner host hygiene to ops lane

### DIFF
--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -57,7 +57,7 @@ jobs:
   runner-host-hygiene:
     runs-on:
       - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+      - ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE }}
     env:
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       RUNNER_HOST_NAME: ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_HOST }}
@@ -134,7 +134,8 @@ jobs:
           builder_args=()
           IFS=',' read -r -a builders <<< "$RUNNER_RETAINED_WARM_BUILDERS"
           for builder in "${builders[@]}"; do
-            trimmed="$(xargs <<< "$builder")"
+            trimmed="${builder#"${builder%%[![:space:]]*}"}"
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
             if [ -n "$trimmed" ]; then
               builder_args+=(--retained-warm-builder "$trimmed")
             fi
@@ -148,7 +149,8 @@ jobs:
           target_volumes="${{ inputs.target_buildkit_state_volumes }}"
           IFS=',' read -r -a volumes <<< "$target_volumes"
           for volume in "${volumes[@]}"; do
-            trimmed="$(xargs <<< "$volume")"
+            trimmed="${volume#"${volume%%[![:space:]]*}"}"
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
             if [ -n "$trimmed" ]; then
               volume_args+=(--target-buildkit-state-volume "$trimmed")
             fi
@@ -158,7 +160,8 @@ jobs:
             allowed_volumes="$RUNNER_ALLOWED_BUILDKIT_STATE_VOLUMES"
             IFS=',' read -r -a volumes <<< "$allowed_volumes"
             for volume in "${volumes[@]}"; do
-              trimmed="$(xargs <<< "$volume")"
+              trimmed="${volume#"${volume%%[![:space:]]*}"}"
+              trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
               if [ -n "$trimmed" ]; then
                 volume_args+=(--allowed-buildkit-state-volume "$trimmed")
               fi

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -133,7 +133,8 @@ calls the service route after it captures the required pre/post host evidence.
 
 The first live executor is `.github/workflows/runner-host-hygiene.yml`. It runs
 on a dedicated self-hosted ops lane selected by the operator-managed
-`LAUNCHPLANE_RUNNER_LABEL` repository variable, authenticates back to
+`LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE` repository variable,
+authenticates back to
 Launchplane with GitHub Actions OIDC, and executes on the runner host as the
 constrained service user. The workflow runs daily on a schedule in dry-run mode
 and can also be manually dispatched for approved mutations. Scheduled runs

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -6,6 +6,7 @@ import unittest
 from collections.abc import Sequence
 from collections.abc import Mapping
 import subprocess
+from pathlib import Path
 from typing import Literal
 from unittest.mock import patch
 from urllib.request import Request
@@ -231,6 +232,23 @@ class _AuditPoster:
             "status": "accepted",
             "records": {"runner_host_hygiene_audit_record_key": audit.audit_record_key},
         }
+
+
+class RunnerHostHygieneWorkflowTests(unittest.TestCase):
+    def test_workflow_runs_on_ops_lane_without_xargs_dependency(self) -> None:
+        workflow_text = Path(".github/workflows/runner-host-hygiene.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn(
+            "    runs-on:\n"
+            "      - self-hosted\n"
+            "      - ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE }}\n",
+            workflow_text,
+        )
+        self.assertNotIn("${{ vars.LAUNCHPLANE_RUNNER_LABEL }}", workflow_text)
+        self.assertNotIn("xargs <<<", workflow_text)
+        self.assertIn('trimmed="${builder#', workflow_text)
 
 
 class RunnerHostHygieneExecutorTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- route Runner Host Hygiene to the configured ops-gate execution lane instead of the broad runner pool
- remove `xargs`-based comma trimming from the constrained ops-lane workflow script
- add workflow regression coverage and update docs to name the hygiene execution-lane variable

## Why
A report-only manual Runner Host Hygiene run failed during workflow validation because it ran on the broad `chris-testing` pool as `gha`, while the executor expects the `launchplane-runner-hygiene` service user on the ops-gate lane.

Failed evidence run: https://github.com/cbusillo/launchplane/actions/runs/27885992466

## Validation
- `uv run python -m unittest tests.test_runner_host_hygiene_executor tests.test_runner_host_hygiene`
- `actionlint .github/workflows/runner-host-hygiene.yml`
- `uv run --extra dev ruff format --check tests/test_runner_host_hygiene_executor.py`
- `uv run --extra dev ruff check tests/test_runner_host_hygiene_executor.py`
- `uv run --extra dev mypy tests/test_runner_host_hygiene_executor.py`
- `npx --yes markdownlint-cli2 docs/runner-host-hygiene.md`
- `git diff --check`
