### PR TITLE
Retire core record direct DB write CLIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ process env for the first bring-up.
 uv run launchplane --help
 uv run launchplane service serve --help
 cd frontend && npx pnpm@10.10.0 validate
-uv run launchplane storage import-core-records --help
 uv run python -m unittest
 ```
 

--- a/control_plane/cli_records.py
+++ b/control_plane/cli_records.py
@@ -19,10 +19,10 @@ from control_plane.storage.postgres import PostgresRecordStore
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
-_DIRECT_DB_MUTATION_MESSAGE = (
-    "Direct local DB mutation is restricted after the Launchplane service boundary. "
-    "Use the deployed service route or operator workflow for shared/production changes, "
-    "or pass --allow-direct-db-mutation only for explicit local/bootstrap repair."
+_LOCAL_REHEARSAL_ONLY_MESSAGE = (
+    "Core-record write commands are local-rehearsal only after the Launchplane "
+    "service boundary. Use the deployed service route or operator workflow for "
+    "shared/production evidence ingress."
 )
 
 
@@ -91,37 +91,9 @@ def _resolve_record_execution_database_url(
     return normalized_database_url
 
 
-def _resolve_record_mutation_database_url(
-    *,
-    database_url: str,
-    local_rehearsal: bool,
-    command_label: str,
-    allow_direct_db_mutation: bool,
-) -> str | None:
-    normalized_database_url = _resolve_record_execution_database_url(
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        command_label=command_label,
-    )
-    if normalized_database_url is not None:
-        _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
-    return normalized_database_url
-
-
-def _direct_db_mutation_acknowledgement_option(
-    function: Callable[..., object],
-) -> Callable[..., object]:
-    return click.option(
-        "--allow-direct-db-mutation",
-        is_flag=True,
-        default=False,
-        help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
-    )(function)
-
-
-def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) -> None:
-    if not allow_direct_db_mutation:
-        raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
+def _require_local_rehearsal(local_rehearsal: bool) -> None:
+    if not local_rehearsal:
+        raise click.ClickException(_LOCAL_REHEARSAL_ONLY_MESSAGE)
 
 
 def _load_json_file(input_file: Path) -> dict[str, object]:
@@ -137,24 +109,17 @@ def artifacts() -> None:
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
-@click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-@_direct_db_mutation_acknowledgement_option
 def artifacts_write(
     state_dir: Path,
-    database_url: str,
     local_rehearsal: bool,
     input_file: Path,
-    allow_direct_db_mutation: bool,
 ) -> None:
     _write_artifact_manifest_command(
         state_dir=state_dir,
-        database_url=database_url,
         local_rehearsal=local_rehearsal,
         input_file=input_file,
-        command_label="artifacts write",
-        allow_direct_db_mutation=allow_direct_db_mutation,
     )
 
 
@@ -167,31 +132,6 @@ def artifacts_write(
 def artifacts_show(state_dir: Path, database_url: str, artifact_id: str) -> None:
     manifest = _store(state_dir, database_url=database_url).read_artifact_manifest(artifact_id)
     click.echo(json.dumps(manifest.model_dump(mode="json"), indent=2, sort_keys=True))
-
-
-@artifacts.command("ingest")
-@click.option(
-    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
-)
-@click.option("--database-url", default="", show_default=False)
-@click.option("--local-rehearsal", is_flag=True, default=False)
-@click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-@_direct_db_mutation_acknowledgement_option
-def artifacts_ingest(
-    state_dir: Path,
-    database_url: str,
-    local_rehearsal: bool,
-    input_file: Path,
-    allow_direct_db_mutation: bool,
-) -> None:
-    _write_artifact_manifest_command(
-        state_dir=state_dir,
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        input_file=input_file,
-        command_label="artifacts ingest",
-        allow_direct_db_mutation=allow_direct_db_mutation,
-    )
 
 
 @artifacts.command("protected")
@@ -225,22 +165,12 @@ def artifacts_protected(
 def _write_artifact_manifest_command(
     *,
     state_dir: Path,
-    database_url: str,
     local_rehearsal: bool,
     input_file: Path,
-    command_label: str,
-    allow_direct_db_mutation: bool,
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        command_label=command_label,
-        allow_direct_db_mutation=allow_direct_db_mutation,
-    )
+    _require_local_rehearsal(local_rehearsal)
     manifest = ArtifactIdentityManifest.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=execution_database_url).write_artifact_manifest(
-        manifest
-    )
+    record_path = _store(state_dir).write_artifact_manifest(manifest)
     click.echo(record_path)
 
 
@@ -303,24 +233,15 @@ def release_tuples_export_catalog(
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
-@click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
-@_direct_db_mutation_acknowledgement_option
 def release_tuples_write_from_promotion(
     state_dir: Path,
-    database_url: str,
     local_rehearsal: bool,
     record_id: str,
-    allow_direct_db_mutation: bool,
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        command_label="release-tuples write-from-promotion",
-        allow_direct_db_mutation=allow_direct_db_mutation,
-    )
-    record_store = _store(state_dir, database_url=execution_database_url)
+    _require_local_rehearsal(local_rehearsal)
+    record_store = _store(state_dir)
     promotion_record = record_store.read_promotion_record(record_id)
     if not control_plane_release_tuples.should_mint_release_tuple_for_channel(
         promotion_record.from_instance
@@ -364,27 +285,16 @@ def backup_gates() -> None:
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
-@click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-@_direct_db_mutation_acknowledgement_option
 def backup_gates_write(
     state_dir: Path,
-    database_url: str,
     local_rehearsal: bool,
     input_file: Path,
-    allow_direct_db_mutation: bool,
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        command_label="backup-gates write",
-        allow_direct_db_mutation=allow_direct_db_mutation,
-    )
+    _require_local_rehearsal(local_rehearsal)
     record = BackupGateRecord.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=execution_database_url).write_backup_gate_record(
-        record
-    )
+    record_path = _store(state_dir).write_backup_gate_record(record)
     click.echo(record_path)
 
 
@@ -433,27 +343,16 @@ def promotions() -> None:
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
-@click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-@_direct_db_mutation_acknowledgement_option
 def promotions_write(
     state_dir: Path,
-    database_url: str,
     local_rehearsal: bool,
     input_file: Path,
-    allow_direct_db_mutation: bool,
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        command_label="promotions write",
-        allow_direct_db_mutation=allow_direct_db_mutation,
-    )
+    _require_local_rehearsal(local_rehearsal)
     record = PromotionRecord.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=execution_database_url).write_promotion_record(
-        record
-    )
+    record_path = _store(state_dir).write_promotion_record(record)
     click.echo(record_path)
 
 
@@ -509,27 +408,16 @@ def deployments() -> None:
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
-@click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--input-file", type=click.Path(exists=True, path_type=Path), required=True)
-@_direct_db_mutation_acknowledgement_option
 def deployments_write(
     state_dir: Path,
-    database_url: str,
     local_rehearsal: bool,
     input_file: Path,
-    allow_direct_db_mutation: bool,
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        command_label="deployments write",
-        allow_direct_db_mutation=allow_direct_db_mutation,
-    )
+    _require_local_rehearsal(local_rehearsal)
     record = DeploymentRecord.model_validate(_load_json_file(input_file))
-    record_path = _store(state_dir, database_url=execution_database_url).write_deployment_record(
-        record
-    )
+    record_path = _store(state_dir).write_deployment_record(record)
     click.echo(record_path)
 
 
@@ -578,24 +466,15 @@ def inventory() -> None:
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
-@click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
-@_direct_db_mutation_acknowledgement_option
 def inventory_write_from_deployment(
     state_dir: Path,
-    database_url: str,
     local_rehearsal: bool,
     record_id: str,
-    allow_direct_db_mutation: bool,
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        command_label="inventory write-from-deployment",
-        allow_direct_db_mutation=allow_direct_db_mutation,
-    )
-    record_store = _store(state_dir, database_url=execution_database_url)
+    _require_local_rehearsal(local_rehearsal)
+    record_store = _store(state_dir)
     deployment_record = record_store.read_deployment_record(record_id)
     inventory_path = _records_callbacks().write_environment_inventory(
         record_store=record_store,
@@ -608,24 +487,15 @@ def inventory_write_from_deployment(
 @click.option(
     "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
 )
-@click.option("--database-url", default="", show_default=False)
 @click.option("--local-rehearsal", is_flag=True, default=False)
 @click.option("--record-id", required=True)
-@_direct_db_mutation_acknowledgement_option
 def inventory_write_from_promotion(
     state_dir: Path,
-    database_url: str,
     local_rehearsal: bool,
     record_id: str,
-    allow_direct_db_mutation: bool,
 ) -> None:
-    execution_database_url = _resolve_record_mutation_database_url(
-        database_url=database_url,
-        local_rehearsal=local_rehearsal,
-        command_label="inventory write-from-promotion",
-        allow_direct_db_mutation=allow_direct_db_mutation,
-    )
-    record_store = _store(state_dir, database_url=execution_database_url)
+    _require_local_rehearsal(local_rehearsal)
+    record_store = _store(state_dir)
     promotion_record = record_store.read_promotion_record(record_id)
     inventory_path = _records_callbacks().write_environment_inventory_from_promotion(
         record_store=record_store,

--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -1,10 +1,8 @@
 import json
-from pathlib import Path
 import click
 
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.secret_record import SecretScope
-from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.provider_target_audit import audit_provider_targets
 from control_plane.workflows.provider_target_backfill import backfill_provider_targets
@@ -14,8 +12,8 @@ _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
 _DIRECT_DB_MUTATION_MESSAGE = (
     "Direct local DB mutation is restricted after the Launchplane service boundary. "
     "Use the deployed service route or operator workflow for shared/production "
-    "core-record or secret writes, or pass --allow-direct-db-mutation only for "
-    "explicit local/bootstrap repair."
+    "secret writes, or pass --allow-direct-db-mutation only for explicit "
+    "local/bootstrap repair."
 )
 
 
@@ -52,33 +50,6 @@ def normalize_secret_scope(scope: str) -> SecretScope:
 def _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation: bool) -> None:
     if not allow_direct_db_mutation:
         raise click.ClickException(_DIRECT_DB_MUTATION_MESSAGE)
-
-
-@storage.command("import-core-records")
-@click.option(
-    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
-)
-@click.option(
-    "--database-url",
-    envvar=_DATABASE_URL_ENV_KEYS,
-    required=True,
-    help="Postgres connection string for Launchplane shared-service core records.",
-)
-@click.option(
-    "--allow-direct-db-mutation",
-    is_flag=True,
-    default=False,
-    help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
-)
-def storage_import_core_records(
-    state_dir: Path, database_url: str, allow_direct_db_mutation: bool
-) -> None:
-    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
-    filesystem_store = FilesystemRecordStore(state_dir=state_dir)
-    postgres_store = PostgresRecordStore(database_url=database_url)
-    postgres_store.ensure_schema()
-    counts = postgres_store.import_core_records_from_filesystem(filesystem_store)
-    click.echo(json.dumps({"status": "ok", "counts": counts}, indent=2, sort_keys=True))
 
 
 @storage.command("provider-target-audit")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,7 +202,7 @@ The first concrete HTTP/OIDC/API shape for that boundary is defined in
 - `odoo-devkit` is the expected build/publish handoff for those manifests: it
   stages the tenant and shared source inputs into a real downstream image
   build context, pushes the image, resolves the pushed digest, and emits JSON
-  for `artifacts write` / `artifacts ingest` here.
+  for local `artifacts write` rehearsal here.
 - Artifact-backed execution also rejects Dokploy targets that still depend on
   the legacy `odoo-ai` monorepo source or mutable addon repository refs.
 - Native ship requests are artifact-backed and do not carry branch-mutation

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -8,24 +8,24 @@ Use `uv run launchplane --help` for the complete CLI surface. The current
 top-level groups are:
 
 Today this CLI is the local Launchplane operator/client surface around the
-service API. DB-backed commands may create stable-lane deploy and promotion
-records for `testing` and `prod`, plus Launchplane preview records and read
-models for PR review flows. Shared or production mutations must prefer the
-deployed service API with GitHub OIDC or the operator UI that calls it. If a live
-mutation still exists only as a local CLI command, stop and add or use a service
-API path instead of running the local command from an arbitrary checkout.
+service API. Shared or production mutations must prefer the deployed service API
+with GitHub OIDC or the operator UI that calls it. Local core-record write
+commands are file-backed rehearsal helpers, not DB-backed shared-state mutation
+paths. If a live mutation still exists only as a local CLI command, stop and add
+or use a service API path instead of running the local command from an arbitrary
+checkout.
 
-- `artifacts`: write, ingest, inspect artifact manifests, and emit protected
-  artifact inventories for registry cleanup deny sets.
-- `backup-gates`: write and inspect backup-gate records.
-- `deployments`: write and inspect deployment records.
+- `artifacts`: rehearse artifact manifest writes, inspect artifact manifests,
+  and emit protected artifact inventories for registry cleanup deny sets.
+- `backup-gates`: rehearse and inspect backup-gate records.
+- `deployments`: rehearse and inspect deployment records.
 - `environments`: write, list, and resolve DB-backed runtime environment
   contracts.
 - `launchplane-previews`: inspect, mutate, render, ingest, and replay
   Launchplane preview state.
 - `inventory`: inspect current environment inventory.
 - `promote`: record, resolve, and execute artifact-backed promotions.
-- `promotions`: write and inspect promotion records.
+- `promotions`: rehearse and inspect promotion records.
 - `product-config`: dry-run and apply trusted product runtime/secret config
   bundles from a live Launchplane context.
 - `release-tuples`: inspect state-backed tuple records and explicitly export a
@@ -40,9 +40,10 @@ API path instead of running the local command from an arbitrary checkout.
 
 `deployments write`, `promotions write`, `inventory write-from-deployment`,
 `inventory write-from-promotion`, and `release-tuples write-from-promotion`
-are the current small evidence-ingest surfaces that let Launchplane accept
-externally-produced deployment and promotion facts without claiming it
-executed that product's runtime action itself.
+are local rehearsal commands. Shared-service evidence ingress uses
+authenticated Launchplane service routes so Launchplane can accept externally
+produced deployment and promotion facts without claiming it executed that
+product's runtime action itself.
 
 Those commands are current implementation scaffolding. The Launchplane boundary
 is a long-running service with authenticated HTTP ingress. The CLI should remain

--- a/docs/records.md
+++ b/docs/records.md
@@ -15,11 +15,11 @@ title: Records
   current baseline revision captures the SQLAlchemy ORM schema that earlier
   deployments created through `create_all`; future GUI/write-flow schema changes
   need explicit migrations instead of relying on implicit table creation.
-- Treat local core-record DB writes as explicit bootstrap/repair only. Direct
-  `artifacts`, `backup-gates`, `promotions`, `deployments`, `inventory`,
-  `release-tuples write-from-promotion`, and `storage import-core-records`
-  mutations require `--allow-direct-db-mutation`; routine shared/live changes
-  should use the deployed Launchplane service route or operator workflow.
+- Shared-service core-record writes use authenticated Launchplane service
+  ingress or operator workflows. Local core-record write commands are
+  file-backed rehearsal helpers only; `storage import-core-records` is removed
+  and arbitrary-checkout core-record DB imports are not a supported v2 mutation
+  path.
 - Direct managed-secret writes through `secrets put` follow the same
   `--allow-direct-db-mutation` bootstrap/repair boundary.
 - Keep git history separate from operational history.
@@ -803,10 +803,11 @@ run` is the foreground loop intended for an external process supervisor, and
 - Promotion execution copies the source channel tuple to the destination
   channel after the destination deploy passes, retaining the promotion and
   deployment record ids that established the promoted state.
