### PR TITLE
Guard local Dokploy target mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,11 @@ preview identities and ephemeral preview stacks instead of a durable shared
 
 Use `uv run launchplane dokploy-targets list` or `show` to inspect the tracked
 DB-backed target catalog without reading legacy TOML files. Use
-`uv run launchplane dokploy-targets put-shopify-protected-store-key --context ... --instance ... --key ...`
-and `unset-shopify-protected-store-key` to update the Shopify protected-store-key
-policy carried by a tracked target record. Those commands mutate the shared
-Postgres-backed target record directly; they do not write repo-local fallback
-files.
+`uv run launchplane dokploy-targets put-shopify-protected-store-key --context ... --instance ... --key ... --allow-direct-db-mutation`
+and `unset-shopify-protected-store-key --allow-direct-db-mutation` only for
+explicit local/bootstrap repair of Shopify protected-store-key policy carried by
+a tracked target record. Routine shared/live target setup and provider-target
+authority changes should use the deployed service route or operator workflow.
 
 ## Service Container Deploy
 

--- a/control_plane/cli_dokploy_targets.py
+++ b/control_plane/cli_dokploy_targets.py
@@ -21,6 +21,11 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use the deployed service route or operator workflow for shared/production changes, "
+    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+)
 DokployTargetType = Literal["compose", "application"]
 
 
@@ -43,6 +48,21 @@ def register_dokploy_target_commands(
 @click.group("dokploy-targets")
 def dokploy_targets() -> None:
     """Tracked Dokploy target record commands."""
+
+
+def _direct_db_mutation_acknowledgement_option(
+    function: Callable[..., object],
+) -> Callable[..., object]:
+    return click.option(
+        "--allow-direct-db-mutation",
+        is_flag=True,
+        help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+    )(function)
+
+
+def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) -> None:
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
 
 
 @dokploy_targets.command("list")
@@ -156,6 +176,7 @@ def dokploy_targets_show(database_url: str, context_name: str, instance_name: st
     default=None,
     help="Optional Launchplane repo root used to resolve Dokploy credentials.",
 )
+@_direct_db_mutation_acknowledgement_option
 def dokploy_targets_adopt(
     database_url: str,
     context_name: str,
@@ -172,14 +193,18 @@ def dokploy_targets_adopt(
     updated_at: str,
     apply_changes: bool,
     control_plane_root: Path | None,
+    allow_direct_db_mutation: bool,
 ) -> None:
     if deploy_timeout_seconds is not None and deploy_timeout_seconds < 1:
         raise click.ClickException("--deploy-timeout-seconds must be at least 1.")
+    if apply_changes:
+        _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     callbacks = _dokploy_target_callbacks()
     launchplane_root = control_plane_root or callbacks.control_plane_root()
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=launchplane_root)
     postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
