### PR TITLE
Retire stale v2 transition doc language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Treat this file as the launch checklist for each Every Code session in
   production live mutations. Do not use local CLI live-target commands from an
   arbitrary checkout as a fallback; add or use a service endpoint first.
 - Treat service-host env as bootstrap-only unless a repo doc explicitly calls
-  out a narrower temporary compatibility fallback.
+  out a narrower scoped bootstrap or rehearsal exception.
 - Do not hard-code real tenant, product, repository, branch, domain, or operator
   values into production defaults, fallback behavior, or checked-in catalogs;
   see the coding standards for the docs/tests boundary.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ Use these docs as the source of truth for `launchplane`.
 - [config-boundary.md](config-boundary.md) — bootstrap-vs-DB config authority
   and checked-in config authority limits.
 - [service-boundary.md](service-boundary.md) — Launchplane HTTP ingress, GitHub
-  OIDC trust, and first API contracts.
+  OIDC trust, and API contracts.
 - [dokploy-service-deployments.md](dokploy-service-deployments.md) — contract
   for simple image-backed services deployed through Dokploy applications.
 - [new-product-repo.md](new-product-repo.md) — checklist for building a new
@@ -16,7 +16,7 @@ Use these docs as the source of truth for `launchplane`.
 - [product-repo-contract.md](product-repo-contract.md) — thin product repo
   approval gate and new website repo checklist.
 - [preview-workflow-contract.md](preview-workflow-contract.md) — reusable thin
-  preview workflow event, idempotency, feedback, and migration contract.
+  preview workflow event, idempotency, feedback, and lifecycle contract.
 - [driver-descriptors.md](driver-descriptors.md) — provider-neutral driver
   descriptor, action safety, registry, and read-model endpoint contract.
 - [driver-development.md](driver-development.md) — when and how to add a new

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,14 +233,13 @@ The first concrete HTTP/OIDC/API shape for that boundary is defined in
 - Keep schema changes backward-compatible enough that deploy rollback can safely
   return to the previous Launchplane image when possible.
 
-## Driver Migration Status
+## Driver Ownership Status
 
-The first Odoo and VeriReel driver migration is complete enough that the old
-driver-migration working plan has been retired. Product repos now keep source,
-build, verification, and thin OIDC request wrappers, while Launchplane owns the
-durable service routes, DB-backed records, managed-secret/runtime authority,
-driver execution, and operator read models for the current Odoo and VeriReel
-deployment, promotion, rollback, backup, and preview paths.
+Product repos keep source, build, verification, and thin OIDC request wrappers,
+while Launchplane owns the durable service routes, DB-backed records,
+managed-secret/runtime authority, driver execution, and operator read models for
+the current Odoo and VeriReel deployment, promotion, rollback, backup, and
+preview paths.
 
 Future driver work should be incremental capability expansion behind the same
 service/read-model contract, not a second migration track.

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -462,13 +462,12 @@ backend handler registration, route dispatch, and fail-closed service
 authorization still have to agree.
 
 POST driver descriptor actions and route aliases execute through native FastAPI
-routes. The legacy WSGI descriptor-backed dispatch bridge is removed. The
-service validates this at startup, so adding a writable descriptor route without
-registering a matching native FastAPI route fails closed instead of silently
-advertising an unimplemented action. This keeps descriptor metadata as the
-route/authz source of truth while preventing an advertised descriptor action
-from becoming executable without implementation. Descriptor route metadata and service
-compatibility policy also drive
+routes. The service validates this at startup, so adding a writable descriptor
+route without registering a matching native FastAPI route fails closed instead
+of silently advertising an unimplemented action. This keeps descriptor metadata
+as the route/authz source of truth while preventing an advertised descriptor
+action from becoming executable without implementation. Descriptor route
+metadata and service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's
 shared lifecycle routes when its profile owns the requested stable lane or

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -33,9 +33,9 @@ API path instead of running the local command from an arbitrary checkout.
 - `service`: run the first local Launchplane HTTP ingress slice.
 - `ship`: plan, resolve, and execute artifact-backed deploy requests.
 - `storage provider-target-audit`: run the read-only provider-target parity