-- Externally produced promotion evidence can mint the same destination tuple
-  through `release-tuples write-from-promotion` when the stored promotion
-  record carries explicit `deployment_record_id` linkage and Launchplane already
-  has the current source tuple for the promoted-from lane.
+- Accepted service-backed promotion evidence can mint the same destination tuple
+  when the stored promotion record carries explicit `deployment_record_id`
+  linkage and Launchplane already has the current source tuple for the
+  promoted-from lane. Local `release-tuples write-from-promotion` is a
+  file-backed rehearsal helper only.
 - Launchplane previews are not long-lived release-tuple channels; they derive
   their baseline from stored tuple evidence plus preview generation records.
 - Local-dev tuple records live under `state/`; shared-service runtime baseline
@@ -1215,7 +1216,8 @@ preflights.
   evidence: accepted deployment evidence refreshes inventory immediately, and
   accepted promotion evidence refreshes destination inventory when the
   promotion record carries explicit deployment linkage.
-- For a second product such as VeriReel, inventory should first be derived from
-  ingested deployment/promotion evidence before Launchplane becomes the runtime
-  executor for that product. The first explicit mutation surfaces for that are
-  `inventory write-from-deployment` and `inventory write-from-promotion`.
+- For a second product such as VeriReel, shared inventory should first be
+  derived from accepted service-backed deployment/promotion evidence before
+  Launchplane becomes the runtime executor for that product. Local
+  `inventory write-from-deployment` and `inventory write-from-promotion` remain
+  file-backed rehearsal helpers only.

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -2054,7 +2054,7 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 ["rollback-plan-newer", "rollback-plan-older"],
             )
 