+    if apply_changes:
+        postgres_store.ensure_schema()
     try:
         result = adopt_dokploy_target(
             record_store=postgres_store,
@@ -270,6 +295,7 @@ def dokploy_targets_adopt(
     default=None,
     help="Optional Launchplane repo root used to resolve Dokploy credentials.",
 )
+@_direct_db_mutation_acknowledgement_option
 def dokploy_targets_create_application(
     database_url: str,
     context_name: str,
@@ -292,14 +318,18 @@ def dokploy_targets_create_application(
     updated_at: str,
     apply_changes: bool,
     control_plane_root: Path | None,
+    allow_direct_db_mutation: bool,
 ) -> None:
     if deploy_timeout_seconds is not None and deploy_timeout_seconds < 1:
         raise click.ClickException("--deploy-timeout-seconds must be at least 1.")
+    if apply_changes:
+        _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     callbacks = _dokploy_target_callbacks()
     launchplane_root = control_plane_root or callbacks.control_plane_root()
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=launchplane_root)
     postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
+    if apply_changes:
+        postgres_store.ensure_schema()
     try:
         result = create_dokploy_application_target(
             record_store=postgres_store,
@@ -371,13 +401,16 @@ def dokploy_targets_create_application(
     help="Protected Shopify store key to add for this tracked Dokploy target.",
 )
 @click.option("--source-label", default="cli", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def dokploy_targets_put_shopify_protected_store_key(
     database_url: str,
     context_name: str,
     instance_name: str,
     keys: tuple[str, ...],
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:
@@ -443,13 +476,16 @@ def dokploy_targets_put_shopify_protected_store_key(
     help="Protected Shopify store key to remove from this tracked Dokploy target.",
 )
 @click.option("--source-label", default="cli", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def dokploy_targets_unset_shopify_protected_store_key(
     database_url: str,
     context_name: str,
     instance_name: str,
     keys: tuple[str, ...],
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:
@@ -508,9 +544,15 @@ def dokploy_targets_unset_shopify_protected_store_key(
 @click.option("--context", "context_name", required=True)
 @click.option("--instance", "instance_name", required=True)
 @click.option("--source-label", required=True)
+@_direct_db_mutation_acknowledgement_option
 def dokploy_targets_relabel(
-    database_url: str, context_name: str, instance_name: str, source_label: str
+    database_url: str,
+    context_name: str,
+    instance_name: str,
+    source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:

--- a/docs/config-boundary.md
+++ b/docs/config-boundary.md
@@ -286,9 +286,12 @@ uv run launchplane dokploy-targets show --context opw --instance testing
 uv run launchplane dokploy-targets put-shopify-protected-store-key \
   --context opw \
   --instance testing \
-  --key yps-your-part-supplier
+  --key yps-your-part-supplier \
+  --allow-direct-db-mutation
 ```
 
-That command family edits the shared `launchplane_dokploy_targets` record set
-directly and keeps target policies in the same DB-backed authority as the rest
-of the tracked stable-lane target definition.
+The mutation commands in that family edit the shared
+`launchplane_dokploy_targets` and provider-target record sets directly, so they
+require `--allow-direct-db-mutation` and are explicit local/bootstrap repair
+only. Routine shared/live target setup should use the deployed service route or
+operator workflow.

--- a/docs/dokploy-service-deployments.md
+++ b/docs/dokploy-service-deployments.md
@@ -68,13 +68,16 @@ Each stable lane also needs DB-backed Dokploy target records:
 For an existing Dokploy app, use `launchplane dokploy-targets adopt` to create
 or refresh those target and target-id records from the live provider id. The
 adoption command is dry-run by default and requires `--apply` to write records;
-it does not copy provider env text into Launchplane. Provider application
-creation for application targets is available through
+local `--apply` also requires `--allow-direct-db-mutation` and is explicit
+local/bootstrap repair only. It does not copy provider env text into
+Launchplane. Provider application creation for application targets is available through
 `launchplane dokploy-targets create-application`. That command is also dry-run
-by default; with `--apply`, it can create or reuse the Dokploy project and
-environment, create the application, and immediately persist the matching target
-records. It still leaves runtime env, managed secrets, volumes, ports, and
-health behavior as explicit setup rather than inferred provider state.
+by default; with local `--apply --allow-direct-db-mutation`, it can create or
+reuse the Dokploy project and environment, create the application, and
+immediately persist the matching target records. Routine shared/live target
+setup should use the deployed service route or operator workflow instead. It
+still leaves runtime env, managed secrets, volumes, ports, and health behavior
+as explicit setup rather than inferred provider state.
 
 Product repos may document these expected facts, but they must not store live
 Launchplane product profiles, target ids, provider credentials, or lifecycle

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -91,9 +91,11 @@ uv run launchplane dokploy-targets adopt \
 The command is a dry run unless `--apply` is supplied. It fetches the live
 Dokploy target, stores only Launchplane-owned target metadata and the target-id
 record, and intentionally does not copy provider env text or secret-shaped
-values. Use `--project-name`, `--target-name`, `--domain`, and
-`--healthcheck-path` when the provider payload does not expose enough redacted
-metadata for the record.
+values. Local apply also requires `--allow-direct-db-mutation` and is explicit
+local/bootstrap repair only; routine shared/live target setup should use the
+manual `Dokploy Target Setup` workflow. Use `--project-name`, `--target-name`,
+`--domain`, and `--healthcheck-path` when the provider payload does not expose
+enough redacted metadata for the record.
 
 For shared or production live mutations, use the manual `Dokploy Target Setup`
 workflow instead of local CLI commands. The workflow calls the deployed
@@ -127,11 +129,13 @@ uv run launchplane dokploy-targets create-application \
   --project-name <dokploy-project-name>
 ```
 
-This command is also dry-run by default. With `--apply`, it can create a
-Dokploy project, environment, and application, then write the matching tracked
-target and target-id records. Use `--project-id` or `--environment-id` to reuse
-existing provider containers, and `--server-id` when the app belongs on a remote
-Dokploy server. It still does not configure secrets or copy provider env text;
+This command is also dry-run by default. With local
+`--apply --allow-direct-db-mutation`, it can create a Dokploy project,
+environment, and application, then write the matching tracked target and
+target-id records. Use `--project-id` or `--environment-id` to reuse existing
+provider containers, and `--server-id` when the app belongs on a remote Dokploy
+server. Routine shared/live creation should use the manual workflow above. It
+still does not configure secrets or copy provider env text;
 runtime and secret records remain separate Launchplane-owned setup steps.
 
 Then import or update DB-backed authz policy records for the product's GitHub

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -503,9 +503,12 @@ DB-backed Launchplane records:
 - inspect tracked stable-lane Dokploy target records with
   `uv run launchplane dokploy-targets list` / `show`
 - mutate tracked target Shopify guard policy with
-  `uv run launchplane dokploy-targets put-shopify-protected-store-key ...` and
-  `unset-shopify-protected-store-key ...` instead of editing repo-local target
-  catalogs or ad-hoc DB rows
+  `uv run launchplane dokploy-targets put-shopify-protected-store-key ... --allow-direct-db-mutation`
+  and `unset-shopify-protected-store-key ... --allow-direct-db-mutation` only
+  for explicit local/bootstrap repair instead of editing repo-local target
+  catalogs or ad-hoc DB rows. Routine shared/live target setup and
+  provider-target authority changes should use the deployed service route or
+  operator workflow.
 
 Two deployment prerequisites remain Dokploy-side operational contracts rather
 than Launchplane CLI validations:

--- a/docs/records.md
+++ b/docs/records.md
@@ -825,7 +825,11 @@ run` is the foreground loop intended for an external process supervisor, and
 - The operator write path for this record family is the Launchplane CLI,
   including `dokploy-targets list`, `show`,
   `put-shopify-protected-store-key`, and
-  `unset-shopify-protected-store-key`.
+  `unset-shopify-protected-store-key`. Direct local writes, including Shopify
+  protected-store-key mutation, relabel, adoption apply, and application-create
+  apply, require `--allow-direct-db-mutation` and are explicit local/bootstrap
+  repair only; routine shared/live target setup should use the deployed service
+  route or operator workflow.
 - Repo-local Dokploy target TOML files are not a supported runtime authority or
   mutation surface for these records.
 - For service-shaped products, persistent volume mounts remain operator-owned

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -10,7 +10,7 @@ from typing import cast
 from unittest.mock import patch
 
 import click
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 from pydantic import ValidationError
 
 from control_plane import dokploy as control_plane_dokploy
@@ -35,6 +35,18 @@ from control_plane.storage.postgres import PostgresRecordStore
 
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
+
+
+def _allow_direct_db_mutation_argument() -> list[str]:
+    return ["--allow-direct-db-mutation"]
+
+
+def _assert_direct_db_mutation_rejected(
+    test_case: unittest.TestCase, result: Result
+) -> None:
+    test_case.assertNotEqual(result.exit_code, 0)
+    test_case.assertIn("Direct local DB mutation is restricted", result.output)
+    test_case.assertIn("--allow-direct-db-mutation", result.output)
 
 
 def _write_dokploy_managed_secrets(*, store: PostgresRecordStore, host: str, token: str) -> None:
@@ -867,6 +879,7 @@ target_type = "compose"
                     "yps-your-part-supplier",
                     "--source-label",
                     "policy:test",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             stored_record = store.read_dokploy_target_record(
@@ -891,6 +904,33 @@ target_type = "compose"
         self.assertEqual(provider_target.target_id, "compose-123")
         self.assertEqual(provider_target.provider_target_type, "compose")
         self.assertEqual(provider_target.source_label, "policy:test")
+
+    def test_dokploy_targets_put_shopify_protected_store_key_requires_direct_db_acknowledgement(
+        self,
+    ) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "dokploy-targets",
+                    "put-shopify-protected-store-key",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--key",
+                    "yps-your-part-supplier",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
 
     def test_dokploy_targets_unset_shopify_protected_store_key_reports_missing_keys(self) -> None:
         runner = CliRunner()
@@ -931,6 +971,7 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
                     "yps-your-part-supplier",
                     "--key",
                     "missing-store",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
             stored_record = store.read_dokploy_target_record(
@@ -948,6 +989,33 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
         self.assertEqual(payload["record"]["shopify_protected_store_keys"], ["spare-store"])
         self.assertEqual(stored_record.policies.shopify.protected_store_keys, ("spare-store",))
         self.assertEqual(provider_target.target_id, "compose-123")
+
+    def test_dokploy_targets_unset_shopify_protected_store_key_requires_direct_db_acknowledgement(
+        self,
+    ) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "dokploy-targets",
+                    "unset-shopify-protected-store-key",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--key",
+                    "yps-your-part-supplier",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
 
     def test_dokploy_targets_put_shopify_protected_store_key_requires_existing_record(self) -> None:
         runner = CliRunner()
@@ -972,11 +1040,88 @@ protected_store_keys = ["yps-your-part-supplier", "spare-store"]
                     "testing",
                     "--key",
                     "yps-your-part-supplier",
+                    *_allow_direct_db_mutation_argument(),
                 ],
             )
 
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("Missing DB-backed tracked Dokploy target record", result.output)
+
+    def test_dokploy_targets_relabel_updates_source_metadata(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            _seed_dokploy_target_records(
+                store=store,
+                payload="""
+schema_version = 2
+
+[[targets]]
+context = "opw"
+instance = "testing"
+target_id = "compose-123"
+target_type = "compose"
+""",
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "dokploy-targets",
+                    "relabel",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "OPW",
+                    "--instance",
+                    "Testing",
+                    "--source-label",
+                    "repair:operator",
+                    *_allow_direct_db_mutation_argument(),
+                ],
+            )
+            stored_record = store.read_dokploy_target_record(
+                context_name="opw", instance_name="testing"
+            )
+            provider_target = store.read_provider_target_record(
+                context_name="opw", instance_name="testing"
+            )
+            store.close()
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["record"]["source_label"], "repair:operator")
+        self.assertEqual(stored_record.source_label, "repair:operator")
+        self.assertEqual(provider_target.source_label, "repair:operator")
+
+    def test_dokploy_targets_relabel_requires_direct_db_acknowledgement(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+
+            result = runner.invoke(
+                main,
+                [
+                    "dokploy-targets",
+                    "relabel",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--source-label",
+                    "repair:operator",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
 
     def test_service_inspect_config_boundary_reports_db_only_authority(self) -> None:
         runner = CliRunner()

--- a/tests/test_dokploy_target_adoption.py
+++ b/tests/test_dokploy_target_adoption.py
@@ -6,7 +6,7 @@ import unittest
 from unittest.mock import patch
 
 from click import Command
-from click.testing import CliRunner
+from click.testing import CliRunner, Result
 
 from control_plane.cli import main
 from control_plane import secrets as control_plane_secrets
@@ -25,6 +25,18 @@ CLI_MAIN = cast(Command, main)
 
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
+
+
+def _allow_direct_db_mutation_argument() -> list[str]:
+    return ["--allow-direct-db-mutation"]
+
+
+def _assert_direct_db_mutation_rejected(
+    test_case: unittest.TestCase, result: Result
+) -> None:
+    test_case.assertNotEqual(result.exit_code, 0)
+    test_case.assertIn("Direct local DB mutation is restricted", result.output)
+    test_case.assertIn("--allow-direct-db-mutation", result.output)
 
 
 def _write_dokploy_managed_secrets(*, store: PostgresRecordStore) -> None:
@@ -532,6 +544,10 @@ class DokployTargetAdoptionTests(unittest.TestCase):
                     "name": "discord-blue-lxc",
                     "environment": {"project": {"name": "Discord Blue"}},
                 },
+            ), patch.object(
+                PostgresRecordStore,
+                "ensure_schema",
+                side_effect=AssertionError("dry-run must not ensure schema"),
             ):
                 with patch.dict(
                     "os.environ",
@@ -640,6 +656,7 @@ class DokployTargetAdoptionTests(unittest.TestCase):
                             "--updated-at",
                             "2026-05-04T22:45:00Z",
                             "--apply",
+                            *_allow_direct_db_mutation_argument(),
                         ],
                     )
 
@@ -661,6 +678,44 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertEqual(target_record.target_name, "discord-blue-prod")
         self.assertEqual(target_record.source_label, "test:adopt")
         self.assertEqual(target_id_record.target_id, "app-123")
+
+    def test_cli_adopt_apply_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temporary_directory / "db.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                _write_dokploy_managed_secrets(store=store)
+            store.close()
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "dokploy-targets",
+                    "adopt",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "discord-blue",
+                    "--instance",
+                    "prod",
+                    "--target-type",
+                    "application",
+                    "--target-id",
+                    "app-123",
+                    "--apply",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
 
     def test_create_application_target_dry_run_plans_provider_requests(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1151,7 +1206,11 @@ class DokployTargetAdoptionTests(unittest.TestCase):
                 _write_dokploy_managed_secrets(store=store)
             store.close()
 
-            with patch.dict(
+            with patch.object(
+                PostgresRecordStore,
+                "ensure_schema",
+                side_effect=AssertionError("dry-run must not ensure schema"),
+            ), patch.dict(
                 "os.environ",
                 {
                     "LAUNCHPLANE_DATABASE_URL": database_url,
@@ -1189,6 +1248,135 @@ class DokployTargetAdoptionTests(unittest.TestCase):
         self.assertEqual(payload["plan"]["application"]["target_name"], "discord-blue-prod")
         self.assertEqual(len(payload["provider_requests"]), 3)
         self.assertEqual(records, ())
+
+    def test_cli_create_application_apply_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temporary_directory / "db.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                _write_dokploy_managed_secrets(store=store)
+            store.close()
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "dokploy-targets",
+                    "create-application",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "discord-blue",
+                    "--instance",
+                    "prod",
+                    "--target-name",
+                    "discord-blue-prod",
+                    "--project-name",
+                    "Discord Blue",
+                    "--apply",
+                ],
+            )
+
+        _assert_direct_db_mutation_rejected(self, result)
+
+    def test_cli_create_application_apply_writes_records_with_direct_db_acknowledgement(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temporary_directory / "db.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            with patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                _write_dokploy_managed_secrets(store=store)
+            store.close()
+
+            def dokploy_request(
+                *,
+                host: str,
+                token: str,
+                path: str,
+                method: str = "GET",
+                payload: JsonObject | None = None,
+                query: dict[str, str | int] | None = None,
+                timeout_seconds: int | float = 60,
+            ) -> JsonObject:
+                del host, token, method, payload, query, timeout_seconds
+                if path == "/api/project.create":
+                    return {"projectId": "project-123"}
+                if path == "/api/environment.create":
+                    return {"environmentId": "env-123"}
+                if path == "/api/application.create":
+                    return {"applicationId": "app-123"}
+                raise AssertionError(path)
+
+            with patch(
+                "control_plane.dokploy.dokploy_request",
+                side_effect=dokploy_request,
+            ), patch(
+                "control_plane.cli.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "discord-blue-prod",
+                    "environment": {"project": {"name": "Discord Blue"}},
+                },
+            ), patch.dict(
+                "os.environ",
+                {
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key",
+                },
+                clear=True,
+            ):
+                result = CliRunner().invoke(
+                    CLI_MAIN,
+                    [
+                        "dokploy-targets",
+                        "create-application",
+                        "--database-url",
+                        database_url,
+                        "--context",
+                        "discord-blue",
+                        "--instance",
+                        "prod",
+                        "--target-name",
+                        "discord-blue-prod",
+                        "--project-name",
+                        "Discord Blue",
+                        "--apply",
+                        *_allow_direct_db_mutation_argument(),
+                    ],
+                )
+
+            self.assertEqual(result.exit_code, 0, result.output)
+            store = PostgresRecordStore(database_url=database_url)
+            target_record = store.read_dokploy_target_record(
+                context_name="discord-blue", instance_name="prod"
+            )
+            target_id_record = store.read_dokploy_target_id_record(
+                context_name="discord-blue", instance_name="prod"
+            )
+            store.close()
+
+        payload = json.loads(result.output)
+        self.assertEqual(payload["mode"], "apply")
+        self.assertTrue(payload["applied"])
+        self.assertEqual(target_record.target_name, "discord-blue-prod")
+        self.assertEqual(target_id_record.target_id, "app-123")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Require `--allow-direct-db-mutation` before local `dokploy-targets` mutation commands persist DB/provider-target changes.
- Keep `dokploy-targets adopt` and `create-application` dry-run paths read-only by avoiding `ensure_schema()` unless `--apply` is acknowledged.
- Update durable docs/examples so local Dokploy-target writes are explicit local/bootstrap repair only, with routine shared/live setup routed through the deployed service/operator workflow.

## Validation

- `uv run python -m unittest tests.test_dokploy tests.test_dokploy_target_adoption tests.test_docs_contracts`
- `uv run --extra dev ruff check --diff control_plane/cli_dokploy_targets.py tests/test_dokploy.py tests/test_dokploy_target_adoption.py README.md docs/config-boundary.md docs/operations.md docs/dokploy-service-deployments.md docs/new-product-repo.md docs/records.md`
- `uv run --extra dev ruff check control_plane/cli_dokploy_targets.py tests/test_dokploy.py tests/test_dokploy_target_adoption.py README.md docs/config-boundary.md docs/operations.md docs/dokploy-service-deployments.md docs/new-product-repo.md docs/records.md`
- `uv run --extra dev mypy control_plane/cli_dokploy_targets.py tests/test_dokploy.py tests/test_dokploy_target_adoption.py`
- `git diff --check`
- CLI help/stale-example spot check for guarded mutation commands and unguarded `list`/`show`

## Review

- Slice-selection agents converged on `dokploy-targets` after #1510 and #1511.
- Review agents found one low docs fragment in `docs/config-boundary.md`; fixed before commit.
- Auto Review ledger has no active/applicable findings for the final checkout.
