### PR TITLE
Retire source-backed generic-web onboarding

### DIFF
--- a/control_plane/contracts/product_onboarding_manifest.py
+++ b/control_plane/contracts/product_onboarding_manifest.py
@@ -102,13 +102,13 @@ class ProductOnboardingTargetManifest(BaseModel):
             raise ValueError("product onboarding target healthcheck_path must start with /")
         return self
 
-    def is_source_backed_compose(self) -> bool:
-        return (
+    def has_source_backed_fields(self) -> bool:
+        return bool(
             self.target_type == "compose"
-            and self.source_type.strip().lower() == "git"
-            and bool(self.custom_git_url.strip())
-            and bool(self.custom_git_branch.strip())
-            and bool(self.compose_path.strip())
+            or self.source_type.strip()
+            or self.custom_git_url.strip()
+            or self.custom_git_branch.strip()
+            or self.compose_path.strip()
         )
 
 
@@ -200,6 +200,7 @@ class ProductOnboardingManifest(BaseModel):
             raise ValueError("product onboarding manifest requires repository")
         if not self.driver_id.strip():
             raise ValueError("product onboarding manifest requires driver_id")
+        self.driver_id = self.driver_id.strip()
         self.image_repository = self.image_repository.strip()
         self.health_path = self.health_path.strip()
         if self.health_path and not self.health_path.startswith("/"):
@@ -255,6 +256,11 @@ class ProductOnboardingManifest(BaseModel):
                     "product onboarding target must match a stable lane: "
                     f"{target.context}/{target.instance}"
                 )
+            if self.driver_id == "generic-web" and target.has_source_backed_fields():
+                raise ValueError(
+                    "generic-web product onboarding no longer accepts source-backed "
+                    "provider target fields; use image-backed application targets"
+                )
             if target.healthcheck_enabled and not (
                 target.healthcheck_path.strip() or self.health_path
             ):
@@ -263,58 +269,9 @@ class ProductOnboardingManifest(BaseModel):
                 )
 
         if not self.image_repository:
-            if self.runtime_port != 0 or self.health_path:
-                raise ValueError(
-                    "image-less product onboarding requires runtime_port=0 and empty health_path"
-                )
-            if not self.provider_targets:
-                raise ValueError(
-                    "image-less product onboarding requires source-backed compose provider target"
-                )
-            source_backed_compose_routes = {
-                (target.context.strip(), target.instance.strip())
-                for target in self.provider_targets
-                if target.is_source_backed_compose()
-            }
-            for lane in self.lanes:
-                if lane.base_url.strip():
-                    raise ValueError(
-                        "image-less product onboarding requires empty base_url; "
-                        "use explicit health_url for source-backed worker health checks"
-                    )
-                has_health_surface = bool(
-                    lane.health_url.strip()
-                    or any(check.enabled for check in lane.health_monitoring.checks)
-                )
-                if not has_health_surface:
-                    continue
-                route = (lane.context.strip(), lane.instance.strip())
-                if route not in source_backed_compose_routes:
-                    raise ValueError(
-                        "image-less product onboarding health surfaces require "
-                        "source-backed compose provider target"
-                    )
-            for target in self.provider_targets:
-                if target.target_type != "compose":
-                    raise ValueError(
-                        "image-less product onboarding requires compose provider targets"
-                    )
-                if target.source_type.strip().lower() != "git" or not target.custom_git_url.strip():
-                    raise ValueError(
-                        "image-less product onboarding requires source-backed compose provider target"
-                    )
-                if not target.custom_git_branch.strip():
-                    raise ValueError("image-less product onboarding requires custom_git_branch")
-                if not target.compose_path.strip():
-                    raise ValueError("image-less product onboarding requires compose_path")
-                if target.domains:
-                    raise ValueError(
-                        "image-less product onboarding requires provider targets without domains"
-                    )
-                if target.healthcheck_enabled:
-                    raise ValueError(
-                        "image-less product onboarding requires disabled provider healthcheck"
-                    )
+            raise ValueError(
+                "product onboarding requires image_repository for immutable image deploy"
+            )
 
         allowed_contexts = {self.product.strip()}
         allowed_contexts.update(lane.context.strip() for lane in self.lanes)

