### PR TITLE
Tune unittest shards to runner capacity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard_index: [0, 1, 2, 3, 4, 5]
+        shard_index: [0, 1, 2, 3]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -261,13 +261,13 @@ jobs:
       - name: Show unit test shard plan
         run: >-
           uv run launchplane ci unittest-shard plan
-          --shard-count 6
+          --shard-count 4
           --timings-file "${UNITTEST_TIMINGS_CACHE}"
 
       - name: Run unit test shard
         run: >-
           uv run launchplane ci unittest-shard run
-          --shard-count 6
+          --shard-count 4
           --shard-index ${{ matrix.shard_index }}
           --timings-file "${UNITTEST_TIMINGS_CACHE}"
           --timings-output "${RUNNER_TEMP}/unittest-timings/shard-${{ matrix.shard_index }}.json"
@@ -333,7 +333,7 @@ jobs:
       - name: Aggregate unittest timings
         run: >-
           uv run launchplane ci unittest-shard aggregate
-          --shard-count 6
+          --shard-count 4
           --results-dir "${RUNNER_TEMP}/unittest-timings"
           --timings-file "${UNITTEST_TIMINGS_CACHE}"
           --timings-output "${UNITTEST_TIMINGS_CACHE}"

--- a/docs/style/testing.md
+++ b/docs/style/testing.md
@@ -21,8 +21,8 @@ CI may shard same-repo unittest runs through Launchplane's helper while keeping
 the canonical framework as stdlib `unittest`:
 
 ```bash
-uv run launchplane ci unittest-shard plan --shard-count 6
-uv run launchplane ci unittest-shard run --shard-count 6 --shard-index 0 --timings-output tmp/shard-0.json
+uv run launchplane ci unittest-shard plan --shard-count 4
+uv run launchplane ci unittest-shard run --shard-count 4 --shard-index 0 --timings-output tmp/shard-0.json
 ```
 
 Shard planning discovers `tests/test*.py` dynamically. Small files run as whole


### PR DESCRIPTION
## Summary
- tune same-repo unittest CI from 6 shards to 4 shards
- keep plan/run/aggregate shard counts aligned
- update testing docs examples to match CI

## Why
The merged target-level sharding change (#1470) made test distribution more flexible, but live CI showed the workflow only gets about four test runner slots while container/static/frontend jobs share the same self-hosted pool. With six shards, two shards consistently wait for a second wave, keeping the aggregate test wall clock near 8 minutes even on a warm target-level cache.

Recent evidence from main CI rerun `28033241454`:
- shards 5,1,0,4 started at 14:32:08Z
- shards 2 and 3 waited until 14:35:58Z / 14:36:05Z
- aggregate test finished at 14:40:25Z

This PR tests the lower-contention shape: four shards that can all start together, each with fuller target-balanced work.

## Validation
- `actionlint -oneline .github/workflows/ci.yml`
- `uv run launchplane ci unittest-shard plan --shard-count 4 --timings-file .ci-cache/unittest-timings/history.json`
- `git diff --check`
