### PR TITLE
Hydrate ready preview feedback URLs

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -594,6 +594,7 @@ from control_plane.workflows.preview_desired_state import discover_github_previe
 from control_plane.workflows.preview_pr_feedback import (
     DEFAULT_PREVIEW_FEEDBACK_MARKER,
     EveryCodeWorkRequestReadStore,
+    PreviewPrFeedbackPreviewReadStore,
     build_preview_pr_feedback_record,
 )
 from control_plane.workflows.generic_web_deploy import product_profile_uses_generic_web_base
@@ -13592,26 +13593,39 @@ def create_launchplane_fastapi_app(
             if supports_every_code_work_requests(record_store)
             else None
         )
-        feedback_record = build_preview_pr_feedback_record(
-            control_plane_root=resolved_control_plane_root,
-            product=feedback_request.product,
-            context=effective_context,
-            source=feedback_request.source,
-            requested_at=utc_now_timestamp(),
-            repository=feedback_request.repository,
-            anchor_repo=feedback_request.anchor_repo,
-            anchor_pr_number=feedback_request.anchor_pr_number,
-            anchor_pr_url=feedback_request.anchor_pr_url,
-            status=feedback_request.status,
-            marker=feedback_request.marker,
-            preview_url=feedback_request.preview_url,
-            immutable_image_reference=feedback_request.immutable_image_reference,
-            refresh_image_reference=feedback_request.refresh_image_reference,
-            revision=feedback_request.revision,
-            run_url=feedback_request.run_url,
-            failure_summary=feedback_request.failure_summary,
-            every_code_record_store=every_code_record_store,
-        )
+        try:
+            feedback_record = build_preview_pr_feedback_record(
+                control_plane_root=resolved_control_plane_root,
+                product=feedback_request.product,
+                context=effective_context,
+                source=feedback_request.source,
+                requested_at=utc_now_timestamp(),
+                repository=feedback_request.repository,
+                anchor_repo=feedback_request.anchor_repo,
+                anchor_pr_number=feedback_request.anchor_pr_number,
+                anchor_pr_url=feedback_request.anchor_pr_url,
+                status=feedback_request.status,
+                marker=feedback_request.marker,
+                preview_url=feedback_request.preview_url,
+                immutable_image_reference=feedback_request.immutable_image_reference,
+                refresh_image_reference=feedback_request.refresh_image_reference,
+                revision=feedback_request.revision,
+                run_url=feedback_request.run_url,
+                failure_summary=feedback_request.failure_summary,
+                every_code_record_store=every_code_record_store,
+                preview_record_store=(
+                    cast(PreviewPrFeedbackPreviewReadStore, record_store)
+                    if callable(getattr(record_store, "list_preview_records", None))
+                    else None
+                ),
+            )
+        except click.ClickException as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="preview_url_unavailable",
+                message=str(error),
+            ) from error
         feedback_store.write_preview_pr_feedback_record(feedback_record)
         notification_attempts = deliver_preview_pr_feedback_notifications(
             record_store=record_store,

--- a/control_plane/workflows/preview_pr_feedback.py
+++ b/control_plane/workflows/preview_pr_feedback.py
@@ -16,6 +16,7 @@ from control_plane.contracts.preview_pr_feedback_record import (
     PreviewPrFeedbackStatus,
     build_preview_pr_feedback_id,
 )
+from control_plane.contracts.preview_record import PreviewRecord
 from control_plane.every_code_worker import every_code_worktree_branch
 from control_plane.workflows.launchplane import (
     create_github_issue_comment,
@@ -70,6 +71,17 @@ class EveryCodePreviewValidationStore(EveryCodeWorkRequestReadStore, Protocol):
     ) -> tuple[EveryCodePrFeedbackRecord, ...]: ...
 
 
+class PreviewPrFeedbackPreviewReadStore(Protocol):
+    def list_preview_records(
+        self,
+        *,
+        context_name: str = "",
+        anchor_repo: str = "",
+        anchor_pr_number: int | None = None,
+        limit: int | None = None,
+    ) -> tuple[PreviewRecord, ...]: ...
+
+
 def _comment_url(payload: dict[str, object]) -> str:
     html_url = payload.get("html_url")
     return html_url if isinstance(html_url, str) else ""
@@ -112,6 +124,29 @@ def _find_every_code_work_request_for_preview(
         if expected_branch == normalized_head_branch:
             return record
     return None
+
+
+def _preview_url_from_latest_record(
+    *,
+    record_store: PreviewPrFeedbackPreviewReadStore | None,
+    context: str,
+    anchor_repo: str,
+    anchor_pr_number: int,
+) -> str:
+    if record_store is None:
+        return ""
+    for preview in record_store.list_preview_records(
+        context_name=context,
+        anchor_repo=anchor_repo,
+        anchor_pr_number=anchor_pr_number,
+        limit=5,
+    ):
+        if preview.state != "active":
+            continue
+        preview_url = preview.canonical_url.strip()
+        if preview_url:
+            return preview_url
+    return ""
 
 
 def _every_code_preview_ready_marker(*, repository: str, pr_number: int) -> str:
@@ -220,9 +255,7 @@ def _render_every_code_ready_to_merge_pr_comment(
     return "\n".join(lines)
 
 
-def _github_issue_author_login(
-    *, owner: str, repo: str, issue_number: int, token: str
-) -> str:
+def _github_issue_author_login(*, owner: str, repo: str, issue_number: int, token: str) -> str:
     payload = github_api_request(
         path=f"/repos/{owner}/{repo}/issues/{issue_number}",
         token=token,
@@ -838,12 +871,26 @@ def build_preview_pr_feedback_record(
     run_url: str = "",
     failure_summary: str = "",
     every_code_record_store: EveryCodeWorkRequestReadStore | None = None,
+    preview_record_store: PreviewPrFeedbackPreviewReadStore | None = None,
 ) -> PreviewPrFeedbackRecord:
+    resolved_preview_url = preview_url.strip()
+    if status == "ready" and not resolved_preview_url:
+        resolved_preview_url = _preview_url_from_latest_record(
+            record_store=preview_record_store,
+            context=context,
+            anchor_repo=anchor_repo,
+            anchor_pr_number=anchor_pr_number,
+        )
+    if status == "ready" and not resolved_preview_url:
+        raise click.ClickException(
+            "Ready preview feedback requires an explicit preview URL or an active "
+            "Launchplane preview record."
+        )
     comment_markdown = _render_preview_pr_feedback_markdown(
         marker=marker,
         status=status,
         anchor_pr_number=anchor_pr_number,
-        preview_url=preview_url.strip(),
+        preview_url=resolved_preview_url,
         immutable_image_reference=immutable_image_reference.strip(),
         refresh_image_reference=refresh_image_reference.strip(),
         revision=revision.strip(),
@@ -916,7 +963,7 @@ def build_preview_pr_feedback_record(
                 delivery_action = "created_comment"
                 comment_id = created_comment_id if isinstance(created_comment_id, int) else 0
                 comment_url = _comment_url(created_comment)
-            if status == "ready" and preview_url.strip():
+            if status == "ready" and resolved_preview_url:
                 source_issue_action = _notify_every_code_preview_ready_source_issue(
                     record_store=every_code_record_store,
                     owner=github_reference["owner"],
@@ -924,7 +971,7 @@ def build_preview_pr_feedback_record(
                     pr_number=github_reference["pr_number"],
                     anchor_pr_url=anchor_pr_url,
                     repository=repository,
-                    preview_url=preview_url,
+                    preview_url=resolved_preview_url,
                     token=github_token,
                 )
                 if not delivery_action:
@@ -950,7 +997,7 @@ def build_preview_pr_feedback_record(
         status=status,
         marker=marker,
         comment_markdown=comment_markdown,
-        preview_url=preview_url,
+        preview_url=resolved_preview_url,
         immutable_image_reference=immutable_image_reference,
         refresh_image_reference=refresh_image_reference,
         revision=revision,

--- a/tests/test_preview_pr_feedback.py
+++ b/tests/test_preview_pr_feedback.py
@@ -102,13 +102,17 @@ class PreviewPrFeedbackWorkflowTests(unittest.TestCase):
         self.assertEqual(source_issue_call.kwargs["issue_number"], 82)
         self.assertIn("@Mbanks89", source_issue_call.kwargs["body"])
         self.assertIn("https://pr-88.sellyouroutboard.dev", source_issue_call.kwargs["body"])
-        self.assertIn("Confirm the preview resolves: Improve image previews", source_issue_call.kwargs["body"])
+        self.assertIn(
+            "Confirm the preview resolves: Improve image previews", source_issue_call.kwargs["body"]
+        )
         self.assertIn("/preview ok", source_issue_call.kwargs["body"])
         self.assertNotIn("/preview approve", source_issue_call.kwargs["body"])
         self.assertIn("author%3AMbanks89", source_issue_call.kwargs["body"])
         self.assertIn("assignee%3Acbusillo", source_issue_call.kwargs["body"])
         self.assertEqual(github_request.call_args_list[3].kwargs["method"], "POST")
-        self.assertEqual(github_request.call_args_list[3].kwargs["body"], {"labels": ["preview-ready"]})
+        self.assertEqual(
+            github_request.call_args_list[3].kwargs["body"], {"labels": ["preview-ready"]}
+        )
 
     def test_ready_feedback_updates_issue_comment_without_review_request(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4360,7 +4360,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             ),
             patch(
-                "control_plane.service.resolve_launchplane_github_token",
+                "control_plane.workflows.preview_pr_feedback.resolve_launchplane_github_token",
                 return_value="github-token",
             ),
             patch(
@@ -4443,6 +4443,238 @@ class LaunchplaneServiceTests(unittest.TestCase):
         )
         create_comment.assert_called_once()
         self.assertIn("@cbusillo", create_comment.call_args.kwargs["body"])
+
+    def test_preview_pr_feedback_hydrates_ready_url_from_preview_record(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.workflows.preview_pr_feedback.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.find_github_issue_comment_by_marker",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.github_api_request",
+                return_value={"user": {"login": "author"}, "head": {"ref": "pr-42"}},
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.create_github_issue_comment",
+                return_value={"id": 987, "html_url": "https://github.example/comment"},
+            ) as create_comment,
+        ):
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-syo-pr-42",
+                    context="sellyouroutboard-testing",
+                    anchor_repo="sellyouroutboard",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/42",
+                    preview_label="preview",
+                    canonical_url="https://pr-42.syo-preview.example.test",
+                    state="active",
+                    created_at="2026-05-03T15:00:00Z",
+                    updated_at="2026-05-03T15:05:00Z",
+                    eligible_at="2026-05-03T15:00:00Z",
+                    active_generation_id="generation-syo-pr-42",
+                    serving_generation_id="generation-syo-pr-42",
+                    latest_generation_id="generation-syo-pr-42",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_test_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "source": "workflow",
+                    "repository": "cbusillo/sellyouroutboard",
+                    "anchor_repo": "sellyouroutboard",
+                    "anchor_pr_number": 42,
+                    "anchor_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/42",
+                    "status": "ready",
+                    "run_url": "https://github.com/cbusillo/sellyouroutboard/actions/runs/42",
+                },
+                headers={"Idempotency-Key": "preview-pr-feedback-ready-hydrate-url"},
+            )
+
+        self.assertEqual(status_code, 202, payload)
+        self.assertEqual(
+            payload["result"]["preview_url"],
+            "https://pr-42.syo-preview.example.test",
+        )
+        self.assertEqual(payload["result"]["delivery_status"], "delivered", payload)
+        create_comment.assert_called_once()
+        self.assertIn(
+            "https://pr-42.syo-preview.example.test",
+            create_comment.call_args.kwargs["body"],
+        )
+
+    def test_preview_pr_feedback_ready_requires_active_preview_url(self) -> None:
+        with (
+            TemporaryDirectory() as temporary_directory_name,
+            patch(
+                "control_plane.workflows.preview_pr_feedback.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.find_github_issue_comment_by_marker",
+                return_value=None,
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.github_api_request",
+                return_value={"user": {"login": "author"}, "head": {"ref": "pr-42"}},
+            ),
+            patch(
+                "control_plane.workflows.preview_pr_feedback.create_github_issue_comment",
+                return_value={"id": 987, "html_url": "https://github.example/comment"},
+            ) as create_comment,
+        ):
+            root = Path(temporary_directory_name)
+            state_dir = root / "state"
+            store = FilesystemRecordStore(state_dir=state_dir)
+            store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-syo-pr-42",
+                    context="sellyouroutboard-testing",
+                    anchor_repo="sellyouroutboard",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/42",
+                    preview_label="preview",
+                    canonical_url="https://failed-pr-42.syo-preview.example.test",
+                    state="failed",
+                    created_at="2026-05-03T15:00:00Z",
+                    updated_at="2026-05-03T15:05:00Z",
+                    eligible_at="2026-05-03T15:00:00Z",
+                    latest_generation_id="generation-syo-pr-42",
+                )
+            )
+            policy = LaunchplaneAuthzPolicy.model_validate(
+                {
+                    "github_actions": [
+                        {
+                            "repository": "cbusillo/sellyouroutboard",
+                            "workflow_refs": [
+                                "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                            ],
+                            "event_names": ["pull_request"],
+                            "products": ["sellyouroutboard"],
+                            "contexts": ["sellyouroutboard-testing"],
+                            "actions": ["preview_refresh.execute"],
+                        }
+                    ]
+                }
+            )
+            app = create_launchplane_fastapi_test_app(
+                state_dir=state_dir,
+                verifier=_StubVerifier(
+                    _identity(
+                        repository="cbusillo/sellyouroutboard",
+                        workflow_ref=(
+                            "cbusillo/sellyouroutboard/.github/workflows/preview-control-plane.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=policy,
+                control_plane_root_path=root,
+            )
+            request_payload = {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "source": "workflow",
+                "repository": "cbusillo/sellyouroutboard",
+                "anchor_repo": "sellyouroutboard",
+                "anchor_pr_number": 42,
+                "anchor_pr_url": "https://github.com/cbusillo/sellyouroutboard/pull/42",
+                "status": "ready",
+                "run_url": "https://github.com/cbusillo/sellyouroutboard/actions/runs/42",
+            }
+            headers = {"Idempotency-Key": "preview-pr-feedback-ready-retry-after-active"}
+
+            failed_status, failed_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload=request_payload,
+                headers=headers,
+            )
+            store.write_preview_record(
+                PreviewRecord(
+                    preview_id="preview-syo-pr-42",
+                    context="sellyouroutboard-testing",
+                    anchor_repo="sellyouroutboard",
+                    anchor_pr_number=42,
+                    anchor_pr_url="https://github.com/cbusillo/sellyouroutboard/pull/42",
+                    preview_label="preview",
+                    canonical_url="https://pr-42.syo-preview.example.test",
+                    state="active",
+                    created_at="2026-05-03T15:00:00Z",
+                    updated_at="2026-05-03T15:06:00Z",
+                    eligible_at="2026-05-03T15:00:00Z",
+                    active_generation_id="generation-syo-pr-42",
+                    serving_generation_id="generation-syo-pr-42",
+                    latest_generation_id="generation-syo-pr-42",
+                )
+            )
+            ready_status, ready_payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/previews/pr-feedback",
+                payload=request_payload,
+                headers=headers,
+            )
+
+        self.assertEqual(failed_status, 409, failed_payload)
+        self.assertEqual(failed_payload["error"]["code"], "preview_url_unavailable")
+        self.assertEqual(ready_status, 202, ready_payload)
+        self.assertEqual(
+            ready_payload["result"]["preview_url"],
+            "https://pr-42.syo-preview.example.test",
+        )
+        create_comment.assert_called_once()
 
     def test_every_code_preview_validation_failure_returns_generic_webhook_response(
         self,


### PR DESCRIPTION
## Summary
- hydrate ready preview feedback URLs from active Launchplane preview records when reusable callers omit preview_url
- fail closed before writing feedback/idempotency when ready feedback has no explicit or active stored preview URL
- add route coverage for hydration and retry after active preview record appears

## Tests
- uv run python -m unittest tests.test_preview_pr_feedback tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_hydrates_ready_url_from_preview_record tests.test_service.LaunchplaneServiceTests.test_preview_pr_feedback_ready_requires_active_preview_url tests.test_service.LaunchplaneServiceTests.test_every_code_preview_ok_comment_marks_pr_ready_to_merge tests.test_preview_workflow_contract.PreviewWorkflowContractTests
- uv run --extra dev ruff check control_plane/http_app.py control_plane/workflows/preview_pr_feedback.py tests/test_service.py tests/test_preview_pr_feedback.py
- uv run --extra dev ruff format --check control_plane/http_app.py control_plane/workflows/preview_pr_feedback.py tests/test_service.py tests/test_preview_pr_feedback.py
- git diff --check