### PR TITLE
Default product-driver stable deploy to testing

### DIFF
--- a/.github/workflows/reusable-product-driver-stable-deploy.yml
+++ b/.github/workflows/reusable-product-driver-stable-deploy.yml
@@ -15,8 +15,9 @@ name: Reusable Product Driver Stable Deploy
         default: ""
         type: string
       instance:
-        description: Stable lane instance to deploy.
-        required: true
+        description: Stable lane instance to deploy. Defaults to testing.
+        required: false
+        default: "testing"
         type: string
       artifact_id:
         description: Immutable image or Launchplane-resolvable artifact identity.

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -455,6 +455,11 @@ record id, and product-owned verification statuses. The route ids are
 Launchplane-owned driver routes; product repos should not derive them from
 product keys or keep local copies of route construction logic.
 
+The product-driver stable deploy workflow defaults to the `testing` lane so a
+testing publish workflow can pass only the immutable artifact identity and tested
+source git ref. Product repos should pass an explicit `instance` only for a
+workflow whose operator input or job purpose genuinely selects a different lane.
+
 The product-driver reusable surface is:
 
 - `reusable-product-driver-stable-environment.yml@main`

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -3261,6 +3261,74 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertNotIn("product", thin_connector_keys)
         self.assertNotIn("instance", thin_connector_keys)
 
+    def test_cli_product_repo_gate_allows_product_driver_stable_deploy_workflow(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            workflow = root / ".github" / "workflows" / "publish-image.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text("name: Publish Image\n", encoding="utf-8")
+            _commit_all(root)
+            _git(root, "branch", "-M", "main")
+            _checkout_branch(root, "feature/product-driver-stable-deploy")
+            workflow.write_text(
+                "---\n"
+                "name: Publish Image\n\n"
+                '"on":\n'
+                "  push:\n"
+                "    branches: [main]\n\n"
+                "jobs:\n"
+                "  publish:\n"
+                "    runs-on: ubuntu-latest\n"
+                "    outputs:\n"
+                "      artifact_id: ${{ steps.image.outputs.artifact_id }}\n"
+                "      source_git_ref: ${{ github.sha }}\n"
+                "    steps:\n"
+                "      - id: image\n"
+                "        run: echo 'artifact_id=ghcr.io/example/product:sha' >> \"$GITHUB_OUTPUT\"\n"
+                "  deploy:\n"
+                "    needs: publish\n"
+                "    uses: cbusillo/launchplane/.github/workflows/reusable-product-driver-stable-deploy.yml@main\n"
+                "    with:\n"
+                "      launchplane_url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}\n"
+                "      artifact_id: ${{ needs.publish.outputs.artifact_id }}\n"
+                "      source_git_ref: ${{ needs.publish.outputs.source_git_ref }}\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            runner = CliRunner()
+            result = runner.invoke(
+                CLI_MAIN,
+                [
+                    "service",
+                    "audit-config-authority",
+                    "--control-plane-root",
+                    str(root),
+                    "--mode",
+                    "changed-files-gate",
+                    "--fail-on-findings",
+                    "--gate-profile",
+                    "product-repo",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        gate = cast("dict[str, object]", payload["gate"])
+        self.assertEqual(gate["status"], "pass")
+        thin_connector_keys = {
+            finding["key"]
+            for finding in _findings(payload)
+            if finding["allow_reason"] == "thin_connector_input"
+        }
+        self.assertIn("uses", thin_connector_keys)
+        self.assertNotIn("product", thin_connector_keys)
+        self.assertNotIn("context", thin_connector_keys)
+        self.assertNotIn("instance", thin_connector_keys)
+
     def test_cli_product_repo_gate_allows_reusable_generic_web_preview_workflow(self) -> None:
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -206,6 +206,10 @@ class DocsContractsTests(TestCase):
         ).read_text(encoding="utf-8")
 
         self.assertIn("Reusable Product-Driver Workflows", product_repo_contract)
+        self.assertIn(
+            "defaults to the `testing` lane",
+            product_repo_contract,
+        )
         self.assertIn("reusable-product-driver-stable-deploy.yml@main", product_repo_contract)
         self.assertIn("reusable-product-driver-prod-promotion.yml@main", product_repo_contract)
         self.assertIn("reusable-product-driver-prod-rollback.yml@main", product_repo_contract)
@@ -214,6 +218,8 @@ class DocsContractsTests(TestCase):
         self.assertIn("should not own Launchplane route construction", product_repo_contract)
 
         self.assertIn("workflow_call:", stable_deploy_workflow)
+        self.assertIn("Stable lane instance to deploy. Defaults to testing.", stable_deploy_workflow)
+        self.assertIn('default: "testing"', stable_deploy_workflow)
         self.assertIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', stable_deploy_workflow)
         self.assertIn("route_path=/v1/drivers/verireel/$INSTANCE-deploy", stable_deploy_workflow)
         self.assertIn("deploy.artifact_id=${{ inputs.artifact_id }}", stable_deploy_workflow)


### PR DESCRIPTION
## Summary

- Default `reusable-product-driver-stable-deploy.yml` to the `testing` lane, matching the generic-web stable deploy wrapper and keeping testing-publish product repos thin.
- Add a product-repo config-authority regression proving callers can use the product-driver stable deploy reusable with only artifact/source facts and Launchplane URL.
- Update the product-repo contract/docs assertions so the default-lane behavior stays documented.

## Why

VeriReel PR cbusillo/verireel#234 delegates testing deploy to this reusable workflow. The product repo should not need to pass a checked-in `instance: testing` value for an operation whose reusable workflow purpose is testing stable deploy.

## Validation

- `uv run python -m unittest tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cli_product_repo_gate_allows_product_driver_stable_deploy_workflow tests.test_docs_contracts`
- `docker run --rm -v ${PWD}:/repo -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml`
- `uv run --extra dev ruff check tests/test_config_authority_audit.py tests/test_docs_contracts.py`
- `git diff --check`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "$PWD" --scope changed_files`

Refs #1526
Refs #1530
