### PR TITLE
Retire local Odoo rollback CLI

### DIFF
--- a/control_plane/cli.py
+++ b/control_plane/cli.py
@@ -57,9 +57,6 @@ from control_plane.cli_launchplane_previews import (
     register_launchplane_preview_commands,
 )
 from control_plane.cli_odoo import OdooCliCallbacks, register_odoo_commands
-from control_plane.cli_odoo import (
-    _normalize_odoo_prod_rollback_source_channel as _normalize_odoo_prod_rollback_source_channel,
-)
 from control_plane.cli_preview_workflow import register_preview_workflow_commands
 from control_plane.cli_policy_profiles import (
     PolicyProfileCliCallbacks,
@@ -125,11 +122,6 @@ from control_plane.workflows.launchplane import (
     resolve_pull_request_event_manifest,
 )
 from control_plane.workflows.inventory import build_environment_inventory
-from control_plane.workflows.odoo_prod_rollback import (
-    OdooProdRollbackRequest,
-    OdooProdRollbackResult,
-    execute_odoo_prod_rollback,
-)
 from control_plane.workflows import promotion_ship_execution
 from control_plane.workflows import promotion_ship_resolution
 from control_plane.workflows.ship import utc_now_timestamp
@@ -219,19 +211,6 @@ def _odoo_store_factory(
     state_dir: Path, *, database_url: str | None = None
 ) -> FilesystemRecordStore | PostgresRecordStore:
     return _store(state_dir, database_url=database_url)
-
-
-def _execute_odoo_prod_rollback_from_cli(
-    *,
-    control_plane_root: Path,
-    record_store: object,
-    request: OdooProdRollbackRequest,
-) -> OdooProdRollbackResult:
-    return execute_odoo_prod_rollback(
-        control_plane_root=control_plane_root,
-        record_store=record_store,
-        request=request,
-    )
 
 
 def _control_plane_root() -> Path:
@@ -3560,7 +3539,6 @@ register_odoo_commands(
     callbacks=OdooCliCallbacks(
         control_plane_root=_control_plane_root,
         store_factory=_odoo_store_factory,
-        execute_odoo_prod_rollback=_execute_odoo_prod_rollback_from_cli,
         normalize_odoo_apply_status=_normalize_odoo_apply_status,
         read_dokploy_config=control_plane_dokploy.read_dokploy_config,
     ),

--- a/control_plane/cli_odoo.py
+++ b/control_plane/cli_odoo.py
@@ -35,10 +35,6 @@ from control_plane.workflows.odoo_prod_backup_gate import (
     OdooProdBackupGateRequest,
     execute_odoo_prod_backup_gate,
 )
-from control_plane.workflows.odoo_prod_rollback import (
-    OdooProdRollbackRequest,
-    OdooProdRollbackResult,
-)
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.odoo_stable_target_replacement import (
     build_odoo_stable_target_replacement_plan,
@@ -54,14 +50,12 @@ _DIRECT_DB_MUTATION_MESSAGE = (
     "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
 )
 OdooOverrideApplyStatus = Literal["skipped", "pending", "pass", "fail"]
-OdooProdRollbackSourceChannel = Literal["testing"]
 
 
 @dataclass(frozen=True)
 class OdooCliCallbacks:
     control_plane_root: Callable[[], Path]
     store_factory: Callable[..., object]
-    execute_odoo_prod_rollback: Callable[..., object]
     normalize_odoo_apply_status: Callable[[str], OdooOverrideApplyStatus]
     read_dokploy_config: Callable[..., tuple[str, str]]
 
@@ -74,7 +68,6 @@ def register_odoo_commands(main: click.Group, *, callbacks: OdooCliCallbacks) ->
     _callbacks = callbacks
     main.add_command(odoo_artifacts)
     main.add_command(odoo_backup_gates)
-    main.add_command(odoo_rollbacks)
     main.add_command(odoo_overrides)
     main.add_command(odoo_targets)
     main.add_command(odoo_ownership)
@@ -94,24 +87,8 @@ def _store(state_dir: Path, *, database_url: str | None = None) -> object:
     return _odoo_callbacks().store_factory(state_dir, database_url=database_url)
 
 
-def _execute_odoo_prod_rollback(**kwargs: object) -> OdooProdRollbackResult:
-    return cast(
-        OdooProdRollbackResult,
-        _odoo_callbacks().execute_odoo_prod_rollback(**kwargs),
-    )
-
-
 def normalize_odoo_apply_status(status: str) -> OdooOverrideApplyStatus:
     return _odoo_callbacks().normalize_odoo_apply_status(status)
-
-
-def _normalize_odoo_prod_rollback_source_channel(
-    source_channel: str,
-) -> OdooProdRollbackSourceChannel:
-    normalized_source_channel = source_channel.strip().lower()
-    if normalized_source_channel != "testing":
-        raise click.ClickException("Odoo prod rollback source channel must be testing.")
-    return "testing"
 
 
 def _read_dokploy_config(*, control_plane_root: Path, database_url: str) -> tuple[str, str]:
@@ -168,11 +145,6 @@ def odoo_artifacts() -> None:
 @click.group("odoo-backup-gates")
 def odoo_backup_gates() -> None:
     """Odoo backup-gate driver commands."""
-
-
-@click.group("odoo-rollbacks")
-def odoo_rollbacks() -> None:
-    """Odoo rollback driver commands."""
 
 
 @odoo_artifacts.command("publish")
@@ -255,60 +227,6 @@ def odoo_backup_gates_capture(
     click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
     if result.backup_status != "pass":
         raise click.ClickException(result.error_message or "Odoo backup gate failed.")
-
-
-@odoo_rollbacks.command("execute")
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane rollback records.",
-)
-@click.option("--context", required=True)
-@click.option("--instance", default="prod", show_default=True)
-@click.option("--source-channel", default="testing", show_default=True)
-@click.option("--promotion-record-id", default="")
-@click.option("--artifact-id", default="")
-@click.option("--reason", default="")
-@click.option("--wait/--no-wait", default=True, show_default=True)
-@click.option("--timeout", "timeout_seconds", type=int, default=None)
-@click.option("--verify-health/--no-verify-health", default=True, show_default=True)
-@click.option("--health-timeout", "health_timeout_seconds", type=int, default=None)
-@click.option("--no-cache", is_flag=True, default=False)
-def odoo_rollbacks_execute(
-    database_url: str,
-    context: str,
-    instance: str,
-    source_channel: str,
-    promotion_record_id: str,
-    artifact_id: str,
-    reason: str,
-    wait: bool,
-    timeout_seconds: int | None,
-    verify_health: bool,
-    health_timeout_seconds: int | None,
-    no_cache: bool,
-) -> None:
-    result = _execute_odoo_prod_rollback(
-        control_plane_root=_control_plane_root(),
-        record_store=_store(Path("state"), database_url=database_url),
-        request=OdooProdRollbackRequest(
-            context=context,
-            instance=instance,
-            source_channel=_normalize_odoo_prod_rollback_source_channel(source_channel),
-            promotion_record_id=promotion_record_id,
-            artifact_id=artifact_id,
-            reason=reason,
-            wait=wait,
-            timeout_seconds=timeout_seconds,
-            verify_health=verify_health,
-            health_timeout_seconds=health_timeout_seconds,
-            no_cache=no_cache,
-        ),
-    )
-    click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
-    if result.rollback_status != "pass":
-        raise click.ClickException(result.error_message or "Odoo prod rollback failed.")
 
 
 def _summarize_odoo_instance_override_record(

--- a/tests/test_merge_train_policy.py
+++ b/tests/test_merge_train_policy.py
@@ -244,10 +244,6 @@ class MergeTrainPolicyTests(unittest.TestCase):
         self.assertEqual(normalize_secret_scope(" Context "), "context")
         self.assertEqual(normalize_odoo_apply_status(" PASS "), "pass")
         self.assertEqual(
-            control_plane_cli._normalize_odoo_prod_rollback_source_channel(" testing "),
-            "testing",
-        )
-        self.assertEqual(
             control_plane_cli._normalize_dokploy_target_type(" APPLICATION "),
             "application",
         )
@@ -263,11 +259,6 @@ class MergeTrainPolicyTests(unittest.TestCase):
                 normalize_odoo_apply_status,
                 "success",
                 "Odoo override apply status must be skipped, pending, pass, or fail.",
-            ),
-            (
-                control_plane_cli._normalize_odoo_prod_rollback_source_channel,
-                "prod",
-                "Odoo prod rollback source channel must be testing.",
             ),
             (
                 control_plane_cli._normalize_dokploy_target_type,

--- a/tests/test_odoo_prod_rollback.py
+++ b/tests/test_odoo_prod_rollback.py
@@ -187,6 +187,10 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
         with self.assertRaisesRegex(ValidationError, "requires context"):
             OdooProdRollbackRequest(context=" ")
 
+    def test_rollback_request_rejects_non_testing_source_channel(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "Input should be 'testing'"):
+            OdooProdRollbackRequest(context="opw", source_channel="prod")  # type: ignore[arg-type]
+
     def _record_store(self) -> Mock:
         record_store = Mock()
         record_store.read_release_tuple_record.return_value = _release_tuple()
@@ -311,53 +315,22 @@ class OdooProdRollbackWorkflowTests(unittest.TestCase):
         final_promotion = record_store.write_promotion_record.call_args_list[-1].args[0]
         self.assertEqual(final_promotion.rollback.status, "fail")
 
-    def test_rollback_cli_executes_driver(self) -> None:
-        with (
-            patch(
-                "control_plane.cli.execute_odoo_prod_rollback",
-                return_value=Mock(
-                    rollback_status="pass",
-                    model_dump=Mock(
-                        return_value={
-                            "context": "cm",
-                            "instance": "prod",
-                            "artifact_id": "artifact-cm-previous",
-                            "promotion_record_id": "promotion-cm-prod",
-                            "deployment_record_id": "deployment-cm-prod",
-                            "release_tuple_id": "cm-prod-artifact-cm-previous",
-                            "rollback_status": "pass",
-                            "rollback_health_status": "pass",
-                            "post_deploy_status": "pass",
-                            "error_message": "",
-                        }
-                    ),
-                ),
-            ) as execute_mock,
-            patch("control_plane.cli._store", return_value=Mock()),
-        ):
-            result = CliRunner().invoke(
-                CLI_MAIN,
-                [
-                    "odoo-rollbacks",
-                    "execute",
-                    "--database-url",
-                    "postgresql://launchplane.example/db",
-                    "--context",
-                    "cm",
-                    "--artifact-id",
-                    "artifact-cm-previous",
-                    "--reason",
-                    "drill",
-                ],
-            )
+    def test_rollback_cli_group_is_retired(self) -> None:
+        result = CliRunner().invoke(
+            CLI_MAIN,
+            [
+                "odoo-rollbacks",
+            ],
+        )
+
+        self.assertEqual(result.exit_code, 2, result.output)
+        self.assertIn("No such command 'odoo-rollbacks'", result.output)
+
+    def test_main_help_omits_retired_rollback_group(self) -> None:
+        result = CliRunner().invoke(CLI_MAIN, ["--help"])
 
         self.assertEqual(result.exit_code, 0, result.output)
-        self.assertIn("artifact-cm-previous", result.output)
-        execute_mock.assert_called_once()
-        request = execute_mock.call_args.kwargs["request"]
-        self.assertEqual(request.context, "cm")
-        self.assertEqual(request.artifact_id, "artifact-cm-previous")
-        self.assertEqual(request.reason, "drill")
+        self.assertNotIn("odoo-rollbacks", result.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the local `odoo-rollbacks` CLI group and its direct rollback execution callback plumbing
- keep the deployed FastAPI `POST /v1/drivers/odoo/prod-rollback` service route and workflow implementation intact
- move source-channel validation coverage to the durable `OdooProdRollbackRequest` contract and assert the retired CLI is absent

## Validation
- `uv run python -m unittest tests.test_odoo_prod_rollback tests.test_http_app_driver_odoo.FastApiOdooProdRollbackTests tests.test_merge_train_policy.MergeTrainPolicyTests.test_cli_choice_normalizers_share_trimmed_case_insensitive_choices tests.test_merge_train_policy.MergeTrainPolicyTests.test_cli_choice_normalizer_preserves_domain_error_messages`
- `uv run --extra dev ruff check --diff control_plane/cli.py control_plane/cli_odoo.py tests/test_odoo_prod_rollback.py tests/test_merge_train_policy.py`
- `uv run --extra dev ruff check control_plane/cli.py control_plane/cli_odoo.py tests/test_odoo_prod_rollback.py tests/test_merge_train_policy.py`
- `uv run --extra dev mypy control_plane/cli.py control_plane/cli_odoo.py tests/test_odoo_prod_rollback.py tests/test_merge_train_policy.py`
- `git diff --check`
- stale-reference search for `odoo-rollbacks`, `_normalize_odoo_prod_rollback_source_channel`, and local rollback callback plumbing

## Review
- Antigravity independently recommended retiring `odoo-rollbacks execute` as the bounded rollback/provider-target local execution slice for #1492.
- Local scan confirmed generic-web, Odoo, and VeriReel rollback service routes remain present; only the local Odoo rollback CLI wrapper was registered.
- Auto Review ledger has no active findings for this checkout.

Closes part of #1492. Updates #1489 progress.