### PR TITLE
Migrate GitHub OAuth routes to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+import logging
 import secrets
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
@@ -10,7 +11,7 @@ from uuid import uuid4
 import click
 from fastapi import Depends, FastAPI, Header, HTTPException, Path, Query, Request, Response
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from jwt import InvalidTokenError
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -200,7 +201,14 @@ from control_plane.service_auth import (
     agent_authz_audit,
     bearer_identity_from_token,
 )
-from control_plane.service_human_auth import HumanSessionManager, LaunchplaneHumanSession
+from control_plane.service_human_auth import (
+    HumanSessionManager,
+    LaunchplaneHumanSession,
+    OAuthLoginState,
+    OAuthLoginStateStore,
+    build_pkce_verifier,
+    safe_oauth_return_to,
+)
 from control_plane.launchplane_mutations import (
     LaunchplaneDestroyPreviewStore,
     LaunchplaneMutationStore,
@@ -258,6 +266,9 @@ EveryCodeGitHubWebhookHandler = Callable[
 ]
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
 _BEARER_CHALLENGE_HEADER = {"WWW-Authenticate": 'Bearer realm="Launchplane API"'}
 _LAUNCHPLANE_DRIVER_READ_PRODUCT = "launchplane"
 _LAUNCHPLANE_DRIVER_READ_CONTEXT = "launchplane"
@@ -308,6 +319,8 @@ _AUTHZ_POLICY_TERMINAL_AGENTS_GRANTS_ROUTE = "/v1/authz-policies/terminal-agents
 _AUTHZ_POLICY_LOCAL_OPERATORS_GRANTS_ROUTE = "/v1/authz-policies/local-operators/grants"
 _AUTHZ_POLICY_LOCAL_ADMINS_GRANTS_ROUTE = "/v1/authz-policies/local-admins/grants"
 _AUTH_SESSION_ROUTE = "/v1/auth/session"
+_AUTH_GITHUB_LOGIN_ROUTE = "/auth/github/login"
+_AUTH_GITHUB_CALLBACK_ROUTE = "/auth/github/callback"
 _AUTH_LOGOUT_ROUTE = "/auth/logout"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _AGENT_WRITE_INTENT_EVALUATE_ROUTE = "/v1/agent/write-intents/evaluate"
@@ -382,6 +395,24 @@ class OdooStableTargetReplacementOperationReadStore(Protocol):
     def read_odoo_stable_target_replacement_operation_record(
         self, operation_id: str
     ) -> OdooStableTargetReplacementOperationRecord: ...
+
+
+class GitHubOAuthLoginClient(Protocol):
+    def authorization_url(self, *, state: str, code_challenge: str) -> str: ...
+
+    def fetch_identity(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        authz_policy: LaunchplaneAuthzPolicy,
+    ) -> GitHubHumanIdentity: ...
+
+
+class OAuthLoginStateRepository(Protocol):
+    def put(self, *, state: str, code_verifier: str, return_to: str) -> OAuthLoginState: ...
+
+    def pop(self, state: str) -> OAuthLoginState | None: ...
 
 
 class LaunchplaneErrorDetail(BaseModel):
@@ -2961,6 +2992,8 @@ def create_launchplane_fastapi_app(
     npmplus_ingress_client_factory: _NpmplusIngressClientFactory | None = None,
     bearer_identity_config: BearerIdentityConfig | None = None,
     human_session_manager: HumanSessionManager | None = None,
+    github_oauth_client: GitHubOAuthLoginClient | None = None,
+    oauth_login_state_store: OAuthLoginStateRepository | None = None,
     control_plane_root_path: FilePath | None = None,
     work_graph_planning_facts_provider: WorkGraphPlanningFactsProvider | None = None,
     work_graph_issue_inbox_provider: WorkGraphIssueInboxProvider | None = None,
@@ -3013,6 +3046,9 @@ def create_launchplane_fastapi_app(
 
     app = FastAPI(title="Launchplane API", version="0.1.0", lifespan=lifespan)
     app.add_middleware(EvidenceIngressRequestContractMiddleware)
+    resolved_oauth_login_state_store = (
+        oauth_login_state_store if oauth_login_state_store is not None else OAuthLoginStateStore()
+    )
 
     def next_trace_id() -> str:
         return f"launchplane_req_{uuid4().hex}"
@@ -3093,6 +3129,95 @@ def create_launchplane_fastapi_app(
         return AuthSessionResponse(
             trace_id=trace_id,
             identity=human_identity_response(session.identity),
+        )
+
+    def reject_github_oauth_not_configured(trace_id: str) -> JSONResponse:
+        return JSONResponse(
+            status_code=503,
+            content=LaunchplaneErrorResponse(
+                trace_id=trace_id,
+                error=LaunchplaneErrorDetail(
+                    code="auth_not_configured",
+                    message="GitHub OAuth is not configured for Launchplane.",
+                ),
+            ).model_dump(mode="json"),
+        )
+
+    def reject_invalid_github_oauth_callback(trace_id: str, message: str) -> JSONResponse:
+        return JSONResponse(
+            status_code=400,
+            content=LaunchplaneErrorResponse(
+                trace_id=trace_id,
+                error=LaunchplaneErrorDetail(
+                    code="invalid_oauth_callback",
+                    message=message,
+                ),
+            ).model_dump(mode="json"),
+        )
+
+    def login_github_oauth(return_to: str = "/") -> Response:
+        trace_id = next_trace_id()
+        if human_session_manager is None or github_oauth_client is None:
+            return reject_github_oauth_not_configured(trace_id)
+        state = secrets.token_urlsafe(32)
+        code_verifier, code_challenge = build_pkce_verifier()
+        resolved_oauth_login_state_store.put(
+            state=state,
+            code_verifier=code_verifier,
+            return_to=safe_oauth_return_to(return_to),
+        )
+        return RedirectResponse(
+            url=github_oauth_client.authorization_url(
+                state=state,
+                code_challenge=code_challenge,
+            ),
+            status_code=302,
+            headers={"Cache-Control": "no-store"},
+        )
+
+    def complete_github_oauth_callback(
+        code: str = "",
+        state: str = "",
+    ) -> Response:
+        trace_id = next_trace_id()
+        if human_session_manager is None or github_oauth_client is None:
+            return reject_github_oauth_not_configured(trace_id)
+        callback_code = code.strip()
+        callback_state = state.strip()
+        login_state = resolved_oauth_login_state_store.pop(callback_state)
+        if not callback_code or login_state is None:
+            return reject_invalid_github_oauth_callback(
+                trace_id,
+                "GitHub OAuth callback is missing a valid code or state.",
+            )
+        try:
+            human_identity = github_oauth_client.fetch_identity(
+                code=callback_code,
+                code_verifier=login_state.code_verifier,
+                authz_policy=resolved_authz_policy_runtime.policy,
+            )
+        except PermissionError:
+            return JSONResponse(
+                status_code=403,
+                content=LaunchplaneErrorResponse(
+                    trace_id=trace_id,
+                    error=LaunchplaneErrorDetail(
+                        code="authorization_denied",
+                        message="GitHub identity is not authorized for Launchplane.",
+                    ),
+                ).model_dump(mode="json"),
+            )
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("GitHub OAuth callback failed", extra={"trace_id": trace_id})
+            return reject_invalid_github_oauth_callback(
+                trace_id,
+                "GitHub OAuth callback could not be completed.",
+            )
+        session = human_session_manager.issue(human_identity)
+        return RedirectResponse(
+            url=login_state.return_to,
+            status_code=302,
+            headers={"Set-Cookie": human_session_manager.session_cookie_header(session)},
         )
 
     def logout_auth_session(
@@ -10422,6 +10547,34 @@ def create_launchplane_fastapi_app(
         operation_id="read_human_auth_session",
         summary="Read human auth session",
         responses={401: {"model": AuthSessionRequiredResponse}},
+    )
+
+    app.add_api_route(
+        _AUTH_GITHUB_LOGIN_ROUTE,
+        login_github_oauth,
+        methods=["GET"],
+        status_code=302,
+        operation_id="login_github_oauth",
+        summary="Start GitHub OAuth login",
+        response_class=RedirectResponse,
+        response_model=None,
+        responses={503: {"model": LaunchplaneErrorResponse}},
+    )
+
+    app.add_api_route(
+        _AUTH_GITHUB_CALLBACK_ROUTE,
+        complete_github_oauth_callback,
+        methods=["GET"],
+        status_code=302,
+        operation_id="complete_github_oauth_callback",
+        summary="Complete GitHub OAuth callback",
+        response_class=RedirectResponse,
+        response_model=None,
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
     )
 
     app.add_api_route(

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -7,11 +7,9 @@ import json
 import logging
 import os
 import re
-import secrets
 import uuid
 from pathlib import Path
 from typing import Any, BinaryIO, Callable, Iterable, Literal, Protocol, cast
-from urllib.parse import parse_qs
 
 import click
 from a2wsgi import WSGIMiddleware
@@ -245,7 +243,6 @@ from control_plane.service_human_auth import (
     InMemoryHumanSessionStore,
     LaunchplaneHumanSession,
     OAuthLoginStateStore,
-    build_pkce_verifier,
     load_github_oauth_config_from_env,
 )
 from control_plane.storage.factory import build_shared_record_store
@@ -1638,19 +1635,6 @@ class LaunchplaneSelfDeployEnvelope(BaseModel):
         if self.product.strip() != "launchplane":
             raise ValueError("Launchplane self deploy requires product 'launchplane'.")
         return self
-
-
-def _redirect_response(
-    *,
-    start_response: _StartResponse,
-    location: str,
-    headers: list[tuple[str, str]] | None = None,
-) -> list[bytes]:
-    body = b""
-    response_headers = [("Location", location), ("Content-Length", "0")]
-    response_headers.extend(headers or [])
-    start_response("302 Found", response_headers)
-    return [body]
 
 
 def _driver_route_authorization_response(
@@ -6248,19 +6232,6 @@ def _read_identity(
         raise PermissionError(str(error)) from error
 
 
-def _human_identity_payload(identity: GitHubHumanIdentity) -> dict[str, object]:
-    return {
-        "provider": "github",
-        "login": identity.login,
-        "github_id": identity.github_id,
-        "name": identity.name,
-        "email": identity.email,
-        "organizations": sorted(identity.organizations),
-        "teams": sorted(identity.teams),
-        "role": identity.role,
-    }
-
-
 def _authz_diagnostic_payload(
     *,
     identity: LaunchplaneIdentity,
@@ -6432,13 +6403,6 @@ def _resolve_descriptor_product_driver_context(
         instance=instance,
         require_profile=require_profile,
     )
-
-
-def _safe_return_to(value: str) -> str:
-    normalized = value.strip() or "/"
-    if not normalized.startswith("/") or normalized.startswith("//"):
-        return "/"
-    return normalized
 
 
 def _now_timestamp() -> str:
@@ -6955,7 +6919,6 @@ def create_launchplane_service_app(
     database_url: str | None = None,
     local_record_store_for_tests: _TestLaunchplaneServiceRecordStore | None = None,
     github_oauth_config: GitHubOAuthConfig | None = None,
-    github_oauth_client: GitHubOAuthClient | None = None,
     human_session_store: HumanSessionStore | None = None,
     preview_pr_feedback_discord_sender: Callable[
         [str, dict[str, object]], object
@@ -6990,7 +6953,6 @@ def create_launchplane_service_app(
         or _human_session_capable_store(record_store)
         or InMemoryHumanSessionStore()
     )
-    oauth_login_states = OAuthLoginStateStore()
     session_manager = (
         HumanSessionManager(
             config=resolved_github_oauth_config,
@@ -6998,15 +6960,6 @@ def create_launchplane_service_app(
         )
         if resolved_github_oauth_config is not None
         else None
-    )
-    resolved_github_oauth_client = (
-        github_oauth_client
-        if github_oauth_client is not None
-        else (
-            GitHubOAuthClient(resolved_github_oauth_config)
-            if resolved_github_oauth_config is not None
-            else None
-        )
     )
     descriptor_driver_dispatch_routes = _descriptor_driver_dispatch_routes()
     _validate_descriptor_driver_dispatch_routes(descriptor_driver_dispatch_routes)
@@ -7041,148 +6994,6 @@ def create_launchplane_service_app(
         request_trace_id = _trace_id()
         method = str(environ.get("REQUEST_METHOD", "GET")).upper()
         path = str(environ.get("PATH_INFO", ""))
-        query = parse_qs(str(environ.get("QUERY_STRING", "")), keep_blank_values=True)
-        if method == "GET" and path == "/auth/github/login":
-            if resolved_github_oauth_config is None or resolved_github_oauth_client is None:
-                return _json_response(
-                    start_response=start_response,
-                    status_code=503,
-                    payload={
-                        "status": "rejected",
-                        "trace_id": request_trace_id,
-                        "error": {
-                            "code": "auth_not_configured",
-                            "message": "GitHub OAuth is not configured for Launchplane.",
-                        },
-                    },
-                )
-            state = secrets.token_urlsafe(32)
-            code_verifier, code_challenge = build_pkce_verifier()
-            return_to = _safe_return_to((query.get("return_to") or ["/"])[0])
-            oauth_login_states.put(
-                state=state,
-                code_verifier=code_verifier,
-                return_to=return_to,
-            )
-            return _redirect_response(
-                start_response=start_response,
-                location=resolved_github_oauth_client.authorization_url(
-                    state=state,
-                    code_challenge=code_challenge,
-                ),
-            )
-        if method == "GET" and path == "/auth/github/callback":
-            if session_manager is None or resolved_github_oauth_client is None:
-                return _json_response(
-                    start_response=start_response,
-                    status_code=503,
-                    payload={
-                        "status": "rejected",
-                        "trace_id": request_trace_id,
-                        "error": {
-                            "code": "auth_not_configured",
-                            "message": "GitHub OAuth is not configured for Launchplane.",
-                        },
-                    },
-                )
-            code = str((query.get("code") or [""])[0]).strip()
-            state = str((query.get("state") or [""])[0]).strip()
-            login_state = oauth_login_states.pop(state)
-            if not code or login_state is None:
-                return _json_response(
-                    start_response=start_response,
-                    status_code=400,
-                    payload={
-                        "status": "rejected",
-                        "trace_id": request_trace_id,
-                        "error": {
-                            "code": "invalid_oauth_callback",
-                            "message": "GitHub OAuth callback is missing a valid code or state.",
-                        },
-                    },
-                )
-            try:
-                human_identity = resolved_github_oauth_client.fetch_identity(
-                    code=code,
-                    code_verifier=login_state.code_verifier,
-                    authz_policy=authz_policy,
-                )
-            except PermissionError:
-                return _json_response(
-                    start_response=start_response,
-                    status_code=403,
-                    payload={
-                        "status": "rejected",
-                        "trace_id": request_trace_id,
-                        "error": {
-                            "code": "authorization_denied",
-                            "message": "GitHub identity is not authorized for Launchplane.",
-                        },
-                    },
-                )
-            except Exception:  # noqa: BLE001
-                _LOGGER.exception(
-                    "GitHub OAuth callback failed", extra={"trace_id": request_trace_id}
-                )
-                return _json_response(
-                    start_response=start_response,
-                    status_code=400,
-                    payload={
-                        "status": "rejected",
-                        "trace_id": request_trace_id,
-                        "error": {
-                            "code": "invalid_oauth_callback",
-                            "message": "GitHub OAuth callback could not be completed.",
-                        },
-                    },
-                )
-            session = session_manager.issue(human_identity)
-            return _redirect_response(
-                start_response=start_response,
-                location=login_state.return_to,
-                headers=[("Set-Cookie", session_manager.session_cookie_header(session))],
-            )
-        if method == "POST" and path == "/auth/logout":
-            if session_manager is not None:
-                session_manager.delete_cookie_session(str(environ.get("HTTP_COOKIE", "")))
-                clear_cookie = session_manager.clear_cookie_header()
-            else:
-                clear_cookie = "launchplane_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax"
-            return _json_response(
-                start_response=start_response,
-                status_code=200,
-                payload={"status": "ok", "trace_id": request_trace_id},
-                headers=[("Set-Cookie", clear_cookie)],
-            )
-        if method == "GET" and path == "/v1/auth/session":
-            auth_session = _session(
-                environ=environ,
-                session_manager=session_manager,
-                on_renewed_session=record_renewed_session,
-            )
-            if auth_session is None:
-                return _json_response(
-                    start_response=start_response,
-                    status_code=401,
-                    payload={
-                        "status": "rejected",
-                        "trace_id": request_trace_id,
-                        "configured": resolved_github_oauth_config is not None,
-                        "error": {
-                            "code": "authentication_required",
-                            "message": "Sign in with GitHub to access Launchplane.",
-                        },
-                    },
-                )
-            return _json_response(
-                start_response=start_response,
-                status_code=200,
-                payload={
-                    "status": "ok",
-                    "trace_id": request_trace_id,
-                    "identity": _human_identity_payload(auth_session.identity),
-                },
-            )
         if method == "GET" and (path == "/" or path == "/ui" or path.startswith("/ui/")):
             return serve_ui_route(
                 start_response=start_response,
@@ -9341,6 +9152,10 @@ def serve_launchplane_service(
         if github_oauth_config is not None
         else None
     )
+    github_oauth_client = (
+        GitHubOAuthClient(github_oauth_config) if github_oauth_config is not None else None
+    )
+    oauth_login_state_store = OAuthLoginStateStore()
     fastapi_application = create_launchplane_fastapi_app(
         verifier=verifier,
         authz_policy=resolved_fastapi_policy.policy,
@@ -9348,6 +9163,8 @@ def serve_launchplane_service(
         record_store_factory=lambda: service_record_store,
         bearer_identity_config=_bearer_identity_config_from_env(),
         human_session_manager=human_session_manager,
+        github_oauth_client=github_oauth_client,
+        oauth_login_state_store=oauth_login_state_store,
         control_plane_root_path=control_plane_root(),
         work_graph_planning_facts_provider=work_graph_planning_facts_provider,
         work_graph_issue_inbox_provider=work_graph_issue_inbox_provider,

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -147,6 +147,13 @@ def build_pkce_verifier() -> tuple[str, str]:
     return verifier, challenge
 
 
+def safe_oauth_return_to(value: str) -> str:
+    normalized = value.strip() or "/"
+    if not normalized.startswith("/") or normalized.startswith("//"):
+        return "/"
+    return normalized
+
+
 class GitHubOAuthClient:
     def __init__(self, config: GitHubOAuthConfig) -> None:
         self._config = config
@@ -314,9 +321,7 @@ class HumanSessionManager:
             return None
         return self._session_store.read_session(session_id)
 
-    def renew_if_needed(
-        self, session: LaunchplaneHumanSession
-    ) -> LaunchplaneHumanSession | None:
+    def renew_if_needed(self, session: LaunchplaneHumanSession) -> LaunchplaneHumanSession | None:
         now = self._now()
         if session.expires_at <= now:
             self._session_store.delete_session(session.session_id)

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -56,14 +56,14 @@ Keep a compatibility surface only when it is one of these:
 - The Launchplane health read uses the native FastAPI `GET /v1/health` route.
   Its legacy WSGI branch is deleted; direct fallback calls fail closed while
   the mounted fallback remains for retained non-native routes.
-- The human auth-session read and logout routes use native FastAPI
-  `GET /v1/auth/session` and `POST /auth/logout` in the mounted service. Session
+- The human auth/session family uses native FastAPI routes in the mounted
+  service: `GET /auth/github/login`, `GET /auth/github/callback`,
+  `GET /v1/auth/session`, and `POST /auth/logout`. GitHub OAuth login preserves
+  PKCE state, same-origin `return_to` sanitization, GitHub authorization
+  redirect, callback error envelopes, and signed session cookie issuance. Session
   read preserves the existing signed-session cookie read/renewal behavior,
   `authentication_required` rejection envelope, and `configured` flag. Logout
   preserves cookie-backed session deletion and the clearing `Set-Cookie` header.
-  The legacy WSGI branches remain only as direct compatibility branches until
-  the GitHub OAuth login and callback routes migrate to the same native
-  auth/session family.
 - Launchplane service runtime and Odoo worker status reads use native FastAPI
   routes for bearer-token and human-session callers. Odoo worker reconcile uses
   native FastAPI `POST /v1/service/odoo-workers/reconcile` on the bearer/OIDC

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -348,15 +348,16 @@ typed Pydantic response, focused OpenAPI assertions, and direct WSGI fallback
 retirement. Do not turn that route into a migration framework; use it as the
 small contract shape for the next route-family slice.
 
-`GET /v1/auth/session` and `POST /auth/logout` use native FastAPI routes in the
-mounted service. Session read preserves the Launchplane human-session response
-shape, renews expiring signed session cookies with the existing
-`HumanSessionManager`, returns `authentication_required` with the `configured`
-flag when no valid human session exists, and has focused OpenAPI coverage. Logout
-deletes the cookie-backed session when auth is configured and always emits the
-Launchplane session clearing cookie. The direct WSGI handlers remain as
-compatibility branches until the GitHub OAuth login and callback routes move to
-the same native auth/session family.
+The human auth/session family uses native FastAPI routes in the mounted service:
+`GET /auth/github/login`, `GET /auth/github/callback`, `GET /v1/auth/session`,
+and `POST /auth/logout`. GitHub OAuth login preserves PKCE state, same-origin
+`return_to` sanitization, GitHub authorization redirect, callback error
+envelopes, and signed session cookie issuance with the existing
+`HumanSessionManager`. Session read preserves the Launchplane human-session
+response shape, renews expiring signed session cookies, and returns
+`authentication_required` with the `configured` flag when no valid human session
+exists. Logout deletes the cookie-backed session when auth is configured and
+always emits the Launchplane session clearing cookie.
 
 Launchplane verifies GitHub OIDC, authorizes workflow identity claims, accepts
 deployment/promotion/preview lifecycle evidence over HTTP, and executes the

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from collections.abc import Callable, MutableMapping
 from typing import Any, Literal, cast
-from urllib.parse import urlencode
+from urllib.parse import parse_qs, urlencode, urlparse
 from unittest.mock import patch
 
 from a2wsgi import WSGIMiddleware
@@ -220,6 +220,291 @@ class FastApiHealthContractTests(unittest.IsolatedAsyncioTestCase):
 
 
 class FastApiAuthSessionReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_github_oauth_login_redirects_to_authorization_url(self) -> None:
+        oauth_client = _StubFastApiGitHubOAuthClient(_github_human_identity())
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=InMemoryHumanSessionStore(),
+            ),
+            github_oauth_client=oauth_client,
+        )
+
+        response = await _asgi_get(app, "/auth/github/login?return_to=/ui")
+
+        self.assertEqual(response.status_code, 302)
+        location = response.headers["Location"]
+        self.assertTrue(location.startswith("https://github.example/authorize?"))
+        query = parse_qs(urlparse(location).query)
+        self.assertEqual(query["state"], [oauth_client.authorization_state])
+        self.assertTrue(query["challenge"][0])
+        self.assertEqual(response.headers["Cache-Control"], "no-store")
+
+    async def test_github_oauth_login_rejects_when_auth_is_not_configured(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/auth/github/login")
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "auth_not_configured")
+
+    async def test_github_oauth_login_rejects_without_session_manager(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            github_oauth_client=_StubFastApiGitHubOAuthClient(_github_human_identity()),
+        )
+
+        response = await _asgi_get(app, "/auth/github/login")
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "auth_not_configured")
+
+    async def test_github_oauth_callback_issues_session_cookie(self) -> None:
+        session_store = InMemoryHumanSessionStore()
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=session_store,
+        )
+        oauth_client = _StubFastApiGitHubOAuthClient(_github_human_identity())
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+            github_oauth_client=oauth_client,
+        )
+        login_response = await _asgi_get(app, "/auth/github/login?return_to=/ui")
+        state = parse_qs(urlparse(login_response.headers["Location"]).query)["state"][0]
+
+        response = await _asgi_get(
+            app,
+            f"/auth/github/callback?code=github-code&state={state}",
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers["Location"], "/ui")
+        self.assertIn("launchplane_session=", response.headers["Set-Cookie"])
+        self.assertIn("HttpOnly", response.headers["Set-Cookie"])
+        self.assertIn("SameSite=Lax", response.headers["Set-Cookie"])
+        self.assertTrue(oauth_client.code_verifier)
+
+    async def test_github_oauth_callback_session_survives_app_recreation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=store,
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_local_operator_launchplane_service_read_policy(),
+                record_store_factory=lambda: store,
+                human_session_manager=session_manager,
+                github_oauth_client=_StubFastApiGitHubOAuthClient(_github_human_identity()),
+            )
+            login_response = await _asgi_get(app, "/auth/github/login")
+            state = parse_qs(urlparse(login_response.headers["Location"]).query)["state"][0]
+            callback_response = await _asgi_get(
+                app,
+                f"/auth/github/callback?code=github-code&state={state}",
+            )
+
+            recreated_store = PostgresRecordStore(database_url=database_url)
+            recreated_session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=recreated_store,
+            )
+            recreated_app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_local_operator_launchplane_service_read_policy(),
+                record_store_factory=lambda: recreated_store,
+                human_session_manager=recreated_session_manager,
+            )
+            session_response = await _asgi_get(
+                recreated_app,
+                "/v1/auth/session",
+                headers={"Cookie": callback_response.headers["Set-Cookie"]},
+            )
+
+        self.assertEqual(callback_response.status_code, 302)
+        self.assertEqual(session_response.status_code, 200)
+        payload = session_response.json()
+        self.assertEqual(payload["identity"]["login"], "example-operator")
+        self.assertEqual(payload["identity"]["role"], "admin")
+
+    async def test_github_oauth_callback_sanitizes_external_return_to(self) -> None:
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=InMemoryHumanSessionStore(),
+        )
+        oauth_client = _StubFastApiGitHubOAuthClient(_github_human_identity())
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+            github_oauth_client=oauth_client,
+        )
+        login_response = await _asgi_get(
+            app,
+            "/auth/github/login?return_to=https%3A%2F%2Fevil.example%2Fui",
+        )
+        state = parse_qs(urlparse(login_response.headers["Location"]).query)["state"][0]
+
+        response = await _asgi_get(
+            app,
+            f"/auth/github/callback?code=github-code&state={state}",
+        )
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.headers["Location"], "/")
+
+    async def test_github_oauth_callback_rejects_missing_code_or_state(self) -> None:
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=InMemoryHumanSessionStore(),
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+            github_oauth_client=_StubFastApiGitHubOAuthClient(_github_human_identity()),
+        )
+
+        response = await _asgi_get(app, "/auth/github/callback?state=missing")
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_oauth_callback")
+
+    async def test_github_oauth_callback_rejects_reused_state(self) -> None:
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=InMemoryHumanSessionStore(),
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+            github_oauth_client=_StubFastApiGitHubOAuthClient(_github_human_identity()),
+        )
+        login_response = await _asgi_get(app, "/auth/github/login")
+        state = parse_qs(urlparse(login_response.headers["Location"]).query)["state"][0]
+        await _asgi_get(app, f"/auth/github/callback?code=github-code&state={state}")
+
+        response = await _asgi_get(
+            app,
+            f"/auth/github/callback?code=github-code&state={state}",
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_oauth_callback")
+
+    async def test_github_oauth_callback_rejects_unauthorized_identity(self) -> None:
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=InMemoryHumanSessionStore(),
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+            github_oauth_client=_StubFastApiGitHubOAuthClient(
+                _github_human_identity(), permission_error=True
+            ),
+        )
+        login_response = await _asgi_get(app, "/auth/github/login")
+        state = parse_qs(urlparse(login_response.headers["Location"]).query)["state"][0]
+
+        response = await _asgi_get(
+            app,
+            f"/auth/github/callback?code=github-code&state={state}",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_github_oauth_callback_maps_client_failure(self) -> None:
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=InMemoryHumanSessionStore(),
+        )
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+            github_oauth_client=_StubFastApiGitHubOAuthClient(
+                _github_human_identity(), fail_fetch=True
+            ),
+        )
+        login_response = await _asgi_get(app, "/auth/github/login")
+        state = parse_qs(urlparse(login_response.headers["Location"]).query)["state"][0]
+
+        with self.assertLogs("control_plane.http_app", level="ERROR") as captured_logs:
+            response = await _asgi_get(
+                app,
+                f"/auth/github/callback?code=github-code&state={state}",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_oauth_callback")
+        self.assertTrue(
+            any("GitHub OAuth callback failed" in entry for entry in captured_logs.output)
+        )
+
+    async def test_github_oauth_routes_precede_wsgi_fallback(self) -> None:
+        session_manager = HumanSessionManager(
+            config=_github_oauth_config(),
+            session_store=InMemoryHumanSessionStore(),
+        )
+        oauth_client = _StubFastApiGitHubOAuthClient(_github_human_identity())
+        app = create_launchplane_fastapi_app(
+            verifier=_RejectingVerifier(),
+            authz_policy=_local_operator_launchplane_service_read_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+            human_session_manager=session_manager,
+            github_oauth_client=oauth_client,
+        )
+        fallback_calls: list[str] = []
+
+        def fallback_app(
+            environ: dict[str, object], start_response: Callable[..., object]
+        ) -> list[bytes]:
+            fallback_calls.append(str(environ.get("PATH_INFO", "")))
+            start_response("599 Legacy Fallback", [("Content-Type", "application/json")])
+            return [b'{"status":"legacy"}']
+
+        app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, fallback_app))))
+        login_response = await _asgi_get(app, "/auth/github/login")
+        state = parse_qs(urlparse(login_response.headers["Location"]).query)["state"][0]
+        callback_response = await _asgi_get(
+            app,
+            f"/auth/github/callback?code=github-code&state={state}",
+        )
+
+        self.assertEqual(login_response.status_code, 302)
+        self.assertEqual(callback_response.status_code, 302)
+        self.assertEqual(fallback_calls, [])
+
     async def test_session_read_rejects_missing_human_session(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_RejectingVerifier(),
@@ -515,6 +800,25 @@ class FastApiAuthSessionReadTests(unittest.IsolatedAsyncioTestCase):
             openapi["components"]["schemas"]["AuthLogoutResponse"]["additionalProperties"],
             False,
         )
