### PR TITLE
Migrate merge train batch candidate to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -111,6 +111,13 @@ from control_plane.merge_train_policy_source import (
     MergeTrainPolicyStoreMissingError,
     resolve_merge_train_policy_record,
 )
+from control_plane.merge_train_batch_candidate import (
+    MergeTrainBatchCandidateRecordNotFoundError,
+    MergeTrainBatchCandidateRunOnceEnvelope,
+    execute_merge_train_batch_candidate_run_once,
+    require_merge_train_batch_candidate_record_store,
+    require_merge_train_stack_collapse_plan_record_store,
+)
 from control_plane.merge_train_github import MergeTrainGitHubError, MergeTrainGitHubStaleHeadError
 from control_plane.merge_train_pr_feedback import (
     MergeTrainPrFeedbackEnvelope,
@@ -354,6 +361,7 @@ _PREVIEW_DESIRED_STATE_ROUTE = "/v1/previews/desired-state"
 _PREVIEW_LIFECYCLE_PLAN_ROUTE = "/v1/previews/lifecycle-plan"
 _PREVIEW_LIFECYCLE_CLEANUP_ROUTE = "/v1/previews/lifecycle-cleanup"
 _PREVIEW_LIFECYCLE_SWEEP_ROUTE = "/v1/previews/lifecycle-sweep"
+_MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _MERGE_TRAIN_PR_FEEDBACK_ROUTE = "/v1/work-graph/merge-train/pr-feedback"
 _RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE = "/v1/runtime-key-safety/policies/apply"
@@ -4973,6 +4981,147 @@ def create_launchplane_fastapi_app(
             },
             targets=targets,
         )
