### PR TITLE
Fix reusable preview feedback outputs

### DIFF
--- a/.github/workflows/reusable-generic-web-preview-lifecycle.yml
+++ b/.github/workflows/reusable-generic-web-preview-lifecycle.yml
@@ -338,7 +338,7 @@ jobs:
           fail-result-paths: result.delivery_status
           output-paths: >-
             trace_id=trace_id,
-            feedback_status=result.feedback_status,
+            feedback_status=result.status,
             error_message=result.error_message
 
       - name: Report unsupported notice result

--- a/.github/workflows/reusable-preview-pr-feedback.yml
+++ b/.github/workflows/reusable-preview-pr-feedback.yml
@@ -186,7 +186,7 @@ jobs:
           fail-result-paths: result.delivery_status
           output-paths: >-
             trace_id=trace_id,
-            feedback_status=result.feedback_status,
+            feedback_status=result.status,
             error_message=result.error_message
 
       - name: Report preview feedback result

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1555,22 +1555,20 @@ preview context, not caller-supplied runtime authority.
 
 Generic web preview refresh uses native FastAPI
 `POST /v1/drivers/generic-web/preview-refresh`. The request names the product,
-preview slug, and immutable image reference. Launchplane resolves the repository
-and preview context from the DB-backed product profile before authorization,
-derives the canonical live preview URL from the context-level
-`LAUNCHPLANE_PREVIEW_BASE_URL` runtime-environment record plus the preview slug,
-derives the anchor pull request from the preview slug when possible, and records
-preview and generation evidence for both successful and failed provider results.
-Product workflows may send
-`anchor_pr_number`, `anchor_pr_url`, and `anchor_head_sha` when the preview slug
-cannot be parsed from the configured slug template or when the workflow has more
-precise anchor metadata than the image reference. `preview_url` remains accepted
-as a compatibility override but is not the product-repo authority for new
-workflows. Preview health failures that return Dokploy Dead Host are classified
-as public preview ingress failures so workflow output and persisted generation
-evidence point at DNS/ingress routing instead of a generic provider timeout.
-The route keeps optional `Idempotency-Key` replay/conflict behavior and skips
-blocked or failed-result replay storage so retries can observe recovered
+anchor pull-request number, and immutable image reference. Launchplane resolves
+the repository, preview context, and preview slug policy from the DB-backed
+product profile before authorization, derives the preview slug from the anchor
+pull-request number, and derives the canonical live preview URL from the
+context-level `LAUNCHPLANE_PREVIEW_BASE_URL` runtime-environment record plus the
+slug. Product workflows may send `anchor_pr_url` and `anchor_head_sha` when the
+workflow has precise anchor metadata. `preview_slug` and `preview_url` remain
+accepted as compatibility overrides but are not product-repo authority for new
+workflows; a supplied slug is rejected when it conflicts with the product profile
+slug policy. Preview health failures that return Dokploy Dead Host are
+classified as public preview ingress failures so workflow output and persisted
+generation evidence point at DNS/ingress routing instead of a generic provider
+timeout. The route keeps optional `Idempotency-Key` replay/conflict behavior and
+skips blocked or failed-result replay storage so retries can observe recovered
 runtime/provider state.
 
 Generic web preview inventory and destroy use

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -16,6 +16,10 @@ from control_plane.contracts.preview_workflow_contract import (
     decide_preview_workflow_operation,
     preview_workflow_idempotency_key,
 )
+from control_plane.workflows.generic_web_preview import (
+    GenericWebPreviewDestroyRequest,
+    GenericWebPreviewRefreshRequest,
+)
 
 
 CLI_MAIN = cast(Command, main)
@@ -169,6 +173,8 @@ class PreviewWorkflowContractTests(unittest.TestCase):
 
         self.assertIn("route-path: /v1/previews/pr-feedback", workflow)
         self.assertIn("status=${{ steps.request.outputs.status }}", workflow)
+        self.assertIn("feedback_status=result.status", workflow)
+        self.assertNotIn("result.feedback_status", workflow)
         self.assertIn("idempotency_key", workflow)
         self.assertIn("preview-pr-feedback", workflow)
 
@@ -192,6 +198,52 @@ class PreviewWorkflowContractTests(unittest.TestCase):
             "cleared",
         ):
             self.assertIn(status, workflow)
+
+    def test_reusable_generic_web_preview_lifecycle_derives_preview_slug(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github/workflows/reusable-generic-web-preview-lifecycle.yml"
+        ).read_text(encoding="utf-8")
+        workflow_inputs = _workflow_call_inputs(workflow)
+
+        self.assertIn("route-path: /v1/drivers/generic-web/preview-refresh", workflow)
+        self.assertIn("route-path: /v1/drivers/generic-web/preview-destroy", workflow)
+        self.assertIn("refresh.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow)
+        self.assertIn("destroy.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow)
+
+        self.assertNotIn("preview_slug", workflow_inputs)
+        self.assertNotIn("preview_url", workflow_inputs)
+        self.assertNotIn("refresh.preview_slug=", workflow)
+        self.assertNotIn("destroy.preview_slug=", workflow)
+
+    def test_reusable_generic_web_preview_lifecycle_feedback_maps_record_status(
+        self,
+    ) -> None:
+        workflow = (
+            REPO_ROOT / ".github/workflows/reusable-generic-web-preview-lifecycle.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("route-path: /v1/previews/pr-feedback", workflow)
+        self.assertIn("feedback_status=result.status", workflow)
+        self.assertNotIn("result.feedback_status", workflow)
+
+    def test_generic_web_preview_requests_accept_anchor_pr_number_without_slug(
+        self,
+    ) -> None:
+        refresh_request = GenericWebPreviewRefreshRequest(
+            product="demo",
+            image_reference="ghcr.io/example/demo@sha256:abc123",
+            anchor_pr_number=42,
+        )
+        destroy_request = GenericWebPreviewDestroyRequest(
+            product="demo",
+            anchor_pr_number=42,
+            destroy_reason="preview_label_removed",
+        )
+
+        self.assertEqual(refresh_request.preview_slug, "")
+        self.assertEqual(refresh_request.anchor_pr_number, 42)
+        self.assertEqual(destroy_request.preview_slug, "")
+        self.assertEqual(destroy_request.anchor_pr_number, 42)
 
 
 class PreviewWorkflowDecisionCliTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
- map reusable preview feedback outputs from Launchplane result.status instead of missing result.feedback_status
- keep generic-web lifecycle inputs PR-number-first so Launchplane derives preview slugs
- update service-boundary docs and workflow contract tests for the v2 boundary

## Validation
- uv run python -m unittest tests.test_preview_workflow_contract
- actionlint .github/workflows/reusable-generic-web-preview-lifecycle.yml .github/workflows/reusable-preview-pr-feedback.yml
- uv run --extra dev ruff check --diff tests/test_preview_workflow_contract.py
- uv run --extra dev ruff check tests/test_preview_workflow_contract.py
- git diff --check

Agent review: code-gpt-5.5 and claude-opus-4.8 both reviewed the diff; no merge blockers after the included test assertions and dual workflow patch.