### PR TITLE
Reject legacy target references on evidence ingress

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1802,9 +1802,30 @@ class DeploymentEvidenceRequest(BaseModel):
     product: str
     deployment: DeploymentRecord
 
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_target_reference_compatibility_input(cls, data: object) -> object:
+        if _mapping_path_contains_key(data, "deployment", "deploy", "target_reference"):
+            raise ValueError(
+                "deployment evidence ingress rejects target_reference compatibility input"
+            )
+        return data
+
     def model_post_init(self, _context: object) -> None:
         if not self.product.strip():
             raise ValueError("deployment evidence requires product")
+
+
+def _mapping_path_contains_key(payload: object, *path: str) -> bool:
+    if not path or not isinstance(payload, Mapping):
+        return False
+    *parent_path, terminal_key = path
+    current: object = payload
+    for path_part in parent_path:
+        if not isinstance(current, Mapping):
+            return False
+        current = current.get(path_part)
+    return isinstance(current, Mapping) and terminal_key in current
 
 
 class BackupGateEvidenceRequest(BaseModel):
@@ -1825,6 +1846,15 @@ class PromotionEvidenceRequest(BaseModel):
     schema_version: int = Field(default=1, ge=1)
     product: str
     promotion: PromotionRecord
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_target_reference_compatibility_input(cls, data: object) -> object:
+        if _mapping_path_contains_key(data, "promotion", "deploy", "target_reference"):
+            raise ValueError(
+                "promotion evidence ingress rejects target_reference compatibility input"
+            )
+        return data
 
     def model_post_init(self, _context: object) -> None:
         if not self.product.strip():

--- a/docs/records.md
+++ b/docs/records.md
@@ -206,8 +206,9 @@ an ORM column/table or remains only in the evidence payload.
   dry-run, or apply evidence as artifacts, writes only complete non-conflicting
   projections, and uses DB-backed `provider_target.audit` or
   `provider_target.backfill` authz grants instead of local checkout writes.
-- Shared ship and promotion request contracts require canonical flat target
-  fields (`target_name`, `target_type`, `provider_id`, `target_category`, and
+- Shared ship and promotion request contracts and new deployment/promotion
+  evidence ingress require canonical flat target fields (`target_name`,
+  `target_type`, `provider_id`, `target_category`, and
   `provider_target_type`) and reject `target_reference` compatibility input.
   Persisted deployment and promotion evidence still accepts `target_reference`
   while loading historical records, but writes flat compatibility fields. Full

--- a/tests/test_http_app_records.py
+++ b/tests/test_http_app_records.py
@@ -1456,6 +1456,82 @@ class FastApiPromotionEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["error"]["code"], "invalid_request")
         self.assertNotIn("detail", payload)
 