--- a/docs/records.md
+++ b/docs/records.md
@@ -405,11 +405,9 @@ Simple service products deployed as Dokploy applications use the same product
 profile shape. For a bot or worker service with an HTTP bridge or health
 endpoint, `runtime_port` is the internal HTTP port, `health_path` names the
 product-level health route, and lane `health_url` can point at an internal URL
-reachable by Launchplane. Source-backed compose workers may use `runtime_port=0`
-and empty product-level image/health fields when any observable health surface is
-an explicit lane `health_url`; source-backed workers without an HTTP surface use
-that shape only when preview, public ingress monitoring, and provider health
-checks are disabled. See
+reachable by Launchplane. Generic-web service profiles must name an immutable
+image repository for stable deploys; source-backed compose onboarding is
+retired with the generic-web source-ref deploy bridge. See
 [dokploy-service-deployments.md](dokploy-service-deployments.md) for the
 service-specific contract.
 

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -241,7 +241,7 @@ def _profile(*, driver_id: str = "generic-web") -> LaunchplaneProductProfileReco
     )
 
 
-def _source_ref_worker_profile() -> LaunchplaneProductProfileRecord:
+def _missing_image_profile() -> LaunchplaneProductProfileRecord:
     return LaunchplaneProductProfileRecord(
         product="repairshopr-sync",
         display_name="RepairShopr Sync",
@@ -315,7 +315,7 @@ def _runtime_secret_binding(
     )
 
 
-def _source_ref_worker_lane() -> ProductLaneProfile:
+def _missing_image_lane() -> ProductLaneProfile:
     return ProductLaneProfile(
         instance="prod",
         context="repairshopr-sync",
@@ -431,7 +431,7 @@ class GenericWebDeployTests(unittest.TestCase):
             "Configure an immutable image repository before using generic-web deploy",
         ):
             normalize_generic_web_artifact_id(
-                profile=_source_ref_worker_profile(),
+                profile=_missing_image_profile(),
                 artifact_id="sha-2da6435e10cade0870ed5cbdf40c8048594f8b1c",
             )
 
@@ -541,7 +541,7 @@ class GenericWebDeployTests(unittest.TestCase):
                 image=ProductImageProfile(),
                 runtime_port=0,
                 health_path="/health",
-                lanes=(_source_ref_worker_lane(),),
+                lanes=(_missing_image_lane(),),
                 updated_at="2026-06-12T20:00:00Z",
                 source="test",
             )
@@ -555,7 +555,7 @@ class GenericWebDeployTests(unittest.TestCase):
                 driver_id="generic-web",
                 image=ProductImageProfile(),
                 runtime_port=8000,
-                lanes=(_source_ref_worker_lane(),),
+                lanes=(_missing_image_lane(),),
                 updated_at="2026-06-12T20:00:00Z",
                 source="test",
             )
@@ -628,10 +628,10 @@ class GenericWebDeployTests(unittest.TestCase):
             store.deployments[0].record_id,
         )
 