-  preflight before Phase Two backfill or provider-target authority cutover.
+  preflight before backfill or provider-target authority cutover.
 - `storage provider-target-backfill`: dry-run or apply explicit provider-target
-  rows from complete Dokploy target/id pairs during Phase Two migration.
+  rows from complete Dokploy target/id pairs.
 
 `deployments write`, `promotions write`, `inventory write-from-deployment`,
 `inventory write-from-promotion`, and `release-tuples write-from-promotion`
@@ -48,24 +48,22 @@ is a long-running service with authenticated HTTP ingress. The CLI should remain
 a client of Launchplane's stable API contract or an explicit DB-backed operator
 tool, not a separate live-state authority.
 
-Provider-target Phase Two data changes for shared or production lanes must use
-the deployed Launchplane service. The manual `Provider Target Operations`
-workflow calls `POST /v1/provider-targets/operations` with GitHub OIDC and is
-authorized through DB-backed `provider_target.audit` and
-`provider_target.backfill` grants for product/context `launchplane`. Run it
-first in `audit` or `backfill-dry-run` mode, review the artifact, then run
-`backfill-apply` only with the exact confirmation phrase and an operator reason.
-The initial Phase Two target set is ordered from the lower-risk proof lane into
-live production lanes: `discord-blue/prod`, `sellyouroutboard/testing`,
-`sellyouroutboard/prod`, `verireel/testing`, `verireel/prod`, `cm/testing`,
-`cm/prod`, `opw/testing`, and `opw/prod`.
+Provider-target data changes for shared or production lanes must use the
+deployed Launchplane service. The manual `Provider Target Operations` workflow
+calls `POST /v1/provider-targets/operations` with GitHub OIDC and is authorized
+through DB-backed `provider_target.audit` and `provider_target.backfill` grants
+for product/context `launchplane`. Run it first in `audit` or
+`backfill-dry-run` mode, review the artifact, then run `backfill-apply` only
+with the exact confirmation phrase and an operator reason. Specific rollout
+lane sets and ordering belong in issue-backed plans and workflow inputs, not in
+checked-in docs.
 
 After the provider-target audit is clean, use the manual
 `Product Environment Evidence` workflow to collect read-model evidence through
 the deployed service. The workflow calls `GET
 /v1/products/{product}/environments/{environment}` with GitHub OIDC, records
 only sanitized provider, target-type, trust-state, and count summaries, and
-fails closed if any Phase Two lane lacks recorded provider-target authority.
+fails closed if any requested lane lacks recorded provider-target authority.
 Raw product environment responses are not uploaded; the artifact contains only
 the route list and sanitized summaries.
 
@@ -1178,11 +1176,9 @@ inside `.github/workflows/preview-control-plane.yml` and
 `.github/workflows/preview-cleanup.yml`. The scheduled orphan backstop in
 `.github/workflows/preview-janitor.yml` should use the same Launchplane destroy
 and evidence contract rather than keeping a second repo-local teardown path.
-Launchplane's handoff contract is moving from evidence-only toward reusable
-preview lifecycle ownership. The target integration is
-OIDC-authenticated HTTP into Launchplane. The local CLI examples below exist only
-to pin the payload shape while the Launchplane service ingress continues to
-absorb the reusable lifecycle behavior.
+Launchplane's reusable preview lifecycle contract is OIDC-authenticated HTTP into
+Launchplane. The local CLI examples below pin the payload shape for local
+rehearsal and repair; shared product workflows should use the service ingress.
 
 For a successful or failed preview refresh, emit two JSON payloads and hand
 them to Launchplane's preview-generation evidence ingress. The current local

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -495,4 +495,5 @@ When creating a new website repo for Launchplane:
   database bootstrap, data migration, backup gates, restore/rollback behavior,
   product smoke checks, or platform-specific post-deploy actions.
 - Keep Launchplane lifecycle config out of the product repo unless this document
