### PR TITLE
Add reusable preview request notice workflow

### DIFF
--- a/.github/workflows/reusable-preview-request-notice.yml
+++ b/.github/workflows/reusable-preview-request-notice.yml
@@ -1,0 +1,167 @@
+---
+name: Reusable Preview Request Notice
+
+"on":
+  workflow_call:
+    inputs:
+      product:
+        description: >-
+          Launchplane product key. Defaults to the caller repository name.
+        required: false
+        default: ""
+        type: string
+      context:
+        description: >-
+          Launchplane preview context. Defaults to the resolved product key.
+        required: false
+        default: ""
+        type: string
+      preview_label:
+        description: Label that requests preview automation.
+        required: false
+        default: preview
+        type: string
+      timeout-ms:
+        description: Launchplane request timeout in milliseconds.
+        required: false
+        default: "300000"
+        type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
+    outputs:
+      feedback_status:
+        description: Preview feedback status returned by Launchplane.
+        value: ${{ jobs.feedback.outputs.feedback_status }}
+      notice_status:
+        description: Resolved notice status.
+        value: ${{ jobs.resolve.outputs.status }}
+      should_record:
+        description: Whether the event required a feedback mutation.
+        value: ${{ jobs.resolve.outputs.should_record }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  resolve:
+    outputs:
+      anchor_pr_number: ${{ steps.notice.outputs.anchor_pr_number }}
+      anchor_pr_url: ${{ steps.notice.outputs.anchor_pr_url }}
+      failure_summary: ${{ steps.notice.outputs.failure_summary }}
+      run_url: ${{ steps.notice.outputs.run_url }}
+      should_record: ${{ steps.notice.outputs.should_record }}
+      status: ${{ steps.notice.outputs.status }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve preview request notice
+        id: notice
+        uses: actions/github-script@v8
+        env:
+          PREVIEW_LABEL: ${{ inputs.preview_label }}
+          RUN_URL: >-
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{
+              github.run_id }}
+        with:
+          script: |
+            if (context.eventName !== 'pull_request_target') {
+              throw new Error('reusable-preview-request-notice must run from pull_request_target.');
+            }
+
+            const pullRequest = context.payload.pull_request;
+            if (!pullRequest) {
+              throw new Error('pull_request payload is required.');
+            }
+
+            const previewLabelName = String(process.env.PREVIEW_LABEL || 'preview')
+              .trim()
+              .toLowerCase();
+            if (!previewLabelName) {
+              throw new Error('preview_label must not be empty.');
+            }
+
+            const labels = pullRequest.labels || [];
+            const previewRequested = labels.some((label) =>
+              String(typeof label === 'string' ? label : label?.name || '')
+                .trim()
+                .toLowerCase() === previewLabelName,
+            );
+            const headRepoFullName = String(pullRequest.head.repo?.full_name || '');
+            const repositoryFullName = String(context.payload.repository?.full_name || '');
+            const sameRepo =
+              Boolean(headRepoFullName) &&
+              Boolean(repositoryFullName) &&
+              headRepoFullName === repositoryFullName;
+            const prAuthor = String(pullRequest.user.login || '')
+              .trim()
+              .toLowerCase();
+            const executionTrust =
+              prAuthor === 'dependabot[bot]'
+                ? 'dependabot'
+                : sameRepo
+                  ? 'same_repo'
+                  : 'fork';
+            const unsupportedTrust =
+              executionTrust === 'dependabot' || executionTrust === 'fork';
+            const action = String(context.payload.action || '').trim();
+            const closed = action === 'closed';
+            const changedLabel = String(context.payload.label?.name || '')
+              .trim()
+              .toLowerCase();
+            const previewLabelChanged = changedLabel === previewLabelName;
+            const previewRefreshAction =
+              action === 'opened' ||
+              action === 'reopened' ||
+              action === 'edited' ||
+              action === 'synchronize';
+            const shouldSetUnsupported =
+              unsupportedTrust &&
+              ((previewRefreshAction && previewRequested) ||
+                (action === 'labeled' && previewLabelChanged));
+            const shouldClear =
+              unsupportedTrust &&
+              (closed || (action === 'unlabeled' && previewLabelChanged));
+            const shouldRecord = shouldSetUnsupported || shouldClear;
+
+            let status = 'cleared';
+            let failureSummary = '';
+            if (shouldSetUnsupported) {
+              status = 'unsupported';
+              failureSummary =
+                executionTrust === 'dependabot'
+                  ? 'Preview automation is disabled for Dependabot PRs because GitHub withholds the deployment secrets needed for artifact publication and provider mutation.'
+                  : 'Preview automation currently supports only branches in this repository, not forked PRs.';
+            }
+
+            core.setOutput('anchor_pr_number', String(pullRequest.number));
+            core.setOutput('anchor_pr_url', String(pullRequest.html_url || ''));
+            core.setOutput('failure_summary', failureSummary);
+            core.setOutput('run_url', process.env.RUN_URL);
+            core.setOutput('should_record', String(shouldRecord));
+            core.setOutput('status', status);
+
+  feedback:
+    if: ${{ needs.resolve.outputs.should_record == 'true' }}
+    needs: resolve
+    uses: cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main
+    with:
+      product: ${{ inputs.product }}
+      context: ${{ inputs.context }}
+      anchor_pr_number: ${{ needs.resolve.outputs.anchor_pr_number }}
+      anchor_pr_url: ${{ needs.resolve.outputs.anchor_pr_url }}
+      status: ${{ needs.resolve.outputs.status }}
+      run_url: ${{ needs.resolve.outputs.run_url }}
+      failure_summary: ${{ needs.resolve.outputs.failure_summary }}
+      timeout-ms: ${{ inputs['timeout-ms'] }}
+      launchplane_url: ${{ inputs.launchplane_url }}
+      launchplane_audience: ${{ inputs.launchplane_audience }}

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -117,9 +117,13 @@ build the PR head:
 - Any PR without the preview label: `ignore`.
 
 Fork and Dependabot PRs use `pull_request_target` only for an unsupported notice.
-That job must run from the base branch, must not check out untrusted PR code, and
-must only call `POST /v1/previews/pr-feedback` with `status="unsupported"`.
-Launchplane will render and deliver the comment.
+That job must run from the base branch and call
+`cbusillo/launchplane/.github/workflows/reusable-preview-request-notice.yml@main`.
+The reusable workflow owns the trusted event decision, unsupported/cleared
+status selection, failure summary, and `/v1/previews/pr-feedback` handoff.
+Product repos must not check out code, choose a checkout ref, render feedback
+markdown, build request payloads, or call `POST /v1/previews/pr-feedback`
+directly from their own fork/Dependabot notice workflows.
 
 Manual `workflow_dispatch` may request `refresh` or `destroy` when a product repo
 needs an operator retry path. Manual refresh still follows the same build,

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -424,12 +424,14 @@ jobs:
       image_reference: ${{ needs.build.outputs.image_digest }}
 ```
 
-Destroy calls set `operation: destroy` and pass `destroy_reason`, while fork and
-Dependabot notices call the same reusable workflow from a trusted base-branch
-job with `operation: unsupported_notice`. Product repos do not pass preview
-slugs, preview URLs, provider application names, feedback markdown, or
-idempotency keys; Launchplane derives those from product profiles, runtime
-records, GitHub OIDC claims, and the run-scoped workflow context.
+Destroy calls set `operation: destroy` and pass `destroy_reason`. Fork and
+Dependabot notices call
+`cbusillo/launchplane/.github/workflows/reusable-preview-request-notice.yml@main`
+from a trusted `pull_request_target` workflow. Product repos do not choose a
+trusted checkout ref, pass preview slugs, preview URLs, provider application
+names, feedback markdown, route payloads, or idempotency keys; Launchplane
+derives those from product profiles, runtime records, GitHub OIDC claims, the PR
+event, and the run-scoped workflow context.
 
 These reusable workflows intentionally do not accept provider targets, target
 ids, health URLs, preview URLs, feedback markdown, record ids, managed secrets,

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -424,12 +424,14 @@ jobs:
       image_reference: ${{ needs.build.outputs.image_digest }}
 ```
 
-Destroy calls set `operation: destroy` and pass `destroy_reason`, while fork and
-Dependabot notices call the same reusable workflow from a trusted base-branch
-job with `operation: unsupported_notice`. Product repos do not pass preview
-slugs, preview URLs, provider application names, feedback markdown, or
-idempotency keys; Launchplane derives those from product profiles, runtime
-records, GitHub OIDC claims, and the run-scoped workflow context.
+Destroy calls set `operation: destroy` and pass `destroy_reason`. Fork and
+Dependabot `unsupported_notice` handoffs call
+`cbusillo/launchplane/.github/workflows/reusable-preview-request-notice.yml@main`
+from a trusted `pull_request_target` workflow. Product repos do not choose a
+trusted checkout ref, pass preview slugs, preview URLs, provider application
+names, feedback markdown, route payloads, or idempotency keys; Launchplane
+derives those from product profiles, runtime records, GitHub OIDC claims, the PR
+event, and the run-scoped workflow context.
 
 These reusable workflows intentionally do not accept provider targets, target
 ids, health URLs, preview URLs, feedback markdown, record ids, managed secrets,

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -199,6 +199,32 @@ class PreviewWorkflowContractTests(unittest.TestCase):
         ):
             self.assertIn(status, workflow)
 