+    async def test_promotion_evidence_rejects_target_reference_input(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _promotion_evidence_payload()
+            promotion = cast(dict[str, object], request_payload["promotion"])
+            deploy = cast(dict[str, object], promotion["deploy"])
+            deploy["target_reference"] = {
+                "target_name": "example-site-prod",
+                "provider_id": "dokploy",
+                "target_category": "application",
+                "provider_target_type": "application",
+            }
+
+            response = await _post_promotion_evidence(app, request_payload)
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Launchplane request validation failed.")
+        self.assertNotIn("detail", payload)
+
+    async def test_promotion_evidence_allows_target_reference_metadata_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _promotion_evidence_payload()
+            promotion = cast(dict[str, object], request_payload["promotion"])
+            backup_gate = cast(dict[str, object], promotion["backup_gate"])
+            evidence = cast(dict[str, object], backup_gate["evidence"])
+            evidence["target_reference"] = "legacy-note"
+
+            response = await _post_promotion_evidence(app, request_payload)
+            promotion_record = store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(promotion_record.backup_gate.evidence["target_reference"], "legacy-note")
+
+    async def test_promotion_evidence_rejects_null_target_reference_input(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = _promotion_evidence_store(state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_promotion_write_identity()),
+                authz_policy=_promotion_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _promotion_evidence_payload()
+            promotion = cast(dict[str, object], request_payload["promotion"])
+            deploy = cast(dict[str, object], promotion["deploy"])
+            deploy["target_reference"] = None
+
+            response = await _post_promotion_evidence(app, request_payload)
+            with self.assertRaises(FileNotFoundError):
+                store.read_promotion_record("promotion-example-site-testing-to-prod")
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Launchplane request validation failed.")
+        self.assertNotIn("detail", payload)
+
     async def test_promotion_evidence_rejects_mismatched_linked_deployment(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name) / "state"
@@ -2923,6 +2999,81 @@ class FastApiDeploymentEvidenceTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["status"], "rejected")
         self.assertEqual(payload["error"]["code"], "invalid_request")
         self.assertNotIn("detail", payload)
+
+    async def test_deployment_evidence_rejects_target_reference_input(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _deployment_evidence_payload()
+            deployment = cast(dict[str, object], request_payload["deployment"])
+            deploy = cast(dict[str, object], deployment["deploy"])
+            deploy["target_reference"] = {
+                "target_name": "example-site-prod",
+                "provider_id": "dokploy",
+                "target_category": "application",
+                "provider_target_type": "application",
+            }
+
+            response = await _post_deployment_evidence(app, request_payload)
+            with self.assertRaises(FileNotFoundError):
+                store.read_deployment_record("deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Launchplane request validation failed.")
+        self.assertNotIn("detail", payload)
+
+    async def test_deployment_evidence_rejects_null_target_reference_input(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _deployment_evidence_payload()
+            deployment = cast(dict[str, object], request_payload["deployment"])
+            deploy = cast(dict[str, object], deployment["deploy"])
+            deploy["target_reference"] = None
+
+            response = await _post_deployment_evidence(app, request_payload)
+            with self.assertRaises(FileNotFoundError):
+                store.read_deployment_record("deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 400)
+        payload = response.json()
+        self.assertEqual(payload["status"], "rejected")
+        self.assertEqual(payload["error"]["code"], "invalid_request")
+        self.assertEqual(payload["error"]["message"], "Launchplane request validation failed.")
+        self.assertNotIn("detail", payload)
+
+    async def test_deployment_evidence_allows_target_reference_metadata_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            state_dir = Path(temporary_directory_name) / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_deployment_write_identity()),
+                authz_policy=_deployment_write_policy(context="example-site"),
+                record_store_factory=lambda: store,
+            )
+            request_payload = _deployment_evidence_payload()
+            deployment = cast(dict[str, object], request_payload["deployment"])
+            runtime_source = cast(dict[str, object], deployment.setdefault("runtime_source", {}))
+            runtime_source["target_reference"] = "legacy-note"
+
+            response = await _post_deployment_evidence(app, request_payload)
+            deployment_record = store.read_deployment_record("deployment-example-site-prod")
+
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(deployment_record.runtime_source["target_reference"], "legacy-note")
 
     async def test_deployment_evidence_requires_json_content_type(self) -> None:
         app = create_launchplane_fastapi_app(


### PR DESCRIPTION
## Summary
- reject legacy `deploy.target_reference` input on new deployment and promotion evidence ingress
- keep historical persisted record compatibility intact by leaving the inner record models unchanged
- document the ingress/storage boundary and cover null legacy input plus unrelated metadata keys

## Plan Alignment
- Advances #1489 by closing a remaining v2 compatibility crack where new native HTTP evidence ingress still accepted v1-style target-reference input.
- Supports the dead-code/compatibility cleanup goal without breaking historical record loading.

## Validation
- `uv run python -m unittest tests.test_http_app_records.FastApiDeploymentEvidenceTests.test_deployment_evidence_rejects_target_reference_input tests.test_http_app_records.FastApiDeploymentEvidenceTests.test_deployment_evidence_rejects_null_target_reference_input tests.test_http_app_records.FastApiDeploymentEvidenceTests.test_deployment_evidence_allows_target_reference_metadata_key tests.test_http_app_records.FastApiPromotionEvidenceTests.test_promotion_evidence_rejects_target_reference_input tests.test_http_app_records.FastApiPromotionEvidenceTests.test_promotion_evidence_rejects_null_target_reference_input tests.test_http_app_records.FastApiPromotionEvidenceTests.test_promotion_evidence_allows_target_reference_metadata_key tests.test_promote.PromoteWorkflowTests.test_deployment_evidence_accepts_target_reference_input tests.test_promote.PromoteWorkflowTests.test_deployment_evidence_accepts_minimal_legacy_target_reference_input`
- `uv run python -m unittest tests.test_http_app_records`
- `uv run python -m unittest tests.test_docs_contracts`
- `uv run --extra dev ruff check --diff control_plane/http_app.py tests/test_http_app_records.py docs/records.md`
- `uv run --extra dev ruff check control_plane/http_app.py tests/test_http_app_records.py docs/records.md`
- `uv run --extra dev ruff format --check control_plane/http_app.py tests/test_http_app_records.py`
- `uv run --extra dev mypy control_plane/http_app.py tests/test_http_app_records.py`
- `git diff --check`

## Review
- Auto Review: no active target-applicable findings.
- GPT review: no findings.
- Claude review: no findings.
- Antigravity review: no findings.