+
+    async def write_merge_train_batch_candidate_run_once(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse | JSONResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            )
+        try:
+            batch_request = MergeTrainBatchCandidateRunOnceEnvelope.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+
+        normalized_idempotency_key = idempotency_key.strip()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if normalized_idempotency_key:
+            (
+                normalized_idempotency_key,
+                payload_fingerprint,
+                replay_response,
+            ) = await replay_apply_idempotency(
+                request=request,
+                record_store=record_store,
+                identity=identity,
+                route_path=_MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                trace_id=trace_id,
+                check_replay=True,
+            )
+            if replay_response is not None:
+                return replay_response
+
+        try:
+            policy_record = resolve_merge_train_policy_record(record_store)
+        except MergeTrainPolicyStoreMissingError as error:
+            raise merge_train_policy_not_configured_error(trace_id=trace_id, error=error) from error
+        try:
+            repository_policy = policy_record.policy.find_repository_policy(
+                repository=batch_request.repository,
+                base_branch=batch_request.base_branch,
+            )
+        except ValueError as error:
+            raise merge_train_invalid_request_error(trace_id=trace_id, error=error) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=repository_policy.service_authz.action,
+            product=repository_policy.service_authz.product,
+            context=repository_policy.service_authz.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot run the requested merge train policy.",
+            )
+        token_env = repository_policy.github_token.env_var
+        if not token_env:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="github_token_not_configured",
+                message="Merge train policy does not define a GitHub token environment variable.",
+            )
+        token = os.environ.get(token_env, "").strip()
+        if not token:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="github_token_not_configured",
+                message="Configured merge train GitHub token is not available.",
+            )
+        try:
+            batch_store = require_merge_train_batch_candidate_record_store(record_store)
+            stack_collapse_store = require_merge_train_stack_collapse_plan_record_store(
+                record_store
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message="Merge train batch candidate storage requires database-backed records.",
+            ) from error
+        try:
+            batch_result = execute_merge_train_batch_candidate_run_once(
+                request=batch_request,
+                policy=policy_record.policy,
+                policy_sha256=policy_record.policy_sha256,
+                token=token,
+                trace_id=trace_id,
+                recorded_at=utc_now_timestamp(),
+                batch_store=batch_store,
+                stack_collapse_store=stack_collapse_store,
+            )
+        except MergeTrainGitHubStaleHeadError as error:
+            return merge_train_github_stale_state_response(trace_id=trace_id, error=error)
+        except MergeTrainGitHubError as error:
+            return merge_train_github_request_failed_response(trace_id=trace_id, error=error)
+        except MergeTrainBatchCandidateRecordNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records=batch_result.records,
+            result=batch_result.accepted_result,
+        )
+        store_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
 
     async def write_merge_train_run_once(
         request: Request,
@@ -12478,6 +12627,35 @@ def create_launchplane_fastapi_app(
         operation_id="read_merge_train_policy_targets",
         summary="Read merge train policy targets",
         responses=merge_train_read_error_responses,
+    )
+
+    app.add_api_route(
+        _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
+        write_merge_train_batch_candidate_run_once,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": MergeTrainBatchCandidateRunOnceEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="write_merge_train_batch_candidate_run_once",
+        summary="Run one merge train batch candidate worker pass",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            502: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
     )
 
     app.add_api_route(

--- a/control_plane/merge_train_batch_candidate.py
+++ b/control_plane/merge_train_batch_candidate.py
@@ -1,0 +1,306 @@
+from dataclasses import dataclass
+from typing import Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.merge_train_batch import (
+    MergeTrainBatchCandidate,
+    MergeTrainBatchCandidateRecord,
+    build_merge_train_batch_candidate,
+    build_merge_train_batch_candidate_record,
+)
+from control_plane.contracts.merge_train_policy import MergeTrainPolicy
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlanRecord,
+    build_merge_train_stack_collapse_plan,
+    build_merge_train_stack_collapse_plan_record,
+)
+from control_plane.merge_train import (
+    MergeTrainDryRunResult,
+    MergeTrainDryRunSnapshot,
+    build_merge_train_dry_run_result,
+    discover_merge_train_stack,
+)
+from control_plane.merge_train_github import (
+    GitHubMergeTrainClient,
+    GitHubMergeTrainSnapshotReader,
+    MergeTrainGitHubTransport,
+    UrllibMergeTrainGitHubTransport,
+)
+
+
+class MergeTrainBatchCandidateRunOnceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    base_branch: str = "main"
+    mode: Literal["plan", "build", "observe"] = "plan"
+    candidate_record_id: str = ""
+    github_api_base_url: str = "https://api.github.com"
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainBatchCandidateRunOnceEnvelope":
+        self.repository = self.repository.strip()
+        self.base_branch = self.base_branch.strip()
+        self.candidate_record_id = self.candidate_record_id.strip()
+        self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
+        if not self.repository:
+            raise ValueError("merge train batch candidate requires repository")
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        if not self.base_branch:
+            raise ValueError("merge train batch candidate requires base_branch")
+        if self.mode in {"build", "observe"} and not self.candidate_record_id:
+            raise ValueError("build and observe require candidate_record_id")
+        return self
+
+
+class MergeTrainBatchCandidateRecordNotFoundError(ValueError):
+    """Raised when a requested batch candidate record is absent."""
+
+
+class MergeTrainBatchCandidateRecordStore(Protocol):
+    def write_merge_train_batch_candidate_record(
+        self, record: MergeTrainBatchCandidateRecord
+    ) -> object: ...
+
+    def list_merge_train_batch_candidate_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainBatchCandidateRecord, ...]: ...
+
+
+class MergeTrainStackCollapsePlanRecordStore(Protocol):
+    def write_merge_train_stack_collapse_plan_record(
+        self, record: MergeTrainStackCollapsePlanRecord
+    ) -> object: ...
+
+    def list_merge_train_stack_collapse_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainStackCollapsePlanRecord, ...]: ...
+
+
+def require_merge_train_batch_candidate_record_store(
+    record_store: object,
+) -> MergeTrainBatchCandidateRecordStore:
+    if hasattr(record_store, "write_merge_train_batch_candidate_record") and hasattr(
+        record_store, "list_merge_train_batch_candidate_records"
+    ):
+        return cast(MergeTrainBatchCandidateRecordStore, record_store)
+    raise TypeError("record store does not support merge train batch candidate records")
+
+
+def require_merge_train_stack_collapse_plan_record_store(
+    record_store: object,
+) -> MergeTrainStackCollapsePlanRecordStore:
+    if hasattr(record_store, "write_merge_train_stack_collapse_plan_record") and hasattr(
+        record_store, "list_merge_train_stack_collapse_plan_records"
+    ):
+        return cast(MergeTrainStackCollapsePlanRecordStore, record_store)
+    raise TypeError("record store does not support merge train stack collapse plans")
+
+
+@dataclass(frozen=True)
+class MergeTrainBatchCandidateRunOnceResult:
+    accepted_result: dict[str, object]
+    records: dict[str, str]
+
+
+def execute_merge_train_batch_candidate_run_once(
+    *,
+    request: MergeTrainBatchCandidateRunOnceEnvelope,
+    policy: MergeTrainPolicy,
+    policy_sha256: str,
+    token: str,
+    trace_id: str,
+    recorded_at: str,
+    batch_store: MergeTrainBatchCandidateRecordStore,
+    stack_collapse_store: MergeTrainStackCollapsePlanRecordStore,
+) -> MergeTrainBatchCandidateRunOnceResult:
+    transport = UrllibMergeTrainGitHubTransport(
+        token=token,
+        api_base_url=request.github_api_base_url,
+    )
+    if request.mode == "plan":
+        return _execute_plan_mode(
+            request=request,
+            policy=policy,
+            policy_sha256=policy_sha256,
+            transport=transport,
+            trace_id=trace_id,
+            recorded_at=recorded_at,
+            batch_store=batch_store,
+            stack_collapse_store=stack_collapse_store,
+        )
+
+    existing_record = read_merge_train_batch_candidate_record(
+        record_store=batch_store,
+        repository=request.repository,
+        base_branch=request.base_branch,
+        record_id=request.candidate_record_id,
+    )
+    candidate = existing_record.candidate
+    github_client = GitHubMergeTrainClient(transport=transport)
+    if request.mode == "build":
+        candidate = github_client.build_batch_candidate(candidate=candidate)
+    else:
+        candidate = github_client.observe_batch_candidate_checks(candidate=candidate)
+    return _persist_candidate_result(
+        candidate=candidate,
+        mode=request.mode,
+        trace_id=trace_id,
+        recorded_at=recorded_at,
+        batch_store=batch_store,
+    )
+
+
+def read_merge_train_batch_candidate_record(
+    *,
+    record_store: MergeTrainBatchCandidateRecordStore,
+    repository: str,
+    base_branch: str,
+    record_id: str,
+) -> MergeTrainBatchCandidateRecord:
+    records = record_store.list_merge_train_batch_candidate_records(
+        repository=repository, base_branch=base_branch
+    )
+    for record in records:
+        if record.record_id == record_id:
+            return record
+    raise MergeTrainBatchCandidateRecordNotFoundError(
+        "merge train batch candidate record not found"
+    )
+
+
+def merge_train_snapshot_has_stack_topology(
+    *, snapshot: MergeTrainDryRunSnapshot, dry_run_result: MergeTrainDryRunResult
+) -> bool:
+    selected_pr = dry_run_result.selected_pr
+    if selected_pr is None:
+        return False
+    for pull_request in snapshot.pull_requests:
+        if pull_request.number != selected_pr.number:
+            continue
+        return all(
+            (
+                pull_request.head_ref,
+                pull_request.head_repository,
+                pull_request.base_ref,
+                pull_request.base_repository,
+            )
+        )
+    return False
+
+
+def _execute_plan_mode(
+    *,
+    request: MergeTrainBatchCandidateRunOnceEnvelope,
+    policy: MergeTrainPolicy,
+    policy_sha256: str,
+    transport: MergeTrainGitHubTransport,
+    trace_id: str,
+    recorded_at: str,
+    batch_store: MergeTrainBatchCandidateRecordStore,
+    stack_collapse_store: MergeTrainStackCollapsePlanRecordStore,
+) -> MergeTrainBatchCandidateRunOnceResult:
+    snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+        repository=request.repository,
+        base_branch=request.base_branch,
+    )
+    dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    selected_pr = dry_run_result.selected_pr
+    if selected_pr is not None and merge_train_snapshot_has_stack_topology(
+        snapshot=snapshot, dry_run_result=dry_run_result
+    ):
+        stack_discovery = discover_merge_train_stack(
+            snapshot=snapshot,
+            root_pull_request_number=selected_pr.number,
+        )
+    else:
+        stack_discovery = None
+
+    if stack_discovery is not None and stack_discovery.status == "ready_for_collapse":
+        stack_collapse_plan = build_merge_train_stack_collapse_plan(
+            discovery_result=stack_discovery,
+            policy_key=dry_run_result.policy_key,
+            policy_sha256=policy_sha256,
+            created_at=recorded_at,
+        )
+        stack_collapse_record = build_merge_train_stack_collapse_plan_record(
+            plan=stack_collapse_plan,
+            source=f"service:{request.mode}:{trace_id}",
+            updated_at=recorded_at,
+        )
+        stack_collapse_store.write_merge_train_stack_collapse_plan_record(stack_collapse_record)
+        return MergeTrainBatchCandidateRunOnceResult(
+            accepted_result={
+                "mode": request.mode,
+                "dry_run_result": dry_run_result.model_dump(mode="json"),
+                "stack_discovery": stack_discovery.model_dump(mode="json"),
+                "stack_collapse_plan": stack_collapse_plan.model_dump(mode="json"),
+            },
+            records={"merge_train_stack_collapse_plan_record_id": stack_collapse_record.record_id},
+        )
+
+    if stack_discovery is not None and stack_discovery.status == "unsupported":
+        return MergeTrainBatchCandidateRunOnceResult(
+            accepted_result={
+                "mode": request.mode,
+                "dry_run_result": dry_run_result.model_dump(mode="json"),
+                "stack_discovery": stack_discovery.model_dump(mode="json"),
+                "next_action": "stack_unsupported",
+            },
+            records={},
+        )
+
+    candidate = build_merge_train_batch_candidate(
+        dry_run_result=dry_run_result,
+        base_sha=snapshot.base_sha,
+        policy_sha256=policy_sha256,
+        created_at=recorded_at,
+    )
+    return _persist_candidate_result(
+        candidate=candidate,
+        mode=request.mode,
+        trace_id=trace_id,
+        recorded_at=recorded_at,
+        batch_store=batch_store,
+        dry_run_result=dry_run_result,
+    )
+
+
+def _persist_candidate_result(
+    *,
+    candidate: MergeTrainBatchCandidate,
+    mode: str,
+    trace_id: str,
+    recorded_at: str,
+    batch_store: MergeTrainBatchCandidateRecordStore,
+    dry_run_result: MergeTrainDryRunResult | None = None,
+) -> MergeTrainBatchCandidateRunOnceResult:
+    candidate_record = build_merge_train_batch_candidate_record(
+        candidate=candidate,
+        source=f"service:{mode}:{trace_id}",
+        updated_at=recorded_at,
+    )
+    batch_store.write_merge_train_batch_candidate_record(candidate_record)
+    accepted_result: dict[str, object] = {
+        "mode": mode,
+        "candidate": candidate.model_dump(mode="json"),
+    }
+    if dry_run_result is not None:
+        accepted_result["dry_run_result"] = dry_run_result.model_dump(mode="json")
+    return MergeTrainBatchCandidateRunOnceResult(
+        accepted_result=accepted_result,
+        records={"merge_train_batch_candidate_record_id": candidate_record.record_id},
+    )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -361,7 +361,6 @@ from control_plane.workflows.verireel_preview_driver import (
 
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _WHOLE_PRODUCT_CONTEXT = "*"
-_MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
 _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
 _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/controller/run-once"
@@ -372,33 +371,6 @@ _NATIVE_FASTAPI_DRIVER_ROUTE_PATHS = frozenset(
         "/v1/drivers/ingress/route-apply",
     }
 )
