### PR TITLE
Derive generic preview context from product profiles

### DIFF
--- a/.github/workflows/reusable-generic-web-preview-lifecycle.yml
+++ b/.github/workflows/reusable-generic-web-preview-lifecycle.yml
@@ -16,7 +16,8 @@ name: Reusable Generic Web Preview Lifecycle
         type: string
       context:
         description: >-
-          Launchplane preview context. Defaults to the resolved product key.
+          Optional preview context compatibility override. Omit to let Launchplane
+          derive the preview context from the product profile.
         required: false
         default: ""
         type: string
@@ -129,10 +130,7 @@ jobs:
           if [ -z "$PRODUCT" ]; then
             PRODUCT="${GITHUB_REPOSITORY#*/}"
           fi
-          if [ -z "$CONTEXT" ]; then
-            CONTEXT="$PRODUCT"
-          fi
-          for required in PRODUCT CONTEXT ANCHOR_PR_NUMBER OPERATION; do
+          for required in PRODUCT ANCHOR_PR_NUMBER OPERATION; do
             if [ -z "${!required}" ]; then
               echo "${required} is required." >&2
               exit 1

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -3199,8 +3199,6 @@ def allows_preview_pr_feedback_write(
 
 def resolve_preview_pr_feedback_context(*, record_store: object, product: str, context: str) -> str:
     requested_context = context.strip()
-    if requested_context:
-        return requested_context
     try:
         profile_store = require_product_profile_read_store(record_store)
         profile = profile_store.read_product_profile_record(product.strip())
@@ -3215,7 +3213,10 @@ def resolve_preview_pr_feedback_context(*, record_store: object, product: str, c
         ) from error
     if not profile.preview.enabled or not profile.preview.context.strip():
         raise ValueError("Product profile does not define an enabled preview context.")
-    return profile.preview.context.strip()
+    profile_context = profile.preview.context.strip()
+    if requested_context and requested_context != profile_context:
+        raise ValueError("Preview PR feedback context does not match product profile.")
+    return profile_context
 
 
 def read_generic_web_preview_profile(

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -94,9 +94,10 @@ jobs:
 The reusable workflow derives the product key from the caller repository by
 default, derives a run-scoped idempotency key, calls the correct Launchplane
 route, and exposes the returned preview slug, preview URL, refresh status,
-destroy status, or feedback status as job outputs. It does not accept
-`preview_slug`, `preview_url`, provider target ids, feedback markdown, or
-idempotency keys as caller inputs.
+destroy status, or feedback status as job outputs. Callers should omit preview
+context so Launchplane can derive it from the product profile before
+authorization and recording. It does not accept `preview_slug`, `preview_url`,
+provider target ids, feedback markdown, or idempotency keys as caller inputs.
 
 Preview comment updates that are not part of the lifecycle workflow use
 `cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main`.
@@ -156,11 +157,12 @@ Preview refresh routes receive only product-local facts:
 - primitive smoke/readiness facts when the check is product-specific
 
 Generic-web preview refresh callers should pass `anchor_pr_number` and omit
-`preview_slug` and `preview_url`. Launchplane derives the slug from the product
-profile slug policy, derives the live URL from the preview context's runtime
-environment records, and rejects a supplied slug when it conflicts with the
-derived value. `preview_slug` and `preview_url` remain compatibility fields for
-older adapters, not product-repo authority.
+context, `preview_slug`, and `preview_url`. Launchplane derives the context from
+the product profile, derives the slug from the product profile slug policy,
+derives the live URL from the preview context's runtime environment records, and
+rejects a supplied slug when it conflicts with the derived value. `context`,
+`preview_slug`, and `preview_url` remain compatibility fields for older
+adapters, not product-repo authority.
 
 Odoo CM is the exception where Launchplane now owns both the isolated provider
 apply planning inputs and the stage-preview smoke contract after refresh. Product
@@ -189,9 +191,10 @@ Odoo-shaped preview verification alias is retired.
 
 Preview destroy routes receive the PR number, source/run metadata, and an
 explicit destroy reason such as `pull_request_closed`, `preview_label_removed`,
-or `manual_destroy_requested`. Generic-web preview destroy follows the same slug
-policy as refresh: callers should pass PR identity, and Launchplane derives the
-preview slug from the product profile before provider deletion.
+or `manual_destroy_requested`. Generic-web preview destroy follows the same
+context and slug policy as refresh: callers should pass PR identity, and
+Launchplane derives the preview context and preview slug from the product
+profile before provider deletion.
 
 Preview feedback routes receive the status and primitive display facts.
 Launchplane derives the marker, rendered markdown, delivery behavior, and record

--- a/tests/test_http_app_preview.py
+++ b/tests/test_http_app_preview.py
@@ -748,6 +748,9 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload("verireel"))
+            )
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_preview_pr_feedback_identity()),
                 authz_policy=_preview_pr_feedback_policy(action="preview_pr_feedback.write"),
