### PR TITLE
Harden evidence ingress requests

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -13,6 +13,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from jwt import InvalidTokenError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from control_plane import authz_grant_service as control_plane_authz_grant_service
 from control_plane import dokploy as control_plane_dokploy
@@ -267,6 +268,18 @@ _PREVIEW_GENERATION_EVIDENCE_ROUTE = "/v1/evidence/previews/generations"
 _PREVIEW_DESTROYED_EVIDENCE_ROUTE = "/v1/evidence/previews/destroyed"
 _RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-host-hygiene/audits"
 _RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-lane-registration/audits"
+_EVIDENCE_INGRESS_MAX_BODY_BYTES = 2 * 1024 * 1024
+_EVIDENCE_INGRESS_ROUTES = frozenset(
+    {
+        _DEPLOYMENT_EVIDENCE_ROUTE,
+        _BACKUP_GATE_EVIDENCE_ROUTE,
+        _PROMOTION_EVIDENCE_ROUTE,
+        _PREVIEW_GENERATION_EVIDENCE_ROUTE,
+        _PREVIEW_DESTROYED_EVIDENCE_ROUTE,
+        _RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE,
+        _RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE,
+    }
+)
 _DOKPLOY_TARGET_SETUP_ROUTE = "/v1/dokploy-targets/setup"
 _PUBLIC_INGRESS_MONITOR_RUN_ONCE_ROUTE = "/v1/products/public-ingress-monitor/run-once"
 _PUBLIC_INGRESS_NOTIFICATION_POLICY_APPLY_ROUTE = "/v1/public-ingress/notification-policies/apply"
@@ -402,6 +415,160 @@ class HealthResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     storage_backend: str
+
+
+class EvidenceIngressRequestContractMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if (
+            scope.get("type") != "http"
+            or str(scope.get("method", "")).upper() != "POST"
+            or str(scope.get("path", "")) not in _EVIDENCE_INGRESS_ROUTES
+        ):
+            await self.app(scope, receive, send)
+            return
+
+        content_type_values = _asgi_header_values(scope=scope, name="content-type")
+        content_type = content_type_values[0] if len(content_type_values) == 1 else ""
+        media_type = content_type.split(";", 1)[0].strip().lower()
+        if media_type != "application/json":
+            await _send_launchplane_error_response(
+                scope=scope,
+                receive=receive,
+                send=send,
+                status_code=400,
+                code="invalid_request",
+                message="Evidence ingress requests require Content-Type: application/json.",
+            )
+            return
+
+        transfer_encoding_tokens = {
+            token.split(";", 1)[0].strip().lower()
+            for value in _asgi_header_values(scope=scope, name="transfer-encoding")
+            for token in value.split(",")
+            if token.strip()
+        }
+        if "chunked" in transfer_encoding_tokens:
+            await _send_launchplane_error_response(
+                scope=scope,
+                receive=receive,
+                send=send,
+                status_code=413,
+                code="request_entity_too_large",
+                message="Evidence ingress requests require a bounded Content-Length.",
+            )
+            return
+
+        content_length_values = _asgi_header_values(scope=scope, name="content-length")
+        if not content_length_values:
+            await _send_launchplane_error_response(
+                scope=scope,
+                receive=receive,
+                send=send,
+                status_code=413,
+                code="request_entity_too_large",
+                message="Evidence ingress requests require a bounded Content-Length.",
+            )
+            return
+        if len(content_length_values) != 1:
+            await _send_launchplane_error_response(
+                scope=scope,
+                receive=receive,
+                send=send,
+                status_code=400,
+                code="invalid_request",
+                message="Evidence ingress requests require exactly one Content-Length header.",
+            )
+            return
+        content_length = content_length_values[0].strip()
+        if not content_length or not all("0" <= character <= "9" for character in content_length):
+            await _send_launchplane_error_response(
+                scope=scope,
+                receive=receive,
+                send=send,
+                status_code=400,
+                code="invalid_request",
+                message="Evidence ingress Content-Length must be an unsigned decimal integer.",
+            )
+            return
+        declared_body_size = int(content_length)
+        if declared_body_size > _EVIDENCE_INGRESS_MAX_BODY_BYTES:
+            await _send_launchplane_error_response(
+                scope=scope,
+                receive=receive,
+                send=send,
+                status_code=413,
+                code="request_entity_too_large",
+                message="Evidence ingress request body is too large.",
+            )
+            return
+
+        buffered_messages: list[Message] = []
+        observed_body_size = 0
+        while True:
+            message = await receive()
+            if message.get("type") != "http.request":
+                buffered_messages.append(message)
+                break
+            body = message.get("body", b"")
+            if isinstance(body, bytes):
+                observed_body_size += len(body)
+            if observed_body_size > _EVIDENCE_INGRESS_MAX_BODY_BYTES:
+                await _send_launchplane_error_response(
+                    scope=scope,
+                    receive=receive,
+                    send=send,
+                    status_code=413,
+                    code="request_entity_too_large",
+                    message="Evidence ingress request body is too large.",
+                )
+                return
+            buffered_messages.append(message)
+            if not message.get("more_body", False):
+                break
+
+        next_message_index = 0
+
+        async def replay_receive() -> Message:
+            nonlocal next_message_index
+            if next_message_index < len(buffered_messages):
+                message = buffered_messages[next_message_index]
+                next_message_index += 1
+                return message
+            return await receive()
+
+        await self.app(scope, replay_receive, send)
+
+
+def _asgi_header_values(*, scope: Scope, name: str) -> list[str]:
+    header_values: list[str] = []
+    normalized_name = name.lower().encode("latin-1")
+    for raw_name, raw_value in scope.get("headers", []):
+        if raw_name.lower() == normalized_name:
+            header_values.append(raw_value.decode("latin-1"))
+    return header_values
+
+
+async def _send_launchplane_error_response(
+    *,
+    scope: Scope,
+    receive: Receive,
+    send: Send,
+    status_code: int,
+    code: str,
+    message: str,
+) -> None:
+    payload = LaunchplaneErrorResponse(
+        trace_id=f"launchplane_req_{uuid4().hex}",
+        error=LaunchplaneErrorDetail(code=code, message=message),
+    )
+    response = JSONResponse(
+        status_code=status_code,
+        content=payload.model_dump(mode="json", exclude_none=True),
+    )
+    await response(scope, receive, send)
 
 
 class LaunchplaneRuntimeStatus(BaseModel):
