### PR TITLE
Allow product image deploy workflows in config audit

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -136,6 +136,9 @@ GITHUB_ENV_REFERENCE_PATTERN = re.compile(r"^env\.[A-Za-z0-9_.-]+$")
 GITHUB_STEP_OUTPUT_REFERENCE_PATTERN = re.compile(
     r"^steps\.[A-Za-z0-9_-]+\.outputs\.[A-Za-z0-9_.-]+$"
 )
+GITHUB_CONTEXT_OR_STEP_OUTPUT_REFERENCE_PATTERN = re.compile(
+    r"^(?:github|steps\.[A-Za-z0-9_-]+\.outputs)\.[A-Za-z0-9_.-]+$"
+)
 GIT_COMMIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
 GITHUB_ROUTE_PATH_FORWARDING_PATTERN = re.compile(
     r"^(?:inputs\.[A-Za-z0-9_.-]+|steps\.[A-Za-z0-9_-]+\.outputs\.[A-Za-z0-9_.-]+)$"
@@ -176,6 +179,14 @@ WORKFLOW_OPERATOR_INPUT_VALUE_KEYS = frozenset(
         "TARGET_ID",
         "TARGET_NAME",
         "TARGET_TYPE",
+    )
+)
+WORKFLOW_LAUNCHPLANE_OPERATOR_VAR_KEYS = frozenset(
+    (
+        "LAUNCHPLANE_CONTEXT",
+        "LAUNCHPLANE_INSTANCE",
+        "LAUNCHPLANE_PRODUCT",
+        "LAUNCHPLANE_PUBLIC_URL",
     )
 )
 LAUNCHPLANE_SELF_MANAGEMENT_WORKFLOW_PATHS = frozenset(
@@ -1962,6 +1973,12 @@ def _allow_reason(
         value=value,
     ):
         return ALLOW_REASON_THIN_CONNECTOR_INPUT
+    if normalized.startswith(".github/workflows/") and _is_workflow_image_artifact_mechanic(
+        path=normalized,
+        key=key,
+        value=value,
+    ):
+        return ALLOW_REASON_THIN_CONNECTOR_INPUT
     if normalized.startswith(".github/workflows/") and _is_launchplane_tool_checkout_reference(
         path=normalized,
         key=key,
@@ -1999,6 +2016,12 @@ def _allow_reason(
     ):
         return ALLOW_REASON_OPERATOR_SUPPLIED_RUNTIME_INPUT
     if normalized.startswith(".github/workflows/") and _is_workflow_operator_input_reference(
+        path=normalized,
+        key=key,
+        value=value,
+    ):
+        return ALLOW_REASON_OPERATOR_SUPPLIED_RUNTIME_INPUT
+    if normalized.startswith(".github/workflows/") and _is_workflow_launchplane_operator_var(
         path=normalized,
         key=key,
         value=value,
@@ -2085,8 +2108,8 @@ def _is_launchplane_public_url_reference(*, path: str, key: str, value: object) 
     ):
         return True
     key_text = key.upper().replace(".", "_").replace("-", "_")
-    if key == "LAUNCHPLANE_URL":
-        return value_text == "${{ vars.LAUNCHPLANE_PUBLIC_URL }}"
+    if key == "LAUNCHPLANE_URL" and value_text == "${{ vars.LAUNCHPLANE_PUBLIC_URL }}":
+        return True
     if key_text == "LAUNCHPLANE_URL":
         return value_text in {
             "${{ env.LAUNCHPLANE_SERVICE_URL }}",
@@ -2148,6 +2171,18 @@ def _is_workflow_operator_input_reference(*, path: str, key: str, value: object)
         return False
     value_text = _string_value(value).strip().rstrip(",")
     return value_text in allowed_values
+
+
+def _is_workflow_launchplane_operator_var(*, path: str, key: str, value: object) -> bool:
+    if path != ".github/workflows/launchplane-deploy.yml":
+        return False
+    key_text = key.upper().replace(".", "_").replace("-", "_")
+    if key_text == "LAUNCHPLANE_URL":
+        key_text = "LAUNCHPLANE_PUBLIC_URL"
+    if key_text not in WORKFLOW_LAUNCHPLANE_OPERATOR_VAR_KEYS:
+        return False
+    value_text = _string_value(value).strip().rstrip(",")
+    return value_text == f"${{{{ vars.{key_text} }}}}"
 
 
 def _is_workflow_context_reference_restricted_key(key: str) -> bool:
@@ -2253,6 +2288,43 @@ def _is_workflow_mechanic_key_value(*, key: str, value: object) -> bool:
     if key_text == "PATH" and re.fullmatch(r"[A-Za-z0-9_.-]+\.json", value_text):
         return True
     return False
+
+
+def _is_workflow_image_artifact_mechanic(*, path: str, key: str, value: object) -> bool:
+    if path != ".github/workflows/launchplane-deploy.yml":
+        return False
+    key_text = key.upper().replace(".", "_").replace("-", "_")
+    value_text = _string_value(value).strip()
+    if key_text == "CONTEXT" and value_text == ".":
+        return True
+    if key_text == "FILE" and re.fullmatch(r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*", value_text):
+        return True
+    if key_text in {"IMAGE_REPOSITORY", "TAGS"} and _is_github_context_or_step_output_reference(
+        value_text
+    ):
+        return True
+    if key_text == "PASSWORD" and value_text == "${{ github.token }}":
+        return True
+    if key_text == "IDEMPOTENCY_KEY" and _is_image_deploy_idempotency_key(value_text):
+        return True
+    return False
+
+
+def _is_github_context_or_step_output_reference(value_text: str) -> bool:
+    match = GITHUB_EXPRESSION_PATTERN.match(value_text)
+    if match is None:
+        return False
+    return bool(GITHUB_CONTEXT_OR_STEP_OUTPUT_REFERENCE_PATTERN.match(match.group("body").strip()))
+
+
+def _is_image_deploy_idempotency_key(value_text: str) -> bool:
+    if "${{ secrets." in value_text:
+        return False
+    if "${{ vars.LAUNCHPLANE_" not in value_text:
+        return False
+    if "${{ github.event.workflow_run.head_sha }}" not in value_text:
+        return False
+    return "${{ steps." in value_text and ".outputs.artifact_id }}" in value_text
 
 
 def _is_workflow_input_mechanic_default(*, path: str, key: str, value: object) -> bool:

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -140,6 +140,10 @@ Checked-in workflows and repo metadata may route to Launchplane, run quality
 gates, and document examples. They must not define the real product catalog,
 repo catalog, lane topology, target inventory, domain inventory, authz grants,
 operator identities, or mutable runtime values used by production behavior.
+Product-repo deploy workflows may forward operator-owned GitHub variables and
+fresh image build outputs into Launchplane request payloads, but fixed image
+references, provider targets, domains, and secret values remain outside the
+checked-in workflow authority boundary.
 
 ### Stale Local Artifacts
 

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -331,6 +331,33 @@ Product workflows that only need to send JSON to an existing Launchplane route
 should not carry their own GitHub OIDC transport client. Use the Launchplane
 repo action instead:
 
+Generic web/service repos that deploy as Dokploy applications should build and
+push their own immutable image, then submit the image digest to Launchplane's
+`generic-web` deploy route. The workflow may derive the GHCR repository from the
+current GitHub repository, publish with `docker/login-action` and
+`docker/build-push-action`, and pass Launchplane product/context/instance values
+from GitHub variables. The checked-in workflow must not hard-code provider
+targets, Dokploy operations, runtime domains, managed secrets, or fixed product
+topology; Launchplane resolves those from DB-backed product and target records.
+
+For this shape, `.github/workflows/launchplane-deploy.yml` is the supported thin
+connector workflow name. It should call:
+
+```yaml
+- name: Request Launchplane deploy
+  uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+  with:
+    launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+    route-path: /v1/drivers/generic-web/deploy
+    payload-file: ${{ steps.launchplane_payload.outputs.payload_path }}
+    idempotency-key: >-
+      generic-web-deploy:${{ vars.LAUNCHPLANE_PRODUCT }}:${{ vars.LAUNCHPLANE_CONTEXT }}:${{ vars.LAUNCHPLANE_INSTANCE }}:${{ github.event.workflow_run.head_sha }}:${{ steps.launchplane_payload.outputs.artifact_id }}
+```
+
+The payload should include the product key, instance, immutable image digest as
+`artifact_id`, and tested source SHA. Mutable image tags and checked-in image
+references are not durable deploy inputs.
+
 ```yaml
 - name: Request Launchplane preview refresh
   uses: cbusillo/launchplane/.github/actions/launchplane-request@main

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1559,6 +1559,21 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ),
             (".github/workflows/ci.yml", "context", "."),
             (
+                ".github/workflows/launchplane-deploy.yml",
+                "IMAGE_REPOSITORY",
+                "${{ steps.image_metadata.outputs.image_repository }}",
+            ),
+            (
+                ".github/workflows/launchplane-deploy.yml",
+                "idempotency-key",
+                "generic-web-deploy:${{ vars.LAUNCHPLANE_PRODUCT }}:${{ vars.LAUNCHPLANE_CONTEXT }}:${{ vars.LAUNCHPLANE_INSTANCE }}:${{ github.event.workflow_run.head_sha }}:${{ steps.launchplane_payload.outputs.artifact_id }}",
+            ),
+            (
+                ".github/workflows/launchplane-deploy.yml",
+                "password",
+                "${{ github.token }}",
+            ),
+            (
                 ".github/workflows/odoo-driver-route-smoke.yml",
                 "odoo-driver-route-smoke",
                 "${{ env.PRODUCT }}:${{ env.CONTEXT_NAME }}",
@@ -1624,6 +1639,26 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 ".github/workflows/reusable-odoo-artifact-publish.yml",
                 "GITHUB_TOKEN",
                 "write",
+            ),
+            (
+                ".github/workflows/generic-workflow.yml",
+                "IMAGE_REPOSITORY",
+                "${{ steps.image_metadata.outputs.image_repository }}",
+            ),
+            (
+                ".github/workflows/launchplane-deploy.yml",
+                "IMAGE_REPOSITORY",
+                "ghcr.io/example/product",
+            ),
+            (
+                ".github/workflows/launchplane-deploy.yml",
+                "idempotency-key",
+                "generic-web-deploy:${{ vars.LAUNCHPLANE_PRODUCT }}:${{ secrets.RUNTIME_SECRET }}:${{ github.event.workflow_run.head_sha }}:${{ steps.launchplane_payload.outputs.artifact_id }}",
+            ),
+            (
+                ".github/workflows/generic-workflow.yml",
+                "password",
+                "${{ github.token }}",
             ),
             (
                 ".github/workflows/launchplane-config-authority.yml",
@@ -2639,6 +2674,106 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         payload = json.loads(result.output)
         gate = cast("dict[str, object]", payload["gate"])
         self.assertEqual(gate["status"], "pass")
+
+    def test_cli_product_repo_gate_allows_image_artifact_deploy_workflow(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            workflow = root / ".github" / "workflows" / "launchplane-deploy.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text("name: Launchplane Deploy\n", encoding="utf-8")
+            _commit_all(root)
+            _git(root, "branch", "-M", "main")
+            _checkout_branch(root, "feature/image-deploy")
+            workflow.write_text(
+                "---\n"
+                "name: Launchplane Deploy\n\n"
+                '"on":\n'
+                "  workflow_run:\n"
+                "    workflows: [Test Suite]\n"
+                "    types: [completed]\n\n"
+                "permissions:\n"
+                "  contents: read\n"
+                "  id-token: write\n"
+                "  packages: write\n\n"
+                "jobs:\n"
+                "  deploy:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    steps:\n"
+                "      - uses: actions/checkout@v6\n"
+                "        with:\n"
+                "          ref: ${{ github.event.workflow_run.head_sha }}\n"
+                "      - name: Prepare image metadata\n"
+                "        id: image_metadata\n"
+                "        run: |\n"
+                "          image_repository=\"ghcr.io/${GITHUB_REPOSITORY,,}\"\n"
+                "          image_tag=\"sha-${GITHUB_SHA}\"\n"
+                "          echo \"image_repository=${image_repository}\" >> \"$GITHUB_OUTPUT\"\n"
+                "          echo \"image_reference=${image_repository}:${image_tag}\" >> \"$GITHUB_OUTPUT\"\n"
+                "      - uses: docker/login-action@v4\n"
+                "        with:\n"
+                "          registry: ghcr.io\n"
+                "          username: ${{ github.actor }}\n"
+                "          password: ${{ github.token }}\n"
+                "      - id: build_image\n"
+                "        uses: docker/build-push-action@v7\n"
+                "        with:\n"
+                "          context: .\n"
+                "          file: docker/Dockerfile.sync\n"
+                "          push: true\n"
+                "          tags: ${{ steps.image_metadata.outputs.image_reference }}\n"
+                "      - id: launchplane_payload\n"
+                "        env:\n"
+                "          IMAGE_REPOSITORY: ${{ steps.image_metadata.outputs.image_repository }}\n"
+                "          IMAGE_DIGEST: ${{ steps.build_image.outputs.digest }}\n"
+                "          TESTED_SHA: ${{ github.event.workflow_run.head_sha }}\n"
+                "          LAUNCHPLANE_PUBLIC_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}\n"
+                "          LAUNCHPLANE_PRODUCT: ${{ vars.LAUNCHPLANE_PRODUCT }}\n"
+                "          LAUNCHPLANE_CONTEXT: ${{ vars.LAUNCHPLANE_CONTEXT }}\n"
+                "          LAUNCHPLANE_INSTANCE: ${{ vars.LAUNCHPLANE_INSTANCE }}\n"
+                "        run: |\n"
+                "          artifact_id=\"${IMAGE_REPOSITORY}@${IMAGE_DIGEST}\"\n"
+                "          echo \"artifact_id=${artifact_id}\" >> \"$GITHUB_OUTPUT\"\n"
+                "      - uses: cbusillo/launchplane/.github/actions/launchplane-request@main\n"
+                "        with:\n"
+                "          launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}\n"
+                "          route-path: /v1/drivers/generic-web/deploy\n"
+                "          payload-file: ${{ steps.launchplane_payload.outputs.payload_path }}\n"
+                "          idempotency-key: >-\n"
+                "            generic-web-deploy:${{ vars.LAUNCHPLANE_PRODUCT }}:${{ vars.LAUNCHPLANE_CONTEXT }}:${{ vars.LAUNCHPLANE_INSTANCE }}:${{ github.event.workflow_run.head_sha }}:${{ steps.launchplane_payload.outputs.artifact_id }}\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "audit-config-authority",
+                    "--control-plane-root",
+                    str(root),
+                    "--mode",
+                    "changed-files-gate",
+                    "--fail-on-findings",
+                    "--gate-profile",
+                    "product-repo",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        gate = cast("dict[str, object]", payload["gate"])
+        self.assertEqual(gate["status"], "pass")
+        thin_connector_keys = {
+            finding["key"]
+            for finding in _findings(payload)
+            if finding["allow_reason"] == "thin_connector_input"
+        }
+        self.assertTrue(
+            {"password", "context", "file", "IMAGE_REPOSITORY", "idempotency-key"}
+            <= thin_connector_keys
+        )
 
     def test_cli_product_repo_gate_allows_compact_launchplane_tool_checkout(self) -> None:
         with TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- allow product-repo launchplane-deploy workflows to forward image build outputs and Launchplane operator vars through the config-authority gate
- add product-repo gate regression and narrowness coverage for image deploy mechanics
- document the supported generic-web image deploy workflow shape

## Validation
- uv run python -m unittest tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_connector_findings_are_classified_narrowly tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_launchplane_public_url_reference_is_self_bootstrap tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cli_product_repo_gate_allows_image_artifact_deploy_workflow
- uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_config_authority_audit.py
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py
- uv run --extra dev mypy control_plane/config_authority_audit.py tests/test_config_authority_audit.py
- uv run launchplane service audit-config-authority --control-plane-root /Users/cbusillo/Developer/repairshopr_api --mode changed-files-gate --fail-on-findings --gate-profile product-repo

## Review
- GPT review scout on earlier root cause agreed this should be scoped to dynamic image workflow mechanics and warned against broad vars/github.token allowances.
- Antigravity architecture review: no blocking findings; recommended docs, now included.
- Auto Review ledger: no target-applicable findings.