### PR TITLE
Default stable environment to testing

### DIFF
--- a/.github/workflows/reusable-product-driver-stable-environment.yml
+++ b/.github/workflows/reusable-product-driver-stable-environment.yml
@@ -15,8 +15,9 @@ name: Reusable Product Driver Stable Environment
         default: ""
         type: string
       instance:
-        description: Stable lane instance to resolve.
-        required: true
+        description: Stable lane instance to resolve. Defaults to testing.
+        required: false
+        default: testing
         type: string
       timeout-ms:
         description: Launchplane request timeout in milliseconds.

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -455,10 +455,12 @@ record id, and product-owned verification statuses. The route ids are
 Launchplane-owned driver routes; product repos should not derive them from
 product keys or keep local copies of route construction logic.
 
-The product-driver stable deploy workflow defaults to the `testing` lane so a
-testing publish workflow can pass only the immutable artifact identity and tested
-source git ref. Product repos should pass an explicit `instance` only for a
-workflow whose operator input or job purpose genuinely selects a different lane.
+The product-driver stable deploy and stable environment workflow surface
+defaults to the `testing` lane so a testing publish workflow can pass only the
+primitive facts it owns, such as immutable artifact identity and tested source
+git ref.
+Product repos should pass an explicit `instance` only for a workflow whose
+operator input or job purpose genuinely selects a different lane.
 
 The product-driver reusable surface is:
 


### PR DESCRIPTION
## Summary
- default the reusable product-driver stable-environment workflow to the testing lane
- update product repo contract docs so stable deploy and stable environment share the same testing default guidance
- unblocks product repos from checking in `instance: testing` for ordinary testing environment resolution

## Validation
- `git diff --check && actionlint -config-file .github/actionlint.yaml .github/workflows/reusable-product-driver-stable-environment.yml`
- `uv run python -m unittest tests.test_config_authority_audit tests.test_product_onboarding`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains PyCharm changed-files inspection: clean

Refs #1526
Refs #1530