+        login_route = openapi["paths"]["/auth/github/login"]["get"]
+        self.assertEqual(login_route["operationId"], "login_github_oauth")
+        self.assertIn("302", login_route["responses"])
+        login_rejected_schema = login_route["responses"]["503"]["content"]["application/json"][
+            "schema"
+        ]
+        self.assertEqual(
+            login_rejected_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse"
+        )
+        callback_route = openapi["paths"]["/auth/github/callback"]["get"]
+        self.assertEqual(callback_route["operationId"], "complete_github_oauth_callback")
+        self.assertIn("302", callback_route["responses"])
+        for status_code in ("400", "403", "503"):
+            callback_schema = callback_route["responses"][status_code]["content"][
+                "application/json"
+            ]["schema"]
+            self.assertEqual(
+                callback_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse"
+            )
 
 
 class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
@@ -20680,6 +20984,40 @@ class _CaseInsensitiveHeaders(dict[str, str]):
 
     def __getitem__(self, key: str) -> str:
         return super().__getitem__(key.lower())
+
+
+class _StubFastApiGitHubOAuthClient:
+    def __init__(
+        self,
+        identity: GitHubHumanIdentity,
+        *,
+        fail_fetch: bool = False,
+        permission_error: bool = False,
+    ) -> None:
+        self.identity = identity
+        self.fail_fetch = fail_fetch
+        self.permission_error = permission_error
+        self.authorization_state = ""
+        self.code_verifier = ""
+
+    def authorization_url(self, *, state: str, code_challenge: str) -> str:
+        self.authorization_state = state
+        return f"https://github.example/authorize?state={state}&challenge={code_challenge}"
+
+    def fetch_identity(
+        self,
+        *,
+        code: str,
+        code_verifier: str,
+        authz_policy: LaunchplaneAuthzPolicy,
+    ) -> GitHubHumanIdentity:
+        del authz_policy
+        self.code_verifier = code_verifier
+        if self.permission_error:
+            raise PermissionError("not authorized")
+        if self.fail_fetch or code != "github-code":
+            raise ValueError("unexpected code")
+        return self.identity
 
 
 class _MissingProductReadStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -9,12 +9,10 @@ import tempfile
 import unittest
 from collections.abc import Callable, Iterable, Mapping, MutableMapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
 from typing import Any, Literal, cast
