### PR TITLE
Allow preview URL feedback handoff

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -2209,6 +2209,11 @@ def _allow_reason(
         value=value,
     ):
         return ALLOW_REASON_THIN_CONNECTOR_INPUT
+    if normalized.startswith(".github/workflows/") and _is_preview_feedback_url_output_forward(
+        key=key,
+        value=value,
+    ):
+        return ALLOW_REASON_THIN_CONNECTOR_INPUT
     if normalized.startswith(".github/workflows/") and _is_launchplane_reusable_workflow(
         key=key,
         value=value,
@@ -2559,6 +2564,17 @@ def _is_workflow_read_model_output_forward(*, key: str, value: object) -> bool:
     if match is None:
         return False
     return bool(GITHUB_NEEDS_OUTPUT_REFERENCE_PATTERN.match(match.group("body").strip()))
+
+
+def _is_preview_feedback_url_output_forward(*, key: str, value: object) -> bool:
+    if _semantic_full_key_text(key) != "PREVIEW_URL":
+        return False
+    value_text = _string_value(value).strip()
+    match = GITHUB_EXPRESSION_PATTERN.match(value_text)
+    if match is None:
+        return False
+    body = match.group("body").strip()
+    return body == "needs.provision_preview.outputs.preview_url"
 
 
 def _is_image_deploy_idempotency_key(value_text: str) -> bool:

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2045,6 +2045,31 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                     "operator_supplied_runtime_input",
                 )
 
+    def test_preview_feedback_url_output_forward_is_narrow(self) -> None:
+        self.assertEqual(
+            _allow_reason(
+                path=".github/workflows/preview-control-plane.yml",
+                key="preview_url",
+                value="${{ needs.provision_preview.outputs.preview_url }}",
+            ),
+            "thin_connector_input",
+        )
+
+        for value in (
+            "https://pr-186.syo-preview.example.test",
+            "${{ needs.other_job.outputs.preview_url }}",
+            "${{ vars.PREVIEW_URL }}",
+        ):
+            with self.subTest(value=value):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/preview-control-plane.yml",
+                        key="preview_url",
+                        value=value,
+                    ),
+                    "",
+                )
+
     def test_workflow_block_fields_are_classified_by_path_only(self) -> None:
         for path, key, value in (
             (".github/workflows/edge-endpoint-apply.yml", "endpoint_key", "$endpoint_key,"),


### PR DESCRIPTION
## Summary
- allow product-repo workflows to forward the preview URL produced by `provision_preview` into Launchplane's reusable preview PR feedback workflow
- keep the allowance narrow: hard-coded preview URLs, vars-provided preview URLs, and unrelated job outputs remain unclassified/rejected

## Why
SYO preview lifecycle proof PR #186 showed that refresh and health verification succeed, but ready feedback is rejected unless the caller passes the Launchplane-produced preview URL. The product-repo authority gate should allow that Launchplane-owned output handoff without allowing product-owned URL authority.

## Validation
- `uv run python -m unittest tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_preview_feedback_url_output_forward_is_narrow tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_jq_response_fields_are_classified_narrowly`
- `uv run python -m unittest tests.test_config_authority_audit`
- `uv run ruff check --diff control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `git diff --check`
- JetBrains changed-files closeout inspection: clean

Refs #1528
Refs #1530
