### PR TITLE
Migrate merge train stack collapse to FastAPI

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -116,7 +116,6 @@ from control_plane.merge_train_batch_candidate import (
     MergeTrainBatchCandidateRunOnceEnvelope,
     execute_merge_train_batch_candidate_run_once,
     require_merge_train_batch_candidate_record_store,
-    require_merge_train_stack_collapse_plan_record_store,
 )
 from control_plane.merge_train_github import MergeTrainGitHubError, MergeTrainGitHubStaleHeadError
 from control_plane.merge_train_pr_feedback import (
@@ -128,6 +127,13 @@ from control_plane.merge_train_run_once import (
     MergeTrainRunOnceEnvelope,
     execute_merge_train_run_once,
     require_merge_train_run_record_store,
+)
+from control_plane.merge_train_stack_collapse import (
+    MergeTrainStackCollapseBatchCandidateStoreMissingError,
+    MergeTrainStackCollapsePlanRecordNotFoundError,
+    MergeTrainStackCollapseRunOnceEnvelope,
+    execute_merge_train_stack_collapse_run_once,
+    require_merge_train_stack_collapse_plan_record_store,
 )
 from control_plane.contracts.product_environment_read_model import (
     ActionAllowed,
@@ -362,6 +368,7 @@ _PREVIEW_LIFECYCLE_PLAN_ROUTE = "/v1/previews/lifecycle-plan"
 _PREVIEW_LIFECYCLE_CLEANUP_ROUTE = "/v1/previews/lifecycle-cleanup"
 _PREVIEW_LIFECYCLE_SWEEP_ROUTE = "/v1/previews/lifecycle-sweep"
 _MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-candidate/run-once"
+_MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
 _MERGE_TRAIN_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/run-once"
 _MERGE_TRAIN_PR_FEEDBACK_ROUTE = "/v1/work-graph/merge-train/pr-feedback"
 _RUNTIME_KEY_SAFETY_POLICY_APPLY_ROUTE = "/v1/runtime-key-safety/policies/apply"
@@ -5116,6 +5123,173 @@ def create_launchplane_fastapi_app(
             record_store=record_store,
             identity=identity,
             route_path=_MERGE_TRAIN_BATCH_CANDIDATE_RUN_ONCE_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
+    async def write_merge_train_stack_collapse_run_once(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse | JSONResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            )
+        try:
+            stack_request = MergeTrainStackCollapseRunOnceEnvelope.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+
+        normalized_idempotency_key = idempotency_key.strip()
+        payload_fingerprint = request_fingerprint(cast(dict[str, object], raw_payload))
+        if normalized_idempotency_key:
+            (
+                normalized_idempotency_key,
+                payload_fingerprint,
+                replay_response,
+            ) = await replay_apply_idempotency(
+                request=request,
+                record_store=record_store,
+                identity=identity,
+                route_path=_MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                trace_id=trace_id,
+                check_replay=True,
+            )
+            if replay_response is not None:
+                return replay_response
+
+        try:
+            policy_record = resolve_merge_train_policy_record(record_store)
+        except MergeTrainPolicyStoreMissingError as error:
+            raise merge_train_policy_not_configured_error(trace_id=trace_id, error=error) from error
+        try:
+            repository_policy = policy_record.policy.find_repository_policy(
+                repository=stack_request.repository,
+                base_branch=stack_request.base_branch,
+            )
+        except ValueError as error:
+            raise merge_train_invalid_request_error(trace_id=trace_id, error=error) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=repository_policy.service_authz.action,
+            product=repository_policy.service_authz.product,
+            context=repository_policy.service_authz.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot run the requested merge train policy.",
+            )
+        token_env = repository_policy.github_token.env_var
+        if not token_env:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="github_token_not_configured",
+                message="Merge train policy does not define a GitHub token environment variable.",
+            )
+        token = os.environ.get(token_env, "").strip()
+        if not token:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="github_token_not_configured",
+                message="Configured merge train GitHub token is not available.",
+            )
+        try:
+            stack_collapse_store = require_merge_train_stack_collapse_plan_record_store(
+                record_store
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message="Merge train stack collapse storage requires database-backed records.",
+            ) from error
+        try:
+            batch_candidate_store = (
+                require_merge_train_batch_candidate_record_store(record_store)
+                if stack_request.mode == "admit"
+                else None
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message="Merge train stack collapse admission requires database-backed candidate records.",
+            ) from error
+        try:
+            stack_result = execute_merge_train_stack_collapse_run_once(
+                request=stack_request,
+                policy=policy_record.policy,
+                policy_sha256=policy_record.policy_sha256,
+                token=token,
+                trace_id=trace_id,
+                recorded_at=utc_now_timestamp(),
+                stack_collapse_store=stack_collapse_store,
+                batch_candidate_store=batch_candidate_store,
+            )
+        except MergeTrainGitHubStaleHeadError as error:
+            return merge_train_github_stale_state_response(trace_id=trace_id, error=error)
+        except MergeTrainGitHubError as error:
+            return merge_train_github_request_failed_response(trace_id=trace_id, error=error)
+        except MergeTrainStackCollapseBatchCandidateStoreMissingError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message="Merge train stack collapse admission requires database-backed candidate records.",
+            ) from error
+        except MergeTrainStackCollapsePlanRecordNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records=stack_result.records,
+            result=stack_result.accepted_result,
+        )
+        store_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
             idempotency_key=normalized_idempotency_key,
             request_fingerprint_value=payload_fingerprint,
             trace_id=trace_id,
@@ -12648,6 +12822,35 @@ def create_launchplane_fastapi_app(
         },
         operation_id="write_merge_train_batch_candidate_run_once",
         summary="Run one merge train batch candidate worker pass",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            502: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
