### PR TITLE
Guard local managed secret writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,11 @@ UI for routine shared and production runtime config changes. Raw
 `uv run launchplane environments unset --scope ... --key KEY --allow-direct-db-mutation`,
 and `uv run launchplane environments relabel --allow-direct-db-mutation` are
 explicit local/bootstrap repair paths only; they reject secret-shaped keys or
-avoid printing plaintext values. Use `uv run launchplane secrets put ...` for
-managed secret values. TOML/env files are not supported runtime import surfaces
-outside minimal bootstrap policy/env.
+avoid printing plaintext values. Use product-config dry-run/apply for routine
+managed secret values; `uv run launchplane secrets put ... --allow-direct-db-mutation`
+is the matching explicit local/bootstrap repair path for direct managed-secret
+writes. TOML/env files are not supported runtime import surfaces outside minimal
+bootstrap policy/env.
 
 Live authz policy is DB-backed through `authz-policies` records. The service
 still requires a minimal bootstrap policy input at startup so it can fail closed

--- a/control_plane/cli_runtime_environments.py
+++ b/control_plane/cli_runtime_environments.py
@@ -50,7 +50,9 @@ def environments() -> None:
     """Runtime environment contract commands."""
 
 
-def _direct_db_mutation_acknowledgement_option(function: Callable[..., object]) -> Callable[..., object]:
+def _direct_db_mutation_acknowledgement_option(
+    function: Callable[..., object],
+) -> Callable[..., object]:
     return click.option(
         "--allow-direct-db-mutation",
         is_flag=True,
@@ -485,7 +487,10 @@ def _parse_runtime_environment_assignment(raw_assignment: str) -> tuple[str, str
         raise click.ClickException("Runtime environment values must be provided as KEY=VALUE.")
     if _runtime_environment_key_requires_secret_store(normalized_key):
         raise click.ClickException(
-            f"Runtime environment key {normalized_key!r} must be written with launchplane secrets put."
+            f"Runtime environment key {normalized_key!r} must be written through "
+            "product-config apply for routine changes, or with "
+            "launchplane secrets put --allow-direct-db-mutation for explicit "
+            "local/bootstrap repair."
         )
     return normalized_key, value
 

--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -16,6 +16,12 @@ _PROVIDER_TARGET_BACKFILL_APPLY_RETIRED_MESSAGE = (
     "Launchplane service route POST /v1/provider-targets/operations or the "
     "Provider Target Operations workflow for shared/live writes."
 )
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use product-config apply through the deployed service route or operator workflow "
+    "for shared/production secret writes, or pass --allow-direct-db-mutation only "
+    "for explicit local/bootstrap repair."
+)
 
 
 def register_storage_secret_commands(main: click.Group) -> None:
@@ -46,6 +52,11 @@ def normalize_secret_scope(scope: str) -> SecretScope:
         raise click.ClickException(
             "Secret scope must be one of global, context, or context_instance."
         ) from exc
+
+
+def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) -> None:
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
 
 
 @storage.command("import-core-records")