-    def test_artifacts_ingest_writes_manifest(self) -> None:
+    def test_artifacts_write_writes_manifest(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             repo_root = Path(temporary_directory_name)
@@ -2081,7 +2081,7 @@ class FilesystemRecordStoreTests(unittest.TestCase):
                 main,
                 [
                     "artifacts",
-                    "ingest",
+                    "write",
                     "--state-dir",
                     str(state_dir),
                     "--local-rehearsal",

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1394,31 +1394,15 @@ class PostgresRecordStoreTests(unittest.TestCase):
             self.assertEqual(len(listed), 1)
             self.assertEqual(listed[0].image.digest, "sha256:image123")
 
-    def test_artifacts_cli_uses_database_store_when_configured(self) -> None:
+    def test_artifacts_show_uses_database_store_when_configured(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             database_url = _sqlite_database_url(
                 Path(temporary_directory_name) / "launchplane.sqlite3"
             )
-            input_path = Path(temporary_directory_name) / "artifact.json"
-            input_path.write_text(
-                _artifact_manifest().model_dump_json(),
-                encoding="utf-8",
-            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_artifact_manifest(_artifact_manifest())
             runner = CliRunner()
-
-            write_result = runner.invoke(
-                main,
-                [
-                    "artifacts",
-                    "write",
-                    "--database-url",
-                    database_url,
-                    "--allow-direct-db-mutation",
-                    "--input-file",
-                    str(input_path),
-                ],
-            )
-            self.assertEqual(write_result.exit_code, 0, write_result.output)
 
             show_result = runner.invoke(
                 main,
@@ -1902,59 +1886,17 @@ class PostgresRecordStoreTests(unittest.TestCase):
 
         self.assertIsNone(loaded)
 
-    def test_storage_import_core_records_command_reports_counts(self) -> None:
-        runner = CliRunner()
-        postgres_store = Mock()
-        postgres_store.import_core_records_from_filesystem.return_value = {
-            "backup_gates": 0,
-            "deployments": 1,
-            "promotions": 0,
-            "inventory": 1,
-            "preview_records": 0,
-            "preview_generations": 0,
-            "release_tuples": 0,
-        }
-
-        with TemporaryDirectory() as temporary_directory_name:
-            with patch(
-                "control_plane.cli_storage_secrets.PostgresRecordStore",
-                return_value=postgres_store,
-            ) as store_class:
-                result = runner.invoke(
-                    main,
-                    [
-                        "storage",
-                        "import-core-records",
-                        "--state-dir",
-                        temporary_directory_name,
-                        "--database-url",
-                        "postgresql://launchplane:test@db/launchplane",
-                        "--allow-direct-db-mutation",
-                    ],
-                )
-
-        self.assertEqual(result.exit_code, 0, msg=result.output)
-        store_class.assert_called_once_with(
-            database_url="postgresql://launchplane:test@db/launchplane"
-        )
-        postgres_store.ensure_schema.assert_called_once_with()
-        postgres_store.import_core_records_from_filesystem.assert_called_once()
-        self.assertIn('"deployments": 1', result.output)
-
-    def test_storage_import_core_records_requires_direct_db_acknowledgement(self) -> None:
+    def test_storage_import_core_records_is_removed(self) -> None:
         result = CliRunner().invoke(
             main,
             [
                 "storage",
                 "import-core-records",
-                "--database-url",
-                "postgresql://launchplane:test@db/launchplane",
             ],
         )
 
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Direct local DB mutation is restricted", result.output)
-        self.assertIn("--allow-direct-db-mutation", result.output)
+        self.assertIn("No such command 'import-core-records'", result.output)
 
     def test_secrets_put_requires_direct_db_acknowledgement(self) -> None:
         result = CliRunner().invoke(

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -2483,7 +2483,7 @@ DOKPLOY_SHIP_MODE = "auto"
                 record,
             )
 
-    def test_deployments_write_requires_database_url_without_local_rehearsal(self) -> None:
+    def test_deployments_write_is_local_rehearsal_only(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             repo_root = Path(temporary_directory_name)
@@ -2518,16 +2518,15 @@ DOKPLOY_SHIP_MODE = "auto"
             )
 
             self.assertNotEqual(result.exit_code, 0)
-            self.assertIn("deployments write requires --database-url", result.output)
+            self.assertIn("Core-record write commands are local-rehearsal only", result.output)
 
-    def test_core_record_writes_require_direct_db_acknowledgement(self) -> None:
+    def test_core_record_writes_reject_direct_database_url(self) -> None:
         runner = CliRunner()
         with TemporaryDirectory() as temporary_directory_name:
             input_file = Path(temporary_directory_name) / "record.json"
             input_file.write_text("{}", encoding="utf-8")
             command_cases = (
                 ("artifacts write", ["artifacts", "write", "--input-file", str(input_file)]),
-                ("artifacts ingest", ["artifacts", "ingest", "--input-file", str(input_file)]),
                 (
                     "release-tuples write-from-promotion",
                     ["release-tuples", "write-from-promotion", "--record-id", "promotion-1"],
@@ -2565,8 +2564,27 @@ DOKPLOY_SHIP_MODE = "auto"
                     )
 
                     self.assertNotEqual(result.exit_code, 0)
-                    self.assertIn("Direct local DB mutation is restricted", result.output)
-                    self.assertIn("--allow-direct-db-mutation", result.output)
+                    self.assertIn("No such option '--database-url'", result.output)
+
+    def test_core_record_write_help_omits_direct_db_acknowledgement(self) -> None:
+        runner = CliRunner()
+        command_cases = (
+            ["artifacts", "write"],
+            ["release-tuples", "write-from-promotion"],
+            ["backup-gates", "write"],
+            ["promotions", "write"],
+            ["deployments", "write"],
+            ["inventory", "write-from-deployment"],
+            ["inventory", "write-from-promotion"],
+        )
+        for command in command_cases:
+            with self.subTest(command=" ".join(command)):
+                result = runner.invoke(main, [*command, "--help"])
+
+                self.assertEqual(result.exit_code, 0, msg=result.output)
+                self.assertIn("--local-rehearsal", result.output)
+                self.assertNotIn("--database-url", result.output)
+                self.assertNotIn("--allow-direct-db-mutation", result.output)
 
     def test_promotions_write_persists_record(self) -> None:
         runner = CliRunner()


### PR DESCRIPTION
## Summary
- make core-record write commands local-rehearsal/file-backed only by removing `--database-url` and `--allow-direct-db-mutation` from the write surfaces
- remove the local `storage import-core-records` command and the dead `artifacts ingest` alias
- preserve DB-backed read/report commands and update docs/tests to point shared evidence ingress at service/operator workflows

## Plan Alignment
- Advances #1492 by removing direct DB core-record write/import plumbing rather than merely guarding it.
- Supports #1489 by deleting dead compatibility code and keeping durable docs aligned with v2 service-boundary ownership.

## Validation
- `uv run python -m unittest tests.test_promote.PromoteCliTests.test_deployments_write_is_local_rehearsal_only tests.test_promote.PromoteCliTests.test_core_record_writes_reject_direct_database_url tests.test_promote.PromoteCliTests.test_core_record_write_help_omits_direct_db_acknowledgement tests.test_promote.PromoteCliTests.test_deployments_write_persists_record tests.test_promote.PromoteCliTests.test_promotions_write_persists_record tests.test_promote.PromoteCliTests.test_inventory_write_from_deployment_persists_inventory tests.test_promote.PromoteCliTests.test_inventory_write_from_promotion_persists_inventory tests.test_promote.PromoteCliTests.test_release_tuples_write_from_promotion_persists_promoted_tuple tests.test_postgres_store.PostgresRecordStoreTests.test_storage_import_core_records_is_removed tests.test_postgres_store.PostgresRecordStoreTests.test_artifacts_show_uses_database_store_when_configured tests.test_filesystem_store.FilesystemRecordStoreTests.test_artifacts_write_writes_manifest`
- `uv run python -m unittest tests.test_promote.PromoteCliTests tests.test_postgres_store.PostgresRecordStoreTests tests.test_filesystem_store.FilesystemRecordStoreTests tests.test_docs_contracts`
- `uv run --extra dev ruff check --diff control_plane/cli_records.py control_plane/cli_storage_secrets.py tests/test_promote.py tests/test_postgres_store.py tests/test_filesystem_store.py README.md docs/records.md docs/operations.md docs/architecture.md`
- `uv run --extra dev ruff check control_plane/cli_records.py control_plane/cli_storage_secrets.py tests/test_promote.py tests/test_postgres_store.py tests/test_filesystem_store.py README.md docs/records.md docs/operations.md docs/architecture.md`
- `uv run --extra dev ruff format --check control_plane/cli_records.py control_plane/cli_storage_secrets.py tests/test_promote.py tests/test_postgres_store.py tests/test_filesystem_store.py`
- `uv run --extra dev mypy control_plane/cli_records.py control_plane/cli_storage_secrets.py tests/test_promote.py tests/test_postgres_store.py tests/test_filesystem_store.py`
- `uv run python -m unittest tests.test_docs_contracts`
- `git diff --check`
- stale-reference scan: no `artifacts ingest` references remain; `import-core-records` remains only in the removal test and removed-command doc note

## Review
- Auto Review: no active target-applicable findings.
- Initial review batch inspected a stale checkout and was discarded.
- Corrected review against `/Users/cbusillo/.code/worktrees/launchplane/main`: Antigravity no findings; GPT no findings; Claude found dead `artifacts ingest` alias, fixed before commit.