+    def test_reusable_preview_request_notice_owns_notice_decision(self) -> None:
+        workflow_path = REPO_ROOT / ".github/workflows/reusable-preview-request-notice.yml"
+        workflow = workflow_path.read_text(encoding="utf-8")
+        workflow_inputs = _workflow_call_inputs(workflow)
+
+        self.assertIn("pull_request_target", workflow)
+        self.assertIn("context.eventName !== 'pull_request_target'", workflow)
+        self.assertIn("uses: actions/github-script@v8", workflow)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main",
+            workflow,
+        )
+        self.assertIn("status: ${{ needs.resolve.outputs.status }}", workflow)
+        self.assertIn("failure_summary: ${{ needs.resolve.outputs.failure_summary }}", workflow)
+        self.assertIn("const unsupportedTrust =", workflow)
+        self.assertIn("action === 'edited'", workflow)
+        self.assertIn("const shouldSetUnsupported =", workflow)
+        self.assertNotIn("status = 'pending'", workflow)
+
+        self.assertNotIn("actions/checkout", workflow)
+        self.assertNotIn("ref:", workflow)
+        self.assertNotIn("marker", workflow_inputs)
+        self.assertNotIn("idempotency-key", workflow_inputs)
+        self.assertNotIn("payload", workflow_inputs)
+        self.assertNotIn("route-path", workflow_inputs)
+
     def test_reusable_generic_web_preview_lifecycle_derives_preview_slug(self) -> None:
         workflow = (
             REPO_ROOT / ".github/workflows/reusable-generic-web-preview-lifecycle.yml"
@@ -207,8 +233,12 @@ class PreviewWorkflowContractTests(unittest.TestCase):
 
         self.assertIn("route-path: /v1/drivers/generic-web/preview-refresh", workflow)
         self.assertIn("route-path: /v1/drivers/generic-web/preview-destroy", workflow)
-        self.assertIn("refresh.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow)
-        self.assertIn("destroy.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow)
+        self.assertIn(
+            "refresh.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow
+        )
+        self.assertIn(
+            "destroy.anchor_pr_number=${{ needs.resolve.outputs.anchor_pr_number }}", workflow
+        )
 
         self.assertNotIn("preview_slug", workflow_inputs)
         self.assertNotIn("preview_url", workflow_inputs)


### PR DESCRIPTION
## Summary
- add a reusable pull_request_target workflow for fork/Dependabot preview request notices
- keep product repos out of trusted checkout refs, payload shaping, feedback markdown, and route selection
- document the thin product-repo contract and cover the reusable notice workflow in preview contract tests

## Validation
- actionlint .github/workflows/reusable-preview-request-notice.yml
- uv run python -m unittest tests.test_preview_workflow_contract
- uv run --extra dev ruff format --check tests/test_preview_workflow_contract.py
- uv run --extra dev ruff check --diff tests/test_preview_workflow_contract.py
- uv run --extra dev ruff check tests/test_preview_workflow_contract.py
- git diff --check