### PR TITLE
Balance unittest shards by target

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -35,7 +35,8 @@
       "default": "uv run python -m unittest",
       "targeted": "uv run python -m unittest {modules}",
       "shardPlan": "uv run launchplane ci unittest-shard plan --shard-count {shard_count}",
-      "shardRun": "uv run launchplane ci unittest-shard run --shard-count {shard_count} --shard-index {shard_index} --timings-output {timings_output}"
+      "shardRun": "uv run launchplane ci unittest-shard run --shard-count {shard_count} --shard-index {shard_index} --timings-output {timings_output}",
+      "shardGranularity": "whole modules by default; large modules may split into unittest target IDs"
     },
     "lint": {
       "default": "uv run --extra dev ruff check .",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,6 +305,17 @@ jobs:
       - name: Install Python
         run: uv python install 3.13
 
+      - name: Restore unittest timings
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.UNITTEST_TIMINGS_CACHE }}
+          key: >-
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-
+            ${{ runner.os }}-python-3.13-unittest-timings-
+
       - name: Require successful test shards
         run: |
           if [ "${{ needs.test_shards.result }}" != "success" ]; then
@@ -324,6 +335,7 @@ jobs:
           uv run launchplane ci unittest-shard aggregate
           --shard-count 6
           --results-dir "${RUNNER_TEMP}/unittest-timings"
+          --timings-file "${UNITTEST_TIMINGS_CACHE}"
           --timings-output "${UNITTEST_TIMINGS_CACHE}"
 
       - name: Save unittest timings

--- a/control_plane/cli_ci.py
+++ b/control_plane/cli_ci.py
@@ -10,6 +10,7 @@ from control_plane.unittest_sharding import (
     UnittestShardingError,
     aggregate_shard_timings,
     discover_test_modules,
+    discover_test_targets,
     plan_shards,
     read_module_timings,
     run_test_modules,
@@ -64,16 +65,34 @@ def list_unittest_modules(start_directory: Path, pattern: str) -> None:
     show_default=True,
 )
 @click.option("--pattern", default="test*.py", show_default=True)
+@click.option("--max-tests-per-target", type=int, default=100, show_default=True)
+@click.option("--max-seconds-per-target", type=float, default=60.0, show_default=True)
+@click.option(
+    "--import-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("."),
+    show_default=True,
+)
 def plan_unittest_shards(
     shard_count: int,
     timings_file: Path | None,
     start_directory: Path,
     pattern: str,
+    max_tests_per_target: int,
+    max_seconds_per_target: float,
+    import_root: Path,
 ) -> None:
     """Print a deterministic unittest shard plan."""
     try:
-        modules = discover_test_modules(start_directory=start_directory, pattern=pattern)
         timings = read_module_timings(timings_file)
+        modules = discover_test_targets(
+            start_directory=start_directory,
+            pattern=pattern,
+            import_root=import_root,
+            max_tests_per_target=max_tests_per_target,
+            max_seconds_per_target=max_seconds_per_target,
+            module_seconds=timings,
+        )
         shard_plan = plan_shards(modules, shard_count=shard_count, module_seconds=timings)
     except UnittestShardingError as error:
         raise click.ClickException(str(error)) from error
@@ -100,6 +119,8 @@ def plan_unittest_shards(
     show_default=True,
 )
 @click.option("--pattern", default="test*.py", show_default=True)