+        write_merge_train_stack_collapse_run_once,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": MergeTrainStackCollapseRunOnceEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="write_merge_train_stack_collapse_run_once",
+        summary="Run one merge train stack collapse worker pass",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/merge_train_stack_collapse.py
+++ b/control_plane/merge_train_stack_collapse.py
@@ -1,0 +1,226 @@
+from dataclasses import dataclass
+from typing import Literal, Protocol, cast
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.merge_train_batch import (
+    build_merge_train_batch_candidate,
+    build_merge_train_batch_candidate_record,
+)
+from control_plane.contracts.merge_train_policy import MergeTrainPolicy
+from control_plane.contracts.merge_train_stack_collapse import (
+    MergeTrainStackCollapsePlan,
+    MergeTrainStackCollapsePlanRecord,
+    build_merge_train_stack_collapse_plan_record,
+    execute_merge_train_stack_collapse_plan,
+)
+from control_plane.merge_train import build_merge_train_dry_run_result
+from control_plane.merge_train_batch_candidate import MergeTrainBatchCandidateRecordStore
+from control_plane.merge_train_github import (
+    GitHubMergeTrainClient,
+    GitHubMergeTrainSnapshotReader,
+    MergeTrainGitHubTransport,
+    UrllibMergeTrainGitHubTransport,
+)
+
+
+class MergeTrainStackCollapseRunOnceEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    repository: str
+    base_branch: str = "main"
+    mode: Literal["execute", "admit"] = "execute"
+    stack_collapse_plan_record_id: str
+    github_api_base_url: str = "https://api.github.com"
+
+    @model_validator(mode="after")
+    def _validate_envelope(self) -> "MergeTrainStackCollapseRunOnceEnvelope":
+        self.repository = self.repository.strip()
+        self.base_branch = self.base_branch.strip()
+        self.stack_collapse_plan_record_id = self.stack_collapse_plan_record_id.strip()
+        self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
+        if not self.repository:
+            raise ValueError("merge train stack collapse requires repository")
+        if "/" not in self.repository:
+            raise ValueError("merge train repository must be owner/name")
+        if not self.base_branch:
+            raise ValueError("merge train stack collapse requires base_branch")
+        if not self.stack_collapse_plan_record_id:
+            raise ValueError("merge train stack collapse requires stack_collapse_plan_record_id")
+        return self
+
+
+class MergeTrainStackCollapsePlanRecordNotFoundError(ValueError):
+    """Raised when a requested stack-collapse plan record is absent."""
+
+
+class MergeTrainStackCollapseBatchCandidateStoreMissingError(RuntimeError):
+    """Raised when admit mode lacks batch-candidate persistence."""
+
+
+class MergeTrainStackCollapsePlanRecordStore(Protocol):
+    def write_merge_train_stack_collapse_plan_record(
+        self, record: MergeTrainStackCollapsePlanRecord
+    ) -> object: ...
+
+    def list_merge_train_stack_collapse_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[MergeTrainStackCollapsePlanRecord, ...]: ...
+
+
+def require_merge_train_stack_collapse_plan_record_store(
+    record_store: object,
+) -> MergeTrainStackCollapsePlanRecordStore:
+    if hasattr(record_store, "write_merge_train_stack_collapse_plan_record") and hasattr(
+        record_store, "list_merge_train_stack_collapse_plan_records"
+    ):
+        return cast(MergeTrainStackCollapsePlanRecordStore, record_store)
+    raise TypeError("record store does not support merge train stack collapse plans")
+
+
+@dataclass(frozen=True)
+class MergeTrainStackCollapseRunOnceResult:
+    accepted_result: dict[str, object]
+    records: dict[str, str]
+
+
+def execute_merge_train_stack_collapse_run_once(
+    *,
+    request: MergeTrainStackCollapseRunOnceEnvelope,
+    policy: MergeTrainPolicy,
+    policy_sha256: str,
+    token: str,
+    trace_id: str,
+    recorded_at: str,
+    stack_collapse_store: MergeTrainStackCollapsePlanRecordStore,
+    batch_candidate_store: MergeTrainBatchCandidateRecordStore | None = None,
+) -> MergeTrainStackCollapseRunOnceResult:
+    existing_record = read_merge_train_stack_collapse_plan_record(
+        record_store=stack_collapse_store,
+        repository=request.repository,
+        base_branch=request.base_branch,
+        record_id=request.stack_collapse_plan_record_id,
+    )
+    transport = UrllibMergeTrainGitHubTransport(
+        token=token,
+        api_base_url=request.github_api_base_url,
+    )
+    if request.mode == "execute":
+        executed_plan = execute_merge_train_stack_collapse_plan(
+            plan=existing_record.plan,
+            branch_client=GitHubMergeTrainClient(transport=transport),
+            updated_at=recorded_at,
+        )
+        collapse_record = build_merge_train_stack_collapse_plan_record(
+            plan=executed_plan,
+            source=f"service:execute:{trace_id}",
+            updated_at=recorded_at,
+        )
+        stack_collapse_store.write_merge_train_stack_collapse_plan_record(collapse_record)
+        return MergeTrainStackCollapseRunOnceResult(
+            accepted_result={
+                "mode": request.mode,
+                "stack_collapse_plan": executed_plan.model_dump(mode="json"),
+            },
+            records={"merge_train_stack_collapse_plan_record_id": collapse_record.record_id},
+        )
+    return _execute_admit_mode(
+        request=request,
+        policy=policy,
+        policy_sha256=policy_sha256,
+        trace_id=trace_id,
+        recorded_at=recorded_at,
+        existing_plan=existing_record.plan,
+        transport=transport,
+        batch_candidate_store=batch_candidate_store,
+    )
+
+
+def read_merge_train_stack_collapse_plan_record(
+    *,
+    record_store: MergeTrainStackCollapsePlanRecordStore,
+    repository: str,
+    base_branch: str,
+    record_id: str,
+) -> MergeTrainStackCollapsePlanRecord:
+    records = record_store.list_merge_train_stack_collapse_plan_records(
+        repository=repository, base_branch=base_branch
+    )
+    for record in records:
+        if record.record_id == record_id:
+            return record
+    raise MergeTrainStackCollapsePlanRecordNotFoundError(
+        "merge train stack collapse plan record not found"
+    )
+
+
+def stack_collapse_expected_root_head_sha(plan: MergeTrainStackCollapsePlan) -> str:
+    for mutation in plan.mutations:
+        if mutation.parent_pull_request_number == plan.root_pull_request_number:
+            return mutation.merge_commit_sha or plan.root_initial_head_sha
+    return plan.root_initial_head_sha
+
+
+def _execute_admit_mode(
+    *,
+    request: MergeTrainStackCollapseRunOnceEnvelope,
+    policy: MergeTrainPolicy,
+    policy_sha256: str,
+    trace_id: str,
+    recorded_at: str,
+    existing_plan: MergeTrainStackCollapsePlan,
+    transport: MergeTrainGitHubTransport,
+    batch_candidate_store: MergeTrainBatchCandidateRecordStore | None,
+) -> MergeTrainStackCollapseRunOnceResult:
+    if batch_candidate_store is None:
+        raise MergeTrainStackCollapseBatchCandidateStoreMissingError(
+            "record store does not support merge train batch candidate records"
+        )
+    if existing_plan.status != "waiting_for_root_checks":
+        raise ValueError("merge train stack collapse plan is not ready for train admission")
+    if existing_plan.policy_sha256 != policy_sha256:
+        raise ValueError("merge train stack collapse policy digest no longer matches")
+    snapshot = GitHubMergeTrainSnapshotReader(transport=transport).read_merge_train_snapshot(
+        repository=request.repository,
+        base_branch=request.base_branch,
+    )
+    root_pull_request = next(
+        (
+            pull_request
+            for pull_request in snapshot.pull_requests
+            if pull_request.number == existing_plan.root_pull_request_number
+        ),
+        None,
+    )
+    if root_pull_request is None:
+        raise ValueError("merge train stack collapse root PR is missing")
+    if root_pull_request.head_sha != stack_collapse_expected_root_head_sha(existing_plan):
+        raise ValueError("merge train stack collapse root PR head no longer matches")
+    snapshot = snapshot.model_copy(update={"pull_requests": (root_pull_request,)})
+    dry_run_result = build_merge_train_dry_run_result(policy=policy, snapshot=snapshot)
+    candidate = build_merge_train_batch_candidate(
+        dry_run_result=dry_run_result,
+        base_sha=snapshot.base_sha,
+        policy_sha256=policy_sha256,
+        created_at=recorded_at,
+    )
+    candidate_record = build_merge_train_batch_candidate_record(
+        candidate=candidate,
+        source=f"service:stack-collapse-admit:{trace_id}",
+        updated_at=recorded_at,
+    )
+    batch_candidate_store.write_merge_train_batch_candidate_record(candidate_record)
+    return MergeTrainStackCollapseRunOnceResult(
+        accepted_result={
+            "mode": request.mode,
+            "dry_run_result": dry_run_result.model_dump(mode="json"),
+            "candidate": candidate.model_dump(mode="json"),
+        },
+        records={"merge_train_batch_candidate_record_id": candidate_record.record_id},
+    )

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -362,7 +362,6 @@ from control_plane.workflows.verireel_preview_driver import (
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _WHOLE_PRODUCT_CONTEXT = "*"
 _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/batch-landing/run-once"
-_MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/stack-collapse/run-once"
 _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE = "/v1/work-graph/merge-train/controller/run-once"
 _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET"
 _NATIVE_FASTAPI_DRIVER_ROUTE_PATHS = frozenset(
@@ -403,33 +402,6 @@ class MergeTrainBatchLandingRunOnceEnvelope(BaseModel):
             raise ValueError("landing plan mode requires candidate_record_id")
         if self.mode == "land" and not self.landing_plan_record_id:
             raise ValueError("landing land mode requires landing_plan_record_id")
-        return self
-
-
-class MergeTrainStackCollapseRunOnceEnvelope(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    schema_version: int = Field(default=1, ge=1)
-    repository: str
-    base_branch: str = "main"
-    mode: Literal["execute", "admit"] = "execute"
-    stack_collapse_plan_record_id: str
-    github_api_base_url: str = "https://api.github.com"
-
-    @model_validator(mode="after")
-    def _validate_envelope(self) -> "MergeTrainStackCollapseRunOnceEnvelope":
-        self.repository = self.repository.strip()
-        self.base_branch = self.base_branch.strip()
-        self.stack_collapse_plan_record_id = self.stack_collapse_plan_record_id.strip()
-        self.github_api_base_url = self.github_api_base_url.strip() or "https://api.github.com"
-        if not self.repository:
-            raise ValueError("merge train stack collapse requires repository")
-        if "/" not in self.repository:
-            raise ValueError("merge train repository must be owner/name")
-        if not self.base_branch:
-            raise ValueError("merge train stack collapse requires base_branch")
-        if not self.stack_collapse_plan_record_id:
-            raise ValueError("merge train stack collapse requires stack_collapse_plan_record_id")
         return self
 
 
@@ -3042,7 +3014,6 @@ def _build_write_routes() -> frozenset[str]:
     launchplane_write_routes = {
         _MERGE_TRAIN_BATCH_LANDING_RUN_ONCE_ROUTE,
         _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE,
-        _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE,
         "/v1/drivers/launchplane/self-deploy",
     }
     return frozenset(launchplane_write_routes | set(_driver_write_routes_from_descriptors()))
@@ -6243,157 +6214,6 @@ def create_launchplane_service_app(
                     driver_result.update(candidate_ref_cleanup_result)
                 if "stack_collapse_plan" in result:
                     driver_result["stack_collapse_plan"] = result["stack_collapse_plan"]
-            elif path == _MERGE_TRAIN_STACK_COLLAPSE_RUN_ONCE_ROUTE:
-                collapse_request = MergeTrainStackCollapseRunOnceEnvelope.model_validate(payload)
-                policy_record = resolve_merge_train_policy_record(record_store)
-                policy = policy_record.policy
-                repository_policy = policy.find_repository_policy(
-                    repository=collapse_request.repository,
-                    base_branch=collapse_request.base_branch,
-                )
-                if not authz_policy.allows(
-                    identity=identity,
-                    action=repository_policy.service_authz.action,
-                    product=repository_policy.service_authz.product,
-                    context=repository_policy.service_authz.context,
-                ):
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=403,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "authorization_denied",
-                                "message": "Workflow cannot run the requested merge train policy.",
-                            },
-                        },
-                    )
-                token_env = repository_policy.github_token.env_var
-                if not token_env:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "github_token_not_configured",
-                                "message": "Merge train policy does not define a GitHub token environment variable.",
-                            },
-                        },
-                    )
-                token = os.environ.get(token_env, "").strip()
-                if not token:
-                    return _json_response(
-                        start_response=start_response,
-                        status_code=503,
-                        payload={
-                            "status": "rejected",
-                            "trace_id": request_trace_id,
-                            "error": {
-                                "code": "github_token_not_configured",
-                                "message": "Configured merge train GitHub token is not available.",
-                            },
-                        },
-                    )
-                collapse_store = _merge_train_stack_collapse_plan_record_store(record_store)
-                collapse_existing_record = _read_merge_train_stack_collapse_plan_record(
-                    record_store=collapse_store,
-                    repository=collapse_request.repository,
-                    base_branch=collapse_request.base_branch,
-                    record_id=collapse_request.stack_collapse_plan_record_id,
-                )
-                recorded_at = _utc_now_timestamp()
-                transport = UrllibMergeTrainGitHubTransport(
-                    token=token,
-                    api_base_url=collapse_request.github_api_base_url,
-                )
-                if collapse_request.mode == "execute":
-                    executed_plan = execute_merge_train_stack_collapse_plan(
-                        plan=collapse_existing_record.plan,
-                        branch_client=GitHubMergeTrainClient(transport=transport),
-                        updated_at=recorded_at,
-                    )
-                    collapse_record = build_merge_train_stack_collapse_plan_record(
-                        plan=executed_plan,
-                        source=f"service:execute:{request_trace_id}",
-                        updated_at=recorded_at,
-                    )
-                    collapse_store.write_merge_train_stack_collapse_plan_record(collapse_record)
-                    result = {
-                        "merge_train_stack_collapse_plan_record_id": collapse_record.record_id,
-                        "repository": executed_plan.repository,
-                        "base_branch": executed_plan.base_branch,
-                        "mode": collapse_request.mode,
-                        "stack_collapse_plan": executed_plan.model_dump(mode="json"),
-                    }
-                    driver_result = {
-                        "mode": collapse_request.mode,
-                        "stack_collapse_plan": result["stack_collapse_plan"],
-                    }
-                else:
-                    stack_collapse_plan = collapse_existing_record.plan
-                    if stack_collapse_plan.status != "waiting_for_root_checks":
-                        raise ValueError(
-                            "merge train stack collapse plan is not ready for train admission"
-                        )
-                    if stack_collapse_plan.policy_sha256 != policy_record.policy_sha256:
-                        raise ValueError(
-                            "merge train stack collapse policy digest no longer matches"
-                        )
-                    snapshot = GitHubMergeTrainSnapshotReader(
-                        transport=transport
-                    ).read_merge_train_snapshot(
-                        repository=collapse_request.repository,
-                        base_branch=collapse_request.base_branch,
-                    )
-                    root_pull_request = next(
-                        (
-                            pull_request
-                            for pull_request in snapshot.pull_requests
-                            if pull_request.number == stack_collapse_plan.root_pull_request_number
-                        ),
-                        None,
-                    )
-                    if root_pull_request is None:
-                        raise ValueError("merge train stack collapse root PR is missing")
-                    if root_pull_request.head_sha != _stack_collapse_expected_root_head_sha(
-                        stack_collapse_plan
-                    ):
-                        raise ValueError(
-                            "merge train stack collapse root PR head no longer matches"
-                        )
-                    snapshot = snapshot.model_copy(update={"pull_requests": (root_pull_request,)})
-                    dry_run_result = build_merge_train_dry_run_result(
-                        policy=policy, snapshot=snapshot
-                    )
-                    candidate = build_merge_train_batch_candidate(
-                        dry_run_result=dry_run_result,
-                        base_sha=snapshot.base_sha,
-                        policy_sha256=policy_record.policy_sha256,
-                        created_at=recorded_at,
-                    )
-                    candidate_record = build_merge_train_batch_candidate_record(
-                        candidate=candidate,
-                        source=f"service:stack-collapse-admit:{request_trace_id}",
-                        updated_at=recorded_at,
-                    )
-                    _merge_train_batch_candidate_record_store(
-                        record_store
-                    ).write_merge_train_batch_candidate_record(candidate_record)
-                    result = {
-                        "merge_train_batch_candidate_record_id": candidate_record.record_id,
-                        "repository": candidate.repository,
-                        "base_branch": candidate.base_branch,
-                        "mode": collapse_request.mode,
-                        "candidate": candidate.model_dump(mode="json"),
-                    }
-                    driver_result = {
-                        "mode": collapse_request.mode,
-                        "dry_run_result": dry_run_result.model_dump(mode="json"),
-                        "candidate": result["candidate"],
-                    }
             elif path == _MERGE_TRAIN_CONTROLLER_RUN_ONCE_ROUTE:
                 controller_request = MergeTrainControllerRunOnceEnvelope.model_validate(payload)
                 policy_record = resolve_merge_train_policy_record(record_store)

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -120,11 +120,11 @@ Keep a compatibility surface only when it is one of these:
   dry-runs remain repeatable.
 - Merge-train admission, controller-status, and policy-target reads use native
   FastAPI routes. Their legacy WSGI read branches are deleted. Merge-train
