### PR TITLE
Add reusable generic web preview verification

### DIFF
--- a/.github/workflows/reusable-generic-web-preview-verification.yml
+++ b/.github/workflows/reusable-generic-web-preview-verification.yml
@@ -1,0 +1,186 @@
+---
+name: Reusable Generic Web Preview Verification
+
+"on":
+  workflow_call:
+    inputs:
+      product:
+        description: >-
+          Launchplane product key. Defaults to the caller repository name.
+        required: false
+        default: ""
+        type: string
+      context:
+        description: >-
+          Optional preview context compatibility override. Omit to let Launchplane
+          derive the preview context from the product profile.
+        required: false
+        default: ""
+        type: string
+      anchor_repo:
+        description: >-
+          Repository name used by Launchplane preview records. Defaults to the
+          caller repository name.
+        required: false
+        default: ""
+        type: string
+      anchor_pr_number:
+        description: Pull request number that owns the preview.
+        required: true
+        type: string
+      verification_status:
+        description: Product smoke verification status.
+        required: true
+        type: string
+      verified_at:
+        description: RFC3339 timestamp for the verification result.
+        required: true
+        type: string
+      checked_urls:
+        description: Optional JSON array of URLs checked by product smoke.
+        required: false
+        default: "[]"
+        type: string
+      timeout-seconds:
+        description: Timeout used for checked URLs, when supplied.
+        required: false
+        default: "null"
+        type: string
+      failure_summary:
+        description: Short failure summary for failed verification states.
+        required: false
+        default: ""
+        type: string
+      timeout-ms:
+        description: Launchplane request timeout in milliseconds.
+        required: false
+        default: "300000"
+        type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
+    outputs:
+      error_message:
+        description: Launchplane verification error message, when present.
+        value: ${{ jobs.verification.outputs.error_message }}
+      verification_status:
+        description: Generic-web preview verification status.
+        value: ${{ jobs.verification.outputs.verification_status }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  verification:
+    outputs:
+      error_message: ${{ steps.lp.outputs.error_message }}
+      verification_status: ${{ steps.lp.outputs.verification_status }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve Launchplane preview verification request
+        id: request
+        env:
+          ANCHOR_PR_NUMBER: ${{ inputs.anchor_pr_number }}
+          ANCHOR_REPO: ${{ inputs.anchor_repo }}
+          PRODUCT: ${{ inputs.product }}
+          VERIFICATION_STATUS: ${{ inputs.verification_status }}
+          VERIFIED_AT: ${{ inputs.verified_at }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PRODUCT" ]; then
+            PRODUCT="${GITHUB_REPOSITORY#*/}"
+          fi
+          if [ -z "$ANCHOR_REPO" ]; then
+            ANCHOR_REPO="${GITHUB_REPOSITORY#*/}"
+          fi
+          VERIFICATION_STATUS="$(printf '%s' "$VERIFICATION_STATUS" | tr '[:upper:]' '[:lower:]' | tr '-' '_')"
+          case "$VERIFICATION_STATUS" in
+            success|passed|pass)
+              VERIFICATION_STATUS=pass
+              ;;
+            failure|failed|fail|cancelled|canceled|timed_out)
+              VERIFICATION_STATUS=fail
+              ;;
+            *)
+              echo "verification_status must be success/pass or failure/fail." >&2
+              exit 1
+              ;;
+          esac
+          for required in PRODUCT ANCHOR_REPO ANCHOR_PR_NUMBER VERIFIED_AT; do
+            if [ -z "${!required}" ]; then
+              echo "${required} is required." >&2
+              exit 1
+            fi
+          done
+          case "$ANCHOR_PR_NUMBER" in
+            ''|*[!0-9]*)
+              echo "ANCHOR_PR_NUMBER must be a positive integer." >&2
+              exit 1
+              ;;
+          esac
+          if [ "$ANCHOR_PR_NUMBER" -lt 1 ]; then
+            echo "ANCHOR_PR_NUMBER must be a positive integer." >&2
+            exit 1
+          fi
+          run_scope="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          {
+            echo "anchor_pr_number=$ANCHOR_PR_NUMBER"
+            echo "anchor_repo=$ANCHOR_REPO"
+            printf '%s=%s:%s:pr-%s:%s:%s\n' \
+              idempotency_key \
+              generic-web-preview-verification \
+              "$PRODUCT" \
+              "$ANCHOR_PR_NUMBER" \
+              "$VERIFICATION_STATUS" \
+              "$run_scope"
+            echo "product=$PRODUCT"
+            echo "verification_status=$VERIFICATION_STATUS"
+            echo "verified_at=$VERIFIED_AT"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Request Launchplane generic-web preview verification
+        id: lp
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
+          route-path: /v1/drivers/generic-web/preview-verification
+          payload: |-
+            {
+              "schema_version": 1,
+              "verification": {
+                "schema_version": 1
+              }
+            }
+          payload-fields: |-
+            product=${{ steps.request.outputs.product }}
+            verification.context=${{ inputs.context }}
+            verification.anchor_repo=${{ steps.request.outputs.anchor_repo }}
+            verification.anchor_pr_number=${{ steps.request.outputs.anchor_pr_number }}
+            verification.verification_status=${{ steps.request.outputs.verification_status }}
+            verification.verified_at=${{ steps.request.outputs.verified_at }}
+            verification.checked_urls=${{ inputs.checked_urls }}
+            verification.timeout_seconds=${{ inputs['timeout-seconds'] }}
+            verification.failure_summary=${{ inputs.failure_summary }}
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: result.verification_status
+          output-paths: >-
+            trace_id=trace_id,
+            verification_status=result.verification_status,
+            error_message=result.generic_web_preview_verification.failure_summary
+
+      - name: Report verification result
+        run: |
+          echo "verification_status=${{ steps.lp.outputs.verification_status }}"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -324,6 +324,10 @@ WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
         "inputs.timeout-ms.default": frozenset(("1800000",)),
         "inputs.timeout-seconds.default": frozenset(("300",)),
     },