-
-
-class MergeTrainBatchCandidateRunOnceEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    repository: str
-    base_branch: str = "main"
-    mode: Literal["plan", "build", "observe"] = "plan"
-    candidate_record_id: str = ""
-    github_api_base_url: str = "https://api.github.com"
-
-    @model_validator(mode="after")
-    def _validate_envelope(self) -> "MergeTrainBatchCandidateRunOnceEnvelope":
-        self.repository = self.repository.strip()
-        self.base_branch = self.base_branch.strip()
-        self.candidate_record_id = self.candidate_record_id.strip()
-        self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
-        if not self.repository:
-            raise ValueError("merge train batch candidate requires repository")
-        if "/" not in self.repository:
-            raise ValueError("merge train repository must be owner/name")
-        if not self.base_branch:
-            raise ValueError("merge train batch candidate requires base_branch")
-        if self.mode in {"build", "observe"} and not self.candidate_record_id:
-            raise ValueError("build and observe require candidate_record_id")
-        return self
 
 
 class MergeTrainBatchLandingRunOnceEnvelope(BaseModel):
@@ -3068,7 +3040,6 @@ def _driver_write_routes_from_descriptors() -> frozenset[str]:
 
 def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
-        _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
@@ -6099,177 +6070,7 @@ def create_launchplane_service_app(
             effective_idempotency_route_path = path
             driver_result: BaseModel | dict[str, object] | None = None
             result: dict[str, object] = {}
-            if path == _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE:
-                batch_request = MergeTrainBatchCandidateRunOnceEnvelope.model_validate(payload)
-                policy_record = resolve_merge_train_policy_record(record_store)
-                policy = policy_record.policy
-                repository_policy = policy.find_repository_policy(
-                    repository=batch_request.repository,
-                    base_branch=batch_request.base_branch,
-                )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action=repository_policy.service_authz.action,
-                    product=repository_policy.service_authz.product,
-                    context=repository_policy.service_authz.context,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot run the requested merge train policy.",
-                            },
-                        },
-                    )
-                token_env = repository_policy.github_token.env_var
-                if not token_env:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "github_token_not_configured",
-                                "message": "Merge train policy does not define a GitHub token environment variable.",
-                            },
-                        },
-                    )
-                token = os.environ.get(token_env, "").strip()
-                if not token:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "github_token_not_configured",
-                                "message": "Configured merge train GitHub token is not available.",
-                            },
-                        },
-                    )
-                batch_store = _merge_train_batch_candidate_record_store(record_store)
-                stack_collapse_store = _merge_train_stack_collapse_plan_record_store(record_store)
-                transport = UrllibMergeTrainGitHubTransport(
-                    token=token,
-                    api_base_url=batch_request.github_api_base_url,
-                )
-                github_client = GitHubMergeTrainClient(transport=transport)
-                recorded_at = _utc_now_timestamp()
-                candidate: MergeTrainBatchCandidate | None = None
-                if batch_request.mode == "plan":
-                    snapshot = GitHubMergeTrainSnapshotReader(
-                        transport=transport
-                    ).read_merge_train_snapshot(
-                        repository=batch_request.repository,
-                        base_branch=batch_request.base_branch,
-                    )
-                    dry_run_result = build_merge_train_dry_run_result(
-                        policy=policy, snapshot=snapshot
-                    )
-                    selected_pr = dry_run_result.selected_pr
-                    if selected_pr is not None and _merge_train_snapshot_has_stack_topology(
-                        snapshot=snapshot, dry_run_result=dry_run_result
-                    ):
-                        stack_discovery = discover_merge_train_stack(
-                            snapshot=snapshot,
-                            root_pull_request_number=selected_pr.number,
-                        )
-                    else:
-                        stack_discovery = None
-                    if (
-                        stack_discovery is not None
-                        and stack_discovery.status == "ready_for_collapse"
-                    ):
-                        stack_collapse_plan = build_merge_train_stack_collapse_plan(
-                            discovery_result=stack_discovery,
-                            policy_key=dry_run_result.policy_key,
-                            policy_sha256=policy_record.policy_sha256,
-                            created_at=recorded_at,
-                        )
-                        stack_collapse_record = build_merge_train_stack_collapse_plan_record(
-                            plan=stack_collapse_plan,
-                            source=f"service:{batch_request.mode}:{request_trace_id}",
-                            updated_at=recorded_at,
-                        )
-                        stack_collapse_store.write_merge_train_stack_collapse_plan_record(
-                            stack_collapse_record
-                        )
-                        result = {
-                            "merge_train_stack_collapse_plan_record_id": stack_collapse_record.record_id,
-                            "repository": stack_collapse_plan.repository,
-                            "base_branch": stack_collapse_plan.base_branch,
-                            "mode": batch_request.mode,
-                            "stack_collapse_plan": stack_collapse_plan.model_dump(mode="json"),
-                        }
-                        driver_result = {
-                            "mode": batch_request.mode,
-                            "dry_run_result": dry_run_result.model_dump(mode="json"),
-                            "stack_discovery": stack_discovery.model_dump(mode="json"),
-                            "stack_collapse_plan": stack_collapse_plan.model_dump(mode="json"),
-                        }
-                    elif stack_discovery is not None and stack_discovery.status == "unsupported":
-                        result = {
-                            "repository": batch_request.repository,
-                            "base_branch": batch_request.base_branch,
-                            "mode": batch_request.mode,
-                        }
-                        driver_result = {
-                            "mode": batch_request.mode,
-                            "dry_run_result": dry_run_result.model_dump(mode="json"),
-                            "stack_discovery": stack_discovery.model_dump(mode="json"),
-                            "next_action": "stack_unsupported",
-                        }
-                    else:
-                        candidate = build_merge_train_batch_candidate(
-                            dry_run_result=dry_run_result,
-                            base_sha=snapshot.base_sha,
-                            policy_sha256=policy_record.policy_sha256,
-                            created_at=recorded_at,
-                        )
-                        driver_result = {
-                            "mode": batch_request.mode,
-                            "dry_run_result": dry_run_result.model_dump(mode="json"),
-                            "candidate": candidate.model_dump(mode="json"),
-                        }
-                else:
-                    existing_record = _read_merge_train_batch_candidate_record(
-                        record_store=batch_store,
-                        repository=batch_request.repository,
-                        base_branch=batch_request.base_branch,
-                        record_id=batch_request.candidate_record_id,
-                    )
-                    candidate = existing_record.candidate
-                    if batch_request.mode == "build":
-                        candidate = github_client.build_batch_candidate(candidate=candidate)
-                    else:
-                        candidate = github_client.observe_batch_candidate_checks(
-                            candidate=candidate
-                        )
-                    driver_result = {
-                        "mode": batch_request.mode,
-                        "candidate": candidate.model_dump(mode="json"),
-                    }
-                if candidate is not None:
-                    candidate_record = build_merge_train_batch_candidate_record(
-                        candidate=candidate,
-                        source=f"service:{batch_request.mode}:{request_trace_id}",
-                        updated_at=recorded_at,
-                    )
-                    batch_store.write_merge_train_batch_candidate_record(candidate_record)
-                    result = {
-                        "merge_train_batch_candidate_record_id": candidate_record.record_id,
-                        "repository": candidate.repository,
-                        "base_branch": candidate.base_branch,
-                        "mode": batch_request.mode,
-                        "candidate": candidate.model_dump(mode="json"),
-                    }
-            elif path == _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE:
+            if path == _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE:
                 landing_request = MergeTrainBatchLandingRunOnceEnvelope.model_validate(payload)
                 policy_record = resolve_merge_train_policy_record(record_store)
                 policy = policy_record.policy

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -120,8 +120,10 @@ Keep a compatibility surface only when it is one of these:
   dry-runs remain repeatable.
 - Merge-train admission, controller-status, and policy-target reads use native
   FastAPI routes. Their legacy WSGI read branches are deleted. Merge-train
