### PR TITLE
Derive preview feedback context from product profiles

### DIFF
--- a/.github/workflows/reusable-preview-pr-feedback.yml
+++ b/.github/workflows/reusable-preview-pr-feedback.yml
@@ -12,7 +12,8 @@ name: Reusable Preview PR Feedback
         type: string
       context:
         description: >-
-          Launchplane preview context. Defaults to the resolved product key.
+          Optional Launchplane preview context. When omitted, Launchplane
+          derives it from the product profile.
         required: false
         default: ""
         type: string
@@ -107,11 +108,8 @@ jobs:
           if [ -z "$PRODUCT" ]; then
             PRODUCT="${GITHUB_REPOSITORY#*/}"
           fi
-          if [ -z "$CONTEXT" ]; then
-            CONTEXT="$PRODUCT"
-          fi
           STATUS="$(printf '%s' "$STATUS" | tr '[:upper:]' '[:lower:]' | tr '-' '_')"
-          for required in PRODUCT CONTEXT ANCHOR_PR_NUMBER ANCHOR_PR_URL STATUS; do
+          for required in PRODUCT ANCHOR_PR_NUMBER ANCHOR_PR_URL STATUS; do
             if [ -z "${!required}" ]; then
               echo "${required} is required." >&2
               exit 1

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1950,7 +1950,7 @@ class PreviewPrFeedbackEnvelope(BaseModel):
 
     schema_version: int = Field(default=1, ge=1)
     product: str
-    context: str
+    context: str = ""
     source: str = "workflow"
     repository: str
     anchor_repo: str
@@ -1970,8 +1970,6 @@ class PreviewPrFeedbackEnvelope(BaseModel):
     def _validate_request(self) -> "PreviewPrFeedbackEnvelope":
         if not self.product.strip():
             raise ValueError("preview PR feedback requires product")
-        if not self.context.strip():
-            raise ValueError("preview PR feedback requires context")
         if not self.source.strip():
             raise ValueError("preview PR feedback requires source")
         if not self.repository.strip():
@@ -3197,6 +3195,27 @@ def allows_preview_pr_feedback_write(
         )
         for action in lifecycle_actions_by_status.get(status, ())
     )
