### PR TITLE
Retire local provider-target backfill apply

### DIFF
--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -11,6 +11,11 @@ from control_plane.workflows.provider_target_backfill import backfill_provider_t
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+_PROVIDER_TARGET_BACKFILL_APPLY_RETIRED_MESSAGE = (
+    "Local provider-target backfill apply is retired. Use the deployed "
+    "Launchplane service route POST /v1/provider-targets/operations or the "
+    "Provider Target Operations workflow for shared/live writes."
+)
 
 
 def register_storage_secret_commands(main: click.Group) -> None:
@@ -100,7 +105,12 @@ def storage_provider_target_audit(
     required=True,
     help="Postgres connection string for Launchplane provider-target records.",
 )
-@click.option("--apply", "apply_changes", is_flag=True, help="Write missing rows.")
+@click.option(
+    "--apply",
+    "apply_changes",
+    is_flag=True,
+    help="Retired local write path; use Provider Target Operations instead.",
+)
 @click.option("--provider-id", default="", help="Optional provider id filter.")
 @click.option("--context", "context_name", default="", help="Optional context filter.")
 @click.option("--instance", "instance_name", default="", help="Optional instance filter.")
@@ -111,12 +121,14 @@ def storage_provider_target_backfill(
     context_name: str,
     instance_name: str,
 ) -> None:
+    if apply_changes:
+        raise click.ClickException(_PROVIDER_TARGET_BACKFILL_APPLY_RETIRED_MESSAGE)
     postgres_store = PostgresRecordStore(database_url=database_url)
     try:
         postgres_store.ensure_schema()
         result = backfill_provider_targets(
             postgres_store,
-            apply=apply_changes,
+            apply=False,
             provider_id=provider_id,
             context_name=context_name,
             instance_name=instance_name,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -34,8 +34,9 @@ API path instead of running the local command from an arbitrary checkout.
 - `ship`: plan, resolve, and execute artifact-backed deploy requests.
 - `storage provider-target-audit`: run the read-only provider-target parity
   preflight before backfill or provider-target authority cutover.
-- `storage provider-target-backfill`: dry-run or apply explicit provider-target
-  rows from complete Dokploy target/id pairs.
+- `storage provider-target-backfill`: dry-run explicit provider-target row
+  projections from complete Dokploy target/id pairs; shared/live apply uses the
+  service-backed Provider Target Operations workflow.
 
 `deployments write`, `promotions write`, `inventory write-from-deployment`,
 `inventory write-from-promotion`, and `release-tuples write-from-promotion`
@@ -81,29 +82,31 @@ missing, partial Dokploy pairs exist, or explicit rows disagree with the
 Dokploy-derived projection. Backfill and authority cutover should not proceed
 until the audit has no unresolved blockers for the affected lanes.
 
-Use the backfill command to seed missing physical rows after reviewing the audit
-output and after dual-write is deployed:
+Use the backfill command to preview missing physical rows after reviewing the
+audit output and after dual-write is deployed:
 
 ```bash
 uv run launchplane storage provider-target-backfill \
   --database-url "$LAUNCHPLANE_DATABASE_URL"
 ```
 
-Dry-run is the default. It reports `would-create`, `skipped-exists`,
-`skipped-incomplete`, `skipped-conflict`, and `unsupported-provider` rows without
-writing anything. Review incomplete pairs and conflicts before applying; conflicts
-are never overwritten automatically. Apply only after the dry-run output is
-acceptable:
+The local command is report-only. It emits dry-run JSON for `would-create`,
+`skipped-exists`, `skipped-incomplete`, `skipped-conflict`, and
+`unsupported-provider` rows without writing anything. Review incomplete pairs and
+conflicts before applying; conflicts are never overwritten automatically.
+Shared/live apply runs through the deployed service route and is normally
+launched by the manual `Provider Target Operations` workflow:
 
 ```bash
-uv run launchplane storage provider-target-backfill \
-  --database-url "$LAUNCHPLANE_DATABASE_URL" \
-  --apply
+gh workflow run provider-target-operations.yml \
+  -f mode=backfill-apply \
+  -f target_set=all \
+  -f reason="issue-backed provider-target backfill"
 ```
 
-Backfill writes only complete, non-conflicting Dokploy-derived rows and is
-idempotent. Re-run `storage provider-target-audit` after apply and require clean
-evidence before provider-target authority cutover.
+Service-backed backfill writes only complete, non-conflicting Dokploy-derived
+rows and is idempotent. Re-run `storage provider-target-audit` after apply and
+require clean evidence before provider-target authority cutover.
 
 Provider-target dual-write is active for Launchplane-owned target identity
 mutations: product onboarding, Dokploy target adoption/creation, product context

--- a/docs/records.md
+++ b/docs/records.md
@@ -188,18 +188,17 @@ an ORM column/table or remains only in the evidence payload.
   with the neutral projection from paired Dokploy target and target-id records,
   reports missing halves and mismatches, and exits nonzero when unresolved
   blockers would make backfill or authority cutover unsafe.
-- `uv run launchplane storage provider-target-backfill` is the seeding path for
-  explicit provider-target rows. Dry-run is the default; `--apply`
-  writes only complete Dokploy target/id projections that have no conflicting
-  physical row. Existing matching physical rows are skipped without churn,
-  incomplete pairs are reported but not guessed, and conflicts or unsupported
-  provider rows are never overwritten automatically.
+- `uv run launchplane storage provider-target-backfill` is the local report-only
+  preview for explicit provider-target row seeding. It emits dry-run output for
+  complete Dokploy target/id projections, existing matching physical rows,
+  incomplete pairs, conflicts, and unsupported provider rows without writing
+  anything.
 - Shared and production backfill uses the deployed service route
   `POST /v1/provider-targets/operations`, normally through the manual
   `Provider Target Operations` workflow. The workflow records per-route audit,
-  dry-run, or apply evidence as artifacts and uses DB-backed
-  `provider_target.audit` or `provider_target.backfill` authz grants instead of
-  local checkout writes.
+  dry-run, or apply evidence as artifacts, writes only complete non-conflicting
+  projections, and uses DB-backed `provider_target.audit` or
+  `provider_target.backfill` authz grants instead of local checkout writes.
 - Shared ship and promotion request contracts require canonical flat target
   fields (`target_name`, `target_type`, `provider_id`, `target_category`, and
   `provider_target_type`) and reject `target_reference` compatibility input.

--- a/tests/test_provider_target_backfill.py
+++ b/tests/test_provider_target_backfill.py
@@ -342,7 +342,7 @@ class ProviderTargetBackfillTests(unittest.TestCase):
             [("testing", "app-syo-testing")],
         )
 