-  run-once and PR feedback also use native FastAPI write routes; controller
-  mutation and phase runner routes remain on the retained fallback until their
+  run-once, batch-candidate run-once, and PR feedback also use native FastAPI
+  write routes. The batch-candidate legacy WSGI branch is deleted and direct
+  fallback calls fail closed; controller mutation, batch landing, and
+  stack-collapse phase runner routes remain on the retained fallback until their
   native write replacements land.
 - Work graph snapshot, work-graph rank, GitHub issue-inbox reads, and GitHub
   issue-inbox reconcile use native FastAPI routes. Their legacy WSGI

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -273,6 +273,7 @@ VeriReel product paths:
   - `POST /v1/work-graph/rank` (native FastAPI)
   - `POST /v1/work-graph/github/issues/reconcile` (native FastAPI)
   - `POST /v1/work-graph/merge-train/run-once` (native FastAPI)
+  - `POST /v1/work-graph/merge-train/batch-candidate/run-once` (native FastAPI)
   - `POST /v1/work-graph/merge-train/pr-feedback` (native FastAPI)
   - `POST /v1/work-graph/merge-train/controller/run-once`
 - product driver routes:
@@ -584,16 +585,20 @@ matrix and public-safe reporting fields.
 
 `POST /v1/work-graph/merge-train/batch-candidate/run-once` executes one
 policy-backed batch-candidate phase for a requested repository/base branch. The
-route accepts `mode: plan`, `mode: build`, or `mode: observe`. Plan mode reads a
-fresh GitHub snapshot, derives one deterministic batch candidate from the
-currently eligible queued PRs, and writes a
-`launchplane_merge_train_batch_candidates` record. Build mode requires a prior
-candidate record id, creates or resets the Launchplane train ref, merges queued
-PR heads into that ref in order, and records the resulting candidate SHA. Observe
-mode requires a prior candidate record id, reads required checks for that exact
-candidate SHA, and records whether the candidate is still pending, passed, or
-failed. The route never lands original PRs; PR-native landing remains a later
-phase with separate records and pre-merge invariants.
+native FastAPI route accepts `mode: plan`, `mode: build`, or `mode: observe`.
+Plan mode reads a fresh GitHub snapshot, derives one deterministic batch
+candidate from the currently eligible queued PRs, and writes a
+`launchplane_merge_train_batch_candidates` record. When the selected PR is the
+root of a supported stack, plan mode writes a stack-collapse plan record instead
+of a batch candidate; unsupported stack topologies return accepted evidence with
+no record write. Build mode requires a prior candidate record id, creates or
+resets the Launchplane train ref, merges queued PR heads into that ref in order,
+and records the resulting candidate SHA. Observe mode requires a prior candidate
+record id, reads required checks for that exact candidate SHA, and records
+whether the candidate is still pending, passed, or failed. The legacy WSGI
+fallback branch is deleted, and direct fallback calls fail closed. The route
+never lands original PRs; PR-native landing remains a later phase with separate
+records and pre-merge invariants.
 
 `POST /v1/work-graph/merge-train/batch-landing/run-once` executes one
 policy-backed batch-landing phase for a requested repository/base branch. The

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -162,6 +162,7 @@ from tests.test_service import (
     _edge_endpoint_record,
     _FakeMergeTrainGitHubClient,
     _FakeMergeTrainSnapshotReader,
+    _FakeStackedMergeTrainSnapshotReader,
     _identity,
     _ingress_canary_route_record,
     _ingress_canary_route_record_apply_payload,
@@ -5476,6 +5477,23 @@ class _UnavailableMergeTrainSnapshotReader(_FakeMergeTrainSnapshotReader):
         )
 
 
+class _UnsupportedStackMergeTrainSnapshotReader(_FakeStackedMergeTrainSnapshotReader):
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainDryRunSnapshot:
+        snapshot = super().read_merge_train_snapshot(repository=repository, base_branch=base_branch)
+        return snapshot.model_copy(
+            update={
+                "pull_requests": tuple(
+                    pull_request.model_copy(update={"head_ref": "feature/root"})
+                    if pull_request.number == 2
+                    else pull_request
+                    for pull_request in snapshot.pull_requests
+                )
+            }
+        )
+
+
 class _UnavailableWorkerMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
     def merge_pull_request(
         self,
@@ -5489,6 +5507,29 @@ class _UnavailableWorkerMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
             "GitHub API request failed for /repos/example/repo/pulls/1/merge",
             status_code=503,
         )
+
+
+class _CountingBatchCandidateMergeTrainSnapshotReader(_FakeMergeTrainSnapshotReader):
+    read_calls = 0
+
+    def read_merge_train_snapshot(
+        self, *, repository: str, base_branch: str
+    ) -> MergeTrainDryRunSnapshot:
+        type(self).read_calls += 1
+        return super().read_merge_train_snapshot(repository=repository, base_branch=base_branch)
+
+
+class _UnavailableBatchCandidateMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    def build_batch_candidate(self, *, candidate: Any) -> Any:
+        raise MergeTrainGitHubError(
+            "GitHub API request failed for /repos/example/repo/git/refs",
+            status_code=503,
+        )
+
+
+class _UnexpectedBatchCandidateMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise AssertionError("batch candidate plan mode should not create a GitHub client")
 
 
 class FastApiMergeTrainRunOnceTests(unittest.IsolatedAsyncioTestCase):