-from urllib.parse import parse_qs, urlparse
 from unittest.mock import patch
 
 from click import ClickException, Command
@@ -154,8 +152,8 @@ from control_plane.service_human_auth import (
     GitHubOAuthClient,
     GitHubOAuthConfig,
     HumanSessionManager,
+    HumanSessionStore,
     InMemoryHumanSessionStore,
-    LaunchplaneHumanSession,
     load_github_oauth_config_from_env,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
@@ -1131,16 +1129,17 @@ def _signed_human_session_cookie(session_id: str, session_secret: str) -> str:
     return f"launchplane_session={session_id}.{signature}"
 
 
-def _signed_in_cookie(app: WsgiApp) -> str:
-    _, login_headers, _ = _invoke_raw_app(app, method="GET", path="/auth/github/login")
-    state = parse_qs(urlparse(login_headers["Location"]).query)["state"][0]
-    _, callback_headers, _ = _invoke_raw_app(
-        app,
-        method="GET",
-        path="/auth/github/callback",
-        query_string=f"code=github-code&state={state}",
+def _signed_in_cookie(
+    session_store: HumanSessionStore,
+    *,
+    role: Literal["read_only", "admin"] = "read_only",
+) -> str:
+    session_manager = HumanSessionManager(
+        config=_github_oauth_config(),
+        session_store=session_store,
     )
-    return callback_headers["Set-Cookie"]
+    human_session = session_manager.issue(_human_identity(role=role))
+    return session_manager.session_cookie_header(human_session)
 
 
 def _fastapi_human_session_manager() -> HumanSessionManager:
@@ -2413,203 +2412,43 @@ class GitHubHumanAuthTests(unittest.TestCase):
         self.assertEqual(identity.role, "admin")
         self.assertIn(GITHUB_EMAILS_URL, oauth_session.requested_urls)
 
-    def _signed_in_cookie(
-        self,
-        app: WsgiApp,
-    ) -> str:
-        _, login_headers, _ = _invoke_raw_app(app, method="GET", path="/auth/github/login")
-        state = parse_qs(urlparse(login_headers["Location"]).query)["state"][0]
-        _, callback_headers, _ = _invoke_raw_app(
-            app,
-            method="GET",
-            path="/auth/github/callback",
-            query_string=f"code=github-code&state={state}",
-        )
-        return callback_headers["Set-Cookie"]
-
-    def test_github_oauth_callback_issues_session_cookie(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
-        )
-        oauth_client = _StubGitHubOAuthClient(_human_identity())
-        with TemporaryDirectory() as tmpdir:
-            app = create_launchplane_service_app(
-                state_dir=Path(tmpdir),
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                github_oauth_config=_github_oauth_config(),
-                github_oauth_client=oauth_client,
-            )
-            status_code, headers, _ = _invoke_raw_app(
-                app,
-                method="GET",
-                path="/auth/github/login",
-                query_string="return_to=/ui",
-            )
-            self.assertEqual(status_code, 302)
-            state = parse_qs(urlparse(headers["Location"]).query)["state"][0]
-
-            status_code, headers, _ = _invoke_raw_app(
-                app,
-                method="GET",
-                path="/auth/github/callback",
-                query_string=f"code=github-code&state={state}",
-            )
-
-        self.assertEqual(status_code, 302)
-        self.assertEqual(headers["Location"], "/ui")
-        self.assertIn("launchplane_session=", headers["Set-Cookie"])
-        self.assertIn("HttpOnly", headers["Set-Cookie"])
-        self.assertTrue(oauth_client.code_verifier)
-
-    def test_session_endpoint_reads_github_human_session(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
-        )
-        oauth_client = _StubGitHubOAuthClient(_human_identity())
-        with TemporaryDirectory() as tmpdir:
-            app = create_launchplane_service_app(
-                state_dir=Path(tmpdir),
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                github_oauth_config=_github_oauth_config(),
-                github_oauth_client=oauth_client,
-            )
-            cookie = _signed_in_cookie(app)
-            status_code, payload = _invoke_app(
-                app,
-                method="GET",
-                path="/v1/auth/session",
-                authorization="",
-                headers={"Cookie": cookie},
-            )
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["identity"]["login"], "alice")
-        self.assertEqual(payload["identity"]["role"], "read_only")
-
-    def test_session_endpoint_does_not_refresh_fresh_session_cookie(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
-        )
-        oauth_client = _StubGitHubOAuthClient(_human_identity())
-        with TemporaryDirectory() as tmpdir:
-            database_url = f"sqlite+pysqlite:///{Path(tmpdir) / 'launchplane.sqlite3'}"
-            app = create_launchplane_service_app(
-                state_dir=Path(tmpdir) / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                database_url=database_url,
-                github_oauth_config=_github_oauth_config(),
-                github_oauth_client=oauth_client,
-            )
-            cookie = _signed_in_cookie(app)
-
-            status_code, headers, body = _invoke_raw_app(
-                app,
-                method="GET",
-                path="/v1/auth/session",
-                authorization="",
-                headers={"Cookie": cookie},
-            )
-
-        self.assertEqual(status_code, 200)
-        payload = json.loads(body)
-        self.assertEqual(payload["identity"]["login"], "alice")
-        self.assertNotIn("Set-Cookie", headers)
-
-    def test_session_endpoint_renews_expiring_database_backed_human_session(
-        self,
-    ) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
-        )
-        session_store = InMemoryHumanSessionStore()
-        session = LaunchplaneHumanSession(
-            session_id="expiring-session",
-            identity=_human_identity(),
-            created_at=datetime.now(timezone.utc) - timedelta(days=13),
-            expires_at=datetime.now(timezone.utc) + timedelta(hours=12),
-        )
-        session_store.write_session(session)
+    def test_auth_session_family_legacy_wsgi_routes_are_retired(self) -> None:
         with TemporaryDirectory() as tmpdir:
             app = create_launchplane_service_app(
                 state_dir=Path(tmpdir) / "state",
                 verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
+                authz_policy=LaunchplaneAuthzPolicy(),
                 github_oauth_config=_github_oauth_config(),
-                human_session_store=session_store,
-            )
-            cookie = _signed_human_session_cookie("expiring-session", "test-session-secret")
-
-            status_code, headers, body = _invoke_raw_app(
-                app,
-                method="GET",
-                path="/v1/auth/session",
-                authorization="",
-                headers={"Cookie": cookie},
             )
 
