### PR TITLE
Default app maintenance to testing

### DIFF
--- a/.github/workflows/reusable-product-driver-app-maintenance.yml
+++ b/.github/workflows/reusable-product-driver-app-maintenance.yml
@@ -15,8 +15,9 @@ name: Reusable Product Driver App Maintenance
         default: ""
         type: string
       instance:
-        description: Runtime instance for the maintenance action.
-        required: true
+        description: Runtime instance for the maintenance action. Defaults to testing.
+        required: false
+        default: testing
         type: string
       action:
         description: Product driver maintenance action.

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -455,10 +455,10 @@ record id, and product-owned verification statuses. The route ids are
 Launchplane-owned driver routes; product repos should not derive them from
 product keys or keep local copies of route construction logic.
 
-The product-driver stable deploy and stable environment workflow surface
-defaults to the `testing` lane so a testing publish workflow can pass only the
-primitive facts it owns, such as immutable artifact identity and tested source
-git ref.
+The product-driver workflow surface for stable deploy, stable environment, and
+app-maintenance defaults to the `testing` lane so a testing publish workflow can
+pass only the primitive facts it owns, such as immutable artifact identity,
+tested source git ref, and operation-level maintenance intent.
 Product repos should pass an explicit `instance` only for a workflow whose
 operator input or job purpose genuinely selects a different lane.
 


### PR DESCRIPTION
## Summary
- make the reusable product-driver app-maintenance workflow default its instance input to testing
- document app-maintenance with the other testing-default product-driver reusable workflows

## Plan alignment
- Supports #1526 and #1530 by removing another product-repo reason to check in `instance: testing` for stable testing handoff flows.
- Unblocks the VeriReel app-maintenance workflow delegation slice without storing testing lane authority in the product repo.

## Validation
- `git diff --check`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/reusable-product-driver-app-maintenance.yml`
- `uv run python -m unittest tests.test_docs_contracts.DocsContractsTests.test_product_driver_reusable_workflows_keep_route_shaping_in_launchplane`
- `uv run python -m unittest tests.test_config_authority_audit tests.test_product_onboarding tests.test_docs_contracts`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "$PWD" --scope changed_files --timeout-ms 300000`

Refs #1526
Refs #1530