### PR TITLE
Disable asyncio debug overhead in HTTP app tests

### DIFF
--- a/docs/style/testing.md
+++ b/docs/style/testing.md
@@ -7,6 +7,8 @@ title: Testing Style
 - Test fail-closed behavior explicitly.
 - Keep fixtures small and inline unless they are reused heavily.
 - Default test entrypoint is `uv run python -m unittest`.
+- Use `tests.async_case.AsyncTestCase` for async test classes. It keeps
+  per-test event-loop isolation without enabling asyncio debug-mode overhead.
 
 ## Local test loop
 

--- a/tests/async_case.py
+++ b/tests/async_case.py
@@ -1,0 +1,10 @@
+import asyncio
+import unittest
+
+
+class AsyncTestCase(unittest.IsolatedAsyncioTestCase):
+    """Isolated async test case without asyncio debug-mode overhead."""
+
+    def _setupAsyncioRunner(self) -> None:
+        assert getattr(self, "_asyncioRunner") is None, "asyncio runner is already initialized"
+        setattr(self, "_asyncioRunner", asyncio.Runner(debug=False, loop_factory=self.loop_factory))

--- a/tests/test_http_app_core.py
+++ b/tests/test_http_app_core.py
@@ -1,7 +1,6 @@
 import base64
 import hashlib
 import json
