### PR TITLE
Fence direct local workflow DB mutations

### DIFF
--- a/control_plane/cli_launchplane_previews.py
+++ b/control_plane/cli_launchplane_previews.py
@@ -49,6 +49,11 @@ from control_plane.workflows.launchplane import (
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use the deployed service route or operator workflow for shared/production changes, "
+    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+)
 LaunchplanePreviewRecordStore = FilesystemRecordStore | PostgresRecordStore
 
 
@@ -91,7 +96,11 @@ def _store(state_dir: Path, *, database_url: str | None = None) -> LaunchplanePr
 
 
 def _resolve_preview_mutation_database_url(
-    *, database_url: str, local_rehearsal: bool, command_label: str
+    *,
+    database_url: str,
+    local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
+    command_label: str,
 ) -> str | None:
     if local_rehearsal:
         return None
@@ -107,7 +116,18 @@ def _resolve_preview_mutation_database_url(
             f"{command_label} requires --database-url or LAUNCHPLANE_DATABASE_URL. "
             "Use --local-rehearsal for explicit local filesystem rehearsal."
         )
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
     return normalized_database_url
+
+
+def _direct_db_mutation_acknowledgement_option(function: Callable[..., object]) -> Callable[..., object]:
+    return click.option(
+        "--allow-direct-db-mutation",
+        is_flag=True,
+        default=False,
+        help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+    )(function)
 
 
 def _control_plane_root() -> Path:
@@ -234,13 +254,19 @@ def launchplane_previews() -> None:
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 def launchplane_previews_write_preview(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
+    input_file: Path,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews write-preview",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -260,13 +286,19 @@ def launchplane_previews_write_preview(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 def launchplane_previews_write_generation(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
+    input_file: Path,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews write-generation",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -285,13 +317,19 @@ def launchplane_previews_write_generation(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 def launchplane_previews_write_enablement(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
+    input_file: Path,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews write-enablement",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -310,16 +348,19 @@ def launchplane_previews_write_enablement(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 def launchplane_previews_request_generation(
     state_dir: Path,
     preview_input_file: Path,
     generation_input_file: Path,
     database_url: str,
     local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews request-generation",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -346,16 +387,19 @@ def launchplane_previews_request_generation(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 def launchplane_previews_write_from_generation(
     state_dir: Path,
     preview_input_file: Path,
     generation_input_file: Path,
     database_url: str,
     local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews write-from-generation",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -378,13 +422,19 @@ def launchplane_previews_write_from_generation(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 def launchplane_previews_write_destroyed(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
+    input_file: Path,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews write-destroyed",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -402,13 +452,19 @@ def launchplane_previews_write_destroyed(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 def launchplane_previews_mark_generation_ready(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
+    input_file: Path,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews mark-generation-ready",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -456,13 +512,19 @@ def launchplane_previews_mark_generation_ready(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 def launchplane_previews_mark_generation_failed(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
+    input_file: Path,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews mark-generation-failed",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -510,13 +572,19 @@ def launchplane_previews_mark_generation_failed(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 def launchplane_previews_destroy_preview(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
+    input_file: Path,
 ) -> None:
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews destroy-preview",
     )
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -534,6 +602,7 @@ def launchplane_previews_destroy_preview(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--apply", "apply_intent", is_flag=True)
 @click.option("--deliver-feedback", is_flag=True)
@@ -541,6 +610,7 @@ def launchplane_previews_ingest_pr_event(
     state_dir: Path,
     database_url: str,
     local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
     input_file: Path,
     apply_intent: bool,
     deliver_feedback: bool,
@@ -548,6 +618,7 @@ def launchplane_previews_ingest_pr_event(
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews ingest-pr-event",
     )
     event = GitHubPullRequestEvent.model_validate(_load_json_file(input_file))
@@ -567,6 +638,7 @@ def launchplane_previews_ingest_pr_event(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--event-name", default="pull_request", show_default=True)
 @click.option("--delivery-id", default="", help="Optional GitHub delivery id for traceability.")
@@ -582,6 +654,7 @@ def launchplane_previews_ingest_github_webhook(
     state_dir: Path,
     database_url: str,
     local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
     input_file: Path,
     event_name: str,
     delivery_id: str,
@@ -593,6 +666,7 @@ def launchplane_previews_ingest_github_webhook(
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews ingest-github-webhook",
     )
     raw_payload_bytes, webhook_payload = _load_github_webhook_json_file(input_file)
@@ -953,6 +1027,7 @@ def launchplane_previews_build_github_webhook_replay_envelope(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--apply", "apply_intent", is_flag=True)
 @click.option("--deliver-feedback", is_flag=True)
@@ -960,6 +1035,7 @@ def launchplane_previews_replay_github_webhook(
     state_dir: Path,
     database_url: str,
     local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
     input_file: Path,
     apply_intent: bool,
     deliver_feedback: bool,
@@ -967,6 +1043,7 @@ def launchplane_previews_replay_github_webhook(
     execution_database_url = _resolve_preview_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
         command_label="launchplane-previews replay-github-webhook",
     )
     try:

--- a/control_plane/cli_promotion_ship.py
+++ b/control_plane/cli_promotion_ship.py
@@ -21,6 +21,11 @@ from control_plane.workflows.promote import (
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use the deployed service route or operator workflow for shared/production changes, "
+    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+)
 
 
 @dataclass(frozen=True)
@@ -64,7 +69,9 @@ def _store(
     return _promotion_ship_callbacks().store_factory(state_dir, database_url=database_url)
 
 
-def _resolve_execution_database_url(*, database_url: str, local_rehearsal: bool) -> str | None:
+def _resolve_execution_database_url(
+    *, database_url: str, local_rehearsal: bool, allow_direct_db_mutation: bool
+) -> str | None:
     if local_rehearsal:
         return None
     normalized_database_url = database_url.strip()
@@ -80,7 +87,18 @@ def _resolve_execution_database_url(*, database_url: str, local_rehearsal: bool)
             "LAUNCHPLANE_DATABASE_URL. Use --local-rehearsal for explicit "
             "local filesystem rehearsal."
         )
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
     return normalized_database_url
+
+
+def _direct_db_mutation_acknowledgement_option(function: Callable[..., object]) -> Callable[..., object]:
+    return click.option(
+        "--allow-direct-db-mutation",
+        is_flag=True,
+        default=False,
+        help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+    )(function)
 
 
 def _load_json_file(input_file: Path) -> dict[str, object]:
@@ -234,18 +252,21 @@ def promote_resolve(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--env-file", type=click.Path(exists=True, path_type=Path), default=None)
 def promote_execute(
     state_dir: Path,
     database_url: str,
     local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
     input_file: Path,
     env_file: Path | None,
 ) -> None:
     execution_database_url = _resolve_execution_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     request = PromotionRequest.model_validate(_load_json_file(input_file))
     record_store = _store(state_dir, database_url=execution_database_url)
@@ -398,18 +419,21 @@ def ship_resolve(
 )
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
 @click.option("--env-file", type=click.Path(exists=True, path_type=Path), default=None)
 def ship_execute(
     state_dir: Path,
     database_url: str,
     local_rehearsal: bool,
+    allow_direct_db_mutation: bool,
     input_file: Path,
     env_file: Path | None,
 ) -> None:
     execution_database_url = _resolve_execution_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     request = ShipRequest.model_validate(_load_json_file(input_file))
     record_path, _record = _execute_ship(

--- a/control_plane/launchplane_rendering.py
+++ b/control_plane/launchplane_rendering.py
@@ -357,7 +357,7 @@ def build_launchplane_promotion_execute_recipe_script(*, state_dir: str) -> str:
             'LAUNCHPLANE_DATABASE_URL="postgresql+psycopg://..."',
             f'STATE_DIR="{state_dir or "/path/to/runtime"}"',
             'PROMOTION_REQUEST_FILE="/tmp/launchplane-promotion-request.json"',
-            'uv run launchplane promote execute --database-url "$LAUNCHPLANE_DATABASE_URL" --state-dir "$STATE_DIR" --input-file "$PROMOTION_REQUEST_FILE"',
+            'uv run launchplane promote execute --database-url "$LAUNCHPLANE_DATABASE_URL" --allow-direct-db-mutation --state-dir "$STATE_DIR" --input-file "$PROMOTION_REQUEST_FILE"',
         )
     )
 
@@ -378,7 +378,7 @@ def build_launchplane_environment_ship_recipe_script(
             f'SHIP_REQUEST_FILE="{request_file}"',
             f'uv run launchplane ship resolve --context "{context_name}" --instance "{instance_name}" --artifact-id "{artifact_id}" --source-ref "{source_git_ref}" >"$SHIP_REQUEST_FILE"',
             'cat "$SHIP_REQUEST_FILE"',
-            'uv run launchplane ship execute --database-url "$LAUNCHPLANE_DATABASE_URL" --state-dir "$STATE_DIR" --input-file "$SHIP_REQUEST_FILE"',
+            'uv run launchplane ship execute --database-url "$LAUNCHPLANE_DATABASE_URL" --allow-direct-db-mutation --state-dir "$STATE_DIR" --input-file "$SHIP_REQUEST_FILE"',
         )
     )
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -616,8 +616,9 @@ Current derived-state behavior:
   the requested artifact, then promotes that exact tuple to the destination
   lane after the deploy passes.
 - `promote execute` and `ship execute` require `--database-url` or
-  `LAUNCHPLANE_DATABASE_URL`; explicit offline filesystem execution must opt in
-  with `--local-rehearsal`.
+  `LAUNCHPLANE_DATABASE_URL` for DB-backed execution and must also pass
+  `--allow-direct-db-mutation`; explicit offline filesystem execution must opt
+  in with `--local-rehearsal`.
 - Current environment inventory is refreshed from successful waited `ship` and
   `promote` executions.
 - Externally produced promotion evidence can also refresh current inventory
@@ -961,8 +962,9 @@ local renders should run with `LAUNCHPLANE_DATABASE_URL` pointed at the same
 shared store that owns the current stable-lane tuple state.
 
 Preview mutation, ingest, replay, and lifecycle transition commands require
-`--database-url` or `LAUNCHPLANE_DATABASE_URL`. Offline JSON writes are local
-rehearsals only and must opt in with `--local-rehearsal`; read and render
+`--database-url` or `LAUNCHPLANE_DATABASE_URL` plus
+`--allow-direct-db-mutation` for DB-backed execution. Offline JSON writes are
+local rehearsals only and must opt in with `--local-rehearsal`; read and render
 commands may still inspect a local `--state-dir`.
 
 Any exported release-tuple catalog is seed/reference material now, not live

--- a/tests/test_launchplane_previews.py
+++ b/tests/test_launchplane_previews.py
@@ -4911,6 +4911,7 @@ ENV_OVERRIDE_DISABLE_CRON = true
                         "ingest-github-webhook",
                         "--database-url",
                         database_url,
+                        "--allow-direct-db-mutation",
                         "--state-dir",
                         str(control_plane_root / "empty-state"),
                         "--input-file",
@@ -4925,6 +4926,35 @@ ENV_OVERRIDE_DISABLE_CRON = true
             payload = json.loads(result.output)
             self.assertEqual(payload["webhook"]["signature_verification"]["context"], "opw")
             self.assertTrue(payload["webhook"]["signature_verification"]["verified"])
+
+    def test_launchplane_previews_ingest_github_webhook_requires_direct_db_acknowledgement(
+        self,
+    ) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _runtime_environments_database_url(control_plane_root)
+            input_file = control_plane_root / "github-webhook.json"
+            input_file.write_text(json.dumps(_github_pull_request_webhook_payload()), encoding="utf-8")
+
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "launchplane-previews",
+                    "ingest-github-webhook",
+                    "--database-url",
+                    database_url,
+                    "--state-dir",
+                    str(control_plane_root / "empty-state"),
+                    "--input-file",
+                    str(input_file),
+                    "--signature-256",
+                    "sha256=unused",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
 
     def test_launchplane_previews_ingest_github_webhook_adapts_closed_pull_request_destroy_intent(
         self,

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1481,6 +1481,40 @@ class PromoteCliTests(unittest.TestCase):
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("require --database-url", result.output)
 
+    def test_promote_execute_requires_direct_db_acknowledgement(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            input_file = repo_root / "promotion-request.json"
+            input_file.write_text(
+                _dokploy_promotion_request(
+                    artifact_id="artifact-sha256-image456",
+                    backup_record_id="backup-opw-prod-20260410T182231Z",
+                    source_git_ref="abc123",
+                    context="opw",
+                    from_instance="testing",
+                    to_instance="prod",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                ).model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "promote",
+                    "execute",
+                    "--input-file",
+                    str(input_file),
+                ],
+                env={"LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root)},
+            )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("Direct local DB mutation is restricted", result.output)
+
     def test_ship_execute_requires_database_url(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
@@ -1512,6 +1546,38 @@ class PromoteCliTests(unittest.TestCase):
 
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("require --database-url", result.output)
+
+    def test_ship_execute_requires_direct_db_acknowledgement(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            repo_root = Path(temporary_directory_name)
+            input_file = repo_root / "ship-request.json"
+            input_file.write_text(
+                _dokploy_ship_request(
+                    artifact_id="artifact-sha256-image456",
+                    context="opw",
+                    instance="prod",
+                    source_git_ref="abc123",
+                    target_name="opw-prod",
+                    target_type="compose",
+                    deploy_mode="dokploy-compose-api",
+                ).model_dump_json(indent=2),
+                encoding="utf-8",
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "ship",
+                    "execute",
+                    "--input-file",
+                    str(input_file),
+                ],
+                env={"LAUNCHPLANE_DATABASE_URL": _runtime_environments_database_url(repo_root)},
+            )
+
+            self.assertNotEqual(result.exit_code, 0)
+            self.assertIn("Direct local DB mutation is restricted", result.output)
 
     def test_promote_execute_persists_record_and_executes_control_plane_ship(self) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- require `--allow-direct-db-mutation` for DB-backed `launchplane-previews` mutation/ingest/replay commands
- require the same acknowledgement for DB-backed `promote execute` and `ship execute`, while preserving `--local-rehearsal` and missing-DB errors
- update rendered operator recipes and operations docs so local DB mutation is explicit break-glass/local repair, not routine shared/prod authority

## Validation
- `uv run python -m unittest tests.test_launchplane_previews tests.test_promote`
- `uv run python -m unittest tests.test_docs_contracts`
- `uv run --extra dev ruff check control_plane/cli_launchplane_previews.py control_plane/cli_promotion_ship.py control_plane/launchplane_rendering.py tests/test_launchplane_previews.py tests/test_promote.py`
- `uv run --extra dev mypy control_plane/cli_launchplane_previews.py control_plane/cli_promotion_ship.py control_plane/launchplane_rendering.py tests/test_launchplane_previews.py tests/test_promote.py`
- `git diff --check`

## Review
- GPT review agent: no findings
- Antigravity review agent: no findings
- Auto Review: no active findings

Refs #1492, #1489