@@ -2806,6 +2973,7 @@ def create_launchplane_fastapi_app(
                 shared_record_store.close()
 
     app = FastAPI(title="Launchplane API", version="0.1.0", lifespan=lifespan)
+    app.add_middleware(EvidenceIngressRequestContractMiddleware)
 
     def next_trace_id() -> str:
         return f"launchplane_req_{uuid4().hex}"
@@ -10692,6 +10860,14 @@ def create_launchplane_fastapi_app(
         409: {"model": LaunchplaneErrorResponse},
         503: {"model": LaunchplaneErrorResponse},
     }
+    evidence_ingress_error_responses: dict[int | str, dict[str, object]] = {
+        400: {"model": LaunchplaneErrorResponse},
+        401: {"model": LaunchplaneErrorResponse},
+        403: {"model": LaunchplaneErrorResponse},
+        409: {"model": LaunchplaneErrorResponse},
+        413: {"model": LaunchplaneErrorResponse},
+        503: {"model": LaunchplaneErrorResponse},
+    }
 
     app.add_api_route(
         _EVERY_CODE_GITHUB_WEBHOOK_ROUTE,
@@ -11629,13 +11805,7 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_backup_gate_evidence",
         summary="Write backup gate evidence",
-        responses={
-            400: {"model": LaunchplaneErrorResponse},
-            401: {"model": LaunchplaneErrorResponse},
-            403: {"model": LaunchplaneErrorResponse},
-            409: {"model": LaunchplaneErrorResponse},
-            503: {"model": LaunchplaneErrorResponse},
-        },
+        responses=evidence_ingress_error_responses,
     )
 
     app.add_api_route(
@@ -11647,13 +11817,7 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_promotion_evidence",
         summary="Write promotion evidence",
-        responses={
-            400: {"model": LaunchplaneErrorResponse},
-            401: {"model": LaunchplaneErrorResponse},
-            403: {"model": LaunchplaneErrorResponse},
-            409: {"model": LaunchplaneErrorResponse},
-            503: {"model": LaunchplaneErrorResponse},
-        },
+        responses=evidence_ingress_error_responses,
     )
 
     app.add_api_route(
@@ -11665,13 +11829,7 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_preview_generation_evidence",
         summary="Write preview generation evidence",
-        responses={
-            400: {"model": LaunchplaneErrorResponse},
-            401: {"model": LaunchplaneErrorResponse},
-            403: {"model": LaunchplaneErrorResponse},
-            409: {"model": LaunchplaneErrorResponse},
-            503: {"model": LaunchplaneErrorResponse},
-        },
+        responses=evidence_ingress_error_responses,
     )
 
     app.add_api_route(
@@ -11683,13 +11841,7 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_preview_destroyed_evidence",
         summary="Write preview destroyed evidence",
-        responses={
-            400: {"model": LaunchplaneErrorResponse},
-            401: {"model": LaunchplaneErrorResponse},
-            403: {"model": LaunchplaneErrorResponse},
-            409: {"model": LaunchplaneErrorResponse},
-            503: {"model": LaunchplaneErrorResponse},
-        },
+        responses=evidence_ingress_error_responses,
     )
 
     app.add_api_route(
@@ -11701,13 +11853,7 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_runner_host_hygiene_audit_evidence",
         summary="Write runner host hygiene audit evidence",
-        responses={
-            400: {"model": LaunchplaneErrorResponse},
-            401: {"model": LaunchplaneErrorResponse},
-            403: {"model": LaunchplaneErrorResponse},
-            409: {"model": LaunchplaneErrorResponse},
-            503: {"model": LaunchplaneErrorResponse},
-        },
+        responses=evidence_ingress_error_responses,
     )
 
     app.add_api_route(
@@ -11719,13 +11865,7 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_runner_lane_registration_audit_evidence",
         summary="Write runner lane registration audit evidence",
-        responses={
-            400: {"model": LaunchplaneErrorResponse},
-            401: {"model": LaunchplaneErrorResponse},
-            403: {"model": LaunchplaneErrorResponse},
-            409: {"model": LaunchplaneErrorResponse},
-            503: {"model": LaunchplaneErrorResponse},
-        },
+        responses=evidence_ingress_error_responses,
     )
 
     app.add_api_route(
@@ -11737,13 +11877,7 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="write_deployment_evidence",
         summary="Write deployment evidence",
-        responses={
-            400: {"model": LaunchplaneErrorResponse},
-            401: {"model": LaunchplaneErrorResponse},
-            403: {"model": LaunchplaneErrorResponse},
-            409: {"model": LaunchplaneErrorResponse},
-            503: {"model": LaunchplaneErrorResponse},
-        },
+        responses=evidence_ingress_error_responses,
     )
 
     def launchplane_http_exception_handler(request: Request, error: Exception) -> JSONResponse:

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -127,6 +127,12 @@ VeriReel product paths:
   - `POST /v1/products/public-ingress-monitor/run-once` (native FastAPI for
     bearer-token callers, with Pydantic/OpenAPI contract coverage,
     idempotency replay preservation, and no legacy `GET` route)
+  - Native `POST /v1/evidence/*` ingress routes reject non-JSON media types with
+    the Launchplane `400 invalid_request` envelope; they require bounded,
+    non-chunked `Content-Length` headers and enforce the same 2 MiB byte ceiling
+    while reading the request stream, returning the Launchplane
+    `413 request_entity_too_large` envelope before route-specific storage
+    mutation.
   - `POST /v1/evidence/backup-gates` (native FastAPI for bearer-token callers,
     with Pydantic/OpenAPI contract coverage and idempotency replay preservation)
   - `POST /v1/evidence/deployments` (native FastAPI for bearer-token callers,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -14025,7 +14025,7 @@ class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
             route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
             "#/components/schemas/AcceptedEvidenceResponse",
         )
-        for status_code in ("400", "401", "403", "409", "503"):
+        for status_code in ("400", "401", "403", "409", "413", "503"):
             self.assertIn("LaunchplaneErrorResponse", json.dumps(route["responses"][status_code]))
         self.assertEqual(
             openapi["components"]["schemas"]["BackupGateEvidenceRequest"]["additionalProperties"],
@@ -14674,7 +14674,7 @@ class FastApiPromotionEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(request_schema["$ref"], "#/components/schemas/PromotionEvidenceRequest")
         success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
         self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
-        for status_code in ("400", "401", "403", "409", "503"):
+        for status_code in ("400", "401", "403", "409", "413", "503"):
             error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
             self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
         promotion_schema = openapi["components"]["schemas"]["PromotionEvidenceRequest"]
@@ -15016,7 +15016,7 @@ class FastApiPreviewGenerationEvidenceTests(unittest.IsolatedAsyncioTestCase):
         )
         success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
         self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
-        for status_code in ("400", "401", "403", "409", "503"):
+        for status_code in ("400", "401", "403", "409", "413", "503"):
             error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
             self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
         envelope_schema = openapi["components"]["schemas"]["PreviewGenerationEvidenceEnvelope"]
@@ -15336,7 +15336,7 @@ class FastApiPreviewDestroyedEvidenceTests(unittest.IsolatedAsyncioTestCase):
         )
         success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
         self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
