### PR TITLE
Make generic preview destroy idempotent

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1521,7 +1521,19 @@ def execute_generic_web_preview_destroy(
         token=token,
         application_name=application_name,
     )
-    application_id = str((application or {}).get("applicationId") or "").strip()
+    if application is None:
+        finished_at = utc_now_timestamp()
+        return GenericWebPreviewDestroyResult(
+            destroy_status="pass",
+            destroy_started_at=started_at,
+            destroy_finished_at=finished_at,
+            product=resolved_profile.product,
+            context=resolved_profile.preview.context,
+            preview_slug=request.preview_slug,
+            application_name=application_name,
+            application_id="",
+        )
+    application_id = str(application.get("applicationId") or application.get("id") or "").strip()
     if not application_id:
         finished_at = utc_now_timestamp()
         return GenericWebPreviewDestroyResult(
@@ -1533,7 +1545,10 @@ def execute_generic_web_preview_destroy(
             preview_slug=request.preview_slug,
             application_name=application_name,
             application_id="",
-            error_message=f"Preview application {application_name!r} was not found.",
+            error_message=(
+                f"Preview application {application_name!r} exists but does not expose "
+                "applicationId."
+            ),
         )
     destroy_result = destroy_dokploy_preview_resource(
         host=host,

--- a/control_plane/workflows/preview_lifecycle_cleanup.py
+++ b/control_plane/workflows/preview_lifecycle_cleanup.py
@@ -141,7 +141,7 @@ def _build_generic_web_cleanup_record(
                 timeout_seconds=timeout_seconds,
             ),
         )
-        if destroy_result.destroy_status == "pass" and destroy_result.application_id.strip():
+        if destroy_result.destroy_status == "pass":
             try:
                 apply_launchplane_destroy_preview(
                     record_store=record_store,
@@ -179,9 +179,6 @@ def _build_generic_web_cleanup_record(
                 )
             continue
         failed_slugs.append(preview_slug)
-        error_message = destroy_result.error_message
-        if destroy_result.destroy_status == "pass":
-            error_message = "Preview destroy returned pass without a provider application id."
         results.append(
             PreviewLifecycleCleanupResult(
                 preview_slug=preview_slug,
@@ -190,7 +187,7 @@ def _build_generic_web_cleanup_record(
                 status="failed",
                 application_name=destroy_result.application_name,
                 application_id=destroy_result.application_id,
-                error_message=error_message,
+                error_message=destroy_result.error_message,
             )
         )
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1576,9 +1576,11 @@ Generic web preview inventory and destroy use
 `POST /v1/drivers/generic-web/preview-destroy`. Both routes run through native
 FastAPI. Inventory scans stateless Dokploy preview applications by the preview
 application-name prefix in the DB-backed product profile. Destroy deletes
-matching preview applications and keeps the legacy preview-destroy idempotency
-fingerprint that ignores `destroy_reason` so reason-only retry metadata does not
-conflict with the original teardown request. Lifecycle cleanup can dispatch to
+matching preview applications and treats an already-missing preview application
+as clean so PR-close cleanup remains idempotent when no preview was ever created.
+The route keeps the legacy preview-destroy idempotency fingerprint that ignores
+`destroy_reason` so reason-only retry metadata does not conflict with the
+original teardown request. Lifecycle cleanup can dispatch to
 this generic path only after a passing plan and a matching stored preview record
 are present. The descriptor routes remain discoverable.
 

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1575,7 +1575,7 @@ class GenericWebPreviewTests(unittest.TestCase):
 
         read_dokploy_config.assert_not_called()
 
-    def test_execute_generic_web_preview_destroy_fails_when_application_missing(self) -> None:
+    def test_execute_generic_web_preview_destroy_passes_when_application_missing(self) -> None:
         store = _GenericWebPreviewStore(_profile())
         requests: list[dict[str, object]] = []
 
@@ -1623,9 +1623,114 @@ class GenericWebPreviewTests(unittest.TestCase):
                 ),
             )
 
+        self.assertEqual(result.destroy_status, "pass")
+        self.assertEqual(result.application_id, "")
+        self.assertEqual(result.error_message, "")
+        self.assertEqual([request["path"] for request in requests], ["/api/project.all"])
+
+    def test_execute_generic_web_preview_destroy_uses_inventory_id_fallback(self) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [
+                    {
+                        "environments": [
+                            {
+                                "applications": [
+                                    {
+                                        "id": "app-42",
+                                        "name": "syo-preview-preview-42-site",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            if path == "/api/domain.byApplicationId":
+                return []
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-04-30T21:00:00Z", "2026-04-30T21:00:02Z"],
+            ),
+        ):
+            result = execute_generic_web_preview_destroy(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewDestroyRequest(
+                    product="sellyouroutboard",
+                    preview_slug="preview-42-site",
+                    destroy_reason="test",
+                ),
+            )
+
+        self.assertEqual(result.destroy_status, "pass")
+        self.assertEqual(result.application_id, "app-42")
+        self.assertEqual(
+            [request["path"] for request in requests],
+            [
+                "/api/project.all",
+                "/api/domain.byApplicationId",
+                "/api/application.delete",
+            ],
+        )
+
+    def test_execute_generic_web_preview_destroy_fails_when_application_id_missing(
+        self,
+    ) -> None:
+        store = _GenericWebPreviewStore(_profile())
+        requests: list[dict[str, object]] = []
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            requests.append(dict(kwargs))
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [
+                    {"environments": [{"applications": [{"name": "syo-preview-preview-42-site"}]}]}
+                ]
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.generic_web_preview.utc_now_timestamp",
+                side_effect=["2026-04-30T21:00:00Z", "2026-04-30T21:00:02Z"],
+            ),
+        ):
+            result = execute_generic_web_preview_destroy(
+                control_plane_root=Path("."),
+                record_store=store,
+                request=GenericWebPreviewDestroyRequest(
+                    product="sellyouroutboard",
+                    preview_slug="preview-42-site",
+                    destroy_reason="test",
+                ),
+            )
+
         self.assertEqual(result.destroy_status, "fail")
         self.assertEqual(result.application_id, "")
-        self.assertIn("syo-preview-preview-42-site", result.error_message)
+        self.assertIn("does not expose applicationId", result.error_message)
         self.assertEqual([request["path"] for request in requests], ["/api/project.all"])
 
     def test_execute_generic_web_preview_destroy_ignores_retired_odoo_compose_domains(self) -> None:
@@ -1660,10 +1765,10 @@ class GenericWebPreviewTests(unittest.TestCase):
                 ),
             )
 
-        self.assertEqual(result.destroy_status, "fail")
+        self.assertEqual(result.destroy_status, "pass")
         self.assertEqual(result.provider_type, "application")
         self.assertEqual(result.application_id, "")
-        self.assertIn("cm-odoo-preview-pr-28", result.error_message)
+        self.assertEqual(result.error_message, "")
         self.assertEqual([request["path"] for request in requests], ["/api/project.all"])
 
 

--- a/tests/test_preview_lifecycle_cleanup.py
+++ b/tests/test_preview_lifecycle_cleanup.py
@@ -104,7 +104,7 @@ class PreviewLifecycleCleanupTests(unittest.TestCase):
         self.assertEqual(record.status, "blocked")
         self.assertEqual(record.blocked_slugs, ("bad-slug",))
 
-    def test_generic_web_cleanup_fails_pass_without_application_id(self) -> None:
+    def test_generic_web_cleanup_treats_missing_application_as_destroyed(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = FilesystemRecordStore(state_dir=root / "state")
@@ -160,11 +160,15 @@ class PreviewLifecycleCleanupTests(unittest.TestCase):
                     preview_slug_template="preview-{number}-site",
                 )
 
-            self.assertEqual(record.status, "fail")
-            self.assertEqual(record.failed_slugs, ("preview-42-site",))
-            self.assertIn("provider application id", record.results[0].error_message)
+            self.assertEqual(record.status, "pass")
+            self.assertEqual(record.destroyed_slugs, ("preview-42-site",))
+            self.assertEqual(record.failed_slugs, ())
+            self.assertEqual(record.results[0].status, "destroyed")
+            self.assertEqual(record.results[0].application_id, "")
+            self.assertEqual(record.results[0].error_message, "")
             preview = store.read_preview_record("preview-syo-testing-sellyouroutboard-pr-42")
-            self.assertEqual(preview.state, "active")
+            self.assertEqual(preview.state, "destroyed")
+            self.assertEqual(preview.destroy_reason, "test_cleanup")
 
     def test_verireel_cleanup_uses_plan_product_as_anchor_repo(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- treat generic-web preview destroy for an already-missing application as an idempotent pass
- keep malformed provider records fail-closed by requiring applicationId/id when an app is present
- reconcile lifecycle cleanup records and stored preview records when provider state is already clean
- document missing-preview cleanup as an idempotent PR-close path

## Dogfood evidence
SellYourOutboard PR #182 merged successfully after the Launchplane workflow fix, then post-merge Preview Cleanup failed because no preview app existed for a Dependabot PR whose preview jobs were skipped. Product repos should not special-case that; Launchplane owns the cleanup semantics.

## Validation
- uv run python -m unittest tests.test_generic_web_preview tests.test_preview_lifecycle_cleanup
- uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py control_plane/workflows/preview_lifecycle_cleanup.py tests/test_generic_web_preview.py tests/test_preview_lifecycle_cleanup.py
- uv run --extra dev ruff format --check control_plane/workflows/generic_web_preview.py control_plane/workflows/preview_lifecycle_cleanup.py tests/test_generic_web_preview.py tests/test_preview_lifecycle_cleanup.py
- git diff --check

## Review
Two read-only agents reviewed the idempotent destroy behavior. A provider-id edge was found and fixed: destroy now uses applicationId/id fallback when an app is present, and only a truly missing app becomes no-op success.