-  run-once, batch-candidate run-once, and PR feedback also use native FastAPI
-  write routes. The batch-candidate legacy WSGI branch is deleted and direct
-  fallback calls fail closed; controller mutation, batch landing, and
-  stack-collapse phase runner routes remain on the retained fallback until their
-  native write replacements land.
+  run-once, batch-candidate run-once, stack-collapse run-once, and PR feedback
+  also use native FastAPI write routes. The batch-candidate and stack-collapse
+  legacy WSGI branches are deleted and direct fallback calls fail closed;
+  controller mutation and batch landing remain on the retained fallback until
+  their native write replacements land.
 - Work graph snapshot, work-graph rank, GitHub issue-inbox reads, and GitHub
   issue-inbox reconcile use native FastAPI routes. Their legacy WSGI
   read/rank/reconcile branches and WSGI-only helpers are deleted.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -274,6 +274,7 @@ VeriReel product paths:
   - `POST /v1/work-graph/github/issues/reconcile` (native FastAPI)
   - `POST /v1/work-graph/merge-train/run-once` (native FastAPI)
   - `POST /v1/work-graph/merge-train/batch-candidate/run-once` (native FastAPI)
+  - `POST /v1/work-graph/merge-train/stack-collapse/run-once` (native FastAPI)
   - `POST /v1/work-graph/merge-train/pr-feedback` (native FastAPI)
   - `POST /v1/work-graph/merge-train/controller/run-once`
 - product driver routes:
@@ -599,6 +600,17 @@ whether the candidate is still pending, passed, or failed. The legacy WSGI
 fallback branch is deleted, and direct fallback calls fail closed. The route
 never lands original PRs; PR-native landing remains a later phase with separate
 records and pre-merge invariants.
+
+`POST /v1/work-graph/merge-train/stack-collapse/run-once` executes one
+policy-backed stack-collapse phase for a requested repository/base branch. The
+native FastAPI route accepts `mode: execute` with an existing stack-collapse plan
+record id, merges supported stack children into the root PR, and persists a
+waiting-for-root-checks stack-collapse plan record. `mode: admit` requires that
+executed record, verifies the active policy digest and the root PR head against
+fresh GitHub evidence, then writes a root-only batch-candidate record for the
+normal candidate build/observe/landing phases. The legacy WSGI fallback branch
+is deleted, direct fallback calls fail closed, and accepted calls support
+optional `Idempotency-Key` replay/conflict handling.
 
 `POST /v1/work-graph/merge-train/batch-landing/run-once` executes one
 policy-backed batch-landing phase for a requested repository/base branch. The

--- a/tests/test_http_app.py
+++ b/tests/test_http_app.py
@@ -53,6 +53,10 @@ from control_plane.contracts.merge_train_policy import (
     MergeTrainPolicyRecord,
     parse_merge_train_policy_toml,
 )
