### PR TITLE
Run unittest timing aggregation on self-hosted lanes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,7 +287,9 @@ jobs:
       always() &&
       (github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository)
-    runs-on: ubuntu-latest
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     env:
       UNITTEST_TIMINGS_CACHE: .ci-cache/unittest-timings/history.json
     steps:


### PR DESCRIPTION
## Summary

- run the aggregate `test` job on the same self-hosted runner class as `test_shards`
- keep the `.ci-cache/unittest-timings/history.json` cache path from #1466

## Why

Refs #1457.

#1465 fixed immutable cache key collisions. #1466 moved the shared history file to a stable relative path and successfully saved new caches, but live proof still showed self-hosted shard restores missing caches saved by the GitHub-hosted aggregate job.

Evidence from main CI run `27995359812`:

- attempt 1 saved `Linux-python-3.13-unittest-timings-main-27995359812-1` with path `.ci-cache/unittest-timings/history.json`
- attempt 2 and delayed attempt 3 still logged `Cache not found` from self-hosted shard restore with restore key prefix `Linux-python-3.13-unittest-timings-main-27995359812-`
- cache API showed the saved caches existed, so the remaining mismatch is runner-environment/cache-version visibility rather than key spelling

The aggregate job only downloads shard artifacts, aggregates JSON, and saves a tiny cache. Running it on the same self-hosted runner class as the shard restore jobs is the smallest robust way to keep cache restore/save in the same runner environment.

## Validation

- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- `uv run python -m unittest tests.test_unittest_sharding tests.test_ci_unittest_cli`
- read-only agents recommended this as the next repair after #1466 proof misses