@@ -6024,6 +6065,701 @@ class FastApiMergeTrainRunOnceTests(unittest.IsolatedAsyncioTestCase):
         request_schema = route["requestBody"]["content"]["application/json"]["schema"]
         self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
         self.assertEqual(request_schema["title"], "MergeTrainRunOnceEnvelope")
+        self.assertTrue(set(route["responses"]) >= {"400", "401", "403", "409", "502", "503"})
+
+
+class FastApiMergeTrainBatchCandidateRunOnceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_plans_candidate_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            policy_record = _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with (
+                patch(
+                    "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                    _FakeMergeTrainSnapshotReader,
+                ),
+                patch(
+                    "control_plane.merge_train_batch_candidate.GitHubMergeTrainClient",
+                    _UnexpectedBatchCandidateMergeTrainGitHubClient,
+                ),
+            ):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            payload = response.json()
+            record_id = payload["records"]["merge_train_batch_candidate_record_id"]
+            listed_records = FilesystemRecordStore(
+                state_dir
+            ).list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "plan")
+        self.assertEqual(payload["result"]["candidate"]["status"], "planned")
+        self.assertEqual(payload["result"]["candidate"]["base_sha"], "current-base-main")
+        self.assertEqual(payload["result"]["candidate"]["entries"][0]["pull_request_number"], 1)
+        self.assertEqual(listed_records[0].record_id, record_id)
+        self.assertEqual(listed_records[0].candidate.policy_key, "cbusillo/sellyouroutboard:main")
+        self.assertEqual(listed_records[0].candidate.policy_sha256, policy_record.policy_sha256)
+
+    async def test_plans_stack_collapse_first_without_candidate_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            payload = response.json()
+            record_id = payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            stack_records = store.list_merge_train_stack_collapse_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+            candidate_records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "plan")
+        self.assertNotIn("candidate", payload["result"])
+        self.assertEqual(payload["result"]["stack_collapse_plan"]["status"], "planned")
+        self.assertEqual(
+            [
+                entry["pull_request_number"]
+                for entry in payload["result"]["stack_collapse_plan"]["entries"]
+            ],
+            [1, 2],
+        )
+        self.assertEqual(stack_records[0].record_id, record_id)
+        self.assertEqual(candidate_records, ())
+
+    async def test_reports_unsupported_stack_without_writing_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _UnsupportedStackMergeTrainSnapshotReader,
+            ):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            candidate_records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+            stack_records = store.list_merge_train_stack_collapse_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["records"], {})
+        self.assertEqual(payload["result"]["next_action"], "stack_unsupported")
+        self.assertEqual(payload["result"]["stack_discovery"]["status"], "unsupported")
+        self.assertEqual(candidate_records, ())
+        self.assertEqual(stack_records, ())
+
+    async def test_builds_existing_candidate_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                plan_response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainClient",
+                _FakeMergeTrainGitHubClient,
+            ):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": plan_response.json()["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["result"]["mode"], "build")
+        self.assertEqual(response.json()["result"]["candidate"]["status"], "ready_for_checks")
+        self.assertEqual(response.json()["result"]["candidate"]["candidate_sha"], "candidate-built")
+
+    async def test_observes_existing_candidate_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                plan_response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainClient",
+                _FakeMergeTrainGitHubClient,
+            ):
+                build_response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": plan_response.json()["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "observe",
+                        "candidate_record_id": build_response.json()["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["result"]["mode"], "observe")
+        self.assertEqual(response.json()["result"]["candidate"]["status"], "passed")
+        self.assertEqual(response.json()["result"]["candidate"]["required_checks_status"], "pass")
+
+    async def test_replays_idempotent_plan_without_rereading_github(self) -> None:
+        request_payload = {
+            "schema_version": 1,
+            "repository": "cbusillo/sellyouroutboard",
+            "base_branch": "main",
+            "mode": "plan",
+        }
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            _CountingBatchCandidateMergeTrainSnapshotReader.read_calls = 0
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _CountingBatchCandidateMergeTrainSnapshotReader,
+            ):
+                first_response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    request_payload,
+                    idempotency_key="merge-train-batch-candidate-plan",
+                )
+                replay_response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    request_payload,
+                    idempotency_key="merge-train-batch-candidate-plan",
+                )
+            records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        self.assertTrue(replay_response.json()["replayed"])
+        self.assertEqual(_CountingBatchCandidateMergeTrainSnapshotReader.read_calls, 1)
+        self.assertEqual(len(records), 1)
+
+    async def test_rejects_reused_idempotency_key_with_different_payload(self) -> None:
+        request_payload = {
+            "schema_version": 1,
+            "repository": "cbusillo/sellyouroutboard",
+            "base_branch": "main",
+            "mode": "plan",
+        }
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                first_response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    request_payload,
+                    idempotency_key="merge-train-batch-candidate-conflict",
+                )
+                conflict_response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {**request_payload, "base_branch": "release"},
+                    idempotency_key="merge-train-batch-candidate-conflict",
+                )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(conflict_response.status_code, 409)
+        self.assertEqual(conflict_response.json()["error"]["code"], "idempotency_key_reused")
+
+    async def test_rejects_invalid_payload_as_launchplane_invalid_request(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_merge_train_service_identity()),
+            authz_policy=_merge_train_service_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_merge_train_batch_candidate_run_once(
+            app,
+            {"schema_version": 1, "repository": "cbusillo", "base_branch": "main"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    async def test_build_requires_candidate_record_id(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_merge_train_service_identity()),
+            authz_policy=_merge_train_service_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_merge_train_batch_candidate_run_once(
+            app,
+            {
+                "schema_version": 1,
+                "repository": "cbusillo/sellyouroutboard",
+                "base_branch": "main",
+                "mode": "build",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    async def test_build_rejects_unknown_candidate_record_without_leaking_detail(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_merge_train_batch_candidate_run_once(
+                app,
+                {
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mode": "build",
+                    "candidate_record_id": "missing-candidate-record",
+                },
+            )
+            records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        self.assertEqual(response.json()["error"]["message"], "Request could not be completed.")
+        self.assertEqual(records, ())
+
+    async def test_rejects_unauthorized_identity(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                record_store_factory=lambda: store,
+            )
+            with patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_rejects_terminal_agent_bearer_mutation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_terminal_agent_merge_train_run_once_policy(),
+                record_store_factory=lambda: store,
+                bearer_identity_config=BearerIdentityConfig(
+                    terminal_agent_token="terminal-read-token",
+                    terminal_agent_subject="local-owner-agent",
+                    terminal_agent_token_label="local-owner-read",
+                ),
+            )
+            response = await _post_merge_train_batch_candidate_run_once(
+                app,
+                {
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mode": "plan",
+                },
+                authorization="Bearer terminal-read-token",
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_rejects_missing_token(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch.dict("os.environ", {}, clear=True):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "github_token_not_configured")
+
+    async def test_rejects_missing_policy_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            response = await _post_merge_train_batch_candidate_run_once(
+                app,
+                {
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mode": "plan",
+                },
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "merge_train_policy_not_configured")
+
+    async def test_maps_stale_github_state_without_writing_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _StaleMergeTrainSnapshotReader,
+            ):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "merge_train_github_stale_state")
+        self.assertEqual(records, ())
+
+    async def test_maps_build_github_request_failure_without_writing_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                plan_response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainClient",
+                _UnavailableBatchCandidateMergeTrainGitHubClient,
+            ):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "build",
+                        "candidate_record_id": plan_response.json()["records"][
+                            "merge_train_batch_candidate_record_id"
+                        ],
+                    },
+                )
+            records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.json()["error"]["code"], "github_request_failed")
+        self.assertEqual(len(records), 1)
+
+    async def test_rejects_missing_batch_candidate_storage(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = _MergeTrainPolicyOnlyStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            response = await _post_merge_train_batch_candidate_run_once(
+                app,
+                {
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mode": "plan",
+                },
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+        self.assertEqual(
+            response.json()["error"]["message"],
+            "Merge train batch candidate storage requires database-backed records.",
+        )
+
+    async def test_fastapi_route_precedes_legacy_wsgi_fallback(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+                local_record_store_for_tests=store,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+            with patch(
+                "control_plane.merge_train_batch_candidate.GitHubMergeTrainSnapshotReader",
+                _FakeMergeTrainSnapshotReader,
+            ):
+                response = await _post_merge_train_batch_candidate_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "plan",
+                    },
+                )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["result"]["mode"], "plan")
+
+    async def test_wsgi_fallback_no_longer_serves_route(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/merge-train/batch-candidate/run-once",
+                payload={
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mode": "plan",
+                },
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_openapi_includes_batch_candidate_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_merge_train_service_identity()),
+            authz_policy=_merge_train_service_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        route = response.json()["paths"]["/v1/work-graph/merge-train/batch-candidate/run-once"][
+            "post"
+        ]
+        success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
+        self.assertEqual(request_schema["title"], "MergeTrainBatchCandidateRunOnceEnvelope")
         self.assertTrue(set(route["responses"]) >= {"400", "401", "403", "409", "502", "503"})
 
 
