### PR TITLE
Document stable product repo image deploy

### DIFF
--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -85,6 +85,13 @@ records as repo-local authority.
 Product repos own image build and publish. Launchplane owns deploy selection and
 evidence after the image exists.
 
+The stable product-repo integration surface for this contract is image-backed
+generic-web deploy through `POST /v1/drivers/generic-web/deploy`, normally via
+the shared `cbusillo/launchplane/.github/actions/launchplane-request` action.
+The product repo submits immutable image identity plus the tested source SHA;
+Launchplane resolves lane, provider target, runtime environment, managed
+secrets, and deployment records from DB-backed authority.
+
 Publish images to the profile's `image.repository` and prefer digest deployment:
 
 ```text
@@ -103,6 +110,14 @@ Dokploy application's Docker image. Do not submit a mutable tag for service
 deploys. If a later slice adds generic artifact-manifest resolution for this
 path, the manifest must still resolve to the same `repository@sha256:digest`
 identity before Dokploy is mutated.
+
+RepairShopr Sync is the first live canary for this stable shape. The
+`cbusillo/repairshopr_api` product workflow built an immutable GHCR image,
+called deployed Launchplane, and received `deploy_status: pass` for deployment
+record `deployment-20260630T034901Z-repairshopr-sync-prod` after Launchplane PR
+#1503 deployed. Treat that run as proof that service-shaped worker products can
+use this contract without source-ref deploy or direct Dokploy mutation in the
+product repo.
 
 Some inherited services still deploy an existing Dokploy compose target directly
 from a Git source ref instead of an immutable image. Use this as a migration
@@ -127,12 +142,13 @@ Dokploy health checks. Image deploy, preview creation, public ingress
 monitoring, provider domains, and provider health checks still require real image
 and HTTP health metadata before they can mutate provider state.
 
-The long-term target is still immutable image deploy. The source-ref bridge does
-not write generic-web deployment records; its durable replay surface is the
-service idempotency record. Treat it as a current but bounded Launchplane-owned
+The stable target is immutable image deploy. The source-ref bridge does not
+write generic-web deployment records; its durable replay surface is the service
+idempotency record. Treat it as a current but bounded Launchplane-owned
 replacement for direct Dokploy workflows only while the product is moved to
-image publishing. #1498 owns the stable product-repo integration surface and
-the eventual replacement/removal condition for this bridge.
+image publishing. Any retained source-ref caller must have an issue-backed
+owner, date, and delete condition; do not use the bridge for products that can
+publish immutable images.
 
 Launchplane also injects a non-secret runtime identity into Dokploy env during
 Launchplane-owned deploys. The standard keys are

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -325,6 +325,32 @@ with an `artifact_protection.read` grant that allows wildcard context for that
 product; context-specific cleanup may pass `context=` and use a matching scoped
 grant.
 
+## Canonical Image Deploy Connector
+
+Image-backed generic-web deploy is the canonical stable product-repo connector
+for simple service and website repos. The product repo builds and publishes an
+immutable image, then calls deployed Launchplane over the shared request action.
+Launchplane resolves product profile, lane, provider target, runtime
+environment, managed secrets, authz, idempotency, and deployment evidence from
+service-owned records.
+
+The first real-world proof for this shape is RepairShopr Sync: after PR #1503
+deployed Launchplane commit `9dbdf15904a86eea2b742f1e42e341db138e4860`,
+`cbusillo/repairshopr_api` Launchplane Deploy run `28415366430` attempt 4
+passed through `/v1/drivers/generic-web/deploy`. The product workflow supplied
+`ghcr.io/cbusillo/repairshopr_api@sha256:7efdbf139f7f5263c02d38509841253e719a41c44c55aa79aa4a223379808eea`
+as `artifact_id`; Launchplane returned deployment record
+`deployment-20260630T034901Z-repairshopr-sync-prod`, `deploy_status: pass`,
+target `cm-repairshopr-sync`, target category `compose`, provider `dokploy`,
+and `post_deploy_status: skipped`. That run is the recovery evidence for this
+contract and the baseline for retiring older source-ref or checkout-and-invoke
+patterns.
+
+For new or repaired product repos, prefer this connector over product-repo
+checkout of Launchplane source or direct invocation of Launchplane internals.
+If a repo still needs a compatibility bridge, the bridge must have an issue
+reference, a dated owner, and a delete condition.
+
 ## Reusable Launchplane Request Action
 
 Product workflows that only need to send JSON to an existing Launchplane route

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1495,14 +1495,22 @@ remain provider execution configuration for Dokploy-backed lanes and must agree
 with the provider-target identity before deploy proceeds. The route keeps
 optional `Idempotency-Key` replay/conflict handling and stores deploy-pass plus
 post-deploy-fail evidence to prevent repeating the completed provider mutation.
+This image-backed route is the canonical product-repo integration surface for
+simple generic-web services. `cbusillo/repairshopr_api` proved the path in live
+Launchplane after #1503 deployed: Launchplane Deploy run `28415366430` attempt 4
+called `/v1/drivers/generic-web/deploy` with immutable GHCR image identity and
+received `deploy_status: pass` for deployment record
+`deployment-20260630T034901Z-repairshopr-sync-prod` on Dokploy target
+`cm-repairshopr-sync`.
 Generic web source-ref deploys use native FastAPI
 `POST /v1/drivers/generic-web/source-ref-deploy`; the route validates the
 request context and instance against the resolved product profile lane before
 authorization, idempotency replay, or provider mutation. This route is a
 current but bounded Launchplane-owned bridge for provider-backed compose targets
-that still deploy from a tested source ref. #1498 owns the stable product-repo
-integration surface and the replacement/removal condition; product repos must
-not regain direct Dokploy mutation authority around this route.
+that still deploy from a tested source ref. Any retained source-ref caller must
+have an issue-backed owner, date, and delete condition; product repos must not
+regain direct Dokploy mutation authority around this route. Do not choose
+source-ref deploy for products that can publish immutable images.
 Product environment reads expose neutral provider-target identity only from
 explicit provider-target rows. Paired DB-backed Dokploy target and target-id
 records remain visible as provider-specific execution/history metadata and as

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -57,6 +57,32 @@ class DocsContractsTests(TestCase):
         self.assertIn("Public registration probes", odoo_smoke_workflow)
         self.assertIn("Authenticated route probes", odoo_smoke_workflow)
 
+    def test_product_repo_integration_contract_prefers_image_deploy(self) -> None:
+        product_repo_contract = Path("docs/product-repo-contract.md").read_text(
+            encoding="utf-8"
+        )
+        dokploy_service_contract = Path("docs/dokploy-service-deployments.md").read_text(
+            encoding="utf-8"
+        )
+        service_boundary = Path("docs/service-boundary.md").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("Canonical Image Deploy Connector", product_repo_contract)
+        self.assertIn("Image-backed generic-web deploy", product_repo_contract)
+        self.assertIn("repairshopr_api", product_repo_contract)
+        self.assertIn("deployment-20260630T034901Z-repairshopr-sync-prod", product_repo_contract)
+        self.assertIn("baseline for retiring older source-ref", product_repo_contract)
+
+        self.assertIn("stable product-repo integration surface", dokploy_service_contract)
+        self.assertIn("RepairShopr Sync is the first live canary", dokploy_service_contract)
+        self.assertIn("without source-ref deploy or direct Dokploy mutation", dokploy_service_contract)
+        self.assertIn("do not use the bridge", dokploy_service_contract)
+        self.assertIn("publish immutable images", dokploy_service_contract)
+
+        self.assertIn("canonical product-repo integration surface", service_boundary)
+        self.assertIn("Do not choose\nsource-ref deploy", service_boundary)
+
     def test_odoo_base_image_promotion_owner_is_documented(self) -> None:
         records_doc = Path("docs/records.md").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- codify image-backed generic-web deploy as the canonical product-repo integration surface
- record the repairshopr_api live deploy proof after #1503 as the first stable image-deploy canary
- reframe source-ref deploy as bounded compatibility requiring issue-backed owner/date/delete condition
- add docs-contract assertions so this wording does not drift

## Validation
- uv run python -m unittest tests.test_docs_contracts
- uv run --extra dev ruff check tests/test_docs_contracts.py

## Review
- Code/GPT and Antigravity review agents checked that the docs keep runtime authority in Launchplane records, avoid stale transient planning text, and do not overclaim the repairshopr proof.

Refs #1498
Refs #1494
Refs #1489