-        self.assertEqual(status_code, 200)
-        payload = json.loads(body)
-        self.assertEqual(payload["identity"]["login"], "alice")
-        self.assertIn("launchplane_session=", headers["Set-Cookie"])
-        self.assertIn("Max-Age=1209600", headers["Set-Cookie"])
-        renewed_session = session_store.read_session("expiring-session")
-        self.assertIsNotNone(renewed_session)
-        assert renewed_session is not None
-        self.assertGreater(renewed_session.expires_at, session.expires_at)
-
-    def test_database_backed_human_session_survives_app_recreation(self) -> None:
-        policy = LaunchplaneAuthzPolicy.model_validate(
-            {"github_humans": [{"logins": ["alice"], "roles": ["read_only"]}]}
-        )
-        oauth_client = _StubGitHubOAuthClient(_human_identity())
-        with TemporaryDirectory() as tmpdir:
-            database_url = f"sqlite+pysqlite:///{Path(tmpdir) / 'launchplane.sqlite3'}"
-            app = create_launchplane_service_app(
-                state_dir=Path(tmpdir) / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                database_url=database_url,
-                github_oauth_config=_github_oauth_config(),
-                github_oauth_client=oauth_client,
-            )
-            cookie = _signed_in_cookie(app)
-            recreated_app = create_launchplane_service_app(
-                state_dir=Path(tmpdir) / "state",
-                verifier=_StubVerifier(_identity()),
-                authz_policy=policy,
-                database_url=database_url,
-                github_oauth_config=_github_oauth_config(),
-                github_oauth_client=oauth_client,
+            responses = tuple(
+                _invoke_app(app, method=method, path=path, authorization="")
+                for method, path in (
+                    ("GET", "/auth/github/login"),
+                    ("GET", "/auth/github/callback"),
+                    ("GET", "/v1/auth/session"),
+                    ("POST", "/auth/logout"),
+                )
             )
 
-            status_code, payload = _invoke_app(
-                recreated_app,
-                method="GET",
-                path="/v1/auth/session",
-                authorization="",
-                headers={"Cookie": cookie},
-            )
-
-        self.assertEqual(status_code, 200)
-        self.assertEqual(payload["identity"]["login"], "alice")
+        for status_code, payload in responses:
+            self.assertEqual(status_code, 404)
+            self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_human_session_does_not_authorize_post_mutations(self) -> None:
         policy = LaunchplaneAuthzPolicy.model_validate(
             {"github_humans": [{"logins": ["alice"], "roles": ["admin"]}]}
         )
-        oauth_client = _StubGitHubOAuthClient(_human_identity(role="admin"))
+        session_store = InMemoryHumanSessionStore()
         with TemporaryDirectory() as tmpdir:
             app = create_launchplane_service_app(
                 state_dir=Path(tmpdir),
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
                 github_oauth_config=_github_oauth_config(),
-                github_oauth_client=oauth_client,
+                human_session_store=session_store,
             )
-            cookie = self._signed_in_cookie(app)
+            cookie = _signed_in_cookie(session_store, role="admin")
             status_code, payload = _invoke_app(
                 app,
                 method="POST",
@@ -15709,6 +15548,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            session_store = InMemoryHumanSessionStore()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
             )
@@ -15731,9 +15571,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=root,
                 github_oauth_config=_github_oauth_config(),
-                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+                human_session_store=session_store,
             )
