### PR TITLE
Add reusable generic web preview lifecycle workflow

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -95,6 +95,7 @@
     "Reusable Odoo Prod Rollback",
     "Reusable Generic Web Stable Deploy",
     "Reusable Generic Web Prod Promotion",
+    "Reusable Generic Web Preview Lifecycle",
     "Odoo Target Replacement Plan",
     "Odoo Target Replacement Apply",
     "Preview Lifecycle",

--- a/.github/workflows/reusable-generic-web-preview-lifecycle.yml
+++ b/.github/workflows/reusable-generic-web-preview-lifecycle.yml
@@ -1,0 +1,346 @@
+---
+name: Reusable Generic Web Preview Lifecycle
+
+"on":
+  workflow_call:
+    inputs:
+      operation:
+        description: Preview lifecycle operation to execute.
+        required: true
+        type: string
+      product:
+        description: >-
+          Launchplane product key. Defaults to the caller repository name.
+        required: false
+        default: ""
+        type: string
+      context:
+        description: >-
+          Launchplane preview context. Defaults to the resolved product key.
+        required: false
+        default: ""
+        type: string
+      anchor_pr_number:
+        description: Pull request number that owns the preview.
+        required: true
+        type: string
+      anchor_pr_url:
+        description: Pull request URL attached to preview evidence.
+        required: false
+        default: ""
+        type: string
+      anchor_head_sha:
+        description: Pull request head SHA attached to refresh evidence.
+        required: false
+        default: ""
+        type: string
+      image_reference:
+        description: Immutable preview image or artifact reference.
+        required: false
+        default: ""
+        type: string
+      destroy_reason:
+        description: Explicit reason for destroy operations.
+        required: false
+        default: ""
+        type: string
+      feedback_status:
+        description: Status for unsupported preview feedback.
+        required: false
+        default: unsupported
+        type: string
+      timeout-seconds:
+        description: Driver operation timeout in seconds.
+        required: false
+        default: "300"
+        type: string
+      timeout-ms:
+        description: Launchplane request timeout in milliseconds.
+        required: false
+        default: "1800000"
+        type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
+    outputs:
+      operation:
+        description: Resolved preview operation.
+        value: ${{ jobs.resolve.outputs.operation }}
+      preview_slug:
+        description: Launchplane-derived preview slug when returned.
+        value: >-
+          ${{ jobs.refresh.outputs.preview_slug || jobs.destroy.outputs.preview_slug }}
+      preview_url:
+        description: Launchplane-derived preview URL when returned.
+        value: ${{ jobs.refresh.outputs.preview_url }}
+      refresh_status:
+        description: Generic-web preview refresh status.
+        value: ${{ jobs.refresh.outputs.refresh_status }}
+      destroy_status:
+        description: Generic-web preview destroy status.
+        value: ${{ jobs.destroy.outputs.destroy_status }}
+      feedback_status:
+        description: Preview feedback status.
+        value: ${{ jobs.unsupported-notice.outputs.feedback_status }}
+      error_message:
+        description: Launchplane driver or feedback error message, when present.
+        value: >-
+          ${{ jobs.refresh.outputs.error_message || jobs.destroy.outputs.error_message || jobs.unsupported-notice.outputs.error_message }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  resolve:
+    outputs:
+      anchor_pr_number: ${{ steps.request.outputs.anchor_pr_number }}
+      context: ${{ steps.request.outputs.context }}
+      destroy_reason: ${{ steps.request.outputs.destroy_reason }}
+      idempotency_key: ${{ steps.request.outputs.idempotency_key }}
+      operation: ${{ steps.request.outputs.operation }}
+      product: ${{ steps.request.outputs.product }}
+      run_url: ${{ steps.request.outputs.run_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve Launchplane preview request
+        id: request
+        env:
+          ANCHOR_PR_NUMBER: ${{ inputs.anchor_pr_number }}
+          CONTEXT: ${{ inputs.context }}
+          DESTROY_REASON: ${{ inputs.destroy_reason }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          IMAGE_REFERENCE: ${{ inputs.image_reference }}
+          OPERATION: ${{ inputs.operation }}
+          PRODUCT: ${{ inputs.product }}
+          TIMEOUT_SECONDS: ${{ inputs['timeout-seconds'] }}
+        run: |
+          set -euo pipefail
+          OPERATION="$(printf '%s' "$OPERATION" | tr '[:upper:]' '[:lower:]')"
+          if [ -z "$PRODUCT" ]; then
+            PRODUCT="${GITHUB_REPOSITORY#*/}"
+          fi
+          if [ -z "$CONTEXT" ]; then
+            CONTEXT="$PRODUCT"
+          fi
+          for required in PRODUCT CONTEXT ANCHOR_PR_NUMBER OPERATION; do
+            if [ -z "${!required}" ]; then
+              echo "${required} is required." >&2
+              exit 1
+            fi
+          done
+          case "$OPERATION" in
+            refresh)
+              if [ "$GITHUB_EVENT_NAME" = "pull_request_target" ]; then
+                echo "refresh must not run from pull_request_target." >&2
+                exit 1
+              fi
+              if [ -z "$IMAGE_REFERENCE" ]; then
+                echo "IMAGE_REFERENCE is required for refresh." >&2
+                exit 1
+              fi
+              ;;
+            destroy)
+              if [ -z "$DESTROY_REASON" ]; then
+                DESTROY_REASON="manual_destroy_requested"
+              fi
+              ;;
+            unsupported_notice)
+              if [ "$GITHUB_EVENT_NAME" != "pull_request_target" ]; then
+                echo "unsupported_notice must run from pull_request_target." >&2
+                exit 1
+              fi
+              ;;
+            *)
+              echo "operation must be refresh, destroy, or unsupported_notice." >&2
+              exit 1
+              ;;
+          esac
+          case "$ANCHOR_PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "ANCHOR_PR_NUMBER must be a positive integer." >&2
+              exit 1
+              ;;
+          esac
+          if [ "$ANCHOR_PR_NUMBER" -lt 1 ]; then
+            echo "ANCHOR_PR_NUMBER must be a positive integer." >&2
+            exit 1
+          fi
+          if [ -z "$TIMEOUT_SECONDS" ]; then
+            TIMEOUT_SECONDS="300"
+          fi
+          case "$TIMEOUT_SECONDS" in
+            ''|*[!0-9]*)
+              echo "timeout-seconds must be a positive integer." >&2
+              exit 1
+              ;;
+          esac
+          if [ "$TIMEOUT_SECONDS" -lt 1 ]; then
+            echo "timeout-seconds must be a positive integer." >&2
+            exit 1
+          fi
+          run_scope="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          {
+            echo "anchor_pr_number=$ANCHOR_PR_NUMBER"
+            echo "context=$CONTEXT"
+            echo "destroy_reason=$DESTROY_REASON"
+            printf '%s=%s:%s:%s:pr-%s:%s\n' \
+              idempotency_key \
+              generic-web-preview-lifecycle \
+              "$PRODUCT" \
+              "$OPERATION" \
+              "$ANCHOR_PR_NUMBER" \
+              "$run_scope"
+            echo "operation=$OPERATION"
+            echo "product=$PRODUCT"
+            echo "run_url=$run_url"
+          } >>"$GITHUB_OUTPUT"
+
+  refresh:
+    if: ${{ needs.resolve.outputs.operation == 'refresh' }}
+    needs: resolve
+    outputs:
+      error_message: ${{ steps.lp.outputs.error_message }}
+      preview_slug: ${{ steps.lp.outputs.preview_slug }}
+      preview_url: ${{ steps.lp.outputs.preview_url }}
+      refresh_status: ${{ steps.lp.outputs.refresh_status }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request Launchplane generic-web preview refresh
+        id: lp
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
+          route-path: /v1/drivers/generic-web/preview-refresh
+          payload: |-
+            {
+              "schema_version": 1,
+              "refresh": {
+                "schema_version": 1
+              }
+            }
+          payload-fields: |-
+            product=${{ needs.resolve.outputs.product }}
+            refresh.product=${{ needs.resolve.outputs.product }}
+            refresh.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}
+            refresh.anchor_pr_url=${{ inputs.anchor_pr_url }}
+            refresh.anchor_head_sha=${{ inputs.anchor_head_sha }}
+            refresh.image_reference=${{ inputs.image_reference }}
+            refresh.source=${{ needs.resolve.outputs.run_url }}
+            refresh.timeout_seconds=${{ inputs['timeout-seconds'] }}
+          idempotency-key: >-
+            ${{ needs.resolve.outputs.idempotency_key }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: result.refresh_status,result.readiness.health_status
+          output-paths: >-
+            trace_id=trace_id,
+            preview_slug=result.preview_slug,
+            preview_url=result.preview_url,
+            refresh_status=result.refresh_status,
+            error_message=result.error_message
+
+      - name: Report refresh result
+        run: |
+          echo "preview_slug=${{ steps.lp.outputs.preview_slug }}"
+          echo "preview_url=${{ steps.lp.outputs.preview_url }}"
+          echo "refresh_status=${{ steps.lp.outputs.refresh_status }}"
+
+  destroy:
+    if: ${{ needs.resolve.outputs.operation == 'destroy' }}
+    needs: resolve
+    outputs:
+      destroy_status: ${{ steps.lp.outputs.destroy_status }}
+      error_message: ${{ steps.lp.outputs.error_message }}
+      preview_slug: ${{ steps.lp.outputs.preview_slug }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request Launchplane generic-web preview destroy
+        id: lp
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
+          route-path: /v1/drivers/generic-web/preview-destroy
+          payload: |-
+            {
+              "schema_version": 1,
+              "destroy": {
+                "schema_version": 1
+              }
+            }
+          payload-fields: |-
+            product=${{ needs.resolve.outputs.product }}
+            destroy.product=${{ needs.resolve.outputs.product }}
+            destroy.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}
+            destroy.destroy_reason=${{ needs.resolve.outputs.destroy_reason }}
+            destroy.timeout_seconds=${{ inputs['timeout-seconds'] }}
+          idempotency-key: >-
+            ${{ needs.resolve.outputs.idempotency_key }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: result.destroy_status
+          output-paths: >-
+            trace_id=trace_id,
+            preview_slug=result.preview_slug,
+            destroy_status=result.destroy_status,
+            error_message=result.error_message
+
+      - name: Report destroy result
+        run: |
+          echo "preview_slug=${{ steps.lp.outputs.preview_slug }}"
+          echo "destroy_status=${{ steps.lp.outputs.destroy_status }}"
+
+  unsupported-notice:
+    if: ${{ needs.resolve.outputs.operation == 'unsupported_notice' }}
+    needs: resolve
+    outputs:
+      error_message: ${{ steps.lp.outputs.error_message }}
+      feedback_status: ${{ steps.lp.outputs.feedback_status }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request Launchplane unsupported preview feedback
+        id: lp
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
+          route-path: /v1/previews/pr-feedback
+          payload: |-
+            {
+              "schema_version": 1
+            }
+          payload-fields: |-
+            product=${{ needs.resolve.outputs.product }}
+            context=${{ needs.resolve.outputs.context }}
+            repository=${{ github.repository }}
+            anchor_repo=${{ github.repository }}
+            anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}
+            anchor_pr_url=${{ inputs.anchor_pr_url }}
+            status=${{ inputs.feedback_status }}
+            source=${{ needs.resolve.outputs.run_url }}
+            run_url=${{ needs.resolve.outputs.run_url }}
+          idempotency-key: >-
+            ${{ needs.resolve.outputs.idempotency_key }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: result.delivery_status
+          output-paths: >-
+            trace_id=trace_id,
+            feedback_status=result.feedback_status,
+            error_message=result.error_message
+
+      - name: Report unsupported notice result
+        run: |
+          echo "feedback_status=${{ steps.lp.outputs.feedback_status }}"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -319,6 +319,11 @@ WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
     ".github/workflows/reusable-odoo-testing-deploy.yml": {
         "inputs.timeout-ms.default": frozenset(("2700000",)),
     },
+    ".github/workflows/reusable-generic-web-preview-lifecycle.yml": {
+        "inputs.feedback_status.default": frozenset(("unsupported",)),
+        "inputs.timeout-ms.default": frozenset(("1800000",)),
+        "inputs.timeout-seconds.default": frozenset(("300",)),
+    },
     ".github/workflows/runner-host-hygiene.yml": {
         "inputs.action.default": frozenset(("prune_docker_cache",)),
         "inputs.minimum_free_disk_bytes.default": frozenset(("0",)),
@@ -378,6 +383,11 @@ WORKFLOW_LAUNCHPLANE_URL_REFERENCE_PATH_VALUES = {
         "launchplane-url": frozenset(
             ("${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}",)
         ),
+    },
+    ".github/workflows/reusable-generic-web-preview-lifecycle.yml": {
+        "launchplane-url": frozenset(
+            ("${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}",)
+        )
     },
 }
 WORKFLOW_LAUNCHPLANE_BOOTSTRAP_CONTEXT_PATH_VALUES = {
@@ -509,6 +519,16 @@ WORKFLOW_OPERATOR_INPUT_REFERENCE_PATH_VALUES = {
         "CONTEXT_NAME": frozenset(("${{ inputs.context }}",)),
         "PRODUCT_INPUT": frozenset(("${{ inputs.product }}",)),
     },
+    ".github/workflows/reusable-generic-web-preview-lifecycle.yml": {
+        "ANCHOR_PR_NUMBER": frozenset(("${{ inputs.anchor_pr_number }}",)),
+        "CONTEXT": frozenset(("${{ inputs.context }}",)),
+        "DESTROY_REASON": frozenset(("${{ inputs.destroy_reason }}",)),
+        "GITHUB_EVENT_NAME": frozenset(("${{ github.event_name }}",)),
+        "IMAGE_REFERENCE": frozenset(("${{ inputs.image_reference }}",)),
+        "OPERATION": frozenset(("${{ inputs.operation }}",)),
+        "PRODUCT": frozenset(("${{ inputs.product }}",)),
+        "TIMEOUT_SECONDS": frozenset(("${{ inputs['timeout-seconds'] }}",)),
+    },
     ".github/workflows/odoo-config-parameter-override.yml": {
         "CONTEXT_NAME": frozenset(("${{ inputs.context }}",)),
         "KEY_NAME": frozenset(("${{ inputs.key }}",)),
@@ -636,6 +656,48 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
     },
     ".github/workflows/reusable-odoo-testing-deploy.yml": {
         "idempotency-key": frozenset(("${{ steps.product.outputs.idempotency_key }}",))
+    },
+    ".github/workflows/reusable-generic-web-preview-lifecycle.yml": {
+        "anchor_pr_number": frozenset(
+            (
+                "${{ needs.resolve.outputs.anchor_pr_number }}",
+                "${{ steps.request.outputs.anchor_pr_number }}",
+            )
+        ),
+        "anchor_repo": frozenset(("${{ github.repository }}",)),
+        "context": frozenset(
+            (
+                "${{ needs.resolve.outputs.context }}",
+                "${{ steps.request.outputs.context }}",
+            )
+        ),
+        "destroy.anchor_pr_number": frozenset(("${{ needs.resolve.outputs.anchor_pr_number }}",)),
+        "destroy.destroy_reason": frozenset(("${{ needs.resolve.outputs.destroy_reason }}",)),
+        "destroy.product": frozenset(("${{ needs.resolve.outputs.product }}",)),
+        "destroy.timeout_seconds": frozenset(("${{ inputs['timeout-seconds'] }}",)),
+        "destroy_reason": frozenset(("${{ steps.request.outputs.destroy_reason }}",)),
+        "idempotency-key": frozenset(("${{ needs.resolve.outputs.idempotency_key }}",)),
+        "idempotency_key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "preview_slug": frozenset(("${{ steps.lp.outputs.preview_slug }}",)),
+        "preview_url": frozenset(("${{ steps.lp.outputs.preview_url }}",)),
+        "product": frozenset(
+            (
+                "${{ needs.resolve.outputs.product }}",
+                "${{ steps.request.outputs.product }}",
+            )
+        ),
+        "refresh.anchor_pr_number": frozenset(("${{ needs.resolve.outputs.anchor_pr_number }}",)),
+        "refresh.source": frozenset(("${{ needs.resolve.outputs.run_url }}",)),
+        "refresh.product": frozenset(("${{ needs.resolve.outputs.product }}",)),
+        "refresh.timeout_seconds": frozenset(("${{ inputs['timeout-seconds'] }}",)),
+        "repository": frozenset(("${{ github.repository }}",)),
+        "run_url": frozenset(
+            (
+                "${{ needs.resolve.outputs.run_url }}",
+                "${{ steps.request.outputs.run_url }}",
+            )
+        ),
+        "source": frozenset(("${{ needs.resolve.outputs.run_url }}",)),
     },
     ".github/workflows/public-ingress-monitor.yml": {
         "idempotency-key": frozenset(

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -75,6 +75,29 @@ event, decision, route path, feedback status, and run-scoped idempotency key as
 JSON so product workflows can branch on the shared contract instead of
 duplicating event semantics.
 
+Once the product workflow has decided to refresh, destroy, or send an
+unsupported notice, it should hand off to Launchplane's reusable workflow instead
+of constructing route payloads locally:
+
+```yaml
+jobs:
+  launchplane-preview:
+    uses: cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@main
+    with:
+      operation: refresh
+      anchor_pr_number: ${{ github.event.pull_request.number }}
+      anchor_pr_url: ${{ github.event.pull_request.html_url }}
+      anchor_head_sha: ${{ github.event.pull_request.head.sha }}
+      image_reference: ${{ needs.build.outputs.image_digest }}
+```
+
+The reusable workflow derives the product key from the caller repository by
+default, derives a run-scoped idempotency key, calls the correct Launchplane
+route, and exposes the returned preview slug, preview URL, refresh status,
+destroy status, or feedback status as job outputs. It does not accept
+`preview_slug`, `preview_url`, provider target ids, feedback markdown, or
+idempotency keys as caller inputs.
+
 ## Required Workflow Shape
 
 Same-repository PRs use `pull_request` because the workflow may check out and
@@ -166,7 +189,7 @@ GitHub credentials and GitHub API failures are Launchplane-owned operator
 signals.
 
 Use `cbusillo/launchplane/.github/actions/launchplane-request@main` for the OIDC
-transport whenever a product workflow only needs to send JSON to Launchplane.
+transport only when a Launchplane-owned reusable workflow does not exist yet.
 
 ## Migration Checklist
 

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -410,6 +410,27 @@ jobs:
       source_git_ref: ${{ github.sha }}
 ```
 
+Preview refresh, destroy, and unsupported-notice handoff use:
+
+```yaml
+jobs:
+  launchplane-preview:
+    uses: cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@main
+    with:
+      operation: refresh
+      anchor_pr_number: ${{ github.event.pull_request.number }}
+      anchor_pr_url: ${{ github.event.pull_request.html_url }}
+      anchor_head_sha: ${{ github.event.pull_request.head.sha }}
+      image_reference: ${{ needs.build.outputs.image_digest }}
+```
+
+Destroy calls set `operation: destroy` and pass `destroy_reason`, while fork and
+Dependabot notices call the same reusable workflow from a trusted base-branch
+job with `operation: unsupported_notice`. Product repos do not pass preview
+slugs, preview URLs, provider application names, feedback markdown, or
+idempotency keys; Launchplane derives those from product profiles, runtime
+records, GitHub OIDC claims, and the run-scoped workflow context.
+
 These reusable workflows intentionally do not accept provider targets, target
 ids, health URLs, preview URLs, feedback markdown, record ids, managed secrets,
 runtime environment values, or idempotency keys. Launchplane derives or records

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1393,6 +1393,10 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             (".github/workflows/reusable-odoo-prod-rollback.yml", "launchplane-url"),
             (".github/workflows/reusable-odoo-testing-deploy.yml", "launchplane-url"),
             (".github/workflows/reusable-odoo-testing-deploy.yml", "LAUNCHPLANE_URL"),
+            (
+                ".github/workflows/reusable-generic-web-preview-lifecycle.yml",
+                "launchplane-url",
+            ),
         ):
             with self.subTest(path=path, key=key):
                 self.assertEqual(
@@ -1607,6 +1611,11 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 "uses",
                 "cbusillo/launchplane/.github/workflows/reusable-generic-web-stable-deploy.yml@main",
             ),
+            (
+                ".github/workflows/preview.yml",
+                "uses",
+                "cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@main",
+            ),
         )
         for case in thin_connectors:
             path, key, value, *context = case
@@ -1632,6 +1641,16 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 ".github/workflows/launchplane-deploy.yml",
                 "uses",
                 "cbusillo/launchplane/.github/workflows/reusable-generic-web-stable-deploy.yml@feature",
+            ),
+            (
+                ".github/workflows/preview.yml",
+                "uses",
+                "cbusillo/not-launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@main",
+            ),
+            (
+                ".github/workflows/preview.yml",
+                "uses",
+                "cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@feature",
             ),
             (
                 ".github/workflows/reusable-odoo-artifact-publish.yml",
@@ -3019,6 +3038,79 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("uses", thin_connector_keys)
         self.assertNotIn("product", thin_connector_keys)
         self.assertNotIn("instance", thin_connector_keys)
+
+    def test_cli_product_repo_gate_allows_reusable_generic_web_preview_workflow(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            workflow = root / ".github" / "workflows" / "preview.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text("name: Preview\n", encoding="utf-8")
+            _commit_all(root)
+            _git(root, "branch", "-M", "main")
+            _checkout_branch(root, "feature/reusable-preview")
+            workflow.write_text(
+                "---\n"
+                "name: Preview\n\n"
+                '"on":\n'
+                "  pull_request:\n"
+                "    types: [opened, synchronize, reopened, labeled, unlabeled, closed]\n\n"
+                "permissions:\n"
+                "  contents: read\n"
+                "  id-token: write\n"
+                "  packages: write\n\n"
+                "jobs:\n"
+                "  build-image:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    outputs:\n"
+                "      image_reference: ${{ steps.image.outputs.image_reference }}\n"
+                "    steps:\n"
+                "      - uses: actions/checkout@v6\n"
+                "      - id: image\n"
+                "        run: echo 'image_reference=ghcr.io/example/app@sha256:test' >> \"$GITHUB_OUTPUT\"\n"
+                "  preview:\n"
+                "    needs: build-image\n"
+                "    uses: cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@main\n"
+                "    with:\n"
+                "      operation: refresh\n"
+                "      launchplane_url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}\n"
+                "      anchor_pr_number: ${{ github.event.pull_request.number }}\n"
+                "      anchor_pr_url: ${{ github.event.pull_request.html_url }}\n"
+                "      anchor_head_sha: ${{ github.event.pull_request.head.sha }}\n"
+                "      image_reference: ${{ needs.build-image.outputs.image_reference }}\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "audit-config-authority",
+                    "--control-plane-root",
+                    str(root),
+                    "--mode",
+                    "changed-files-gate",
+                    "--fail-on-findings",
+                    "--gate-profile",
+                    "product-repo",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        gate = cast("dict[str, object]", payload["gate"])
+        self.assertEqual(gate["status"], "pass")
+        thin_connector_keys = {
+            finding["key"]
+            for finding in _findings(payload)
+            if finding["allow_reason"] == "thin_connector_input"
+        }
+        self.assertIn("uses", thin_connector_keys)
+        self.assertNotIn("preview_slug", thin_connector_keys)
+        self.assertNotIn("preview_url", thin_connector_keys)
+        self.assertNotIn("idempotency-key", thin_connector_keys)
 
     def test_cli_product_repo_gate_allows_compact_launchplane_tool_checkout(self) -> None:
         with TemporaryDirectory() as temp_dir:

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -121,21 +121,30 @@ class DocsContractsTests(TestCase):
         promotion_workflow = Path(
             ".github/workflows/reusable-generic-web-prod-promotion.yml"
         ).read_text(encoding="utf-8")
+        preview_workflow = Path(
+            ".github/workflows/reusable-generic-web-preview-lifecycle.yml"
+        ).read_text(encoding="utf-8")
         repo_metadata = Path(".github/github.json").read_text(encoding="utf-8")
 
         self.assertIn("Reusable Generic-Web Lifecycle Workflows", product_repo_contract)
         self.assertIn("reusable-generic-web-stable-deploy.yml@main", product_repo_contract)
         self.assertIn("reusable-generic-web-prod-promotion.yml@main", product_repo_contract)
+        self.assertIn("reusable-generic-web-preview-lifecycle.yml@main", product_repo_contract)
         self.assertIn("route path, request JSON shape", product_repo_contract)
         self.assertIn("product key from the caller repository name", product_repo_contract)
         self.assertIn("`testing` stable lane", product_repo_contract)
         self.assertIn("idempotency key", product_repo_contract)
+        self.assertIn("Destroy calls set `operation: destroy`", product_repo_contract)
+        self.assertIn("unsupported_notice", product_repo_contract)
         self.assertIn("do not accept provider targets", product_repo_contract)
         self.assertIn("`preview_slug`", product_repo_contract)
         self.assertIn("`preview_url` are compatibility overrides", product_repo_contract)
         self.assertIn("anchor_pr_number` and omit", preview_contract)
         self.assertIn("conflicts with the", preview_contract)
         self.assertIn("derived value", preview_contract)
+        self.assertIn("reusable-generic-web-preview-lifecycle.yml@main", preview_contract)
+        self.assertIn("does not accept", preview_contract)
+        self.assertIn("idempotency keys as caller inputs", preview_contract)
 
         self.assertIn("workflow_call:", deploy_workflow)
         self.assertIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', deploy_workflow)
@@ -155,5 +164,29 @@ class DocsContractsTests(TestCase):
         self.assertNotIn("health_url", promotion_workflow)
         self.assertNotIn("preview_url", promotion_workflow)
 
+        self.assertIn("workflow_call:", preview_workflow)
+        self.assertIn("operation:", preview_workflow)
+        self.assertIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', preview_workflow)
+        self.assertIn("route-path: /v1/drivers/generic-web/preview-refresh", preview_workflow)
+        self.assertIn("route-path: /v1/drivers/generic-web/preview-destroy", preview_workflow)
+        self.assertIn("route-path: /v1/previews/pr-feedback", preview_workflow)
+        self.assertIn("generic-web-preview-lifecycle", preview_workflow)
+        self.assertIn(
+            "refresh.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}",
+            preview_workflow,
+        )
+        self.assertIn("refresh.image_reference=${{ inputs.image_reference }}", preview_workflow)
+        self.assertIn(
+            "destroy.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}",
+            preview_workflow,
+        )
+        self.assertIn("status=${{ inputs.feedback_status }}", preview_workflow)
+        self.assertNotIn("inputs.preview_slug", preview_workflow)
+        self.assertNotIn("inputs.preview_url", preview_workflow)
+        self.assertNotIn("target_id", preview_workflow)
+        self.assertNotIn("provider_target", preview_workflow)
+        self.assertNotIn("feedback_markdown", preview_workflow)
+
         self.assertIn("Reusable Generic Web Stable Deploy", repo_metadata)
         self.assertIn("Reusable Generic Web Prod Promotion", repo_metadata)
+        self.assertIn("Reusable Generic Web Preview Lifecycle", repo_metadata)


### PR DESCRIPTION
## Summary
- add a Launchplane-owned reusable generic-web preview lifecycle workflow for refresh, destroy, and unsupported notices
- derive product/idempotency inside the reusable workflow and keep preview slug/url/provider/feedback markdown out of caller inputs
- document the product-repo handoff shape and update config-authority/docs contract coverage

## Validation
- actionlint .github/workflows/reusable-generic-web-preview-lifecycle.yml
- uv run python -m unittest tests.test_docs_contracts.DocsContractsTests.test_generic_web_reusable_workflows_keep_product_inputs_minimal tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_launchplane_public_url_reference_is_self_bootstrap tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_connector_findings_are_classified_narrowly tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cli_product_repo_gate_allows_reusable_generic_web_preview_workflow
- timeout 180 uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate --fail-on-findings
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_docs_contracts.py
- uv run --extra dev ruff format --check --diff control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_docs_contracts.py
- git diff --check