### PR TITLE
Require acknowledgement for policy profile DB writes

### DIFF
--- a/control_plane/cli_policy_profiles.py
+++ b/control_plane/cli_policy_profiles.py
@@ -45,6 +45,11 @@ from control_plane.workflows.ship import utc_now_timestamp
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use the deployed service route or operator workflow for shared/production changes, "
+    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+)
 
 
 @dataclass(frozen=True)
@@ -89,6 +94,22 @@ def _launchplane_action_slug(value: str) -> str:
 
 def _post_launchplane_service_json(**kwargs: object) -> dict[str, object]:
     return _policy_profile_callbacks().post_launchplane_service_json(**kwargs)
+
+
+def _direct_db_mutation_acknowledgement_option(
+    function: Callable[..., object],
+) -> Callable[..., object]:
+    return click.option(
+        "--allow-direct-db-mutation",
+        is_flag=True,
+        default=False,
+        help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+    )(function)
+
+
+def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) -> None:
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
 
 
 def _build_authz_policy_record(
@@ -331,7 +352,14 @@ def authz_policies_list(database_url: str, status_filter: str) -> None:
     help="TOML policy file to import into DB-backed authz policy records.",
 )
 @click.option("--source-label", default="cli:import-toml", show_default=True)
-def authz_policies_import_toml(database_url: str, policy_file: Path, source_label: str) -> None:
+@_direct_db_mutation_acknowledgement_option
+def authz_policies_import_toml(
+    database_url: str,
+    policy_file: Path,
+    source_label: str,
+    allow_direct_db_mutation: bool,
+) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     record = _build_authz_policy_record(policy_file=policy_file, source_label=source_label)
@@ -835,6 +863,7 @@ def merge_train_policies_list(database_url: str, status_filter: str) -> None:
 )
 @click.option("--dry-run", "mode", flag_value="dry_run", default="dry_run")
 @click.option("--apply", "mode", flag_value="apply")