+from control_plane.contracts.merge_train_stack_collapse import (
+    build_merge_train_stack_collapse_plan_record,
+    execute_merge_train_stack_collapse_plan,
+)
 from control_plane.merge_train import MergeTrainDryRunSnapshot
 from control_plane.merge_train_github import MergeTrainGitHubError, MergeTrainGitHubStaleHeadError
 from control_plane.contracts.odoo_stable_bootstrap_operation import (
@@ -160,8 +164,10 @@ from tests.test_service import (
     _generic_site_profile_payload,
     _edge_endpoint_apply_payload,
     _edge_endpoint_record,
+    _FakeCollapsedRootStackedMergeTrainSnapshotReader,
     _FakeMergeTrainGitHubClient,
     _FakeMergeTrainSnapshotReader,
+    _FakeMovedRootStackedMergeTrainSnapshotReader,
     _FakeStackedMergeTrainSnapshotReader,
     _identity,
     _ingress_canary_route_record,
@@ -182,6 +188,7 @@ from tests.test_service import (
     _product_config_payload,
     _product_config_secrets,
     _seed_merge_train_policy,
+    _seed_merge_train_stack_collapse_plan_record,
     _seed_tracked_target_records,
     _sqlite_database_url,
     _write_runtime_key_safety_policy,
@@ -5530,6 +5537,482 @@ class _UnavailableBatchCandidateMergeTrainGitHubClient(_FakeMergeTrainGitHubClie
 class _UnexpectedBatchCandidateMergeTrainGitHubClient(_FakeMergeTrainGitHubClient):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         raise AssertionError("batch candidate plan mode should not create a GitHub client")
+
+
+class _StackCollapseWithoutBatchCandidateStore:
+    backend_name = "test-stack-collapse-without-batch-candidate"
+
+    def __init__(self, *, state_dir: Path) -> None:
+        self.delegate = FilesystemRecordStore(state_dir=state_dir)
+
+    def close(self) -> None:
+        return None
+
+    def read_idempotency_record(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+    ) -> Any:
+        return self.delegate.read_idempotency_record(
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+        )
+
+    def write_idempotency_record(self, record: LaunchplaneIdempotencyRecord) -> object:
+        return self.delegate.write_idempotency_record(record)
+
+    def list_merge_train_policy_records(
+        self, *, status: str = "", limit: int | None = None
+    ) -> tuple[MergeTrainPolicyRecord, ...]:
+        return self.delegate.list_merge_train_policy_records(status=status, limit=limit)
+
+    def write_merge_train_stack_collapse_plan_record(self, record: Any) -> object:
+        return self.delegate.write_merge_train_stack_collapse_plan_record(record)
+
+    def list_merge_train_stack_collapse_plan_records(
+        self,
+        *,
+        repository: str = "",
+        base_branch: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[Any, ...]:
+        return self.delegate.list_merge_train_stack_collapse_plan_records(
+            repository=repository,
+            base_branch=base_branch,
+            status=status,
+            limit=limit,
+        )
+
+
+class FastApiMergeTrainStackCollapseRunOnceTests(unittest.IsolatedAsyncioTestCase):
+    async def test_executes_existing_plan_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainClient",
+                _FakeMergeTrainGitHubClient,
+            ):
+                response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            payload = response.json()
+            executed_record_id = payload["records"]["merge_train_stack_collapse_plan_record_id"]
+            executed_records = store.list_merge_train_stack_collapse_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+            executed_record = next(
+                record for record in executed_records if record.record_id == executed_record_id
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "execute")
+        self.assertEqual(
+            payload["result"]["stack_collapse_plan"]["status"], "waiting_for_root_checks"
+        )
+        self.assertEqual(
+            payload["result"]["stack_collapse_plan"]["mutations"][0]["status"], "mutated"
+        )
+        self.assertEqual(
+            payload["result"]["stack_collapse_plan"]["mutations"][0]["merge_commit_sha"],
+            "stack-merge-2-into-1",
+        )
+        self.assertEqual(executed_record.plan.status, "waiting_for_root_checks")
+
+    async def test_admits_executed_root_only(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainClient",
+                _FakeMergeTrainGitHubClient,
+            ):
+                execute_response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            executed_record_id = execute_response.json()["records"][
+                "merge_train_stack_collapse_plan_record_id"
+            ]
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainSnapshotReader",
+                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
+            ):
+                response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "admit",
+                        "stack_collapse_plan_record_id": executed_record_id,
+                    },
+                )
+            payload = response.json()
+            candidate_record_id = payload["records"]["merge_train_batch_candidate_record_id"]
+            candidate_records = store.list_merge_train_batch_candidate_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(payload["result"]["mode"], "admit")
+        self.assertEqual(payload["result"]["candidate"]["entries"][0]["pull_request_number"], 1)
+        self.assertEqual(len(payload["result"]["candidate"]["entries"]), 1)
+        candidate_record = next(
+            record for record in candidate_records if record.record_id == candidate_record_id
+        )
+        self.assertEqual(candidate_record.candidate.entries[0].pull_request_number, 1)
+
+    async def test_rejects_admit_when_root_head_moves(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainClient",
+                _FakeMergeTrainGitHubClient,
+            ):
+                execute_response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainSnapshotReader",
+                _FakeMovedRootStackedMergeTrainSnapshotReader,
+            ):
+                response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "admit",
+                        "stack_collapse_plan_record_id": execute_response.json()["records"][
+                            "merge_train_stack_collapse_plan_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        self.assertEqual(response.json()["error"]["message"], "Request could not be completed.")
+
+    async def test_rejects_admit_when_policy_digest_changes(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainClient",
+                _FakeMergeTrainGitHubClient,
+            ):
+                execute_response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+            _seed_merge_train_policy(
+                state_dir,
+                policy=MergeTrainPolicyRecord(
+                    record_id="merge-train-policy-20260513T220000Z-test",
+                    status="active",
+                    source="test",
+                    updated_at="2026-05-13T22:00:00Z",
+                    policy=build_test_merge_train_policy_with_codex_skills(),
+                ),
+            )
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainSnapshotReader",
+                _FakeStackedMergeTrainSnapshotReader,
+            ):
+                response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "admit",
+                        "stack_collapse_plan_record_id": execute_response.json()["records"][
+                            "merge_train_stack_collapse_plan_record_id"
+                        ],
+                    },
+                )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        self.assertEqual(response.json()["error"]["message"], "Request could not be completed.")
+
+    async def test_replays_idempotent_execute_without_reexecuting_stack(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
+            request_payload = {
+                "schema_version": 1,
+                "repository": "cbusillo/sellyouroutboard",
+                "base_branch": "main",
+                "mode": "execute",
+                "stack_collapse_plan_record_id": plan_record_id,
+            }
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainClient",
+                _FakeMergeTrainGitHubClient,
+            ):
+                first_response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    request_payload,
+                    idempotency_key="merge-train-stack-collapse-execute",
+                )
+                replay_response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    request_payload,
+                    idempotency_key="merge-train-stack-collapse-execute",
+                )
+            stack_records = store.list_merge_train_stack_collapse_plan_records(
+                repository="cbusillo/sellyouroutboard", base_branch="main"
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        self.assertTrue(replay_response.json()["replayed"])
+        self.assertEqual(len(stack_records), 2)
+
+    async def test_rejects_missing_stack_collapse_storage(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            store = _MergeTrainPolicyOnlyStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            response = await _post_merge_train_stack_collapse_run_once(
+                app,
+                {
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mode": "execute",
+                    "stack_collapse_plan_record_id": "missing-stack-collapse-plan",
+                },
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+
+    async def test_rejects_missing_batch_candidate_storage_for_admit(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
+            full_store = FilesystemRecordStore(state_dir=state_dir)
+            executed_record = execute_merge_train_stack_collapse_plan(
+                plan=next(
+                    record
+                    for record in full_store.list_merge_train_stack_collapse_plan_records(
+                        repository="cbusillo/sellyouroutboard", base_branch="main"
+                    )
+                    if record.record_id == plan_record_id
+                ).plan,
+                branch_client=_FakeMergeTrainGitHubClient(transport=object()),
+                updated_at="2026-05-13T21:02:00Z",
+            )
+            executed_plan_record = build_merge_train_stack_collapse_plan_record(
+                plan=executed_record,
+                source="test:execute",
+                updated_at="2026-05-13T21:02:00Z",
+            )
+            full_store.write_merge_train_stack_collapse_plan_record(executed_plan_record)
+            store = _StackCollapseWithoutBatchCandidateStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            response = await _post_merge_train_stack_collapse_run_once(
+                app,
+                {
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mode": "admit",
+                    "stack_collapse_plan_record_id": executed_plan_record.record_id,
+                },
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
+        self.assertEqual(
+            response.json()["error"]["message"],
+            "Merge train stack collapse admission requires database-backed candidate records.",
+        )
+
+    async def test_fastapi_route_precedes_legacy_wsgi_fallback(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
+        ):
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                record_store_factory=lambda: store,
+            )
+            legacy_app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_RejectingVerifier(),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+                local_record_store_for_tests=store,
+            )
+            app.mount("/", cast(ASGIApp, WSGIMiddleware(cast(Any, legacy_app))))
+            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
+            with patch(
+                "control_plane.merge_train_stack_collapse.GitHubMergeTrainClient",
+                _FakeMergeTrainGitHubClient,
+            ):
+                response = await _post_merge_train_stack_collapse_run_once(
+                    app,
+                    {
+                        "schema_version": 1,
+                        "repository": "cbusillo/sellyouroutboard",
+                        "base_branch": "main",
+                        "mode": "execute",
+                        "stack_collapse_plan_record_id": plan_record_id,
+                    },
+                )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["result"]["mode"], "execute")
+
+    async def test_wsgi_fallback_no_longer_serves_route(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            _seed_merge_train_policy(state_dir)
+            app = create_launchplane_service_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(_merge_train_service_identity()),
+                authz_policy=_merge_train_service_policy(),
+                control_plane_root_path=Path(temporary_directory_name),
+            )
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/work-graph/merge-train/stack-collapse/run-once",
+                payload={
+                    "schema_version": 1,
+                    "repository": "cbusillo/sellyouroutboard",
+                    "base_branch": "main",
+                    "mode": "execute",
+                    "stack_collapse_plan_record_id": "missing-stack-collapse-plan",
+                },
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    async def test_openapi_includes_stack_collapse_contract(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_merge_train_service_identity()),
+            authz_policy=_merge_train_service_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _asgi_get(app, "/openapi.json")
+
+        self.assertEqual(response.status_code, 200)
+        route = response.json()["paths"]["/v1/work-graph/merge-train/stack-collapse/run-once"][
+            "post"
+        ]
+        success_schema = route["responses"]["202"]["content"]["application/json"]["schema"]
+        request_schema = route["requestBody"]["content"]["application/json"]["schema"]
+        self.assertEqual(success_schema["$ref"], "#/components/schemas/AcceptedEvidenceResponse")
+        self.assertEqual(request_schema["title"], "MergeTrainStackCollapseRunOnceEnvelope")
+        self.assertTrue(set(route["responses"]) >= {"400", "401", "403", "409", "502", "503"})
 
 
 class FastApiMergeTrainRunOnceTests(unittest.IsolatedAsyncioTestCase):
@@ -22905,6 +23388,25 @@ async def _post_merge_train_batch_candidate_run_once(
         app,
         "POST",
         "/v1/work-graph/merge-train/batch-candidate/run-once",
+        headers=headers,
+        payload=payload,
+    )
+
+
+async def _post_merge_train_stack_collapse_run_once(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+) -> _AsgiResponse:
+    headers = {"Authorization": authorization} if authorization else {}
+    if idempotency_key:
+        headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/work-graph/merge-train/stack-collapse/run-once",
         headers=headers,
         payload=payload,
     )

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -69,6 +69,7 @@ from control_plane.merge_train_github import MergeTrainGitHubStaleHeadError
 from control_plane.contracts.merge_train_stack_collapse import (
     build_merge_train_stack_collapse_plan,
     build_merge_train_stack_collapse_plan_record,
+    execute_merge_train_stack_collapse_plan,
 )
 from control_plane.contracts.odoo_instance_override_record import OdooConfigParameterOverride
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
@@ -1168,6 +1169,87 @@ def _seed_merge_train_stack_collapse_plan_record(
     )
     FilesystemRecordStore(state_dir).write_merge_train_stack_collapse_plan_record(record)
     return record.record_id
+
+
+def _seed_executed_merge_train_stack_collapse_plan_record(
+    state_dir: Path,
+    *,
+    policy: MergeTrainPolicy | None = None,
+    snapshot_reader: type[
+        _FakeStackedMergeTrainSnapshotReader
+    ] = _FakeStackedMergeTrainSnapshotReader,
+) -> str:
+    planned_record_id = _seed_merge_train_stack_collapse_plan_record(
+        state_dir,
+        policy=policy,
+        snapshot_reader=snapshot_reader,
+    )
+    store = FilesystemRecordStore(state_dir)
+    planned_record = next(
+        record
+        for record in store.list_merge_train_stack_collapse_plan_records(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+        if record.record_id == planned_record_id
+    )
+    executed_plan = execute_merge_train_stack_collapse_plan(
+        plan=planned_record.plan,
+        branch_client=_FakeMergeTrainGitHubClient(transport=object()),
+        updated_at="2026-05-13T21:02:00Z",
+    )
+    executed_record = build_merge_train_stack_collapse_plan_record(
+        plan=executed_plan,
+        source="test:execute",
+        updated_at="2026-05-13T21:02:00Z",
+    )
+    store.write_merge_train_stack_collapse_plan_record(executed_record)
+    return executed_record.record_id
+
+
+def _seed_admitted_merge_train_stack_collapse_candidate(
+    state_dir: Path,
+    *,
+    executed_record_id: str,
+    policy: MergeTrainPolicy | None = None,
+    snapshot_reader: type[
+        _FakeStackedMergeTrainSnapshotReader
+    ] = _FakeCollapsedRootStackedMergeTrainSnapshotReader,
+) -> MergeTrainBatchCandidateRecord:
+    merge_train_policy = policy or build_test_merge_train_policy()
+    store = FilesystemRecordStore(state_dir)
+    executed_record = next(
+        record
+        for record in store.list_merge_train_stack_collapse_plan_records(
+            repository="cbusillo/sellyouroutboard", base_branch="main"
+        )
+        if record.record_id == executed_record_id
+    )
+    snapshot = snapshot_reader(transport=object()).read_merge_train_snapshot(
+        repository="cbusillo/sellyouroutboard",
+        base_branch="main",
+    )
+    root_pull_request = next(
+        pull_request
+        for pull_request in snapshot.pull_requests
+        if pull_request.number == executed_record.plan.root_pull_request_number
+    )
+    dry_run_result = build_merge_train_dry_run_result(
+        policy=merge_train_policy,
+        snapshot=snapshot.model_copy(update={"pull_requests": (root_pull_request,)}),
+    )
+    candidate = build_merge_train_batch_candidate(
+        dry_run_result=dry_run_result,
+        base_sha=snapshot.base_sha,
+        policy_sha256=merge_train_policy.policy_sha256,
+        created_at="2026-05-13T21:03:00Z",
+    )
+    candidate_record = build_merge_train_batch_candidate_record(
+        candidate=candidate,
+        source="test:stack-collapse-admit",
+        updated_at="2026-05-13T21:03:00Z",
+    )
+    store.write_merge_train_batch_candidate_record(candidate_record)
+    return candidate_record
 
 
 def _identity(
@@ -4772,228 +4854,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "merge_train_controller_invalid_state")
         self.assertIn("merge train repository must be owner/name", payload["error"]["message"])
 
-    def test_merge_train_stack_collapse_service_executes_existing_plan_record(self) -> None:
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            _seed_merge_train_policy(state_dir)
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_merge_train_service_identity()),
-                authz_policy=_merge_train_service_policy(),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "stack_collapse_plan_record_id": plan_record_id,
-                    },
-                )
-            executed_record_id = payload["records"]["merge_train_stack_collapse_plan_record_id"]
-            executed_records = FilesystemRecordStore(
-                state_dir
-            ).list_merge_train_stack_collapse_plan_records(
-                repository="cbusillo/sellyouroutboard", base_branch="main"
-            )
-            executed_record = next(
-                record for record in executed_records if record.record_id == executed_record_id
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["mode"], "execute")
-        self.assertEqual(
-            payload["result"]["stack_collapse_plan"]["status"], "waiting_for_root_checks"
-        )
-        self.assertEqual(
-            payload["result"]["stack_collapse_plan"]["mutations"][0]["status"], "mutated"
-        )
-        self.assertEqual(
-            payload["result"]["stack_collapse_plan"]["mutations"][0]["merge_commit_sha"],
-            "stack-merge-2-into-1",
-        )
-        self.assertEqual(executed_record.plan.status, "waiting_for_root_checks")
-
-    def test_merge_train_stack_collapse_service_admits_executed_root_only(self) -> None:
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            _seed_merge_train_policy(state_dir)
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_merge_train_service_identity()),
-                authz_policy=_merge_train_service_policy(),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, execute_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "execute",
-                        "stack_collapse_plan_record_id": plan_record_id,
-                    },
-                )
-            executed_record_id = execute_payload["records"][
-                "merge_train_stack_collapse_plan_record_id"
-            ]
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
-            ):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "admit",
-                        "stack_collapse_plan_record_id": executed_record_id,
-                    },
-                )
-            candidate_record_id = payload["records"]["merge_train_batch_candidate_record_id"]
-            candidate_records = FilesystemRecordStore(
-                state_dir
-            ).list_merge_train_batch_candidate_records(
-                repository="cbusillo/sellyouroutboard", base_branch="main"
-            )
-
-        self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["mode"], "admit")
-        self.assertEqual(payload["result"]["candidate"]["entries"][0]["pull_request_number"], 1)
-        self.assertEqual(len(payload["result"]["candidate"]["entries"]), 1)
-        candidate_record = next(
-            record for record in candidate_records if record.record_id == candidate_record_id
-        )
-        self.assertEqual(candidate_record.candidate.entries[0].pull_request_number, 1)
-
-    def test_merge_train_stack_collapse_service_rejects_admit_when_root_head_moves(self) -> None:
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            _seed_merge_train_policy(state_dir)
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_merge_train_service_identity()),
-                authz_policy=_merge_train_service_policy(),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, execute_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "execute",
-                        "stack_collapse_plan_record_id": plan_record_id,
-                    },
-                )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeMovedRootStackedMergeTrainSnapshotReader,
-            ):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "admit",
-                        "stack_collapse_plan_record_id": execute_payload["records"][
-                            "merge_train_stack_collapse_plan_record_id"
-                        ],
-                    },
-                )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_request")
-
-    def test_merge_train_stack_collapse_service_rejects_admit_when_policy_digest_changes(
-        self,
-    ) -> None:
-        with (
-            TemporaryDirectory() as temporary_directory_name,
-            patch.dict("os.environ", {"GH_TOKEN": "token"}, clear=True),
-        ):
-            state_dir = Path(temporary_directory_name) / "state"
-            _seed_merge_train_policy(state_dir)
-            app = create_launchplane_service_app(
-                state_dir=state_dir,
-                verifier=_StubVerifier(_merge_train_service_identity()),
-                authz_policy=_merge_train_service_policy(),
-                control_plane_root_path=Path(temporary_directory_name),
-            )
-            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, execute_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "execute",
-                        "stack_collapse_plan_record_id": plan_record_id,
-                    },
-                )
-            _seed_merge_train_policy(
-                state_dir,
-                policy=MergeTrainPolicyRecord(
-                    record_id="merge-train-policy-20260513T220000Z-test",
-                    status="active",
-                    source="test",
-                    updated_at="2026-05-13T22:00:00Z",
-                    policy=build_test_merge_train_policy_with_codex_skills(),
-                ),
-            )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeStackedMergeTrainSnapshotReader,
-            ):
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "admit",
-                        "stack_collapse_plan_record_id": execute_payload["records"][
-                            "merge_train_stack_collapse_plan_record_id"
-                        ],
-                    },
-                )
-
-        self.assertEqual(status_code, 400)
-        self.assertEqual(payload["error"]["code"], "invalid_request")
-
     def test_merge_train_batch_landing_service_plans_from_passed_candidate(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -5267,42 +5127,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, execute_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "execute",
-                        "stack_collapse_plan_record_id": plan_record_id,
-                    },
-                )
-            executed_record_id = execute_payload["records"][
-                "merge_train_stack_collapse_plan_record_id"
-            ]
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
-            ):
-                _, admit_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "admit",
-                        "stack_collapse_plan_record_id": executed_record_id,
-                    },
-                )
+            executed_record_id = _seed_executed_merge_train_stack_collapse_plan_record(state_dir)
+            admitted_candidate_record = _seed_admitted_merge_train_stack_collapse_candidate(
+                state_dir,
+                executed_record_id=executed_record_id,
+            )
             passed_candidate_record = _mark_merge_train_batch_candidate_record_passed(
                 state_dir,
-                record_id=admit_payload["records"]["merge_train_batch_candidate_record_id"],
+                record_id=admitted_candidate_record.record_id,
             )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, landing_plan_payload = _invoke_app(
@@ -5369,42 +5201,14 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, execute_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "execute",
-                        "stack_collapse_plan_record_id": plan_record_id,
-                    },
-                )
-            executed_record_id = execute_payload["records"][
-                "merge_train_stack_collapse_plan_record_id"
-            ]
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
-            ):
-                _, admit_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "admit",
-                        "stack_collapse_plan_record_id": executed_record_id,
-                    },
-                )
+            executed_record_id = _seed_executed_merge_train_stack_collapse_plan_record(state_dir)
+            admitted_candidate_record = _seed_admitted_merge_train_stack_collapse_candidate(
+                state_dir,
+                executed_record_id=executed_record_id,
+            )
             passed_candidate_record = _mark_merge_train_batch_candidate_record_passed(
                 state_dir,
-                record_id=admit_payload["records"]["merge_train_batch_candidate_record_id"],
+                record_id=admitted_candidate_record.record_id,
             )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, landing_plan_payload = _invoke_app(
@@ -5474,43 +5278,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            plan_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, execute_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "execute",
-                        "stack_collapse_plan_record_id": plan_record_id,
-                    },
-                )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
-            ):
-                _, admit_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "admit",
-                        "stack_collapse_plan_record_id": execute_payload["records"][
-                            "merge_train_stack_collapse_plan_record_id"
-                        ],
-                    },
-                )
-            stale_stack_record_id = plan_record_id
+            stale_stack_record_id = _seed_merge_train_stack_collapse_plan_record(state_dir)
+            executed_record_id = _seed_executed_merge_train_stack_collapse_plan_record(state_dir)
+            admitted_candidate_record = _seed_admitted_merge_train_stack_collapse_candidate(
+                state_dir,
+                executed_record_id=executed_record_id,
+            )
             _FakeMergeTrainGitHubClient.land_batch_candidate_calls = 0
             passed_candidate_record = _mark_merge_train_batch_candidate_record_passed(
                 state_dir,
-                record_id=admit_payload["records"]["merge_train_batch_candidate_record_id"],
+                record_id=admitted_candidate_record.record_id,
             )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, landing_plan_payload = _invoke_app(
@@ -5598,45 +5375,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 authz_policy=_merge_train_service_policy(),
                 control_plane_root_path=Path(temporary_directory_name),
             )