-            cookie = _signed_in_cookie(app)
+            cookie = _signed_in_cookie(session_store, role="admin")
 
             with patch(
                 "control_plane.drivers.generic_web_dispatch.execute_generic_web_prod_promotion",
@@ -15785,6 +15625,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            session_store = InMemoryHumanSessionStore()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
             )
@@ -15807,9 +15648,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=root,
                 github_oauth_config=_github_oauth_config(),
-                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+                human_session_store=session_store,
             )
-            cookie = _signed_in_cookie(app)
+            cookie = _signed_in_cookie(session_store, role="admin")
 
             status_code, payload = _invoke_app(
                 app,
@@ -15838,6 +15679,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            session_store = InMemoryHumanSessionStore()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
             )
@@ -15860,7 +15702,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=root,
                 github_oauth_config=_github_oauth_config(),
-                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+                human_session_store=session_store,
             )
             request_payload = {
                 "schema_version": 1,
@@ -15895,7 +15737,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     },
                 )
             )
-            cookie = _signed_in_cookie(app)
+            cookie = _signed_in_cookie(session_store, role="admin")
 
             status_code, payload = _invoke_app(
                 app,
@@ -15914,6 +15756,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            session_store = InMemoryHumanSessionStore()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
             )
@@ -15936,9 +15779,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=root,
                 github_oauth_config=_github_oauth_config(),
