### PR TITLE
Migrate auth session read to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -307,6 +307,7 @@ _AUTHZ_POLICY_GITHUB_HUMANS_GRANTS_ROUTE = "/v1/authz-policies/github-humans/gra
 _AUTHZ_POLICY_TERMINAL_AGENTS_GRANTS_ROUTE = "/v1/authz-policies/terminal-agents/grants"
 _AUTHZ_POLICY_LOCAL_OPERATORS_GRANTS_ROUTE = "/v1/authz-policies/local-operators/grants"
 _AUTHZ_POLICY_LOCAL_ADMINS_GRANTS_ROUTE = "/v1/authz-policies/local-admins/grants"
+_AUTH_SESSION_ROUTE = "/v1/auth/session"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _AGENT_WRITE_INTENT_EVALUATE_ROUTE = "/v1/agent/write-intents/evaluate"
 _EVERY_CODE_WORK_REQUEST_RERUN_ROUTE = "/v1/every-code/work-requests/rerun"
@@ -415,6 +416,36 @@ class HealthResponse(BaseModel):
     status: Literal["ok"] = "ok"
     trace_id: str
     storage_backend: str
+
+
+class GitHubHumanIdentityResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    provider: Literal["github"] = "github"
+    login: str
+    github_id: int
+    name: str
+    email: str
+    organizations: tuple[str, ...]
+    teams: tuple[str, ...]
+    role: Literal["read_only", "admin"]
+
+
+class AuthSessionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    identity: GitHubHumanIdentityResponse
+
+
+class AuthSessionRequiredResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["rejected"] = "rejected"
+    trace_id: str
+    error: LaunchplaneErrorDetail
+    configured: bool
 
 
 class EvidenceIngressRequestContractMiddleware:
@@ -3014,6 +3045,47 @@ def create_launchplane_fastapi_app(
             response.headers.append("Set-Cookie", session_cookie_header)
             request.state.launchplane_renewed_session_cookie = session_cookie_header
         return session.identity
+
+    def human_identity_response(identity: GitHubHumanIdentity) -> GitHubHumanIdentityResponse:
+        return GitHubHumanIdentityResponse(
+            login=identity.login,
+            github_id=identity.github_id,
+            name=identity.name,
+            email=identity.email,
+            organizations=tuple(sorted(identity.organizations)),
+            teams=tuple(sorted(identity.teams)),
+            role=identity.role,
+        )
+
+    def read_auth_session(
+        request: Request,
+        response: Response,
+        cookie: Annotated[str, Header(alias="Cookie")] = "",
+    ) -> AuthSessionResponse | JSONResponse:
+        trace_id = next_trace_id()
+        session_result = read_human_session(cookie_header=cookie)
+        if session_result is None:
+            payload = AuthSessionRequiredResponse(
+                trace_id=trace_id,
+                error=LaunchplaneErrorDetail(
+                    code="authentication_required",
+                    message="Sign in with GitHub to access Launchplane.",
+                ),
+                configured=human_session_manager is not None,
+            )
+            return JSONResponse(
+                status_code=401,
+                content=payload.model_dump(mode="json"),
+            )
+        session, was_renewed = session_result
+        if was_renewed and human_session_manager is not None:
+            session_cookie_header = human_session_manager.session_cookie_header(session)
+            response.headers.append("Set-Cookie", session_cookie_header)
+            request.state.launchplane_renewed_session_cookie = session_cookie_header
+        return AuthSessionResponse(
+            trace_id=trace_id,
+            identity=human_identity_response(session.identity),
+        )
 
     def read_identity(
         request: Request,
@@ -10318,6 +10390,17 @@ def create_launchplane_fastapi_app(
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
         },
+    )
+
+    app.add_api_route(
+        _AUTH_SESSION_ROUTE,
+        read_auth_session,
+        methods=["GET"],
+        response_model=AuthSessionResponse,
+        response_model_exclude_none=True,
+        operation_id="read_human_auth_session",
+        summary="Read human auth session",
+        responses={401: {"model": AuthSessionRequiredResponse}},
     )
 
     app.add_api_route(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -56,6 +56,12 @@ Keep a compatibility surface only when it is one of these:
 - The Launchplane health read uses the native FastAPI `GET /v1/health` route.
   Its legacy WSGI branch is deleted; direct fallback calls fail closed while
   the mounted fallback remains for retained non-native routes.
+- The human auth-session read uses native FastAPI `GET /v1/auth/session` in the
+  mounted service. It preserves the existing signed-session cookie read/renewal
+  behavior, `authentication_required` rejection envelope, and `configured` flag.
+  The legacy WSGI session-read branch remains only as a direct compatibility
+  branch until the GitHub OAuth login, callback, and logout routes migrate to the
+  same native auth/session family.
 - Launchplane service runtime and Odoo worker status reads use native FastAPI
   routes for bearer-token and human-session callers. Odoo worker reconcile uses
   native FastAPI `POST /v1/service/odoo-workers/reconcile` on the bearer/OIDC

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -348,6 +348,14 @@ typed Pydantic response, focused OpenAPI assertions, and direct WSGI fallback
 retirement. Do not turn that route into a migration framework; use it as the
 small contract shape for the next route-family slice.
 
+`GET /v1/auth/session` uses the native FastAPI route in the mounted service. It
+preserves the Launchplane human-session response shape, renews expiring signed
+session cookies with the existing `HumanSessionManager`, returns
+`authentication_required` with the `configured` flag when no valid human session
+exists, and has focused OpenAPI coverage. The direct WSGI handler remains as a
+compatibility branch until the GitHub OAuth login, callback, and logout routes
+move to the same native auth/session family.
+
 Launchplane verifies GitHub OIDC, authorizes workflow identity claims, accepts
 deployment/promotion/preview lifecycle evidence over HTTP, and executes the
 current Odoo/VeriReel artifact, deploy, backup, promotion, rollback, maintenance,

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -219,6 +219,193 @@ class FastApiHealthContractTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("shinycomputers", example_text)
 
 
+class FastApiAuthSessionReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_session_read_rejects_missing_human_session(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/v1/auth/session")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+        self.assertEqual(payload["error"]["message"], "Sign in with GitHub to access Launchplane.")
+        self.assertFalse(payload["configured"])
+        self.assertTrue(str(payload["trace_id"]).startswith("launchplane_req_"))
+        self.assertNotIn("WWW-Authenticate", response.headers)
+
+    async def test_session_read_rejects_missing_cookie_when_auth_is_configured(self) -> None:
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=InMemoryHumanSessionStore(),
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+
+        response = await _asgi_get(app, "/v1/auth/session")
+
+        self.assertEqual(response.status_code, 401)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "authentication_required")
+        self.assertTrue(payload["configured"])
+        self.assertNotIn("WWW-Authenticate", response.headers)
+
+    async def test_session_read_returns_github_human_identity(self) -> None:
+        session_store = InMemoryHumanSessionStore()
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=session_store,
+        )
+        human_session = session_manager.issue(
+            GitHubHumanIdentity(
+                login="example-operator",
+                github_id=123,
+                name="Example Operator",
+                email="operator@example.com",
+                organizations=frozenset({"z-org", "a-org"}),
+                teams=frozenset({"z-org/admins", "a-org/operators"}),
+                role="admin",
+            )
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+
+        response = await _asgi_get(
+            app,
+            "/v1/auth/session",
+            headers={"Cookie": session_manager.session_cookie_header(human_session)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("Set-Cookie", response.headers)
+        payload = response.json()
+        self.assertEqual(payload["status"], "ok")
+        self.assertTrue(str(payload["trace_id"]).startswith("launchplane_req_"))
+        self.assertEqual(
+            payload["identity"],
+            {
+                "provider": "github",
+                "login": "example-operator",
+                "github_id": 123,
+                "name": "Example Operator",
+                "email": "operator@example.com",
+                "organizations": ["a-org", "z-org"],
+                "teams": ["a-org/operators", "z-org/admins"],
+                "role": "admin",
+            },
+        )
+
+    async def test_session_read_renews_expiring_human_session(self) -> None:
+        session_store = InMemoryHumanSessionStore()
+        now = datetime.now(timezone.utc)
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=session_store,
+            now=lambda: now,
+        )
+        expiring_session = LaunchplaneHumanSession(
+            session_id="expiring-session",
+            identity=_github_human_identity(role="read_only"),
+            created_at=now - timedelta(days=13),
+            expires_at=now + timedelta(hours=12),
+        )
+        session_store.write_session(expiring_session)
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+
+        response = await _asgi_get(
+            app,
+            "/v1/auth/session",
+            headers={"Cookie": session_manager.session_cookie_header(expiring_session)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("launchplane_session=", response.headers["Set-Cookie"])
+        self.assertIn("Max-Age=1209600", response.headers["Set-Cookie"])
+        renewed_session = session_store.read_session("expiring-session")
+        self.assertIsNotNone(renewed_session)
+        assert renewed_session is not None
+        self.assertGreater(renewed_session.expires_at, expiring_session.expires_at)
+
+    async def test_session_read_native_route_precedes_wsgi_fallback(self) -> None:
+        session_store = InMemoryHumanSessionStore()
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=session_store,
+        )
+        human_session = session_manager.issue(_github_human_identity())
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+        fallback_calls: list[str] = []
+
+        def fallback_app(
+            environ: dict[str, object], start_response: Callable[..., object]
+        ) -> list[bytes]:
+            fallback_calls.append(str(environ.get("PATH_INFO", "")))
+            start_response("599 Legacy Fallback", [("Content-Type", "application/json")])
+            return [b'{"status":"legacy"}']
+
+        app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, fallback_app))))
+
+        response = await _asgi_get(
+            app,
+            "/v1/auth/session",
+            headers={"Cookie": session_manager.session_cookie_header(human_session)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["identity"]["login"], "example-operator")
+        self.assertEqual(fallback_calls, [])
+
+    async def test_openapi_includes_auth_session_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        route = openapi["paths"]["/v1/auth/session"]["get"]
+        self.assertEqual(route["operationId"], "read_human_auth_session")
+        success_schema = route["responses"]["200"]["content"]["application/json"]["schema"]
+        self.assertEqual(success_schema["$ref"], "#/components/schemas/AuthSessionResponse")
+        rejected_schema = route["responses"]["401"]["content"]["application/json"]["schema"]
+        self.assertEqual(
+            rejected_schema["$ref"], "#/components/schemas/AuthSessionRequiredResponse"
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["AuthSessionResponse"]["additionalProperties"],
+            False,
+        )
+        self.assertEqual(
+            openapi["components"]["schemas"]["AuthSessionRequiredResponse"]["additionalProperties"],
+            False,
+        )
+
+
 class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
     async def test_runtime_reports_current_image_and_policy_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add native FastAPI GET /v1/auth/session with strict Pydantic/OpenAPI response contracts
- preserve legacy human-session rejection message and configured flag while omitting bearer challenge on cookie-only auth-session reads
- cover missing session, configured missing-cookie rejection, identity payload, renewal, WSGI fallback precedence, and OpenAPI shape
- document the v2 checkpoint and retained WSGI removal condition for the later OAuth route-family slice

## Validation
- uv run python -m unittest tests.test_http_app.FastApiAuthSessionReadTests
- uv run python -m unittest tests.test_http_app
- uv run python -m unittest tests.test_work_graph_issue_inbox
- ulimit -n 4096 && uv run python -m unittest
- uv run ruff check --diff control_plane/http_app.py tests/test_http_app.py
- uv run ruff check control_plane/http_app.py tests/test_http_app.py
- uv run mypy control_plane/http_app.py tests/test_http_app.py
- uv run --extra dev mypy control_plane tests
- uv run markdownlint-cli2 docs/service-boundary.md docs/compatibility-retirement.md

## Notes
- Initial full unittest with the default macOS soft limit (ulimit -n 256) hit Errno 24: Too many open files after 2,945 tests; the affected work-graph issue-inbox module passed in isolation, and the full suite passed after raising the shell limit to 4096.
- Repo-wide ruff format check still reports pre-existing unrelated formatting drift in 54 files; changed files are formatted and changed-file Ruff is clean.
- Review agents: code-gpt-5.5 and Antigravity reviewed the slice; post-fix review was clean.