-  or a driver-specific doc explicitly names a temporary compatibility exception.
+  or a driver-specific doc explicitly names a scoped bootstrap or rehearsal
+  exception.

--- a/docs/records.md
+++ b/docs/records.md
@@ -183,18 +183,18 @@ an ORM column/table or remains only in the evidence payload.
   `provider_target_ids` keys. Dokploy target and target-id records can still be
   the provider-specific source records copied or deleted by those workflows, but
   they are not exposed as Dokploy-named response buckets.
-- `uv run launchplane storage provider-target-audit` is the read-only Phase Two
-  preflight for this record family. It compares explicit provider-target rows
+- `uv run launchplane storage provider-target-audit` is the read-only preflight
+  for this record family. It compares explicit provider-target rows
   with the neutral projection from paired Dokploy target and target-id records,
   reports missing halves and mismatches, and exits nonzero when unresolved
   blockers would make backfill or authority cutover unsafe.
-- `uv run launchplane storage provider-target-backfill` is the Phase Two seeding
-  path for explicit provider-target rows. Dry-run is the default; `--apply`
+- `uv run launchplane storage provider-target-backfill` is the seeding path for
+  explicit provider-target rows. Dry-run is the default; `--apply`
   writes only complete Dokploy target/id projections that have no conflicting
   physical row. Existing matching physical rows are skipped without churn,
   incomplete pairs are reported but not guessed, and conflicts or unsupported
   provider rows are never overwritten automatically.
-- Shared and production Phase Two backfill uses the deployed service route
+- Shared and production backfill uses the deployed service route
   `POST /v1/provider-targets/operations`, normally through the manual
   `Provider Target Operations` workflow. The workflow records per-route audit,
   dry-run, or apply evidence as artifacts and uses DB-backed
@@ -688,8 +688,8 @@ state/
   for a concurrent owner id to settle, then give that owner record its own
   bounded settle window before clearing abandoned empty or orphaned reservations
   so an interrupted writer cannot block the lane forever.
-- The v2 target execution model for these Odoo long-running operation records is
-  a dedicated Launchplane worker process backed by DB leases and heartbeats. The
+- The target execution model for these Odoo long-running operation records is a
+  dedicated Launchplane worker process backed by DB leases and heartbeats. The
   HTTP route creates or replays the operation record and returns the poll URL;
   execution is owned by the supervised worker process, not by request-process
   daemon threads. Operation

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -97,12 +97,12 @@ state block the read or write instead of silently trying another source.
 
 ## Secret Provider Boundary
 
-The accepted v2 provider for this slice is Launchplane-managed secrets backed by
-Launchplane storage and a minimal bootstrap decryption root. Future Vault, HSM,
-KMS, or cloud-secret-manager integrations are deferred provider candidates. They
-require a named Launchplane problem, local/dev bootstrap plan, operational owner,
-failure mode, rollback posture, and proof that live secret values and
-assignments remain out of checked-in files.
+The accepted provider is Launchplane-managed secrets backed by Launchplane
+storage and a minimal bootstrap decryption root. Future Vault, HSM, KMS, or
+cloud-secret-manager integrations are deferred provider candidates. They require
+a named Launchplane problem, local/dev bootstrap plan, operational owner,
+failure mode, rollback posture, and proof that live secret values and assignments
+remain out of checked-in files.
 
 Provider adapters expose generic operations only: write encrypted version,
 resolve metadata, resolve plaintext for an authorized in-process use,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -38,7 +38,7 @@ VeriReel product paths:
 - CLI: `uv run launchplane service serve`
 - server runtime: FastAPI served directly by Uvicorn
 - native FastAPI health route: `GET /v1/health`, backed by a Pydantic response
-  model and included in OpenAPI as the first v2 contract proof
+  model and included in OpenAPI as a service contract proof
 - native FastAPI Launchplane service runtime reads:
   - `GET /v1/service/runtime`, requiring `launchplane_service.read` for the
     Launchplane service context and returning runtime metadata only
@@ -382,9 +382,9 @@ metadata rather than echoing workflow refs, human logins, owner-agent subjects,
 or the full policy body.
 
 The service also serves the built operator UI shell at `/`, with `/ui` retained
