### PR TITLE
Add smoke maintenance client setup action

### DIFF
--- a/.github/actions/setup-smoke-maintenance-client/action.yml
+++ b/.github/actions/setup-smoke-maintenance-client/action.yml
@@ -1,0 +1,17 @@
+---
+name: Setup smoke maintenance client
+description: Write Launchplane's VeriReel smoke-maintenance Node client.
+
+inputs:
+  output-path:
+    description: Path where the ESM client module should be written.
+    required: false
+    default: .launchplane/smoke-maintenance-client.mjs
+
+outputs:
+  client-path:
+    description: Path to the generated ESM client module.
+
+runs:
+  using: node24
+  main: dist/index.js

--- a/.github/actions/setup-smoke-maintenance-client/dist/index.js
+++ b/.github/actions/setup-smoke-maintenance-client/dist/index.js
@@ -1,0 +1,42 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function inputNameToEnvKey(name) {
+  return `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+}
+
+function getInput(name, options = {}) {
+  const value = String(
+    process.env[inputNameToEnvKey(name)] ?? options.defaultValue ?? "",
+  ).trim();
+  if (options.required && !value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function setOutput(name, value) {
+  const outputPath = String(process.env.GITHUB_OUTPUT ?? "").trim();
+  if (!outputPath) {
+    return;
+  }
+  fs.appendFileSync(outputPath, `${name}=${value}\n`, "utf8");
+}
+
+function main() {
+  const outputPath = getInput("output-path", {
+    defaultValue: ".launchplane/smoke-maintenance-client.mjs",
+  });
+  const sourcePath = path.join(__dirname, "..", "src", "smoke-maintenance-client.mjs");
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.copyFileSync(sourcePath, outputPath);
+  setOutput("client-path", outputPath);
+  console.log(`Wrote Launchplane smoke maintenance client to ${outputPath}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/.github/actions/setup-smoke-maintenance-client/src/smoke-maintenance-client.mjs
+++ b/.github/actions/setup-smoke-maintenance-client/src/smoke-maintenance-client.mjs
@@ -4,6 +4,14 @@ const SMOKE_MAINTENANCE_ACTIONS = new Set([
   "promote-owner",
 ]);
 
+const VERIREEL_SMOKE_MAINTENANCE_INTENTS = new Map([
+  ["verireel:delete-user", "owner-route-delete-user"],
+  ["verireel:grant-sponsored", "stable-testing-remote-e2e-grant-sponsored"],
+  ["verireel:promote-owner", "owner-route-promote-owner"],
+  ["verireel-testing:delete-user", "remote-e2e-delete-user"],
+  ["verireel-testing:grant-sponsored", "remote-e2e-grant-sponsored"],
+]);
+
 function normalizeRequiredText(value, label) {
   const normalized = String(value ?? "").trim();
   if (!normalized) {
@@ -24,6 +32,31 @@ function normalizeSmokeMaintenanceAction(action) {
     );
   }
   return normalizedAction;
+}
+
+export function smokeMaintenanceIntentForAction(context, action) {
+  const normalizedContext = normalizeRequiredText(context, "Context");
+  const normalizedAction = normalizeSmokeMaintenanceAction(action);
+  const intent = VERIREEL_SMOKE_MAINTENANCE_INTENTS.get(
+    `${normalizedContext}:${normalizedAction}`,
+  );
+  if (!intent) {
+    throw new Error(
+      `Unsupported VeriReel smoke maintenance context/action combination: ${normalizedContext}/${normalizedAction}.`,
+    );
+  }
+  return intent;
+}
+
+function normalizeSmokeMaintenanceIntent(options, context, action) {
+  const derivedIntent = smokeMaintenanceIntentForAction(context, action);
+  const explicitIntent = normalizeOptionalText(options.intent);
+  if (explicitIntent && explicitIntent !== derivedIntent) {
+    throw new Error(
+      `VeriReel smoke maintenance intent '${explicitIntent}' does not match derived intent '${derivedIntent}'.`,
+    );
+  }
+  return derivedIntent;
 }
 
 function parsePositiveInteger(value, label) {
@@ -130,14 +163,16 @@ async function requestGitHubOidcToken(audience, options) {
 }
 
 export function buildLaunchplaneSmokeMaintenanceIdempotencyKey(options) {
+  const context = normalizeRequiredText(options.context, "Context");
   const action = normalizeSmokeMaintenanceAction(options.action);
+  const intent = normalizeSmokeMaintenanceIntent(options, context, action);
   return [
     "product-smoke-maintenance",
     normalizeRequiredText(options.product, "Product"),
-    normalizeRequiredText(options.context, "Context"),
+    context,
     normalizeRequiredText(options.instance, "Instance"),
     action,
-    normalizeRequiredText(options.intent, "Intent"),
+    intent,
     normalizeOptionalText(options.applicationName),
     normalizeOptionalText(options.previewSlug),
     normalizeOptionalText(options.email),
@@ -145,13 +180,15 @@ export function buildLaunchplaneSmokeMaintenanceIdempotencyKey(options) {
 }
 
 export function buildLaunchplaneSmokeMaintenanceRequest(options) {
+  const context = normalizeRequiredText(options.context, "Context");
   const action = normalizeSmokeMaintenanceAction(options.action);
+  const intent = normalizeSmokeMaintenanceIntent(options, context, action);
   const maintenance = {
     schema_version: 1,
-    context: normalizeRequiredText(options.context, "Context"),
+    context,
     instance: normalizeRequiredText(options.instance, "Instance"),
     action,
-    intent: normalizeRequiredText(options.intent, "Intent"),
+    intent,
     timeout_seconds: parsePositiveInteger(options.timeoutSeconds, "timeoutSeconds"),
   };
   const email = normalizeOptionalText(options.email);

--- a/.github/actions/setup-smoke-maintenance-client/src/smoke-maintenance-client.mjs
+++ b/.github/actions/setup-smoke-maintenance-client/src/smoke-maintenance-client.mjs
@@ -1,0 +1,246 @@
+const SMOKE_MAINTENANCE_ACTIONS = new Set([
+  "delete-user",
+  "grant-sponsored",
+  "promote-owner",
+]);
+
+function normalizeRequiredText(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${label} is required.`);
+  }
+  return normalized;
+}
+
+function normalizeOptionalText(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeSmokeMaintenanceAction(action) {
+  const normalizedAction = normalizeRequiredText(action, "Action");
+  if (!SMOKE_MAINTENANCE_ACTIONS.has(normalizedAction)) {
+    throw new Error(
+      `Unsupported Launchplane smoke maintenance action: ${normalizedAction}. Expected delete-user, grant-sponsored, or promote-owner.`,
+    );
+  }
+  return normalizedAction;
+}
+
+function parsePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseNonNegativeInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${label} must be a non-negative integer.`);
+  }
+  return parsed;
+}
+
+function defaultAudienceForBaseUrl(launchplaneBaseUrl) {
+  return new URL(launchplaneBaseUrl).host;
+}
+
+function buildAbortSignal(timeoutMs, label) {
+  const normalizedTimeoutMs = parseNonNegativeInteger(timeoutMs, label);
+  if (!normalizedTimeoutMs) {
+    return undefined;
+  }
+  return AbortSignal.timeout(normalizedTimeoutMs);
+}
+
+function isAbortError(error) {
+  return error instanceof DOMException
+    ? error.name === "AbortError" || error.name === "TimeoutError"
+    : error?.name === "AbortError" || error?.name === "TimeoutError";
+}
+
+function describeError(error) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+async function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithRetry(url, initOrFactory, options) {
+  const attempts = parsePositiveInteger(options.retryAttempts ?? 3, "retryAttempts");
+  const delayMs = parseNonNegativeInteger(options.retryDelayMs ?? 250, "retryDelayMs");
+  let lastError = null;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const init = typeof initOrFactory === "function"
+        ? await initOrFactory()
+        : initOrFactory;
+      return await options.fetchImpl(url, init);
+    } catch (error) {
+      lastError = error;
+      if (isAbortError(error) || attempt >= attempts) {
+        break;
+      }
+      await sleep(delayMs * attempt);
+    }
+  }
+  throw new Error(
+    `${options.label} failed after ${attempts} attempts: ${describeError(lastError)}`,
+  );
+}
+
+async function requestGitHubOidcToken(audience, options) {
+  const requestUrl = String(options.env.ACTIONS_ID_TOKEN_REQUEST_URL ?? "").trim();
+  const requestToken = String(options.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN ?? "").trim();
+  if (!requestUrl || !requestToken) {
+    throw new Error(
+      "GitHub OIDC request environment is missing. Ensure the workflow job grants id-token: write.",
+    );
+  }
+
+  const tokenUrl = new URL(requestUrl);
+  tokenUrl.searchParams.set("audience", audience);
+  const response = await fetchWithRetry(
+    tokenUrl.toString(),
+    {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${requestToken}`,
+        Accept: "application/json",
+      },
+      signal: buildAbortSignal(options.oidcTimeoutMs ?? 30000, "oidcTimeoutMs"),
+    },
+    { ...options, label: "GitHub OIDC token request" },
+  );
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`GitHub OIDC token request failed with ${response.status}: ${body}`);
+  }
+  const parsed = body ? JSON.parse(body) : {};
+  const token = String(parsed.value ?? "").trim();
+  if (!token) {
+    throw new Error("GitHub OIDC token response did not include a token value.");
+  }
+  return token;
+}
+
+export function buildLaunchplaneSmokeMaintenanceIdempotencyKey(options) {
+  const action = normalizeSmokeMaintenanceAction(options.action);
+  return [
+    "product-smoke-maintenance",
+    normalizeRequiredText(options.product, "Product"),
+    normalizeRequiredText(options.context, "Context"),
+    normalizeRequiredText(options.instance, "Instance"),
+    action,
+    normalizeRequiredText(options.intent, "Intent"),
+    normalizeOptionalText(options.applicationName),
+    normalizeOptionalText(options.previewSlug),
+    normalizeOptionalText(options.email),
+  ].join(":");
+}
+
+export function buildLaunchplaneSmokeMaintenanceRequest(options) {
+  const action = normalizeSmokeMaintenanceAction(options.action);
+  const maintenance = {
+    schema_version: 1,
+    context: normalizeRequiredText(options.context, "Context"),
+    instance: normalizeRequiredText(options.instance, "Instance"),
+    action,
+    intent: normalizeRequiredText(options.intent, "Intent"),
+    timeout_seconds: parsePositiveInteger(options.timeoutSeconds, "timeoutSeconds"),
+  };
+  const email = normalizeOptionalText(options.email);
+  const applicationName = normalizeOptionalText(options.applicationName);
+  const previewSlug = normalizeOptionalText(options.previewSlug);
+  if (email) {
+    maintenance.email = email;
+  }
+  if (applicationName) {
+    maintenance.application_name = applicationName;
+  }
+  if (previewSlug) {
+    maintenance.preview_slug = previewSlug;
+  }
+
+  return {
+    routePath: "/v1/drivers/verireel/app-maintenance",
+    payload: {
+      schema_version: 1,
+      product: normalizeRequiredText(options.product, "Product"),
+      maintenance,
+    },
+  };
+}
+
+export async function requestLaunchplaneSmokeMaintenance(
+  options,
+  env = process.env,
+  fetchImpl = fetch,
+) {
+  const launchplaneBaseUrl = normalizeRequiredText(
+    options.launchplaneUrl,
+    "Launchplane URL",
+  );
+  const audience = normalizeOptionalText(options.audience)
+    || defaultAudienceForBaseUrl(launchplaneBaseUrl);
+  const { routePath, payload } = buildLaunchplaneSmokeMaintenanceRequest(options);
+  const idempotencyKey = buildLaunchplaneSmokeMaintenanceIdempotencyKey(options);
+  const tokenOptions = {
+    env,
+    fetchImpl,
+    oidcTimeoutMs: options.oidcTimeoutMs ?? 30000,
+    retryAttempts: options.retryAttempts ?? 3,
+    retryDelayMs: options.retryDelayMs ?? 250,
+  };
+  const token = await requestGitHubOidcToken(audience, tokenOptions);
+  const requestUrl = new URL(routePath, launchplaneBaseUrl);
+  const response = await fetchWithRetry(
+    requestUrl.toString(),
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        "Idempotency-Key": idempotencyKey,
+      },
+      body: JSON.stringify(payload),
+      signal: buildAbortSignal(options.timeoutMs ?? 0, "timeoutMs"),
+    },
+    {
+      fetchImpl,
+      label: "Launchplane smoke maintenance request",
+      retryAttempts: options.retryAttempts ?? 3,
+      retryDelayMs: options.retryDelayMs ?? 250,
+    },
+  );
+  const responseText = await response.text();
+  let responseBody = {};
+  if (!response.ok) {
+    throw new Error(
+      `Launchplane smoke maintenance request failed with ${response.status}: ${responseText}`,
+    );
+  }
+  if (responseText) {
+    responseBody = JSON.parse(responseText);
+  }
+  const maintenanceStatus = String(responseBody?.result?.maintenance_status ?? "").trim();
+  if (["blocked", "fail"].includes(maintenanceStatus)) {
+    const message = String(responseBody?.result?.error_message ?? "").trim();
+    throw new Error(message || `Launchplane smoke maintenance returned ${maintenanceStatus}.`);
+  }
+  return {
+    audience,
+    idempotencyKey,
+    payload,
+    responseBody,
+    routePath,
+    statusCode: response.status,
+    url: requestUrl.toString(),
+  };
+}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ __pycache__/
 .venv/
 build/
 dist/
+!.github/actions/*/dist/
+!.github/actions/*/dist/**
 *.egg-info/
 node_modules/
 frontend/node_modules/

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -178,8 +178,8 @@ Launchplane-owned smoke maintenance client with
 `cbusillo/launchplane/.github/actions/setup-smoke-maintenance-client@main` and
 import the generated client from the smoke script. The workflow job must grant
 `id-token: write` for the client to authenticate to Launchplane. Do not copy
-Launchplane OIDC, route, payload, idempotency, or retry helpers into the product
-repo for that path.
+Launchplane OIDC, route, payload, driver intent, idempotency, or retry helpers
+into the product repo for that path.
 
 ## Choose A Driver
 

--- a/docs/new-product-repo.md
+++ b/docs/new-product-repo.md
@@ -172,6 +172,15 @@ copying an OIDC/fetch helper into the product repo. Product repos can still keep
 small scripts that assemble product-specific payload JSON until Launchplane owns
 that request-shaping layer too.
 
+If a product-owned smoke test creates dynamic users and needs Launchplane to
+grant, promote, or clean them up during the same browser run, install the
+Launchplane-owned smoke maintenance client with
+`cbusillo/launchplane/.github/actions/setup-smoke-maintenance-client@main` and
+import the generated client from the smoke script. The workflow job must grant
+`id-token: write` for the client to authenticate to Launchplane. Do not copy
+Launchplane OIDC, route, payload, idempotency, or retry helpers into the product
+repo for that path.
+
 ## Choose A Driver
 
 Use `generic-web` when the product is a stateless or mostly stateless web app,

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -193,9 +193,11 @@ Launchplane. The initial client covers VeriReel generated-user smoke
 maintenance; add new Launchplane-owned clients for other products rather than
 copying or generalizing product-specific route logic in product repos. The
 product script may pass primitive smoke facts such as action, email, context,
-instance, preview slug, and timeout. It should not own Launchplane route paths,
-request envelopes, idempotency-key recipes, GitHub OIDC token exchange, retry
-behavior, or driver-result failure rules.
+instance, preview slug, and timeout. The client derives the Launchplane driver
+intent for supported smoke actions. The product script should not own
+Launchplane route paths, request envelopes, driver intent strings,
+idempotency-key recipes, GitHub OIDC token exchange, retry behavior, or
+driver-result failure rules.
 
 ## What Launchplane Owns
 
@@ -512,8 +514,8 @@ Generated-user smoke setup that must happen inside a product browser flow should
 use `setup-smoke-maintenance-client@main` instead of a workflow-level
 app-maintenance call. The setup action writes an importable Node ESM client into
 the product job so the browser script can keep its dynamic test email while
-Launchplane owns request shaping and OIDC transport. The job using the generated
-client must include `permissions: id-token: write`.
+Launchplane owns request shaping, driver intent derivation, and OIDC transport.
+The job using the generated client must include `permissions: id-token: write`.
 
 ## Reusable Launchplane Request Action
 

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -183,6 +183,20 @@ Launchplane rather than defining product topology, target inventory, domains, or
 runtime authority. Generic runtime health and revision checks should move to
 Launchplane drivers once the driver has the necessary profile data.
 
+When product smoke checks need Launchplane-backed generated-user setup or
+cleanup during the same browser run, the workflow should install a
+Launchplane-owned smoke maintenance client with
+`cbusillo/launchplane/.github/actions/setup-smoke-maintenance-client@main` and
+pass the generated client path to the product script. The workflow job must
+grant `id-token: write` so the client can request a GitHub OIDC token for
+Launchplane. The initial client covers VeriReel generated-user smoke
+maintenance; add new Launchplane-owned clients for other products rather than
+copying or generalizing product-specific route logic in product repos. The
+product script may pass primitive smoke facts such as action, email, context,
+instance, preview slug, and timeout. It should not own Launchplane route paths,
+request envelopes, idempotency-key recipes, GitHub OIDC token exchange, retry
+behavior, or driver-result failure rules.
+
 ## What Launchplane Owns
 
 - Product profile records, lane profiles, preview policy, runtime port, health
@@ -493,6 +507,13 @@ call `reusable-product-driver-testing-reset.yml@main` rather than wiring
 stable-testing-reset` itself. Product-owned smoke checks may still consume
 Launchplane reusable outputs, such as a resolved `primary_base_url`, as
 pass-through evidence for product behavior checks.
+
+Generated-user smoke setup that must happen inside a product browser flow should
+use `setup-smoke-maintenance-client@main` instead of a workflow-level
+app-maintenance call. The setup action writes an importable Node ESM client into
+the product job so the browser script can keep its dynamic test email while
+Launchplane owns request shaping and OIDC transport. The job using the generated
+client must include `permissions: id-token: write`.
 
 ## Reusable Launchplane Request Action
 

--- a/tests/test_smoke_maintenance_client_action.py
+++ b/tests/test_smoke_maintenance_client_action.py
@@ -71,6 +71,7 @@ console.log(Object.keys(client).sort().join(','));
             )
             self.assertEqual(import_result.returncode, 0, import_result.stderr)
             self.assertIn("requestLaunchplaneSmokeMaintenance", import_result.stdout)
+            self.assertIn("smokeMaintenanceIntentForAction", import_result.stdout)
 
     def test_client_builds_verireel_smoke_request(self) -> None:
         with TemporaryDirectory() as temporary_directory:
@@ -85,7 +86,6 @@ const request = client.buildLaunchplaneSmokeMaintenanceRequest({
   context: 'verireel-testing',
   instance: 'preview',
   action: 'grant-sponsored',
-  intent: 'remote-e2e-grant-sponsored',
   email: 'creator@example.com',
   previewSlug: 'pr-42',
   timeoutSeconds: 300,
@@ -95,7 +95,6 @@ const idempotencyKey = client.buildLaunchplaneSmokeMaintenanceIdempotencyKey({
   context: 'verireel-testing',
   instance: 'preview',
   action: 'grant-sponsored',
-  intent: 'remote-e2e-grant-sponsored',
   email: 'creator@example.com',
   previewSlug: 'pr-42',
 });
@@ -125,6 +124,79 @@ console.log(JSON.stringify({ request, idempotencyKey }));
             "product-smoke-maintenance:verireel:verireel-testing:preview:grant-sponsored:remote-e2e-grant-sponsored::pr-42:creator@example.com",
         )
 
+    def test_client_derives_stable_owner_smoke_intent(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildLaunchplaneSmokeMaintenanceRequest({
+  product: 'verireel',
+  context: 'verireel',
+  instance: 'testing',
+  action: 'promote-owner',
+  email: 'owner@example.com',
+  timeoutSeconds: 300,
+});
+console.log(JSON.stringify(request.payload.maintenance));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["intent"],
+            "owner-route-promote-owner",
+        )
+
+    def test_client_rejects_mismatched_smoke_intent(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+client.buildLaunchplaneSmokeMaintenanceRequest({
+  product: 'verireel',
+  context: 'verireel-testing',
+  instance: 'preview',
+  action: 'delete-user',
+  intent: 'owner-route-delete-user',
+  email: 'creator@example.com',
+  previewSlug: 'pr-42',
+  timeoutSeconds: 300,
+});
+""",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("does not match derived intent 'remote-e2e-delete-user'", result.stderr)
+
+    def test_client_rejects_unsupported_smoke_context_action(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+client.buildLaunchplaneSmokeMaintenanceRequest({
+  product: 'verireel',
+  context: 'verireel-testing',
+  instance: 'preview',
+  action: 'promote-owner',
+  email: 'creator@example.com',
+  previewSlug: 'pr-42',
+  timeoutSeconds: 300,
+});
+""",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unsupported VeriReel smoke maintenance context/action combination", result.stderr)
+
     def test_client_rejects_workflow_maintenance_action(self) -> None:
         with TemporaryDirectory() as temporary_directory:
             client_path = Path(temporary_directory) / "smoke-client.mjs"
@@ -138,7 +210,6 @@ client.buildLaunchplaneSmokeMaintenanceRequest({
   context: 'verireel',
   instance: 'testing',
   action: 'migrate',
-  intent: 'stable-testing-migration',
   timeoutSeconds: 300,
 });
 """,
@@ -172,7 +243,6 @@ const result = await client.requestLaunchplaneSmokeMaintenance({
   context: 'verireel',
   instance: 'testing',
   action: 'promote-owner',
-  intent: 'owner-route-promote-owner',
   email: 'owner@example.com',
   timeoutSeconds: 300,
 }, {
@@ -216,7 +286,6 @@ await client.requestLaunchplaneSmokeMaintenance({
   context: 'verireel',
   instance: 'testing',
   action: 'delete-user',
-  intent: 'owner-route-delete-user',
   email: 'owner@example.com',
   timeoutSeconds: 300,
 }, {
@@ -254,7 +323,6 @@ await client.requestLaunchplaneSmokeMaintenance({
   context: 'verireel',
   instance: 'testing',
   action: 'delete-user',
-  intent: 'owner-route-delete-user',
   email: 'owner@example.com',
   timeoutSeconds: 300,
 }, {
@@ -281,7 +349,6 @@ await client.requestLaunchplaneSmokeMaintenance({
   context: 'verireel',
   instance: 'testing',
   action: 'delete-user',
-  intent: 'owner-route-delete-user',
   email: 'owner@example.com',
   timeoutSeconds: 300,
 }, {}, async () => new Response('{}', { status: 200 }));

--- a/tests/test_smoke_maintenance_client_action.py
+++ b/tests/test_smoke_maintenance_client_action.py
@@ -150,6 +150,58 @@ console.log(JSON.stringify(request.payload.maintenance));
             "owner-route-promote-owner",
         )
 
+    def test_client_derives_stable_grant_smoke_intent(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildLaunchplaneSmokeMaintenanceRequest({
+  product: 'verireel',
+  context: 'verireel',
+  instance: 'testing',
+  action: 'grant-sponsored',
+  email: 'creator@example.com',
+  timeoutSeconds: 300,
+});
+console.log(JSON.stringify(request.payload.maintenance));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["intent"],
+            "stable-testing-remote-e2e-grant-sponsored",
+        )
+
+    def test_client_derives_stable_delete_smoke_intent(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildLaunchplaneSmokeMaintenanceRequest({
+  product: 'verireel',
+  context: 'verireel',
+  instance: 'testing',
+  action: 'delete-user',
+  email: 'owner@example.com',
+  timeoutSeconds: 300,
+});
+console.log(JSON.stringify(request.payload.maintenance));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout)["intent"],
+            "owner-route-delete-user",
+        )
+
     def test_client_rejects_mismatched_smoke_intent(self) -> None:
         with TemporaryDirectory() as temporary_directory:
             client_path = Path(temporary_directory) / "smoke-client.mjs"

--- a/tests/test_smoke_maintenance_client_action.py
+++ b/tests/test_smoke_maintenance_client_action.py
@@ -1,0 +1,296 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+
+ACTION_ENTRYPOINT = Path(".github/actions/setup-smoke-maintenance-client/dist/index.js")
+ACTION_METADATA = Path(".github/actions/setup-smoke-maintenance-client/action.yml")
+
+
+class SmokeMaintenanceClientActionTests(unittest.TestCase):
+    def test_action_metadata_uses_supported_node_runtime(self) -> None:
+        self.assertIn(
+            "using: node24",
+            ACTION_METADATA.read_text(encoding="utf-8"),
+        )
+
+    def run_setup_action(self, *, output_path: Path, github_output: Path) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the smoke maintenance action")
+
+        env = os.environ.copy()
+        env["INPUT_OUTPUT-PATH"] = str(output_path)
+        env["GITHUB_OUTPUT"] = str(github_output)
+        return subprocess.run(
+            ["node", ACTION_ENTRYPOINT.as_posix()],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+    def run_client_script(self, client_path: Path, script_body: str) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the smoke maintenance client")
+
+        script = f"""
+import * as client from {json.dumps(client_path.as_uri())};
+{script_body}
+"""
+        return subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_setup_action_writes_importable_client_and_output(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            client_path = temporary_root / ".launchplane" / "smoke-client.mjs"
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=client_path,
+                github_output=github_output,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(client_path.exists())
+            self.assertIn(f"client-path={client_path}", github_output.read_text(encoding="utf-8"))
+
+            import_result = self.run_client_script(
+                client_path,
+                """
+console.log(Object.keys(client).sort().join(','));
+""",
+            )
+            self.assertEqual(import_result.returncode, 0, import_result.stderr)
+            self.assertIn("requestLaunchplaneSmokeMaintenance", import_result.stdout)
+
+    def test_client_builds_verireel_smoke_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildLaunchplaneSmokeMaintenanceRequest({
+  product: 'verireel',
+  context: 'verireel-testing',
+  instance: 'preview',
+  action: 'grant-sponsored',
+  intent: 'remote-e2e-grant-sponsored',
+  email: 'creator@example.com',
+  previewSlug: 'pr-42',
+  timeoutSeconds: 300,
+});
+const idempotencyKey = client.buildLaunchplaneSmokeMaintenanceIdempotencyKey({
+  product: 'verireel',
+  context: 'verireel-testing',
+  instance: 'preview',
+  action: 'grant-sponsored',
+  intent: 'remote-e2e-grant-sponsored',
+  email: 'creator@example.com',
+  previewSlug: 'pr-42',
+});
+console.log(JSON.stringify({ request, idempotencyKey }));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["request"]["routePath"], "/v1/drivers/verireel/app-maintenance")
+        self.assertEqual(payload["request"]["payload"]["product"], "verireel")
+        self.assertEqual(
+            payload["request"]["payload"]["maintenance"],
+            {
+                "schema_version": 1,
+                "context": "verireel-testing",
+                "instance": "preview",
+                "action": "grant-sponsored",
+                "intent": "remote-e2e-grant-sponsored",
+                "email": "creator@example.com",
+                "preview_slug": "pr-42",
+                "timeout_seconds": 300,
+            },
+        )
+        self.assertEqual(
+            payload["idempotencyKey"],
+            "product-smoke-maintenance:verireel:verireel-testing:preview:grant-sponsored:remote-e2e-grant-sponsored::pr-42:creator@example.com",
+        )
+
+    def test_client_rejects_workflow_maintenance_action(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+client.buildLaunchplaneSmokeMaintenanceRequest({
+  product: 'verireel',
+  context: 'verireel',
+  instance: 'testing',
+  action: 'migrate',
+  intent: 'stable-testing-migration',
+  timeoutSeconds: 300,
+});
+""",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Unsupported Launchplane smoke maintenance action: migrate", result.stderr)
+
+    def test_client_posts_oidc_authenticated_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const calls = [];
+const fetchImpl = async (url, init) => {
+  calls.push({ url, init });
+  if (url.startsWith('https://oidc.example/token')) {
+    return new Response(JSON.stringify({ value: 'oidc-token' }), { status: 200 });
+  }
+  return new Response(JSON.stringify({
+    status: 'accepted',
+    result: { maintenance_status: 'pass', error_message: '' },
+  }), { status: 200 });
+};
+const result = await client.requestLaunchplaneSmokeMaintenance({
+  launchplaneUrl: 'https://launchplane.example',
+  product: 'verireel',
+  context: 'verireel',
+  instance: 'testing',
+  action: 'promote-owner',
+  intent: 'owner-route-promote-owner',
+  email: 'owner@example.com',
+  timeoutSeconds: 300,
+}, {
+  ACTIONS_ID_TOKEN_REQUEST_URL: 'https://oidc.example/token',
+  ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'request-token',
+}, fetchImpl);
+console.log(JSON.stringify({ calls, result }));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        calls = payload["calls"]
+        self.assertEqual(calls[0]["url"], "https://oidc.example/token?audience=launchplane.example")
+        self.assertEqual(calls[1]["url"], "https://launchplane.example/v1/drivers/verireel/app-maintenance")
+        self.assertEqual(calls[1]["init"]["headers"]["Authorization"], "Bearer oidc-token")
+        self.assertEqual(
+            calls[1]["init"]["headers"]["Idempotency-Key"],
+            "product-smoke-maintenance:verireel:verireel:testing:promote-owner:owner-route-promote-owner:::owner@example.com",
+        )
+        self.assertEqual(json.loads(calls[1]["init"]["body"])["maintenance"]["action"], "promote-owner")
+        self.assertEqual(payload["result"]["statusCode"], 200)
+
+    def test_client_reports_non_json_http_failure_body(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const fetchImpl = async (url) => {
+  if (url.startsWith('https://oidc.example/token')) {
+    return new Response(JSON.stringify({ value: 'oidc-token' }), { status: 200 });
+  }
+  return new Response('gateway unavailable', { status: 502 });
+};
+await client.requestLaunchplaneSmokeMaintenance({
+  launchplaneUrl: 'https://launchplane.example',
+  product: 'verireel',
+  context: 'verireel',
+  instance: 'testing',
+  action: 'delete-user',
+  intent: 'owner-route-delete-user',
+  email: 'owner@example.com',
+  timeoutSeconds: 300,
+}, {
+  ACTIONS_ID_TOKEN_REQUEST_URL: 'https://oidc.example/token',
+  ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'request-token',
+}, fetchImpl);
+""",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Launchplane smoke maintenance request failed with 502: gateway unavailable",
+            result.stderr,
+        )
+
+    def test_client_fails_on_blocked_maintenance_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const fetchImpl = async (url) => {
+  if (url.startsWith('https://oidc.example/token')) {
+    return new Response(JSON.stringify({ value: 'oidc-token' }), { status: 200 });
+  }
+  return new Response(JSON.stringify({
+    result: { maintenance_status: 'blocked', error_message: 'owner route blocked' },
+  }), { status: 200 });
+};
+await client.requestLaunchplaneSmokeMaintenance({
+  launchplaneUrl: 'https://launchplane.example',
+  product: 'verireel',
+  context: 'verireel',
+  instance: 'testing',
+  action: 'delete-user',
+  intent: 'owner-route-delete-user',
+  email: 'owner@example.com',
+  timeoutSeconds: 300,
+}, {
+  ACTIONS_ID_TOKEN_REQUEST_URL: 'https://oidc.example/token',
+  ACTIONS_ID_TOKEN_REQUEST_TOKEN: 'request-token',
+}, fetchImpl);
+""",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("owner route blocked", result.stderr)
+
+    def test_client_requires_github_oidc_environment(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "smoke-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+await client.requestLaunchplaneSmokeMaintenance({
+  launchplaneUrl: 'https://launchplane.example',
+  product: 'verireel',
+  context: 'verireel',
+  instance: 'testing',
+  action: 'delete-user',
+  intent: 'owner-route-delete-user',
+  email: 'owner@example.com',
+  timeoutSeconds: 300,
+}, {}, async () => new Response('{}', { status: 200 }));
+""",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("GitHub OIDC request environment is missing", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `setup-smoke-maintenance-client`, a Launchplane-owned action that writes an importable Node ESM smoke-maintenance client into product jobs
- move VeriReel generated-user smoke request shaping, OIDC transport, idempotency, and failure handling into the generated client contract
- document the in-process smoke-support boundary and required `id-token: write` job permission for product repos

## Plan alignment
- Supports #1526 and #1530 by providing the Launchplane-owned script-callable contract needed to retire VeriReel's remaining direct app-maintenance request helper while preserving dynamic per-test emails.
- Keeps workflow-level app maintenance on `reusable-product-driver-app-maintenance.yml@main`; this action covers generated-user smoke setup/cleanup that must happen inside product browser flows.

## Validation
- `git diff --check`
- `node --check .github/actions/setup-smoke-maintenance-client/dist/index.js`
- `node --check .github/actions/setup-smoke-maintenance-client/src/smoke-maintenance-client.mjs`
- `uv run python -m unittest tests.test_smoke_maintenance_client_action tests.test_docs_contracts tests.test_verireel_app_maintenance`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- `uv run /Users/cbusillo/Developer/codex-skills/jetbrains-inspection/scripts/jb-inspect.py inspect-closeout --repo "$PWD" --scope changed_files --timeout-ms 600000`

## Review
- Read-only agent review returned conditional pass; the blocking non-JSON error diagnostic and `id-token: write` documentation items were fixed before opening this PR.

Refs #1526
Refs #1530