### PR TITLE
Remove unused driver route aliases

### DIFF
--- a/control_plane/contracts/driver_descriptor.py
+++ b/control_plane/contracts/driver_descriptor.py
@@ -41,16 +41,6 @@ class DriverActionDescriptor(BaseModel):
     writes_records: tuple[str, ...] = ()
 
 
-class DriverRouteAliasDescriptor(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    action_id: str
-    route_path: str
-    method: Literal["GET", "POST"] = "POST"
-    authz_action: str
-    operator_visible: bool = False
-
-
 class DriverCapabilityDescriptor(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -85,7 +75,6 @@ class DriverDescriptor(BaseModel):
     provider_boundary: str
     capabilities: tuple[DriverCapabilityDescriptor, ...] = ()
     actions: tuple[DriverActionDescriptor, ...] = ()
-    route_aliases: tuple[DriverRouteAliasDescriptor, ...] = ()
     setting_groups: tuple[DriverSettingGroupDescriptor, ...] = ()
 
 

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -15,7 +15,6 @@ from control_plane.contracts.driver_descriptor import (
     DriverCapabilityDescriptor,
     DriverContextView,
     DriverDescriptor,
-    DriverRouteAliasDescriptor,
     DriverSettingGroupDescriptor,
     DriverView,
 )
@@ -280,22 +279,6 @@ def _action(
         alternate_authz_actions=alternate_authz_actions,
         operator_visible=operator_visible,
         writes_records=writes_records,
-    )
-
-
-def _route_alias(
-    action_id: str,
-    route_path: str,
-    authz_action: str,
-    *,
-    method: Literal["GET", "POST"] = "POST",
-) -> DriverRouteAliasDescriptor:
-    return DriverRouteAliasDescriptor(
-        action_id=action_id,
-        route_path=route_path,
-        method=method,
-        authz_action=authz_action,
-        operator_visible=False,
     )
 
 

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -520,23 +520,6 @@ def _driver_route_metadata_from_descriptors() -> dict[str, _DriverRouteMetadata]
                 authz_action=action.authz_action,
                 operator_visible=action.operator_visible,
             )
-        for route_alias in descriptor.route_aliases:
-            if not route_alias.route_path.startswith("/v1/drivers/"):
-                continue
-            if not route_alias.authz_action:
-                raise ValueError(
-                    f"Driver route alias {descriptor.driver_id}.{route_alias.action_id} "
-                    "must declare authz_action."
-                )
-            if route_alias.route_path in route_metadata:
-                raise ValueError(f"Duplicate driver action route path: {route_alias.route_path}")
-            route_metadata[route_alias.route_path] = _DriverRouteMetadata(
-                driver_id=descriptor.driver_id,
-                action_id=route_alias.action_id,
-                method=route_alias.method,
-                authz_action=route_alias.authz_action,
-                operator_visible=route_alias.operator_visible,
-            )
     return route_metadata
 
 

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -448,8 +448,8 @@ them without parsing free-form descriptions. Some service callback routes, such
 as verification writeback routes, are declared with `operator_visible=false`;
 they remain in the driver route authorization map but are not surfaced as
 operator actions. Compatibility routes that should remain callable but not
-advertised as current driver actions belong in `route_aliases` with
-`operator_visible=false`.
+advertised as current driver actions require an issue-backed bridge and removal
+condition; descriptors no longer carry a separate route-alias catalog.
 Native FastAPI product-driver POST routes read authorization actions from
 descriptor route metadata, so new drivers do not need a second hardcoded
 authz-action entry.
@@ -461,13 +461,13 @@ topology. OpenFGA does not make an advertised action executable by itself;
 backend handler registration, route dispatch, and fail-closed service
 authorization still have to agree.
 
-POST driver descriptor actions and route aliases execute through native FastAPI
-routes. The service validates this at startup, so adding a writable descriptor
-route without registering a matching native FastAPI route fails closed instead
-of silently advertising an unimplemented action. This keeps descriptor metadata
-as the route/authz source of truth while preventing an advertised descriptor
-action from becoming executable without implementation. Descriptor route
-metadata and service compatibility policy also drive
+POST driver descriptor actions execute through native FastAPI routes. The
+service validates this at startup, so adding a writable descriptor route without
+registering a matching native FastAPI route fails closed instead of silently
+advertising an unimplemented action. This keeps descriptor metadata as the
+route/authz source of truth while preventing an advertised descriptor action
+from becoming executable without implementation. Descriptor route metadata and
+service compatibility policy also drive
 product-driver compatibility checks. A
 product whose descriptor names a `base_driver_id` can use the base driver's
 shared lifecycle routes when its profile owns the requested stable lane or

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -199,9 +199,6 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     def test_odoo_descriptor_marks_prod_rollback_as_destructive(self) -> None:
         descriptor = read_driver_descriptor("odoo")
         actions = {action.action_id: action for action in descriptor.actions}
-        route_aliases = {
-            route_alias.action_id: route_alias for route_alias in descriptor.route_aliases
-        }
 
         self.assertEqual(descriptor.base_driver_id, "generic-web")
         self.assertEqual(actions["prod_backup_gate"].safety, "safe_write")
@@ -210,15 +207,7 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertEqual(actions["prod_rollback"].safety, "destructive")
         self.assertEqual(actions["prod_rollback"].route_path, "/v1/drivers/odoo/prod-rollback")
         self.assertNotIn("preview_refresh", actions)
-        self.assertNotIn("preview_refresh", route_aliases)
-        self.assertNotIn("preview_destroy", route_aliases)
-        self.assertNotIn("preview_desired_state", route_aliases)
-        self.assertNotIn("preview_inventory", route_aliases)
-        self.assertNotIn("preview_readiness", route_aliases)
         self.assertNotIn("preview_verification", actions)
-        self.assertNotIn("preview_verification", route_aliases)
-        self.assertNotIn("stable_verification", route_aliases)
-        self.assertNotIn("prod_rollback_plan", route_aliases)
         self.assertEqual(actions["stable_bootstrap"].safety, "destructive")
         self.assertEqual(
             actions["stable_bootstrap"].route_path,
@@ -404,19 +393,6 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             for action in descriptor.actions
             if action.method == "POST" and action.route_path.startswith("/v1/drivers/")
         }
-        descriptor_post_route_metadata.update(
-            {
-                route_alias.route_path: (
-                    descriptor.driver_id,
-                    route_alias.action_id,
-                    route_alias.authz_action,
-                )
-                for descriptor in list_driver_descriptors()
-                for route_alias in descriptor.route_aliases
-                if route_alias.method == "POST"
-                and route_alias.route_path.startswith("/v1/drivers/")
-            }
-        )
         service_route_metadata = control_plane_service._driver_route_metadata_from_descriptors()
 
         self.assertTrue(descriptor_post_route_metadata)


### PR DESCRIPTION
## Summary
- remove unused driver route-alias descriptor machinery
- keep descriptor-backed native `/v1/drivers/...` action validation intact
- update driver descriptor docs to require issue-backed bridges rather than route-alias metadata

## Validation
- `uv run python -m unittest tests.test_driver_descriptors`
- `uv run --extra dev ruff check --diff control_plane/contracts/driver_descriptor.py control_plane/drivers/registry.py control_plane/service.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff check control_plane/contracts/driver_descriptor.py control_plane/drivers/registry.py control_plane/service.py tests/test_driver_descriptors.py`
- `uv run --extra dev ruff format --check control_plane/contracts/driver_descriptor.py control_plane/drivers/registry.py control_plane/service.py tests/test_driver_descriptors.py`
- `uv run --extra dev mypy control_plane/contracts/driver_descriptor.py control_plane/drivers/registry.py control_plane/service.py tests/test_driver_descriptors.py`
- `git diff --check`

Note: I attempted a stale `tests.test_http_app_core.FastApiServiceStartupTests...` target; that class no longer exists. The actual descriptor startup validation tests are in `tests.test_driver_descriptors`, and that module passed.

## Review
- GPT review: no blockers
- Antigravity review: no blockers
- Auto Review: no actionable findings in ledger

Refs #1489