@@ -22155,6 +22891,25 @@ async def _post_merge_train_run_once(
     )
 
 
+async def _post_merge_train_batch_candidate_run_once(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/work-graph/merge-train/batch-candidate/run-once",
+        headers=headers,
+        payload=payload,
+    )
+
+
 def _query_params(**values: str) -> dict[str, str]:
     return {key: value for key, value in values.items() if value != ""}
 
@@ -23245,6 +24000,37 @@ class _StubFastApiGitHubOAuthClient:
 
 class _MissingProductReadStore:
     pass
+
+
+class _MergeTrainPolicyOnlyStore:
+    backend_name = "test-merge-train-policy-only"
+
+    def __init__(self, *, state_dir: Path) -> None:
+        self.delegate = FilesystemRecordStore(state_dir=state_dir)
+
+    def close(self) -> None:
+        return None
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> Any:
+        return self.delegate.read_idempotency_record(
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+        )
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> object:
+        return self.delegate.write_idempotency_record(record)
+
+    def list_merge_train_policy_records(
+        self, *, status: str = "", limit: int | None = None
+    ) -> tuple[MergeTrainPolicyRecord, ...]:
+        return self.delegate.list_merge_train_policy_records(status=status, limit=limit)
 
 
 class _PreviewLifecycleSweepProfileOnlyStore:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -62,6 +62,7 @@ from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidate
 from control_plane.contracts.merge_train_batch import MergeTrainBatchEntry
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlan
+from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate
 from control_plane.contracts.merge_train_batch import build_merge_train_batch_candidate_record
 from control_plane.merge_train_github import MergeTrainGitHubError
 from control_plane.merge_train_github import MergeTrainGitHubStaleHeadError
@@ -1062,6 +1063,111 @@ def _merge_train_run_record(
         dry_run_result=dry_run_result,
         worker_step_result=worker_step_result,
     )
+
+
+def _seed_merge_train_batch_candidate_record(
+    state_dir: Path,
+    *,
+    status: str = "planned",
+    required_checks_status: str = "pending",
+    candidate_sha: str = "",
+    policy: MergeTrainPolicy | None = None,
+    snapshot_reader: type[_FakeMergeTrainSnapshotReader] = _FakeMergeTrainSnapshotReader,
+) -> MergeTrainBatchCandidateRecord:
+    merge_train_policy = policy or build_test_merge_train_policy()
+    snapshot = snapshot_reader(transport=object()).read_merge_train_snapshot(
+        repository="cbusillo/sellyouroutboard",
+        base_branch="main",
+    )
+    dry_run_result = build_merge_train_dry_run_result(
+        policy=merge_train_policy,
+        snapshot=snapshot,
+    )
+    candidate = build_merge_train_batch_candidate(
+        dry_run_result=dry_run_result,
+        base_sha=snapshot.base_sha,
+        policy_sha256=merge_train_policy.policy_sha256,
+        created_at="2026-05-13T21:00:00Z",
+    ).model_copy(
+        update={
+            "status": status,
+            "required_checks_status": required_checks_status,
+            "candidate_sha": candidate_sha,
+        }
+    )
+    record = build_merge_train_batch_candidate_record(
+        candidate=candidate,
+        source=f"test:{status}",
+        updated_at="2026-05-13T21:00:00Z",
+    )
+    FilesystemRecordStore(state_dir).write_merge_train_batch_candidate_record(record)
+    return record
+
+
+def _mark_merge_train_batch_candidate_record_passed(
+    state_dir: Path, *, record_id: str
+) -> MergeTrainBatchCandidateRecord:
+    store = FilesystemRecordStore(state_dir)
+    existing_record = next(
+        record
+        for record in store.list_merge_train_batch_candidate_records(
+            repository="cbusillo/sellyouroutboard",
+            base_branch="main",
+        )
+        if record.record_id == record_id
+    )
+    candidate = existing_record.candidate.model_copy(
+        update={
+            "status": "passed",
+            "required_checks_status": "pass",
+            "candidate_sha": "candidate-built",
+        }
+    )
+    passed_record = build_merge_train_batch_candidate_record(
+        candidate=candidate,
+        source="test:passed",
+        updated_at="2026-05-13T21:05:00Z",
+    )
+    store.write_merge_train_batch_candidate_record(passed_record)
+    return passed_record
+
+
+def _seed_merge_train_stack_collapse_plan_record(
+    state_dir: Path,
+    *,
+    policy: MergeTrainPolicy | None = None,
+    snapshot_reader: type[
+        _FakeStackedMergeTrainSnapshotReader
+    ] = _FakeStackedMergeTrainSnapshotReader,
+) -> str:
+    merge_train_policy = policy or build_test_merge_train_policy()
+    snapshot = snapshot_reader(transport=object()).read_merge_train_snapshot(
+        repository="cbusillo/sellyouroutboard",
+        base_branch="main",
+    )
+    dry_run_result = build_merge_train_dry_run_result(
+        policy=merge_train_policy,
+        snapshot=snapshot,
+    )
+    selected_pr = dry_run_result.selected_pr
+    assert selected_pr is not None
+    stack_discovery = discover_merge_train_stack(
+        snapshot=snapshot,
+        root_pull_request_number=selected_pr.number,
+    )
+    stack_collapse_plan = build_merge_train_stack_collapse_plan(
+        discovery_result=stack_discovery,
+        policy_key=dry_run_result.policy_key,
+        policy_sha256=merge_train_policy.policy_sha256,
+        created_at="2026-05-13T21:00:00Z",
+    )
+    record = build_merge_train_stack_collapse_plan_record(
+        plan=stack_collapse_plan,
+        source="test:plan",
+        updated_at="2026-05-13T21:00:00Z",
+    )
+    FilesystemRecordStore(state_dir).write_merge_train_stack_collapse_plan_record(record)
+    return record.record_id
 
 
 def _identity(
@@ -3041,103 +3147,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
             "",
         )
 
