### PR TITLE
Use DB runtime env for generic web deploy

### DIFF
--- a/control_plane/runtime_environments.py
+++ b/control_plane/runtime_environments.py
@@ -70,19 +70,11 @@ def resolve_runtime_environment_values(
         control_plane_root=control_plane_root,
         database_url=database_url,
     )
-    merged_values: dict[str, str] = _normalize_scalar_map(definition.shared_env)
-    context_definition = definition.contexts.get(context_name)
-    if context_definition is None:
-        raise click.ClickException(
-            f"Runtime environments file has no context definition for {context_name!r}."
-        )
-    merged_values.update(_normalize_scalar_map(context_definition.shared_env))
-    instance_definition = context_definition.instances.get(instance_name)
-    if instance_definition is None:
-        raise click.ClickException(
-            f"Runtime environments file has no instance definition for {context_name}/{instance_name}."
-        )
-    merged_values.update(_normalize_scalar_map(instance_definition.env))
+    merged_values = resolve_values_from_definition(
+        definition=definition,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
     merged_values.update(
         resolve_tracked_target_environment_values(
             control_plane_root=control_plane_root,
@@ -97,6 +89,46 @@ def resolve_runtime_environment_values(
         instance_name=instance_name,
         database_url=database_url,
     )
+
+
+def resolve_values_from_definition(
+    *,
+    definition: RuntimeEnvironmentDefinition,
+    context_name: str,
+    instance_name: str,
+) -> dict[str, str]:
+    merged_values: dict[str, str] = _normalize_scalar_map(definition.shared_env)
+    context_definition = definition.contexts.get(context_name)
+    if context_definition is None:
+        raise click.ClickException(
+            f"Runtime environments file has no context definition for {context_name!r}."
+        )
+    merged_values.update(_normalize_scalar_map(context_definition.shared_env))
+    instance_definition = context_definition.instances.get(instance_name)
+    if instance_definition is None:
+        raise click.ClickException(
+            f"Runtime environments file has no instance definition for {context_name}/{instance_name}."
+        )
+    merged_values.update(_normalize_scalar_map(instance_definition.env))
+    return merged_values
+
+
+def resolve_optional_values_from_definition(
+    *,
+    definition: RuntimeEnvironmentDefinition,
+    context_name: str,
+    instance_name: str,
+) -> dict[str, str]:
+    merged_values: dict[str, str] = _normalize_scalar_map(definition.shared_env)
+    context_definition = definition.contexts.get(context_name)
+    if context_definition is None:
+        return merged_values
+    merged_values.update(_normalize_scalar_map(context_definition.shared_env))
+    instance_definition = context_definition.instances.get(instance_name)
+    if instance_definition is None:
+        return merged_values
+    merged_values.update(_normalize_scalar_map(instance_definition.env))
+    return merged_values
 
 
 def resolve_runtime_context_values(

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -172,10 +172,29 @@ def _scope_matches_record(
     return record.context == context_name and record.instance == instance_name
 
 
-def _binding_for_secret(record_store: SecretReadStore, *, secret_id: str) -> SecretBinding | None:
-    for binding in record_store.list_secret_bindings(limit=None):
-        if binding.secret_id == secret_id and binding.status == SECRET_STATUS_CONFIGURED:
-            return binding
+def _binding_for_secret(
+    record_store: SecretReadStore,
+    *,
+    secret_id: str,
+    integration: str | None = None,
+    context_name: str | None = None,
+    instance_name: str | None = None,
+) -> SecretBinding | None:
+    for binding in record_store.list_secret_bindings(
+        integration=integration or "",
+        context_name=context_name or "",
+        instance_name=instance_name or "",
+        limit=None,
+    ):
+        if binding.secret_id != secret_id or binding.status != SECRET_STATUS_CONFIGURED:
+            continue
+        if integration is not None and binding.integration != integration:
+            continue
+        if context_name is not None and binding.context != context_name:
+            continue
+        if instance_name is not None and binding.instance != instance_name:
+            continue
+        return binding
     return None
 
 
@@ -190,27 +209,48 @@ def resolve_secret_values_for_integration(
     if store is None:
         return {}
     try:
-        candidate_records = [
-            record
-            for record in store.list_secret_records(integration=integration)
-            if record.status == SECRET_STATUS_CONFIGURED
-            and _scope_matches_record(
-                record, context_name=context_name, instance_name=instance_name
-            )
-        ]
-        candidate_records.sort(
-            key=lambda record: (_scope_rank(record.scope), record.updated_at, record.secret_id)
+        return resolve_secret_values_for_integration_from_store(
+            record_store=store,
+            integration=integration,
+            context_name=context_name,
+            instance_name=instance_name,
         )
-        resolved_values: dict[str, str] = {}
-        for record in candidate_records:
-            binding = _binding_for_secret(store, secret_id=record.secret_id)
-            if binding is None:
-                continue
-            version = store.read_secret_version(record.current_version_id)
-            resolved_values[binding.binding_key] = _decrypt_secret_value(version.ciphertext)
-        return resolved_values
     finally:
         store.close()
+
+
+def resolve_secret_values_for_integration_from_store(
+    *,
+    record_store: SecretReadStore,
+    integration: str,
+    context_name: str = "",
+    instance_name: str = "",
+) -> dict[str, str]:
+    candidate_records = [
+        record
+        for record in record_store.list_secret_records(integration=integration)
+        if record.status == SECRET_STATUS_CONFIGURED
+        and _scope_matches_record(
+            record, context_name=context_name, instance_name=instance_name
+        )
+    ]
+    candidate_records.sort(
+        key=lambda record: (_scope_rank(record.scope), record.updated_at, record.secret_id)
+    )
+    resolved_values: dict[str, str] = {}
+    for record in candidate_records:
+        binding = _binding_for_secret(
+            record_store,
+            secret_id=record.secret_id,
+            integration=record.integration,
+            context_name=record.context,
+            instance_name=record.instance,
+        )
+        if binding is None:
+            continue
+        version = record_store.read_secret_version(record.current_version_id)
+        resolved_values[binding.binding_key] = _decrypt_secret_value(version.ciphertext)
+    return resolved_values
 
 
 def overlay_dokploy_environment_values(
@@ -241,6 +281,26 @@ def overlay_runtime_environment_secret_values(
         context_name=context_name,
         instance_name=instance_name,
         database_url=database_url,
+    )
+    if not managed_values:
+        return environment_values
+    merged_values = dict(environment_values)
+    merged_values.update(managed_values)
+    return merged_values
+
+
+def overlay_runtime_environment_secret_values_from_store(
+    *,
+    environment_values: dict[str, str],
+    record_store: SecretReadStore,
+    context_name: str,
+    instance_name: str = "",
+) -> dict[str, str]:
+    managed_values = resolve_secret_values_for_integration_from_store(
+        record_store=record_store,
+        integration=RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+        context_name=context_name,
+        instance_name=instance_name,
     )
     if not managed_values:
         return environment_values

--- a/control_plane/workflows/generic_web_deploy_provider.py
+++ b/control_plane/workflows/generic_web_deploy_provider.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
+from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.deploy_target import (
     DeployedTargetReference,
     DeployTargetCompatibilityType,
@@ -20,6 +21,7 @@ from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
 )
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.promotion_record import HealthcheckEvidence
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
@@ -35,7 +37,7 @@ class GenericWebResolvedDeployTarget(BaseModel):
     deploy_timeout_seconds: int = Field(ge=1)
 
 
-class DokployGenericWebDeployStore(Protocol):
+class DokployGenericWebDeployStore(control_plane_secrets.SecretReadStore, Protocol):
     def read_provider_target_record(
         self, *, context_name: str, instance_name: str
     ) -> ProviderTargetRecord: ...
@@ -47,6 +49,10 @@ class DokployGenericWebDeployStore(Protocol):
     def read_dokploy_target_id_record(
         self, *, context_name: str, instance_name: str
     ) -> DokployTargetIdRecord: ...
+
+    def list_runtime_environment_records(
+        self, *, context_name: str = "", instance_name: str = ""
+    ) -> tuple[RuntimeEnvironmentRecord, ...]: ...
 
 
 class GenericWebDeployProvider(Protocol):
@@ -127,10 +133,11 @@ class DokployGenericWebDeployProvider:
             provider_target=provider_target
         )
 
-        environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
-            control_plane_root=control_plane_root,
+        environment_values = _resolve_store_runtime_environment_values(
+            record_store=dokploy_store,
             context_name=lane.context,
             instance_name=lane.instance,
+            target_environment=target_definition.env,
         )
         configured_ship_mode = control_plane_dokploy.resolve_dokploy_ship_mode(
             lane.context,
@@ -210,6 +217,13 @@ def _require_dokploy_deploy_store(
         "read_provider_target_record",
         "read_dokploy_target_record",
         "read_dokploy_target_id_record",
+        "list_runtime_environment_records",
+        "read_secret_record",
+        "list_secret_records",
+        "read_secret_version",
+        "list_secret_versions",
+        "list_secret_bindings",
+        "list_secret_audit_events",
     )
     missing_methods = tuple(
         method_name
@@ -218,10 +232,39 @@ def _require_dokploy_deploy_store(
     )
     if missing_methods:
         raise click.ClickException(
-            "Generic web Dokploy deploy requires DB-backed provider-target and Dokploy target records. "
+            "Generic web Dokploy deploy requires DB-backed provider-target, Dokploy target, "
+            "runtime-environment, and managed-secret records. "
             f"Missing methods: {', '.join(missing_methods)}."
         )
     return cast(DokployGenericWebDeployStore, record_store)
+
+
+def _resolve_store_runtime_environment_values(
+    *,
+    record_store: DokployGenericWebDeployStore,
+    context_name: str,
+    instance_name: str,
+    target_environment: dict[str, str],
+) -> dict[str, str]:
+    definition = control_plane_runtime_environments.load_optional_runtime_environment_definition_from_store(
+        record_store=record_store
+    )
+    merged_values: dict[str, str] = {}
+    if definition is not None:
+        merged_values.update(
+            control_plane_runtime_environments.resolve_optional_values_from_definition(
+                definition=definition,
+                context_name=context_name,
+                instance_name=instance_name,
+            )
+        )
+    merged_values.update(target_environment)
+    return control_plane_secrets.overlay_runtime_environment_secret_values_from_store(
+        environment_values=merged_values,
+        record_store=record_store,
+        context_name=context_name,
+        instance_name=instance_name,
+    )
 
 
 def _dokploy_target_definition_for_lane(

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -13,14 +13,23 @@ from control_plane.contracts.promotion_record import PostDeployUpdateEvidence
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
+    ProductLaneHealthCheck,
+    ProductLaneHealthMonitoringPolicy,
     ProductLaneProfile,
     ProductPreviewProfile,
-    ProductLaneHealthMonitoringPolicy,
-    ProductLaneHealthCheck,
 )
+from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.contracts.secret_record import (
+    SecretAuditEvent,
+    SecretBinding,
+    SecretRecord,
+    SecretScope,
+    SecretVersion,
+)
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
+from control_plane import secrets as control_plane_secrets
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployRequest,
     GenericWebDeployStore,
@@ -74,8 +83,16 @@ class _DokployGenericWebDeployStore(_GenericWebDeployStore):
         provider_target: ProviderTargetRecord | None = None,
         dokploy_target: DokployTargetRecord | None = None,
         dokploy_target_id: DokployTargetIdRecord | None = None,
+        runtime_environment_records: tuple[RuntimeEnvironmentRecord, ...] = (),
+        secret_records: tuple[SecretRecord, ...] = (),
+        secret_versions: tuple[SecretVersion, ...] = (),
+        secret_bindings: tuple[SecretBinding, ...] = (),
     ) -> None:
         super().__init__(profile)
+        self.runtime_environment_records = runtime_environment_records
+        self.secret_records = secret_records
+        self.secret_versions = secret_versions
+        self.secret_bindings = secret_bindings
         self.provider_target = provider_target or ProviderTargetRecord(
             context="sellyouroutboard-testing",
             instance="testing",
@@ -133,6 +150,69 @@ class _DokployGenericWebDeployStore(_GenericWebDeployStore):
             return self.dokploy_target_id
         raise FileNotFoundError(f"{context_name}/{instance_name}")
 
+    def list_runtime_environment_records(
+        self, *, context_name: str = "", instance_name: str = ""
+    ) -> tuple[RuntimeEnvironmentRecord, ...]:
+        return tuple(
+            record
+            for record in self.runtime_environment_records
+            if (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        )
+
+    def list_secret_records(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretRecord, ...]:
+        records = tuple(
+            record
+            for record in self.secret_records
+            if (not integration or record.integration == integration)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        )
+        return records[:limit] if limit is not None else records
+
+    def read_secret_record(self, secret_id: str) -> SecretRecord:
+        for record in self.secret_records:
+            if record.secret_id == secret_id:
+                return record
+        raise FileNotFoundError(secret_id)
+
+    def read_secret_version(self, version_id: str) -> SecretVersion:
+        for version in self.secret_versions:
+            if version.version_id == version_id:
+                return version
+        raise FileNotFoundError(version_id)
+
+    def list_secret_versions(self, *, secret_id: str) -> tuple[SecretVersion, ...]:
+        return tuple(version for version in self.secret_versions if version.secret_id == secret_id)
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        bindings = tuple(
+            binding
+            for binding in self.secret_bindings
+            if (not integration or binding.integration == integration)
+            and (not context_name or binding.context == context_name)
+            and (not instance_name or binding.instance == instance_name)
+        )
+        return bindings[:limit] if limit is not None else bindings
+
+    def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:
+        del secret_id
+        return ()
+
 
 def _profile(*, driver_id: str = "generic-web") -> LaunchplaneProductProfileRecord:
     return LaunchplaneProductProfileRecord(
@@ -177,6 +257,61 @@ def _source_ref_worker_profile() -> LaunchplaneProductProfileRecord:
         ),
         updated_at="2026-06-12T20:00:00Z",
         source="test",
+    )
+
+
+def _runtime_secret_record(
+    *,
+    secret_id: str,
+    scope: SecretScope,
+    name: str,
+    version_id: str,
+    context: str = "",
+    instance: str = "",
+) -> SecretRecord:
+    return SecretRecord(
+        secret_id=secret_id,
+        scope=scope,
+        integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+        name=name,
+        context=context,
+        instance=instance,
+        description="Runtime secret test fixture",
+        current_version_id=version_id,
+        created_at="2026-04-30T22:00:00Z",
+        updated_at="2026-04-30T22:00:00Z",
+    )
+
+
+def _runtime_secret_version(
+    *, secret_id: str, version_id: str, plaintext_value: str
+) -> SecretVersion:
+    return SecretVersion(
+        version_id=version_id,
+        secret_id=secret_id,
+        created_at="2026-04-30T22:00:00Z",
+        ciphertext=control_plane_secrets._encrypt_secret_value(plaintext_value),
+    )
+
+
+def _runtime_secret_binding(
+    *,
+    secret_id: str,
+    binding_key: str,
+    context: str = "",
+    instance: str = "",
+    binding_id_suffix: str | None = None,
+    updated_at: str = "2026-04-30T22:00:00Z",
+) -> SecretBinding:
+    return SecretBinding(
+        binding_id=f"{secret_id}-binding-{binding_id_suffix or binding_key.lower().replace('_', '-')}",
+        secret_id=secret_id,
+        integration=control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+        binding_key=binding_key,
+        context=context,
+        instance=instance,
+        created_at="2026-04-30T22:00:00Z",
+        updated_at=updated_at,
     )
 
 
@@ -801,22 +936,18 @@ class GenericWebDeployTests(unittest.TestCase):
         provider = DokployGenericWebDeployProvider()
         store = _DokployGenericWebDeployStore(_profile())
 
-        with patch(
-            "control_plane.workflows.generic_web_deploy_provider.control_plane_runtime_environments.resolve_runtime_environment_values",
-            return_value={},
-        ):
-            resolved = provider.resolve_deploy_target(
-                control_plane_root=Path("."),
-                request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
-                request_source_git_ref="abc123",
-                request_timeout_seconds=45,
-                request_no_cache=True,
-                record_store=store,
-                profile=_profile(),
-                lane=_profile().lanes[0],
-                normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
-                fallback_target_name="fallback-target",
-            )
+        resolved = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            request_source_git_ref="abc123",
+            request_timeout_seconds=45,
+            request_no_cache=True,
+            record_store=store,
+            profile=_profile(),
+            lane=_profile().lanes[0],
+            normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            fallback_target_name="fallback-target",
+        )
 
         self.assertEqual(resolved.ship_request.provider_id, "dokploy")
         self.assertEqual(resolved.ship_request.deploy_mode, "dokploy-application-api")
@@ -898,10 +1029,129 @@ class GenericWebDeployTests(unittest.TestCase):
         provider = DokployGenericWebDeployProvider()
         store = StoreWithDangerousListMethods(_profile())
 
-        with patch(
-            "control_plane.workflows.generic_web_deploy_provider.control_plane_runtime_environments.resolve_runtime_environment_values",
-            return_value={},
+        resolved = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            request_source_git_ref="abc123",
+            request_timeout_seconds=45,
+            request_no_cache=True,
+            record_store=store,
+            profile=_profile(),
+            lane=_profile().lanes[0],
+            normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            fallback_target_name="fallback-target",
+        )
+
+        self.assertEqual(resolved.resolved_target.target_id, "target-123")
+
+    def test_dokploy_provider_uses_db_runtime_environment_ship_mode_override(
+        self,
+    ) -> None:
+        provider = DokployGenericWebDeployProvider()
+        store = _DokployGenericWebDeployStore(
+            _profile(),
+            runtime_environment_records=(
+                RuntimeEnvironmentRecord(
+                    scope="context",
+                    context="sellyouroutboard-testing",
+                    env={"DOKPLOY_SHIP_MODE": "compose"},
+                    updated_at="2026-04-30T22:00:00Z",
+                    source_label="test",
+                ),
+            ),
+        )
+
+        resolved = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            request_source_git_ref="abc123",
+            request_timeout_seconds=45,
+            request_no_cache=True,
+            record_store=store,
+            profile=_profile(),
+            lane=_profile().lanes[0],
+            normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            fallback_target_name="fallback-target",
+        )
+
+        self.assertEqual(resolved.ship_request.deploy_mode, "dokploy-compose-api")
+
+    def test_dokploy_provider_ignores_sparse_runtime_environment_records(
+        self,
+    ) -> None:
+        provider = DokployGenericWebDeployProvider()
+        store = _DokployGenericWebDeployStore(
+            _profile(),
+            runtime_environment_records=(
+                RuntimeEnvironmentRecord(
+                    scope="context",
+                    context="other-context",
+                    env={"DOKPLOY_SHIP_MODE": "compose"},
+                    updated_at="2026-04-30T22:00:00Z",
+                    source_label="test",
+                ),
+            ),
+        )
+
+        resolved = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            request_source_git_ref="abc123",
+            request_timeout_seconds=45,
+            request_no_cache=True,
+            record_store=store,
+            profile=_profile(),
+            lane=_profile().lanes[0],
+            normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            fallback_target_name="fallback-target",
+        )
+
+        self.assertEqual(resolved.ship_request.deploy_mode, "dokploy-application-api")
+
+    def test_dokploy_provider_uses_managed_runtime_secret_ship_mode_override(
+        self,
+    ) -> None:
+        provider = DokployGenericWebDeployProvider()
+        secret_id = "secret-runtime-ship-mode-syo-testing"
+        version_id = f"{secret_id}-version-current"
+
+        with patch.dict(
+            "os.environ",
+            {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
         ):
+            store = _DokployGenericWebDeployStore(
+                _profile(),
+                secret_records=(
+                    _runtime_secret_record(
+                        secret_id=secret_id,
+                        scope="context",
+                        name="dokploy-ship-mode",
+                        version_id=version_id,
+                        context="sellyouroutboard-testing",
+                    ),
+                ),
+                secret_versions=(
+                    _runtime_secret_version(
+                        secret_id=secret_id,
+                        version_id=version_id,
+                        plaintext_value="compose",
+                    ),
+                ),
+                secret_bindings=(
+                    _runtime_secret_binding(
+                        secret_id=secret_id,
+                        binding_key="STALE_DOKPLOY_SHIP_MODE",
+                        context="other-context",
+                        binding_id_suffix="stale",
+                        updated_at="2026-04-30T22:01:00Z",
+                    ),
+                    _runtime_secret_binding(
+                        secret_id=secret_id,
+                        binding_key="DOKPLOY_SHIP_MODE",
+                        context="sellyouroutboard-testing",
+                    ),
+                ),
+            )
             resolved = provider.resolve_deploy_target(
                 control_plane_root=Path("."),
                 request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
@@ -915,7 +1165,78 @@ class GenericWebDeployTests(unittest.TestCase):
                 fallback_target_name="fallback-target",
             )
 
-        self.assertEqual(resolved.resolved_target.target_id, "target-123")
+        self.assertEqual(resolved.ship_request.deploy_mode, "dokploy-compose-api")
+
+    def test_dokploy_provider_prefers_context_instance_runtime_secret_over_global(
+        self,
+    ) -> None:
+        provider = DokployGenericWebDeployProvider()
+        global_secret_id = "secret-runtime-ship-mode-global"
+        global_version_id = f"{global_secret_id}-version-current"
+        instance_secret_id = "secret-runtime-ship-mode-syo-testing-instance"
+        instance_version_id = f"{instance_secret_id}-version-current"
+
+        with patch.dict(
+            "os.environ",
+            {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+        ):
+            store = _DokployGenericWebDeployStore(
+                _profile(),
+                secret_records=(
+                    _runtime_secret_record(
+                        secret_id=global_secret_id,
+                        scope="global",
+                        name="dokploy-ship-mode-global",
+                        version_id=global_version_id,
+                    ),
+                    _runtime_secret_record(
+                        secret_id=instance_secret_id,
+                        scope="context_instance",
+                        name="dokploy-ship-mode-testing",
+                        version_id=instance_version_id,
+                        context="sellyouroutboard-testing",
+                        instance="testing",
+                    ),
+                ),
+                secret_versions=(
+                    _runtime_secret_version(
+                        secret_id=global_secret_id,
+                        version_id=global_version_id,
+                        plaintext_value="application",
+                    ),
+                    _runtime_secret_version(
+                        secret_id=instance_secret_id,
+                        version_id=instance_version_id,
+                        plaintext_value="compose",
+                    ),
+                ),
+                secret_bindings=(
+                    _runtime_secret_binding(
+                        secret_id=global_secret_id,
+                        binding_key="DOKPLOY_SHIP_MODE",
+                    ),
+                    _runtime_secret_binding(
+                        secret_id=instance_secret_id,
+                        binding_key="DOKPLOY_SHIP_MODE",
+                        context="sellyouroutboard-testing",
+                        instance="testing",
+                    ),
+                ),
+            )
+            resolved = provider.resolve_deploy_target(
+                control_plane_root=Path("."),
+                request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                request_source_git_ref="abc123",
+                request_timeout_seconds=45,
+                request_no_cache=True,
+                record_store=store,
+                profile=_profile(),
+                lane=_profile().lanes[0],
+                normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+                fallback_target_name="fallback-target",
+            )
+
+        self.assertEqual(resolved.ship_request.deploy_mode, "dokploy-compose-api")
 
     def test_resolve_generic_web_profile_lane_rejects_missing_lane(self) -> None:
         store = _GenericWebDeployStore(_profile())


### PR DESCRIPTION
## Summary
- resolve native generic-web Dokploy deploy runtime environment from DB-backed records instead of the legacy runtime-environments authority
- merge target environment from the already-loaded DB Dokploy target record and overlay DB-managed runtime secrets from the same store
- tighten managed secret binding resolution so runtime secret bindings match the same integration and scope route

## Validation
- uv run python -m unittest tests.test_generic_web_deploy tests.test_secrets tests.test_runtime_environments tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_uses_profile_lane_for_authorization tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_accepts_base_driver_product tests.test_service.LaunchplaneServiceTests.test_generic_web_deploy_route_resolves_literal_generic_web_profile
- uv run --extra dev ruff check control_plane/workflows/generic_web_deploy_provider.py control_plane/runtime_environments.py control_plane/secrets.py tests/test_generic_web_deploy.py
- uv run --extra dev mypy control_plane tests

## Review
- Code/GPT and Antigravity review agents checked v2 authority boundaries, sparse runtime-env behavior, and managed secret binding scope.