-        for status_code in ("400", "401", "403", "409", "503"):
+        for status_code in ("400", "401", "403", "409", "413", "503"):
             error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
             self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
         envelope_schema = openapi["components"]["schemas"]["PreviewDestroyedEvidenceEnvelope"]
@@ -15658,7 +15658,7 @@ class FastApiRunnerHostHygieneAuditEvidenceTests(unittest.IsolatedAsyncioTestCas
         )
         success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
         self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
-        for status_code in ("400", "401", "403", "409", "503"):
+        for status_code in ("400", "401", "403", "409", "413", "503"):
             error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
             self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
         envelope_schema = openapi["components"]["schemas"]["RunnerHostHygieneAuditEvidenceEnvelope"]
@@ -15988,7 +15988,7 @@ class FastApiRunnerLaneRegistrationAuditEvidenceTests(unittest.IsolatedAsyncioTe
         )
         success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
         self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
-        for status_code in ("400", "401", "403", "409", "503"):
+        for status_code in ("400", "401", "403", "409", "413", "503"):
             error_schema = route["responses"][status_code]["content"]["application/json"]["schema"]
             self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
         envelope_schema = openapi["components"]["schemas"][
@@ -16163,6 +16163,335 @@ class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["error"]["code"], "invalid_request")
         self.assertNotIn("detail", payload)
 