-                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+                human_session_store=session_store,
             )
-            cookie = _signed_in_cookie(app)
+            cookie = _signed_in_cookie(session_store, role="admin")
 
             with patch(
                 "control_plane.drivers.generic_web_dispatch.dispatch_generic_web_promotion_workflow",
@@ -15990,6 +15833,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            session_store = InMemoryHumanSessionStore()
             profile_payload = _product_profile_payload_with_prod()
             profile_payload["lanes"] = tuple(
                 {**lane, "context": f"  {lane['context']}  "}
@@ -16017,9 +15861,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=root,
                 github_oauth_config=_github_oauth_config(),
-                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+                human_session_store=session_store,
             )
-            cookie = _signed_in_cookie(app)
+            cookie = _signed_in_cookie(session_store, role="admin")
 
             with patch(
                 "control_plane.drivers.generic_web_dispatch.dispatch_generic_web_promotion_workflow",
@@ -16065,6 +15909,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            session_store = InMemoryHumanSessionStore()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
             )
@@ -16074,9 +15919,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_humans": []}),
                 control_plane_root_path=root,
                 github_oauth_config=_github_oauth_config(),
-                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+                human_session_store=session_store,
             )
-            cookie = _signed_in_cookie(app)
+            cookie = _signed_in_cookie(session_store, role="admin")
 
             status_code, payload = _invoke_app(
                 app,
@@ -16185,6 +16030,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             root = Path(temporary_directory_name)
             state_dir = root / "state"
             store = FilesystemRecordStore(state_dir=state_dir)
+            session_store = InMemoryHumanSessionStore()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
             )
