### PR TITLE
Guard local Odoo override mutations

### DIFF
--- a/control_plane/cli_odoo.py
+++ b/control_plane/cli_odoo.py
@@ -48,6 +48,11 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 _SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use the deployed service route or operator workflow for shared/production changes, "
+    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+)
 OdooOverrideApplyStatus = Literal["skipped", "pending", "pass", "fail"]
 OdooProdRollbackSourceChannel = Literal["testing"]
 
@@ -113,6 +118,21 @@ def _read_dokploy_config(*, control_plane_root: Path, database_url: str) -> tupl
     return _odoo_callbacks().read_dokploy_config(
         control_plane_root=control_plane_root, database_url=database_url
     )
+
+
+def _direct_db_mutation_acknowledgement_option(
+    function: Callable[..., object],
+) -> Callable[..., object]:
+    return click.option(
+        "--allow-direct-db-mutation",
+        is_flag=True,
+        help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+    )(function)
+
+
+def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) -> None:
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
 
 
 def _relabel_odoo_override_secret_binding(
@@ -761,6 +781,7 @@ def odoo_targets_replacement_plan(
     "--secret-binding-id", default="", help="Managed secret binding id for secret values."
 )
 @click.option("--source-label", default="cli", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def odoo_overrides_put_config_param(
     database_url: str,
     context_name: str,
@@ -769,7 +790,9 @@ def odoo_overrides_put_config_param(
     value: str | None,
     secret_binding_id: str,
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     override_value = _build_odoo_override_value(
         value=value,
         secret_binding_id=secret_binding_id,
@@ -815,6 +838,7 @@ def odoo_overrides_put_config_param(
     "--secret-binding-id", default="", help="Managed secret binding id for secret values."
 )
 @click.option("--source-label", default="cli", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def odoo_overrides_put_addon_setting(
     database_url: str,
     context_name: str,
@@ -824,7 +848,9 @@ def odoo_overrides_put_addon_setting(
     value: str | None,
     secret_binding_id: str,
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     value_name = f"{addon_name}.{setting_name}"
     override_value = _build_odoo_override_value(
         value=value,
@@ -872,13 +898,16 @@ def odoo_overrides_put_addon_setting(
     help="JSON file containing a typed devkit website_bootstrap payload.",
 )
 @click.option("--source-label", default="cli", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def odoo_overrides_put_website_bootstrap(
     database_url: str,
     context_name: str,
     instance_name: str,
     payload_file: Path,
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     try:
         raw_payload = json.loads(payload_file.read_text(encoding="utf-8"))
         website_bootstrap = OdooWebsiteBootstrapPayload.model_validate(raw_payload)
@@ -924,20 +953,25 @@ def odoo_overrides_put_website_bootstrap(
     default="odoo-secret-transport-migration",
     show_default=True,
 )
+@_direct_db_mutation_acknowledgement_option
 def odoo_overrides_migrate_secret_transport(
     database_url: str,
     context_name: str,
     instance_name: str,
     apply_changes: bool,
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
     normalized_context = context_name.strip().lower()
     normalized_instance = instance_name.strip().lower()
     if normalized_instance and not normalized_context:
         raise click.ClickException("--instance requires --context.")
+    if apply_changes:
+        _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
 
     postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
+    if apply_changes:
+        postgres_store.ensure_schema()
     try:
         records = postgres_store.list_odoo_instance_override_records()
         selected_records = [
@@ -1049,6 +1083,7 @@ def odoo_overrides_show(database_url: str, context_name: str, instance_name: str
 @click.option("--applied-at", default="", help="UTC timestamp for completed apply results.")
 @click.option("--detail", default="")
 @click.option("--source-label", default="cli", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def odoo_overrides_mark_apply(
     database_url: str,
     context_name: str,
@@ -1057,7 +1092,9 @@ def odoo_overrides_mark_apply(
     applied_at: str,
     detail: str,
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -838,8 +838,10 @@ context only, and `context_instance` has both context and instance.
 - Odoo rollback is image/release-tuple rollback, not VM snapshot rollback. Do not
   invent artifact ids, source commits, backup gates, or env-file overlays to make
   a rollback proceed; write or import the real Launchplane records first.
-- `odoo-overrides put-config-param` writes a typed Odoo `ir.config_parameter`
-  override for a context and instance.
+- `odoo-overrides put-config-param --allow-direct-db-mutation` writes a typed
+  Odoo `ir.config_parameter` override for a context and instance. This direct
+  local DB path is explicit local/bootstrap repair only; routine shared/live
+  changes should use the trusted service route or operator workflow.
 - For shared/live targets, use the trusted `Odoo Config Parameter Override`
   workflow instead of local CLI writes. It calls
   `POST /v1/drivers/odoo/config-parameter-override` with GitHub Actions OIDC and
@@ -850,15 +852,20 @@ context only, and `context_instance` has both context and instance.
   Service-written `web.base.url` records are always marked for `deploy` and
   `promotion` application so Odoo post-deploy and stable-bootstrap drivers can
   apply the canonical URL before verification.
-- `odoo-overrides put-addon-setting` writes addon-shaped Odoo override intent
-  such as Authentik or Shopify settings for a context and instance.
+- `odoo-overrides put-addon-setting --allow-direct-db-mutation` writes
+  addon-shaped Odoo override intent such as Authentik or Shopify settings for a
+  context and instance. Use it only for explicit local/bootstrap repair.
+- `odoo-overrides put-website-bootstrap --allow-direct-db-mutation` writes typed
+  website-bootstrap override intent for explicit local/bootstrap repair only.
 - Secret-shaped override names, including `*_TOKEN`, `*_PASSWORD`, and
   `*_KEY`, must use `--secret-binding-id`; plaintext secret writes are rejected.
 - `odoo-overrides list` and `odoo-overrides show` return keys, counts, source
   labels, and timestamps only. They do not echo literal values or managed secret
   binding ids.
-- `odoo-overrides mark-apply` updates the latest apply status metadata for a
-  record, giving the future Odoo driver a tested result-write path.
+- `odoo-overrides migrate-secret-transport --apply` and `odoo-overrides
+  mark-apply` require `--allow-direct-db-mutation` before they persist local DB
+  changes. `migrate-secret-transport` dry-run, `odoo-overrides list`, and
+  `odoo-overrides show` stay read-only inspection paths.
 - Compose post-deploy updates consume deploy-phase overrides from these records
   and pass them to Odoo as one typed payload env var. Deploy-phase payloads are
   persisted to the Dokploy compose target environment before the web container

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -11,7 +11,7 @@ from control_plane.odoo_instance_overrides import LAUNCHPLANE_WEBSITE_BOOTSTRAP_
 from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
 from control_plane.odoo_instance_overrides import build_post_deploy_environment
 from control_plane.odoo_instance_overrides import render_post_deploy_payload
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 from pydantic import ValidationError
 
 from control_plane.cli import main
@@ -51,6 +51,16 @@ def _ship_request() -> ShipRequest:
         provider_target_type="compose",
         deploy_mode="dokploy-compose-api",
     )
+
+
+def _allow_direct_db_mutation_argument() -> list[str]:
+    return ["--allow-direct-db-mutation"]
+
+
+def _assert_direct_db_mutation_rejected(test_case: unittest.TestCase, result: Result) -> None:
+    test_case.assertNotEqual(result.exit_code, 0)
+    test_case.assertIn("Direct local DB mutation is restricted", result.output)
+    test_case.assertIn("--allow-direct-db-mutation", result.output)
 
 
 class OdooInstanceOverrideTests(unittest.TestCase):
@@ -233,6 +243,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "https://opw-prod.example.com",
                     "--source-label",
                     "test",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
 
@@ -251,6 +262,31 @@ class OdooInstanceOverrideTests(unittest.TestCase):
         self.assertEqual(
             stored_record.config_parameters[0].value.value, "https://opw-prod.example.com"
         )
+
+    def test_cli_put_config_param_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-config-param",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "prod",
+                    "--key",
+                    "web.base.url",
+                    "--value",
+                    "https://opw-prod.example.com",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
 
     def test_cli_put_config_param_adds_deploy_phases_to_existing_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -294,6 +330,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "web.base.url",
                     "--value",
                     "https://opw-prod.example.com",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             store = PostgresRecordStore(database_url=database_url)
@@ -329,6 +366,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "api_token",
                     "--value",
                     "plain-token",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
 
@@ -358,6 +396,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "api_token",
                     "--secret-binding-id",
                     "secret-binding-shopify-token",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             list_result = runner.invoke(
@@ -369,6 +408,33 @@ class OdooInstanceOverrideTests(unittest.TestCase):
         payload = json.loads(list_result.output)
         self.assertEqual(payload["records"][0]["addon_settings"], ["shopify.api_token"])
         self.assertNotIn("secret-binding-shopify-token", list_result.output)
+
+    def test_cli_put_addon_setting_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-addon-setting",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "prod",
+                    "--addon",
+                    "shopify",
+                    "--setting",
+                    "shop_url_key",
+                    "--value",
+                    "candidate-store",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
 
     def test_cli_put_addon_setting_adds_deploy_phases_to_existing_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -416,6 +482,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "api_token",
                     "--secret-binding-id",
                     "secret-binding-shopify-token",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             store = PostgresRecordStore(database_url=database_url)
@@ -467,6 +534,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "web.base.url",
                     "--value",
                     "https://opw-testing.example.com",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             put_bootstrap_result = runner.invoke(
@@ -482,6 +550,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "testing",
                     "--payload-file",
                     str(payload_file),
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             store = PostgresRecordStore(database_url=database_url)
@@ -547,6 +616,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "testing",
                     "--payload-file",
                     str(payload_file),
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             store = PostgresRecordStore(database_url=database_url)
@@ -557,6 +627,32 @@ class OdooInstanceOverrideTests(unittest.TestCase):
 
         self.assertEqual(put_bootstrap_result.exit_code, 0, msg=put_bootstrap_result.output)
         self.assertEqual(stored_record.apply_on, ("manual", "deploy", "promotion"))
+
+    def test_cli_put_website_bootstrap_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temp_dir = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temp_dir / "launchplane.sqlite3")
+            payload_file = temp_dir / "website-bootstrap.json"
+            payload_file.write_text(
+                json.dumps({"tenant": "opw", "name": "OPW"}), encoding="utf-8"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-website-bootstrap",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--payload-file",
+                    str(payload_file),
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
 
     def test_cli_put_website_bootstrap_reports_schema_errors(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -578,6 +674,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "testing",
                     "--payload-file",
                     str(payload_file),
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
 
@@ -606,6 +703,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "web.base.url",
                     "--value",
                     "https://opw-prod.example.com",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             mark_result = runner.invoke(
@@ -625,6 +723,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "2026-04-23T12:00:00Z",
                     "--detail",
                     "Applied through test driver.",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
 
@@ -639,6 +738,29 @@ class OdooInstanceOverrideTests(unittest.TestCase):
         self.assertIn('"last_apply_status": "pass"', mark_result.output)
         self.assertEqual(stored_record.last_apply.status, "pass")
         self.assertEqual(stored_record.last_apply.applied_at, "2026-04-23T12:00:00Z")
+
+    def test_cli_mark_apply_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "mark-apply",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "prod",
+                    "--status",
+                    "pass",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
 
     def test_post_deploy_update_renders_literal_odoo_overrides_and_marks_pass(self) -> None:
         def capture_post_deploy_update(**kwargs: object) -> None:
@@ -939,6 +1061,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
                     "--context",
                     "opw",
                     "--apply",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
 
@@ -970,6 +1093,55 @@ class OdooInstanceOverrideTests(unittest.TestCase):
             "configured",
         )
         self.assertNotIn("encrypted-value-placeholder", result.output)
+
+    def test_cli_migrate_secret_transport_apply_requires_direct_db_acknowledgement(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "migrate-secret-transport",
+                    "--database-url",
+                    database_url,
+                    "--apply",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
+
+    def test_cli_migrate_secret_transport_dry_run_does_not_require_direct_db_acknowledgement(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.close()
+            with patch.object(
+                PostgresRecordStore,
+                "ensure_schema",
+                side_effect=AssertionError("dry-run must not ensure schema"),
+            ):
+                result = CliRunner().invoke(
+                    main,
+                    [
+                        "odoo-overrides",
+                        "migrate-secret-transport",
+                        "--database-url",
+                        database_url,
+                    ],
+                )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "dry-run")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Require `--allow-direct-db-mutation` before local `odoo-overrides` write/apply commands persist DB changes.
- Keep `odoo-overrides list`, `show`, and `migrate-secret-transport` dry-run as read-only inspection paths.
- Update operations docs to frame local Odoo override writes as explicit local/bootstrap repair only, with shared/live changes using the trusted service/operator workflow.

## Validation

- `uv run python -m unittest tests.test_odoo_instance_overrides`
- `uv run --extra dev ruff check --diff control_plane/cli_odoo.py tests/test_odoo_instance_overrides.py docs/operations.md`
- `uv run --extra dev ruff check control_plane/cli_odoo.py tests/test_odoo_instance_overrides.py docs/operations.md`
- `uv run --extra dev mypy control_plane/cli_odoo.py tests/test_odoo_instance_overrides.py`
- `uv run python -m unittest tests.test_docs_contracts`
- `git diff --check`
- `uv run launchplane odoo-overrides <command> --help` spot-check for guarded write commands and unguarded read commands

## Review

- Slice-selection agents converged on `odoo-overrides` as the next #1492 local-mutation audit slice.
- Review agents found one real issue: dry-run still called `ensure_schema()`. Fixed by keeping schema creation behind `--apply` and adding test coverage that fails if dry-run calls `ensure_schema()`.
- Auto Review ledger has no active/applicable findings for the final checkout.
