### PR TITLE
Migrate generic-web rollback to FastAPI

### DIFF
--- a/control_plane/drivers/generic_web_dispatch.py
+++ b/control_plane/drivers/generic_web_dispatch.py
@@ -9,8 +9,6 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.generic_web_rollback import (
     GenericWebRollbackPlanRequest,
-    GenericWebRollbackPlanStore,
-    execute_generic_web_rollback_plan,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.contracts.promotion_record import HealthcheckEvidence, ReleaseStatus
@@ -54,10 +52,6 @@ from control_plane.workflows.generic_web_promotion import (
 from control_plane.workflows.generic_web_promotion_workflow import (
     GenericWebPromotionWorkflowRequest,
     dispatch_generic_web_promotion_workflow,
-)
-from control_plane.workflows.generic_web_rollback import (
-    GenericWebRollbackApplyStore,
-    execute_generic_web_rollback,
 )
 from control_plane.workflows.odoo_generic_web_post_deploy import (
     generic_web_post_deploy_executor_for_driver_id,
@@ -438,27 +432,6 @@ def _handle_generic_web_stable_verification(
     )
 
 
-def _handle_generic_web_rollback_plan(
-    request: GenericWebRollbackPlanEnvelope,
-    resolved_context: _ResolvedProductDriverContext,
-    record_store: object,
-    control_plane_root_path: Path,
-) -> _DescriptorDriverDispatchResult:
-    del control_plane_root_path
-    if resolved_context.profile is None or resolved_context.lane is None:
-        raise ProductDriverMismatchError(
-            "Generic web rollback plan requires a product profile lane."
-        )
-    driver_result = execute_generic_web_rollback_plan(
-        record_store=cast(GenericWebRollbackPlanStore, record_store),
-        request=request.rollback_plan,
-    )
-    return _DescriptorDriverDispatchResult(
-        result={"generic_web_rollback_plan_id": driver_result.plan_id},
-        driver_result=driver_result,
-    )
-
-
 def _handle_generic_web_deploy(
     request: GenericWebDeployEnvelope,
     resolved_context: _ResolvedProductDriverContext,
@@ -567,34 +540,6 @@ def _handle_generic_web_prod_promotion(
             "release_tag": driver_result.release_tag,
             "release_url": driver_result.release_url,
             "dry_run": driver_result.dry_run,
-        },
-        driver_result=driver_result,
-    )
-
-
-def _handle_generic_web_rollback(
-    request: GenericWebRollbackEnvelope,
-    resolved_context: _ResolvedProductDriverContext,
-    record_store: object,
-    control_plane_root_path: Path,
-) -> _DescriptorDriverDispatchResult:
-    if resolved_context.profile is None or resolved_context.lane is None:
-        raise ProductDriverMismatchError("Generic web rollback requires a product profile lane.")
-    driver_result = execute_generic_web_rollback(
-        control_plane_root=control_plane_root_path,
-        record_store=cast(GenericWebRollbackApplyStore, record_store),
-        request=request.rollback,
-        post_deploy_executor=_generic_web_post_deploy_executor_for_profile(
-            resolved_context.profile
-        ),
-    )
-    return _DescriptorDriverDispatchResult(
-        result={
-            "generic_web_rollback_plan_id": driver_result.plan_id,
-            "deployment_record_id": driver_result.deployment_record_id,
-            "rollback_status": driver_result.rollback_status,
-            "deploy_status": driver_result.deploy_status,
-            "post_deploy_status": driver_result.post_deploy_status,
         },
         driver_result=driver_result,
     )

--- a/control_plane/generic_web_rollback_http.py
+++ b/control_plane/generic_web_rollback_http.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneProfile,
+)
+from control_plane.drivers.generic_web_dispatch import (
+    GenericWebRollbackEnvelope,
+    GenericWebRollbackPlanEnvelope,
+    _GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+    _GENERIC_WEB_ROLLBACK_ROUTE,
+    _generic_web_post_deploy_executor_for_profile,
+)
+from control_plane.drivers.registry import read_driver_descriptor
+from control_plane.contracts.generic_web_rollback import (
+    GenericWebRollbackPlanStore,
+    execute_generic_web_rollback_plan,
+)
+from control_plane.workflows.generic_web_rollback import (
+    GenericWebRollbackApplyStore,
+    execute_generic_web_rollback,
+)
+
+
+GENERIC_WEB_DRIVER_ID = "generic-web"
+GENERIC_WEB_ROLLBACK_PLAN_ROUTE = _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path
+GENERIC_WEB_ROLLBACK_ROUTE = _GENERIC_WEB_ROLLBACK_ROUTE.route_path
+GENERIC_WEB_ROLLBACK_PLAN_ACTION = "generic_web_prod_rollback.plan"
+GENERIC_WEB_ROLLBACK_ACTION = "generic_web_prod_rollback.execute"
+
+__all__ = [
+    "GENERIC_WEB_ROLLBACK_ACTION",
+    "GENERIC_WEB_ROLLBACK_PLAN_ACTION",
+    "GENERIC_WEB_ROLLBACK_PLAN_ROUTE",
+    "GENERIC_WEB_ROLLBACK_ROUTE",
+    "GenericWebRollbackEnvelope",
+    "GenericWebRollbackPlanEnvelope",
+    "GenericWebRollbackProductMismatchError",
+    "GenericWebRollbackRouteDependencyError",
+    "execute_generic_web_rollback_plan_result",
+    "execute_generic_web_rollback_result",
+    "resolve_generic_web_rollback_lane",
+    "should_store_generic_web_rollback_idempotency",
+]
+
+
+class GenericWebRollbackProductMismatchError(ValueError):
+    pass
+
+
+class GenericWebRollbackRouteDependencyError(ValueError):
+    pass
+
+
+def resolve_generic_web_rollback_lane(
+    *, record_store: object, product: str, route_path: str, instance: str
+) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile]:
+    read_profile = getattr(record_store, "read_product_profile_record", None)
+    if not callable(read_profile):
+        raise ValueError("Product driver validation requires product profile storage.")
+    try:
+        profile = read_profile(product.strip())
+    except FileNotFoundError as error:
+        raise GenericWebRollbackRouteDependencyError from error
+    if not isinstance(profile, LaunchplaneProductProfileRecord):
+        profile = LaunchplaneProductProfileRecord.model_validate(profile)
+    if not product_profile_supports_generic_web_route(profile=profile, route_path=route_path):
+        raise GenericWebRollbackProductMismatchError(
+            "Product profile is not compatible with the requested driver route."
+        )
+    normalized_instance = instance.strip()
+    for lane in profile.lanes:
+        if lane.instance.strip() == normalized_instance:
+            return profile, lane
+    raise GenericWebRollbackProductMismatchError(
+        "Product profile does not own the requested driver lane."
+    )
+
+
+def product_profile_supports_generic_web_route(
+    *, profile: LaunchplaneProductProfileRecord, route_path: str
+) -> bool:
+    profile_driver_id = profile.driver_id.strip()
+    if profile_driver_id == GENERIC_WEB_DRIVER_ID:
+        return True
+    try:
+        descriptor = read_driver_descriptor(profile_driver_id)
+    except FileNotFoundError:
+        return False
+    return descriptor.base_driver_id == GENERIC_WEB_DRIVER_ID and route_path in {
+        GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+        GENERIC_WEB_ROLLBACK_ROUTE,
+    }
+
+
+def execute_generic_web_rollback_plan_result(
+    *, record_store: object, request: GenericWebRollbackPlanEnvelope
+) -> tuple[dict[str, object], dict[str, object]]:
+    driver_result = execute_generic_web_rollback_plan(
+        record_store=cast(GenericWebRollbackPlanStore, record_store),
+        request=request.rollback_plan,
+    )
+    return {"generic_web_rollback_plan_id": driver_result.plan_id}, driver_result.model_dump(
+        mode="json"
+    )
+
+
+def execute_generic_web_rollback_result(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebRollbackEnvelope,
+    profile: LaunchplaneProductProfileRecord,
+) -> tuple[dict[str, object], dict[str, object]]:
+    driver_result = execute_generic_web_rollback(
+        control_plane_root=control_plane_root,
+        record_store=cast(GenericWebRollbackApplyStore, record_store),
+        request=request.rollback,
+        post_deploy_executor=_generic_web_post_deploy_executor_for_profile(profile),
+    )
+    records: dict[str, object] = {
+        "generic_web_rollback_plan_id": driver_result.plan_id,
+        "deployment_record_id": driver_result.deployment_record_id,
+        "rollback_status": driver_result.rollback_status,
+        "deploy_status": driver_result.deploy_status,
+        "post_deploy_status": driver_result.post_deploy_status,
+    }
+    return records, driver_result.model_dump(mode="json")
+
+
+def should_store_generic_web_rollback_idempotency(driver_result: dict[str, object]) -> bool:
+    if any(str(value).strip() == "blocked" for value in _status_values(driver_result)):
+        return False
+    if (
+        str(driver_result.get("deploy_status", "")).strip() == "pass"
+        and str(driver_result.get("post_deploy_status", "")).strip() == "fail"
+    ):
+        return True
+    return not any(str(value).strip() == "fail" for value in _status_values(driver_result))
+
+
+def _status_values(driver_result: dict[str, object]) -> tuple[object, ...]:
+    return tuple(
+        value for key, value in driver_result.items() if key.endswith("_status") or key == "status"
+    )

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -151,6 +151,20 @@ from control_plane.launchplane_self_deploy_http import (
     LaunchplaneSelfDeployEnvelope,
     launchplane_self_deploy_records,
 )
+from control_plane.generic_web_rollback_http import (
+    GENERIC_WEB_ROLLBACK_ACTION,
+    GENERIC_WEB_ROLLBACK_PLAN_ACTION,
+    GENERIC_WEB_ROLLBACK_PLAN_ROUTE as _GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+    GENERIC_WEB_ROLLBACK_ROUTE as _GENERIC_WEB_ROLLBACK_ROUTE,
+    GenericWebRollbackEnvelope,
+    GenericWebRollbackPlanEnvelope,
+    GenericWebRollbackProductMismatchError,
+    GenericWebRollbackRouteDependencyError,
+    execute_generic_web_rollback_plan_result,
+    execute_generic_web_rollback_result,
+    resolve_generic_web_rollback_lane,
+    should_store_generic_web_rollback_idempotency,
+)
 from control_plane.odoo_artifact_publish_inputs_http import (
     ODOO_ARTIFACT_PUBLISH_INPUTS_ACTION,
     ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE as _ODOO_ARTIFACT_PUBLISH_INPUTS_ROUTE,
@@ -6709,6 +6723,256 @@ def create_launchplane_fastapi_app(
             records={key: str(value) for key, value in records.items()},
             result=driver_result,
         )
+
+    async def write_generic_web_rollback_plan(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse | JSONResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            )
+        try:
+            rollback_request = GenericWebRollbackPlanEnvelope.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        try:
+            _profile, lane = resolve_generic_web_rollback_lane(
+                record_store=record_store,
+                product=rollback_request.product,
+                route_path=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+                instance=rollback_request.rollback_plan.instance,
+            )
+        except GenericWebRollbackRouteDependencyError:
+            return driver_route_dependency_not_found_response(
+                trace_id=trace_id,
+                route_path=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+            )
+        except GenericWebRollbackProductMismatchError as error:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="product_driver_mismatch",
+                message="Product is not configured for the requested driver route.",
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=GENERIC_WEB_ROLLBACK_PLAN_ACTION,
+            product=rollback_request.product,
+            context=lane.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot plan the generic web prod rollback"
+                    " for the requested product/context."
+                ),
+            )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+        try:
+            records, driver_result = execute_generic_web_rollback_plan_result(
+                record_store=record_store,
+                request=rollback_request,
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=f"No Launchplane route for {_GENERIC_WEB_ROLLBACK_PLAN_ROUTE}.",
+            ) from error
+        except (ValueError, click.ClickException) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={key: str(value) for key, value in records.items()},
+            result=driver_result,
+        )
+        if should_store_generic_web_rollback_idempotency(driver_result):
+            store_apply_idempotency(
+                record_store=record_store,
+                identity=identity,
+                route_path=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=response,
+            )
+        return response
+
+    async def write_generic_web_rollback(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse | JSONResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            )
+        try:
+            rollback_request = GenericWebRollbackEnvelope.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        try:
+            profile, lane = resolve_generic_web_rollback_lane(
+                record_store=record_store,
+                product=rollback_request.product,
+                route_path=_GENERIC_WEB_ROLLBACK_ROUTE,
+                instance=rollback_request.rollback.instance,
+            )
+        except GenericWebRollbackRouteDependencyError:
+            return driver_route_dependency_not_found_response(
+                trace_id=trace_id,
+                route_path=_GENERIC_WEB_ROLLBACK_ROUTE,
+            )
+        except GenericWebRollbackProductMismatchError as error:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="product_driver_mismatch",
+                message="Product is not configured for the requested driver route.",
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=GENERIC_WEB_ROLLBACK_ACTION,
+            product=rollback_request.product,
+            context=lane.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot execute the generic web prod rollback"
+                    " for the requested product/context."
+                ),
+            )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_GENERIC_WEB_ROLLBACK_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+        try:
+            records, driver_result = execute_generic_web_rollback_result(
+                control_plane_root=resolved_control_plane_root,
+                record_store=record_store,
+                request=rollback_request,
+                profile=profile,
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=f"No Launchplane route for {_GENERIC_WEB_ROLLBACK_ROUTE}.",
+            ) from error
+        except (ValueError, click.ClickException) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={key: str(value) for key, value in records.items()},
+            result=driver_result,
+        )
+        if should_store_generic_web_rollback_idempotency(driver_result):
+            store_apply_idempotency(
+                record_store=record_store,
+                identity=identity,
+                route_path=_GENERIC_WEB_ROLLBACK_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=response,
+            )
+        return response
 
     async def write_odoo_prod_rollback(
         request: Request,
@@ -14873,6 +15137,62 @@ def create_launchplane_fastapi_app(
         },
         operation_id="write_odoo_prod_backup_gate",
         summary="Execute Odoo prod backup gate",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
+        write_generic_web_rollback_plan,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": GenericWebRollbackPlanEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="write_generic_web_rollback_plan",
+        summary="Plan generic web prod rollback",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _GENERIC_WEB_ROLLBACK_ROUTE,
+        write_generic_web_rollback,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {"schema": GenericWebRollbackEnvelope.model_json_schema()}
+                },
+            }
+        },
+        operation_id="write_generic_web_rollback",
+        summary="Execute generic web prod rollback",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -102,8 +102,6 @@ from control_plane.drivers.generic_web_dispatch import (
     _handle_generic_web_deploy as _handle_generic_web_deploy,
     _handle_generic_web_prod_promotion as _handle_generic_web_prod_promotion,
     _handle_generic_web_promotion_workflow as _handle_generic_web_promotion_workflow,
-    _handle_generic_web_rollback as _handle_generic_web_rollback,
-    _handle_generic_web_rollback_plan as _handle_generic_web_rollback_plan,
     _handle_generic_web_stable_verification as _handle_generic_web_stable_verification,
     _handle_generic_web_source_ref_deploy as _handle_generic_web_source_ref_deploy,
     _stable_verification_health_evidence as _stable_verification_health_evidence,
@@ -306,6 +304,8 @@ _EVERY_CODE_GITHUB_WEBHOOK_SECRET_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHO
 _NATIVE_FASTAPI_DRIVER_ROUTE_PATHS = frozenset(
     {
         "/v1/drivers/generic-web/preview-desired-state",
+        _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
+        _GENERIC_WEB_ROLLBACK_ROUTE.route_path,
         "/v1/drivers/ingress/route-apply",
         "/v1/drivers/odoo/artifact-publish-inputs",
         ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE,
@@ -1295,26 +1295,6 @@ def _descriptor_driver_dispatch_routes() -> dict[str, _DescriptorDriverDispatchR
             pre_idempotency_validator=_validate_generic_web_prod_promotion_lanes,
             pre_authorization_validator=_reject_human_live_generic_web_prod_promotion,
             handler=_handle_generic_web_prod_promotion,
-        ),
-        _GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path: _DescriptorDriverDispatchRoute(
-            execution_metadata=_GENERIC_WEB_ROLLBACK_PLAN_ROUTE,
-            context_resolver=lambda request: _DescriptorDriverDispatchContext(
-                product=request.product,
-                context="",
-                instance=request.rollback_plan.instance,
-                require_profile=True,
-            ),
-            handler=_handle_generic_web_rollback_plan,
-        ),
-        _GENERIC_WEB_ROLLBACK_ROUTE.route_path: _DescriptorDriverDispatchRoute(
-            execution_metadata=_GENERIC_WEB_ROLLBACK_ROUTE,
-            context_resolver=lambda request: _DescriptorDriverDispatchContext(
-                product=request.rollback.product,
-                context="",
-                instance=request.rollback.instance,
-                require_profile=True,
-            ),
-            handler=_handle_generic_web_rollback,
         ),
         _GENERIC_WEB_STABLE_VERIFICATION_ROUTE.route_path: _DescriptorDriverDispatchRoute(
             execution_metadata=_GENERIC_WEB_STABLE_VERIFICATION_ROUTE,
@@ -3094,8 +3074,6 @@ def _accepted_payload(
 def _accepted_payload_extra_record_keys(*, route_path: str) -> frozenset[str]:
     if route_path == _ODOO_TARGET_REPLACEMENT_APPLY_ROUTE.route_path:
         return frozenset({"deployment_record_id", "release_tuple_id"})
-    if route_path == _GENERIC_WEB_ROLLBACK_ROUTE.route_path:
-        return frozenset({"rollback_status", "deploy_status", "post_deploy_status"})
     return frozenset()
 
 

--- a/docs/compatibility-retirement.md
+++ b/docs/compatibility-retirement.md
@@ -201,6 +201,19 @@ Keep a compatibility surface only when it is one of these:
   retries can observe recovered deployment/provider state. The descriptor route
   remains discoverable, but legacy WSGI descriptor dispatch is exempted and
   direct fallback calls fail closed.
+- Generic-web prod rollback planning and apply use native FastAPI routes:
+  `POST /v1/drivers/generic-web/prod-rollback-plan` and
+  `POST /v1/drivers/generic-web/prod-rollback`. Both routes preserve
+  product/profile and lane validation, lane-context authorization,
+  dependency-miss `503` classification, handler-side `404` file-miss parity,
+  raw-payload `Idempotency-Key` replay/conflict behavior, and descriptor
+  discoverability. Rollback apply preserves the generic deploy post-deploy
+  extension hook for Odoo-based profiles. Blocked plan/apply results and
+  ordinary failed apply results are not cached so retries can observe recovered
+  Launchplane/provider state; apply results where deploy passed but post-deploy
+  failed are cached because provider mutation already occurred. Legacy WSGI
+  descriptor dispatch is exempted for both paths, and direct fallback calls fail
+  closed.
 - Odoo prod-promotion inputs, prod-promotion run, and the older monolithic
   prod-promotion compatibility route use native FastAPI routes:
   `POST /v1/drivers/odoo/prod-promotion-inputs`,

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -173,8 +173,9 @@ Launchplane reads the product profile, destination lane, selected deployment
 record, and optional backup gate evidence, then writes a
 `GenericWebRollbackPlanRecord`. It does not mutate the provider. Odoo rollback
 planning uses this generic-web route; the former Odoo-shaped rollback-plan alias
-is retired. This route is registered through descriptor-backed dispatch, so
-descriptor/handler drift fails closed before the service starts.
+is retired. This route is executed by native FastAPI. Its descriptor remains
+discoverable for driver views and authz metadata, while legacy WSGI
+descriptor-backed dispatch is exempted so direct fallback calls fail closed.
 
 The `prod_rollback` action routes to
 `POST /v1/drivers/generic-web/prod-rollback`. It re-runs the same rollback-plan
@@ -183,8 +184,9 @@ generic-web deploy path using the previous immutable artifact identity. Generic
 rollback also forwards the generic deploy post-deploy extension hook, so a
 based driver can keep product-only post-deploy checks while reusing the common
 rollback deployment path once its other invariants are represented. This route
-is registered through descriptor-backed dispatch, so descriptor/handler drift
-fails closed before the service starts. Product drivers keep their own
+is executed by native FastAPI. Its descriptor remains discoverable for driver
+views and authz metadata, while legacy WSGI descriptor-backed dispatch is
+exempted so direct fallback calls fail closed. Product drivers keep their own
 `prod_rollback` action only when they need additional product-specific gates,
 such as Odoo backup, release tuple, manifest, migration, or post-deploy checks.
 Odoo keeps `POST /v1/drivers/odoo/prod-rollback` as its

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -283,8 +283,8 @@ VeriReel product paths:
   - `POST /v1/drivers/generic-web/deploy`
   - `POST /v1/drivers/generic-web/prod-promotion`
   - `POST /v1/drivers/generic-web/prod-promotion-workflow`
-  - `POST /v1/drivers/generic-web/prod-rollback-plan`
-  - `POST /v1/drivers/generic-web/prod-rollback`
+  - `POST /v1/drivers/generic-web/prod-rollback-plan` (native FastAPI)
+  - `POST /v1/drivers/generic-web/prod-rollback` (native FastAPI)
   - `POST /v1/drivers/generic-web/stable-verification`
   - `POST /v1/drivers/generic-web/preview-desired-state` (native FastAPI)
   - `POST /v1/drivers/generic-web/preview-refresh`
@@ -1547,6 +1547,23 @@ The legacy response-only `target_type` alias is retired; Dokploy execution
 configuration still uses provider-specific target type fields internally where
 application-vs-compose behavior is required.
 
+Generic web prod rollback planning and apply use native FastAPI routes:
+`POST /v1/drivers/generic-web/prod-rollback-plan` and
+`POST /v1/drivers/generic-web/prod-rollback`. Both routes resolve the product
+profile and destination lane before authorization, then authorize against the
+lane context stored in Launchplane rather than request-supplied runtime
+authority. Rollback planning writes a `GenericWebRollbackPlanRecord` without
+mutating the provider. Rollback apply re-runs planning, applies ready plans via
+the common generic-web deploy path, and preserves the post-deploy extension hook
+for drivers such as Odoo that inherit generic-web behavior. Optional
+`Idempotency-Key` replay is available for non-blocked plan results and for
+successful apply results; blocked results and ordinary deploy failures are left
+uncached so a later retry can observe recovered Launchplane/provider state.
+Apply results where deploy passed but post-deploy failed are cached because the
+provider mutation already occurred. The descriptors remain discoverable, but
+legacy WSGI descriptor dispatch is exempted for both paths and direct fallback
+calls fail closed.
+
 Generic web preview desired-state discovery uses
 `POST /v1/drivers/generic-web/preview-desired-state`, now owned by native
 FastAPI. The request names the product and optional pull-request label/page
@@ -1798,6 +1815,8 @@ These use the same authn/authz boundary as evidence ingress:
 - `POST /v1/drivers/odoo/prod-promotion` (native FastAPI compatibility route)
 - `POST /v1/drivers/odoo/prod-rollback` (native FastAPI)
 - `POST /v1/drivers/generic-web/prod-promotion`
+- `POST /v1/drivers/generic-web/prod-rollback-plan` (native FastAPI)
+- `POST /v1/drivers/generic-web/prod-rollback` (native FastAPI)
 - `POST /v1/drivers/verireel/...`
 
 The first driver route handlers now in service are admitted from descriptor

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -3582,6 +3582,50 @@ async def _post_odoo_prod_rollback(
     )
 
 
+async def _post_generic_web_rollback_plan(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/drivers/generic-web/prod-rollback-plan",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
+async def _post_generic_web_rollback(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/drivers/generic-web/prod-rollback",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _post_odoo_stable_bootstrap(
     app: FastAPI,
     payload: dict[str, object],

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -642,22 +642,28 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         )
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
-    def test_rollback_plan_registered_in_descriptor_dispatch(self) -> None:
+    def test_generic_web_rollback_plan_is_native_fastapi_dispatch_exempt(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        route_path = control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path
 
+        self.assertIn(route_path, control_plane_service._driver_route_metadata_from_descriptors())
         self.assertIn(
-            control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
-            dispatch_routes,
+            route_path, control_plane_service._descriptor_driver_dispatch_exempt_route_paths()
         )
+        self.assertNotIn(route_path, dispatch_routes)
+        self.assertNotIn(route_path, control_plane_service._driver_write_routes_from_descriptors())
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
-    def test_generic_web_rollback_registered_in_descriptor_dispatch(self) -> None:
+    def test_generic_web_rollback_is_native_fastapi_dispatch_exempt(self) -> None:
         dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+        route_path = control_plane_service._GENERIC_WEB_ROLLBACK_ROUTE.route_path
 
+        self.assertIn(route_path, control_plane_service._driver_route_metadata_from_descriptors())
         self.assertIn(
-            control_plane_service._GENERIC_WEB_ROLLBACK_ROUTE.route_path,
-            dispatch_routes,
+            route_path, control_plane_service._descriptor_driver_dispatch_exempt_route_paths()
         )
+        self.assertNotIn(route_path, dispatch_routes)
+        self.assertNotIn(route_path, control_plane_service._driver_write_routes_from_descriptors())
         control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_preview_verification_registered_in_descriptor_dispatch(self) -> None:
@@ -1065,15 +1071,16 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                 ),
             ),
         ):
-            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
-                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
-
-    def test_generic_web_rollback_descriptor_requires_dispatch_registration(self) -> None:
-        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
-        dispatch_routes.pop(control_plane_service._GENERIC_WEB_ROLLBACK_ROUTE.route_path)
-
-        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+
+    def test_generic_web_rollback_descriptor_allows_native_fastapi_exemption(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
+
+        self.assertNotIn(
+            control_plane_service._GENERIC_WEB_ROLLBACK_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_generic_web_promotion_workflow_descriptor_requires_dispatch_registration(
         self,
@@ -1180,8 +1187,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                 ),
             ),
         ):
-            with self.assertRaisesRegex(ValueError, "must be declared by a driver descriptor"):
-                control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_preview_verification_dispatch_registration_requires_descriptor_route(
         self,
@@ -1587,12 +1593,14 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "must be registered by the service"):
             control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
-    def test_rollback_plan_descriptor_requires_dispatch_registration(self) -> None:
-        dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())
-        dispatch_routes.pop(control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path)
+    def test_rollback_plan_descriptor_allows_native_fastapi_exemption(self) -> None:
+        dispatch_routes = control_plane_service._descriptor_driver_dispatch_routes()
 
-        with self.assertRaisesRegex(ValueError, "must be registered by the service"):
-            control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
+        self.assertNotIn(
+            control_plane_service._GENERIC_WEB_ROLLBACK_PLAN_ROUTE.route_path,
+            dispatch_routes,
+        )
+        control_plane_service._validate_descriptor_driver_dispatch_routes(dispatch_routes)
 
     def test_preview_verification_descriptor_requires_dispatch_registration(self) -> None:
         dispatch_routes = dict(control_plane_service._descriptor_driver_dispatch_routes())

--- a/tests/test_generic_web_rollback.py
+++ b/tests/test_generic_web_rollback.py
@@ -1,12 +1,16 @@
 import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Literal, cast
 from unittest.mock import patch
 
+from fastapi import FastAPI
 from pydantic import ValidationError
 
 from control_plane.contracts.backup_gate_record import BackupGateRecord
 from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.generic_web_rollback import GenericWebRollbackBlocker
 from control_plane.contracts.generic_web_rollback import (
     GenericWebRollbackPlanRequest,
     build_generic_web_rollback_plan,
@@ -20,12 +24,27 @@ from control_plane.contracts.product_profile_record import (
 from control_plane.contracts.promotion_record import ArtifactIdentityReference, HealthcheckEvidence
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
+from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
+from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployResult,
     GenericWebPostDeployExecutor,
 )
-from control_plane.workflows.generic_web_rollback import execute_generic_web_rollback
+from control_plane.workflows.generic_web_rollback import (
+    GenericWebRollbackApplyResult,
+    execute_generic_web_rollback,
+)
+from control_plane.workflows.odoo_generic_web_post_deploy import (
+    execute_odoo_generic_web_post_deploy,
+)
 from control_plane.workflows.ship import build_deployment_record
+from tests.http_app_test_support import (
+    _asgi_get,
+    _post_generic_web_rollback,
+    _post_generic_web_rollback_plan,
+)
+from tests.test_service import _StubVerifier, _identity, _invoke_app, create_launchplane_service_app
 
 
 class _GenericWebRollbackStore:
@@ -172,6 +191,93 @@ def _backup_gate(**overrides: object) -> BackupGateRecord:
     }
     payload.update(overrides)
     return BackupGateRecord.model_validate(payload)
+
+
+def _rollback_route_policy(
+    *actions: str,
+    product: str = "sellyouroutboard",
+    context: str = "sellyouroutboard-testing",
+    repository: str = "every/verireel",
+    workflow_ref: str = "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main",
+    event_name: str = "pull_request",
+) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": repository,
+                    "workflow_refs": [workflow_ref],
+                    "event_names": [event_name],
+                    "products": [product],
+                    "contexts": [context],
+                    "actions": list(actions),
+                }
+            ]
+        }
+    )
+
+
+def _rollback_plan_payload(**overrides: object) -> dict[str, object]:
+    rollback_plan: dict[str, object] = {
+        "schema_version": 1,
+        "product": "sellyouroutboard",
+        "instance": "prod",
+        "rollback_deployment_record_id": "deployment-syo-prod-previous",
+    }
+    rollback_plan.update(cast(dict[str, object], overrides.pop("rollback_plan", {})))
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "product": "sellyouroutboard",
+        "rollback_plan": rollback_plan,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _rollback_payload(**overrides: object) -> dict[str, object]:
+    rollback: dict[str, object] = {
+        "schema_version": 1,
+        "product": "sellyouroutboard",
+        "instance": "prod",
+        "rollback_deployment_record_id": "deployment-syo-prod-previous",
+    }
+    rollback.update(cast(dict[str, object], overrides.pop("rollback", {})))
+    payload: dict[str, object] = {
+        "schema_version": 1,
+        "product": "sellyouroutboard",
+        "rollback": rollback,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _fastapi_rollback_identity(
+    *,
+    repository: str = "every/verireel",
+    workflow_ref: str = "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main",
+    event_name: str = "pull_request",
+) -> GitHubActionsIdentity:
+    return _identity(
+        repository=repository,
+        workflow_ref=workflow_ref,
+        event_name=event_name,
+    )
+
+
+def _odoo_inherited_profile() -> LaunchplaneProductProfileRecord:
+    return _profile().model_copy(
+        update={
+            "product": "odoo-tenant-cm",
+            "driver_id": "odoo",
+            "lanes": (
+                ProductLaneProfile(
+                    instance="prod",
+                    context="cm",
+                    base_url="https://cm.example.com",
+                ),
+            ),
+        }
+    )
 
 
 class GenericWebRollbackPlanTests(unittest.TestCase):
@@ -426,6 +532,654 @@ class GenericWebRollbackPlanTests(unittest.TestCase):
         self.assertEqual(
             [blocker.code for blocker in plan.blockers], ["mutable_artifact_reference"]
         )
+
+
+class FastApiGenericWebRollbackTests(unittest.IsolatedAsyncioTestCase):
+    def _app(
+        self,
+        *,
+        root: Path,
+        store: FilesystemRecordStore,
+        policy: LaunchplaneAuthzPolicy,
+        identity: GitHubActionsIdentity | None = None,
+    ) -> FastAPI:
+        return create_launchplane_fastapi_app(
+            verifier=_StubVerifier(identity or _fastapi_rollback_identity()),
+            authz_policy=policy,
+            record_store_factory=lambda: store,
+            control_plane_root_path=root,
+        )
+
+    def _write_profile_and_previous_deployment(
+        self,
+        store: FilesystemRecordStore,
+        *,
+        profile: LaunchplaneProductProfileRecord | None = None,
+        deployment: DeploymentRecord | None = None,
+    ) -> None:
+        store.write_product_profile_record(profile or _profile())
+        store.write_deployment_record(deployment or _deployment_record())
+
+    async def test_rollback_plan_route_writes_plan_record(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            self._write_profile_and_previous_deployment(store)
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.plan"),
+            )
+
+            response = await _post_generic_web_rollback_plan(
+                app,
+                _rollback_plan_payload(),
+                idempotency_key="generic-web-rollback-plan-syo-prod",
+            )
+            plans = store.list_generic_web_rollback_plan_records(
+                context_name="sellyouroutboard-testing",
+                instance_name="prod",
+                limit=1,
+            )
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(len(plans), 1)
+        self.assertEqual(payload["records"]["generic_web_rollback_plan_id"], plans[0].plan_id)
+        self.assertEqual(payload["result"]["status"], "ready")
+        self.assertEqual(plans[0].product, "sellyouroutboard")
+        self.assertEqual(plans[0].context, "sellyouroutboard-testing")
+
+    async def test_rollback_plan_route_rejects_unknown_lane(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.plan"),
+            )
+
+            response = await _post_generic_web_rollback_plan(
+                app,
+                _rollback_plan_payload(rollback_plan={"instance": "missing"}),
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "product_driver_mismatch")
+
+    async def test_rollback_plan_route_rejects_non_generic_web_profile(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                _profile().model_copy(update={"driver_id": "ingress"})
+            )
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.plan"),
+            )
+
+            response = await _post_generic_web_rollback_plan(
+                app,
+                _rollback_plan_payload(),
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "product_driver_mismatch")
+
+    async def test_rollback_plan_route_reports_missing_profile_dependency(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.plan"),
+            )
+
+            response = await _post_generic_web_rollback_plan(
+                app,
+                _rollback_plan_payload(),
+            )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "driver_route_dependency_not_found")
+
+    async def test_rollback_plan_route_rejects_unauthorized_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy(
+                    "generic_web_prod_rollback.plan", context="other-context"
+                ),
+            )
+
+            response = await _post_generic_web_rollback_plan(
+                app,
+                _rollback_plan_payload(),
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_rollback_plan_route_replays_idempotent_response(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            self._write_profile_and_previous_deployment(store)
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.plan"),
+            )
+            request_payload = _rollback_plan_payload()
+
+            first = await _post_generic_web_rollback_plan(
+                app,
+                request_payload,
+                idempotency_key="generic-web-rollback-plan-replay-syo-prod",
+            )
+            second = await _post_generic_web_rollback_plan(
+                app,
+                request_payload,
+                idempotency_key="generic-web-rollback-plan-replay-syo-prod",
+            )
+            plans = store.list_generic_web_rollback_plan_records(
+                context_name="sellyouroutboard-testing",
+                instance_name="prod",
+                limit=10,
+            )
+
+        self.assertEqual(first.status_code, 202)
+        self.assertEqual(second.status_code, 202)
+        self.assertEqual(first.json()["records"], second.json()["records"])
+        self.assertTrue(second.json()["replayed"])
+        self.assertEqual(len(plans), 1)
+
+    async def test_rollback_plan_route_does_not_cache_blocked_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.plan"),
+            )
+            request_payload = _rollback_plan_payload()
+
+            first = await _post_generic_web_rollback_plan(
+                app,
+                request_payload,
+                idempotency_key="generic-web-rollback-plan-blocked-syo-prod",
+            )
+            second = await _post_generic_web_rollback_plan(
+                app,
+                request_payload,
+                idempotency_key="generic-web-rollback-plan-blocked-syo-prod",
+            )
+            plans = store.list_generic_web_rollback_plan_records(
+                context_name="sellyouroutboard-testing",
+                instance_name="prod",
+                limit=10,
+            )
+
+        self.assertEqual(first.status_code, 202)
+        self.assertEqual(second.status_code, 202)
+        self.assertEqual(first.json()["result"]["status"], "blocked")
+        self.assertNotIn("replayed", second.json())
+        self.assertEqual(len(plans), 1)
+
+    async def test_rollback_plan_route_returns_404_for_workflow_file_miss(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            self._write_profile_and_previous_deployment(store)
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.plan"),
+            )
+
+            with patch(
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback_plan",
+                side_effect=FileNotFoundError("missing rollback source"),
+            ):
+                response = await _post_generic_web_rollback_plan(
+                    app,
+                    _rollback_plan_payload(),
+                )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_rollback_route_applies_ready_plan(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.execute"),
+            )
+            driver_result = GenericWebRollbackApplyResult(
+                plan_id="generic-web-rollback-syo-prod",
+                deployment_record_id="deployment-syo-prod-rollback",
+                rollback_status="pass",
+                deploy_status="pass",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                rollback_deployment_record_id="deployment-syo-prod-previous",
+            )
+
+            with patch(
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
+                return_value=driver_result,
+            ) as rollback:
+                response = await _post_generic_web_rollback(
+                    app,
+                    _rollback_payload(),
+                    idempotency_key="generic-web-rollback-syo-prod",
+                )
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(
+            payload["records"]["generic_web_rollback_plan_id"],
+            "generic-web-rollback-syo-prod",
+        )
+        self.assertEqual(payload["records"]["deployment_record_id"], "deployment-syo-prod-rollback")
+        self.assertEqual(payload["records"]["rollback_status"], "pass")
+        self.assertEqual(payload["records"]["deploy_status"], "pass")
+        self.assertEqual(payload["records"]["post_deploy_status"], "skipped")
+        rollback.assert_called_once()
+        self.assertEqual(rollback.call_args.kwargs["request"].product, "sellyouroutboard")
+        self.assertIsNone(rollback.call_args.kwargs["post_deploy_executor"])
+
+    async def test_rollback_route_reports_missing_profile_dependency(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.execute"),
+            )
+
+            response = await _post_generic_web_rollback(app, _rollback_payload())
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "driver_route_dependency_not_found")
+
+    async def test_rollback_route_returns_404_for_workflow_file_miss(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.execute"),
+            )
+
+            with patch(
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
+                side_effect=FileNotFoundError("missing rollback plan"),
+            ):
+                response = await _post_generic_web_rollback(app, _rollback_payload())
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_rollback_route_passes_odoo_post_deploy_adapter_for_odoo_profile(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_odoo_inherited_profile())
+            identity = _fastapi_rollback_identity(
+                repository="cbusillo/odoo-tenant-cm",
+                workflow_ref=(
+                    "cbusillo/odoo-tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
+                ),
+                event_name="workflow_dispatch",
+            )
+            app = self._app(
+                root=root,
+                store=store,
+                identity=identity,
+                policy=_rollback_route_policy(
+                    "generic_web_prod_rollback.execute",
+                    product="odoo-tenant-cm",
+                    context="cm",
+                    repository="cbusillo/odoo-tenant-cm",
+                    workflow_ref=(
+                        "cbusillo/odoo-tenant-cm/.github/workflows/deploy-odoo.yml@refs/heads/main"
+                    ),
+                    event_name="workflow_dispatch",
+                ),
+            )
+            driver_result = GenericWebRollbackApplyResult(
+                plan_id="generic-web-rollback-cm-prod",
+                deployment_record_id="deployment-cm-prod-rollback",
+                rollback_status="pass",
+                deploy_status="pass",
+                product="odoo-tenant-cm",
+                context="cm",
+                instance="prod",
+                rollback_deployment_record_id="deployment-cm-prod-previous",
+            )
+
+            with patch(
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
+                return_value=driver_result,
+            ) as rollback:
+                response = await _post_generic_web_rollback(
+                    app,
+                    _rollback_payload(
+                        product="odoo-tenant-cm",
+                        rollback={
+                            "product": "odoo-tenant-cm",
+                            "rollback_deployment_record_id": "deployment-cm-prod-previous",
+                        },
+                    ),
+                    idempotency_key="generic-web-rollback-cm-prod",
+                )
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(
+            response.json()["records"]["deployment_record_id"], "deployment-cm-prod-rollback"
+        )
+        rollback.assert_called_once()
+        self.assertIs(
+            rollback.call_args.kwargs["post_deploy_executor"],
+            execute_odoo_generic_web_post_deploy,
+        )
+
+    async def test_rollback_route_replays_idempotent_response_shape(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.execute"),
+            )
+            driver_result = GenericWebRollbackApplyResult(
+                plan_id="generic-web-rollback-syo-prod",
+                deployment_record_id="deployment-syo-prod-rollback",
+                rollback_status="pass",
+                deploy_status="pass",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                rollback_deployment_record_id="deployment-syo-prod-previous",
+            )
+            request_payload = _rollback_payload()
+
+            with patch(
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
+                return_value=driver_result,
+            ) as rollback:
+                first = await _post_generic_web_rollback(
+                    app,
+                    request_payload,
+                    idempotency_key="generic-web-rollback-replay-syo-prod",
+                )
+                second = await _post_generic_web_rollback(
+                    app,
+                    request_payload,
+                    idempotency_key="generic-web-rollback-replay-syo-prod",
+                )
+
+        self.assertEqual(first.status_code, 202)
+        self.assertEqual(second.status_code, 202)
+        self.assertEqual(first.json()["records"], second.json()["records"])
+        self.assertEqual(second.json()["records"]["rollback_status"], "pass")
+        self.assertEqual(second.json()["records"]["deploy_status"], "pass")
+        self.assertEqual(second.json()["records"]["post_deploy_status"], "skipped")
+        self.assertTrue(second.json()["replayed"])
+        rollback.assert_called_once()
+
+    async def test_rollback_route_does_not_cache_blocked_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.execute"),
+            )
+            driver_result = GenericWebRollbackApplyResult(
+                plan_id="generic-web-rollback-syo-prod-blocked",
+                rollback_status="blocked",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                rollback_deployment_record_id="deployment-syo-prod-previous",
+                blockers=(
+                    GenericWebRollbackBlocker(
+                        code="missing_rollback_target",
+                        message="No rollback deployment record found.",
+                    ),
+                ),
+            )
+            request_payload = _rollback_payload()
+
+            with patch(
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
+                return_value=driver_result,
+            ) as rollback:
+                first = await _post_generic_web_rollback(
+                    app,
+                    request_payload,
+                    idempotency_key="generic-web-rollback-blocked-syo-prod",
+                )
+                second = await _post_generic_web_rollback(
+                    app,
+                    request_payload,
+                    idempotency_key="generic-web-rollback-blocked-syo-prod",
+                )
+
+        self.assertEqual(first.status_code, 202)
+        self.assertEqual(second.status_code, 202)
+        self.assertEqual(first.json()["records"]["rollback_status"], "blocked")
+        self.assertNotIn("replayed", second.json())
+        self.assertEqual(rollback.call_count, 2)
+
+    async def test_rollback_route_does_not_cache_failed_deploy_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.execute"),
+            )
+            driver_result = GenericWebRollbackApplyResult(
+                plan_id="generic-web-rollback-syo-prod-fail",
+                deployment_record_id="deployment-syo-prod-rollback",
+                rollback_status="fail",
+                deploy_status="fail",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                rollback_deployment_record_id="deployment-syo-prod-previous",
+                error_message="deploy failed",
+            )
+            request_payload = _rollback_payload()
+
+            with patch(
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
+                return_value=driver_result,
+            ) as rollback:
+                first = await _post_generic_web_rollback(
+                    app,
+                    request_payload,
+                    idempotency_key="generic-web-rollback-fail-syo-prod",
+                )
+                second = await _post_generic_web_rollback(
+                    app,
+                    request_payload,
+                    idempotency_key="generic-web-rollback-fail-syo-prod",
+                )
+
+        self.assertEqual(first.status_code, 202)
+        self.assertEqual(second.status_code, 202)
+        self.assertEqual(first.json()["records"]["deploy_status"], "fail")
+        self.assertNotIn("replayed", second.json())
+        self.assertEqual(rollback.call_count, 2)
+
+    async def test_rollback_route_caches_post_deploy_failure_after_deploy_passes(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy("generic_web_prod_rollback.execute"),
+            )
+            driver_result = GenericWebRollbackApplyResult(
+                plan_id="generic-web-rollback-syo-prod-post-deploy-fail",
+                deployment_record_id="deployment-syo-prod-rollback",
+                rollback_status="fail",
+                deploy_status="pass",
+                post_deploy_status="fail",
+                product="sellyouroutboard",
+                context="sellyouroutboard-testing",
+                instance="prod",
+                rollback_deployment_record_id="deployment-syo-prod-previous",
+                error_message="post deploy failed",
+            )
+            request_payload = _rollback_payload()
+
+            with patch(
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
+                return_value=driver_result,
+            ) as rollback:
+                first = await _post_generic_web_rollback(
+                    app,
+                    request_payload,
+                    idempotency_key="generic-web-rollback-post-deploy-fail-syo-prod",
+                )
+                second = await _post_generic_web_rollback(
+                    app,
+                    request_payload,
+                    idempotency_key="generic-web-rollback-post-deploy-fail-syo-prod",
+                )
+
+        self.assertEqual(first.status_code, 202)
+        self.assertEqual(second.status_code, 202)
+        self.assertEqual(second.json()["records"]["post_deploy_status"], "fail")
+        self.assertTrue(second.json()["replayed"])
+        rollback.assert_called_once()
+
+    async def test_rollback_route_rejects_unauthorized_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(_profile())
+            app = self._app(
+                root=root,
+                store=store,
+                policy=_rollback_route_policy(
+                    "generic_web_prod_rollback.execute", context="other-context"
+                ),
+            )
+
+            response = await _post_generic_web_rollback(app, _rollback_payload())
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_routes_are_in_openapi(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = self._app(
+                root=root,
+                store=store,
+                policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+            )
+
+            response = await _asgi_get(app, "/openapi.json")
+
+        payload = response.json()
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("/v1/drivers/generic-web/prod-rollback-plan", payload["paths"])
+        self.assertIn("/v1/drivers/generic-web/prod-rollback", payload["paths"])
+
+    def test_legacy_wsgi_routes_are_retired(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_fastapi_rollback_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+
+            plan_status_code, plan_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-rollback-plan",
+                payload=_rollback_plan_payload(),
+            )
+            rollback_status_code, rollback_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-rollback",
+                payload=_rollback_payload(),
+            )
+
+        self.assertEqual(plan_status_code, 404)
+        self.assertEqual(plan_payload["error"]["code"], "not_found")
+        self.assertEqual(rollback_status_code, 404)
+        self.assertEqual(rollback_payload["error"]["code"], "not_found")
+
+    def test_odoo_rollback_plan_alias_is_retired(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_service_app(
+                state_dir=root / "state",
+                verifier=_StubVerifier(_fastapi_rollback_identity()),
+                authz_policy=LaunchplaneAuthzPolicy.model_validate({"github_actions": []}),
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/odoo/prod-rollback-plan",
+                payload={
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm",
+                    "rollback_plan": {
+                        "schema_version": 1,
+                        "product": "odoo-tenant-cm",
+                        "instance": "prod",
+                        "rollback_deployment_record_id": "deployment-cm-prod-previous",
+                    },
+                },
+                headers={"Idempotency-Key": "odoo-rollback-plan-cm-prod"},
+            )
+
+        self.assertEqual(status_code, 404)
+        self.assertEqual(payload["error"]["code"], "not_found")
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -10863,10 +10863,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
+                record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
 
@@ -10925,10 +10926,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
+                record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
 
@@ -10975,10 +10977,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
+                record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
 
@@ -11051,10 +11054,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
+                record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
             request_payload = {
@@ -11147,10 +11151,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
+                record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
             driver_result = GenericWebRollbackApplyResult(
@@ -11165,7 +11170,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.drivers.generic_web_dispatch.execute_generic_web_rollback",
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
                 return_value=driver_result,
             ) as rollback:
                 status_code, payload = _invoke_app(
@@ -11226,7 +11231,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(
                     _identity(
@@ -11238,6 +11243,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     )
                 ),
                 authz_policy=policy,
+                record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
             driver_result = GenericWebRollbackApplyResult(
@@ -11252,7 +11258,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
 
             with patch(
-                "control_plane.drivers.generic_web_dispatch.execute_generic_web_rollback",
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
                 return_value=driver_result,
             ) as rollback:
                 status_code, payload = _invoke_app(
@@ -11305,10 +11311,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
+                record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
             driver_result = GenericWebRollbackApplyResult(
@@ -11333,7 +11340,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             }
 
             with patch(
-                "control_plane.drivers.generic_web_dispatch.execute_generic_web_rollback",
+                "control_plane.generic_web_rollback_http.execute_generic_web_rollback",
                 return_value=driver_result,
             ) as rollback:
                 first_status_code, first_payload = _invoke_app(
@@ -11384,10 +11391,11 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     ]
                 }
             )
-            app = create_launchplane_service_app(
+            app = create_launchplane_fastapi_wsgi_app(
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
+                record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
 


### PR DESCRIPTION
## Summary
- migrate generic-web prod rollback plan/apply from descriptor-backed WSGI dispatch to native FastAPI handlers
- preserve descriptor metadata discoverability while retiring direct WSGI fallback for both rollback routes
- keep lane-context authz, product/profile/lane validation, idempotency replay/no-cache behavior, and Odoo inherited post-deploy execution
- update rollback docs and add FastAPI parity coverage for success, replay, fail/blocked cache behavior, 503 dependency miss, 404 workflow file miss, and descriptor exemptions

## Validation
- `uv run --extra dev ruff format --check control_plane/drivers/generic_web_dispatch.py control_plane/generic_web_rollback_http.py control_plane/http_app.py control_plane/service.py tests/http_app_test_support.py tests/test_driver_descriptors.py tests/test_generic_web_rollback.py tests/test_service.py`
- `uv run --extra dev ruff check control_plane/drivers/generic_web_dispatch.py control_plane/generic_web_rollback_http.py control_plane/http_app.py control_plane/service.py tests/http_app_test_support.py tests/test_driver_descriptors.py tests/test_generic_web_rollback.py tests/test_service.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run python -m unittest tests.test_generic_web_rollback tests.test_driver_descriptors` (135 tests OK)
- `ulimit -n 4096; uv run python -m unittest tests.test_generic_web_rollback tests.test_driver_descriptors tests.test_service tests.test_http_app_driver_odoo tests.test_http_app_preview` (581 tests OK)
- `ulimit -n 4096; uv run python -m unittest` (3118 tests OK)
- `git diff --check`

## Review Notes
- Scoped final patch review by Claude, GPT, and Antigravity found no bugs/regressions.
- Branch-wide Auto Review did not produce findings because the accumulated diff exceeded the background review limit (`1203505` chars over `120000`).
- Repo-wide `ruff format --check .` still reports unrelated pre-existing formatting drift in 55 untouched files; this PR kept formatting scoped to changed Python files.

Refs #1322