+    ".github/workflows/reusable-generic-web-preview-verification.yml": {
+        "inputs.timeout-ms.default": frozenset(("300000",)),
+        "inputs.timeout-seconds.default": frozenset(("null",)),
+    },
     ".github/workflows/runner-host-hygiene.yml": {
         "inputs.action.default": frozenset(("prune_docker_cache",)),
         "inputs.minimum_free_disk_bytes.default": frozenset(("0",)),
@@ -385,6 +389,11 @@ WORKFLOW_LAUNCHPLANE_URL_REFERENCE_PATH_VALUES = {
         ),
     },
     ".github/workflows/reusable-generic-web-preview-lifecycle.yml": {
+        "launchplane-url": frozenset(
+            ("${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}",)
+        )
+    },
+    ".github/workflows/reusable-generic-web-preview-verification.yml": {
         "launchplane-url": frozenset(
             ("${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}",)
         )
@@ -698,6 +707,28 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
             )
         ),
         "source": frozenset(("${{ needs.resolve.outputs.run_url }}",)),
+    },
+    ".github/workflows/reusable-generic-web-preview-verification.yml": {
+        "anchor_pr_number": frozenset(("${{ steps.request.outputs.anchor_pr_number }}",)),
+        "anchor_repo": frozenset(("${{ steps.request.outputs.anchor_repo }}",)),
+        "context": frozenset(("${{ inputs.context }}",)),
+        "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "idempotency_key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "product": frozenset(("${{ steps.request.outputs.product }}",)),
+        "verification.anchor_pr_number": frozenset(
+            ("${{ steps.request.outputs.anchor_pr_number }}",)
+        ),
+        "verification.anchor_repo": frozenset(("${{ steps.request.outputs.anchor_repo }}",)),
+        "verification.checked_urls": frozenset(("${{ inputs.checked_urls }}",)),
+        "verification.context": frozenset(("${{ inputs.context }}",)),
+        "verification.failure_summary": frozenset(("${{ inputs.failure_summary }}",)),
+        "verification.timeout_seconds": frozenset(("${{ inputs['timeout-seconds'] }}",)),
+        "verification.verification_status": frozenset(
+            ("${{ steps.request.outputs.verification_status }}",)
+        ),
+        "verification.verified_at": frozenset(("${{ steps.request.outputs.verified_at }}",)),
+        "verification_status": frozenset(("${{ steps.lp.outputs.verification_status }}",)),
+        "verified_at": frozenset(("${{ steps.request.outputs.verified_at }}",)),
     },
     ".github/workflows/public-ingress-monitor.yml": {
         "idempotency-key": frozenset(

--- a/control_plane/drivers/generic_web_preview_dispatch.py
+++ b/control_plane/drivers/generic_web_preview_dispatch.py
@@ -167,7 +167,7 @@ class GenericWebPreviewVerificationRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     schema_version: int = Field(default=1, ge=1)
-    context: str
+    context: str = ""
     anchor_repo: str
     anchor_pr_number: int = Field(ge=1)
     verification_status: ReleaseStatus
@@ -190,8 +190,6 @@ class GenericWebPreviewVerificationRequest(BaseModel):
 
     @model_validator(mode="after")
     def _validate_request(self) -> "GenericWebPreviewVerificationRequest":
-        if not self.context.strip():
-            raise ValueError("Generic web preview verification requires context.")
         if not self.anchor_repo.strip():
             raise ValueError("Generic web preview verification requires anchor_repo.")
         if self.verification_status not in {"pass", "fail"}:

--- a/control_plane/generic_web_verification_http.py
+++ b/control_plane/generic_web_verification_http.py
@@ -97,7 +97,7 @@ def resolve_generic_web_preview_verification_profile(
         raise click.ClickException(
             f"Product {profile.product!r} does not define a preview context."
         )
-    if profile.preview.context.strip() != context.strip():
+    if context.strip() and profile.preview.context.strip() != context.strip():
         raise GenericWebVerificationProductMismatchError(
             "Product profile does not own the requested preview context."
         )

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -15766,6 +15766,7 @@ def create_launchplane_fastapi_app(
         )
         if replayed_response is not None:
             return replayed_response
+        verification_request.verification.context = profile.preview.context
         try:
             result = apply_generic_web_preview_verification_result(
                 control_plane_root=resolved_control_plane_root,

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -180,14 +180,16 @@ ready-to-comment signal instead of independently deciding readiness from raw
 health checks.
 If a later browser or product-specific smoke workflow needs to publish common
 preview evidence, it should call
-`POST /v1/drivers/generic-web/preview-verification` with the product key, PR
-identity, `verification_status`, `verified_at`, optional checked URLs plus
-timeout, and optional failure summary. Launchplane resolves generic-web base
-driver compatibility from the product profile, updates the latest preview
-generation, and returns a typed `generic_web_preview_verification` result while
-preserving durable status/failure evidence in the same preview records used by
-refresh. Odoo preview verification uses this generic-web route; the former
-Odoo-shaped preview verification alias is retired.
+`cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-verification.yml@main`
+with the PR number, `verification_status`, `verified_at`, optional checked URLs
+plus timeout, and optional failure summary. The reusable workflow owns the
+`POST /v1/drivers/generic-web/preview-verification` payload, route handoff, and
+run-scoped idempotency key. Launchplane resolves the preview context and
+generic-web base-driver compatibility from the product profile, updates the
+latest preview generation, and returns a typed `generic_web_preview_verification`
+result while preserving durable status/failure evidence in the same preview
+records used by refresh. Odoo preview verification uses this generic-web route;
+the former Odoo-shaped preview verification alias is retired.
 
 Preview destroy routes receive the PR number, source/run metadata, and an
 explicit destroy reason such as `pull_request_closed`, `preview_label_removed`,

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1397,6 +1397,10 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 ".github/workflows/reusable-generic-web-preview-lifecycle.yml",
                 "launchplane-url",
             ),
+            (
+                ".github/workflows/reusable-generic-web-preview-verification.yml",
+                "launchplane-url",
+            ),
         ):
             with self.subTest(path=path, key=key):
                 self.assertEqual(
@@ -1616,6 +1620,26 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 "uses",
                 "cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@main",
             ),
+            (
+                ".github/workflows/preview.yml",
+                "uses",
+                "cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-verification.yml@main",
+            ),
+            (
+                ".github/workflows/reusable-generic-web-preview-verification.yml",
+                "verification.timeout_seconds",
+                "${{ inputs['timeout-seconds'] }}",
+            ),
+            (
+                ".github/workflows/reusable-generic-web-preview-verification.yml",
+                "verification.checked_urls",
+                "${{ inputs.checked_urls }}",
+            ),
+            (
+                ".github/workflows/reusable-generic-web-preview-verification.yml",
+                "verification.verified_at",
+                "${{ steps.request.outputs.verified_at }}",
+            ),
         )
         for case in thin_connectors:
             path, key, value, *context = case
@@ -1651,6 +1675,16 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 ".github/workflows/preview.yml",
                 "uses",
                 "cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@feature",
+            ),
+            (
+                ".github/workflows/preview.yml",
+                "uses",
+                "cbusillo/not-launchplane/.github/workflows/reusable-generic-web-preview-verification.yml@main",
+            ),
+            (
+                ".github/workflows/preview.yml",
+                "uses",
+                "cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-verification.yml@feature",
             ),
             (
                 ".github/workflows/reusable-odoo-artifact-publish.yml",
@@ -2112,6 +2146,23 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 self.assertEqual(
                     _allow_reason(path=path, key=key, value="${{ inputs.idempotency_key }}"),
                     "",
+                )
+
+    def test_generic_web_preview_verification_workflow_defaults_are_thin_connector_inputs(
+        self,
+    ) -> None:
+        for key, value in (
+            ("inputs.timeout-ms.default", "300000"),
+            ("inputs.timeout-seconds.default", "null"),
+        ):
+            with self.subTest(key=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/reusable-generic-web-preview-verification.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
                 )
 
     def test_ingress_workflow_jq_forwards_and_route_options_are_narrow(self) -> None:

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -261,6 +261,29 @@ class PreviewWorkflowContractTests(unittest.TestCase):
         self.assertIn("feedback_status=result.status", workflow)
         self.assertNotIn("result.feedback_status", workflow)
 
+    def test_reusable_generic_web_preview_verification_derives_context(self) -> None:
+        workflow = (
+            REPO_ROOT / ".github/workflows/reusable-generic-web-preview-verification.yml"
+        ).read_text(encoding="utf-8")
+        workflow_inputs = _workflow_call_inputs(workflow)
+
+        self.assertIn("route-path: /v1/drivers/generic-web/preview-verification", workflow)
+        self.assertIn("verification.context=${{ inputs.context }}", workflow)
+        self.assertIn(
+            "verification.anchor_pr_number=${{ steps.request.outputs.anchor_pr_number }}",
+            workflow,
+        )
+        self.assertIn(
+            "verification.verification_status=${{ steps.request.outputs.verification_status }}",
+            workflow,
+        )
+        self.assertIn("verification_status=result.verification_status", workflow)
+        self.assertIn("generic-web-preview-verification", workflow)
+
+        self.assertNotIn("idempotency-key", workflow_inputs)
+        self.assertNotIn("payload", workflow_inputs)
+        self.assertNotIn("route-path", workflow_inputs)
+
     def test_generic_web_preview_requests_accept_anchor_pr_number_without_slug(
         self,
     ) -> None:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -11621,7 +11621,6 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         "product": "sellyouroutboard",
                         "verification": {
                             "schema_version": 1,
-                            "context": "sellyouroutboard-testing",
                             "anchor_repo": "sellyouroutboard",
                             "anchor_pr_number": 42,
                             "verification_status": "pass",
@@ -11635,6 +11634,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
         self.assertEqual(payload["records"]["transition"], "ready")
         apply_records.assert_called_once()
         self.assertEqual(apply_records.call_args.kwargs["control_plane_root_path"], root)
+        self.assertEqual(
+            apply_records.call_args.kwargs["request"].context,
+            "sellyouroutboard-testing",
+        )
 
     def test_generic_web_preview_verification_route_rejects_unauthorized_context(
         self,


### PR DESCRIPTION
## Summary
- add a reusable generic-web preview verification workflow for product smoke evidence
- derive generic-web preview verification context from product profiles when callers omit context
- extend config-authority allowlists/tests for the new reusable workflow mechanics

## Tests
- uv run python -m unittest tests.test_preview_workflow_contract.PreviewWorkflowContractTests tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_launchplane_public_url_reference_is_self_bootstrap tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_generic_web_preview_verification_workflow_defaults_are_thin_connector_inputs tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_docs_tests_and_bootstrap_have_explicit_allow_reasons tests.test_service.LaunchplaneServiceTests.test_generic_web_preview_verification_route_does_not_require_lane
- actionlint .github/workflows/reusable-generic-web-preview-verification.yml
- uv run --extra dev ruff check control_plane/drivers/generic_web_preview_dispatch.py control_plane/generic_web_verification_http.py control_plane/http_app.py control_plane/config_authority_audit.py tests/test_preview_workflow_contract.py tests/test_service.py tests/test_config_authority_audit.py
- uv run --extra dev ruff format --check control_plane/drivers/generic_web_preview_dispatch.py control_plane/generic_web_verification_http.py control_plane/http_app.py control_plane/config_authority_audit.py tests/test_preview_workflow_contract.py tests/test_service.py tests/test_config_authority_audit.py
- git diff --check
- agent review: two-agent review completed; findings patched
