### PR TITLE
Derive generic web stable deploy defaults

### DIFF
--- a/.github/workflows/reusable-generic-web-stable-deploy.yml
+++ b/.github/workflows/reusable-generic-web-stable-deploy.yml
@@ -5,12 +5,15 @@ name: Reusable Generic Web Stable Deploy
   workflow_call:
     inputs:
       product:
-        description: Launchplane product key.
-        required: true
+        description: >-
+          Launchplane product key. Defaults to the caller repository name.
+        required: false
+        default: ""
         type: string
       instance:
-        description: Stable Launchplane lane instance, such as testing or prod.
-        required: true
+        description: Stable Launchplane lane instance. Defaults to testing.
+        required: false
+        default: "testing"
         type: string
       artifact_id:
         description: Immutable image or Launchplane-resolvable artifact identity.
@@ -73,6 +76,12 @@ jobs:
           SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
         run: |
           set -euo pipefail
+          if [ -z "$PRODUCT" ]; then
+            PRODUCT="${GITHUB_REPOSITORY#*/}"
+          fi
+          if [ -z "$INSTANCE" ]; then
+            INSTANCE="testing"
+          fi
           for required in PRODUCT INSTANCE ARTIFACT_ID SOURCE_GIT_REF; do
             if [ -z "${!required}" ]; then
               echo "${required} is required." >&2

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -382,8 +382,10 @@ reference, a dated owner, and a delete condition.
 Generic-web product repos should prefer Launchplane-owned reusable workflows
 before calling raw driver routes. The reusable workflow owns the Launchplane
 route path, request JSON shape, response-output mapping, and run-scoped
-idempotency key. The product repo supplies only primitive facts: product key,
-lane instance, immutable artifact identity, and tested source git ref.
+idempotency key. The product repo supplies only primitive facts: immutable
+artifact identity and tested source git ref. The stable deploy workflow derives
+the product key from the caller repository name by default and uses the
+`testing` stable lane unless the caller supplies a narrower operator override.
 
 Stable deploy uses:
 
@@ -392,8 +394,6 @@ jobs:
   launchplane-deploy:
     uses: cbusillo/launchplane/.github/workflows/reusable-generic-web-stable-deploy.yml@main
     with:
-      product: ${{ vars.LAUNCHPLANE_PRODUCT }}
-      instance: testing
       artifact_id: ${{ needs.build.outputs.image_digest }}
       source_git_ref: ${{ github.sha }}
 ```

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2985,8 +2985,6 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 "    uses: cbusillo/launchplane/.github/workflows/reusable-generic-web-stable-deploy.yml@main\n"
                 "    with:\n"
                 "      launchplane_url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}\n"
-                "      product: ${{ vars.LAUNCHPLANE_PRODUCT }}\n"
-                "      instance: ${{ vars.LAUNCHPLANE_INSTANCE }}\n"
                 "      artifact_id: ${{ needs.build-image.outputs.artifact_id }}\n"
                 "      source_git_ref: ${{ needs.build-image.outputs.source_git_ref }}\n",
                 encoding="utf-8",
@@ -3018,13 +3016,9 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             for finding in _findings(payload)
             if finding["allow_reason"] == "thin_connector_input"
         }
-        operator_input_keys = {
-            finding["key"]
-            for finding in _findings(payload)
-            if finding["allow_reason"] == "operator_supplied_runtime_input"
-        }
         self.assertIn("uses", thin_connector_keys)
-        self.assertTrue({"product", "instance"} <= operator_input_keys)
+        self.assertNotIn("product", thin_connector_keys)
+        self.assertNotIn("instance", thin_connector_keys)
 
     def test_cli_product_repo_gate_allows_compact_launchplane_tool_checkout(self) -> None:
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -127,6 +127,8 @@ class DocsContractsTests(TestCase):
         self.assertIn("reusable-generic-web-stable-deploy.yml@main", product_repo_contract)
         self.assertIn("reusable-generic-web-prod-promotion.yml@main", product_repo_contract)
         self.assertIn("route path, request JSON shape", product_repo_contract)
+        self.assertIn("product key from the caller repository name", product_repo_contract)
+        self.assertIn("`testing` stable lane", product_repo_contract)
         self.assertIn("idempotency key", product_repo_contract)
         self.assertIn("do not accept provider targets", product_repo_contract)
         self.assertIn("`preview_slug`", product_repo_contract)
@@ -136,6 +138,8 @@ class DocsContractsTests(TestCase):
         self.assertIn("derived value", preview_contract)
 
         self.assertIn("workflow_call:", deploy_workflow)
+        self.assertIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', deploy_workflow)
+        self.assertIn('INSTANCE="testing"', deploy_workflow)
         self.assertIn("route-path: /v1/drivers/generic-web/deploy", deploy_workflow)
         self.assertIn("generic-web-stable-deploy", deploy_workflow)
         self.assertIn("deploy.artifact_id=${{ inputs.artifact_id }}", deploy_workflow)


### PR DESCRIPTION
## Summary
- make reusable generic-web stable deploy derive the product from the caller repository name when omitted
- default the stable lane instance to testing so product repos do not need LAUNCHPLANE_PRODUCT/LAUNCHPLANE_INSTANCE vars for the common path
- update product repo contract docs and config-authority regression coverage for the minimal caller shape

## Context
SYO's first post-merge reusable stable deploy proof reached the Launchplane reusable workflow, but failed before request dispatch because the repo did not define LAUNCHPLANE_PRODUCT or LAUNCHPLANE_INSTANCE. Rather than adding those repo vars, this keeps the product repo thinner and lets Launchplane's product profile records accept or reject the derived product/lane.

## Validation
- actionlint .github/workflows/reusable-generic-web-stable-deploy.yml
- uv run python -m unittest tests.test_docs_contracts.DocsContractsTests.test_generic_web_reusable_workflows_keep_product_inputs_minimal tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cli_product_repo_gate_allows_reusable_generic_web_deploy_workflow
- uv run --extra dev ruff check tests/test_docs_contracts.py tests/test_config_authority_audit.py
- uv run --extra dev ruff format --check --diff tests/test_docs_contracts.py tests/test_config_authority_audit.py
- git diff --check