### PR TITLE
Keep rendered promotion recipes local-only

### DIFF
--- a/control_plane/launchplane_rendering.py
+++ b/control_plane/launchplane_rendering.py
@@ -108,7 +108,7 @@ def build_launchplane_action_script(
 ) -> str:
     lines = [
         "# Local rehearsal only. Shared/live mutations must use the deployed "
-        "Launchplane service API or DB-backed operator flows.",
+        "Launchplane service API or operator workflow.",
         'STATE_DIR="/path/to/local-state"',
     ]
     for variable_name, file_path, payload in file_payloads:
@@ -339,7 +339,7 @@ def build_launchplane_backup_gate_write_recipe_script(
     }
     lines = [
         "# Local rehearsal only. Shared/live mutations must use the deployed "
-        "Launchplane service API or DB-backed operator flows.",
+        "Launchplane service API or operator workflow.",
         'STATE_DIR="/path/to/local-state"',
         'BACKUP_GATE_FILE="/tmp/launchplane-backup-gate.json"',
         "cat >\"$BACKUP_GATE_FILE\" <<'JSON'",
@@ -353,11 +353,11 @@ def build_launchplane_backup_gate_write_recipe_script(
 def build_launchplane_promotion_execute_recipe_script(*, state_dir: str) -> str:
     return "\n".join(
         (
-            "# DB-backed execution authority. For offline rehearsal only, replace --database-url with --local-rehearsal.",
-            'LAUNCHPLANE_DATABASE_URL="postgresql+psycopg://..."',
+            "# Local rehearsal only. Shared/live promotion execution must use "
+            "the deployed Launchplane service API or operator workflow.",
             f'STATE_DIR="{state_dir or "/path/to/runtime"}"',
             'PROMOTION_REQUEST_FILE="/tmp/launchplane-promotion-request.json"',
-            'uv run launchplane promote execute --database-url "$LAUNCHPLANE_DATABASE_URL" --allow-direct-db-mutation --state-dir "$STATE_DIR" --input-file "$PROMOTION_REQUEST_FILE"',
+            'uv run launchplane promote execute --local-rehearsal --state-dir "$STATE_DIR" --input-file "$PROMOTION_REQUEST_FILE"',
         )
     )
 
@@ -372,13 +372,13 @@ def build_launchplane_environment_ship_recipe_script(
     request_file = f"/tmp/launchplane-{context_name}-{instance_name}-ship-request.json"
     return "\n".join(
         (
-            "# DB-backed execution authority. For offline rehearsal only, replace --database-url with --local-rehearsal.",
-            'LAUNCHPLANE_DATABASE_URL="postgresql+psycopg://..."',
+            "# Local rehearsal only. Shared/live ship execution must use "
+            "the deployed Launchplane service API or operator workflow.",
             'STATE_DIR="/path/to/runtime"',
             f'SHIP_REQUEST_FILE="{request_file}"',
             f'uv run launchplane ship resolve --context "{context_name}" --instance "{instance_name}" --artifact-id "{artifact_id}" --source-ref "{source_git_ref}" >"$SHIP_REQUEST_FILE"',
             'cat "$SHIP_REQUEST_FILE"',
-            'uv run launchplane ship execute --database-url "$LAUNCHPLANE_DATABASE_URL" --allow-direct-db-mutation --state-dir "$STATE_DIR" --input-file "$SHIP_REQUEST_FILE"',
+            'uv run launchplane ship execute --local-rehearsal --state-dir "$STATE_DIR" --input-file "$SHIP_REQUEST_FILE"',
         )
     )
 
@@ -3997,7 +3997,7 @@ def render_launchplane_preview_status_page_html(
     <section class=\"preview-detail-section\" id=\"operator-actions\">
       <div class=\"section-label\">Operator actions</div>
       <h2>Write-side Launchplane recipes</h2>
-      <p>Launchplane still renders as a static operator surface here, so each action is shown as a local rehearsal recipe for this preview identity. Shared and production mutations should use the deployed service API or DB-backed operator flows.</p>
+      <p>Launchplane still renders as a static operator surface here, so each action is shown as a local rehearsal recipe for this preview identity. Shared and production mutations should use the deployed service API or operator workflow.</p>
       <div class=\"action-stack\">{operator_actions_html}</div>
     </section>
     """

--- a/tests/test_launchplane_previews.py
+++ b/tests/test_launchplane_previews.py
@@ -1407,6 +1407,15 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertEqual(payload["environment_actions"]["testing"]["status"], "actionable")
             self.assertEqual(payload["environment_actions"]["prod"]["status"], "actionable")
             self.assertIn("ship resolve", payload["environment_actions"]["testing"]["recipe"])
+            self.assertIn("--local-rehearsal", payload["environment_actions"]["testing"]["recipe"])
+            self.assertNotIn(
+                "--allow-direct-db-mutation",
+                payload["environment_actions"]["testing"]["recipe"],
+            )
+            self.assertNotIn(
+                "LAUNCHPLANE_DATABASE_URL",
+                payload["environment_actions"]["testing"]["recipe"],
+            )
             self.assertEqual(
                 payload["promotion_action"]["candidate_artifact_id"], "artifact-testing"
             )
@@ -1796,6 +1805,9 @@ ODOO_DB_PASSWORD = "local-secret"
             )
             self.assertIn("promote resolve", rendered_html)
             self.assertIn("promote execute", rendered_html)
+            self.assertIn("--local-rehearsal", rendered_html)
+            self.assertNotIn("--allow-direct-db-mutation", rendered_html)
+            self.assertNotIn("LAUNCHPLANE_DATABASE_URL", rendered_html)
             self.assertNotIn("backup-gates write", rendered_html)
             self.assertIn("Why each PR does or does not have a preview", rendered_html)
             self.assertIn("Eligible tenant PR. No preview request is active yet.", rendered_html)
@@ -2652,6 +2664,10 @@ ODOO_DB_PASSWORD = "local-secret"
             self.assertIn(
                 "promotion-2026-04-14T11:10:00Z-opw-testing-to-prod", promotion_detail_html
             )
+            self.assertIn("promote execute", promotion_detail_html)
+            self.assertIn("--local-rehearsal", promotion_detail_html)
+            self.assertNotIn("--allow-direct-db-mutation", promotion_detail_html)
+            self.assertNotIn("LAUNCHPLANE_DATABASE_URL", promotion_detail_html)
 
     def test_launchplane_promotion_status_html_uses_shared_status_tone_for_evidence(
         self,
@@ -4935,7 +4951,9 @@ ENV_OVERRIDE_DISABLE_CRON = true
             control_plane_root = Path(temporary_directory_name)
             database_url = _runtime_environments_database_url(control_plane_root)
             input_file = control_plane_root / "github-webhook.json"
-            input_file.write_text(json.dumps(_github_pull_request_webhook_payload()), encoding="utf-8")
+            input_file.write_text(
+                json.dumps(_github_pull_request_webhook_payload()), encoding="utf-8"
+            )
 
             result = runner.invoke(
                 CLI_MAIN,


### PR DESCRIPTION
## Summary
- render promotion and ship execution recipes as local rehearsal only
- remove direct DB mutation acknowledgement guidance from static operator recipes
- add rendered-page assertions that promotion/ship recipes avoid direct DB mutation flags

## Validation
- `uv run python -m unittest tests.test_launchplane_previews.LaunchplanePreviewReadModelTests.test_launchplane_previews_show_tenant_surfaces_environment_and_preview_lanes tests.test_launchplane_previews.LaunchplanePreviewReadModelTests.test_launchplane_previews_render_index_page_leads_with_tenant_environment_when_scoped tests.test_launchplane_previews.LaunchplanePreviewReadModelTests.test_launchplane_previews_render_site_writes_promotion_detail_page_and_link_from_overview`
- `uv run python -m unittest tests.test_launchplane_previews`
- `uv run --extra dev ruff check --diff control_plane/launchplane_rendering.py tests/test_launchplane_previews.py`
- `uv run --extra dev ruff check control_plane/launchplane_rendering.py tests/test_launchplane_previews.py`
- `uv run --extra dev ruff format --check control_plane/launchplane_rendering.py tests/test_launchplane_previews.py`
- `uv run --extra dev mypy control_plane/launchplane_rendering.py tests/test_launchplane_previews.py`
- `git diff --check`

## Review
- Initial recipe-boundary scouts: identified rendered direct DB recipe drift.
- GPT final review on actual isolated worktree: no findings.
- Corrected Claude review on actual isolated worktree: no findings.
- Corrected Antigravity review on actual isolated worktree: no blockers.
- Auto Review ledger: no active target-applicable findings.

Refs #1492
Refs #1489
