### PR TITLE
Guard shared ensure schema behind verification

### DIFF
--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -1519,6 +1519,9 @@ class PostgresRecordStore(HumanSessionStore):
         return "postgres"
 
     def ensure_schema(self) -> None:
+        if self._engine.url.get_backend_name() != "sqlite":
+            self.verify_schema()
+            return
         Base.metadata.create_all(self._engine)
 
     def verify_schema(self) -> None:

--- a/docs/records.md
+++ b/docs/records.md
@@ -24,9 +24,10 @@ Launchplane uses SQLAlchemy ORM models as the persistence boundary and Alembic a
 the versioned migration mechanism for shared-service Postgres databases. Hosted
 service startup runs Alembic to the checked-in head revision before starting the
 HTTP service; schema or payload changes must therefore land as explicit Alembic
-revisions. Runtime code can still call `ensure_schema()` for compatibility and
-ephemeral test/local databases, but new production schema changes should not rely
-on implicit table creation.
+revisions. Runtime code can still call `ensure_schema()` for compatibility, but
+it only creates tables for local SQLite/test databases. For shared-service
+database URLs, `ensure_schema()` verifies that Alembic has already created the
+required tables and columns and fails closed when migrations are missing.
 
 For a fresh database, apply the current schema with:
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1271,6 +1271,20 @@ class PostgresRecordStoreTests(unittest.TestCase):
             self.assertNotIn("payload", artifact_columns)
             store.close()
 
+    def test_ensure_schema_verifies_non_sqlite_schema_without_create_all(self) -> None:
+        store = object.__new__(PostgresRecordStore)
+        store._engine = Mock()
+        store._engine.url.get_backend_name.return_value = "postgresql"
+
+        with (
+            patch.object(store, "verify_schema") as verify_schema,
+            patch("control_plane.storage.postgres.Base.metadata.create_all") as create_all,
+        ):
+            store.ensure_schema()
+
+        verify_schema.assert_called_once_with()
+        create_all.assert_not_called()
+
     def test_shared_record_store_verifies_existing_schema_without_creating_it(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(


### PR DESCRIPTION
## Summary
- make `PostgresRecordStore.ensure_schema()` create tables only for SQLite/local compatibility
- route non-SQLite/shared DBs through `verify_schema()` so Alembic remains the production schema authority
- document the updated migration boundary and add regression coverage that non-SQLite `ensure_schema()` does not call `create_all`

## Validation
- `uv run python -m unittest tests.test_postgres_store`
- `uv run python -m unittest tests.test_start_launchplane_service tests.test_service.LaunchplaneServiceTests.test_service_serve_rejects_missing_database_url tests.test_runtime_environments tests.test_product_onboarding`
- `uv run --extra dev ruff check control_plane/storage/postgres.py tests/test_postgres_store.py`
- `uv run --extra dev mypy control_plane/storage/postgres.py tests/test_postgres_store.py`
- `uv run python -m unittest tests.test_docs_contracts`
- `git diff --check`

## Review
- GPT review agent: no findings
- Antigravity review agent: no findings
- Auto Review: no active findings

Refs #1493, #1489