-    def test_execute_generic_web_deploy_records_failure_for_source_ref_worker_profile(
+    def test_execute_generic_web_deploy_records_failure_for_missing_image_profile(
         self,
     ) -> None:
-        store = _GenericWebDeployStore(_source_ref_worker_profile())
+        store = _GenericWebDeployStore(_missing_image_profile())
         deploy_provider = _FakeGenericWebDeployProvider()
 
         result = execute_generic_web_deploy(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -2155,7 +2155,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
 
         self.assertEqual(manifest.provider_targets, ())
 
-    def test_product_onboarding_manifest_accepts_source_ref_worker_without_http_surface(
+    def test_product_onboarding_manifest_rejects_missing_image_repository(
         self,
     ) -> None:
         payload: dict[str, object] = {
@@ -2163,6 +2163,86 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             "display_name": "RepairShopr Sync",
             "repository": "cbusillo/repairshopr_api",
             "driver_id": "generic-web",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "repairshopr-sync",
+                    "health_monitoring": {"checks": []},
+                }
+            ],
+            "provider_targets": [
+                {
+                    "context": "repairshopr-sync",
+                    "instance": "prod",
+                    "target_id": "app-123",
+                    "target_type": "application",
+                    "target_name": "cm-repairshopr-sync",
+                    "healthcheck_enabled": False,
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "requires image_repository"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_manifest_rejects_health_check_alert_issue_url(
+        self,
+    ) -> None:
+        payload = _manifest_payload()
+        lanes = payload["lanes"]
+        assert isinstance(lanes, list)
+        first_lane = lanes[0]
+        assert isinstance(first_lane, dict)
+        health_monitoring = first_lane["health_monitoring"]
+        assert isinstance(health_monitoring, dict)
+        checks = health_monitoring["checks"]
+        assert isinstance(checks, list)
+        first_check = checks[0]
+        assert isinstance(first_check, dict)
+        first_check["alert_issue_url"] = "https://github.com/example/ops/issues/123"
+
+        with self.assertRaisesRegex(ValueError, "alert_issue_url"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_manifest_rejects_enabled_target_healthcheck_without_path(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "product": "repairshopr-sync",
+            "display_name": "RepairShopr Sync",
+            "repository": "cbusillo/repairshopr_api",
+            "driver_id": "generic-web",
+            "image_repository": "ghcr.io/cbusillo/repairshopr-sync",
+            "lanes": [
+                {
+                    "instance": "prod",
+                    "context": "repairshopr-sync",
+                    "health_monitoring": {"checks": []},
+                }
+            ],
+            "provider_targets": [
+                {
+                    "context": "repairshopr-sync",
+                    "instance": "prod",
+                    "target_id": "app-123",
+                    "target_type": "application",
+                    "healthcheck_enabled": True,
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(ValueError, "healthcheck requires"):
+            ProductOnboardingManifest.model_validate(payload)
+
+    def test_product_onboarding_manifest_rejects_generic_web_source_backed_target(
+        self,
+    ) -> None:
+        payload: dict[str, object] = {
+            "product": "repairshopr-sync",
+            "display_name": "RepairShopr Sync",
+            "repository": "cbusillo/repairshopr_api",
+            "driver_id": "generic-web",
+            "image_repository": "ghcr.io/cbusillo/repairshopr-sync",
             "lanes": [
                 {
                     "instance": "prod",
@@ -2186,434 +2266,18 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             ],
         }
 
-        with TemporaryDirectory() as temporary_directory_name:
-            store = PostgresRecordStore(
-                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
-            )
-            store.ensure_schema()
-            manifest = ProductOnboardingManifest.model_validate(payload)
-            result = apply_product_onboarding_manifest(
-                record_store=store,
-                manifest=manifest,
-                updated_at="2026-06-12T20:00:00Z",
-            )
-            profile = store.read_product_profile_record("repairshopr-sync")
-            targets = store.list_dokploy_target_records()
-            store.close()
-
-        self.assertEqual(result.product, "repairshopr-sync")
-        self.assertEqual(profile.image.repository, "")
-        self.assertEqual(profile.runtime_port, 0)
-        self.assertEqual(profile.health_path, "")
-        self.assertEqual(profile.lanes[0].health_url, "")
-        self.assertEqual(profile.lanes[0].health_monitoring.checks, ())
-        self.assertEqual(len(targets), 1)
-        self.assertEqual(targets[0].target_type, "compose")
-        self.assertFalse(targets[0].healthcheck_enabled)
-        self.assertEqual(targets[0].healthcheck_path, "")
-
-    def test_product_onboarding_manifest_rejects_image_less_application_target(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "app-123",
-                    "target_type": "application",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "requires compose provider targets"):
+        with self.assertRaisesRegex(ValueError, "no longer accepts source-backed"):
             ProductOnboardingManifest.model_validate(payload)
 
-    def test_product_onboarding_manifest_rejects_image_less_compose_without_source(
+    def test_product_onboarding_manifest_normalizes_driver_id_before_source_backed_guard(
         self,
     ) -> None:
         payload: dict[str, object] = {
             "product": "repairshopr-sync",
             "display_name": "RepairShopr Sync",
             "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "requires source-backed compose"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_compose_without_compose_path(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "custom_git_branch": "main",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "requires compose_path"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_compose_without_branch(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "requires custom_git_branch"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_http_surface(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "base_url": "https://repairshopr-sync.example.test",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "custom_git_branch": "main",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "requires empty base_url"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_accepts_image_less_explicit_health_url_surface(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_url": "https://repairshopr-sync.example.test/health",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "custom_git_branch": "main",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with TemporaryDirectory() as temporary_directory_name:
-            store = PostgresRecordStore(
-                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
-            )
-            store.ensure_schema()
-            manifest = ProductOnboardingManifest.model_validate(payload)
-            result = apply_product_onboarding_manifest(
-                record_store=store,
-                manifest=manifest,
-                updated_at="2026-06-12T20:00:00Z",
-            )
-            profile = store.read_product_profile_record("repairshopr-sync")
-            targets = store.list_dokploy_target_records()
-            store.close()
-
-        self.assertEqual(result.product, "repairshopr-sync")
-        self.assertEqual(profile.image.repository, "")
-        self.assertEqual(profile.runtime_port, 0)
-        self.assertEqual(profile.health_path, "")
-        self.assertEqual(
-            profile.lanes[0].health_url,
-            "https://repairshopr-sync.example.test/health",
-        )
-        self.assertEqual(profile.lanes[0].health_monitoring.checks, ())
-        self.assertEqual(len(targets), 1)
-        self.assertEqual(targets[0].target_type, "compose")
-        self.assertFalse(targets[0].healthcheck_enabled)
-
-    def test_product_onboarding_manifest_accepts_image_less_health_monitoring(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_url": "https://repairshopr-sync.example.test/health",
-                    "health_monitoring": {
-                        "checks": [
-                            {
-                                "name": "public-ingress",
-                                "kind": "public_http",
-                            }
-                        ]
-                    },
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "custom_git_branch": "main",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with TemporaryDirectory() as temporary_directory_name:
-            store = PostgresRecordStore(
-                database_url=_sqlite_database_url(Path(temporary_directory_name) / "db.sqlite3")
-            )
-            store.ensure_schema()
-            manifest = ProductOnboardingManifest.model_validate(payload)
-            apply_product_onboarding_manifest(
-                record_store=store,
-                manifest=manifest,
-                updated_at="2026-06-12T20:00:00Z",
-            )
-            profile = store.read_product_profile_record("repairshopr-sync")
-            store.close()
-
-        self.assertEqual(
-            profile.lanes[0].health_url,
-            "https://repairshopr-sync.example.test/health",
-        )
-        self.assertTrue(profile.lanes[0].health_monitoring.checks[0].enabled)
-
-    def test_product_onboarding_manifest_rejects_health_check_alert_issue_url(
-        self,
-    ) -> None:
-        payload = _manifest_payload()
-        lanes = payload["lanes"]
-        assert isinstance(lanes, list)
-        first_lane = lanes[0]
-        assert isinstance(first_lane, dict)
-        health_monitoring = first_lane["health_monitoring"]
-        assert isinstance(health_monitoring, dict)
-        checks = health_monitoring["checks"]
-        assert isinstance(checks, list)
-        first_check = checks[0]
-        assert isinstance(first_check, dict)
-        first_check["alert_issue_url"] = "https://github.com/example/ops/issues/123"
-
-        with self.assertRaisesRegex(ValueError, "alert_issue_url"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_health_monitoring_without_url(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_monitoring": {
-                        "checks": [{"name": "public-ingress", "kind": "public_http"}]
-                    },
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "custom_git_branch": "main",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "requires base_url or explicit health_url"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_health_url_without_source_route(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_url": "https://repairshopr-sync.example.test/health",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "staging",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "custom_git_branch": "main",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "target must match a stable lane"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_health_url_without_source_backed_target(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_url": "https://repairshopr-sync.example.test/health",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "healthcheck_enabled": False,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "health surfaces require source-backed compose"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_product_health_surface(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "runtime_port": 8000,
-            "health_path": "/health",
+            "driver_id": " generic-web ",
+            "image_repository": "ghcr.io/cbusillo/repairshopr-sync",
             "lanes": [
                 {
                     "instance": "prod",
@@ -2636,104 +2300,7 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             ],
         }
 
-        with self.assertRaisesRegex(ValueError, "requires runtime_port=0"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_provider_domains(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "custom_git_branch": "main",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": False,
-                    "domains": ["repairshopr-sync.example.test"],
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "requires provider targets without domains"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_enabled_target_healthcheck_without_path(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "healthcheck_enabled": True,
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "healthcheck requires"):
-            ProductOnboardingManifest.model_validate(payload)
-
-    def test_product_onboarding_manifest_rejects_image_less_target_healthcheck(
-        self,
-    ) -> None:
-        payload: dict[str, object] = {
-            "product": "repairshopr-sync",
-            "display_name": "RepairShopr Sync",
-            "repository": "cbusillo/repairshopr_api",
-            "driver_id": "generic-web",
-            "lanes": [
-                {
-                    "instance": "prod",
-                    "context": "repairshopr-sync",
-                    "health_monitoring": {"checks": []},
-                }
-            ],
-            "provider_targets": [
-                {
-                    "context": "repairshopr-sync",
-                    "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
-                    "source_type": "git",
-                    "custom_git_url": "git@github.com:cbusillo/repairshopr_api.git",
-                    "custom_git_branch": "main",
-                    "compose_path": "docker/coolify/compose.yml",
-                    "healthcheck_enabled": True,
-                    "healthcheck_path": "/health",
-                }
-            ],
-        }
-
-        with self.assertRaisesRegex(ValueError, "requires disabled provider healthcheck"):
+        with self.assertRaisesRegex(ValueError, "no longer accepts source-backed"):
             ProductOnboardingManifest.model_validate(payload)
 
     def test_product_onboarding_manifest_rejects_inert_health_monitoring(
@@ -3029,8 +2596,8 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "context": "repairshopr-sync",
                     "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
+                    "target_id": "app-123",
+                    "target_type": "application",
                     "healthcheck_enabled": False,
                 }
             ],
@@ -3059,8 +2626,8 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 {
                     "context": "repairshopr-sync",
                     "instance": "prod",
-                    "target_id": "compose-123",
-                    "target_type": "compose",
+                    "target_id": "app-123",
+                    "target_type": "application",
                     "healthcheck_enabled": False,
                 }
             ],

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -92,7 +92,6 @@ class ProductOnboardingServiceTests(unittest.TestCase):
                         "target_id": "app-discord-blue",
                         "target_type": "application",
                         "target_name": "discord-blue",
-                        "custom_git_url": "https://github.com/cbusillo/discord-blue.git",
                         "env": {"DISCORD_BLUE_TARGET_ENV": "stored-only"},
                         "domains": ["discord-blue.example.test"],
                         "healthcheck_enabled": False,
@@ -159,7 +158,6 @@ class ProductOnboardingServiceTests(unittest.TestCase):
         self.assertNotIn("secret_bindings", driver_result)
         self.assertNotIn("secret_id", str(driver_result))
         self.assertNotIn("app-discord-blue", str(driver_result))
-        self.assertNotIn("custom_git_url", str(driver_result))
         self.assertNotIn("DISCORD_BLUE_TARGET_ENV", str(driver_result))
         self.assertNotIn("discord-blue.example.test", str(driver_result))
         self.assertNotIn("test:discord-blue-onboarding", str(driver_result))


### PR DESCRIPTION
## Summary
- require product onboarding manifests to declare an immutable image repository
- reject generic-web onboarding targets that still carry compose/source-backed target fields
- remove obsolete image-less/source-backed onboarding tests and update service profile docs

## Validation
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_product_onboarding_manifest_rejects_missing_image_repository tests.test_product_onboarding.ProductOnboardingTests.test_product_onboarding_manifest_rejects_enabled_target_healthcheck_without_path tests.test_product_onboarding.ProductOnboardingTests.test_product_onboarding_manifest_rejects_generic_web_source_backed_target tests.test_product_onboarding.ProductOnboardingTests.test_product_onboarding_manifest_normalizes_driver_id_before_source_backed_guard tests.test_product_onboarding.ProductOnboardingTests.test_product_onboarding_manifest_rejects_zero_runtime_port_with_health_path tests.test_product_onboarding.ProductOnboardingTests.test_product_onboarding_manifest_rejects_runtime_port_without_health_path
- uv run python -m unittest tests.test_product_onboarding tests.test_generic_web_deploy tests.test_docs_contracts
- uv run --extra dev ruff check --diff control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py tests/test_generic_web_deploy.py
- uv run --extra dev ruff check control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py tests/test_generic_web_deploy.py
- uv run --extra dev ruff format --check control_plane/contracts/product_onboarding_manifest.py tests/test_product_onboarding.py tests/test_generic_web_deploy.py
- uv run --extra dev mypy control_plane/contracts/product_onboarding_manifest.py
- git diff --check

## Review
- Auto Review: no active findings for this checkout
- Antigravity review: clean after final fixes
- GPT review: found source-backed target and whitespace driver_id bypasses; both fixed and re-reviewed clean
- Claude review attempted earlier on this slice but failed with /login

Refs #1498
Refs #1489