### PR TITLE
Migrate auth logout to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -308,6 +308,7 @@ _AUTHZ_POLICY_TERMINAL_AGENTS_GRANTS_ROUTE = "/v1/authz-policies/terminal-agents
 _AUTHZ_POLICY_LOCAL_OPERATORS_GRANTS_ROUTE = "/v1/authz-policies/local-operators/grants"
 _AUTHZ_POLICY_LOCAL_ADMINS_GRANTS_ROUTE = "/v1/authz-policies/local-admins/grants"
 _AUTH_SESSION_ROUTE = "/v1/auth/session"
+_AUTH_LOGOUT_ROUTE = "/auth/logout"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _AGENT_WRITE_INTENT_EVALUATE_ROUTE = "/v1/agent/write-intents/evaluate"
 _EVERY_CODE_WORK_REQUEST_RERUN_ROUTE = "/v1/every-code/work-requests/rerun"
@@ -446,6 +447,13 @@ class AuthSessionRequiredResponse(BaseModel):
     trace_id: str
     error: LaunchplaneErrorDetail
     configured: bool
+
+
+class AuthLogoutResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
 
 
 class EvidenceIngressRequestContractMiddleware:
@@ -3086,6 +3094,19 @@ def create_launchplane_fastapi_app(
             trace_id=trace_id,
             identity=human_identity_response(session.identity),
         )