@@ -16207,9 +16053,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=policy,
                 control_plane_root_path=root,
                 github_oauth_config=_github_oauth_config(),
-                github_oauth_client=_StubGitHubOAuthClient(_human_identity(role="admin")),
+                human_session_store=session_store,
             )
-            cookie = _signed_in_cookie(app)
+            cookie = _signed_in_cookie(session_store, role="admin")
 
             with patch(
                 "control_plane.drivers.generic_web_dispatch.dispatch_generic_web_promotion_workflow"


### PR DESCRIPTION
## Summary
- migrate GitHub OAuth login/callback to native FastAPI routes
- retire the legacy WSGI auth/session/logout route family from the direct WSGI service
- keep OAuth state/session dependencies injectable and document the updated v2 auth boundary

## Validation
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py control_plane/service_human_auth.py tests/test_http_app.py tests/test_service.py docs/service-boundary.md docs/compatibility-retirement.md`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_http_app.FastApiAuthSessionReadTests tests.test_service.GitHubHumanAuthTests`
- `ulimit -n 4096 && uv run python -m unittest tests.test_http_app tests.test_service`
- `ulimit -n 4096 && uv run python -m unittest`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "$PWD" --scope changed_files`

## Review
- Code review agent: no blocking findings; addressed low findings for 302 OpenAPI docs, partial OAuth wiring, and DB-backed session persistence coverage.
- Gemini/Antigravity review: recommends landing; notes future v2 hardening should replace in-memory OAuth state with stateless signed transient cookie or DB-backed state for multi-worker resilience.
