### PR TITLE
Re-own source-ref deploy bridge

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -323,11 +323,11 @@ GENERIC_WEB_DRIVER = DriverDescriptor(
             panels=("lane_health", "deployment_evidence", "promotion_evidence"),
         ),
         DriverCapabilityDescriptor(
-            capability_id="legacy_source_ref_deployable",
-            label="Legacy source-ref deployable",
+            capability_id="source_ref_deployable",
+            label="Source-ref deployable",
             description=(
-                "Bridge legacy provider-backed git-ref deploys while products migrate "
-                "to immutable image deploys."
+                "Bridge provider-backed git-ref deploys for products that have not yet "
+                "moved to immutable image deploys."
             ),
             actions=("source_ref_deploy",),
             panels=("audit",),

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -129,8 +129,10 @@ and HTTP health metadata before they can mutate provider state.
 
 The long-term target is still immutable image deploy. The source-ref bridge does
 not write generic-web deployment records; its durable replay surface is the
-service idempotency record. Treat it as a bounded replacement for legacy direct
-Dokploy workflows only while the product is moved to image publishing.
+service idempotency record. Treat it as a current but bounded Launchplane-owned
+replacement for direct Dokploy workflows only while the product is moved to
+image publishing. #1498 owns the stable product-repo integration surface and
+the eventual replacement/removal condition for this bridge.
 
 Launchplane also injects a non-secret runtime identity into Dokploy env during
 Launchplane-owned deploys. The standard keys are

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -158,7 +158,11 @@ The `source_ref_deploy` action routes to the native FastAPI
 same product profile lane resolution as stable deploy and validates the request
 context and instance against the resolved lane before authorization,
 idempotency replay, or provider mutation. Descriptor discovery and driver authz
-metadata stay intact while native FastAPI owns execution.
+metadata stay intact while native FastAPI owns execution. This remains a
+current Launchplane-owned bridge for provider-backed compose targets that have
+not yet moved to immutable image deploys. The replacement path is tracked by the
+stable product-repo integration and image-deploy work in #1498; do not add new
+product-specific direct provider mutation around this route.
 
 The `prod_promotion` action routes to the native FastAPI
 `POST /v1/drivers/generic-web/prod-promotion` endpoint. It promotes a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1498,7 +1498,11 @@ post-deploy-fail evidence to prevent repeating the completed provider mutation.
 Generic web source-ref deploys use native FastAPI
 `POST /v1/drivers/generic-web/source-ref-deploy`; the route validates the
 request context and instance against the resolved product profile lane before
-authorization, idempotency replay, or provider mutation.
+authorization, idempotency replay, or provider mutation. This route is a
+current but bounded Launchplane-owned bridge for provider-backed compose targets
+that still deploy from a tested source ref. #1498 owns the stable product-repo
+integration surface and the replacement/removal condition; product repos must
+not regain direct Dokploy mutation authority around this route.
 Product environment reads expose neutral provider-target identity only from
 explicit provider-target rows. Paired DB-backed Dokploy target and target-id
 records remain visible as provider-specific execution/history metadata and as

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -262,7 +262,8 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertEqual(descriptor.base_driver_id, "")
         self.assertEqual(descriptor.context_patterns, ())
         self.assertIn("image_deployable", capability_ids)
-        self.assertIn("legacy_source_ref_deployable", capability_ids)
+        self.assertIn("source_ref_deployable", capability_ids)
+        self.assertNotIn("legacy_source_ref_deployable", capability_ids)
         self.assertIn("health_checked", capability_ids)
         self.assertIn("previewable", capability_ids)
         self.assertIn("preview_inventory_managed", capability_ids)
@@ -272,7 +273,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         }
         self.assertNotIn("source_ref_deploy", capabilities["image_deployable"].actions)
         self.assertEqual(
-            capabilities["legacy_source_ref_deployable"].actions,
+            capabilities["source_ref_deployable"].actions,
             ("source_ref_deploy",),
         )
         actions = {action.action_id: action for action in descriptor.actions}
@@ -532,6 +533,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     control_plane_service._GENERIC_WEB_DEPLOY_ROUTE,
                     control_plane_service.GenericWebDeployEnvelope,
                     "deploy driver",
+                ),
+                "source_ref_deploy": (
+                    control_plane_service._GENERIC_WEB_SOURCE_REF_DEPLOY_ROUTE,
+                    control_plane_service.GenericWebSourceRefDeployEnvelope,
+                    "source-ref deploy driver",
                 ),
                 "prod_promotion": (
                     control_plane_service._GENERIC_WEB_PROD_PROMOTION_ROUTE,


### PR DESCRIPTION
## Summary
- Re-own `generic-web/source-ref-deploy` as a current but bounded Launchplane bridge instead of stale legacy framing.
- Rename descriptor capability `legacy_source_ref_deployable` to `source_ref_deployable` while keeping the external route/action/authz contract stable.
- Document that #1498 owns the stable product-repo integration path and eventual replacement/removal condition.

## Decision
A local cross-repo usage audit found an active product workflow still calling `POST /v1/drivers/generic-web/source-ref-deploy`, so this slice should not remove the route. It keeps the route available, removes the stale legacy descriptor name, and makes the removal dependency explicit.

## Validation
- `uv run python -m unittest tests.test_driver_descriptors tests.test_dokploy_deploy tests.test_service.LaunchplaneServiceTests.test_generic_web_source_ref_deploy_route_uses_distinct_authz_and_replays tests.test_service.LaunchplaneServiceTests.test_generic_web_source_ref_deploy_route_resolves_context_when_instances_match tests.test_service.LaunchplaneServiceTests.test_generic_web_source_ref_deploy_route_validates_lane_before_replay`
- `uv run python -m unittest tests.test_docs_contracts`
- `uv run --extra dev ruff format --diff control_plane/drivers/registry.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff check control_plane/drivers/registry.py tests/test_driver_descriptors.py`
- `uv run --extra dev mypy control_plane/drivers/registry.py tests/test_driver_descriptors.py`
- `git diff --check`

## Review
- Review agents: Claude, GPT, and Antigravity all reported no findings.
- Residual risk: #1498 must keep the removal path honest so this bounded bridge does not become permanent.

Closes #1491.
Refs #1489, #1498.