+
+
+def resolve_preview_pr_feedback_context(*, record_store: object, product: str, context: str) -> str:
+    requested_context = context.strip()
+    if requested_context:
+        return requested_context
+    try:
+        profile_store = require_product_profile_read_store(record_store)
+        profile = profile_store.read_product_profile_record(product.strip())
+    except TypeError as error:
+        raise TypeError(
+            "Preview PR feedback context derivation requires product profile reads: "
+            "read_product_profile_record"
+        ) from error
+    except FileNotFoundError as error:
+        raise FileNotFoundError(
+            "Preview PR feedback context derivation requires an existing product profile."
+        ) from error
+    if not profile.preview.enabled or not profile.preview.context.strip():
+        raise ValueError("Product profile does not define an enabled preview context.")
+    return profile.preview.context.strip()
 
 
 def read_generic_web_preview_profile(
@@ -13487,11 +13506,38 @@ def create_launchplane_fastapi_app(
         idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
     ) -> AcceptedEvidenceResponse:
         trace_id = next_trace_id()
+        try:
+            effective_context = resolve_preview_pr_feedback_context(
+                record_store=record_store,
+                product=feedback_request.product,
+                context=feedback_request.context,
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message=str(error),
+            ) from error
         if not allows_preview_pr_feedback_write(
             authz_policy=resolved_authz_policy_runtime.policy,
             identity=identity,
             product=feedback_request.product,
-            context=feedback_request.context,
+            context=effective_context,
             status=feedback_request.status,
         ):
             raise _launchplane_http_error(
@@ -13507,7 +13553,7 @@ def create_launchplane_fastapi_app(
                 "dry_run": True,
                 "preview_pr_feedback": "authorized",
                 "product": feedback_request.product,
-                "context": feedback_request.context,
+                "context": effective_context,
                 "status": feedback_request.status,
                 "anchor_pr_number": feedback_request.anchor_pr_number,
             }
@@ -13548,7 +13594,7 @@ def create_launchplane_fastapi_app(
         feedback_record = build_preview_pr_feedback_record(
             control_plane_root=resolved_control_plane_root,
             product=feedback_request.product,
-            context=feedback_request.context,
+            context=effective_context,
             source=feedback_request.source,
             requested_at=utc_now_timestamp(),
             repository=feedback_request.repository,

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -103,7 +103,9 @@ Preview comment updates that are not part of the lifecycle workflow use
 Callers provide only primitive display facts such as PR number, status, preview
 URL, image references, revision, run URL, and failure summary. The reusable
 feedback workflow owns the `/v1/previews/pr-feedback` route, marker, payload
-shape, delivery behavior, and run-scoped idempotency key.
+shape, delivery behavior, and run-scoped idempotency key. Callers may omit
+preview context; Launchplane derives it from the product profile before
+authorization and recording.
 
 ## Required Workflow Shape
 
@@ -140,13 +142,14 @@ preview-workflow:<product>:<context>:<operation>:pr-<number>:<run-id>:<run-attem
 
 Run-scoped keys make repeated HTTP attempts safe while preserving a distinct
 record for a later retry or GitHub rerun. Ignored decisions do not have
-idempotency keys.
+idempotency keys. Launchplane-owned reusable workflows may use an equivalent
+route-specific key when the service derives context from product records.
 
 ## Route Handoff
 
 Preview refresh routes receive only product-local facts:
 
-- product key and context when the route still requires them
+- product key, and context only for compatibility routes that still require it
 - PR number and source SHA
 - immutable image or artifact reference
 - run URL

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -429,9 +429,9 @@ Dependabot `unsupported_notice` handoffs call
 `cbusillo/launchplane/.github/workflows/reusable-preview-request-notice.yml@main`
 from a trusted `pull_request_target` workflow. Product repos do not choose a
 trusted checkout ref, pass preview slugs, preview URLs, provider application
-names, feedback markdown, route payloads, or idempotency keys; Launchplane
-derives those from product profiles, runtime records, GitHub OIDC claims, the PR
-event, and the run-scoped workflow context.
+names, feedback context, feedback markdown, route payloads, or idempotency keys;
+Launchplane derives those from product profiles, runtime records, GitHub OIDC
+claims, the PR event, and the run-scoped workflow context.
 
 These reusable workflows intentionally do not accept provider targets, target
 ids, health URLs, preview URLs, feedback markdown, record ids, managed secrets,

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -2303,11 +2303,11 @@ def _preview_pr_feedback_policy(*, action: str) -> LaunchplaneAuthzPolicy:
 def _preview_pr_feedback_payload(
     *,
     status: str = "ready",
+    context: str | None = "verireel-testing",
     dry_run: bool = False,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "product": "verireel",
-        "context": "verireel-testing",
         "source": "preview-control-plane",
         "repository": "every/verireel",
         "anchor_repo": "verireel",
@@ -2320,6 +2320,8 @@ def _preview_pr_feedback_payload(
         "revision": "a1b2c3d4",
         "run_url": "https://github.com/every/verireel/actions/runs/123",
     }
+    if context is not None:
+        payload["context"] = context
     if dry_run:
         payload["dry_run"] = True
     return payload

--- a/tests/test_http_app_preview.py
+++ b/tests/test_http_app_preview.py
@@ -770,6 +770,84 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Launchplane preview is ready", payload["result"]["comment_markdown"])
         self.assertIn("GITHUB_TOKEN", feedback_records[0].error_message)
 
+    async def test_preview_pr_feedback_derives_context_from_product_profile(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload("verireel"))
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_pr_feedback_identity()),
+                authz_policy=_preview_pr_feedback_policy(action="preview_pr_feedback.write"),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_preview_pr_feedback(
+                app,
+                _preview_pr_feedback_payload(context=None),
+            )
+            feedback_records = store.list_preview_pr_feedback_records(
+                context_name="verireel-testing"
+            )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["result"]["context"], "verireel-testing")
+        self.assertEqual(feedback_records[0].context, "verireel-testing")
+
+    async def test_preview_pr_feedback_context_derivation_requires_product_profile(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_pr_feedback_identity()),
+                authz_policy=_preview_pr_feedback_policy(action="preview_pr_feedback.write"),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_preview_pr_feedback(
+                app,
+                _preview_pr_feedback_payload(context=None),
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_preview_pr_feedback_context_derivation_requires_enabled_preview(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            product_profile = _product_profile_payload("verireel")
+            product_profile["preview"] = {
+                "enabled": False,
+                "context": "verireel-testing",
+                "slug_template": "pr-{number}",
+            }
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(product_profile)
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_pr_feedback_identity()),
+                authz_policy=_preview_pr_feedback_policy(action="preview_pr_feedback.write"),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_preview_pr_feedback(
+                app,
+                _preview_pr_feedback_payload(context=None),
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
     async def test_preview_pr_feedback_replays_idempotent_notification(self) -> None:
         sent_payloads: list[tuple[str, dict[str, object]]] = []
 
@@ -860,15 +938,19 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload("verireel"))
+            )
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_preview_pr_feedback_identity()),
                 authz_policy=_preview_pr_feedback_policy(action="preview_pr_feedback.write"),
+                control_plane_root_path=root,
                 record_store_factory=lambda: store,
             )
 
             response = await _post_preview_pr_feedback(
                 app,
-                _preview_pr_feedback_payload(dry_run=True),
+                _preview_pr_feedback_payload(context=None, dry_run=True),
             )
             feedback_records = store.list_preview_pr_feedback_records(
                 context_name="verireel-testing"
@@ -876,6 +958,7 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.status_code, 202)
         self.assertEqual(response.json()["result"]["preview_pr_feedback"], "authorized")
+        self.assertEqual(response.json()["result"]["context"], "verireel-testing")
         self.assertEqual(feedback_records, ())
 
     async def test_preview_pr_feedback_accepts_lifecycle_refresh_grant(self) -> None:

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -175,6 +175,9 @@ class PreviewWorkflowContractTests(unittest.TestCase):
         self.assertIn("status=${{ steps.request.outputs.status }}", workflow)
         self.assertIn("feedback_status=result.status", workflow)
         self.assertNotIn("result.feedback_status", workflow)
+        self.assertIn("for required in PRODUCT ANCHOR_PR_NUMBER ANCHOR_PR_URL STATUS", workflow)
+        self.assertIn("context=${{ steps.request.outputs.context }}", workflow)
+        self.assertNotIn('CONTEXT="$PRODUCT"', workflow)
         self.assertIn("idempotency_key", workflow)
         self.assertIn("preview-pr-feedback", workflow)
 


### PR DESCRIPTION
## Summary
- let reusable preview PR feedback calls omit preview context
- derive omitted feedback context from Launchplane product profiles before authz/dry-run/recording
- document the product-repo ownership boundary and cover derived-context feedback paths

## Verification
- actionlint .github/workflows/reusable-preview-pr-feedback.yml .github/workflows/reusable-generic-web-preview-lifecycle.yml
- uv run python -m unittest tests.test_http_app_preview tests.test_preview_workflow_contract tests.test_docs_contracts.DocsContractsTests.test_generic_web_reusable_workflows_keep_product_inputs_minimal
- uv run python -m unittest tests.test_http_app_preview.FastApiPreviewPrFeedbackTests tests.test_preview_workflow_contract.PreviewWorkflowContractTests.test_reusable_preview_feedback_workflow_owns_request_details
- uv run --extra dev ruff check control_plane/http_app.py tests/http_app_test_support.py tests/test_http_app_preview.py tests/test_preview_workflow_contract.py
- uv run --extra dev ruff format --check control_plane/http_app.py tests/http_app_test_support.py tests/test_http_app_preview.py tests/test_preview_workflow_contract.py
- git diff --check