### PR TITLE
Guard local runtime environment mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,14 +78,15 @@ target records, and Dokploy target-id records are DB-backed concerns;
 bootstrap stays in process env long enough to bring the service up and write
 the real records.
 
-Use `uv run launchplane environments put --scope ... --set KEY=VALUE` to write
-non-secret runtime values directly into DB-backed runtime-environment records;
-secret-shaped keys are rejected there. Use `uv run launchplane secrets put ...`
-for managed secret values. TOML/env files are not supported runtime import
-surfaces outside minimal bootstrap policy/env. Use `uv run launchplane environments
-unset --scope ... --key KEY` to remove stale runtime keys without reading or
-printing plaintext values. Use `uv run launchplane environments relabel` to
-correct stale record metadata without changing runtime values.
+Use product-config dry-run/apply through the deployed service route or operator
+UI for routine shared and production runtime config changes. Raw
+`uv run launchplane environments put --scope ... --set KEY=VALUE --allow-direct-db-mutation`,
+`uv run launchplane environments unset --scope ... --key KEY --allow-direct-db-mutation`,
+and `uv run launchplane environments relabel --allow-direct-db-mutation` are
+explicit local/bootstrap repair paths only; they reject secret-shaped keys or
+avoid printing plaintext values. Use `uv run launchplane secrets put ...` for
+managed secret values. TOML/env files are not supported runtime import surfaces
+outside minimal bootstrap policy/env.
 
 Live authz policy is DB-backed through `authz-policies` records. The service
 still requires a minimal bootstrap policy input at startup so it can fail closed

--- a/control_plane/cli_runtime_environments.py
+++ b/control_plane/cli_runtime_environments.py
@@ -22,6 +22,11 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use the deployed service route or operator workflow for shared/production changes, "
+    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+)
 _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
 _REDACTED_RUNTIME_ENVIRONMENT_VALUE = "<redacted>"
 
@@ -45,6 +50,20 @@ def environments() -> None:
     """Runtime environment contract commands."""
 
 