@@ -158,6 +169,12 @@ def storage_provider_target_backfill(
 @click.option("--instance", "instance_name", default="")
 @click.option("--description", default="")
 @click.option("--actor", default="cli", show_default=True)
+@click.option(
+    "--allow-direct-db-mutation",
+    is_flag=True,
+    default=False,
+    help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+)
 def secrets_put(
     database_url: str,
     scope: str,
@@ -169,7 +186,9 @@ def secrets_put(
     instance_name: str,
     description: str,
     actor: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -259,6 +259,11 @@ decryption key state denies the reveal or resolution.
   Routine shared and production config changes should use product-config
   dry-run/apply through the deployed service route or operator UI instead of
   arbitrary local runtime-environment writes.
+- `uv run launchplane secrets put ... --allow-direct-db-mutation` is the
+  matching explicit local/bootstrap repair path for direct managed-secret
+  writes. Routine shared and production secret changes should use product-config
+  dry-run/apply through the deployed service route or operator UI instead of
+  arbitrary local secret writes.
 - `uv run launchplane product-config apply --input-file bundle.json --dry-run`
   previews an approved product runtime/secret bundle without printing plaintext
   values or writing records. `--apply` writes non-secret runtime keys and

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1939,6 +1939,112 @@ class PostgresRecordStoreTests(unittest.TestCase):
         postgres_store.import_core_records_from_filesystem.assert_called_once()
         self.assertIn('"deployments": 1', result.output)
 
+    def test_secrets_put_requires_direct_db_acknowledgement(self) -> None:
+        result = CliRunner().invoke(
+            main,
+            [
+                "secrets",
+                "put",
+                "--database-url",
+                "postgresql://launchplane:test@db/launchplane",
+                "--scope",
+                "context_instance",
+                "--integration",
+                "dokploy",
+                "--name",
+                "token",
+                "--binding-key",
+                "DOKPLOY_TOKEN",
+                "--value",
+                "secret-value",
+                "--context",
+                "verireel",
+                "--instance",
+                "prod",
+            ],
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
+        self.assertNotIn("secret-value", result.output)
+
+    def test_secrets_put_allows_explicit_bootstrap_repair(self) -> None:
+        postgres_store = Mock()
+        secret_result = {"secret_id": "secret-dokploy-token", "version_id": "version-1"}
+        secret_status = {
+            "secret_id": "secret-dokploy-token",
+            "binding_key": "DOKPLOY_TOKEN",
+            "status": "configured",
+        }
+
+        with (
+            patch(
+                "control_plane.cli_storage_secrets.PostgresRecordStore",
+                return_value=postgres_store,
+            ) as store_class,
+            patch(
+                "control_plane.cli_storage_secrets.control_plane_secrets.write_secret_value",
+                return_value=secret_result,
+            ) as write_secret_value,
+            patch(
+                "control_plane.cli_storage_secrets.control_plane_secrets.build_secret_status",
+                return_value=secret_status,
+            ) as build_secret_status,
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "secrets",
+                    "put",
+                    "--database-url",
+                    "postgresql://launchplane:test@db/launchplane",
+                    "--scope",
+                    "context_instance",
+                    "--integration",
+                    "dokploy",
+                    "--name",
+                    "token",
+                    "--binding-key",
+                    "DOKPLOY_TOKEN",
+                    "--value",
+                    "secret-value",
+                    "--context",
+                    "verireel",
+                    "--instance",
+                    "prod",
+                    "--actor",
+                    "local-repair",
+                    "--allow-direct-db-mutation",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        store_class.assert_called_once_with(
+            database_url="postgresql://launchplane:test@db/launchplane"
+        )
+        postgres_store.ensure_schema.assert_called_once_with()
+        write_secret_value.assert_called_once_with(
+            record_store=postgres_store,
+            scope="context_instance",
+            integration="dokploy",
+            name="token",
+            plaintext_value="secret-value",
+            binding_key="DOKPLOY_TOKEN",
+            context_name="verireel",
+            instance_name="prod",
+            description="",
+            actor="local-repair",
+        )
+        build_secret_status.assert_called_once_with(
+            postgres_store, secret_id="secret-dokploy-token"
+        )
+        postgres_store.close.assert_called_once_with()
+        self.assertNotIn("secret-value", result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["status"], "ok")
+        self.assertEqual(payload["secret"], secret_status)
+
     def test_write_and_read_deployment_record(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -831,7 +831,8 @@ class RuntimeEnvironmentTests(unittest.TestCase):
             )
 
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("must be written with launchplane secrets put", result.output)
+        self.assertIn("must be written through product-config apply", result.output)
+        self.assertIn("secrets put --allow-direct-db-mutation", result.output)
         self.assertNotIn("secret-value", result.output)
 
     def test_environments_unset_removes_keys_without_echoing_values(self) -> None:


### PR DESCRIPTION
## Summary
- require `--allow-direct-db-mutation` before local `launchplane secrets put` writes shared managed-secret records
- restore fail-closed rejection for secret-shaped `environments put` keys and point users to product-config first
- update README and secrets docs so direct local secret writes are explicit bootstrap/repair only

## Plan Alignment
- Advances #1492 by closing another local direct-DB mutation path behind an explicit bootstrap/repair acknowledgement.
- Contributes to #1489 by removing stale guidance and tightening the final v2 retirement audit surface.

## Validation
- `uv run python -m unittest tests.test_runtime_environments.RuntimeEnvironmentTests.test_environments_put_rejects_secret_shaped_keys tests.test_postgres_store.PostgresRecordStoreTests.test_secrets_put_requires_direct_db_acknowledgement tests.test_postgres_store.PostgresRecordStoreTests.test_secrets_put_allows_explicit_bootstrap_repair`
- `uv run python -m unittest tests.test_runtime_environments tests.test_postgres_store`
- `uv run --extra dev ruff check control_plane/cli_storage_secrets.py control_plane/cli_runtime_environments.py tests/test_postgres_store.py tests/test_runtime_environments.py`
- `uv run --extra dev ruff format --check control_plane/cli_storage_secrets.py control_plane/cli_runtime_environments.py tests/test_postgres_store.py tests/test_runtime_environments.py`
- `uv run --extra dev mypy control_plane/cli_storage_secrets.py control_plane/cli_runtime_environments.py tests/test_postgres_store.py tests/test_runtime_environments.py`
- `git diff --check`

Review agents: GPT final review clean; Antigravity found stale runtime-env guidance, fixed in this PR.