-            plan_record_id = _seed_merge_train_stack_collapse_plan_record(
+            executed_record_id = _seed_executed_merge_train_stack_collapse_plan_record(
                 state_dir,
                 policy=policy_without_stack_child_label,
             )
-            with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
-                _, execute_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "execute",
-                        "stack_collapse_plan_record_id": plan_record_id,
-                    },
-                )
-            with patch(
-                "control_plane.service.GitHubMergeTrainSnapshotReader",
-                _FakeCollapsedRootStackedMergeTrainSnapshotReader,
-            ):
-                _, admit_payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/work-graph/merge-train/stack-collapse/run-once",
-                    payload={
-                        "schema_version": 1,
-                        "repository": "cbusillo/sellyouroutboard",
-                        "base_branch": "main",
-                        "mode": "admit",
-                        "stack_collapse_plan_record_id": execute_payload["records"][
-                            "merge_train_stack_collapse_plan_record_id"
-                        ],
-                    },
-                )
+            admitted_candidate_record = _seed_admitted_merge_train_stack_collapse_candidate(
+                state_dir,
+                executed_record_id=executed_record_id,
+                policy=policy_without_stack_child_label,
+            )
             _FakeMergeTrainGitHubClient.land_batch_candidate_calls = 0
             passed_candidate_record = _mark_merge_train_batch_candidate_record_passed(
                 state_dir,
-                record_id=admit_payload["records"]["merge_train_batch_candidate_record_id"],
+                record_id=admitted_candidate_record.record_id,
             )
             with patch("control_plane.service.GitHubMergeTrainClient", _FakeMergeTrainGitHubClient):
                 _, landing_plan_payload = _invoke_app(
@@ -5663,9 +5414,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "landing_plan_record_id": landing_plan_payload["records"][
                             "merge_train_batch_landing_plan_record_id"
                         ],
-                        "stack_collapse_plan_record_id": execute_payload["records"][
-                            "merge_train_stack_collapse_plan_record_id"
-                        ],
+                        "stack_collapse_plan_record_id": executed_record_id,
                     },
                 )
 


