### PR TITLE
Make config authority gate baseline aware

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 import hashlib
@@ -759,6 +760,10 @@ class ConfigAuthorityFinding:
     parser: str
     git_status: str
 
+    @property
+    def fingerprint(self) -> tuple[str, str, str, str]:
+        return (self.path, self.rule_id, self.key, self.value_hash)
+
     def as_payload(self) -> dict[str, object]:
         return {
             "finding_id": self.finding_id,
@@ -800,6 +805,17 @@ def build_config_authority_audit(
     root = control_plane_root.resolve()
     repo_metadata = _repo_metadata(root)
     git_file_state = _git_file_state(root)
+    changed_file_merge_base = _git_merge_base(root) if mode == "changed-files-gate" else ""
+    changed_file_status_entries = _git_status_entries(root) if mode == "changed-files-gate" else []
+    baseline_fingerprint_counts = (
+        _changed_file_baseline_fingerprint_counts(
+            root,
+            merge_base=changed_file_merge_base,
+            status_entries=changed_file_status_entries,
+        )
+        if mode == "changed-files-gate"
+        else Counter()
+    )
     source_files, coverage_gaps = _discover_source_files(
         root=root,
         mode=mode,
@@ -812,24 +828,50 @@ def build_config_authority_audit(
     raw_findings: list[dict[str, object]] = []
     for source_file in source_files:
         file_findings, file_gaps = _scan_source_file(source_file)
+        if baseline_fingerprint_counts:
+            file_findings = _mark_preexisting_changed_file_findings(
+                file_findings,
+                baseline_fingerprint_counts=baseline_fingerprint_counts,
+            )
         findings.extend(file_findings)
         coverage_gaps.extend(file_gaps)
         raw_findings.extend(_raw_finding_payload(finding) for finding in file_findings)
+    if (
+        mode == "changed-files-gate"
+        and not paths
+        and not changed_file_merge_base
+        and not changed_file_status_entries
+    ):
+        gap = CoverageGap(
+            path=".",
+            reason="merge_base_unavailable",
+            detail="Changed-files gate could not resolve origin/main or main and found no dirty files to compare against HEAD.",
+        )
+        finding = _changed_files_gate_base_finding()
+        coverage_gaps.append(gap)
+        findings.append(finding)
+        raw_findings.append(_raw_finding_payload(finding))
 
     findings = sorted(findings, key=lambda item: (item.path, item.line, item.rule_id, item.key))
     finding_payloads = [finding.as_payload() for finding in findings]
     source_payloads = [source_file.as_payload() for source_file in source_files]
+    scanner_payload: dict[str, object] = {
+        "version": HASH_VERSION,
+        "include_untracked": include_untracked,
+        "include_ignored": include_ignored,
+        "max_scanned_file_bytes": MAX_SCANNED_FILE_BYTES,
+    }
+    if mode == "changed-files-gate":
+        scanner_payload["changed_files_gate"] = {
+            "preexisting_findings_are_report_only": True,
+        }
+
     payload: dict[str, object] = {
         "status": "ok",
         "mode": mode,
         "control_plane_root": str(root),
         "repo": repo_metadata,
-        "scanner": {
-            "version": HASH_VERSION,
-            "include_untracked": include_untracked,
-            "include_ignored": include_ignored,
-            "max_scanned_file_bytes": MAX_SCANNED_FILE_BYTES,
-        },
+        "scanner": scanner_payload,
         "coverage": {
             "source_file_count": len(source_files),
             "finding_count": len(findings),
@@ -1088,6 +1130,105 @@ def _scan_source_file(
                 detail=str(error),
             )
         ]
+    return _scan_source_text(source_file=source_file, text=text)
+
+
+def _mark_preexisting_changed_file_findings(
+    findings: Sequence[ConfigAuthorityFinding],
+    *,
+    baseline_fingerprint_counts: Counter[tuple[str, str, str, str]],
+) -> list[ConfigAuthorityFinding]:
+    remaining_counts = baseline_fingerprint_counts.copy()
+    marked_findings: list[ConfigAuthorityFinding] = []
+    for finding in findings:
+        if remaining_counts[finding.fingerprint] > 0:
+            marked_findings.append(_mark_preexisting_changed_file_finding(finding))
+            remaining_counts[finding.fingerprint] -= 1
+            continue
+        marked_findings.append(finding)
+    return marked_findings
+
+
+def _mark_preexisting_changed_file_finding(
+    finding: ConfigAuthorityFinding,
+) -> ConfigAuthorityFinding:
+    if finding.classification != "needs_classification":
+        return finding
+    return ConfigAuthorityFinding(
+        finding_id=finding.finding_id,
+        path=finding.path,
+        line=finding.line,
+        rule_id=finding.rule_id,
+        severity="info",
+        key=finding.key,
+        value_hash=finding.value_hash,
+        evidence=finding.evidence,
+        classification="allowed",
+        allow_reason="preexisting_changed_file_finding",
+        parser=finding.parser,
+        git_status=finding.git_status,
+    )
+
+
+def _changed_file_baseline_fingerprint_counts(
+    root: Path,
+    *,
+    merge_base: str,
+    status_entries: Sequence[tuple[str, str]],
+) -> Counter[tuple[str, str, str, str]]:
+    if not merge_base:
+        return Counter()
+    fingerprints: Counter[tuple[str, str, str, str]] = Counter()
+    baseline_paths = set(_git_branch_changed_relative_paths(root))
+    baseline_paths.update(relative_path for _, relative_path in status_entries)
+    for relative_path in sorted(baseline_paths):
+        baseline_text = _git_output(root, "show", f"{merge_base}:{relative_path}")
+        if not baseline_text:
+            continue
+        path = root / relative_path
+        source_file = AuditSourceFile(
+            path=path,
+            relative_path=relative_path,
+            sha256=_stable_hash(baseline_text),
+            size=len(baseline_text.encode("utf-8")),
+            mtime_ns=0,
+            git_status="baseline",
+            head_blob_sha="",
+            index_blob_sha="",
+            worktree_sha256="",
+        )
+        findings, _ = _scan_source_text(source_file=source_file, text=baseline_text)
+        fingerprints.update(finding.fingerprint for finding in findings)
+    return fingerprints
+
+
+def _changed_files_gate_base_finding() -> ConfigAuthorityFinding:
+    value_hash = _stable_hash("merge_base_unavailable")
+    return ConfigAuthorityFinding(
+        finding_id=_finding_id(
+            path=".",
+            line=0,
+            rule_id="changed_files_gate_base_unavailable",
+            key="changed_files_gate.merge_base",
+            value_hash=value_hash,
+        ),
+        path=".",
+        line=0,
+        rule_id="changed_files_gate_base_unavailable",
+        severity="medium",
+        key="changed_files_gate.merge_base",
+        value_hash=value_hash,
+        evidence="origin/main or main merge base unavailable",
+        classification="needs_classification",
+        allow_reason="",
+        parser="git",
+        git_status="unknown",
+    )
+
+
+def _scan_source_text(
+    *, source_file: AuditSourceFile, text: str
+) -> tuple[list[ConfigAuthorityFinding], list[CoverageGap]]:
     parser = _parser_name(source_file.path)
     candidates: list[tuple[int, str, object]] = []
     coverage_gaps: list[CoverageGap] = []
@@ -2291,15 +2432,20 @@ def _git_changed_files(root: Path) -> list[Path]:
 
 
 def _git_branch_changed_relative_paths(root: Path) -> list[str]:
-    merge_base = _git_output(root, "merge-base", "HEAD", "origin/main")
-    if not merge_base:
-        merge_base = _git_output(root, "merge-base", "HEAD", "main")
+    merge_base = _git_merge_base(root)
     if not merge_base:
         return []
     output = _git_output(root, "diff", "--name-only", "--diff-filter=ACMRT", merge_base, "HEAD")
     if not output:
         return []
     return [line for line in output.splitlines() if line]
+
+
+def _git_merge_base(root: Path) -> str:
+    merge_base = _git_output(root, "merge-base", "HEAD", "origin/main")
+    if merge_base:
+        return merge_base
+    return _git_output(root, "merge-base", "HEAD", "main")
 
 
 def _git_untracked_relative_paths(root: Path) -> list[str]:

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -258,13 +258,18 @@ uv run launchplane service audit-config-authority \
 
 `--fail-on-findings` preserves the JSON or Markdown report, adds a JSON `gate`
 summary when enforcement is enabled, and then exits non-zero when the selected
-gate profile rejects a finding. Allowed docs, tests, schema examples,
-Launchplane self-bootstrap wiring, operator-supplied inputs, and thin connector
-mechanics keep explicit allow reasons and do not fail the default gate. The
-`product-repo` profile also rejects test fixtures that carry Launchplane
-lifecycle authority such as authz, runtime-environment, provider target,
-target-id, managed-secret, route-batch, or topology material. Product repos
-should use this changed-file gate to reject reintroduced
+gate profile rejects a finding. In changed-file mode, findings that already
+existed at the merge base remain in the report as
+`preexisting_changed_file_finding`, but only new unclassified findings block the
+gate. If the gate cannot resolve `origin/main` or `main` and has no dirty files
+to compare against `HEAD`, it fails closed instead of returning an empty green
+report. Allowed docs, tests, schema examples, Launchplane self-bootstrap wiring,
+operator-supplied inputs, and thin connector mechanics keep explicit allow
+reasons and do not fail the default gate. The `product-repo` profile also
+rejects test fixtures that carry Launchplane lifecycle authority such as authz,
+runtime-environment, provider target, target-id, managed-secret, route-batch, or
+topology material. Product repos should use this changed-file gate to reject
+reintroduced
 Launchplane-owned authz, route, provider-target, domain, runtime-environment,
 managed-secret, topology, or workflow-default fixtures before merge.
 

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -109,21 +109,28 @@ uv run launchplane service audit-config-authority \
 ```
 
 The gate prints the same redacted audit report as the full scanner, adds a JSON
-`gate` summary when enforcement is enabled, then exits non-zero for findings
-that still need classification. Docs, tests, schema fixtures, bootstrap wiring,
-and explicitly allowed thin connector mechanics are reported with allow reasons
-instead of blocking the default gate. The `product-repo` profile keeps ordinary
+`gate` summary when enforcement is enabled, then exits non-zero for new findings
+that still need classification. In changed-file mode, findings that already
+existed at the merge base stay visible in the report with
+`preexisting_changed_file_finding`, but they do not block unrelated edits to the
+same file. Configure product-repo checkouts with enough history for the gate to
+resolve `origin/main` or `main`; when no merge base or dirty local comparison is
+available, the gate fails closed rather than silently passing. Docs, tests,
+schema fixtures, bootstrap wiring, and explicitly allowed thin connector
+mechanics are reported with allow reasons instead of blocking the default gate.
+The `product-repo` profile keeps ordinary
 product-owned test fixtures allowed, but also rejects test fixtures that carry
 Launchplane lifecycle authority such as authz policy, provider target,
 runtime-environment, managed secret, route batch, topology, or target-id
 material.
 
 When a product repository runs the gate from GitHub Actions, use a dedicated
-`.github/workflows/launchplane-config-authority.yml` workflow. Its Launchplane
-tool checkout may reference only `${{ github.repository_owner }}/launchplane`
-and must pin `ref` to a 40-character commit SHA; hard-coded owners, mutable
-branches, and non-checkout `repository` values are rejected by the product-repo
-profile.
+`.github/workflows/launchplane-config-authority.yml` workflow until the gate has
+a Launchplane-owned service/reusable-workflow endpoint. The transitional
+Launchplane tool checkout may reference only
+`${{ github.repository_owner }}/launchplane` and must pin `ref` to a
+40-character commit SHA; hard-coded owners, mutable branches, and non-checkout
+`repository` values are rejected by the product-repo profile.
 
 ## What Product Repos Own
 

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2314,9 +2314,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             _git(root, "branch", "-M", "main")
             _checkout_branch(root, "feature/product-fixture")
             workflow.write_text(
-                "name: Deploy\n"
-                "env:\n"
-                "  PRODUCT_DOMAIN: https://real-product.example.test\n",
+                "name: Deploy\nenv:\n  PRODUCT_DOMAIN: https://real-product.example.test\n",
                 encoding="utf-8",
             )
             _commit_all(root)
@@ -2343,6 +2341,245 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         payload = json.loads(result.output.split("Error:", 1)[0])
         gate = cast("dict[str, object]", payload["gate"])
         self.assertEqual(gate["status"], "fail")
+
+    def test_cli_changed_files_gate_allows_preexisting_package_json_finding(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            package_json = root / "package.json"
+            package_json.write_text(
+                json.dumps(
+                    {
+                        "scripts": {"seo:submit-indexnow": "node scripts/seo/submit-indexnow.mjs"},
+                        "devDependencies": {"globals": "^17.6.0"},
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+            _git(root, "branch", "-M", "main")
+            _checkout_branch(root, "dependabot/dev-dependencies")
+            package_json.write_text(
+                json.dumps(
+                    {
+                        "scripts": {"seo:submit-indexnow": "node scripts/seo/submit-indexnow.mjs"},
+                        "devDependencies": {"globals": "^17.7.0"},
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "audit-config-authority",
+                    "--control-plane-root",
+                    str(root),
+                    "--mode",
+                    "changed-files-gate",
+                    "--fail-on-findings",
+                    "--gate-profile",
+                    "product-repo",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        gate = cast("dict[str, object]", payload["gate"])
+        self.assertEqual(gate["status"], "pass")
+        finding = _findings(payload)[0]
+        self.assertEqual(finding["key"], "scripts.seo:submit-indexnow")
+        self.assertEqual(finding["classification"], "allowed")
+        self.assertEqual(finding["allow_reason"], "preexisting_changed_file_finding")
+
+    def test_cli_changed_files_gate_allows_preexisting_dirty_package_json_finding(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            package_json = root / "package.json"
+            package_json.write_text(
+                json.dumps(
+                    {
+                        "scripts": {"seo:submit-indexnow": "node scripts/seo/submit-indexnow.mjs"},
+                        "devDependencies": {"globals": "^17.6.0"},
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+            _git(root, "branch", "-M", "main")
+            package_json.write_text(
+                json.dumps(
+                    {
+                        "scripts": {"seo:submit-indexnow": "node scripts/seo/submit-indexnow.mjs"},
+                        "devDependencies": {"globals": "^17.7.0"},
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            runner = CliRunner()
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "audit-config-authority",
+                    "--control-plane-root",
+                    str(root),
+                    "--mode",
+                    "changed-files-gate",
+                    "--fail-on-findings",
+                    "--gate-profile",
+                    "product-repo",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        finding = _findings(payload)[0]
+        self.assertEqual(finding["allow_reason"], "preexisting_changed_file_finding")
+
+    def test_cli_changed_files_gate_rejects_new_package_json_finding(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            package_json = root / "package.json"
+            package_json.write_text(
+                json.dumps({"devDependencies": {"globals": "^17.6.0"}}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+            _git(root, "branch", "-M", "main")
+            _checkout_branch(root, "feature/new-script")
+            package_json.write_text(
+                json.dumps(
+                    {
+                        "scripts": {"seo:submit-indexnow": "node scripts/seo/submit-indexnow.mjs"},
+                        "devDependencies": {"globals": "^17.6.0"},
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "audit-config-authority",
+                    "--control-plane-root",
+                    str(root),
+                    "--mode",
+                    "changed-files-gate",
+                    "--fail-on-findings",
+                    "--gate-profile",
+                    "product-repo",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        payload = json.loads(result.output.split("Error:", 1)[0])
+        gate = cast("dict[str, object]", payload["gate"])
+        self.assertEqual(gate["status"], "fail")
+        rejected = cast("list[dict[str, object]]", gate["rejected_findings"])
+        self.assertEqual(rejected[0]["key"], "scripts.seo:submit-indexnow")
+
+    def test_cli_changed_files_gate_rejects_new_duplicate_finding(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            script = root / "scripts" / "deploy.sh"
+            script.parent.mkdir()
+            script.write_text(
+                "#!/usr/bin/env bash\necho cbusillo/launchplane\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+            _git(root, "branch", "-M", "main")
+            _checkout_branch(root, "feature/duplicate-finding")
+            script.write_text(
+                "#!/usr/bin/env bash\necho cbusillo/launchplane\necho cbusillo/launchplane\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "audit-config-authority",
+                    "--control-plane-root",
+                    str(root),
+                    "--mode",
+                    "changed-files-gate",
+                    "--fail-on-findings",
+                    "--gate-profile",
+                    "product-repo",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        payload = json.loads(result.output.split("Error:", 1)[0])
+        gate = cast("dict[str, object]", payload["gate"])
+        self.assertEqual(gate["status"], "fail")
+        findings = _findings(payload)
+        self.assertEqual(findings[0]["allow_reason"], "preexisting_changed_file_finding")
+        self.assertEqual(findings[1]["classification"], "needs_classification")
+
+    def test_cli_changed_files_gate_fails_closed_without_merge_base(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            package_json = root / "package.json"
+            package_json.write_text(
+                json.dumps({"devDependencies": {"globals": "^17.6.0"}}, indent=2) + "\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "audit-config-authority",
+                    "--control-plane-root",
+                    str(root),
+                    "--mode",
+                    "changed-files-gate",
+                    "--fail-on-findings",
+                    "--gate-profile",
+                    "product-repo",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        payload = json.loads(result.output.split("Error:", 1)[0])
+        gate = cast("dict[str, object]", payload["gate"])
+        self.assertEqual(gate["status"], "fail")
+        rejected = cast("list[dict[str, object]]", gate["rejected_findings"])
+        self.assertEqual(rejected[0]["rule_id"], "changed_files_gate_base_unavailable")
 
     def test_cli_product_repo_gate_allows_launchplane_tool_checkout(self) -> None:
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary

- make changed-file config-authority gates report pre-existing findings without blocking unrelated edits
- count baseline finding occurrences so newly added duplicates still fail
- fail closed when changed-file mode cannot resolve a merge base or dirty local comparison
- document the transitional product-repo workflow shape and changed-file gate behavior

## Validation

- `uv run python -m unittest tests.test_config_authority_audit tests.test_docs_contracts`
- `uv run ruff format --diff control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run ruff format control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run --extra dev mypy control_plane tests`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- `git diff --check`
- SYO PR #180 local canary: changed-file product-repo gate passes while reporting `scripts.seo:submit-indexnow` as `preexisting_changed_file_finding`

## Review

- initial review found duplicate-finding masking and vacuous no-merge-base pass risks
- follow-up review on the actual worktree found the Counter-based occurrence guard and fail-closed merge-base behavior resolved

## Notes

- unsharded `uv run python -m unittest` was still progressing through slow HTTP tests when the local command hit the 30-minute timeout; CI should use the current 12-shard path for full-suite proof

Refs #1489
Refs #1494