+def _direct_db_mutation_acknowledgement_option(function: Callable[..., object]) -> Callable[..., object]:
+    return click.option(
+        "--allow-direct-db-mutation",
+        is_flag=True,
+        default=False,
+        help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+    )(function)
+
+
+def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) -> None:
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
+
+
 @environments.command("put")
 @click.option(
     "--database-url",
@@ -63,6 +82,7 @@ def environments() -> None:
     help="Runtime value assignment as KEY=VALUE.",
 )
 @click.option("--source-label", default="cli", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def environments_put(
     database_url: str,
     scope: str,
@@ -70,7 +90,9 @@ def environments_put(
     instance_name: str,
     assignments: tuple[str, ...],
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:
@@ -116,6 +138,7 @@ def environments_put(
     help="Runtime value key to remove from the record.",
 )
 @click.option("--source-label", default="cli", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def environments_unset(
     database_url: str,
     scope: str,
@@ -123,7 +146,9 @@ def environments_unset(
     instance_name: str,
     keys: tuple[str, ...],
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:
@@ -167,6 +192,7 @@ def environments_unset(
 @click.option("--allow-tracked-target", is_flag=True, default=False)
 @click.option("--dry-run", "dry_run", is_flag=True, default=False)
 @click.option("--apply", "apply_changes", is_flag=True, default=False)
+@_direct_db_mutation_acknowledgement_option
 def environments_delete_record(
     database_url: str,
     scope: str,
@@ -176,9 +202,12 @@ def environments_delete_record(
     allow_tracked_target: bool,
     dry_run: bool,
     apply_changes: bool,
+    allow_direct_db_mutation: bool,
 ) -> None:
     if dry_run == apply_changes:
         raise click.ClickException("Choose exactly one of --dry-run or --apply.")
+    if apply_changes:
+        _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     normalized_context = context_name.strip()
     normalized_instance = instance_name.strip()
     normalized_scope = _validate_runtime_environment_scope_route(
@@ -263,13 +292,16 @@ def environments_delete_record(
 @click.option("--context", "context_name", default="")
 @click.option("--instance", "instance_name", default="")
 @click.option("--source-label", required=True)
+@_direct_db_mutation_acknowledgement_option
 def environments_relabel(
     database_url: str,
     scope: str,
     context_name: str,
     instance_name: str,
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -674,10 +674,12 @@ Current derived-state behavior:
 
 ## Runtime Environment Contracts
 
-- `environments put` writes explicit non-secret `KEY=VALUE` runtime settings
-  directly into DB-backed runtime-environment records for `global`, `context`,
-  or `instance` scope. It rejects secret-shaped keys and returns key metadata
-  only, not plaintext values.
+- `environments put` remains an explicit local/bootstrap repair path for
+  non-secret `KEY=VALUE` runtime settings in DB-backed runtime-environment
+  records. It requires `--allow-direct-db-mutation`, rejects secret-shaped keys,
+  and returns key metadata only, not plaintext values. Routine shared and
+  production runtime config changes should use product-config dry-run/apply
+  through the deployed service route or operator UI.
 - `product-config apply --dry-run --input-file <json>` remains a local planning
   helper for trusted product runtime config bundles. Direct local DB
   `--apply` is restricted after the service boundary and requires
@@ -719,17 +721,21 @@ Current derived-state behavior:
   result before enabling apply, clears rendered secret input values after each
   submit, and shows only key/action/count metadata from Launchplane responses.
 - `environments unset` removes named keys from a DB-backed runtime-environment
-  record without reading or printing plaintext values.
+  record without reading or printing plaintext values. It requires
+  `--allow-direct-db-mutation` and is intended only for explicit local/bootstrap
+  repair.
 - `environments delete-record --dry-run|--apply` deletes a whole mistaken
   runtime-environment record for `global`, `context`, or `instance` scope. The
   dry-run and apply responses include record identity, source label, update
   timestamp, key names, key count, actor, and delete-event metadata only. Apply
-  refuses records that can affect a tracked Dokploy target unless
-  `--allow-tracked-target` is provided. Apply also fails closed if the target
-  record changes after the command reads it; re-run the command after reviewing
-  the current record.
+  requires `--allow-direct-db-mutation` and refuses records that can affect a
+  tracked Dokploy target unless `--allow-tracked-target` is provided. Apply also
+  fails closed if the target record changes after the command reads it; re-run
+  the command after reviewing the current record.
 - `environments relabel` updates runtime-environment record source metadata
-  without reading or printing plaintext values.
+  without reading or printing plaintext values. It requires
+  `--allow-direct-db-mutation` and is intended only for explicit
+  local/bootstrap repair.
 - `environments list` shows DB-backed runtime-environment record metadata and
   keys without echoing plaintext values.
 - `environments resolve` reads the control-plane-owned runtime environment

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -252,10 +252,13 @@ decryption key state denies the reveal or resolution.
   emits the resolved runtime environment payload for a tenant environment with
   secret-shaped values redacted by default. Use `--include-secret-values` only
   from a trusted operator shell when plaintext resolved values are required.
-- `uv run launchplane environments put --scope <scope> --set KEY=VALUE` writes
-  non-secret runtime values directly to DB-backed runtime-environment records
-  and redacts values from command output. Secret-shaped keys are rejected and
-  should be written with `secrets put`.
+- `uv run launchplane environments put --scope <scope> --set KEY=VALUE --allow-direct-db-mutation`
+  is an explicit local/bootstrap repair path for non-secret runtime values in
+  DB-backed runtime-environment records and redacts values from command output.
+  Secret-shaped keys are rejected and should be written with `secrets put`.
+  Routine shared and production config changes should use product-config
+  dry-run/apply through the deployed service route or operator UI instead of
+  arbitrary local runtime-environment writes.
 - `uv run launchplane product-config apply --input-file bundle.json --dry-run`
   previews an approved product runtime/secret bundle without printing plaintext
   values or writing records. `--apply` writes non-secret runtime keys and
@@ -282,11 +285,12 @@ decryption key state denies the reveal or resolution.
   retires the disabled placeholder from active runtime-secret lookups. Later
   onboarding imports preserve the configured binding instead of recreating the
   disabled placeholder.
-- `uv run launchplane environments unset --scope <scope> --key KEY` removes
-  stale keys from DB-backed runtime-environment records without reading or
-  printing plaintext values.
-- `uv run launchplane environments relabel --scope <scope> --source-label ...`
-  updates stale source metadata without changing runtime values.
+- `uv run launchplane environments unset --scope <scope> --key KEY --allow-direct-db-mutation`
+  removes stale keys from DB-backed runtime-environment records without reading
+  or printing plaintext values. Use it only for explicit local/bootstrap repair.
+- `uv run launchplane environments relabel --scope <scope> --source-label ... --allow-direct-db-mutation`
+  updates stale source metadata without changing runtime values. Use it only for
+  explicit local/bootstrap repair.
 - In steady state that payload comes from Launchplane DB-backed runtime
   environment records.
 - Launchplane preview write/build helpers read `LAUNCHPLANE_PREVIEW_BASE_URL`

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -647,6 +647,30 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("No such command", result.output)
 
+    def test_environments_put_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "put",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "global",
+                    "--set",
+                    "PUBLIC_URL=https://example.com",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
+
     def test_environments_put_writes_db_record_without_echoing_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
@@ -671,6 +695,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "VERIREEL_PROD_CT_ID=101",
                     "--source-label",
                     "operator-cli",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -734,6 +759,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "prod",
                     "--set",
                     "VERIREEL_PROD_CT_ID=101",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -775,6 +801,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "verireel",
                     "--set",
                     "VERIREEL_PROD_CT_ID=101",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -799,6 +826,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "verireel",
                     "--set",
                     "GITHUB_TOKEN=secret-value",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -850,6 +878,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "MISSING_KEY",
                     "--source-label",
                     "operator-cli",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -873,6 +902,29 @@ class RuntimeEnvironmentTests(unittest.TestCase):
 
         self.assertNotIn("VERIREEL_PROD_CT_ID", resolved_values)
         self.assertEqual(resolved_values["VERIREEL_PROD_PROXMOX_HOST"], "proxmox.example.com")
+
+    def test_environments_unset_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "unset",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "global",
+                    "--key",
+                    "PUBLIC_URL",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
 
     def test_environments_unset_rejects_empty_result_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -899,6 +951,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "global",
                     "--key",
                     "ONLY_KEY",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -1013,6 +1066,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "--actor",
                     "operator@example.com",
                     "--apply",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -1042,6 +1096,30 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         self.assertEqual(len(delete_events), 1)
         self.assertEqual(delete_events[0].actor, "operator@example.com")
         self.assertEqual(delete_events[0].env_keys, ("TAWK_PROPERTY_ID", "TAWK_WIDGET_ID"))
+
+    def test_environments_delete_record_apply_requires_direct_db_acknowledgement(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "delete-record",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "global",
+                    "--apply",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
 
     def test_environments_delete_record_apply_refuses_changed_snapshot(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1086,6 +1164,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                         "--instance",
                         "prod",
                         "--apply",
+                        "--allow-direct-db-mutation",
                     ],
                 )
 
@@ -1136,6 +1215,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                         "--actor",
                         "operator@example.com",
                         "--apply",
+                        "--allow-direct-db-mutation",
                     ],
                 )
                 self.assertEqual(result.exit_code, 0, result.output)
@@ -1258,6 +1338,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "--instance",
                     "prod",
                     "--apply",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -1328,6 +1409,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "prod",
                     "--allow-tracked-target",
                     "--apply",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -1415,6 +1497,7 @@ class RuntimeEnvironmentTests(unittest.TestCase):
                     "global",
                     "--source-label",
                     "operator:db-native",
+                    "--allow-direct-db-mutation",
                 ],
             )
 
@@ -1423,6 +1506,28 @@ class RuntimeEnvironmentTests(unittest.TestCase):
         payload = json.loads(result.output)
         self.assertEqual(payload["record"]["source_label"], "operator:db-native")
         self.assertEqual(payload["record"]["env_keys"], ["ODOO_DB_USER"])
+
+    def test_environments_relabel_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "environments",
+                    "relabel",
+                    "--database-url",
+                    database_url,
+                    "--scope",
+                    "global",
+                    "--source-label",
+                    "operator:db-native",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
 
     def test_environments_list_redacts_values(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary

- Require `--allow-direct-db-mutation` for local `launchplane environments` write/apply commands: `put`, `unset`, `delete-record --apply`, and `relabel`.
- Leave runtime-environment reads and `delete-record --dry-run` unblocked.
- Update operator docs and the root README so routine shared/prod runtime config points to product-config/service/operator paths, while raw `environments` writes are explicit local/bootstrap repair only.

## Validation

- `uv run python -m unittest tests.test_runtime_environments`
- `uv run --extra dev ruff check README.md control_plane/cli_runtime_environments.py tests/test_runtime_environments.py`
- `uv run --extra dev mypy control_plane/cli_runtime_environments.py tests/test_runtime_environments.py`
- `uv run python -m unittest tests.test_docs_contracts`
- `git diff --check`
- `rg -n "launchplane environments (put|unset|delete-record|relabel)|environments (put|unset|delete-record|relabel)" README.md docs .github control_plane tests -S`

## Review

- Slice-selection agents converged on runtime-environment direct DB writes as the next #1492 surface after #1509.
- GPT review found one stale root README example; fixed before PR.
- Antigravity review found only a consistency assertion nit; fixed before PR.
- Claude review could not run due 401 auth.
- Auto Review ledger had no active findings before PR creation.

Part of #1492 and #1489.