-    def test_merge_train_batch_candidate_service_plans_candidate_record(self) -> None:
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            _seed_merge_train_policy(state_dir)
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_merge_train_service_identity()),
-                authz_policy=_merge_train_service_policy(),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeMergeTrainSnapshotReader,
-            ):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            record_id = payload["records"]["merge_train_batch_candidate_record_id"]
-            listed_records = FilesystemRecordStore(
-                state_dir
-            ).list_merge_train_batch_candidate_records(
-                repository="cbusillo/sellyouroutboard", base_branch="main"
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["mode"], "plan")
-        self.assertEqual(payload["result"]["candidate"]["status"], "planned")
-        self.assertEqual(payload["result"]["candidate"]["base_sha"], "current-base-main")
-        self.assertEqual(payload["result"]["candidate"]["entries"][0]["pull_request_number"], 1)
-        self.assertEqual(listed_records[0].record_id, record_id)
-        self.assertEqual(listed_records[0].candidate.policy_key, "cbusillo/sellyouroutboard:main")
-
-    def test_merge_train_batch_candidate_service_plans_stack_collapse_first(self) -> None:
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            _seed_merge_train_policy(state_dir)
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_merge_train_service_identity()),
-                authz_policy=_merge_train_service_policy(),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            record_id = payload["records"]["merge_train_stack_collapse_plan_record_id"]
-            store = FilesystemRecordStore(state_dir)
-            stack_records = store.list_merge_train_stack_collapse_plan_records(
-                repository="cbusillo/sellyouroutboard", base_branch="main"
-            )
-            candidate_records = store.list_merge_train_batch_candidate_records(
-                repository="cbusillo/sellyouroutboard", base_branch="main"
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["mode"], "plan")
-        self.assertNotIn("candidate", payload["result"])
-        self.assertEqual(payload["result"]["stack_collapse_plan"]["status"], "planned")
-        self.assertEqual(
-            [
-                entry["pull_request_number"]
-                for entry in payload["result"]["stack_collapse_plan"]["entries"]
-            ],
-            [1, 2],
-        )
-        self.assertEqual(stack_records[0].record_id, record_id)
-        self.assertEqual(stack_records[0].plan.root_pull_request_number, 1)
-        self.assertEqual(stack_records[0].plan.mutations[0].child_pull_request_number, 2)
-        self.assertEqual(stack_records[0].plan.mutations[0].parent_pull_request_number, 1)
-        self.assertEqual(candidate_records, ())
-
     def test_merge_train_controller_advances_unstacked_batch_flow(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -4776,22 +4785,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 status_code, payload = _invoke_app(
                     app,
@@ -4841,22 +4835,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, execute_payload = _invoke_app(
                     app,
@@ -4918,22 +4897,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, execute_payload = _invoke_app(
                     app,
@@ -4984,22 +4948,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, execute_payload = _invoke_app(
                     app,
@@ -5045,118 +4994,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(status_code, 400)
         self.assertEqual(payload["error"]["code"], "invalid_request")
 
-    def test_merge_train_batch_candidate_service_builds_existing_candidate_record(self) -> None:
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            _seed_merge_train_policy(state_dir)
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_merge_train_service_identity()),
-                authz_policy=_merge_train_service_policy(),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": plan_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["mode"], "build")
-        self.assertEqual(payload["result"]["candidate"]["status"], "ready_for_checks")
-        self.assertEqual(payload["result"]["candidate"]["candidate_sha"], "candidate-built")
-
-    def test_merge_train_batch_candidate_service_observes_existing_candidate_record(self) -> None:
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            _seed_merge_train_policy(state_dir)
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_merge_train_service_identity()),
-                authz_policy=_merge_train_service_policy(),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, build_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": plan_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "observe",
-                        "candidate_record_id": build_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["mode"], "observe")
-        self.assertEqual(payload["result"]["candidate"]["status"], "passed")
-        self.assertEqual(payload["result"]["candidate"]["required_checks_status"], "pass")
-
     def test_merge_train_batch_landing_service_plans_from_passed_candidate(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -5170,50 +5007,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
+            passed_candidate_record = _seed_merge_train_batch_candidate_record(
+                state_dir,
+                status="passed",
+                required_checks_status="pass",
+                candidate_sha="candidate-built",
+            )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, build_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": plan_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-                _, observe_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "observe",
-                        "candidate_record_id": build_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -5223,9 +5023,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
                         "mode": "plan",
-                        "candidate_record_id": observe_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
+                        "candidate_record_id": passed_candidate_record.record_id,
                     },
                 )
             listed_records = FilesystemRecordStore(
@@ -5255,50 +5053,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeMergeTrainSnapshotReader,
-            ):
-                _, candidate_plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
+            passed_candidate_record = _seed_merge_train_batch_candidate_record(
+                state_dir,
+                status="passed",
+                required_checks_status="pass",
+                candidate_sha="candidate-built",
+            )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, build_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": candidate_plan_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-                _, observe_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "observe",
-                        "candidate_record_id": build_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
                 _, landing_plan_payload = _invoke_app(
                     app,
                     method="POST",
@@ -5308,9 +5069,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
                         "mode": "plan",
-                        "candidate_record_id": observe_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
+                        "candidate_record_id": passed_candidate_record.record_id,
                     },
                 )
                 status_code, payload = _invoke_app(
@@ -5352,53 +5111,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeMergeTrainSnapshotReader,
-            ):
-                _, candidate_plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
+            passed_candidate_record = _seed_merge_train_batch_candidate_record(
+                state_dir,
+                status="passed",
+                required_checks_status="pass",
+                candidate_sha="candidate-built",
+            )
             with patch(
                 "control_plane.service.GitHubMergeTrainClient",
                 _CleanupFailingMergeTrainGitHubClient,
             ):
-                _, build_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": candidate_plan_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-                _, observe_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "observe",
-                        "candidate_record_id": build_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
                 _, landing_plan_payload = _invoke_app(
                     app,
                     method="POST",
@@ -5408,9 +5130,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
                         "mode": "plan",
-                        "candidate_record_id": observe_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
+                        "candidate_record_id": passed_candidate_record.record_id,
                     },
                 )
                 status_code, payload = _invoke_app(
@@ -5547,22 +5267,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, execute_payload = _invoke_app(
                     app,
@@ -5595,35 +5300,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "stack_collapse_plan_record_id": executed_record_id,
                     },
                 )