+    async def test_deployment_evidence_requires_json_content_type(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "text/plain",
+            },
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress requests require Content-Type: application/json.",
+        )
+
+    async def test_deployment_evidence_accepts_json_content_type_with_charset(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _asgi_request(
+                app,
+                "POST",
+                "/v1/evidence/deployments",
+                headers={
+                    "Authorization": "Bearer valid-token",
+                    "Content-Type": "application/json; charset=utf-8",
+                },
+                raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["status"], "accepted")
+
+    async def test_deployment_evidence_rejects_invalid_content_length(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Content-Length": "not-a-number",
+            },
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress Content-Length must be an unsigned decimal integer.",
+        )
+
+    async def test_deployment_evidence_rejects_empty_content_length(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Content-Length": "   ",
+            },
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress Content-Length must be an unsigned decimal integer.",
+        )
+
+    async def test_deployment_evidence_rejects_plus_prefixed_content_length(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Content-Length": "+2",
+            },
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress Content-Length must be an unsigned decimal integer.",
+        )
+
+    async def test_deployment_evidence_rejects_duplicate_content_length(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Content-Length": "2",
+            },
+            extra_headers=[("Content-Length", "200")],
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress requests require exactly one Content-Length header.",
+        )
+
+    async def test_deployment_evidence_rejects_negative_content_length(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Content-Length": "-1",
+            },
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+        )
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress Content-Length must be an unsigned decimal integer.",
+        )
+
+    async def test_deployment_evidence_requires_bounded_content_length(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+            },
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+            set_content_length=False,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "request_entity_too_large")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress requests require a bounded Content-Length.",
+        )
+
+    async def test_deployment_evidence_rejects_duplicate_chunked_transfer_encoding(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Transfer-Encoding": "identity",
+            },
+            extra_headers=[("Transfer-Encoding", "chunked")],
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+            set_content_length=False,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "request_entity_too_large")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress requests require a bounded Content-Length.",
+        )
+
+    async def test_deployment_evidence_rejects_chunked_transfer_encoding(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Transfer-Encoding": "chunked",
+            },
+            raw_body=json.dumps(_deployment_evidence_payload()).encode("utf-8"),
+            set_content_length=False,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "request_entity_too_large")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Evidence ingress requests require a bounded Content-Length.",
+        )
+
+    async def test_deployment_evidence_rejects_oversized_content_length(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Content-Length": str(2 * 1024 * 1024 + 1),
+            },
+            raw_body=b"{}",
+        )
+
+        self.assertEqual(response.status_code, 413)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "request_entity_too_large")
+        self.assertEqual(payload["error"]["message"], "Evidence ingress request body is too large.")
+
+    async def test_deployment_evidence_rejects_stream_body_over_limit(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(context="example-site"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/v1/evidence/deployments",
+            headers={
+                "Authorization": "Bearer valid-token",
+                "Content-Type": "application/json",
+                "Content-Length": "2",
+            },
+            raw_body=b"{" + (b" " * (2 * 1024 * 1024 + 1)),
+        )
+
+        self.assertEqual(response.status_code, 413)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "request_entity_too_large")
+        self.assertEqual(payload["error"]["message"], "Evidence ingress request body is too large.")
+
     async def test_deployment_evidence_replays_idempotent_write(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -16248,7 +16577,7 @@ class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
             route["responses"]["202"]["content"]["application/json"]["schema"]["$ref"],
             "#/components/schemas/AcceptedEvidenceResponse",
         )