+
+    def logout_auth_session(
+        response: Response,
+        cookie: Annotated[str, Header(alias="Cookie")] = "",
+    ) -> AuthLogoutResponse:
+        trace_id = next_trace_id()
+        if human_session_manager is not None:
+            human_session_manager.delete_cookie_session(cookie)
+            clear_cookie = human_session_manager.clear_cookie_header()
+        else:
+            clear_cookie = "launchplane_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax"
+        response.headers.append("Set-Cookie", clear_cookie)
+        return AuthLogoutResponse(trace_id=trace_id)
 
     def read_identity(
         request: Request,
@@ -10401,6 +10422,16 @@ def create_launchplane_fastapi_app(
         operation_id="read_human_auth_session",
         summary="Read human auth session",
         responses={401: {"model": AuthSessionRequiredResponse}},
+    )
+
+    app.add_api_route(
+        _AUTH_LOGOUT_ROUTE,
+        logout_auth_session,
+        methods=["POST"],
+        response_model=AuthLogoutResponse,
+        response_model_exclude_none=True,
+        operation_id="logout_human_auth_session",
+        summary="Logout human auth session",
     )
 
     app.add_api_route(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -56,12 +56,14 @@ Keep a compatibility surface only when it is one of these:
 - The Launchplane health read uses the native FastAPI `GET /v1/health` route.
   Its legacy WSGI branch is deleted; direct fallback calls fail closed while
   the mounted fallback remains for retained non-native routes.
-- The human auth-session read uses native FastAPI `GET /v1/auth/session` in the
-  mounted service. It preserves the existing signed-session cookie read/renewal
-  behavior, `authentication_required` rejection envelope, and `configured` flag.
-  The legacy WSGI session-read branch remains only as a direct compatibility
-  branch until the GitHub OAuth login, callback, and logout routes migrate to the
-  same native auth/session family.
+- The human auth-session read and logout routes use native FastAPI
+  `GET /v1/auth/session` and `POST /auth/logout` in the mounted service. Session
+  read preserves the existing signed-session cookie read/renewal behavior,
+  `authentication_required` rejection envelope, and `configured` flag. Logout
+  preserves cookie-backed session deletion and the clearing `Set-Cookie` header.
+  The legacy WSGI branches remain only as direct compatibility branches until
+  the GitHub OAuth login and callback routes migrate to the same native
+  auth/session family.
 - Launchplane service runtime and Odoo worker status reads use native FastAPI
   routes for bearer-token and human-session callers. Odoo worker reconcile uses
   native FastAPI `POST /v1/service/odoo-workers/reconcile` on the bearer/OIDC

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -348,13 +348,15 @@ typed Pydantic response, focused OpenAPI assertions, and direct WSGI fallback
 retirement. Do not turn that route into a migration framework; use it as the
 small contract shape for the next route-family slice.
 
-`GET /v1/auth/session` uses the native FastAPI route in the mounted service. It
-preserves the Launchplane human-session response shape, renews expiring signed
-session cookies with the existing `HumanSessionManager`, returns
-`authentication_required` with the `configured` flag when no valid human session
-exists, and has focused OpenAPI coverage. The direct WSGI handler remains as a
-compatibility branch until the GitHub OAuth login, callback, and logout routes
-move to the same native auth/session family.
+`GET /v1/auth/session` and `POST /auth/logout` use native FastAPI routes in the
+mounted service. Session read preserves the Launchplane human-session response
+shape, renews expiring signed session cookies with the existing
+`HumanSessionManager`, returns `authentication_required` with the `configured`
+flag when no valid human session exists, and has focused OpenAPI coverage. Logout
+deletes the cookie-backed session when auth is configured and always emits the
+Launchplane session clearing cookie. The direct WSGI handlers remain as
+compatibility branches until the GitHub OAuth login and callback routes move to
+the same native auth/session family.
 
 Launchplane verifies GitHub OIDC, authorizes workflow identity claims, accepts
 deployment/promotion/preview lifecycle evidence over HTTP, and executes the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -377,6 +377,109 @@ class FastApiAuthSessionReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["identity"]["login"], "example-operator")
         self.assertEqual(fallback_calls, [])
 
+    async def test_logout_deletes_session_and_clears_cookie(self) -> None:
+        session_store = InMemoryHumanSessionStore()
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=session_store,
+        )
+        human_session = session_manager.issue(_github_human_identity())
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/auth/logout",
+            headers={"Cookie": session_manager.session_cookie_header(human_session)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+        self.assertTrue(str(response.json()["trace_id"]).startswith("launchplane_req_"))
+        self.assertIsNone(session_store.read_session(human_session.session_id))
+        self.assertIn("launchplane_session=", response.headers["Set-Cookie"])
+        self.assertIn("Max-Age=0", response.headers["Set-Cookie"])
+        self.assertIn("HttpOnly", response.headers["Set-Cookie"])
+        self.assertIn("SameSite=Lax", response.headers["Set-Cookie"])
+        self.assertNotIn("Secure", response.headers["Set-Cookie"])
+
+    async def test_logout_clears_cookie_when_auth_is_not_configured(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_request(app, "POST", "/auth/logout")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+        self.assertEqual(
+            response.headers["Set-Cookie"],
+            "launchplane_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax",
+        )
+
+    async def test_logout_clears_cookie_when_auth_is_configured_without_cookie(self) -> None:
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=InMemoryHumanSessionStore(),
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+
+        response = await _asgi_request(app, "POST", "/auth/logout")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+        self.assertIn("launchplane_session=", response.headers["Set-Cookie"])
+        self.assertIn("Max-Age=0", response.headers["Set-Cookie"])
+        self.assertIn("HttpOnly", response.headers["Set-Cookie"])
+        self.assertIn("SameSite=Lax", response.headers["Set-Cookie"])
+
+    async def test_logout_native_route_precedes_wsgi_fallback(self) -> None:
+        session_store = InMemoryHumanSessionStore()
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=session_store,
+        )
+        human_session = session_manager.issue(_github_human_identity())
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+        )
+        fallback_calls: list[str] = []
+
+        def fallback_app(
+            environ: dict[str, object], start_response: Callable[..., object]
+        ) -> list[bytes]:
+            fallback_calls.append(str(environ.get("PATH_INFO", "")))
+            start_response("599 Legacy Fallback", [("Content-Type", "application/json")])
+            return [b'{"status":"legacy"}']
+
+        app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, fallback_app))))
+
+        response = await _asgi_request(
+            app,
+            "POST",
+            "/auth/logout",
+            headers={"Cookie": session_manager.session_cookie_header(human_session)},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ok")
+        self.assertEqual(fallback_calls, [])
+
     async def test_openapi_includes_auth_session_contract(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_RejectingVerifier(),
@@ -402,6 +505,14 @@ class FastApiAuthSessionReadTests(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(
             openapi["components"]["schemas"]["AuthSessionRequiredResponse"]["additionalProperties"],
+            False,
+        )
+        logout_route = openapi["paths"]["/auth/logout"]["post"]
+        self.assertEqual(logout_route["operationId"], "logout_human_auth_session")
+        logout_schema = logout_route["responses"]["200"]["content"]["application/json"]["schema"]
+        self.assertEqual(logout_schema["$ref"], "#/components/schemas/AuthLogoutResponse")
+        self.assertEqual(
+            openapi["components"]["schemas"]["AuthLogoutResponse"]["additionalProperties"],
             False,
         )
 


### PR DESCRIPTION
## Summary
- add native FastAPI POST /auth/logout with the existing session deletion and clearing-cookie behavior
- keep direct WSGI logout compatibility until the remaining GitHub OAuth login/callback routes migrate
- extend auth-session OpenAPI/tests/docs for logout parity and fallback precedence

## Validation
- uv run python -m unittest tests.test_http_app.FastApiAuthSessionReadTests
- uv run python -m unittest tests.test_http_app
- ulimit -n 4096 && uv run python -m unittest
- uv run --extra dev ruff check control_plane/http_app.py tests/test_http_app.py docs/service-boundary.md docs/compatibility-retirement.md
- uv run --extra dev mypy control_plane tests
- uv run markdownlint-cli2 docs/service-boundary.md docs/compatibility-retirement.md
- git diff --check
- uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "/Users/cbusillo/Developer/launchplane" --scope changed_files

## Review
- code-gpt-5.5 post-fix review: clean
- Antigravity/Gemini-family post-fix review: clean
