### PR TITLE
Add preview prepare client action

### DIFF
--- a/.github/actions/setup-preview-prepare-client/action.yml
+++ b/.github/actions/setup-preview-prepare-client/action.yml
@@ -1,0 +1,17 @@
+---
+name: Setup preview prepare client
+description: Write Launchplane's same-repo preview prepare Node client.
+
+inputs:
+  output-path:
+    description: Path where the ESM client module should be written.
+    required: false
+    default: .launchplane/preview-prepare-client.mjs
+
+outputs:
+  client-path:
+    description: Path to the generated ESM client module.
+
+runs:
+  using: node24
+  main: dist/index.js

--- a/.github/actions/setup-preview-prepare-client/dist/index.js
+++ b/.github/actions/setup-preview-prepare-client/dist/index.js
@@ -1,0 +1,42 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function inputNameToEnvKey(name) {
+  return `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+}
+
+function getInput(name, options = {}) {
+  const value = String(
+    process.env[inputNameToEnvKey(name)] ?? options.defaultValue ?? "",
+  ).trim();
+  if (options.required && !value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function setOutput(name, value) {
+  const outputPath = String(process.env.GITHUB_OUTPUT ?? "").trim();
+  if (!outputPath) {
+    return;
+  }
+  fs.appendFileSync(outputPath, `${name}=${value}\n`, "utf8");
+}
+
+function main() {
+  const outputPath = getInput("output-path", {
+    defaultValue: ".launchplane/preview-prepare-client.mjs",
+  });
+  const sourcePath = path.join(__dirname, "..", "src", "preview-prepare-client.mjs");
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.copyFileSync(sourcePath, outputPath);
+  setOutput("client-path", outputPath);
+  console.log(`Wrote Launchplane preview prepare client to ${outputPath}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/.github/actions/setup-preview-prepare-client/src/preview-prepare-client.mjs
+++ b/.github/actions/setup-preview-prepare-client/src/preview-prepare-client.mjs
@@ -1,0 +1,145 @@
+export const DEFAULT_PREVIEW_LABEL_NAME = "preview";
+export const PREVIEW_LABEL_NAME = DEFAULT_PREVIEW_LABEL_NAME;
+
+function normalizeRequiredText(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${label} is required.`);
+  }
+  return normalized;
+}
+
+function normalizeOptionalText(value) {
+  return String(value ?? "").trim();
+}
+
+function normalizeRepository(value) {
+  return normalizeRequiredText(value, "Repository").toLowerCase();
+}
+
+function parsePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function normalizeSha(sha) {
+  const normalized = normalizeRequiredText(sha, "Preview source SHA").toLowerCase();
+  if (!/^[0-9a-f]{7,64}$/.test(normalized)) {
+    throw new Error("Preview image tags require a hexadecimal commit SHA.");
+  }
+  return normalized;
+}
+
+function normalizePreviewLabelName(previewLabelName = DEFAULT_PREVIEW_LABEL_NAME) {
+  return normalizeRequiredText(previewLabelName, "Preview label").toLowerCase();
+}
+
+function labelName(label) {
+  if (typeof label === "string") {
+    return label;
+  }
+  return label?.name ?? "";
+}
+
+export function normalizeLabelNames(labels) {
+  return (labels ?? [])
+    .map(labelName)
+    .map((label) => String(label).trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function hasPreviewLabel(
+  labels,
+  previewLabelName = DEFAULT_PREVIEW_LABEL_NAME,
+) {
+  return normalizeLabelNames(labels).includes(
+    normalizePreviewLabelName(previewLabelName),
+  );
+}
+
+export function buildPreviewSlugFromPrNumber(prNumber) {
+  return `pr-${parsePositiveInteger(prNumber, "PR number")}`;
+}
+
+export function buildPreviewImageTags({ prNumber, sha }) {
+  const previewSlug = buildPreviewSlugFromPrNumber(prNumber);
+  const normalizedSha = normalizeSha(sha);
+  return {
+    previewSlug,
+    floatingTag: previewSlug,
+    immutableTag: `${previewSlug}-sha-${normalizedSha}`,
+  };
+}
+
+export function buildPreviewImageReferences({ imageName, prNumber, sha }) {
+  const normalizedImageName = normalizeRequiredText(imageName, "Image name").toLowerCase();
+  const imageTags = buildPreviewImageTags({ prNumber, sha });
+  return {
+    ...imageTags,
+    imageName: normalizedImageName,
+    floatingImageReference: `${normalizedImageName}:${imageTags.floatingTag}`,
+    immutableImageReference: `${normalizedImageName}:${imageTags.immutableTag}`,
+  };
+}
+
+export function buildSameRepoPreviewPrepareOutputs(options = {}) {
+  const event = options.event ?? {};
+  const pullRequest = event.pull_request ?? {};
+  const action = normalizeOptionalText(options.action ?? event.action);
+  const previewLabelName = normalizePreviewLabelName(options.previewLabelName);
+  const labels = options.labels ?? pullRequest.labels ?? [];
+  const actionLabelName = String(
+    options.actionLabelName ?? event.label?.name ?? "",
+  ).trim().toLowerCase();
+  const previewRequested = hasPreviewLabel(labels, previewLabelName);
+  const currentRepository = normalizeRepository(
+    options.currentRepository ?? event.repository?.full_name,
+  );
+  const headRepository = normalizeRepository(
+    options.headRepository ?? pullRequest.head?.repo?.full_name,
+  );
+  const sameRepo = currentRepository === headRepository;
+  const actor = String(options.actor ?? pullRequest.user?.login ?? "")
+    .trim()
+    .toLowerCase();
+  const previewSupported = Boolean(actor) && sameRepo && actor !== "dependabot[bot]";
+
+  let mode = "noop";
+  if (
+    (action === "labeled" && actionLabelName === previewLabelName) ||
+    (["opened", "reopened", "synchronize", "edited"].includes(action) &&
+      previewRequested)
+  ) {
+    mode = previewSupported ? "refresh" : "unsupported";
+  }
+
+  const prNumber = parsePositiveInteger(
+    options.prNumber ?? pullRequest.number ?? event.number,
+    "PR number",
+  );
+  const prSha = normalizeSha(options.prSha ?? pullRequest.head?.sha);
+  const imageReferences = buildPreviewImageReferences({
+    imageName: options.imageName,
+    prNumber,
+    sha: prSha,
+  });
+  const runUrl = normalizeOptionalText(options.runUrl);
+
+  return {
+    mode,
+    same_repo: String(sameRepo),
+    preview_supported: String(previewSupported),
+    pr_number: String(prNumber),
+    pr_sha: prSha,
+    image_name: imageReferences.imageName,
+    immutable_tag: imageReferences.immutableTag,
+    floating_tag: imageReferences.floatingTag,
+    immutable_image_reference: imageReferences.immutableImageReference,
+    floating_image_reference: imageReferences.floatingImageReference,
+    preview_slug: imageReferences.previewSlug,
+    run_url: runUrl,
+  };
+}

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -2165,6 +2165,12 @@ def _allow_reason(
         value=value,
     ):
         return ALLOW_REASON_THIN_CONNECTOR_INPUT
+    if normalized.startswith(".github/actions/") and _is_github_action_metadata_mechanic(
+        path=normalized,
+        key=key,
+        value=value,
+    ):
+        return ALLOW_REASON_THIN_CONNECTOR_INPUT
     if normalized.startswith(".github/workflows/") and _is_workflow_image_artifact_mechanic(
         path=normalized,
         key=key,
@@ -2513,6 +2519,21 @@ def _is_workflow_mechanic_key_value(*, key: str, value: object) -> bool:
         return True
     if key_text == "PATH" and re.fullmatch(r"[A-Za-z0-9_.-]+\.json", value_text):
         return True
+    return False
+
+
+def _is_github_action_metadata_mechanic(*, path: str, key: str, value: object) -> bool:
+    if not path.endswith("/action.yml"):
+        return False
+    value_text = _string_value(value).strip()
+    key_text = key.upper().replace(".", "_").replace("-", "_")
+    if key_text == "MAIN":
+        return re.fullmatch(r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\.js", value_text) is not None
+    if key_text == "DEFAULT":
+        return re.fullmatch(
+            r"\.[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\.mjs",
+            value_text,
+        ) is not None
     return False
 
 

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -75,6 +75,16 @@ event, decision, route path, feedback status, and run-scoped idempotency key as
 JSON so product workflows can branch on the shared contract instead of
 duplicating event semantics.
 
+Same-repository preview build jobs that need an importable helper for GitHub
+event labels and image tags should use
+`cbusillo/launchplane/.github/actions/setup-preview-prepare-client@main`. The
+generated client is read-only and product-agnostic: callers pass the current
+repository, head repository, PR author, PR number, source SHA, image name,
+labels, and run URL; the client returns refresh/unsupported/noop mode, same-repo
+support flags, `pr-<number>` image tags, and full image references. It does not
+call Launchplane, choose provider targets, render comments, derive preview URLs,
+or store lifecycle truth.
+
 Once the product workflow has decided to refresh, destroy, or send an
 unsupported notice, it should hand off to Launchplane's reusable workflow instead
 of constructing route payloads locally:

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -517,6 +517,15 @@ the product job so the browser script can keep its dynamic test email while
 Launchplane owns request shaping, driver intent derivation, and OIDC transport.
 The job using the generated client must include `permissions: id-token: write`.
 
+Same-repository preview jobs that need label normalization and preview image tag
+derivation should use `setup-preview-prepare-client@main` instead of carrying a
+product-local helper. The generated Node ESM client returns refresh/noop or
+unsupported mode, same-repo support flags, `pr-<number>` image tags, and full
+caller-supplied image references from primitive GitHub event facts. It is a
+read-only adapter for product-owned artifact publication; Launchplane records
+still own preview URL policy, provider targets, lifecycle records, comments, and
+cleanup truth.
+
 ## Reusable Launchplane Request Action
 
 Product workflows that only need to send JSON to an existing Launchplane route

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -471,6 +471,40 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertEqual(findings[0]["allow_reason"], "schema_only")
         self.assertEqual(findings[0]["classification"], "allowed")
 
+    def test_github_action_metadata_paths_are_action_mechanics(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            action = root / ".github" / "actions" / "setup-client" / "action.yml"
+            action.parent.mkdir(parents=True)
+            action.write_text(
+                "---\n"
+                "name: Setup client\n"
+                "inputs:\n"
+                "  output-path:\n"
+                "    default: .launchplane/client.mjs\n"
+                "  product-path:\n"
+                "    default: products/concrete-product.yml\n"
+                "runs:\n"
+                "  using: node24\n"
+                "  main: dist/index.js\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            payload = build_config_authority_audit(control_plane_root=root)
+
+        default_findings = [finding for finding in _findings(payload) if finding["key"] == "default"]
+        output_default = next(finding for finding in default_findings if finding["line"] == 5)
+        product_path_default = next(finding for finding in default_findings if finding["line"] == 7)
+        findings_by_key = {finding["key"]: finding for finding in _findings(payload)}
+        self.assertEqual(output_default["classification"], "allowed")
+        self.assertEqual(output_default["allow_reason"], "thin_connector_input")
+        self.assertEqual(findings_by_key["main"]["classification"], "allowed")
+        self.assertEqual(findings_by_key["main"]["allow_reason"], "thin_connector_input")
+        self.assertEqual(product_path_default["classification"], "needs_classification")
+        self.assertEqual(product_path_default["allow_reason"], "")
+
     def test_artifact_publish_schema_constants_are_schema_only(self) -> None:
         for key, value in (
             ("DEVKIT_RUNTIME_ENVIRONMENT_PAYLOAD_KEY", "ODOO_DEVKIT_RUNTIME_ENVIRONMENT_JSON"),

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -125,6 +125,9 @@ class DocsContractsTests(TestCase):
             ".github/workflows/reusable-generic-web-preview-lifecycle.yml"
         ).read_text(encoding="utf-8")
         repo_metadata = Path(".github/github.json").read_text(encoding="utf-8")
+        preview_prepare_action = Path(
+            ".github/actions/setup-preview-prepare-client/action.yml"
+        ).read_text(encoding="utf-8")
 
         self.assertIn("Reusable Generic-Web Lifecycle Workflows", product_repo_contract)
         self.assertIn("reusable-generic-web-stable-deploy.yml@main", product_repo_contract)
@@ -143,8 +146,11 @@ class DocsContractsTests(TestCase):
         self.assertIn("conflicts with the", preview_contract)
         self.assertIn("derived value", preview_contract)
         self.assertIn("reusable-generic-web-preview-lifecycle.yml@main", preview_contract)
+        self.assertIn("setup-preview-prepare-client@main", preview_contract)
+        self.assertIn("setup-preview-prepare-client@main", product_repo_contract)
         self.assertIn("does not accept", preview_contract)
         self.assertIn("idempotency keys as caller inputs", preview_contract)
+        self.assertIn("read-only adapter", product_repo_contract)
 
         self.assertIn("workflow_call:", deploy_workflow)
         self.assertIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', deploy_workflow)
@@ -190,6 +196,8 @@ class DocsContractsTests(TestCase):
         self.assertIn("Reusable Generic Web Stable Deploy", repo_metadata)
         self.assertIn("Reusable Generic Web Prod Promotion", repo_metadata)
         self.assertIn("Reusable Generic Web Preview Lifecycle", repo_metadata)
+        self.assertIn("using: node24", preview_prepare_action)
+        self.assertIn("preview-prepare-client.mjs", preview_prepare_action)
 
     def test_product_driver_reusable_workflows_keep_route_shaping_in_launchplane(
         self,

--- a/tests/test_preview_prepare_client_action.py
+++ b/tests/test_preview_prepare_client_action.py
@@ -1,0 +1,212 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+
+ACTION_ENTRYPOINT = Path(".github/actions/setup-preview-prepare-client/dist/index.js")
+ACTION_METADATA = Path(".github/actions/setup-preview-prepare-client/action.yml")
+
+
+class PreviewPrepareClientActionTests(unittest.TestCase):
+    def test_action_metadata_uses_supported_node_runtime(self) -> None:
+        self.assertIn(
+            "using: node24",
+            ACTION_METADATA.read_text(encoding="utf-8"),
+        )
+
+    def run_setup_action(self, *, output_path: Path, github_output: Path) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the preview prepare action")
+
+        env = os.environ.copy()
+        env["INPUT_OUTPUT-PATH"] = str(output_path)
+        env["GITHUB_OUTPUT"] = str(github_output)
+        return subprocess.run(
+            ["node", ACTION_ENTRYPOINT.as_posix()],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+    def run_client_script(self, client_path: Path, script_body: str) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the preview prepare client")
+
+        script = f"""
+import * as client from {json.dumps(client_path.as_uri())};
+{script_body}
+"""
+        return subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_setup_action_writes_importable_client_and_output(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            client_path = temporary_root / ".launchplane" / "preview-client.mjs"
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=client_path,
+                github_output=github_output,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(client_path.exists())
+            self.assertIn(f"client-path={client_path}", github_output.read_text(encoding="utf-8"))
+
+            import_result = self.run_client_script(
+                client_path,
+                """
+console.log(Object.keys(client).sort().join(','));
+""",
+            )
+            self.assertEqual(import_result.returncode, 0, import_result.stderr)
+            self.assertIn("buildSameRepoPreviewPrepareOutputs", import_result.stdout)
+            self.assertIn("hasPreviewLabel", import_result.stdout)
+            self.assertIn("PREVIEW_LABEL_NAME", import_result.stdout)
+
+    def test_client_builds_same_repo_refresh_outputs(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "preview-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const outputs = client.buildSameRepoPreviewPrepareOutputs({
+  action: 'synchronize',
+  labels: [{ name: 'preview' }],
+  currentRepository: 'cbusillo/verireel',
+  headRepository: 'cbusillo/verireel',
+  actor: 'cbusillo',
+  prNumber: 42,
+  prSha: 'ABC1234',
+  imageName: 'ghcr.io/CBUSILLO/verireel-app',
+  runUrl: 'https://github.com/cbusillo/verireel/actions/runs/1',
+});
+console.log(JSON.stringify(outputs));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        outputs = json.loads(result.stdout)
+        self.assertEqual(outputs["mode"], "refresh")
+        self.assertEqual(outputs["same_repo"], "true")
+        self.assertEqual(outputs["preview_supported"], "true")
+        self.assertEqual(outputs["pr_number"], "42")
+        self.assertEqual(outputs["pr_sha"], "abc1234")
+        self.assertEqual(outputs["image_name"], "ghcr.io/cbusillo/verireel-app")
+        self.assertEqual(outputs["preview_slug"], "pr-42")
+        self.assertEqual(outputs["floating_tag"], "pr-42")
+        self.assertEqual(outputs["immutable_tag"], "pr-42-sha-abc1234")
+        self.assertEqual(
+            outputs["immutable_image_reference"],
+            "ghcr.io/cbusillo/verireel-app:pr-42-sha-abc1234",
+        )
+        self.assertEqual(
+            outputs["floating_image_reference"],
+            "ghcr.io/cbusillo/verireel-app:pr-42",
+        )
+
+    def test_client_marks_fork_or_dependabot_preview_as_unsupported(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "preview-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const fork = client.buildSameRepoPreviewPrepareOutputs({
+  action: 'labeled',
+  actionLabelName: 'preview',
+  currentRepository: 'cbusillo/verireel',
+  headRepository: 'someone/verireel',
+  actor: 'contributor',
+  prNumber: 42,
+  prSha: 'abc1234',
+  imageName: 'ghcr.io/cbusillo/verireel-app',
+});
+const dependabot = client.buildSameRepoPreviewPrepareOutputs({
+  action: 'synchronize',
+  labels: [{ name: 'preview' }],
+  currentRepository: 'cbusillo/verireel',
+  headRepository: 'cbusillo/verireel',
+  actor: 'dependabot[bot]',
+  prNumber: 43,
+  prSha: 'def5678',
+  imageName: 'ghcr.io/cbusillo/verireel-app',
+});
+console.log(JSON.stringify({ fork, dependabot }));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        outputs = json.loads(result.stdout)
+        self.assertEqual(outputs["fork"]["mode"], "unsupported")
+        self.assertEqual(outputs["fork"]["same_repo"], "false")
+        self.assertEqual(outputs["dependabot"]["mode"], "unsupported")
+        self.assertEqual(outputs["dependabot"]["preview_supported"], "false")
+
+    def test_client_fails_closed_when_actor_is_missing(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "preview-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+const outputs = client.buildSameRepoPreviewPrepareOutputs({
+  action: 'synchronize',
+  labels: [{ name: 'preview' }],
+  currentRepository: 'cbusillo/verireel',
+  headRepository: 'cbusillo/verireel',
+  prNumber: 42,
+  prSha: 'abc1234',
+  imageName: 'ghcr.io/cbusillo/verireel-app',
+});
+console.log(JSON.stringify(outputs));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        outputs = json.loads(result.stdout)
+        self.assertEqual(outputs["mode"], "unsupported")
+        self.assertEqual(outputs["same_repo"], "true")
+        self.assertEqual(outputs["preview_supported"], "false")
+
+    def test_client_rejects_invalid_preview_image_facts(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "preview-client.mjs"
+            self.run_setup_action(output_path=client_path, github_output=Path(temporary_directory) / "out")
+
+            result = self.run_client_script(
+                client_path,
+                """
+client.buildSameRepoPreviewPrepareOutputs({
+  action: 'synchronize',
+  labels: [{ name: 'preview' }],
+  currentRepository: 'cbusillo/verireel',
+  headRepository: 'cbusillo/verireel',
+  actor: 'cbusillo',
+  prNumber: 42,
+  prSha: 'not-a-sha',
+  imageName: 'ghcr.io/cbusillo/verireel-app',
+});
+""",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("hexadecimal commit SHA", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `setup-preview-prepare-client`, a Launchplane-owned setup action that writes an importable Node ESM preview prepare client.
- Derive preview label checks, same-repo/fork/Dependabot mode, PR image tags, and full caller-supplied image references without calling Launchplane or storing product runtime authority.
- Document the new preview migration surface and teach the config-authority audit to classify GitHub action metadata mechanics narrowly.

## Validation

- `node --check .github/actions/setup-preview-prepare-client/dist/index.js`
- `node --check .github/actions/setup-preview-prepare-client/src/preview-prepare-client.mjs`
- `git diff --check`
- `uv run python -m unittest tests.test_preview_prepare_client_action tests.test_docs_contracts tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_github_action_metadata_paths_are_action_mechanics`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_preview_prepare_client_action.py tests/test_docs_contracts.py --diff`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_preview_prepare_client_action.py tests/test_docs_contracts.py`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate --fail-on-findings`

JetBrains changed-files inspection was attempted with `~/Applications/PyCharm.app/Contents/bin/inspect.sh`, but local PyCharm inspection was blocked because another PyCharm instance is already running.

## Review

- Agent review found and patch addressed missing-actor fail-closed behavior.
- Boundary review found and patch addressed `PREVIEW_LABEL_NAME` migration alias.

Refs #1526
Refs #1530