-        for status_code in ("400", "401", "403", "409", "503"):
+        for status_code in ("400", "401", "403", "409", "413", "503"):
             self.assertIn("LaunchplaneErrorResponse", json.dumps(route["responses"][status_code]))
         self.assertEqual(
             openapi["components"]["schemas"]["DeploymentEvidenceRequest"]["additionalProperties"],
@@ -19983,8 +20312,10 @@ async def _asgi_request(
     path: str,
     *,
     headers: dict[str, str] | None = None,
+    extra_headers: list[tuple[str, str]] | None = None,
     payload: dict[str, object] | None = None,
     raw_body: bytes | None = None,
+    set_content_length: bool = True,
 ) -> _AsgiResponse:
     request_path, separator, raw_query_string = path.partition("?")
     request_headers_dict = dict(headers or {})
@@ -19994,11 +20325,15 @@ async def _asgi_request(
     elif payload is not None:
         body = json.dumps(payload).encode("utf-8")
         request_headers_dict.setdefault("Content-Type", "application/json")
-    request_headers_dict.setdefault("Content-Length", str(len(body)))
+    if set_content_length:
+        request_headers_dict.setdefault("Content-Length", str(len(body)))
     request_headers = [
         (key.lower().encode("ascii"), value.encode("latin-1"))
         for key, value in request_headers_dict.items()
     ]
+    request_headers.extend(
+        (key.lower().encode("ascii"), value.encode("latin-1")) for key, value in extra_headers or []
+    )
     scope = {
         "type": "http",
         "asgi": {"version": "3.0", "spec_version": "2.3"},


### PR DESCRIPTION
## Summary
- add exact-path ASGI request contract middleware for native evidence ingress POST routes
- reject ambiguous/non-JSON/unbounded evidence requests before storage mutation and enforce the 2 MiB stream ceiling
- advertise 413 for evidence ingress routes and document the boundary behavior

## Verification
- uv run python -m unittest tests.test_http_app.FastApiDeploymentEvidenceTests tests.test_http_app.FastApiBackupGateEvidenceTests tests.test_http_app.FastApiPromotionEvidenceTests tests.test_http_app.FastApiPreviewGenerationEvidenceTests tests.test_http_app.FastApiPreviewDestroyedEvidenceTests tests.test_http_app.FastApiRunnerHostHygieneAuditEvidenceTests tests.test_http_app.FastApiRunnerLaneRegistrationAuditEvidenceTests
- uv run --extra dev ruff check control_plane/http_app.py tests/test_http_app.py
- uv run --extra dev ruff format --check control_plane/http_app.py tests/test_http_app.py
- uv run --extra dev mypy control_plane/http_app.py tests/test_http_app.py
- uv run --extra dev markdownlint-cli2 docs/service-boundary.md
- uv run python -m unittest tests.test_http_app
- ulimit -n 4096 && uv run python -m unittest

## Review
- GPT and Antigravity/Gemini-family review agents checked the final empty Content-Length fix and reported no blockers.