### PR TITLE
Remove provider-target backfill CLI apply flag

### DIFF
--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -11,11 +11,6 @@ from control_plane.workflows.provider_target_backfill import backfill_provider_t
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
-_PROVIDER_TARGET_BACKFILL_APPLY_RETIRED_MESSAGE = (
-    "Local provider-target backfill apply is retired. Use the deployed "
-    "Launchplane service route POST /v1/provider-targets/operations or the "
-    "Provider Target Operations workflow for shared/live writes."
-)
 _DIRECT_DB_MUTATION_MESSAGE = (
     "Direct local DB mutation is restricted after the Launchplane service boundary. "
     "Use the deployed service route or operator workflow for shared/production "
@@ -125,24 +120,15 @@ def storage_provider_target_audit(
     required=True,
     help="Postgres connection string for Launchplane provider-target records.",
 )
-@click.option(
-    "--apply",
-    "apply_changes",
-    is_flag=True,
-    help="Retired local write path; use Provider Target Operations instead.",
-)
 @click.option("--provider-id", default="", help="Optional provider id filter.")
 @click.option("--context", "context_name", default="", help="Optional context filter.")
 @click.option("--instance", "instance_name", default="", help="Optional instance filter.")
 def storage_provider_target_backfill(
     database_url: str,
-    apply_changes: bool,
     provider_id: str,
     context_name: str,
     instance_name: str,
 ) -> None:
-    if apply_changes:
-        raise click.ClickException(_PROVIDER_TARGET_BACKFILL_APPLY_RETIRED_MESSAGE)
     postgres_store = PostgresRecordStore(database_url=database_url)
     try:
         postgres_store.ensure_schema()

--- a/control_plane/workflows/provider_target_backfill.py
+++ b/control_plane/workflows/provider_target_backfill.py
@@ -87,9 +87,7 @@ class ProviderTargetBackfillResult(BaseModel):
             "blocked_count": self.blocked_count,
             "warning_count": self.warning_count,
             "counts": self.counts,
-            "items": [
-                item.model_dump(mode="json", exclude_none=True) for item in self.items
-            ],
+            "items": [item.model_dump(mode="json", exclude_none=True) for item in self.items],
         }
 
 
@@ -117,9 +115,7 @@ def backfill_provider_targets(
         for record in record_store.list_dokploy_target_id_records()
     }
     route_keys = sorted(
-        physical_records.keys()
-        | dokploy_target_records.keys()
-        | dokploy_target_id_records.keys()
+        physical_records.keys() | dokploy_target_records.keys() | dokploy_target_id_records.keys()
     )
     items: list[ProviderTargetBackfillItem] = []
     inspected_route_count = 0
@@ -139,7 +135,7 @@ def backfill_provider_targets(
         ):
             continue
         inspected_route_count += 1
-        item, write_candidate = _plan_backfill_route(
+        item = _plan_backfill_route(
             context=context,
             instance=instance,
             physical_record=physical_record,
@@ -161,9 +157,7 @@ def backfill_provider_targets(
             )
         )
     if apply and not any(item.severity == "blocked" for item in items):
-        conditional_create = getattr(
-            record_store, "create_provider_target_record_if_absent", None
-        )
+        conditional_create = getattr(record_store, "create_provider_target_record_if_absent", None)
         applied_items: list[ProviderTargetBackfillItem] = []
         for item in items:
             if item.status != "would-create":
@@ -242,19 +236,16 @@ def _plan_backfill_route(
     physical_record: ProviderTargetRecord | None,
     target_record: DokployTargetRecord | None,
     target_id_record: DokployTargetIdRecord | None,
-) -> tuple[ProviderTargetBackfillItem, ProviderTargetRecord | None]:
+) -> ProviderTargetBackfillItem:
     if physical_record is not None and physical_record.provider_id != "dokploy":
