### PR TITLE
Migrate preview desired-state routes to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -127,6 +127,7 @@ from control_plane.contracts.preview_evidence import (
     PreviewGenerationEvidenceEnvelope,
 )
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
 from control_plane.contracts.preview_lifecycle_plan_record import (
     PreviewLifecycleDesiredPreview,
@@ -162,6 +163,10 @@ from control_plane.contracts.secret_record import SecretScope
 from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationPolicyRecord
 from control_plane.drivers.registry import build_driver_context_view, list_driver_descriptors
 from control_plane.drivers.registry import read_driver_descriptor as read_driver_descriptor_record
+from control_plane.drivers.generic_web_preview_dispatch import (
+    GenericWebPreviewDesiredStateEnvelope,
+    _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE,
+)
 from control_plane.every_code_work_request_write import (
     EveryCodeWorkRequestCreateEnvelope,
     build_every_code_work_request_record,
@@ -245,6 +250,12 @@ from control_plane.workflows.odoo_stable_operation_worker import (
     reconcile_stale_odoo_stable_operation_records,
 )
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
+from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
+from control_plane.workflows.generic_web_deploy import product_profile_uses_generic_web_base
+from control_plane.workflows.generic_web_preview import (
+    GenericWebPreviewProfileStore,
+    discover_generic_web_preview_desired_state,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.work_graph_issue_inbox import (
     GitHubIssueInboxReadModel,
@@ -298,6 +309,7 @@ _EVERY_CODE_NOTIFICATION_POLICY_APPLY_ROUTE = "/v1/every-code/notification-polic
 _PREVIEW_PR_FEEDBACK_NOTIFICATION_POLICY_APPLY_ROUTE = (
     "/v1/previews/pr-feedback/notification-policies/apply"
 )
+_PREVIEW_DESIRED_STATE_ROUTE = "/v1/previews/desired-state"
 _PREVIEW_LIFECYCLE_PLAN_ROUTE = "/v1/previews/lifecycle-plan"
 _RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE = "/v1/runtime-key-safety/policies/apply"
 _EDGE_ENDPOINT_APPLY_ROUTE = "/v1/edge-endpoints/apply"
@@ -379,6 +391,13 @@ class AgentContextReadStore(ProductReadModelStore, Protocol):
 
 class ProductProfileWriteStore(Protocol):
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> object: ...
+
+
+class PreviewDesiredStateWriteStore(Protocol):
+    def write_preview_desired_state_record(
+        self,
+        record: PreviewDesiredStateRecord,
+    ) -> object: ...
 
 
 class WorkGraphSnapshotReadStore(ProductReadModelStore, WorkGraphWorkRequestStore, Protocol):
@@ -1483,6 +1502,38 @@ class PreviewLifecyclePlanEnvelope(BaseModel):
         return self
 
 
+class PreviewDesiredStateEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    source: str = "workflow"
+    repository: str
+    label: str = "preview"
+    anchor_repo: str
+    preview_slug_prefix: str = "pr-"
+    max_pages: int = Field(default=10, ge=1, le=20)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "PreviewDesiredStateEnvelope":
+        if not self.product.strip():
+            raise ValueError("preview desired state requires product")
+        if not self.context.strip():
+            raise ValueError("preview desired state requires context")
+        if not self.source.strip():
+            raise ValueError("preview desired state requires source")
+        if not self.repository.strip():
+            raise ValueError("preview desired state requires repository")
+        if not self.label.strip():
+            raise ValueError("preview desired state requires label")
+        if not self.anchor_repo.strip():
+            raise ValueError("preview desired state requires anchor_repo")
+        if not self.preview_slug_prefix.strip():
+            raise ValueError("preview desired state requires preview_slug_prefix")
+        return self
+
+
 class EdgeEndpointApplyEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -2572,6 +2623,44 @@ def require_preview_lifecycle_plan_apply_store(
             f"{missing_summary}"
         )
     return cast(_PreviewLifecyclePlanApplyStore, record_store)
+
+
+def require_preview_desired_state_write_store(
+    record_store: object,
+) -> PreviewDesiredStateWriteStore:
+    write_record = getattr(record_store, "write_preview_desired_state_record", None)
+    if not callable(write_record):
+        raise TypeError(
+            "Launchplane record store does not support preview desired-state writes: "
+            "write_preview_desired_state_record"
+        )
+    return cast(PreviewDesiredStateWriteStore, record_store)
+
+
+def read_generic_web_preview_profile(
+    *, record_store: object, product: str
+) -> LaunchplaneProductProfileRecord:
+    try:
+        profile_store = require_product_profile_read_store(record_store)
+        profile = profile_store.read_product_profile_record(product.strip())
+    except TypeError as error:
+        raise TypeError(
+            "Launchplane record store does not support generic web preview desired-state "
+            "profile reads: read_product_profile_record"
+        ) from error
+    except FileNotFoundError as error:
+        raise FileNotFoundError(
+            "Generic web preview desired-state requires an existing product profile."
+        ) from error
+    if not product_profile_uses_generic_web_base(profile):
+        raise ValueError(
+            "Product profile is not compatible with the generic-web preview desired-state route."
+        )
+    if not profile.preview.enabled:
+        raise ValueError("Product profile does not have generic-web previews enabled.")
+    if not profile.preview.context.strip():
+        raise ValueError("Product profile does not define a preview context.")
+    return profile
 
 
 def require_ingress_edge_endpoint_read_store(record_store: object) -> _IngressEdgeEndpointReadStore:
@@ -9257,6 +9346,184 @@ def create_launchplane_fastapi_app(
         )
         return response
 
+    async def apply_preview_desired_state(
+        request: Request,
+        desired_state_request: PreviewDesiredStateEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="preview_desired_state.discover",
+            product=desired_state_request.product,
+            context=desired_state_request.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot discover preview desired state for the requested "
+                    "product/context."
+                ),
+            )
+        (
+            normalized_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_PREVIEW_DESIRED_STATE_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=True,
+        )
+        if replayed_response is not None:
+            return replayed_response
+        try:
+            desired_state_store = require_preview_desired_state_write_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        driver_result = discover_github_preview_desired_state(
+            control_plane_root=resolved_control_plane_root,
+            product=desired_state_request.product,
+            context=desired_state_request.context,
+            source=desired_state_request.source,
+            discovered_at=utc_now_timestamp(),
+            repository=desired_state_request.repository,
+            label=desired_state_request.label,
+            anchor_repo=desired_state_request.anchor_repo,
+            preview_slug_prefix=desired_state_request.preview_slug_prefix,
+            max_pages=desired_state_request.max_pages,
+        )
+        desired_state_store.write_preview_desired_state_record(driver_result)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"preview_desired_state_id": driver_result.desired_state_id},
+            result=driver_result.model_dump(mode="json"),
+        )
+        if driver_result.status != "fail":
+            store_apply_idempotency(
+                record_store=record_store,
+                identity=identity,
+                route_path=_PREVIEW_DESIRED_STATE_ROUTE,
+                idempotency_key=normalized_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=response,
+            )
+        return response
+
+    async def apply_generic_web_preview_desired_state(
+        request: Request,
+        desired_state_request: GenericWebPreviewDesiredStateEnvelope,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            profile = read_generic_web_preview_profile(
+                record_store=record_store,
+                product=desired_state_request.product,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="driver_route_dependency_not_found",
+                message=(
+                    "Driver route is registered, but required product or runtime records "
+                    "were not found."
+                ),
+            ) from error
+        except (ValueError, click.ClickException) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="preview_desired_state.discover",
+            product=profile.product,
+            context=profile.preview.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot discover generic web preview desired state "
+                    "for the requested product/context."
+                ),
+            )
+        (
+            normalized_key,
+            payload_fingerprint,
+            replayed_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=True,
+        )
+        if replayed_response is not None:
+            return replayed_response
+        try:
+            desired_state_store = require_preview_desired_state_write_store(record_store)
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        driver_result = discover_generic_web_preview_desired_state(
+            control_plane_root=resolved_control_plane_root,
+            record_store=cast(GenericWebPreviewProfileStore, record_store),
+            request=desired_state_request.desired_state,
+            discovered_at=utc_now_timestamp(),
+            profile=profile,
+        )
+        desired_state_store.write_preview_desired_state_record(driver_result)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"preview_desired_state_id": driver_result.desired_state_id},
+            result=driver_result.model_dump(mode="json"),
+        )
+        if driver_result.status != "fail":
+            store_apply_idempotency(
+                record_store=record_store,
+                identity=identity,
+                route_path=_GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path,
+                idempotency_key=normalized_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=response,
+            )
+        return response
+
     async def apply_ingress_canary_route(
         request: Request,
         canary_request: IngressCanaryRouteApplyEnvelope,
@@ -10672,6 +10939,24 @@ def create_launchplane_fastapi_app(
     )
 
     app.add_api_route(
+        _PREVIEW_DESIRED_STATE_ROUTE,
+        apply_preview_desired_state,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="apply_preview_desired_state",
+        summary="Discover preview desired state",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
         _PREVIEW_LIFECYCLE_PLAN_ROUTE,
         apply_preview_lifecycle_plan,
         methods=["POST"],
@@ -10680,6 +10965,24 @@ def create_launchplane_fastapi_app(
         response_model_exclude_none=True,
         operation_id="apply_preview_lifecycle_plan",
         summary="Plan preview lifecycle",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path,
+        apply_generic_web_preview_desired_state,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        operation_id="apply_generic_web_preview_desired_state",
+        summary="Discover generic web preview desired state",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -178,7 +178,6 @@ from control_plane.drivers.generic_web_dispatch import (
     _validate_generic_web_prod_promotion_lanes as _validate_generic_web_prod_promotion_lanes,
 )
 from control_plane.drivers.generic_web_preview_dispatch import (
-    GenericWebPreviewDesiredStateEnvelope as GenericWebPreviewDesiredStateEnvelope,
     GenericWebPreviewDestroyEnvelope as GenericWebPreviewDestroyEnvelope,
     GenericWebPreviewInventoryEnvelope as GenericWebPreviewInventoryEnvelope,
     GenericWebPreviewReadinessEnvelope as GenericWebPreviewReadinessEnvelope,
@@ -203,7 +202,6 @@ from control_plane.drivers.generic_web_preview_dispatch import (
     _generic_web_preview_refresh_mutation_requests as _generic_web_preview_refresh_mutation_requests,
     _generic_web_preview_refresh_states as _generic_web_preview_refresh_states,
     _generic_web_preview_refresh_timing as _generic_web_preview_refresh_timing,
-    _handle_generic_web_preview_desired_state as _handle_generic_web_preview_desired_state,
     _handle_generic_web_preview_destroy as _handle_generic_web_preview_destroy,
     _handle_generic_web_preview_inventory as _handle_generic_web_preview_inventory,
     _handle_generic_web_preview_readiness as _handle_generic_web_preview_readiness,
@@ -301,7 +299,6 @@ from control_plane.workflows.odoo_preview_runtime import (
     build_odoo_preview_apply_inputs,
     execute_odoo_preview_dokploy_apply,
 )
-from control_plane.workflows.preview_desired_state import discover_github_preview_desired_state
 from control_plane.workflows.preview_lifecycle import build_preview_lifecycle_plan
 from control_plane.workflows.preview_lifecycle_cleanup import (
     build_preview_lifecycle_cleanup_record,
@@ -418,7 +415,12 @@ _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/controller/
 _MERGE_TRAIN_PR_FEEDBACK_ROUTE = "/v1/work-graph/merge-train/pr-feedback"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
-_NATIVE_FASTAPI_DRIVER_ROUTE_PATHS = frozenset({"/v1/drivers/ingress/route-apply"})
+_NATIVE_FASTAPI_DRIVER_ROUTE_PATHS = frozenset(
+    {
+        "/v1/drivers/generic-web/preview-desired-state",
+        "/v1/drivers/ingress/route-apply",
+    }
+)
 
 
 class MergeTrainRunOnceEnvelope(BaseModel):
@@ -839,38 +841,6 @@ _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS = frozenset(
 _GENERIC_WEB_BASE_DRIVER_ROUTE_PATHS = frozenset(
     _GENERIC_WEB_BASE_DRIVER_SHARED_ROUTE_PATHS | _GENERIC_WEB_BASE_DRIVER_PREVIEW_ROUTE_PATHS
 )
-
-
-class PreviewDesiredStateEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    product: str
-    context: str
-    source: str = "workflow"
-    repository: str
-    label: str = "preview"
-    anchor_repo: str
-    preview_slug_prefix: str = "pr-"
-    max_pages: int = Field(default=10, ge=1, le=20)
-
-    @model_validator(mode="after")
-    def _validate_request(self) -> "PreviewDesiredStateEnvelope":
-        if not self.product.strip():
-            raise ValueError("preview desired state requires product")
-        if not self.context.strip():
-            raise ValueError("preview desired state requires context")
-        if not self.source.strip():
-            raise ValueError("preview desired state requires source")
-        if not self.repository.strip():
-            raise ValueError("preview desired state requires repository")
-        if not self.label.strip():
-            raise ValueError("preview desired state requires label")
-        if not self.anchor_repo.strip():
-            raise ValueError("preview desired state requires anchor_repo")
-        if not self.preview_slug_prefix.strip():
-            raise ValueError("preview desired state requires preview_slug_prefix")
-        return self
 
 
 class PreviewLifecycleCleanupEnvelope(BaseModel):
@@ -2625,17 +2595,6 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             ),
             handler=_handle_generic_web_stable_verification,
         ),
-        _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path: _DescriptorDriverDispatchRoute(
-            execution_metadata=_GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE,
-            context_resolver=lambda request: _DescriptorDriverDispatchContext(
-                product=request.product,
-                context="",
-                use_preview_context_for_authorization=True,
-                require_profile=True,
-            ),
-            handler=_handle_generic_web_preview_desired_state,
-            pre_idempotency_validator=_validate_generic_web_preview_profile,
-        ),
         _GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_GENERIC_WEB_PREVIEW_INVENTORY_ROUTE,
             context_resolver=lambda request: _DescriptorDriverDispatchContext(
@@ -2967,7 +2926,6 @@ def _required_descriptor_driver_dispatch_route_paths() -> frozenset[str]:
             _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
             _GENERIC_WEB_ROLLBACK_ROUTE.route_path,
             _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path,
-            _GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_REFRESH_ROUTE.route_path,
             _GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path,
@@ -3305,7 +3263,6 @@ def _build_write_routes() -> frozenset[str]:
         _MERGE_TRAIN_PR_FEEDBACK_ROUTE,
         _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_RUN_ONCE_ROUTE,
-        "/v1/previews/desired-state",
         "/v1/previews/pr-feedback",
         "/v1/previews/lifecycle-cleanup",
         "/v1/previews/lifecycle-sweep",
@@ -8507,57 +8464,6 @@ def create_launchplane_service_app(
                     control_plane_root_path=resolved_root,
                     request=self_deploy_request.deploy,
                 ).model_dump(mode="json")
-            elif path == "/v1/previews/desired-state":
-                preview_desired_state_request = PreviewDesiredStateEnvelope.model_validate(payload)
-                if not authz_policy.allows(
-                    identity=identity,
-                    action="preview_desired_state.discover",
-                    product=preview_desired_state_request.product,
-                    context=preview_desired_state_request.context,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": (
-                                    "Workflow cannot discover preview desired state for the requested"
-                                    " product/context."
-                                ),
-                            },
-                        },
-                    )
-                idempotent_response = _check_idempotent_request(
-                    record_store=record_store,
-                    scope=request_scope,
-                    route_path=path,
-                    idempotency_key=request_idempotency_key,
-                    request_fingerprint=request_fingerprint,
-                    start_response=start_response,
-                    trace_id=request_trace_id,
-                )
-                if idempotent_response is not None:
-                    return idempotent_response
-                driver_result = discover_github_preview_desired_state(
-                    control_plane_root=resolved_root,
-                    product=preview_desired_state_request.product,
-                    context=preview_desired_state_request.context,
-                    source=preview_desired_state_request.source,
-                    discovered_at=_utc_now_timestamp(),
-                    repository=preview_desired_state_request.repository,
-                    label=preview_desired_state_request.label,
-                    anchor_repo=preview_desired_state_request.anchor_repo,
-                    preview_slug_prefix=preview_desired_state_request.preview_slug_prefix,
-                    max_pages=preview_desired_state_request.max_pages,
-                )
-                preview_desired_state_id = _write_preview_desired_state_if_supported(
-                    record_store=record_store,
-                    record=driver_result,
-                )
-                result = {"preview_desired_state_id": preview_desired_state_id}
             elif path == "/v1/previews/pr-feedback":
                 preview_pr_feedback_request = PreviewPrFeedbackEnvelope.model_validate(payload)
                 if not _allows_preview_pr_feedback_write(

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -207,6 +207,14 @@ Keep a compatibility surface only when it is one of these:
   replay/conflict behavior, writes the typed lifecycle plan record, and returns
   the stored plan as accepted evidence. Its legacy WSGI write branch is deleted,
   and direct WSGI fallback calls fail closed.
+- Preview desired-state discovery uses native FastAPI
+  `POST /v1/previews/desired-state` and
+  `POST /v1/drivers/generic-web/preview-desired-state`, preserves
+  `preview_desired_state.discover` authorization and optional successful-scan
+  `Idempotency-Key` replay/conflict behavior, requires a store capable of
+  persisting desired-state records, and returns the stored scan as accepted
+  evidence. The central WSGI branch and generic-web descriptor fallback branch
+  are deleted/exempted, and direct WSGI fallback calls fail closed.
 - Public ingress, Every Code, and preview PR feedback notification policy apply
   use native FastAPI routes for bearer-token callers and preserve DB-backed
   storage enforcement, local operator reason requirements, explicit preview

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -278,7 +278,7 @@ VeriReel product paths:
   - `POST /v1/drivers/generic-web/prod-rollback-plan`
   - `POST /v1/drivers/generic-web/prod-rollback`
   - `POST /v1/drivers/generic-web/stable-verification`
-  - `POST /v1/drivers/generic-web/preview-desired-state`
+  - `POST /v1/drivers/generic-web/preview-desired-state` (native FastAPI)
   - `POST /v1/drivers/generic-web/preview-refresh`
   - `POST /v1/drivers/generic-web/preview-inventory`
   - `POST /v1/drivers/generic-web/preview-readiness`
@@ -1120,7 +1120,15 @@ report-only behavior and records the cleanup request/result next to the plan.
 Destructive provider cleanup is only attempted when `apply=true` is explicitly
 supplied by an authorized GitHub Actions workflow.
 
-`POST /v1/previews/lifecycle-plan` is a native FastAPI route. It requires
+`POST /v1/previews/desired-state` and `POST /v1/previews/lifecycle-plan` are
+native FastAPI routes. Desired-state discovery requires
+`preview_desired_state.discover` authorization for the requested product/context,
+requires storage that can persist `PreviewDesiredStateRecord`, preserves optional
+`Idempotency-Key` replay/conflict behavior for successful scans, and returns the
+stored scan as accepted evidence. Its legacy WSGI fallback branch is deleted;
+direct fallback calls fail closed.
+
+`POST /v1/previews/lifecycle-plan` requires
 `preview_lifecycle.plan` authorization for the requested product/context,
 preserves optional `Idempotency-Key` replay/conflict behavior, writes the typed
 preview lifecycle plan record, and has its legacy WSGI fallback branch deleted;
@@ -1468,10 +1476,14 @@ configuration still uses provider-specific target type fields internally where
 application-vs-compose behavior is required.
 
 Generic web preview desired-state discovery uses
-`POST /v1/drivers/generic-web/preview-desired-state`. The request names the
-product and optional pull-request label/page limit; Launchplane resolves the
-repository, preview context, anchor repo, and preview slug template from the
-DB-backed product profile before recording desired preview state.
+`POST /v1/drivers/generic-web/preview-desired-state`, now owned by native
+FastAPI. The request names the product and optional pull-request label/page
+limit; Launchplane resolves the repository, preview context, anchor repo, and
+preview slug template from the DB-backed product profile before recording
+desired preview state. Authorization uses the resolved profile product and
+preview context, not caller-supplied runtime authority, and the legacy WSGI
+descriptor branch is exempted from the fallback dispatcher so direct fallback
+calls fail closed.
 
 Generic web preview refresh uses
 `POST /v1/drivers/generic-web/preview-refresh`. The request names the product,

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -19,6 +19,9 @@ from control_plane.contracts.product_profile_record import (
 from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.contracts.preview_summary import LaunchplanePreviewSummary
 from control_plane.drivers import registry
+from control_plane.drivers.generic_web_preview_dispatch import (
+    GenericWebPreviewDesiredStateEnvelope,
+)
 from control_plane.drivers.registry import (
     build_driver_context_view,
     effective_driver_actions,
@@ -661,10 +664,6 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
         self.assertIn(
-            control_plane_service._GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path,
-            dispatch_routes,
-        )
-        self.assertIn(
             control_plane_service._GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path,
             dispatch_routes,
         )
@@ -680,6 +679,20 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             control_plane_service._GENERIC_WEB_PREVIEW_DESTROY_ROUTE.route_path,
             dispatch_routes,
         )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_preview_desired_state_is_native_fastapi_dispatch_exempt(
+        self,
+    ) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        route_path = control_plane_service._GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path
+
+        self.assertIn(route_path, control_plane_service._driver_route_metadata_from_descriptors())
+        self.assertIn(
+            route_path, control_plane_service._descriptor_driver_dispatch_exempt_route_paths()
+        )
+        self.assertNotIn(route_path, dispatch_routes)
+        self.assertNotIn(route_path, control_plane_service._driver_write_routes_from_descriptors())
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_generic_web_source_ref_deploy_registered_in_descriptor_dispatch(self) -> None:
@@ -1505,9 +1518,6 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
 
     def test_generic_web_preview_descriptor_requires_dispatch_registration(self) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
-        dispatch_routes.pop(
-            control_plane_service._GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE.route_path
-        )
         dispatch_routes.pop(control_plane_service._GENERIC_WEB_PREVIEW_INVENTORY_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._GENERIC_WEB_PREVIEW_REFRESH_ROUTE.route_path)
         dispatch_routes.pop(control_plane_service._GENERIC_WEB_PREVIEW_READINESS_ROUTE.route_path)
@@ -1876,7 +1886,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                 ),
                 "preview_desired_state": (
                     control_plane_service._GENERIC_WEB_PREVIEW_DESIRED_STATE_ROUTE,
-                    control_plane_service.GenericWebPreviewDesiredStateEnvelope,
+                    GenericWebPreviewDesiredStateEnvelope,
                     "preview desired state",
                 ),
                 "preview_inventory": (

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -60,11 +60,13 @@ from control_plane.contracts.odoo_stable_target_replacement_operation import (
     OdooStableTargetReplacementOperationRecord,
 )
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_generation_record import (
     PreviewGenerationState,
     PreviewGenerationRecord,
     PreviewPullRequestSummary,
 )
+from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecycleDesiredPreview
 from control_plane.contracts.preview_pr_feedback_notifications import (
     PreviewPrFeedbackNotificationAttemptRecord,
     PreviewPrFeedbackNotificationDestination,
@@ -11740,6 +11742,219 @@ class FastApiEndpointApplyTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
+class FastApiPreviewDesiredStateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_preview_desired_state_discovers_and_records_labeled_prs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_notification_policy_apply_policy(
+                    action="preview_desired_state.discover",
+                    product="verireel",
+                    context="verireel-testing",
+                ),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+            record = PreviewDesiredStateRecord(
+                desired_state_id="preview-desired-state-verireel-testing-20260429T213000Z",
+                product="verireel",
+                context="verireel-testing",
+                source="launchplane-preview-lifecycle",
+                discovered_at="2026-04-29T21:30:00Z",
+                repository="every/verireel",
+                label="preview",
+                anchor_repo="verireel",
+                status="pass",
+                desired_count=1,
+                desired_previews=(
+                    PreviewLifecycleDesiredPreview(
+                        preview_slug="pr-42",
+                        anchor_repo="verireel",
+                        anchor_pr_number=42,
+                        anchor_pr_url="https://github.com/every/verireel/pull/42",
+                        head_sha="abc1234",
+                    ),
+                ),
+            )
+
+            with patch(
+                "control_plane.http_app.discover_github_preview_desired_state",
+                return_value=record,
+            ) as discover:
+                first_response = await _post_preview_desired_state(
+                    app,
+                    _preview_desired_state_payload(),
+                    idempotency_key="preview-desired-state:verireel-testing",
+                )
+                replay_response = await _post_preview_desired_state(
+                    app,
+                    _preview_desired_state_payload(),
+                    idempotency_key="preview-desired-state:verireel-testing",
+                )
+            records = store.list_preview_desired_state_records(context_name="verireel-testing")
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        payload = first_response.json()
+        self.assertEqual(
+            payload["records"]["preview_desired_state_id"],
+            "preview-desired-state-verireel-testing-20260429T213000Z",
+        )
+        self.assertEqual(payload["result"]["desired_previews"][0]["preview_slug"], "pr-42")
+        self.assertTrue(replay_response.json()["replayed"])
+        self.assertEqual(len(records), 1)
+        discover.assert_called_once()
+
+    async def test_preview_desired_state_rejects_unauthorized_workflow(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_notification_policy_apply_policy(
+                action="preview_lifecycle.plan",
+                product="verireel",
+                context="verireel-testing",
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_preview_desired_state(app, _preview_desired_state_payload())
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_generic_web_preview_desired_state_uses_profile_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_generic_web_preview_desired_state_identity()),
+                authz_policy=_generic_web_preview_desired_state_policy(
+                    context="sellyouroutboard-testing"
+                ),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+            record = PreviewDesiredStateRecord(
+                desired_state_id="preview-desired-state-syo-testing-1",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                source="generic-web-preview",
+                discovered_at="2026-04-30T21:00:00Z",
+                repository="cbusillo/sellyouroutboard",
+                label="preview",
+                anchor_repo="sellyouroutboard",
+                status="pass",
+                desired_count=0,
+            )
+
+            with patch(
+                "control_plane.http_app.discover_generic_web_preview_desired_state",
+                return_value=record,
+            ) as discover:
+                response = await _post_generic_web_preview_desired_state(
+                    app,
+                    _generic_web_preview_desired_state_payload(),
+                    idempotency_key="generic-web-preview-desired-state:syo",
+                )
+            records = store.list_preview_desired_state_records(
+                context_name="sellyouroutboard-testing"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(
+            response.json()["records"]["preview_desired_state_id"],
+            "preview-desired-state-syo-testing-1",
+        )
+        discover.assert_called_once()
+        _, kwargs = discover.call_args
+        self.assertEqual(kwargs["profile"].preview.context, "sellyouroutboard-testing")
+        self.assertEqual(records[0].desired_state_id, "preview-desired-state-syo-testing-1")
+
+    async def test_generic_web_preview_desired_state_rejects_wrong_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_generic_web_preview_desired_state_identity()),
+                authz_policy=_generic_web_preview_desired_state_policy(context="different-context"),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_generic_web_preview_desired_state(
+                app,
+                _generic_web_preview_desired_state_payload(),
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_generic_web_preview_desired_state_keeps_profile_errors_invalid_request(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            profile_payload = _product_profile_payload()
+            profile_payload["preview"] = {
+                "enabled": False,
+                "context": "sellyouroutboard-testing",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_generic_web_preview_desired_state_identity()),
+                authz_policy=_generic_web_preview_desired_state_policy(
+                    context="sellyouroutboard-testing"
+                ),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+
+            with patch(
+                "control_plane.http_app.discover_generic_web_preview_desired_state"
+            ) as discover:
+                response = await _post_generic_web_preview_desired_state(
+                    app,
+                    _generic_web_preview_desired_state_payload(),
+                )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        discover.assert_not_called()
+
+    async def test_openapi_includes_preview_desired_state_routes(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=LaunchplaneAuthzPolicy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        openapi = response.json()
+        self.assertEqual(
+            openapi["paths"]["/v1/previews/desired-state"]["post"]["operationId"],
+            "apply_preview_desired_state",
+        )
+        self.assertEqual(
+            openapi["paths"]["/v1/drivers/generic-web/preview-desired-state"]["post"][
+                "operationId"
+            ],
+            "apply_generic_web_preview_desired_state",
+        )
+
+
 class FastApiIngressRouteApplyTests(unittest.IsolatedAsyncioTestCase):
     async def test_ingress_route_dry_run_returns_plan_without_mutation(self) -> None:
         client = _FakeNpmplusIngressClient()
@@ -18959,6 +19174,34 @@ def _notification_policy_apply_policy(
     )
 
 
+def _generic_web_preview_desired_state_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "cbusillo/sellyouroutboard",
+                    "workflow_refs": [
+                        "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["sellyouroutboard"],
+                    "contexts": [context],
+                    "actions": ["preview_desired_state.discover"],
+                }
+            ]
+        }
+    )
+
+
+def _generic_web_preview_desired_state_identity() -> GitHubActionsIdentity:
+    return _identity(
+        repository="cbusillo/sellyouroutboard",
+        workflow_ref=(
+            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+        ),
+    )
+
+
 def _runtime_key_safety_policy_apply_policy(*, action: str) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
@@ -20523,6 +20766,72 @@ async def _post_product_profile(
         app,
         "POST",
         "/v1/product-profiles",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
+def _preview_desired_state_payload(*, label: str = "preview") -> dict[str, object]:
+    return {
+        "product": "verireel",
+        "context": "verireel-testing",
+        "source": "launchplane-preview-lifecycle",
+        "repository": "every/verireel",
+        "label": label,
+        "anchor_repo": "verireel",
+    }
+
+
+async def _post_preview_desired_state(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/previews/desired-state",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
+def _generic_web_preview_desired_state_payload() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": "sellyouroutboard",
+        "desired_state": {
+            "schema_version": 1,
+            "product": "sellyouroutboard",
+        },
+    }
+
+
+async def _post_generic_web_preview_desired_state(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/drivers/generic-web/preview-desired-state",
         headers=request_headers,
         payload=payload,
     )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -83,10 +83,7 @@ from control_plane.contracts.preview_generation_record import (
     PreviewPullRequestSummary,
 )
 from control_plane.contracts.preview_inventory_scan_record import PreviewInventoryScanRecord
-from control_plane.contracts.preview_lifecycle_plan_record import (
-    PreviewLifecycleDesiredPreview,
-    PreviewLifecyclePlanRecord,
-)
+from control_plane.contracts.preview_lifecycle_plan_record import PreviewLifecyclePlanRecord
 from control_plane.contracts.preview_pr_feedback_notifications import (
     PreviewPrFeedbackNotificationAttemptRecord,
     PreviewPrFeedbackNotificationDestination,
@@ -16147,125 +16144,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
         dispatch_mock.assert_not_called()
 
-    def test_generic_web_preview_desired_state_route_uses_profile_context(self) -> None:
+    def test_generic_web_preview_desired_state_legacy_wsgi_route_is_retired(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/sellyouroutboard",
-                            "workflow_refs": [
-                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["sellyouroutboard"],
-                            "contexts": ["sellyouroutboard-testing"],
-                            "actions": ["preview_desired_state.discover"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/sellyouroutboard",
-                        workflow_ref=(
-                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-            record = PreviewDesiredStateRecord(
-                desired_state_id="preview-desired-state-syo-testing-1",
-                product="sellyouroutboard",
-                context="sellyouroutboard-testing",
-                source="generic-web-preview",
-                discovered_at="2026-04-30T21:00:00Z",
-                repository="cbusillo/sellyouroutboard",
-                label="preview",
-                anchor_repo="sellyouroutboard",
-                status="pass",
-                desired_count=0,
-            )
-
-            with patch(
-                "control_plane.drivers.generic_web_preview_dispatch.discover_generic_web_preview_desired_state",
-                return_value=record,
-            ) as discover:
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/drivers/generic-web/preview-desired-state",
-                    payload={
-                        "schema_version": 1,
-                        "product": "sellyouroutboard",
-                        "desired_state": {
-                            "schema_version": 1,
-                            "product": "sellyouroutboard",
-                        },
-                    },
-                    headers={"Idempotency-Key": "generic-web-preview-desired-state:syo"},
-                )
-            records = FilesystemRecordStore(state_dir=state_dir).list_preview_desired_state_records(
-                context_name="sellyouroutboard-testing"
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(
-            payload["records"]["preview_desired_state_id"],
-            "preview-desired-state-syo-testing-1",
-        )
-        discover.assert_called_once()
-        _, kwargs = discover.call_args
-        self.assertEqual(kwargs["profile"].product, "sellyouroutboard")
-        self.assertEqual(kwargs["profile"].preview.context, "sellyouroutboard-testing")
-        self.assertEqual(records[0].desired_state_id, "preview-desired-state-syo-testing-1")
-
-    def test_generic_web_preview_desired_state_route_rejects_wrong_context(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/sellyouroutboard",
-                            "workflow_refs": [
-                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["sellyouroutboard"],
-                            "contexts": ["different-context"],
-                            "actions": ["preview_desired_state.discover"],
-                        }
-                    ]
-                }
-            )
             app = create_launchplane_service_app(
                 state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/sellyouroutboard",
-                        workflow_ref=(
-                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=policy,
+                verifier=_StubVerifier(_identity(repository="cbusillo/sellyouroutboard")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
                 control_plane_root_path=root,
             )
 
@@ -16283,77 +16168,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
 
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
-
-    def test_generic_web_preview_desired_state_route_keeps_profile_errors_invalid_request(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
-            profile_payload = _product_profile_payload()
-            profile_payload["preview"] = {
-                "enabled": False,
-                "context": "sellyouroutboard-testing",
-                "slug_template": "pr-{number}",
-            }
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(profile_payload)
-            )
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "cbusillo/sellyouroutboard",
-                            "workflow_refs": [
-                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
-                            ],
-                            "event_names": ["pull_request"],
-                            "products": ["sellyouroutboard"],
-                            "contexts": ["sellyouroutboard-testing"],
-                            "actions": ["preview_desired_state.discover"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="cbusillo/sellyouroutboard",
-                        workflow_ref=(
-                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            with patch(
-                "control_plane.drivers.generic_web_preview_dispatch.discover_generic_web_preview_desired_state"
-            ) as discover:
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/drivers/generic-web/preview-desired-state",
-                    payload={
-                        "schema_version": 1,
-                        "product": "sellyouroutboard",
-                        "desired_state": {
-                            "schema_version": 1,
-                            "product": "sellyouroutboard",
-                        },
-                    },
-                    headers={"Idempotency-Key": "generic-web-preview-disabled:syo"},
-                )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_request")
-        discover.assert_not_called()
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_generic_web_preview_inventory_route_writes_scan_from_driver_result(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -23916,123 +23732,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "database_storage_required")
         self.assertIn("preview lifecycle plan applies", payload["error"]["message"])
 
-    def test_preview_desired_state_endpoint_discovers_and_records_labeled_prs(self) -> None:
+    def test_preview_desired_state_endpoint_legacy_wsgi_route_is_retired(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/launchplane",
-                            "workflow_refs": [
-                                "every/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["verireel"],
-                            "contexts": ["verireel-testing"],
-                            "actions": ["preview_desired_state.discover"],
-                        }
-                    ]
-                }
-            )
             app = create_launchplane_service_app(
                 state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="every/launchplane",
-                        workflow_ref=(
-                            "every/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
-                control_plane_root_path=root,
-            )
-
-            with patch(
-                "control_plane.service.discover_github_preview_desired_state",
-                return_value=PreviewDesiredStateRecord(
-                    desired_state_id="preview-desired-state-verireel-testing-20260429T213000Z",
-                    product="verireel",
-                    context="verireel-testing",
-                    source="launchplane-preview-lifecycle",
-                    discovered_at="2026-04-29T21:30:00Z",
-                    repository="every/verireel",
-                    label="preview",
-                    anchor_repo="verireel",
-                    status="pass",
-                    desired_count=1,
-                    desired_previews=(
-                        PreviewLifecycleDesiredPreview(
-                            preview_slug="pr-42",
-                            anchor_repo="verireel",
-                            anchor_pr_number=42,
-                            anchor_pr_url="https://github.com/every/verireel/pull/42",
-                            head_sha="abc1234",
-                        ),
-                    ),
-                ),
-            ) as discover_mock:
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/previews/desired-state",
-                    payload={
-                        "product": "verireel",
-                        "context": "verireel-testing",
-                        "source": "launchplane-preview-lifecycle",
-                        "repository": "every/verireel",
-                        "label": "preview",
-                        "anchor_repo": "verireel",
-                    },
-                )
-
-            records = FilesystemRecordStore(
-                state_dir=root / "state"
-            ).list_preview_desired_state_records(context_name="verireel-testing")
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(
-            payload["records"]["preview_desired_state_id"],
-            "preview-desired-state-verireel-testing-20260429T213000Z",
-        )
-        self.assertEqual(payload["result"]["desired_previews"][0]["preview_slug"], "pr-42")
-        self.assertEqual(len(records), 1)
-        self.assertEqual(records[0].desired_count, 1)
-        discover_mock.assert_called_once()
-
-    def test_preview_desired_state_endpoint_rejects_unauthorized_workflow(self) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            policy = LaunchplaneAuthzPolicy.model_validate(
-                {
-                    "github_actions": [
-                        {
-                            "repository": "every/launchplane",
-                            "workflow_refs": [
-                                "every/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main"
-                            ],
-                            "event_names": ["workflow_dispatch"],
-                            "products": ["verireel"],
-                            "contexts": ["verireel-testing"],
-                            "actions": ["preview_lifecycle.plan"],
-                        }
-                    ]
-                }
-            )
-            app = create_launchplane_service_app(
-                state_dir=root / "state",
-                verifier=_StubVerifier(
-                    _identity(
-                        repository="every/launchplane",
-                        workflow_ref=(
-                            "every/launchplane/.github/workflows/preview-lifecycle.yml@refs/heads/main"
-                        ),
-                        event_name="workflow_dispatch",
-                    )
-                ),
-                authz_policy=policy,
+                verifier=_StubVerifier(_identity(repository="every/launchplane")),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
                 control_plane_root_path=root,
             )
 
@@ -24048,8 +23754,8 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             )
 
-        self.assertEqual(status_code, 403)
-        self.assertEqual(payload["error"]["code"], "authorization_denied")
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
     def test_preview_lifecycle_sweep_uses_enabled_product_profiles(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- migrate `POST /v1/previews/desired-state` to native FastAPI with workflow authz, idempotency replay, desired-state persistence, and accepted-evidence responses
- migrate `POST /v1/drivers/generic-web/preview-desired-state` to native FastAPI using DB-backed product profile context for authorization
- retire the corresponding direct WSGI fallback/descriptor dispatch paths and update descriptor tests/docs for the native exemption

## Validation

- `uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff check control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run --extra dev mypy control_plane/http_app.py control_plane/service.py tests/test_http_app.py tests/test_service.py tests/test_driver_descriptors.py`
- `uv run python -m unittest tests.test_driver_descriptors`
- `ulimit -n 4096 && uv run python -m unittest tests.test_http_app.FastApiPreviewDesiredStateTests tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_desired_state_legacy_wsgi_route_is_retired tests.test_service.LaunchplaneServiceTests.test_preview_desired_state_endpoint_legacy_wsgi_route_is_retired tests.test_driver_descriptors`
- `ulimit -n 4096 && uv run python -m unittest tests.test_http_app tests.test_service`
- `ulimit -n 4096 && uv run python -m unittest`
- JetBrains `inspect-closeout --scope changed_files`: GREEN, 0 findings

## Review

- Read-only review agents run with `code-gpt-5.5` and `antigravity`/Gemini.
- Review finding about stale descriptor tests was fixed; reran descriptor and full unit gates after the fix.