+            passed_candidate_record = _mark_merge_train_batch_candidate_record_passed(
+                state_dir,
+                record_id=admit_payload["records"]["merge_train_batch_candidate_record_id"],
+            )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, build_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": admit_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-                _, observe_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "observe",
-                        "candidate_record_id": build_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
                 _, landing_plan_payload = _invoke_app(
                     app,
                     method="POST",
@@ -5633,9 +5314,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
                         "mode": "plan",
-                        "candidate_record_id": observe_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
+                        "candidate_record_id": passed_candidate_record.record_id,
                     },
                 )
                 status_code, payload = _invoke_app(
@@ -5690,22 +5369,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, execute_payload = _invoke_app(
                     app,
@@ -5738,35 +5402,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "stack_collapse_plan_record_id": executed_record_id,
                     },
                 )
+            passed_candidate_record = _mark_merge_train_batch_candidate_record_passed(
+                state_dir,
+                record_id=admit_payload["records"]["merge_train_batch_candidate_record_id"],
+            )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, build_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": admit_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-                _, observe_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "observe",
-                        "candidate_record_id": build_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
                 _, landing_plan_payload = _invoke_app(
                     app,
                     method="POST",
@@ -5776,9 +5416,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
                         "mode": "plan",
-                        "candidate_record_id": observe_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
+                        "candidate_record_id": passed_candidate_record.record_id,
                     },
                 )
             failing_store = _StackCollapseWriteFailingFilesystemRecordStore(state_dir)
@@ -5836,22 +5474,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, execute_payload = _invoke_app(
                     app,
@@ -5885,35 +5508,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 )
             stale_stack_record_id = plan_record_id
             _FakeMergeTrainGitHubClient.land_batch_candidate_calls = 0
+            passed_candidate_record = _mark_merge_train_batch_candidate_record_passed(
+                state_dir,
+                record_id=admit_payload["records"]["merge_train_batch_candidate_record_id"],
+            )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, build_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": admit_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-                _, observe_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "observe",
-                        "candidate_record_id": build_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
                 _, landing_plan_payload = _invoke_app(
                     app,
                     method="POST",
@@ -5923,9 +5522,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
                         "mode": "plan",
-                        "candidate_record_id": observe_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
+                        "candidate_record_id": passed_candidate_record.record_id,
                     },
                 )
                 status_code, payload = _invoke_app(
@@ -5956,6 +5553,35 @@ class LaunchplaneServiceTests(unittest.TestCase):
             patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
         ):
             state_dir = Path(temporary_directory_name) / "state"
+            policy_without_stack_child_label = parse_merge_train_policy_toml(
+                """
+                schema_version = 1
+
+                [[policies]]
+                repository = "cbusillo/sellyouroutboard"
+                base_branch = "main"
+                enqueue_label = "ready-to-merge"
+                blocked_label = "merge-blocked"
+                merge_method = "merge"
+                failure_policy = "pause_train"
+
+                [policies.enqueue]
+                label_required = true
+                allowed_actor_roles = ["repo_owner", "repo_admin"]
+
+                [policies.merge_identity]
+                kind = "github_actions_oidc"
+                name = "launchplane-merge-train"
+
+                [policies.service_authz]
+                action = "merge_train.run_once"
+                product = "launchplane"
+                context = "launchplane"
+
+                [policies.github_token]
+                env_var = "GH_TOKEN"
+                """
+            )
             _seed_merge_train_policy(
                 state_dir,
                 policy=MergeTrainPolicyRecord(
@@ -5963,35 +5589,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     status="active",
                     source="test",
                     updated_at="2026-05-13T21:00:00Z",
-                    policy=parse_merge_train_policy_toml(
-                        """
-                        schema_version = 1
-
-                        [[policies]]
-                        repository = "cbusillo/sellyouroutboard"
-                        base_branch = "main"
-                        enqueue_label = "ready-to-merge"
-                        blocked_label = "merge-blocked"
-                        merge_method = "merge"
-                        failure_policy = "pause_train"
-
-                        [policies.enqueue]
-                        label_required = true
-                        allowed_actor_roles = ["repo_owner", "repo_admin"]
-
-                        [policies.merge_identity]
-                        kind = "github_actions_oidc"
-                        name = "launchplane-merge-train"
-
-                        [policies.service_authz]
-                        action = "merge_train.run_once"
-                        product = "launchplane"
-                        context = "launchplane"
-
-                        [policies.github_token]
-                        env_var = "GH_TOKEN"
-                        """
-                    ),
+                    policy=policy_without_stack_child_label,
                 ),
             )
             app = create_launchplane_service_app(
@@ -6000,22 +5598,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                _, plan_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "plan",
-                    },
-                )
-            plan_record_id = plan_payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(
+                state_dir,
+                policy=policy_without_stack_child_label,
+            )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, execute_payload = _invoke_app(
                     app,
@@ -6048,35 +5634,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     },
                 )
             _FakeMergeTrainGitHubClient.land_batch_candidate_calls = 0
+            passed_candidate_record = _mark_merge_train_batch_candidate_record_passed(
+                state_dir,
+                record_id=admit_payload["records"]["merge_train_batch_candidate_record_id"],
+            )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, build_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "build",
-                        "candidate_record_id": admit_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
-                _, observe_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/batch-candidate/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "observe",
-                        "candidate_record_id": build_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
-                    },
-                )
                 _, landing_plan_payload = _invoke_app(
                     app,
                     method="POST",
@@ -6086,9 +5648,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "repository": "cbusillo/sellyouroutboard",
                         "base_branch": "main",
                         "mode": "plan",
-                        "candidate_record_id": observe_payload["records"][
-                            "merge_train_batch_candidate_record_id"
-                        ],
+                        "candidate_record_id": passed_candidate_record.record_id,
                     },
                 )
                 status_code, payload = _invoke_app(


### PR DESCRIPTION
## Summary
- move POST /v1/work-graph/merge-train/batch-candidate/run-once into native FastAPI with extracted execution logic
- retire the legacy WSGI batch-candidate route and keep direct fallback calls fail-closed
- decouple remaining service-phase tests from the retired route by seeding typed records directly
- update v2 service-boundary and compatibility-retirement docs

## Local validation
- uv run --extra dev ruff check .
- uv run --extra dev mypy control_plane tests
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/service.py control_plane/merge_train_batch_candidate.py tests/test_http_app.py tests/test_service.py
- uv run python -m unittest tests.test_http_app.FastApiMergeTrainBatchCandidateRunOnceTests -q
- ulimit -n 4096 && uv run python -m unittest tests.test_http_app.FastApiMergeTrainBatchCandidateRunOnceTests tests.test_http_app.FastApiMergeTrainRunOnceTests tests.test_http_app.FastApiMergeTrainPrFeedbackTests tests.test_service.LaunchplaneServiceTests -q
- ulimit -n 4096 && uv run python -m unittest -q
- JetBrains inspect-closeout --scope changed_files: GREEN

## Notes
- Full repo ruff format still reports unrelated pre-existing drift outside these touched files; touched files are formatted.
- Final review agents, including Antigravity, reported no blockers.