### PR TITLE
Wait for preview runtime identity convergence

### DIFF
--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -1025,11 +1025,15 @@ def _wait_for_preview_health(
                             if status == "match":
                                 return
                             if status == "mismatch":
-                                raise click.ClickException(
-                                    "Preview runtime identity did not match the expected "
-                                    f"deployment identity: {detail}."
-                                )
-                            last_detail = detail
+                                if _preview_runtime_identity_mismatch_is_converging(detail):
+                                    last_detail = detail
+                                else:
+                                    raise click.ClickException(
+                                        "Preview runtime identity did not match the expected "
+                                        f"deployment identity: {detail}."
+                                    )
+                            else:
+                                last_detail = detail
         except HTTPError as exc:
             body = exc.read().decode("utf-8", errors="replace")
             if "dokploy dead host" in body.lower():
@@ -1045,6 +1049,26 @@ def _wait_for_preview_health(
     raise click.ClickException(
         f"Timed out waiting for {health_url} to report healthy: {last_detail}."
     )
+
+
+def _runtime_identity_mismatch_fields(detail: str) -> tuple[str, ...]:
+    prefix = "Runtime identity mismatched fields: "
+    if not detail.startswith(prefix):
+        return ()
+    return tuple(
+        field.strip()
+        for field in detail.removeprefix(prefix).split(",")
+        if field.strip()
+    )
+
+
+def _preview_runtime_identity_mismatch_is_converging(detail: str) -> bool:
+    fields = set(_runtime_identity_mismatch_fields(detail))
+    return bool(fields) and fields <= {
+        "deployment_record_id",
+        "artifact_id",
+        "source_git_ref",
+    }
 
 
 def evaluate_generic_web_preview_readiness(

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -146,6 +146,13 @@ record for a later retry or GitHub rerun. Ignored decisions do not have
 idempotency keys. Launchplane-owned reusable workflows may use an equivalent
 route-specific key when the service derives context from product records.
 
+Preview refresh readiness should allow the serving runtime identity to converge
+after a provider deploy trigger. A health response that still reports the prior
+deployment/artifact/source identity for the same product, context, preview slug,
+and environment kind remains a polling signal until the route timeout; a
+different product, context, preview slug, or environment kind remains a hard
+mismatch.
+
 ## Route Handoff
 
 Preview refresh routes receive only product-local facts:

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1008,7 +1008,7 @@ class GenericWebPreviewTests(unittest.TestCase):
 
         self.assertEqual(sleeps, [5])
 
-    def test_wait_for_preview_health_fails_fast_on_mismatched_runtime_identity(self) -> None:
+    def test_wait_for_preview_health_waits_for_rollout_runtime_identity(self) -> None:
         expected_identity = RuntimeIdentity(
             product="sellyouroutboard",
             context="sellyouroutboard-testing",
@@ -1021,10 +1021,63 @@ class GenericWebPreviewTests(unittest.TestCase):
             preview_id="pr-42",
         )
         stale_identity = expected_identity.model_copy(
-            update={"artifact_id": "ghcr.io/cbusillo/sellyouroutboard:stale"}
+            update={
+                "deployment_record_id": "deployment-20260614T195500Z-syo-pr-42",
+                "artifact_id": "ghcr.io/cbusillo/sellyouroutboard:stale",
+                "source_git_ref": "previous-sha",
+            }
         )
         responses = iter(
-            ({"ok": True, "runtime_identity": stale_identity.model_dump(mode="json")},)
+            (
+                {"ok": True, "runtime_identity": stale_identity.model_dump(mode="json")},
+                {"ok": True, "runtime_identity": expected_identity.model_dump(mode="json")},
+            )
+        )
+
+        class _Response:
+            status = 200
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(next(responses)).encode("utf-8")
+
+        sleeps: list[float] = []
+
+        with (
+            patch("control_plane.workflows.generic_web_preview.urlopen", return_value=_Response()),
+            patch(
+                "control_plane.workflows.generic_web_preview.time.sleep", side_effect=sleeps.append
+            ),
+        ):
+            _wait_for_preview_health(
+                preview_url="https://preview-42.example.test",
+                health_path="/api/health",
+                timeout_seconds=30,
+                expected_runtime_identity=expected_identity,
+            )
+
+        self.assertEqual(sleeps, [5])
+
+    def test_wait_for_preview_health_fails_fast_on_wrong_preview_identity(self) -> None:
+        expected_identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-testing",
+            instance="pr-42",
+            environment_kind="preview",
+            deployment_record_id="deployment-20260614T200000Z-syo-pr-42",
+            artifact_id="ghcr.io/cbusillo/sellyouroutboard:sha",
+            source_git_ref="6b3c9d7e8f901234567890abcdef1234567890ab",
+            image_reference="ghcr.io/cbusillo/sellyouroutboard:sha",
+            preview_id="pr-42",
+        )
+        wrong_identity = expected_identity.model_copy(update={"instance": "pr-41"})
+        responses = iter(
+            ({"ok": True, "runtime_identity": wrong_identity.model_dump(mode="json")},)
         )
 
         class _Response:


### PR DESCRIPTION
## Summary

- keep generic-web preview health polling when only rollout-version runtime identity fields still show the prior deployment
- preserve fail-fast behavior for wrong product/context/preview/environment identity mismatches
- document preview runtime identity convergence during provider deploys

## Plan Alignment

Refs #1528.
Refs #1530.

This addresses the repeated-refresh idempotency behavior exposed by SYO PR #186, where a rerun could see the previous preview deployment identity immediately after triggering a new provider deploy and fail before the runtime converged.

## Validation

- `uv run python -m unittest tests.test_generic_web_preview`
- `uv run --extra dev ruff check --diff control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `uv run --extra dev ruff check control_plane/workflows/generic_web_preview.py tests/test_generic_web_preview.py`
- `git diff --check`
