### PR TITLE
Fix unittest timing cache keys

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,8 +250,10 @@ jobs:
         with:
           path: ${{ runner.temp }}/unittest-timings/history.json
           key: >-
-            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: |
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-
             ${{ runner.os }}-python-3.13-unittest-timings-
 
       - name: Show unit test shard plan
@@ -324,7 +326,7 @@ jobs:
         with:
           path: ${{ runner.temp }}/unittest-timings/history.json
           key: >-
-            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
 
   test_fork:
     if: >-


### PR DESCRIPTION
## Summary

- make unittest timing cache restore use the same attempt-aware key shape as save
- add restore fallbacks for same workflow run, same branch, then broad unittest timing history
- include `github.run_attempt` in the save key so reruns can publish fresh timing history instead of colliding on the first attempt cache key

## Why

Refs #1457.

CI run `27990441819` attempt 4 showed the cache issue directly:

- `Restore unittest timings` reported no cache found for `Linux-python-3.13-unittest-timings-main` / broad prefix.
- `Save unittest timings` tried to save `Linux-python-3.13-unittest-timings-main-27990441819` and failed with `Unable to reserve cache...`, because rerun attempts reused the same immutable cache key.
- The fresh attempt-4 artifacts produced a balanced next shard plan locally at about `192.6s` per shard, so the shard planner is learning correctly once it receives current timings.

This keeps the current shard count and runner lane topology unchanged. It is the next #1457 step after proving lane 5 only reduced wall clock by roughly five seconds.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `uv run python -m unittest tests.test_unittest_sharding tests.test_ci_unittest_cli`
- read-only agent review: no blockers