+@click.option("--max-tests-per-target", type=int, default=100, show_default=True)
+@click.option("--max-seconds-per-target", type=float, default=60.0, show_default=True)
 @click.option(
     "--import-root",
     type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
@@ -114,13 +135,22 @@ def run_unittest_shard(
     timings_output: Path,
     start_directory: Path,
     pattern: str,
+    max_tests_per_target: int,
+    max_seconds_per_target: float,
     import_root: Path,
     verbosity: int,
 ) -> None:
     """Run one unittest shard and write its timing artifact."""
     try:
-        modules = discover_test_modules(start_directory=start_directory, pattern=pattern)
         timings = read_module_timings(timings_file)
+        modules = discover_test_targets(
+            start_directory=start_directory,
+            pattern=pattern,
+            import_root=import_root,
+            max_tests_per_target=max_tests_per_target,
+            max_seconds_per_target=max_seconds_per_target,
+            module_seconds=timings,
+        )
         shard = plan_shards(modules, shard_count=shard_count, module_seconds=timings).shard(
             shard_index
         )
@@ -164,22 +194,47 @@ def run_unittest_shard(
     required=True,
 )
 @click.option(
+    "--timings-file",
+    type=click.Path(path_type=Path, dir_okay=False),
+    default=None,
+)
+@click.option(
     "--start-directory",
     type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
     default=Path("tests"),
     show_default=True,
 )
 @click.option("--pattern", default="test*.py", show_default=True)
+@click.option("--max-tests-per-target", type=int, default=100, show_default=True)
+@click.option("--max-seconds-per-target", type=float, default=60.0, show_default=True)
+@click.option(
+    "--import-root",
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    default=Path("."),
+    show_default=True,
+)
 def aggregate_unittest_shards(
     shard_count: int,
     results_dir: Path,
     timings_output: Path,
+    timings_file: Path | None,
     start_directory: Path,
     pattern: str,
+    max_tests_per_target: int,
+    max_seconds_per_target: float,
+    import_root: Path,
 ) -> None:
     """Aggregate shard timing artifacts into a next-run timing file."""
     try:
-        modules = discover_test_modules(start_directory=start_directory, pattern=pattern)
+        timings = read_module_timings(timings_file)
+        modules = discover_test_targets(
+            start_directory=start_directory,
+            pattern=pattern,
+            import_root=import_root,
+            max_tests_per_target=max_tests_per_target,
+            max_seconds_per_target=max_seconds_per_target,
+            module_seconds=timings,
+        )
         payload = aggregate_shard_timings(
             results_directory=results_dir,
             shard_count=shard_count,

--- a/control_plane/unittest_sharding.py
+++ b/control_plane/unittest_sharding.py
@@ -7,7 +7,7 @@ import sys
 import time
 from pathlib import Path
 from types import TracebackType
-from typing import Any, TextIO
+from typing import Any, Iterable, TextIO
 import unittest
 
 TIMING_SCHEMA_VERSION = 1
@@ -37,10 +37,13 @@ class ShardPlan:
         return self.shards[shard_index]
 
     def as_payload(self) -> dict[str, object]:
+        all_targets = [module_name for shard in self.shards for module_name in shard.modules]
         return {
             "schema_version": TIMING_SCHEMA_VERSION,
             "record_type": "unittest_shard_plan",
             "shard_count": self.shard_count,
+            "target_count": len(all_targets),
+            "target_granularity": "module_or_unittest_target",
             "shards": [
                 {
                     "index": shard.index,
@@ -141,6 +144,124 @@ def discover_test_modules(*, start_directory: Path, pattern: str = "test*.py") -
     return tuple(dict.fromkeys(modules))
 
 
+def discover_test_targets(
+    *,
+    start_directory: Path,
+    import_root: Path,
+    pattern: str = "test*.py",
+    max_tests_per_target: int = 40,
+    max_seconds_per_target: float = 60.0,
+    module_seconds: dict[str, float] | None = None,
+) -> tuple[str, ...]:
+    modules = discover_test_modules(start_directory=start_directory, pattern=pattern)
+    if max_tests_per_target < 1:
+        raise UnittestShardingError("max tests per target must be at least 1")
+    if max_seconds_per_target <= 0:
+        raise UnittestShardingError("max seconds per target must be greater than zero")
+    seconds_by_module = module_seconds or {}
+
+    loader = unittest.TestLoader()
+    targets: list[str] = []
+    with TemporaryImportRoot(import_root):
+        for module_name in modules:
+            suite = loader.loadTestsFromName(module_name)
+            if contains_failed_test(suite):
+                targets.append(module_name)
+                continue
+            test_case_targets = tuple(iter_test_case_target_ids(suite))
+            module_targets = tuple(iter_test_target_ids(suite))
+            if not test_case_targets and not module_targets:
+                targets.append(module_name)
+                continue
+            should_split = should_split_module_target(
+                module_name=module_name,
+                module_targets=module_targets,
+                max_tests_per_target=max_tests_per_target,
+                max_seconds_per_target=max_seconds_per_target,
+                seconds_by_module=seconds_by_module,
+            )
+            if not should_split:
+                targets.append(module_name)
+                continue
+            targets.extend(split_module_targets(test_case_targets, module_targets, max_tests_per_target))
+    return tuple(dict.fromkeys(targets))
+
+
+def split_module_targets(
+    test_case_targets: tuple[str, ...],
+    method_targets: tuple[str, ...],
+    max_tests_per_target: int,
+) -> tuple[str, ...]:
+    tests_by_case: dict[str, list[str]] = {test_case_target: [] for test_case_target in test_case_targets}
+    for method_target in method_targets:
+        case_target = ".".join(method_target.split(".")[:-1])
+        tests_by_case.setdefault(case_target, []).append(method_target)
+
+    split_targets: list[str] = []
+    for test_case_target in sorted(tests_by_case):
+        case_methods = tuple(sorted(tests_by_case[test_case_target]))
+        if len(case_methods) > max_tests_per_target:
+            split_targets.extend(case_methods)
+            continue
+        split_targets.append(test_case_target)
+    return tuple(split_targets)
+
+
+def iter_test_case_target_ids(suite: unittest.TestSuite) -> Iterable[str]:
+    case_target_ids: set[str] = set()
+    for test_id in iter_test_target_ids(suite):
+        parts = test_id.split(".")
+        if len(parts) < 4:
+            continue
+        case_target_ids.add(".".join(parts[:-1]))
+    return tuple(sorted(case_target_ids))
+
+
+def should_split_module_target(
+    *,
+    module_name: str,
+    module_targets: tuple[str, ...],
+    max_tests_per_target: int,
+    max_seconds_per_target: float,
+    seconds_by_module: dict[str, float],
+) -> bool:
+    if len(module_targets) > max_tests_per_target:
+        return True
+    module_seconds = seconds_by_module.get(module_name)
+    if module_seconds is not None and module_seconds > max_seconds_per_target:
+        return True
+    target_prefix = f"{module_name}."
+    return any(target_name.startswith(target_prefix) for target_name in seconds_by_module)
+
+
+def iter_test_target_ids(suite: unittest.TestSuite) -> Iterable[str]:
+    for test in suite:
+        if isinstance(test, unittest.TestSuite):
+            yield from iter_test_target_ids(test)
+            continue
+        test_id = test.id()
+        if is_failed_test(test):
+            continue
+        yield test_id
+
+
+def contains_failed_test(suite: unittest.TestSuite) -> bool:
+    for test in suite:
+        if isinstance(test, unittest.TestSuite):
+            if contains_failed_test(test):
+                return True
+            continue
+        if is_failed_test(test):
+            return True
+    return False
+
+
+def is_failed_test(test: unittest.TestCase) -> bool:
+    return test.__class__.__name__ == "_FailedTest" or test.id().startswith(
+        "unittest.loader._FailedTest."
+    )
+
+
 def module_name_for_test_file(test_file: Path, *, start_directory: Path) -> str:
     try:
         relative_file = test_file.resolve().relative_to(start_directory.resolve().parent)
@@ -179,17 +300,18 @@ def plan_shards(
 ) -> ShardPlan:
     validate_shard_count(shard_count)
     seconds_by_module = module_seconds or {}
+    estimated_seconds_by_target = estimate_target_seconds(modules, seconds_by_module)
     shard_modules: list[list[str]] = [[] for _ in range(shard_count)]
     shard_estimates = [0.0 for _ in range(shard_count)]
 
     weighted_modules = sorted(
         tuple(dict.fromkeys(modules)),
-        key=lambda module_name: (-seconds_by_module.get(module_name, DEFAULT_MODULE_SECONDS), module_name),
+        key=lambda module_name: (-estimated_seconds_by_target[module_name], module_name),
     )
     for module_name in weighted_modules:
         shard_index = min(range(shard_count), key=lambda index: (shard_estimates[index], index))
         shard_modules[shard_index].append(module_name)
-        shard_estimates[shard_index] += seconds_by_module.get(module_name, DEFAULT_MODULE_SECONDS)
+        shard_estimates[shard_index] += estimated_seconds_by_target[module_name]
 
     return ShardPlan(
         shard_count=shard_count,
@@ -204,6 +326,42 @@ def plan_shards(
     )
 
 
+def estimate_target_seconds(
+    targets: tuple[str, ...],
+    seconds_by_target: dict[str, float],
+) -> dict[str, float]:
+    unique_targets = tuple(dict.fromkeys(targets))
+    child_counts_by_module: dict[str, int] = {}
+    for target in unique_targets:
+        module_name = parent_module_name(target)
+        if module_name != target and module_name in seconds_by_target:
+            child_counts_by_module[module_name] = child_counts_by_module.get(module_name, 0) + 1
+
+    estimates: dict[str, float] = {}
+    for target in unique_targets:
+        exact_seconds = seconds_by_target.get(target)
+        if exact_seconds is not None:
+            estimates[target] = exact_seconds
+            continue
+        module_name = parent_module_name(target)
+        module_seconds = seconds_by_target.get(module_name)
+        child_count = child_counts_by_module.get(module_name, 0)
+        if module_seconds is not None and child_count > 0:
+            estimates[target] = module_seconds / child_count
+            continue
+        estimates[target] = DEFAULT_MODULE_SECONDS
+    return estimates
+
+
+def parent_module_name(target: str) -> str:
+    parts = target.split(".")
+    if len(parts) >= 4 and parts[-1].startswith("test_") and parts[-2][:1].isupper():
+        return ".".join(parts[:-2])
+    if len(parts) >= 3 and parts[-1][:1].isupper():
+        return ".".join(parts[:-1])
+    return target
+
+
 def run_test_modules(
     modules: tuple[str, ...],
     *,
@@ -215,7 +373,7 @@ def run_test_modules(
 ) -> ShardRunSummary:
     validate_shard_index(shard_count=shard_count, shard_index=shard_index)
     if not modules:
-        raise UnittestShardingError(f"shard {shard_index} has no test modules")
+        raise UnittestShardingError(f"shard {shard_index} has no test targets")
 
     loader = unittest.TestLoader()
     module_timings: list[ModuleRunTiming] = []
@@ -223,6 +381,8 @@ def run_test_modules(
     with TemporaryImportRoot(import_root):
         for module_name in modules:
             suite = loader.loadTestsFromName(module_name)
+            if contains_failed_test(suite):
+                raise UnittestShardingError(f"failed to load unittest target: {module_name}")
             started_at = time.monotonic()
             result = unittest.TextTestRunner(stream=stream, verbosity=verbosity).run(suite)
             elapsed_seconds = time.monotonic() - started_at
@@ -254,6 +414,11 @@ def aggregate_shard_timings(
 ) -> dict[str, object]:
     validate_shard_count(shard_count)
     discovered_module_set = set(discovered_modules)
+    discovered_by_parent_module: dict[str, list[str]] = {}
+    for discovered_module in discovered_modules:
+        parent_module = parent_module_name(discovered_module)
+        if parent_module != discovered_module:
+            discovered_by_parent_module.setdefault(parent_module, []).append(discovered_module)
     aggregate_modules: dict[str, dict[str, object]] = {}
 
     for shard_index in range(shard_count):
@@ -272,15 +437,27 @@ def aggregate_shard_timings(
         if not isinstance(modules_payload, dict):
             raise UnittestShardingError(f"shard timing modules must be an object: {shard_file}")
         for module_name, module_payload in modules_payload.items():
-            if module_name not in discovered_module_set:
+            target_names: tuple[str, ...]
+            if module_name in discovered_module_set:
+                target_names = (module_name,)
+            else:
+                target_names = tuple(discovered_by_parent_module.get(module_name, ()))
+            if not target_names:
                 continue
-            if module_name in aggregate_modules:
-                raise UnittestShardingError(f"duplicate module timing: {module_name}")
-            aggregate_modules[module_name] = normalize_module_timing_payload(
+            normalized_payload = normalize_module_timing_payload(
                 module_name=module_name,
                 module_payload=module_payload,
                 timings_file=shard_file,
             )
+            if len(target_names) > 1:
+                normalized_payload = split_module_timing_payload(
+                    normalized_payload,
+                    split_count=len(target_names),
+                )
+            for target_name in target_names:
+                if target_name in aggregate_modules:
+                    raise UnittestShardingError(f"duplicate module timing: {target_name}")
+                aggregate_modules[target_name] = normalized_payload
 
     missing_modules = sorted(discovered_module_set.difference(aggregate_modules))
     if missing_modules:
@@ -315,6 +492,25 @@ def normalize_module_timing_payload(
     if not isinstance(tests_run_value, int) or tests_run_value < 0:
         raise UnittestShardingError(f"invalid tests_run for module {module_name} in {timings_file}")
     return {"seconds": round(float(seconds_value), 6), "tests_run": tests_run_value}
+
+
+def split_module_timing_payload(
+    module_payload: dict[str, object],
+    *,
+    split_count: int,
+) -> dict[str, object]:
+    seconds_value = module_payload["seconds"]
+    tests_run_value = module_payload["tests_run"]
+    if not isinstance(seconds_value, int | float):
+        raise UnittestShardingError("module seconds must be numeric")
+    if not isinstance(tests_run_value, int):
+        raise UnittestShardingError("module tests_run must be an integer")
+    if split_count < 1:
+        raise UnittestShardingError("split count must be at least 1")
+    return {
+        "seconds": round(float(seconds_value) / split_count, 6),
+        "tests_run": max(1, round(tests_run_value / split_count)),
+    }
 
 
 def read_json_object(input_file: Path) -> dict[str, Any]:

--- a/docs/style/testing.md
+++ b/docs/style/testing.md
@@ -25,5 +25,10 @@ uv run launchplane ci unittest-shard plan --shard-count 6
 uv run launchplane ci unittest-shard run --shard-count 6 --shard-index 0 --timings-output tmp/shard-0.json
 ```
 
-Shard planning discovers `tests/test*.py` dynamically. Timing files are
-balancing hints only; discovered test modules remain the source of truth.
+Shard planning discovers `tests/test*.py` dynamically. Small files run as whole
+modules. Large or timing-known-slow files may be split into unittest target IDs,
+preferably `tests.test_module.TestCase` and only down to
+`tests.test_module.TestCase.test_behavior` when a single test case is still too
+large. This lets hot modules distribute across shards without physical file
+moves. Timing files are balancing hints only; discovered tests remain the source
+of truth.

--- a/tests/test_ci_unittest_cli.py
+++ b/tests/test_ci_unittest_cli.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import tempfile
+import sys
 import unittest
 
 from click.testing import CliRunner
@@ -13,7 +14,8 @@ class CiUnittestCliTests(unittest.TestCase):
     def test_list_outputs_discovered_modules(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            tests_directory = _write_test_package(root)
+            tests_directory = _write_test_package(root, package_name="sample_cli_list_tests")
+            _remove_imported_package("sample_cli_list_tests")
 
             result = CliRunner().invoke(
                 main,
@@ -27,12 +29,13 @@ class CiUnittestCliTests(unittest.TestCase):
             )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertEqual(result.output.strip(), "tests.test_sample")
+        self.assertEqual(result.output.strip(), "sample_cli_list_tests.test_sample")
 
     def test_plan_outputs_json_with_all_modules_once(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            tests_directory = _write_test_package(root)
+            tests_directory = _write_test_package(root, package_name="sample_cli_plan_tests")
+            _remove_imported_package("sample_cli_plan_tests")
 
             result = CliRunner().invoke(
                 main,
@@ -55,12 +58,59 @@ class CiUnittestCliTests(unittest.TestCase):
             for module_name in shard["modules"]
         ]
         self.assertEqual(payload["shard_count"], 2)
-        self.assertEqual(modules, ["tests.test_sample"])
+        self.assertEqual(modules, ["sample_cli_plan_tests.test_sample"])
+
+    def test_plan_splits_large_modules_when_requested(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            tests_directory = _write_test_package(
+                root,
+                package_name="sample_cli_split_plan_tests",
+                extra_test=True,
+            )
+            _remove_imported_package("sample_cli_split_plan_tests")
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "ci",
+                    "unittest-shard",
+                    "plan",
+                    "--shard-count",
+                    "2",
+                    "--start-directory",
+                    str(tests_directory),
+                    "--import-root",
+                    str(root),
+                    "--max-tests-per-target",
+                    "1",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        modules = [
+            module_name
+            for shard in payload["shards"]
+            for module_name in shard["modules"]
+        ]
+        self.assertEqual(
+            sorted(modules),
+            [
+                "sample_cli_split_plan_tests.test_sample.SampleTests.test_other",
+                "sample_cli_split_plan_tests.test_sample.SampleTests.test_sample",
+            ],
+        )
 
     def test_run_writes_timing_artifact_and_returns_failure_for_failing_shard(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            tests_directory = _write_test_package(root, passing=False)
+            tests_directory = _write_test_package(
+                root,
+                passing=False,
+                package_name="sample_cli_failing_run_tests",
+            )
+            _remove_imported_package("sample_cli_failing_run_tests")
             output_file = root / "timings" / "shard-0.json"
 
             result = CliRunner().invoke(
@@ -89,12 +139,58 @@ class CiUnittestCliTests(unittest.TestCase):
         self.assertIn('"modules"', result.output)
         self.assertEqual(payload["record_type"], SHARD_RUN_RECORD_TYPE)
         self.assertFalse(payload["successful"])
-        self.assertEqual(payload["modules"]["tests.test_sample"]["tests_run"], 1)
+        self.assertEqual(payload["modules"]["sample_cli_failing_run_tests.test_sample"]["tests_run"], 1)
+
+    def test_run_writes_split_target_timing_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            tests_directory = _write_test_package(
+                root,
+                package_name="sample_cli_split_run_tests",
+                extra_test=True,
+            )
+            _remove_imported_package("sample_cli_split_run_tests")
+            output_file = root / "timings" / "shard-0.json"
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "ci",
+                    "unittest-shard",
+                    "run",
+                    "--shard-count",
+                    "1",
+                    "--shard-index",
+                    "0",
+                    "--start-directory",
+                    str(tests_directory),
+                    "--import-root",
+                    str(root),
+                    "--timings-output",
+                    str(output_file),
+                    "--max-tests-per-target",
+                    "1",
+                    "--verbosity",
+                    "1",
+                ],
+            )
+            payload = json.loads(output_file.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            payload["modules"]["sample_cli_split_run_tests.test_sample.SampleTests.test_other"]["tests_run"],
+            1,
+        )
+        self.assertEqual(
+            payload["modules"]["sample_cli_split_run_tests.test_sample.SampleTests.test_sample"]["tests_run"],
+            1,
+        )
 
     def test_aggregate_writes_next_run_timing_file(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            tests_directory = _write_test_package(root)
+            tests_directory = _write_test_package(root, package_name="sample_cli_aggregate_tests")
+            _remove_imported_package("sample_cli_aggregate_tests")
             results_directory = root / "results"
             results_directory.mkdir()
             (results_directory / "shard-0.json").write_text(
@@ -106,13 +202,14 @@ class CiUnittestCliTests(unittest.TestCase):
                         "shard_count": 1,
                         "successful": True,
                         "modules": {
-                            "tests.test_sample": {"seconds": 0.5, "tests_run": 1}
+                            "sample_cli_aggregate_tests.test_sample": {"seconds": 0.5, "tests_run": 1}
                         },
                     }
                 ),
                 encoding="utf-8",
             )
             output_file = root / "aggregate" / "timings.json"
+            input_file = root / "aggregate" / "previous.json"
 
             result = CliRunner().invoke(
                 main,
@@ -126,6 +223,8 @@ class CiUnittestCliTests(unittest.TestCase):
                     str(results_directory),
                     "--timings-output",
                     str(output_file),
+                    "--timings-file",
+                    str(input_file),
                     "--start-directory",
                     str(tests_directory),
                 ],
@@ -133,19 +232,124 @@ class CiUnittestCliTests(unittest.TestCase):
             payload = json.loads(output_file.read_text(encoding="utf-8"))
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertEqual(payload["modules"]["tests.test_sample"]["seconds"], 0.5)
+        self.assertEqual(payload["modules"]["sample_cli_aggregate_tests.test_sample"]["seconds"], 0.5)
+
+    def test_aggregate_writes_split_target_timing_file(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            tests_directory = _write_test_package(
+                root,
+                package_name="sample_cli_split_aggregate_tests",
+                extra_test=True,
+            )
+            _remove_imported_package("sample_cli_split_aggregate_tests")
+            results_directory = root / "results"
+            results_directory.mkdir()
+            (results_directory / "shard-0.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": TIMING_SCHEMA_VERSION,
+                        "record_type": SHARD_RUN_RECORD_TYPE,
+                        "shard_index": 0,
+                        "shard_count": 1,
+                        "successful": True,
+                        "modules": {
+                            "sample_cli_split_aggregate_tests.test_sample.SampleTests.test_sample": {
+                                "seconds": 0.5,
+                                "tests_run": 1,
+                            },
+                            "sample_cli_split_aggregate_tests.test_sample.SampleTests.test_other": {
+                                "seconds": 0.25,
+                                "tests_run": 1,
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            output_file = root / "aggregate" / "timings.json"
+            input_file = root / "aggregate" / "previous.json"
+            input_file.parent.mkdir(parents=True)
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": TIMING_SCHEMA_VERSION,
+                        "record_type": "unittest_module_timings",
+                        "modules": {
+                            "sample_cli_split_aggregate_tests.test_sample": {
+                                "seconds": 1.0,
+                                "tests_run": 2,
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                main,
+                [
+                    "ci",
+                    "unittest-shard",
+                    "aggregate",
+                    "--shard-count",
+                    "1",
+                    "--results-dir",
+                    str(results_directory),
+                    "--timings-output",
+                    str(output_file),
+                    "--timings-file",
+                    str(input_file),
+                    "--start-directory",
+                    str(tests_directory),
+                    "--import-root",
+                    str(root),
+                    "--max-tests-per-target",
+                    "1",
+                ],
+            )
+            payload = json.loads(output_file.read_text(encoding="utf-8"))
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(
+            payload["modules"]["sample_cli_split_aggregate_tests.test_sample.SampleTests.test_sample"]["seconds"],
+            0.5,
+        )
+        self.assertEqual(
+            payload["modules"]["sample_cli_split_aggregate_tests.test_sample.SampleTests.test_other"]["seconds"],
+            0.25,
+        )
 
 
-def _write_test_package(root: Path, *, passing: bool = True) -> Path:
-    tests_directory = root / "tests"
+def _write_test_package(
+    root: Path,
+    *,
+    passing: bool = True,
+    package_name: str = "sample_cli_tests",
+    extra_test: bool = False,
+) -> Path:
+    tests_directory = root / package_name
     tests_directory.mkdir()
     (tests_directory / "__init__.py").write_text("", encoding="utf-8")
     assertion = "self.assertTrue(True)" if passing else "self.assertTrue(False)"
+    extra_method = (
+        "    def test_other(self):\n"
+        f"        {assertion}\n"
+        if extra_test
+        else ""
+    )
     (tests_directory / "test_sample.py").write_text(
         "import unittest\n\n"
         "class SampleTests(unittest.TestCase):\n"
         "    def test_sample(self):\n"
-        f"        {assertion}\n",
+        f"        {assertion}\n"
+        f"{extra_method}",
         encoding="utf-8",
     )
     return tests_directory
+
+
+def _remove_imported_package(package_name: str) -> None:
+    for module_name in tuple(sys.modules):
+        if module_name == package_name or module_name.startswith(f"{package_name}."):
+            del sys.modules[module_name]

--- a/tests/test_unittest_sharding.py
+++ b/tests/test_unittest_sharding.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 import tempfile
+import sys
 import unittest
 
 from control_plane.unittest_sharding import (
@@ -10,6 +11,8 @@ from control_plane.unittest_sharding import (
     UnittestShardingError,
     aggregate_shard_timings,
     discover_test_modules,
+    discover_test_targets,
+    estimate_target_seconds,
     plan_shards,
     read_module_timings,
     run_test_modules,
@@ -35,6 +38,88 @@ class UnittestShardingTests(unittest.TestCase):
 
         self.assertEqual(modules, ("tests.nested.test_c", "tests.test_a", "tests.test_b"))
 
+    def test_discover_test_targets_splits_large_modules_by_test_case(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            tests_directory = _write_test_package(root, package_name="target_tests")
+            (tests_directory / "test_big.py").write_text(
+                "import unittest\n\n"
+                "class BigTests(unittest.TestCase):\n"
+                "    def test_a(self):\n"
+                "        self.assertTrue(True)\n"
+                "    def test_b(self):\n"
+                "        self.assertTrue(True)\n\n"
+                "class SmallTests(unittest.TestCase):\n"
+                "    def test_c(self):\n"
+                "        self.assertTrue(True)\n",
+                encoding="utf-8",
+            )
+            _remove_imported_package("target_tests")
+
+            targets = discover_test_targets(
+                start_directory=tests_directory,
+                import_root=root,
+                max_tests_per_target=2,
+            )
+
+        self.assertIn("target_tests.test_big.BigTests", targets)
+        self.assertIn("target_tests.test_big.SmallTests", targets)
+        self.assertIn("target_tests.test_sample", targets)
+
+    def test_discover_test_targets_splits_oversized_test_cases_by_method(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            tests_directory = _write_test_package(root, package_name="target_tests")
+            (tests_directory / "test_big.py").write_text(
+                "import unittest\n\n"
+                "class BigTests(unittest.TestCase):\n"
+                "    def test_a(self):\n"
+                "        self.assertTrue(True)\n"
+                "    def test_b(self):\n"
+                "        self.assertTrue(True)\n",
+                encoding="utf-8",
+            )
+            _remove_imported_package("target_tests")
+
+            targets = discover_test_targets(
+                start_directory=tests_directory,
+                import_root=root,
+                max_tests_per_target=1,
+            )
+
+        self.assertIn("target_tests.test_big.BigTests.test_a", targets)
+        self.assertIn("target_tests.test_big.BigTests.test_b", targets)
+
+    def test_discover_test_targets_keeps_small_modules_as_modules(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            tests_directory = _write_test_package(root, package_name="target_tests")
+            _remove_imported_package("target_tests")
+
+            targets = discover_test_targets(
+                start_directory=tests_directory,
+                import_root=root,
+                max_tests_per_target=40,
+            )
+
+        self.assertEqual(targets, ("target_tests.test_sample",))
+
+    def test_discover_test_targets_splits_timing_known_slow_modules(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            tests_directory = _write_test_package(root, package_name="target_tests")
+            _remove_imported_package("target_tests")
+
+            targets = discover_test_targets(
+                start_directory=tests_directory,
+                import_root=root,
+                max_tests_per_target=40,
+                max_seconds_per_target=0.25,
+                module_seconds={"target_tests.test_sample": 1.0},
+            )
+
+        self.assertEqual(targets, ("target_tests.test_sample.SampleTests",))
+
     def test_plan_rejects_zero_shards(self) -> None:
         with self.assertRaisesRegex(UnittestShardingError, "shard count"):
             plan_shards(("tests.test_a",), shard_count=0)
@@ -57,6 +142,33 @@ class UnittestShardingTests(unittest.TestCase):
             shard_plan.shard(1).modules,
             ("tests.test_fast_a", "tests.test_fast_b"),
         )
+
+    def test_plan_spreads_split_target_estimates_from_parent_module_timing(self) -> None:
+        shard_plan = plan_shards(
+            (
+                "tests.test_big.BigTests",
+                "tests.test_big.SmallTests",
+                "tests.test_small",
+            ),
+            shard_count=2,
+            module_seconds={"tests.test_big": 10.0, "tests.test_small": 1.0},
+        )
+
+        self.assertEqual(
+            tuple(sorted(shard.modules for shard in shard_plan.shards)),
+            (("tests.test_big.BigTests", "tests.test_small"), ("tests.test_big.SmallTests",)),
+        )
+
+    def test_estimate_target_seconds_prefers_exact_target_timing(self) -> None:
+        estimates = estimate_target_seconds(
+            ("tests.test_big.BigTests",),
+            {
+                "tests.test_big": 10.0,
+                "tests.test_big.BigTests": 3.0,
+            },
+        )
+
+        self.assertEqual(estimates["tests.test_big.BigTests"], 3.0)
 
     def test_plan_is_stable_when_timings_are_missing(self) -> None:
         shard_plan = plan_shards(
@@ -82,7 +194,7 @@ class UnittestShardingTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             with (root / "test-output.txt").open("w", encoding="utf-8") as stream:
-                with self.assertRaisesRegex(UnittestShardingError, "no test modules"):
+                with self.assertRaisesRegex(UnittestShardingError, "no test targets"):
                     run_test_modules(
                         (),
                         shard_index=0,
@@ -111,6 +223,23 @@ class UnittestShardingTests(unittest.TestCase):
         self.assertTrue(payload["successful"])
         self.assertEqual(payload["modules"]["sample_run_tests.test_sample"]["tests_run"], 1)
         self.assertGreaterEqual(payload["modules"]["sample_run_tests.test_sample"]["seconds"], 0)
+
+    def test_run_writes_timing_records_for_split_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            _write_test_package(root, package_name="sample_run_tests")
+            with (root / "test-output.txt").open("w", encoding="utf-8") as stream:
+                summary = run_test_modules(
+                    ("sample_run_tests.test_sample.SampleTests",),
+                    shard_index=0,
+                    shard_count=1,
+                    import_root=root,
+                    stream=stream,
+                )
+
+        self.assertTrue(summary.successful)
+        self.assertEqual(summary.modules[0].module, "sample_run_tests.test_sample.SampleTests")
+        self.assertEqual(summary.modules[0].tests_run, 1)
 
     def test_aggregate_requires_all_shard_outputs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory_name:
@@ -175,6 +304,40 @@ class UnittestShardingTests(unittest.TestCase):
             {"tests.test_sample": {"seconds": 1.5, "tests_run": 2}},
         )
 
+    def test_aggregate_splits_parent_module_timings_for_new_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            write_json_object(
+                root / "shard-0.json",
+                {
+                    "schema_version": TIMING_SCHEMA_VERSION,
+                    "record_type": SHARD_RUN_RECORD_TYPE,
+                    "shard_index": 0,
+                    "shard_count": 1,
+                    "successful": True,
+                    "modules": {
+                        "tests.test_big": {"seconds": 10.0, "tests_run": 4},
+                    },
+                },
+            )
+
+            payload = aggregate_shard_timings(
+                results_directory=root,
+                shard_count=1,
+                discovered_modules=(
+                    "tests.test_big.BigTests",
+                    "tests.test_big.SmallTests",
+                ),
+            )
+
+        self.assertEqual(
+            payload["modules"],
+            {
+                "tests.test_big.BigTests": {"seconds": 5.0, "tests_run": 2},
+                "tests.test_big.SmallTests": {"seconds": 5.0, "tests_run": 2},
+            },
+        )
+
 
 def _write_test_package(root: Path, *, package_name: str = "tests") -> Path:
     tests_directory = root / package_name
@@ -188,3 +351,9 @@ def _write_test_package(root: Path, *, package_name: str = "tests") -> Path:
         encoding="utf-8",
     )
     return tests_directory
+
+
+def _remove_imported_package(package_name: str) -> None:
+    for module_name in tuple(sys.modules):
+        if module_name == package_name or module_name.startswith(f"{package_name}."):
+            del sys.modules[module_name]


### PR DESCRIPTION
## Summary

- shard same-repo unittests by unittest targets instead of only whole modules when a file is large or timing-known slow
- prefer `module.TestCase` targets and only split to `module.TestCase.test_method` when a single test case is still too large
- restore timing history in the aggregate `test` job so shard run and aggregate use the same target-discovery inputs
- keep old module-level timing artifacts usable by splitting parent module timings across newly discovered child targets

## Evidence

Recent `main` run `28027016407` had six warm-cache shard totals around 189-199 seconds, but CI wall clock stayed around 8 minutes due to runner waves. Using those timing artifacts with this branch's planner estimates six shards at ~192.36 seconds each while distributing hot HTTP/service targets across shards.

## Validation

- `uv run python -m unittest tests.test_unittest_sharding tests.test_ci_unittest_cli`
- `uv run --extra dev ruff check --diff control_plane/cli_ci.py control_plane/unittest_sharding.py tests/test_unittest_sharding.py tests/test_ci_unittest_cli.py`
- `uv run --extra dev ruff check control_plane/cli_ci.py control_plane/unittest_sharding.py tests/test_unittest_sharding.py tests/test_ci_unittest_cli.py`
- `uv run --extra dev mypy control_plane/cli_ci.py control_plane/unittest_sharding.py tests/test_unittest_sharding.py tests/test_ci_unittest_cli.py`
- `actionlint .github/workflows/ci.yml`
- `git diff --check`
- CLI smoke: plan/run/aggregate on `tests/test_unittest_sharding.py` with `--max-tests-per-target 5`

Refs #1457
