### PR TITLE
Fence direct local product config DB apply

### DIFF
--- a/control_plane/cli_product_config.py
+++ b/control_plane/cli_product_config.py
@@ -18,6 +18,11 @@ from control_plane.workflows.product_onboarding import apply_product_onboarding_
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use the deployed service route or operator workflow for shared/production changes, "
+    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+)
 
 
 def register_product_config_commands(
@@ -72,6 +77,12 @@ def product_onboarding() -> None:
 @click.option("--source-label", default="product-config-apply", show_default=True)
 @click.option("--dry-run", "dry_run", is_flag=True, default=False)
 @click.option("--apply", "apply_changes", is_flag=True, default=False)
+@click.option(
+    "--allow-direct-db-mutation",
+    is_flag=True,
+    default=False,
+    help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+)
 def product_config_apply(
     database_url: str,
     input_file: Path,
@@ -79,9 +90,12 @@ def product_config_apply(
     source_label: str,
     dry_run: bool,
     apply_changes: bool,
+    allow_direct_db_mutation: bool,
 ) -> None:
     if dry_run == apply_changes:
         raise click.ClickException("Choose exactly one of --dry-run or --apply.")
+    if apply_changes and not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
 
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
@@ -114,7 +128,21 @@ def product_config_apply(
     help="Operator-approved JSON product onboarding manifest.",
 )
 @click.option("--updated-at", default="", help="Override manifest updated_at timestamp.")
-def product_onboarding_apply(database_url: str, manifest_file: Path, updated_at: str) -> None:
+@click.option(
+    "--allow-direct-db-mutation",
+    is_flag=True,
+    default=False,
+    help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+)
+def product_onboarding_apply(
+    database_url: str,
+    manifest_file: Path,
+    updated_at: str,
+    allow_direct_db_mutation: bool,
+) -> None:
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
+
     callbacks = _product_onboarding_apply_callbacks()
     try:
         manifest_payload = json.loads(manifest_file.read_text())

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -47,12 +47,15 @@ as Discord Blue's Every Code bridge port `8787`.
 ## Launchplane Records
 
 Before wiring workflows, seed or verify these records in Launchplane with an
-operator-owned onboarding manifest:
+operator-owned onboarding manifest through the Product Onboarding workflow or
+`POST /v1/product-onboarding/apply`. Direct local DB apply from a checkout is a
+break-glass local/bootstrap repair path and requires an explicit acknowledgement:
 
 ```sh
 uv run launchplane product-onboarding apply \
   --database-url "$LAUNCHPLANE_DATABASE_URL" \
-  --manifest-file state/product-onboarding/<product>.json
+  --manifest-file state/product-onboarding/<product>.json \
+  --allow-direct-db-mutation
 ```
 
 The manifest is applied idempotently and writes Launchplane-owned records for:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -679,12 +679,15 @@ Current derived-state behavior:
   directly into DB-backed runtime-environment records for `global`, `context`,
   or `instance` scope. It rejects secret-shaped keys and returns key metadata
   only, not plaintext values.
-- `product-config apply --dry-run|--apply --input-file <json>` is the supported
-  trusted-context bundle path for product runtime config changes. It writes
-  non-secret values to runtime-environment records and secret-shaped values to
-  managed secret records while returning only key names, actions, counts, actor,
-  and source metadata. Use it from a live Launchplane context that already has
-  current `LAUNCHPLANE_DATABASE_URL`; bundles with secrets also require
+- `product-config apply --dry-run --input-file <json>` remains a local planning
+  helper for trusted product runtime config bundles. Direct local DB
+  `--apply` is restricted after the service boundary and requires
+  `--allow-direct-db-mutation`; use it only for explicit local/bootstrap repair,
+  not routine shared or production mutation from an arbitrary checkout. The
+  service route below is the normal shared/prod path. Product-config apply
+  writes non-secret values to runtime-environment records and secret-shaped
+  values to managed secret records while returning only key names, actions,
+  counts, actor, and source metadata. Bundles with secrets require
   `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`. Runtime and secret scopes default from
   the top-level `context`/`instance`; nested `runtime_env` and secret routes must
   match that top-level target. Dry-run validates secret scope/route

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -3143,6 +3143,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                     database_url,
                     "--manifest-file",
                     str(manifest_path),
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -3152,6 +3153,28 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertEqual(payload["product"], "example-site")
         self.assertEqual(payload["secret_binding_count"], 1)
         self.assertNotIn("secret_id", payload["secret_bindings"][0])
+
+    def test_product_onboarding_cli_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temporary_directory / "db.sqlite3")
+            manifest_path = temporary_directory / "product-onboarding.json"
+            manifest_path.write_text(json.dumps(_manifest_payload()))
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "product-onboarding",
+                    "apply",
+                    "--database-url",
+                    database_url,
+                    "--manifest-file",
+                    str(manifest_path),
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
 
 
 if __name__ == "__main__":

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -1966,6 +1966,7 @@ ODOO_DB_PASSWORD = "file-secret"
                         "--source-label",
                         "issue-110-test",
                         "--apply",
+                        "--allow-direct-db-mutation",
                     ],
                 )
                 resolved_values = (
@@ -1995,6 +1996,51 @@ ODOO_DB_PASSWORD = "file-secret"
                 audit_events = store.list_secret_audit_events(secret_id=secret_records[0].secret_id)
                 self.assertEqual(audit_events[0].actor, "operator@example.com")
                 self.assertEqual(audit_events[0].metadata["source"], "issue-110-test")
+            finally:
+                store.close()
+
+    def test_product_config_apply_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            input_file = control_plane_root / "product-config.json"
+            _write_runtime_key_safety_policy(database_url=database_url)
+            input_file.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "product": "sellyouroutboard",
+                        "context": "sellyouroutboard",
+                        "instance": "prod",
+                        "runtime_env": {"CONTACT_EMAIL_MODE": "smtp"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with patch.dict(
+                os.environ,
+                {"LAUNCHPLANE_DATABASE_URL": database_url},
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "product-config",
+                        "apply",
+                        "--input-file",
+                        str(input_file),
+                        "--apply",
+                    ],
+                )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("Direct local DB mutation is restricted", result.output)
+
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                self.assertEqual(store.list_runtime_environment_records(), ())
+                self.assertEqual(store.list_secret_records(), ())
             finally:
                 store.close()
 
@@ -2178,6 +2224,7 @@ ODOO_DB_PASSWORD = "file-secret"
                         "--input-file",
                         str(input_file),
                         "--apply",
+                        "--allow-direct-db-mutation",
                     ],
                 )
 
@@ -2236,6 +2283,7 @@ ODOO_DB_PASSWORD = "file-secret"
                         "--input-file",
                         str(input_file),
                         "--apply",
+                        "--allow-direct-db-mutation",
                     ],
                 )
 


### PR DESCRIPTION
## Summary
- require an explicit `--allow-direct-db-mutation` acknowledgement for local `product-config apply --apply` and `product-onboarding apply`
- keep dry-run/service-route behavior intact while preserving the local/bootstrap repair path
- update operator docs and regression tests for the v2 service-boundary expectation

## Validation
- `uv run python -m unittest tests.test_runtime_environments tests.test_product_onboarding`
- `uv run python -m unittest tests.test_docs_contracts`
- `uv run --extra dev ruff check control_plane/cli_product_config.py tests/test_runtime_environments.py tests/test_product_onboarding.py`
- `uv run --extra dev mypy control_plane/cli_product_config.py tests/test_runtime_environments.py tests/test_product_onboarding.py`
- `git diff --check`

## Review
- GPT review agent: no findings
- Antigravity review agent: found a real test regression; fixed before commit
- Auto Review: no active findings

Refs #1492, #1489