-as a compatibility alias. This route family is native FastAPI. Built assets live
-under `/ui/assets/...`, while `/ui/*` falls back to the app shell so the frontend
-can own client-side routes. Versioned API ingress remains under `/v1`.
+as a route alias. This route family is native FastAPI. Built assets live under
+`/ui/assets/...`, while `/ui/*` falls back to the app shell so the frontend can
+own client-side routes. Versioned API ingress remains under `/v1`.
 
 Validate the operator UI shell with browser navigation or `GET /ui`. Do not use
 `HEAD /ui` as the only availability check, because static app-shell fallback
@@ -1401,7 +1401,7 @@ deleted runtime identity records under neutral `provider_targets` and
 provider-specific execution/config storage where needed, but service responses
 must not reintroduce Dokploy-named target buckets for these workflows.
 
-Provider-target Phase Two operations use the native FastAPI
+Provider-target operations use the native FastAPI
 `POST /v1/provider-targets/operations` route. The route accepts one
 Launchplane-owned route at a time with mode `audit`, `backfill-dry-run`, or
 `backfill-apply`, `provider_id`, `context`, `instance`, and an apply-only
@@ -1411,7 +1411,7 @@ apply, always scoped to product/context `launchplane`. Apply requests are
 idempotency-keyed and write only complete non-conflicting Dokploy target/id
 projections; existing rows and conflicts are reported rather than overwritten.
 The manual `Provider Target Operations` workflow is the supported shared and
-production caller for Phase Two backfill evidence.
+production caller for backfill evidence.
 
 Launchplane self-deploy uses the native FastAPI
 `POST /v1/drivers/launchplane/self-deploy` route. The route executes only the
@@ -1457,10 +1457,10 @@ workflow is the supported shared and production caller when operators need
 provider evidence without mutating Dokploy or Launchplane records.
 
 The manual `Product Environment Evidence` workflow is the supported read-only
-Phase Two caller for product environment read-model evidence. It uses GitHub
-OIDC and `product_environment.read` to call `GET
-/v1/products/{product}/environments/{environment}` for the same Phase Two target
-set, then uploads sanitized summaries only. It must not upload raw product
+caller for product environment read-model evidence. It uses GitHub OIDC and
+`product_environment.read` to call `GET
+/v1/products/{product}/environments/{environment}` for the requested target set,
+then uploads sanitized summaries only. It must not upload raw product
 environment responses because those responses can include provider target
 identifiers, runtime key names, managed-secret binding keys, and operational
 metadata.
@@ -2319,9 +2319,8 @@ Current commands such as:
 - `control-plane launchplane-previews write-from-generation`
 - `control-plane launchplane-previews write-destroyed`
 
-should be treated as temporary compatibility clients of these Launchplane payloads.
-They should not remain the permanent integration boundary for external product
-workflows.
+are local rehearsal and repair clients for these Launchplane payloads. They are
+not the shared integration boundary for external product workflows.
 
 ## Driver Relationship
 


### PR DESCRIPTION
## Summary
- rewrite lingering v2/Phase Two/temporary-compatibility wording into current-state docs
- remove product lane ordering from checked-in docs and point that authority to issue-backed plans/workflow inputs
- align AGENTS bootstrap exception language with the current docs

## Validation
- uv run python -m unittest tests.test_docs_contracts
- git diff --check
- rg -n "v2-foundation-adr|compatibility-retirement|\bV2\b|\bv2\b|Phase Two|temporary compatibility|compatibility alias|is moving|first v2|legacy WSGI|complete enough|old driver-migration|same Phase Two|temporary compatibility fallback" AGENTS.md docs .code -S
  - only remaining hit: docs/driver-descriptors.md retired Odoo alias sentence

## Review
- code-gpt-5.5 review: no findings
- antigravity review: AGENTS wording consistency nit fixed in this PR
- claude-sonnet review unavailable: 401 auth failure
- Auto Review: no active findings

Closes part of #1489.