### PR TITLE
Guard core record DB write CLIs

### DIFF
--- a/control_plane/cli_records.py
+++ b/control_plane/cli_records.py
@@ -19,6 +19,11 @@ from control_plane.storage.postgres import PostgresRecordStore
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
+_DIRECT_DB_MUTATION_MESSAGE = (
+    "Direct local DB mutation is restricted after the Launchplane service boundary. "
+    "Use the deployed service route or operator workflow for shared/production changes, "
+    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+)
 
 
 @dataclass(frozen=True)
@@ -63,8 +68,11 @@ def _store(
     return _records_callbacks().store_factory(state_dir, database_url=database_url)
 
 
-def _resolve_record_mutation_database_url(
-    *, database_url: str, local_rehearsal: bool, command_label: str
+def _resolve_record_execution_database_url(
+    *,
+    database_url: str,
+    local_rehearsal: bool,
+    command_label: str,
 ) -> str | None:
     if local_rehearsal:
         return None
@@ -83,6 +91,39 @@ def _resolve_record_mutation_database_url(
     return normalized_database_url
 
 
+def _resolve_record_mutation_database_url(
+    *,
+    database_url: str,
+    local_rehearsal: bool,
+    command_label: str,
+    allow_direct_db_mutation: bool,
+) -> str | None:
+    normalized_database_url = _resolve_record_execution_database_url(
+        database_url=database_url,
+        local_rehearsal=local_rehearsal,
+        command_label=command_label,
+    )
+    if normalized_database_url is not None:
+        _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
+    return normalized_database_url
+
+
+def _direct_db_mutation_acknowledgement_option(
+    function: Callable[..., object],
+) -> Callable[..., object]:
+    return click.option(
+        "--allow-direct-db-mutation",
+        is_flag=True,
+        default=False,
+        help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+    )(function)
+
+
+def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) -> None:
+    if not allow_direct_db_mutation:
+        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
+
+
 def _load_json_file(input_file: Path) -> dict[str, object]:
     return _records_callbacks().load_json_file(input_file)
 
@@ -99,8 +140,13 @@ def artifacts() -> None:
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
+@_direct_db_mutation_acknowledgement_option
 def artifacts_write(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    input_file: Path,
+    allow_direct_db_mutation: bool,
 ) -> None:
     _write_artifact_manifest_command(
         state_dir=state_dir,
@@ -108,6 +154,7 @@ def artifacts_write(
         local_rehearsal=local_rehearsal,
         input_file=input_file,
         command_label="artifacts write",
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
 
 
@@ -129,8 +176,13 @@ def artifacts_show(state_dir: Path, database_url: str, artifact_id: str) -> None
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
+@_direct_db_mutation_acknowledgement_option
 def artifacts_ingest(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    input_file: Path,
+    allow_direct_db_mutation: bool,
 ) -> None:
     _write_artifact_manifest_command(
         state_dir=state_dir,
@@ -138,6 +190,7 @@ def artifacts_ingest(
         local_rehearsal=local_rehearsal,
         input_file=input_file,
         command_label="artifacts ingest",
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
 
 
@@ -156,7 +209,7 @@ def artifacts_protected(
     product_name: str,
     context_name: str,
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
+    execution_database_url = _resolve_record_execution_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
         command_label="artifacts protected",
@@ -176,11 +229,13 @@ def _write_artifact_manifest_command(
     local_rehearsal: bool,
     input_file: Path,
     command_label: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_record_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
         command_label=command_label,
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     manifest = ArtifactIdentityManifest.model_validate(_load_json_file(input_file))
     record_path = _store(state_dir, database_url=execution_database_url).write_artifact_manifest(
@@ -251,13 +306,19 @@ def release_tuples_export_catalog(
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
+@_direct_db_mutation_acknowledgement_option
 def release_tuples_write_from_promotion(
-    state_dir: Path, database_url: str, local_rehearsal: bool, record_id: str
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    record_id: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_record_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
         command_label="release-tuples write-from-promotion",
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     record_store = _store(state_dir, database_url=execution_database_url)
     promotion_record = record_store.read_promotion_record(record_id)
@@ -306,13 +367,19 @@ def backup_gates() -> None:
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
+@_direct_db_mutation_acknowledgement_option
 def backup_gates_write(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    input_file: Path,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_record_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
         command_label="backup-gates write",
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     record = BackupGateRecord.model_validate(_load_json_file(input_file))
     record_path = _store(state_dir, database_url=execution_database_url).write_backup_gate_record(
@@ -369,13 +436,19 @@ def promotions() -> None:
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
+@_direct_db_mutation_acknowledgement_option
 def promotions_write(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    input_file: Path,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_record_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
         command_label="promotions write",
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     record = PromotionRecord.model_validate(_load_json_file(input_file))
     record_path = _store(state_dir, database_url=execution_database_url).write_promotion_record(
@@ -439,13 +512,19 @@ def deployments() -> None:
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
+@_direct_db_mutation_acknowledgement_option
 def deployments_write(
-    state_dir: Path, database_url: str, local_rehearsal: bool, input_file: Path
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    input_file: Path,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_record_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
         command_label="deployments write",
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     record = DeploymentRecord.model_validate(_load_json_file(input_file))
     record_path = _store(state_dir, database_url=execution_database_url).write_deployment_record(
@@ -502,13 +581,19 @@ def inventory() -> None:
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
+@_direct_db_mutation_acknowledgement_option
 def inventory_write_from_deployment(
-    state_dir: Path, database_url: str, local_rehearsal: bool, record_id: str
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    record_id: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_record_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
         command_label="inventory write-from-deployment",
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     record_store = _store(state_dir, database_url=execution_database_url)
     deployment_record = record_store.read_deployment_record(record_id)
@@ -526,13 +611,19 @@ def inventory_write_from_deployment(
 @click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
+@_direct_db_mutation_acknowledgement_option
 def inventory_write_from_promotion(
-    state_dir: Path, database_url: str, local_rehearsal: bool, record_id: str
+    state_dir: Path,
+    database_url: str,
+    local_rehearsal: bool,
+    record_id: str,
+    allow_direct_db_mutation: bool,
 ) -> None:
     execution_database_url = _resolve_record_mutation_database_url(
         database_url=database_url,
         local_rehearsal=local_rehearsal,
         command_label="inventory write-from-promotion",
+        allow_direct_db_mutation=allow_direct_db_mutation,
     )
     record_store = _store(state_dir, database_url=execution_database_url)
     promotion_record = record_store.read_promotion_record(record_id)

--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -18,9 +18,9 @@ _PROVIDER_TARGET_BACKFILL_APPLY_RETIRED_MESSAGE = (
 )
 _DIRECT_DB_MUTATION_MESSAGE = (
     "Direct local DB mutation is restricted after the Launchplane service boundary. "
-    "Use product-config apply through the deployed service route or operator workflow "
-    "for shared/production secret writes, or pass --allow-direct-db-mutation only "
-    "for explicit local/bootstrap repair."
+    "Use the deployed service route or operator workflow for shared/production "
+    "core-record or secret writes, or pass --allow-direct-db-mutation only for "
+    "explicit local/bootstrap repair."
 )
 
 
@@ -69,7 +69,16 @@ def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) 
     required=True,
     help="Postgres connection string for Launchplane shared-service core records.",
 )
-def storage_import_core_records(state_dir: Path, database_url: str) -> None:
+@click.option(
+    "--allow-direct-db-mutation",
+    is_flag=True,
+    default=False,
+    help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+)
+def storage_import_core_records(
+    state_dir: Path, database_url: str, allow_direct_db_mutation: bool
+) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     filesystem_store = FilesystemRecordStore(state_dir=state_dir)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()

--- a/docs/records.md
+++ b/docs/records.md
@@ -15,6 +15,13 @@ title: Records
   current baseline revision captures the SQLAlchemy ORM schema that earlier
   deployments created through `create_all`; future GUI/write-flow schema changes
   need explicit migrations instead of relying on implicit table creation.
+- Treat local core-record DB writes as explicit bootstrap/repair only. Direct
+  `artifacts`, `backup-gates`, `promotions`, `deployments`, `inventory`,
+  `release-tuples write-from-promotion`, and `storage import-core-records`
+  mutations require `--allow-direct-db-mutation`; routine shared/live changes
+  should use the deployed Launchplane service route or operator workflow.
+- Direct managed-secret writes through `secrets put` follow the same
+  `--allow-direct-db-mutation` bootstrap/repair boundary.
 - Keep git history separate from operational history.
 - Favor append-style writes for promotion records.
 

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1413,6 +1413,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                     "write",
                     "--database-url",
                     database_url,
+                    "--allow-direct-db-mutation",
                     "--input-file",
                     str(input_path),
                 ],
@@ -1928,6 +1929,7 @@ class PostgresRecordStoreTests(unittest.TestCase):
                         temporary_directory_name,
                         "--database-url",
                         "postgresql://launchplane:test@db/launchplane",
+                        "--allow-direct-db-mutation",
                     ],
                 )
 
@@ -1938,6 +1940,21 @@ class PostgresRecordStoreTests(unittest.TestCase):
         postgres_store.ensure_schema.assert_called_once_with()
         postgres_store.import_core_records_from_filesystem.assert_called_once()
         self.assertIn('"deployments": 1', result.output)
+
+    def test_storage_import_core_records_requires_direct_db_acknowledgement(self) -> None:
+        result = CliRunner().invoke(
+            main,
+            [
+                "storage",
+                "import-core-records",
+                "--database-url",
+                "postgresql://launchplane:test@db/launchplane",
+            ],
+        )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Direct local DB mutation is restricted", result.output)
+        self.assertIn("--allow-direct-db-mutation", result.output)
 
     def test_secrets_put_requires_direct_db_acknowledgement(self) -> None:
         result = CliRunner().invoke(

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -2520,6 +2520,54 @@ DOKPLOY_SHIP_MODE = "auto"
             self.assertNotEqual(result.exit_code, 0)
             self.assertIn("deployments write requires --database-url", result.output)
 
+    def test_core_record_writes_require_direct_db_acknowledgement(self) -> None:
+        runner = CliRunner()
+        with TemporaryDirectory() as temporary_directory_name:
+            input_file = Path(temporary_directory_name) / "record.json"
+            input_file.write_text("{}", encoding="utf-8")
+            command_cases = (
+                ("artifacts write", ["artifacts", "write", "--input-file", str(input_file)]),
+                ("artifacts ingest", ["artifacts", "ingest", "--input-file", str(input_file)]),
+                (
+                    "release-tuples write-from-promotion",
+                    ["release-tuples", "write-from-promotion", "--record-id", "promotion-1"],
+                ),
+                (
+                    "backup-gates write",
+                    ["backup-gates", "write", "--input-file", str(input_file)],
+                ),
+                (
+                    "promotions write",
+                    ["promotions", "write", "--input-file", str(input_file)],
+                ),
+                (
+                    "deployments write",
+                    ["deployments", "write", "--input-file", str(input_file)],
+                ),
+                (
+                    "inventory write-from-deployment",
+                    ["inventory", "write-from-deployment", "--record-id", "deployment-1"],
+                ),
+                (
+                    "inventory write-from-promotion",
+                    ["inventory", "write-from-promotion", "--record-id", "promotion-1"],
+                ),
+            )
+            for command_label, command in command_cases:
+                with self.subTest(command=command_label):
+                    result = runner.invoke(
+                        main,
+                        [
+                            *command,
+                            "--database-url",
+                            "postgresql://launchplane:test@db/launchplane",
+                        ],
+                    )
+
+                    self.assertNotEqual(result.exit_code, 0)
+                    self.assertIn("Direct local DB mutation is restricted", result.output)
+                    self.assertIn("--allow-direct-db-mutation", result.output)
+
     def test_promotions_write_persists_record(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- require explicit --allow-direct-db-mutation for core record write/import CLIs when they use a DB URL
- keep local rehearsal and read/report commands unguarded, including provider-target report mode
- document the bootstrap/repair boundary for core record and managed-secret local writes

## Validation
- uv run python -m unittest tests.test_promote.PromoteCliTests.test_core_record_writes_require_direct_db_acknowledgement tests.test_postgres_store.PostgresRecordStoreTests.test_storage_import_core_records_command_reports_counts tests.test_postgres_store.PostgresRecordStoreTests.test_storage_import_core_records_requires_direct_db_acknowledgement tests.test_postgres_store.PostgresRecordStoreTests.test_secrets_put_requires_direct_db_acknowledgement
- uv run python -m unittest tests.test_promote.PromoteCliTests tests.test_postgres_store.PostgresRecordStoreTests
- uv run --extra dev ruff check --diff control_plane/cli_records.py control_plane/cli_storage_secrets.py tests/test_promote.py tests/test_postgres_store.py docs/records.md
- uv run --extra dev ruff check control_plane/cli_records.py control_plane/cli_storage_secrets.py tests/test_promote.py tests/test_postgres_store.py docs/records.md
- uv run --extra dev ruff format --check control_plane/cli_records.py control_plane/cli_storage_secrets.py tests/test_promote.py tests/test_postgres_store.py
- uv run --extra dev mypy control_plane/cli_records.py control_plane/cli_storage_secrets.py tests/test_promote.py tests/test_postgres_store.py
- git diff --check

## Review
- code-gpt-5.5 review agent: no blockers, high confidence
- Antigravity review agent: core guard correct; docs/message follow-up applied

Closes part of #1492; updates #1489 evidence.