-        return (
-            _item(
-                context=context,
-                instance=instance,
-                status="unsupported-provider",
-                severity="warning",
-                detail="explicit provider-target row is not managed by Dokploy backfill",
-                provider_id=physical_record.provider_id,
-                physical_record=physical_record,
-            ),
-            None,
+        return _item(
+            context=context,
+            instance=instance,
+            status="unsupported-provider",
+            severity="warning",
+            detail="explicit provider-target row is not managed by Dokploy backfill",
+            provider_id=physical_record.provider_id,
+            physical_record=physical_record,
         )
     if target_record is None or target_id_record is None:
         missing_parts = []
@@ -265,57 +256,45 @@ def _plan_backfill_route(
         severity: ProviderTargetBackfillSeverity = (
             "blocked" if physical_record is not None else "warning"
         )
-        return (
-            _item(
-                context=context,
-                instance=instance,
-                status="skipped-incomplete",
-                severity=severity,
-                detail="Dokploy route is incomplete; missing " + ", ".join(missing_parts),
-                physical_record=physical_record,
-            ),
-            None,
+        return _item(
+            context=context,
+            instance=instance,
+            status="skipped-incomplete",
+            severity=severity,
+            detail="Dokploy route is incomplete; missing " + ", ".join(missing_parts),
+            physical_record=physical_record,
         )
     projected_record = ProviderTargetRecord.from_dokploy_records(
         target_record=target_record,
         target_id_record=target_id_record,
     )
     if physical_record is None:
-        return (
-            _item(
-                context=context,
-                instance=instance,
-                status="would-create",
-                severity="ok",
-                detail="would create explicit provider-target row",
-                projected_record=projected_record,
-            ),
-            projected_record,
-        )
-    if _authority_payload(physical_record) == _authority_payload(projected_record):
-        return (
-            _item(
-                context=context,
-                instance=instance,
-                status="skipped-exists",
-                severity="ok",
-                detail="explicit provider-target row already matches the Dokploy projection",
-                physical_record=physical_record,
-                projected_record=projected_record,
-            ),
-            None,
-        )
-    return (
-        _item(
+        return _item(
             context=context,
             instance=instance,
-            status="skipped-conflict",
-            severity="blocked",
-            detail="existing provider-target row differs from the Dokploy projection",
+            status="would-create",
+            severity="ok",
+            detail="would create explicit provider-target row",
+            projected_record=projected_record,
+        )
+    if _authority_payload(physical_record) == _authority_payload(projected_record):
+        return _item(
+            context=context,
+            instance=instance,
+            status="skipped-exists",
+            severity="ok",
+            detail="explicit provider-target row already matches the Dokploy projection",
             physical_record=physical_record,
             projected_record=projected_record,
-        ),
-        None,
+        )
+    return _item(
+        context=context,
+        instance=instance,
+        status="skipped-conflict",
+        severity="blocked",
+        detail="existing provider-target row differs from the Dokploy projection",
+        physical_record=physical_record,
+        projected_record=projected_record,
     )
 
 

--- a/tests/test_provider_target_backfill.py
+++ b/tests/test_provider_target_backfill.py
@@ -371,7 +371,7 @@ class ProviderTargetBackfillTests(unittest.TestCase):
         self.assertEqual(dry_run_payload["counts"], {"would-create": 1})
         self.assertEqual(physical_records, ())
 
-    def test_cli_apply_is_retired_before_writing(self) -> None:
+    def test_cli_rejects_apply_option_before_writing(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
             database_url = _sqlite_database_url(database_path)
@@ -395,22 +395,20 @@ class ProviderTargetBackfillTests(unittest.TestCase):
             physical_records = store.list_physical_provider_target_records()
             store.close()
 
-        self.assertEqual(result.exit_code, 1, result.output)
-        self.assertIn("Local provider-target backfill apply is retired", result.output)
+        self.assertEqual(result.exit_code, 2, result.output)
+        self.assertIn("No such option", result.output)
+        self.assertIn("--apply", result.output)
         self.assertEqual(physical_records, ())
 
-    def test_cli_help_points_apply_to_provider_target_operations(self) -> None:
+    def test_cli_help_describes_report_only_mode(self) -> None:
         result = CliRunner().invoke(
             main,
             ["storage", "provider-target-backfill", "--help"],
         )
 
         self.assertEqual(result.exit_code, 0, result.output)
-        normalized_output = " ".join(result.output.split())
-        self.assertIn(
-            "Retired local write path; use Provider Target Operations instead",
-            normalized_output,
-        )
+        self.assertNotIn("--apply", result.output)
+        self.assertIn("--provider-id", result.output)
 
     def test_cli_dry_run_exits_nonzero_on_conflicts(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- remove the retired local storage provider-target-backfill --apply option
- keep the local provider-target backfill CLI report-only
- preserve service-route backfill-apply by keeping backfill_provider_targets(apply=True) for Provider Target Operations
- simplify the provider-target backfill planner return type by removing an unused write candidate

## Validation
- uv run python -m unittest tests.test_provider_target_backfill tests.test_service.LaunchplaneServiceTests.test_provider_target_operation_endpoint_backfills_route
- uv run --extra dev ruff check --diff control_plane/cli_storage_secrets.py control_plane/workflows/provider_target_backfill.py tests/test_provider_target_backfill.py
- uv run --extra dev ruff check control_plane/cli_storage_secrets.py control_plane/workflows/provider_target_backfill.py tests/test_provider_target_backfill.py
- uv run --extra dev ruff format --check control_plane/cli_storage_secrets.py control_plane/workflows/provider_target_backfill.py tests/test_provider_target_backfill.py
- uv run --extra dev mypy control_plane/cli_storage_secrets.py control_plane/workflows/provider_target_backfill.py tests/test_provider_target_backfill.py
- git diff --check

## Review
- code-gpt-5.5 review agents: no blockers, high confidence
- Claude review agents: no blockers, high confidence
- Antigravity review agent: no blockers, high confidence

Refs #1492
Refs #1489