-import unittest
 from collections.abc import Callable
 from datetime import (
     datetime,
@@ -40,6 +39,7 @@ from control_plane.service_human_auth import (
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.launchplane_self_deploy import LAUNCHPLANE_IMAGE_REFERENCE_ENV_KEY
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _asgi_request,
@@ -71,7 +71,7 @@ from tests.test_service import (
 )
 
 
-class FastApiHealthContractTests(unittest.IsolatedAsyncioTestCase):
+class FastApiHealthContractTests(AsyncTestCase):
     async def test_health_returns_typed_public_safe_payload(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -116,7 +116,7 @@ class FastApiHealthContractTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("shinycomputers", example_text)
 
 
-class FastApiAuthSessionReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiAuthSessionReadTests(AsyncTestCase):
     async def test_github_oauth_login_redirects_to_authorization_url(self) -> None:
         oauth_client = _StubFastApiGitHubOAuthClient(_github_human_identity())
         app = create_launchplane_fastapi_app(
@@ -718,7 +718,7 @@ class FastApiAuthSessionReadTests(unittest.IsolatedAsyncioTestCase):
             )
 
 
-class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiServiceRuntimeReadTests(AsyncTestCase):
     async def test_runtime_reports_current_image_and_policy_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             policy = _local_operator_launchplane_service_read_policy()
@@ -1144,7 +1144,7 @@ class FastApiServiceRuntimeReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
-class FastApiOdooOperationStatusReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiOdooOperationStatusReadTests(AsyncTestCase):
     async def test_stable_bootstrap_operation_status_returns_native_payload(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")

--- a/tests/test_http_app_driver_dokploy.py
+++ b/tests/test_http_app_driver_dokploy.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 from datetime import (
     datetime,
     timedelta,
@@ -26,6 +25,7 @@ from control_plane.service_human_auth import (
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _asgi_request,
@@ -57,7 +57,7 @@ from tests.test_service import (
 )
 
 
-class FastApiDriverDescriptorTests(unittest.IsolatedAsyncioTestCase):
+class FastApiDriverDescriptorTests(AsyncTestCase):
     async def test_driver_descriptors_return_provider_neutral_metadata(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_RejectingVerifier(),
@@ -406,7 +406,7 @@ class FastApiDriverDescriptorTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("authz", payload)
 
 
-class FastApiDriverContextViewTests(unittest.IsolatedAsyncioTestCase):
+class FastApiDriverContextViewTests(AsyncTestCase):
     async def test_driver_instance_view_returns_lane_summary(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             record_store = _driver_context_store(Path(temporary_directory_name) / "state")
@@ -572,7 +572,7 @@ class FastApiDriverContextViewTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiDokployTargetInspectReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiDokployTargetInspectReadTests(AsyncTestCase):
     async def test_dokploy_target_inspect_reads_redacted_provider_identity(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -823,7 +823,7 @@ class FastApiDokployTargetInspectReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
-class FastApiLaunchplaneSelfDeployTests(unittest.IsolatedAsyncioTestCase):
+class FastApiLaunchplaneSelfDeployTests(AsyncTestCase):
     def _policy(self) -> LaunchplaneAuthzPolicy:
         return LaunchplaneAuthzPolicy.model_validate(
             {
@@ -1189,7 +1189,7 @@ class FastApiLaunchplaneSelfDeployTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["error"]["code"], "not_found")
 
 
-class FastApiDokployTargetSetupTests(unittest.IsolatedAsyncioTestCase):
+class FastApiDokployTargetSetupTests(AsyncTestCase):
     async def test_openapi_includes_dokploy_target_setup_contract(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_identity()),
@@ -1315,7 +1315,7 @@ class FastApiDokployTargetSetupTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["result"]["mode"], "dry-run")
 
 
-class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiTrackedTargetLogsReadTests(AsyncTestCase):
     async def test_tracked_target_logs_returns_redacted_application_logs(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -11,6 +11,7 @@ from control_plane.contracts.product_profile_record import LaunchplaneProductPro
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _MissingProductReadStore,
@@ -25,7 +26,7 @@ from tests.test_service import (
 )
 
 
-class FastApiOdooArtifactPublishInputsTests(unittest.IsolatedAsyncioTestCase):
+class FastApiOdooArtifactPublishInputsTests(AsyncTestCase):
     def _policy(
         self,
         *,

--- a/tests/test_http_app_every_code.py
+++ b/tests/test_http_app_every_code.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
@@ -28,6 +27,7 @@ from control_plane.service_auth import (
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _asgi_request,
@@ -71,7 +71,7 @@ from tests.test_service import (
 )
 
 
-class FastApiEveryCodeReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiEveryCodeReadTests(AsyncTestCase):
     async def test_every_code_work_request_create_queues_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")

--- a/tests/test_http_app_evidence.py
+++ b/tests/test_http_app_evidence.py
@@ -1,6 +1,5 @@
-import unittest
-
 from control_plane.http_app import create_launchplane_fastapi_app
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _backup_gate_evidence_payload,
     _backup_gate_write_identity,
@@ -46,7 +45,7 @@ from tests.http_app_test_support import (
 from tests.test_service import _StubVerifier
 
 
-class FastApiDeploymentEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiDeploymentEvidenceStoreGateTests(AsyncTestCase):
     async def test_deployment_evidence_accepts_store_without_promotion_methods(self) -> None:
         store = _DeploymentEvidenceOnlyStore()
         app = create_launchplane_fastapi_app(
@@ -104,7 +103,7 @@ class FastApiDeploymentEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(store.write_environment_inventory_calls, 1)
 
 
-class FastApiBackupGateEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiBackupGateEvidenceStoreGateTests(AsyncTestCase):
     async def test_backup_gate_evidence_accepts_store_with_only_backup_gate_method(self) -> None:
         store = _BackupGateEvidenceOnlyStore()
         app = create_launchplane_fastapi_app(
@@ -172,7 +171,7 @@ class FastApiBackupGateEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(store.write_backup_gate_calls, 1)
 
 
-class FastApiPromotionEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPromotionEvidenceStoreGateTests(AsyncTestCase):
     async def test_promotion_evidence_accepts_record_only_store_without_deployment_methods(
         self,
     ) -> None:
@@ -264,7 +263,7 @@ class FastApiPromotionEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(store.write_promotion_calls, 1)
 
 
-class FastApiPreviewGenerationEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPreviewGenerationEvidenceStoreGateTests(AsyncTestCase):
     async def test_preview_generation_evidence_requires_preview_generation_store(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_preview_generation_write_identity()),
@@ -316,7 +315,7 @@ class FastApiPreviewGenerationEvidenceStoreGateTests(unittest.IsolatedAsyncioTes
         self.assertEqual(store.write_preview_generation_evidence_calls, 1)
 
 
-class FastApiPreviewDestroyedEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPreviewDestroyedEvidenceStoreGateTests(AsyncTestCase):
     async def test_preview_destroyed_evidence_requires_preview_destroyed_store(
         self,
     ) -> None:
@@ -371,7 +370,7 @@ class FastApiPreviewDestroyedEvidenceStoreGateTests(unittest.IsolatedAsyncioTest
         self.assertEqual(store.write_preview_record_calls, 1)
 
 
-class FastApiRunnerHostHygieneAuditEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiRunnerHostHygieneAuditEvidenceStoreGateTests(AsyncTestCase):
     async def test_runner_host_hygiene_audit_evidence_requires_audit_store(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
@@ -424,7 +423,7 @@ class FastApiRunnerHostHygieneAuditEvidenceStoreGateTests(unittest.IsolatedAsync
         self.assertEqual(store.write_runner_host_hygiene_audit_calls, 1)
 
 
-class FastApiRunnerLaneRegistrationAuditEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiRunnerLaneRegistrationAuditEvidenceStoreGateTests(AsyncTestCase):
     async def test_runner_lane_registration_audit_evidence_requires_audit_store(
         self,
     ) -> None:

--- a/tests/test_http_app_ingress.py
+++ b/tests/test_http_app_ingress.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
@@ -22,6 +21,7 @@ from control_plane.workflows.npmplus_ingress import (
     NpmplusIngressApplyResult,
     NpmplusIngressOperation,
 )
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _asgi_request,
@@ -62,7 +62,7 @@ from tests.test_service import (
 )
 
 
-class FastApiEdgeEndpointReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiEdgeEndpointReadTests(AsyncTestCase):
     async def test_edge_endpoint_read_returns_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -259,7 +259,7 @@ class FastApiEdgeEndpointReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
-class FastApiPrivateHealthEndpointReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPrivateHealthEndpointReadTests(AsyncTestCase):
     async def test_private_health_endpoint_read_returns_record_for_authorized_workflow(
         self,
     ) -> None:
@@ -511,7 +511,7 @@ class FastApiPrivateHealthEndpointReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
-class FastApiEndpointApplyTests(unittest.IsolatedAsyncioTestCase):
+class FastApiEndpointApplyTests(AsyncTestCase):
     async def test_edge_endpoint_apply_writes_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -1002,7 +1002,7 @@ class FastApiEndpointApplyTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiIngressRouteApplyTests(unittest.IsolatedAsyncioTestCase):
+class FastApiIngressRouteApplyTests(AsyncTestCase):
     async def test_ingress_route_dry_run_returns_plan_without_mutation(self) -> None:
         client = _FakeNpmplusIngressClient()
         with TemporaryDirectory() as temporary_directory_name:
@@ -1557,7 +1557,7 @@ class FastApiIngressRouteApplyTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiIngressCanaryRouteApplyTests(unittest.IsolatedAsyncioTestCase):
+class FastApiIngressCanaryRouteApplyTests(AsyncTestCase):
     async def test_ingress_canary_route_record_apply_writes_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -2133,7 +2133,7 @@ class FastApiIngressCanaryRouteApplyTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiIngressCanaryRouteReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiIngressCanaryRouteReadTests(AsyncTestCase):
     async def test_ingress_canary_route_read_returns_record_for_authorized_workflow(
         self,
     ) -> None:
@@ -2353,7 +2353,7 @@ class FastApiIngressCanaryRouteReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
-class FastApiIngressRouteAuditReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiIngressRouteAuditReadTests(AsyncTestCase):
     async def test_ingress_route_audit_reads_return_native_payloads(self) -> None:
         planned_record = _ingress_route_audit_record()
         newer_applied_record = _ingress_route_audit_record(

--- a/tests/test_http_app_merge_train.py
+++ b/tests/test_http_app_merge_train.py
@@ -1,4 +1,3 @@
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
@@ -25,6 +24,7 @@ from control_plane.service_auth import (
     LaunchplaneAuthzPolicy,
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _BatchLandingWithoutLandingPlanStore,
@@ -79,7 +79,7 @@ from tests.test_service import (
 )
 
 
-class FastApiMergeTrainReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiMergeTrainReadTests(AsyncTestCase):
     async def test_admission_reads_store_decision(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -302,7 +302,7 @@ class FastApiMergeTrainReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["admission"]["status"], "admitted")
 
 
-class FastApiMergeTrainBatchLandingRunOnceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiMergeTrainBatchLandingRunOnceTests(AsyncTestCase):
     async def test_plans_from_passed_candidate(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -961,7 +961,7 @@ class FastApiMergeTrainBatchLandingRunOnceTests(unittest.IsolatedAsyncioTestCase
         self.assertTrue(set(route["responses"]) >= {"400", "401", "403", "409", "502", "503"})
 
 
-class FastApiMergeTrainStackCollapseRunOnceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiMergeTrainStackCollapseRunOnceTests(AsyncTestCase):
     async def test_executes_existing_plan_record(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -1388,7 +1388,7 @@ class FastApiMergeTrainStackCollapseRunOnceTests(unittest.IsolatedAsyncioTestCas
         self.assertTrue(set(route["responses"]) >= {"400", "401", "403", "409", "502", "503"})
 
 
-class FastApiMergeTrainRunOnceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiMergeTrainRunOnceTests(AsyncTestCase):
     async def test_returns_dry_run_from_policy_and_records_run(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -1924,7 +1924,7 @@ class FastApiMergeTrainRunOnceTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(set(route["responses"]) >= {"400", "401", "403", "409", "502", "503"})
 
 
-class FastApiMergeTrainControllerRunOnceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiMergeTrainControllerRunOnceTests(AsyncTestCase):
     async def test_advances_unstacked_batch_flow(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -2314,7 +2314,7 @@ class FastApiMergeTrainControllerRunOnceTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(set(route["responses"]) >= {"400", "401", "403", "409", "502", "503"})
 
 
-class FastApiMergeTrainBatchCandidateRunOnceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiMergeTrainBatchCandidateRunOnceTests(AsyncTestCase):
     async def test_plans_candidate_record(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,
@@ -3009,7 +3009,7 @@ class FastApiMergeTrainBatchCandidateRunOnceTests(unittest.IsolatedAsyncioTestCa
         self.assertTrue(set(route["responses"]) >= {"400", "401", "403", "409", "502", "503"})
 
 
-class FastApiMergeTrainPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
+class FastApiMergeTrainPrFeedbackTests(AsyncTestCase):
     async def test_creates_managed_comment_and_records_evidence(self) -> None:
         with (
             TemporaryDirectory() as temporary_directory_name,

--- a/tests/test_http_app_policy_apply.py
+++ b/tests/test_http_app_policy_apply.py
@@ -1,6 +1,5 @@
 import json
 import os
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
@@ -32,6 +31,7 @@ from control_plane.service_human_auth import (
 )
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _AGENT_WRITE_INTENT_SOURCE_URL,
     _agent_write_intent_payload,
@@ -82,7 +82,7 @@ from tests.test_service import (
 )
 
 
-class FastApiNotificationPolicyApplyTests(unittest.IsolatedAsyncioTestCase):
+class FastApiNotificationPolicyApplyTests(AsyncTestCase):
     async def test_public_ingress_notification_policy_apply_writes_db_policy(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(
@@ -1062,7 +1062,7 @@ class FastApiNotificationPolicyApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("/v1/previews/pr-feedback/notification-policies/apply", paths)
 
 
-class FastApiRuntimeKeySafetyPolicyApplyTests(unittest.IsolatedAsyncioTestCase):
+class FastApiRuntimeKeySafetyPolicyApplyTests(AsyncTestCase):
     async def test_runtime_key_safety_policy_apply_reconciles_rules_and_replays(
         self,
     ) -> None:
@@ -1328,7 +1328,7 @@ class FastApiRuntimeKeySafetyPolicyApplyTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn("LaunchplaneErrorResponse", json.dumps(route["responses"][status_code]))
 
 
-class FastApiAgentWriteIntentEvaluateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiAgentWriteIntentEvaluateTests(AsyncTestCase):
     async def test_evaluate_returns_allowed_dry_run_without_execution(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1801,7 +1801,7 @@ class FastApiAgentWriteIntentEvaluateTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["result"]["intent"]["status"], "allowed")
 
 
-class FastApiProductConfigApplyTests(unittest.IsolatedAsyncioTestCase):
+class FastApiProductConfigApplyTests(AsyncTestCase):
     async def test_product_config_dry_run_returns_redacted_plan_without_writes(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -2622,7 +2622,7 @@ class FastApiProductConfigApplyTests(unittest.IsolatedAsyncioTestCase):
             self.assertIn(status_code, route["responses"])
 
 
-class FastApiProductContextCutoverTests(unittest.IsolatedAsyncioTestCase):
+class FastApiProductContextCutoverTests(AsyncTestCase):
     async def test_context_cutover_apply_updates_profile_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_http_app_preview.py
+++ b/tests/test_http_app_preview.py
@@ -1,6 +1,5 @@
 import json
 import os
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
@@ -32,6 +31,7 @@ from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewInventoryItem,
     GenericWebPreviewInventoryResult,
 )
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _asgi_request,
@@ -69,7 +69,7 @@ from tests.test_service import (
 )
 
 
-class FastApiPreviewLifecycleCleanupTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPreviewLifecycleCleanupTests(AsyncTestCase):
     def _cleanup_policy(self, actions: list[str]) -> LaunchplaneAuthzPolicy:
         return LaunchplaneAuthzPolicy.model_validate(
             {
@@ -581,7 +581,7 @@ class FastApiPreviewLifecycleCleanupTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["error"]["code"], "not_found")
 
 
-class FastApiPreviewDesiredStateTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPreviewDesiredStateTests(AsyncTestCase):
     async def test_preview_desired_state_discovers_and_records_labeled_prs(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -794,7 +794,7 @@ class FastApiPreviewDesiredStateTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPreviewPrFeedbackTests(AsyncTestCase):
     async def test_preview_pr_feedback_records_skipped_delivery_without_token(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -978,7 +978,7 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiPreviewReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPreviewReadTests(AsyncTestCase):
     async def test_preview_read_returns_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")

--- a/tests/test_http_app_product.py
+++ b/tests/test_http_app_product.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
@@ -30,6 +29,7 @@ from control_plane.work_graph_issue_inbox import (
     GitHubIssueInboxReadModel,
     GitHubIssueInboxReconcileResult,
 )
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _asgi_request,
@@ -84,7 +84,7 @@ from tests.test_service import (
 )
 
 
-class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCase):
+class FastApiProductEnvironmentConfigStatusTests(AsyncTestCase):
     async def test_config_status_redacts_expected_config_status(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -469,7 +469,7 @@ class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCas
         self.assertIn("trace_id", health_payload)
 
 
-class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiProductEnvironmentReadTests(AsyncTestCase):
     async def test_repo_product_mapping_returns_managed_and_awareness_repos(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -1630,7 +1630,7 @@ class FastApiProductEnvironmentReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(config_status_response.status_code, 200)
 
 
-class FastApiProductProfileTests(unittest.IsolatedAsyncioTestCase):
+class FastApiProductProfileTests(AsyncTestCase):
     async def test_list_product_profiles_returns_profiles_for_driver(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -2137,7 +2137,7 @@ class FastApiProductProfileTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(stored_profile.driver_id, "generic-web")
 
 
-class FastApiProtectedArtifactsTests(unittest.IsolatedAsyncioTestCase):
+class FastApiProtectedArtifactsTests(AsyncTestCase):
     async def test_protected_artifacts_returns_launchplane_inventory(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             record_store = FilesystemRecordStore(Path(temporary_directory_name) / "state")

--- a/tests/test_http_app_records.py
+++ b/tests/test_http_app_records.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import (
@@ -27,6 +26,7 @@ from control_plane.workflows.public_ingress_monitor import (
     PublicIngressMonitorResult,
     public_ingress_managed_secret_resolver,
 )
+from tests.async_case import AsyncTestCase
 from tests.http_app_test_support import (
     _asgi_get,
     _asgi_request,
@@ -108,7 +108,7 @@ from tests.test_service import (
 )
 
 
-class FastApiDeploymentPromotionReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiDeploymentPromotionReadTests(AsyncTestCase):
     async def test_deployment_read_returns_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -392,7 +392,7 @@ class FastApiDeploymentPromotionReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(promotion_response.json()["status"], "ok")
 
 
-class FastApiEnvironmentInventoryReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiEnvironmentInventoryReadTests(AsyncTestCase):
     async def test_inventory_read_returns_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -543,7 +543,7 @@ class FastApiEnvironmentInventoryReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
-class FastApiRecentOperationsReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiRecentOperationsReadTests(AsyncTestCase):
     async def test_recent_operations_returns_operator_read_model(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -682,7 +682,7 @@ class FastApiRecentOperationsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.json()["status"], "ok")
 
 
-class FastApiSecretStatusReadTests(unittest.IsolatedAsyncioTestCase):
+class FastApiSecretStatusReadTests(AsyncTestCase):
     async def test_secret_status_routes_return_metadata_only_models(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -929,7 +929,7 @@ class FastApiSecretStatusReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(show_response.json()["status"], "ok")
 
 
-class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiBackupGateEvidenceTests(AsyncTestCase):
     async def test_backup_gate_evidence_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -1174,7 +1174,7 @@ class FastApiBackupGateEvidenceTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiPublicIngressMonitorTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPublicIngressMonitorTests(AsyncTestCase):
     async def test_public_ingress_monitor_runs_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
@@ -1510,7 +1510,7 @@ class FastApiPublicIngressMonitorTests(unittest.IsolatedAsyncioTestCase):
         run_monitor.assert_called_once()
 
 
-class FastApiPromotionEvidenceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPromotionEvidenceTests(AsyncTestCase):
     async def test_promotion_evidence_writes_record_and_inventory_for_authorized_workflow(
         self,
     ) -> None:
@@ -1822,7 +1822,7 @@ class FastApiPromotionEvidenceTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiPreviewGenerationEvidenceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPreviewGenerationEvidenceTests(AsyncTestCase):
     async def test_preview_generation_evidence_writes_records_for_authorized_workflow(
         self,
     ) -> None:
@@ -2171,7 +2171,7 @@ class FastApiPreviewGenerationEvidenceTests(unittest.IsolatedAsyncioTestCase):
         )
 
 
-class FastApiPreviewDestroyedEvidenceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiPreviewDestroyedEvidenceTests(AsyncTestCase):
     async def test_preview_destroyed_evidence_writes_record_for_authorized_workflow(
         self,
     ) -> None:
@@ -2489,7 +2489,7 @@ class FastApiPreviewDestroyedEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["records"]["transition"], "destroyed")
 
 
-class FastApiRunnerHostHygieneAuditEvidenceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiRunnerHostHygieneAuditEvidenceTests(AsyncTestCase):
     async def test_runner_host_hygiene_audit_evidence_writes_record_for_authorized_workflow(
         self,
     ) -> None:
@@ -2813,7 +2813,7 @@ class FastApiRunnerHostHygieneAuditEvidenceTests(unittest.IsolatedAsyncioTestCas
         )
 
 
-class FastApiRunnerLaneRegistrationAuditEvidenceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiRunnerLaneRegistrationAuditEvidenceTests(AsyncTestCase):
     async def test_runner_lane_registration_audit_evidence_writes_record_for_authorized_workflow(
         self,
     ) -> None:
@@ -3145,7 +3145,7 @@ class FastApiRunnerLaneRegistrationAuditEvidenceTests(unittest.IsolatedAsyncioTe
         )
 
 
-class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
+class FastApiDeploymentEvidenceTests(AsyncTestCase):
     async def test_deployment_evidence_writes_record_for_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"


### PR DESCRIPTION
## Summary
- add `tests.async_case.AsyncTestCase`, preserving per-test event-loop isolation while disabling asyncio debug mode
- convert high-volume HTTP app async tests to use the shared async test base
- document the async test base in the testing style guide

## Why
Python 3.13's `unittest.IsolatedAsyncioTestCase` creates `asyncio.Runner(debug=True)`. The HTTP app tests trip slow-callback debug logging heavily, adding stderr churn and measurable overhead without adding signal for the normal CI test gate.

This is test-only and keeps the same isolated event-loop model.

## Local timing signal
Before this patch, local targeted runs showed:
- `FastApiEveryCodeReadTests`: 56 tests in 8.065s, with asyncio slow-callback stderr noise
- `FastApiProductEnvironmentReadTests`: 41 tests in 8.637s, with asyncio slow-callback stderr noise

After this patch:
- `FastApiEveryCodeReadTests`: 56 tests in 6.980s, clean output
- `FastApiProductEnvironmentReadTests`: 41 tests in 7.212s, clean output
- combined targeted run: 97 tests in 15.529s, clean output
- broader HTTP subset: `tests.test_http_app_every_code tests.test_http_app_product tests.test_http_app_core`, 189 tests in 55.442s, clean output

## Validation
- `uv run --extra dev ruff check tests/async_case.py tests/test_http_app_*.py`
- `uv run --extra dev mypy tests/async_case.py tests/test_http_app_every_code.py tests/test_http_app_product.py tests/test_http_app_core.py`
- `uv run python -m unittest tests.test_http_app_every_code.FastApiEveryCodeReadTests tests.test_http_app_product.FastApiProductEnvironmentReadTests`
- `uv run python -m unittest tests.test_http_app_every_code tests.test_http_app_product tests.test_http_app_core`
- `git diff --check`

Note: background auto-review could not produce findings because its diff snapshot exceeded the configured size limit; targeted local checks above passed.