+@_direct_db_mutation_acknowledgement_option
 def merge_train_policies_import_policy(
     database_url: str,
     service_url: str,
@@ -846,6 +875,7 @@ def merge_train_policies_import_policy(
     reason: str,
     idempotency_key: str,
     mode: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
     record = _build_merge_train_policy_record(
         policy_file=policy_file,
@@ -881,6 +911,7 @@ def merge_train_policies_import_policy(
         raise click.ClickException("Direct database import requires --apply.")
     if not database_url.strip():
         raise click.ClickException("Provide --service-url or --database-url.")
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     try:
@@ -911,12 +942,15 @@ def merge_train_policies_import_policy(
 )
 @click.option("--status", type=click.Choice(["active", "superseded"]), default="active")
 @click.option("--source-label", default="cli:import-policy", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def runtime_key_safety_import_policy(
     database_url: str,
     policy_file: Path,
     status: RuntimeKeySafetyPolicyStatus,
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
     record = _build_runtime_key_safety_policy_record(
@@ -1117,6 +1151,7 @@ def product_profiles_audit_context_cutover(
 @click.option("--preview-slug-template", default="pr-{number}", show_default=True)
 @click.option("--updated-at", default="", help="Override updated timestamp.")
 @click.option("--source-label", default="cli:product-profiles:upsert", show_default=True)
+@_direct_db_mutation_acknowledgement_option
 def product_profiles_upsert(
     database_url: str,
     product: str,
@@ -1133,7 +1168,9 @@ def product_profiles_upsert(
     preview_slug_template: str,
     updated_at: str,
     source_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     try:
         record = LaunchplaneProductProfileRecord(
             product=product,

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -251,8 +251,8 @@ uv run launchplane merge-train-policies import-policy \
 
 The command reads the bearer token from `LAUNCHPLANE_SERVICE_TOKEN` unless a
 browser `--session-cookie` is supplied. Direct `--database-url --apply` import is
-reserved for local development and DB repair, not shared or production live
-mutation.
+reserved for local development and DB repair, requires
+`--allow-direct-db-mutation`, and is not for shared or production live mutation.
 
 For local development or DB repair only:
 
@@ -261,6 +261,7 @@ uv run launchplane merge-train-policies import-policy \
   --database-url "$LAUNCHPLANE_DATABASE_URL" \
   --policy-file path/to/merge-train-policy.toml \
   --source-label operator:update \
+  --allow-direct-db-mutation \
   --apply
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -346,7 +346,9 @@ uv run launchplane service render-authz-policy --policy-file ./bootstrap-policy.
 uv run launchplane service render-authz-policy \
   --policy-file ./bootstrap-policy.toml \
   --format b64
-uv run launchplane authz-policies import-toml --policy-file ./bootstrap-policy.toml
+uv run launchplane authz-policies import-toml \
+  --policy-file ./bootstrap-policy.toml \
+  --allow-direct-db-mutation
 ```
 
 When operators need to preview or apply an explicit emergency bootstrap policy to

--- a/docs/records.md
+++ b/docs/records.md
@@ -411,9 +411,11 @@ require the `product_profile.write` action for the target product in the
 Launchplane service context; reads use `product_profile.read`.
 
 For initial seed or repair work, operators can write the same DB-backed record
-directly with `uv run launchplane product-profiles upsert --database-url ...`.
-That command is an operator tool for creating the Launchplane record; it is not
-a repo-local manifest and should not become product repo authority.
+directly with
+`uv run launchplane product-profiles upsert --database-url ... --allow-direct-db-mutation`.
+That command is an explicit local/bootstrap repair tool for creating the
+Launchplane record; it is not a repo-local manifest and should not become
+product repo authority.
 
 ## Public Ingress Observation Records
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -2434,6 +2434,51 @@ class PostgresRecordStoreTests(unittest.TestCase):
             listed_records[0].policy.github_actions[0].repository, "cbusillo/launchplane"
         )
 
+    def test_authz_policy_import_allows_explicit_bootstrap_repair(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            policy_file = Path(temporary_directory_name) / "launchplane-authz.toml"
+            policy_file.write_text(
+                """
+schema_version = 1
+
+[[github_actions]]
+repository = "cbusillo/launchplane"
+workflow_refs = ["cbusillo/launchplane/.github/workflows/deploy-launchplane.yml@refs/heads/main"]
+event_names = ["workflow_dispatch"]
+products = ["launchplane"]
+contexts = ["launchplane"]
+actions = ["launchplane_service_deploy.execute"]
+""".strip(),
+                encoding="utf-8",
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "authz-policies",
+                    "import-toml",
+                    "--database-url",
+                    database_url,
+                    "--policy-file",
+                    str(policy_file),
+                    "--source-label",
+                    "test",
+                    "--allow-direct-db-mutation",
+                ],
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            listed_records = store.list_authz_policy_records(status="active", limit=1)
+            store.close()
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        self.assertEqual(len(listed_records), 1)
+        self.assertEqual(listed_records[0].source, "test")
+        self.assertEqual(
+            listed_records[0].policy.github_actions[0].repository, "cbusillo/launchplane"
+        )
+
     def test_runtime_key_safety_policy_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -2518,6 +2563,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     str(policy_file),
                     "--source-label",
                     "test",
+                    "--allow-direct-db-mutation",
                 ],
             )
             list_result = runner.invoke(
@@ -2555,6 +2601,39 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertIn('"count": 1', list_result.output)
         self.assertEqual(evaluate_result.exit_code, 0, evaluate_result.output)
         self.assertIn('"status": "pass"', evaluate_result.output)
+
+    def test_runtime_key_safety_import_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy_file = Path(temporary_directory_name) / "runtime-key-safety.json"
+            policy_file.write_text(
+                json.dumps(
+                    {
+                        "updated_at": "2026-05-05T20:00:00Z",
+                        "rules": [
+                            {
+                                "binding_key": "SHOPIFY_ACCESS_TOKEN",
+                                "secret_class": "testing",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "runtime-key-safety",
+                    "import-policy",
+                    "--database-url",
+                    "postgresql://launchplane:test@db/launchplane",
+                    "--policy-file",
+                    str(policy_file),
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
 
     def test_merge_train_policy_cli_imports_and_lists_policy(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2598,6 +2677,7 @@ env_var = "GH_TOKEN"
                     str(policy_file),
                     "--source-label",
                     "test",
+                    "--allow-direct-db-mutation",
                 ],
             )
             list_result = runner.invoke(
@@ -2618,6 +2698,70 @@ env_var = "GH_TOKEN"
         self.assertEqual(list_result.exit_code, 0, list_result.output)
         self.assertIn('"count": 1', list_result.output)
         self.assertIn('"cbusillo/codex-skills:main"', list_result.output)
+
+    def test_merge_train_policy_direct_import_requires_direct_db_acknowledgement(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy_file = Path(temporary_directory_name) / "merge-train-policy.toml"
+            policy_file.write_text(
+                """
+schema_version = 1
+
+[[policies]]
+repository = "cbusillo/codex-skills"
+base_branch = "main"
+enqueue_label = "ready-to-merge"
+blocked_label = "merge-blocked"
+merge_method = "merge"
+failure_policy = "pause_train"
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner"]
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+[policies.github_token]
+env_var = "GH_TOKEN"
+""".strip(),
+                encoding="utf-8",
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "merge-train-policies",
+                    "import-policy",
+                    "--database-url",
+                    "postgresql://launchplane:test@db/launchplane",
+                    "--apply",
+                    "--policy-file",
+                    str(policy_file),
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
+
+    def test_authz_policy_import_requires_direct_db_acknowledgement(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy_file = Path(temporary_directory_name) / "launchplane-authz.toml"
+            policy_file.write_text("schema_version = 1\n", encoding="utf-8")
+            result = CliRunner().invoke(
+                main,
+                [
+                    "authz-policies",
+                    "import-toml",
+                    "--database-url",
+                    "postgresql://launchplane:test@db/launchplane",
+                    "--policy-file",
+                    str(policy_file),
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
 
     def test_product_profile_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -2726,6 +2870,7 @@ env_var = "GH_TOKEN"
                     "2026-04-30T22:00:00Z",
                     "--source-label",
                     "test",
+                    "--allow-direct-db-mutation",
                 ],
             )
             self.assertEqual(upsert_result.exit_code, 0, upsert_result.output)
@@ -2761,6 +2906,33 @@ env_var = "GH_TOKEN"
         self.assertIn('"preview_enable_label": "preview"', list_result.output)
         self.assertIn('"enable_label": "preview"', show_result.output)
         self.assertIn('"health_path": "/api/health"', show_result.output)
+
+    def test_product_profiles_upsert_requires_direct_db_acknowledgement(self) -> None:
+        result = CliRunner().invoke(
+            main,
+            [
+                "product-profiles",
+                "upsert",
+                "--database-url",
+                "postgresql://launchplane:test@db/launchplane",
+                "--product",
+                "sellyouroutboard",
+                "--display-name",
+                "SellYourOutboard.com",
+                "--repository",
+                "cbusillo/sellyouroutboard",
+                "--image-repository",
+                "ghcr.io/cbusillo/sellyouroutboard",
+                "--runtime-port",
+                "3000",
+                "--health-path",
+                "/api/health",
+            ],
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
 
     def test_preview_lifecycle_plan_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- require `--allow-direct-db-mutation` for direct local DB policy/profile writes
- keep service-backed merge-train policy import outside the acknowledgement path
- update operator docs and records docs so local direct writes are explicit seed/repair only

## Validation
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_authz_policy_import_allows_explicit_bootstrap_repair tests.test_postgres_store.PostgresRecordStoreTests.test_authz_policy_import_requires_direct_db_acknowledgement tests.test_postgres_store.PostgresRecordStoreTests.test_runtime_key_safety_cli_imports_lists_and_evaluates_policy tests.test_postgres_store.PostgresRecordStoreTests.test_runtime_key_safety_import_requires_direct_db_acknowledgement tests.test_postgres_store.PostgresRecordStoreTests.test_merge_train_policy_cli_imports_and_lists_policy tests.test_postgres_store.PostgresRecordStoreTests.test_merge_train_policy_direct_import_requires_direct_db_acknowledgement tests.test_postgres_store.PostgresRecordStoreTests.test_product_profiles_cli_upserts_lists_and_shows_records tests.test_postgres_store.PostgresRecordStoreTests.test_product_profiles_upsert_requires_direct_db_acknowledgement`
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_product_profiles_cli_upserts_lists_and_shows_records tests.test_postgres_store.PostgresRecordStoreTests.test_product_profiles_upsert_requires_direct_db_acknowledgement tests.test_postgres_store.PostgresRecordStoreTests.test_authz_policy_import_allows_explicit_bootstrap_repair tests.test_postgres_store.PostgresRecordStoreTests.test_authz_policy_import_requires_direct_db_acknowledgement tests.test_merge_train_policy`
- `uv run --extra dev ruff check --diff control_plane/cli_policy_profiles.py tests/test_postgres_store.py`
- `uv run --extra dev ruff check control_plane/cli_policy_profiles.py tests/test_postgres_store.py`
- `uv run --extra dev ruff format --check control_plane/cli_policy_profiles.py tests/test_postgres_store.py`
- `uv run --extra dev mypy control_plane/cli_policy_profiles.py tests/test_postgres_store.py`
- `git diff --check`

## Review
- Auto Review: no findings for current checkout
- Antigravity review: found missing authz success coverage; fixed with `test_authz_policy_import_allows_explicit_bootstrap_repair`
- Final GPT review against isolated worktree: no blockers

Refs #1492
Refs #1489