@@ -797,6 +800,30 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["result"]["context"], "verireel-testing")
         self.assertEqual(feedback_records[0].context, "verireel-testing")
 
+    async def test_preview_pr_feedback_rejects_context_mismatch(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload("verireel"))
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_pr_feedback_identity()),
+                authz_policy=_preview_pr_feedback_policy(action="preview_pr_feedback.write"),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
+
+            response = await _post_preview_pr_feedback(
+                app,
+                _preview_pr_feedback_payload(context="wrong-context"),
+            )
+            feedback_records = store.list_preview_pr_feedback_records()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        self.assertEqual(feedback_records, ())
+
     async def test_preview_pr_feedback_context_derivation_requires_product_profile(
         self,
     ) -> None:
@@ -817,6 +844,23 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_preview_pr_feedback_context_derivation_requires_profile_store(
+        self,
+    ) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_preview_pr_feedback_identity()),
+            authz_policy=_preview_pr_feedback_policy(action="preview_pr_feedback.write"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_preview_pr_feedback(
+            app,
+            _preview_pr_feedback_payload(context=None),
+        )
+
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()["error"]["code"], "database_storage_required")
 
     async def test_preview_pr_feedback_context_derivation_requires_enabled_preview(
         self,
@@ -866,6 +910,9 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
             store = PostgresRecordStore(database_url=database_url)
             store.ensure_schema()
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload("verireel"))
+            )
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_preview_pr_feedback_identity()),
                 authz_policy=_preview_pr_feedback_policy(action="preview_pr_feedback.write"),
@@ -965,6 +1012,9 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload("verireel"))
+            )
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(_preview_pr_feedback_identity()),
                 authz_policy=_preview_pr_feedback_policy(action="preview_refresh.execute"),
@@ -981,13 +1031,20 @@ class FastApiPreviewPrFeedbackTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(feedback_records[0].status, "ready")
 
     async def test_preview_pr_feedback_rejects_unauthorized_workflow(self) -> None:
-        app = create_launchplane_fastapi_app(
-            verifier=_StubVerifier(_preview_pr_feedback_identity()),
-            authz_policy=_preview_pr_feedback_policy(action="preview_generation.write"),
-            record_store_factory=lambda: _MissingProductReadStore(),
-        )
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = FilesystemRecordStore(state_dir=root / "state")
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload("verireel"))
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_preview_pr_feedback_identity()),
+                authz_policy=_preview_pr_feedback_policy(action="preview_generation.write"),
+                control_plane_root_path=root,
+                record_store_factory=lambda: store,
+            )
 
-        response = await _post_preview_pr_feedback(app, _preview_pr_feedback_payload())
+            response = await _post_preview_pr_feedback(app, _preview_pr_feedback_payload())
 
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()["error"]["code"], "authorization_denied")

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -245,6 +245,8 @@ class PreviewWorkflowContractTests(unittest.TestCase):
 
         self.assertNotIn("preview_slug", workflow_inputs)
         self.assertNotIn("preview_url", workflow_inputs)
+        self.assertNotIn('CONTEXT="$PRODUCT"', workflow)
+        self.assertNotIn("PRODUCT CONTEXT ANCHOR_PR_NUMBER", workflow)
         self.assertNotIn("refresh.preview_slug=", workflow)
         self.assertNotIn("destroy.preview_slug=", workflow)
 


### PR DESCRIPTION
## Summary
- stop defaulting reusable generic-web preview lifecycle context to the product key
- require PR feedback context to match the product profile when explicitly supplied
- document generic-web preview lifecycle callers omitting context and add regression tests

## Tests
- uv run python -m unittest tests.test_http_app_preview.FastApiPreviewPrFeedbackTests tests.test_preview_workflow_contract.PreviewWorkflowContractTests
- actionlint .github/workflows/reusable-generic-web-preview-lifecycle.yml
- uv run --extra dev ruff check control_plane/http_app.py tests/test_http_app_preview.py tests/test_preview_workflow_contract.py
- uv run --extra dev ruff format --check control_plane/http_app.py tests/test_http_app_preview.py tests/test_preview_workflow_contract.py
- git diff --check