### PR TITLE
Show unittest shard plan in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-python-3.13-unittest-timings-
 
+      - name: Show unit test shard plan
+        run: >-
+          uv run launchplane ci unittest-shard plan
+          --shard-count 6
+          --timings-file "${RUNNER_TEMP}/unittest-timings/history.json"
+
       - name: Run unit test shard
         run: >-
           uv run launchplane ci unittest-shard run


### PR DESCRIPTION
## Summary
- prints the unittest shard plan before each CI test shard runs
- uses the same shard count and timing history path as the actual shard run
- keeps test behavior unchanged while making timing-cache quality visible in logs

## Plan Alignment
Refs #1457.

This is the next evidence-first step after landing the cache/shard/HTTP-app split stack. The latest timing artifacts show the timing-aware planner can rebalance shards closely once history is available, while the post-merge main run still shows runner queue/start delay. This PR makes future CI runs show the exact plan each shard used so we can distinguish cold/stale timings, true module imbalance, and runner availability before doing another refactor.

## Validation
- `uv run launchplane ci unittest-shard plan --shard-count 6 --timings-file /tmp/launchplane-does-not-exist/history.json`
- `actionlint .github/workflows/ci.yml`
- simulated #1463 timing artifact plan: six shards estimated at ~189s each
- two read-only review agents found no issues
