### PR TITLE
Forward expected build in prod readiness

### DIFF
--- a/.github/workflows/reusable-product-driver-prod-launch-readiness.yml
+++ b/.github/workflows/reusable-product-driver-prod-launch-readiness.yml
@@ -14,6 +14,16 @@ name: Reusable Product Driver Prod Launch Readiness
         required: false
         default: ""
         type: string
+      expected_build_revision:
+        description: Expected production runtime build revision, when known.
+        required: false
+        default: ""
+        type: string
+      expected_build_tag:
+        description: Expected production runtime build tag, when known.
+        required: false
+        default: ""
+        type: string
       launchplane_url:
         description: Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
         required: false
@@ -89,6 +99,8 @@ jobs:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}
       instance: prod
+      expected_build_revision: ${{ inputs.expected_build_revision }}
+      expected_build_tag: ${{ inputs.expected_build_tag }}
       timeout-seconds: "300"
       interval-seconds: "5"
       launchplane_url: ${{ inputs.launchplane_url }}

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -461,6 +461,9 @@ pass only the primitive facts it owns, such as immutable artifact identity,
 tested source git ref, and operation-level maintenance intent.
 Product repos should pass an explicit `instance` only for a workflow whose
 operator input or job purpose genuinely selects a different lane.
+Production readiness wrappers may also accept expected runtime build identity
+from operator input or upstream workflow evidence and forward it to
+Launchplane-owned runtime verification.
 
 The product-driver reusable surface is:
 


### PR DESCRIPTION
## Summary
- add optional expected build revision/tag inputs to the reusable product-driver prod launch-readiness workflow
- forward those inputs into the existing reusable runtime-verification job
- document expected runtime build identity as operator/provenance input, not product-owned route construction

## Plan alignment
- Supports #1526 and #1530 by letting product repos retire direct runtime-verification request builders while preserving manual production build-identity confirmation through Launchplane-owned reusable workflows.

## Validation
- `git diff --check`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/reusable-product-driver-prod-launch-readiness.yml`
- `uv run python -m unittest tests.test_docs_contracts tests.test_config_authority_audit`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "$PWD" --scope changed_files --timeout-ms 300000`
- Product-repo changed-files config-authority gate against the dependent VeriReel branch: pass, `rejected_finding_count: 0`

Refs #1526
Refs #1530