### PR DESCRIPTION
## Summary

- Move `POST /v1/work-graph/merge-train/stack-collapse/run-once` to native FastAPI with explicit execute/admit orchestration and idempotency handling.
- Retire the legacy WSGI stack-collapse route branch and port route parity coverage to FastAPI tests, including fallback fail-closed checks.
- Decouple remaining batch-landing WSGI tests from the retired route by seeding stack-collapse records directly.
- Update v2 service-boundary and compatibility-retirement docs for current route ownership.

## Validation

- `uv run python -m unittest tests.test_http_app.FastApiMergeTrainStackCollapseRunOnceTests -q`
- `uv run python -m unittest tests.test_http_app.FastApiMergeTrainStackCollapseRunOnceTests tests.test_http_app.FastApiMergeTrainBatchCandidateRunOnceTests tests.test_http_app.FastApiMergeTrainRunOnceTests tests.test_http_app.FastApiMergeTrainPrFeedbackTests -q`
- `uv run python -m unittest tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_closes_stack_children_after_root_lands tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_persists_root_merge_before_child_record_failure tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_validates_stack_before_root_merge tests.test_service.LaunchplaneServiceTests.test_merge_train_batch_landing_service_requires_stack_child_policy_before_root_merge -q`
- `uv run --extra dev ruff check .`
- `uv run --extra dev mypy control_plane tests`
- `ulimit -n 4096 && uv run python -m unittest -q` (2,990 tests, passed)
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "$PWD" --scope changed_files --timeout-ms 900000` (GREEN)

## Review

- Antigravity/Gemini review: no findings.
- Claude review: requested explicit admit-mode missing batch-candidate storage coverage; addressed with a named domain exception and FastAPI 503 test.