-    def test_cli_dry_run_and_apply_emit_json(self) -> None:
+    def test_cli_dry_run_emits_json_without_writing(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = _sqlite_database_url(database_path)
@@ -361,7 +361,27 @@ class ProviderTargetBackfillTests(unittest.TestCase):
                     database_url,
                 ],
             )
-            apply_result = CliRunner().invoke(
+            store = PostgresRecordStore(database_url=database_url)
+            physical_records = store.list_physical_provider_target_records()
+            store.close()
+
+        self.assertEqual(dry_run.exit_code, 0, dry_run.output)
+        dry_run_payload = json.loads(dry_run.output)
+        self.assertFalse(dry_run_payload["applied"])
+        self.assertEqual(dry_run_payload["counts"], {"would-create": 1})
+        self.assertEqual(physical_records, ())
+
+    def test_cli_apply_is_retired_before_writing(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            database_url = _sqlite_database_url(database_path)
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_dokploy_target_record(_dokploy_target_record())
+            store.write_dokploy_target_id_record(_dokploy_target_id_record())
+            store.close()
+
+            result = CliRunner().invoke(
                 main,
                 [
                     "storage",
@@ -372,22 +392,27 @@ class ProviderTargetBackfillTests(unittest.TestCase):
                 ],
             )
             store = PostgresRecordStore(database_url=database_url)
-            physical_record = store.read_provider_target_record(
-                context_name="syo", instance_name="prod"
-            )
+            physical_records = store.list_physical_provider_target_records()
             store.close()
 
-        self.assertEqual(dry_run.exit_code, 0, dry_run.output)
-        dry_run_payload = json.loads(dry_run.output)
-        self.assertFalse(dry_run_payload["applied"])
-        self.assertEqual(dry_run_payload["counts"], {"would-create": 1})
-        self.assertEqual(apply_result.exit_code, 0, apply_result.output)
-        apply_payload = json.loads(apply_result.output)
-        self.assertTrue(apply_payload["applied"])
-        self.assertEqual(apply_payload["counts"], {"created": 1})
-        self.assertEqual(physical_record.target_id, "app-syo-prod")
+        self.assertEqual(result.exit_code, 1, result.output)
+        self.assertIn("Local provider-target backfill apply is retired", result.output)
+        self.assertEqual(physical_records, ())
 
-    def test_cli_exits_nonzero_on_conflicts(self) -> None:
+    def test_cli_help_points_apply_to_provider_target_operations(self) -> None:
+        result = CliRunner().invoke(
+            main,
+            ["storage", "provider-target-backfill", "--help"],
+        )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        normalized_output = " ".join(result.output.split())
+        self.assertIn(
+            "Retired local write path; use Provider Target Operations instead",
+            normalized_output,
+        )
+
+    def test_cli_dry_run_exits_nonzero_on_conflicts(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = _sqlite_database_url(database_path)
@@ -407,7 +432,6 @@ class ProviderTargetBackfillTests(unittest.TestCase):
                     "provider-target-backfill",
                     "--database-url",
                     database_url,
-                    "--apply",
                 ],
             )
 


### PR DESCRIPTION
## Summary
- retire local `storage provider-target-backfill --apply` so arbitrary checkout-local DB writes fail closed
- keep local provider-target backfill as dry-run/report-only
- update provider-target docs to route shared/live apply through the deployed Provider Target Operations workflow/service route

## Validation
- `uv run python -m unittest tests.test_provider_target_backfill tests.test_provider_target_audit tests.test_docs_contracts`
- `uv run --extra dev ruff check --diff control_plane/cli_storage_secrets.py tests/test_provider_target_backfill.py docs/operations.md docs/records.md`
- `uv run --extra dev ruff check control_plane/cli_storage_secrets.py tests/test_provider_target_backfill.py docs/operations.md docs/records.md`
- `uv run --extra dev mypy control_plane/cli_storage_secrets.py tests/test_provider_target_backfill.py`
- `git diff --check`

## Review
- Slice-selection agents converged on provider-target backfill as the next #1492 candidate; Antigravity also flagged rollback as a broader follow-up.
- Patch review agents accidentally inspected the original checkout and reported the pre-patch gap this PR closes; local gates and Auto Review had no active findings on the actual patched worktree.

Closes part of #1492. Updates #1489 progress.