### PR TITLE
Add Odoo preview workflow request builders

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -72,6 +72,171 @@ ODOO_PREVIEW_REQUIRED_ENV_KEYS = (
     "ODOO_MASTER_PASSWORD",
     "ODOO_ADMIN_PASSWORD",
 )
+ODOO_PREVIEW_ARTIFACT_PUBLISH_INPUTS_ROUTE = "/v1/drivers/odoo/artifact-publish-inputs"
+ODOO_PREVIEW_APPLY_INPUTS_ROUTE = "/v1/drivers/odoo/preview-apply-inputs"
+ODOO_PREVIEW_APPLY_ROUTE = "/v1/drivers/odoo/preview-apply"
+
+
+class OdooPreviewWorkflowRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    route_path: str
+    payload: dict[str, object]
+    idempotency_key: str
+    payload_json_files: dict[str, str] = Field(default_factory=dict)
+    response_output_path: str = ""
+    fail_result_paths: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooPreviewWorkflowRequest":
+        self.route_path = _required_text(
+            self.route_path, "Odoo preview workflow request requires route_path"
+        )
+        self.idempotency_key = _required_text(
+            self.idempotency_key,
+            "Odoo preview workflow request requires idempotency_key",
+        )
+        self.payload_json_files = {
+            _required_text(path, "Odoo preview payload file binding requires path"): _required_text(
+                file_path, "Odoo preview payload file binding requires file_path"
+            )
+            for path, file_path in self.payload_json_files.items()
+        }
+        self.response_output_path = self.response_output_path.strip()
+        self.fail_result_paths = tuple(
+            _required_text(path, "Odoo preview fail-result path cannot be blank")
+            for path in self.fail_result_paths
+        )
+        return self
+
+
+class OdooPreviewWorkflowRequestFacts(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product: str
+    context: str
+    instance: str = "testing"
+    operation: OdooPreviewRuntimeOperation = "refresh"
+    pr_number: int = Field(ge=1)
+    preview_slug: str = ""
+    source_git_ref: str = ""
+    run_id: str
+    run_attempt: str
+    source: str = ""
+
+    @model_validator(mode="after")
+    def _validate_facts(self) -> "OdooPreviewWorkflowRequestFacts":
+        self.product = _required_text(self.product, "Odoo preview request facts require product")
+        self.context = _required_text(self.context, "Odoo preview request facts require context")
+        self.instance = _required_text(self.instance, "Odoo preview request facts require instance")
+        self.preview_slug = self.preview_slug.strip()
+        self.source_git_ref = self.source_git_ref.strip()
+        if self.operation == "refresh":
+            self.source_git_ref = _required_text(
+                self.source_git_ref,
+                "Odoo preview refresh request facts require source_git_ref",
+            )
+        self.run_id = _required_text(self.run_id, "Odoo preview request facts require run_id")
+        self.run_attempt = _required_text(
+            self.run_attempt, "Odoo preview request facts require run_attempt"
+        )
+        if not self.source.strip():
+            self.source = f"{self.product}-preview-apply-inputs"
+        else:
+            self.source = self.source.strip()
+        return self
+
+
+def build_odoo_preview_artifact_publish_inputs_workflow_request(
+    *, facts: OdooPreviewWorkflowRequestFacts
+) -> OdooPreviewWorkflowRequest:
+    return OdooPreviewWorkflowRequest(
+        route_path=ODOO_PREVIEW_ARTIFACT_PUBLISH_INPUTS_ROUTE,
+        payload={
+            "schema_version": 1,
+            "product": facts.product,
+            "inputs": {
+                "schema_version": 1,
+                "context": facts.context,
+                "instance": facts.instance,
+                "pr_number": facts.pr_number,
+                "isolated": True,
+                "source_git_ref": facts.source_git_ref,
+            },
+        },
+        idempotency_key=(
+            "odoo-artifact-publish-inputs:"
+            f"{facts.product}:{facts.context}:{facts.instance}:"
+            f"preview-{facts.pr_number}-run-{facts.run_id}-attempt-{facts.run_attempt}"
+        ),
+        fail_result_paths=("result.input_status",),
+        response_output_path="result",
+    )
+
+
+def build_odoo_preview_apply_inputs_workflow_request(
+    *, facts: OdooPreviewWorkflowRequestFacts, manifest_file: str = ""
+) -> OdooPreviewWorkflowRequest:
+    manifest_file = manifest_file.strip()
+    if facts.operation == "refresh" and not manifest_file:
+        raise ValueError("Odoo preview refresh apply-inputs request requires manifest_file.")
+    return OdooPreviewWorkflowRequest(
+        route_path=ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
+        payload={
+            "schema_version": 1,
+            "product": facts.product,
+            "inputs": {
+                "schema_version": 1,
+                "product": facts.product,
+                "operation": facts.operation,
+                "pr_number": facts.pr_number,
+                "source_git_ref": facts.source_git_ref,
+                "source": facts.source,
+                "timeout_seconds": 300,
+                "no_cache": False,
+            },
+        },
+        payload_json_files={"inputs.manifest": manifest_file} if manifest_file else {},
+        idempotency_key=(
+            "odoo-preview-apply-inputs:"
+            f"{facts.product}:{_preview_request_token(facts)}:{facts.source_git_ref or 'destroy'}:"
+            f"inputs-run-{facts.run_id}-attempt-{facts.run_attempt}"
+        ),
+        fail_result_paths=("result.status",),
+        response_output_path="result.dry_run_plan",
+    )
+
+
+def build_odoo_preview_apply_workflow_request(
+    *,
+    facts: OdooPreviewWorkflowRequestFacts,
+    dry_run_plan_file: str,
+    manifest_file: str = "",
+) -> OdooPreviewWorkflowRequest:
+    if facts.operation == "refresh" and not manifest_file.strip():
+        raise ValueError("Odoo preview refresh apply request requires manifest_file.")
+    payload_json_files = {"apply.dry_run_plan": dry_run_plan_file}
+    if manifest_file.strip():
+        payload_json_files["apply.manifest"] = manifest_file.strip()
+    return OdooPreviewWorkflowRequest(
+        route_path=ODOO_PREVIEW_APPLY_ROUTE,
+        payload={
+            "schema_version": 1,
+            "product": facts.product,
+            "apply": {
+                "timeout_seconds": 600,
+                "wait_for_deploy": True,
+                "smoke_check": facts.operation == "refresh",
+            },
+        },
+        payload_json_files=payload_json_files,
+        idempotency_key=(
+            "odoo-preview-apply:"
+            f"{facts.product}:{_preview_request_token(facts)}:{facts.operation}:"
+            f"run-{facts.run_id}-attempt-{facts.run_attempt}"
+        ),
+        fail_result_paths=("result.status",),
+    )
 
 
 class OdooPreviewApplyInputsStore(Protocol):
@@ -305,6 +470,10 @@ def _preview_slug(
     if request.preview_slug.strip():
         return request.preview_slug.strip()
     return profile.preview.slug_template.strip().replace("{number}", str(request.pr_number))
+
+
+def _preview_request_token(facts: OdooPreviewWorkflowRequestFacts) -> str:
+    return facts.preview_slug or f"pr-{facts.pr_number}"
 
 
 def resolve_odoo_preview_url(
@@ -616,9 +785,7 @@ def _iter_dokploy_search_composes(raw_search_matches: object) -> tuple[JsonObjec
             if isinstance(value, list):
                 search_items.extend(value)
     else:
-        raise click.ClickException(
-            "Dokploy compose search returned an invalid response payload."
-        )
+        raise click.ClickException("Dokploy compose search returned an invalid response payload.")
 
     composes: list[JsonObject] = []
     for raw_compose in search_items:
@@ -643,61 +810,6 @@ def _blocked_inputs_message(
         *[blocker.message for blocker in dry_run_plan.blockers],
     ]
     return "; ".join(messages) or "Odoo preview apply inputs are blocked."
-
-
-def _blocked_apply_inputs_result(
-    *,
-    profile: LaunchplaneProductProfileRecord,
-    request: OdooPreviewApplyInputsRequest,
-    preview_slug: str,
-    preview_url: str,
-    runtime_plan: OdooPreviewRuntimePlan | None,
-    dry_run_plan: OdooPreviewDokployDryRunPlan | None,
-    message: str,
-) -> OdooPreviewApplyInputsResult:
-    resolved_runtime_plan = runtime_plan or OdooPreviewRuntimePlan(
-        status="blocked",
-        operation=request.operation,
-        product=profile.product,
-        repository=profile.repository,
-        pr_number=request.pr_number,
-        preview_slug=preview_slug,
-        preview_url=preview_url,
-        strategy="unknown",
-        blockers=(
-            OdooPreviewRuntimeBlocker(code="runtime_strategy_not_isolated", message=message),
-        ),
-        summary="Odoo preview runtime plan is blocked",
-    )
-    resolved_dry_run_plan = dry_run_plan or OdooPreviewDokployDryRunPlan(
-        status="blocked",
-        operation=request.operation,
-        product=profile.product,
-        repository=profile.repository,
-        preview_slug=preview_slug,
-        preview_url=preview_url,
-        compose_ref=f"{profile.product}-{preview_slug}",
-        compose_name=preview_application_name(
-            app_name_prefix=effective_preview_app_name_prefix(profile=profile),
-            preview_slug=preview_slug,
-        ),
-        blockers=(OdooPreviewDokployDryRunBlocker(code="runtime_plan_not_ready", message=message),),
-        summary="Odoo preview Dokploy dry-run plan is blocked",
-    )
-    return OdooPreviewApplyInputsResult(
-        status="blocked",
-        product=profile.product,
-        context=profile.preview.context,
-        template_instance=profile.preview.template_instance,
-        operation=request.operation,
-        preview_slug=preview_slug,
-        preview_url=preview_url,
-        repository=profile.repository,
-        runtime_plan=resolved_runtime_plan,
-        dry_run_plan=resolved_dry_run_plan,
-        source=request.source,
-        error_message=message,
-    )
 
 
 class OdooPreviewDokployEndpointSpec(BaseModel):

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -181,6 +181,15 @@ rejects a supplied slug when it conflicts with the derived value. `context`,
 `preview_slug`, and `preview_url` remain compatibility fields for older
 adapters, not product-repo authority.
 
+Launchplane also owns the reusable request-shape builders for Odoo tenant
+preview workflows. Tenant repos may keep thin adapter jobs for checkout, image
+publication, runner selection, and product smoke facts, but the route paths,
+payload skeletons, JSON-file bindings, fail-result paths, and run-scoped
+idempotency keys for `artifact-publish-inputs`, `preview-apply-inputs`, and
+`preview-apply` are Launchplane contract fixtures. New or migrated tenant
+preview workflows should consume those builders through a Launchplane-owned
+reusable workflow/action instead of copying inline JSON request bodies.
+
 Odoo CM is the exception where Launchplane now owns both the isolated provider
 apply planning inputs and the stage-preview smoke contract after refresh. Product
 workflows should call `POST /v1/drivers/odoo/preview-apply-inputs` with PR,

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -2,7 +2,7 @@ import unittest
 from email.message import Message
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
-from typing import Iterator, Literal
+from typing import Iterator, Literal, cast
 from unittest.mock import ANY, patch
 from urllib.error import HTTPError
 
@@ -31,8 +31,12 @@ from control_plane.workflows.odoo_preview_runtime import (
     OdooPreviewDokployDryRunRequest,
     OdooPreviewDokployEndpointSpec,
     OdooPreviewApplyInputsRequest,
+    OdooPreviewWorkflowRequestFacts,
     build_odoo_preview_dokploy_dry_run,
     build_odoo_preview_apply_inputs,
+    build_odoo_preview_apply_inputs_workflow_request,
+    build_odoo_preview_apply_workflow_request,
+    build_odoo_preview_artifact_publish_inputs_workflow_request,
     execute_odoo_preview_dokploy_apply,
     _wait_for_smoke_check,
 )
@@ -183,6 +187,21 @@ class _OdooApplyInputsStore:
         return filtered
 
 
+def _workflow_facts(
+    *, operation: Literal["refresh", "destroy"] = "refresh"
+) -> OdooPreviewWorkflowRequestFacts:
+    return OdooPreviewWorkflowRequestFacts(
+        product="odoo-tenant-cm-website",
+        context="cm_website",
+        operation=operation,
+        pr_number=42,
+        preview_slug="pr-42",
+        source_git_ref="abc123",
+        run_id="456",
+        run_attempt="2",
+    )
+
+
 def _profile() -> LaunchplaneProductProfileRecord:
     return LaunchplaneProductProfileRecord(
         product="odoo-tenant-cm",
@@ -282,6 +301,177 @@ def _patched_apply_inputs_runtime(*, dokploy_side_effect: object) -> Iterator[No
 
 
 class OdooPreviewDokployDryRunTests(unittest.TestCase):
+    def test_builds_artifact_publish_inputs_workflow_request_shape(self) -> None:
+        request = build_odoo_preview_artifact_publish_inputs_workflow_request(
+            facts=_workflow_facts()
+        )
+
+        self.assertEqual(request.route_path, "/v1/drivers/odoo/artifact-publish-inputs")
+        self.assertEqual(
+            request.payload,
+            {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm-website",
+                "inputs": {
+                    "schema_version": 1,
+                    "context": "cm_website",
+                    "instance": "testing",
+                    "pr_number": 42,
+                    "isolated": True,
+                    "source_git_ref": "abc123",
+                },
+            },
+        )
+        self.assertEqual(
+            request.idempotency_key,
+            "odoo-artifact-publish-inputs:odoo-tenant-cm-website:cm_website:testing:preview-42-run-456-attempt-2",
+        )
+        self.assertEqual(request.fail_result_paths, ("result.input_status",))
+        self.assertEqual(request.response_output_path, "result")
+
+    def test_builds_preview_apply_inputs_workflow_request_shape(self) -> None:
+        request = build_odoo_preview_apply_inputs_workflow_request(
+            facts=_workflow_facts(),
+            manifest_file="/tmp/preview-artifact.json",
+        )
+
+        self.assertEqual(request.route_path, "/v1/drivers/odoo/preview-apply-inputs")
+        self.assertEqual(
+            request.payload,
+            {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm-website",
+                "inputs": {
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm-website",
+                    "operation": "refresh",
+                    "pr_number": 42,
+                    "source_git_ref": "abc123",
+                    "source": "odoo-tenant-cm-website-preview-apply-inputs",
+                    "timeout_seconds": 300,
+                    "no_cache": False,
+                },
+            },
+        )
+        self.assertEqual(
+            request.payload_json_files, {"inputs.manifest": "/tmp/preview-artifact.json"}
+        )
+        self.assertEqual(
+            request.idempotency_key,
+            "odoo-preview-apply-inputs:odoo-tenant-cm-website:pr-42:abc123:inputs-run-456-attempt-2",
+        )
+        self.assertEqual(request.fail_result_paths, ("result.status",))
+        self.assertEqual(request.response_output_path, "result.dry_run_plan")
+
+    def test_apply_inputs_builder_allows_destroy_without_manifest(self) -> None:
+        request = build_odoo_preview_apply_inputs_workflow_request(
+            facts=_workflow_facts(operation="destroy"),
+        )
+
+        self.assertEqual(request.payload_json_files, {})
+        inputs = cast(dict[str, object], request.payload["inputs"])
+        self.assertIsInstance(inputs, dict)
+        self.assertEqual(inputs["operation"], "destroy")
+        self.assertNotIn("preview_slug", inputs)
+        self.assertEqual(
+            request.idempotency_key,
+            "odoo-preview-apply-inputs:odoo-tenant-cm-website:pr-42:abc123:inputs-run-456-attempt-2",
+        )
+
+    def test_apply_inputs_destroy_without_source_ref_uses_destroy_idempotency_token(self) -> None:
+        facts = _workflow_facts(operation="destroy")
+        facts.source_git_ref = ""
+
+        request = build_odoo_preview_apply_inputs_workflow_request(facts=facts)
+
+        self.assertEqual(
+            request.idempotency_key,
+            "odoo-preview-apply-inputs:odoo-tenant-cm-website:pr-42:destroy:inputs-run-456-attempt-2",
+        )
+
+    def test_apply_inputs_builder_requires_manifest_for_refresh(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires manifest_file"):
+            build_odoo_preview_apply_inputs_workflow_request(facts=_workflow_facts())
+
+    def test_builds_preview_apply_workflow_request_shape(self) -> None:
+        request = build_odoo_preview_apply_workflow_request(
+            facts=_workflow_facts(),
+            dry_run_plan_file="/tmp/dry-run.json",
+            manifest_file="/tmp/preview-artifact.json",
+        )
+
+        self.assertEqual(request.route_path, "/v1/drivers/odoo/preview-apply")
+        self.assertEqual(
+            request.payload,
+            {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm-website",
+                "apply": {
+                    "timeout_seconds": 600,
+                    "wait_for_deploy": True,
+                    "smoke_check": True,
+                },
+            },
+        )
+        self.assertEqual(
+            request.payload_json_files,
+            {
+                "apply.dry_run_plan": "/tmp/dry-run.json",
+                "apply.manifest": "/tmp/preview-artifact.json",
+            },
+        )
+        self.assertEqual(
+            request.idempotency_key,
+            "odoo-preview-apply:odoo-tenant-cm-website:pr-42:refresh:run-456-attempt-2",
+        )
+
+    def test_destroy_preview_apply_request_skips_manifest_and_smoke(self) -> None:
+        request = build_odoo_preview_apply_workflow_request(
+            facts=_workflow_facts(operation="destroy"),
+            dry_run_plan_file="/tmp/destroy-dry-run.json",
+        )
+
+        self.assertEqual(
+            request.payload_json_files, {"apply.dry_run_plan": "/tmp/destroy-dry-run.json"}
+        )
+        apply = cast(dict[str, object], request.payload["apply"])
+        self.assertIsInstance(apply, dict)
+        self.assertEqual(apply["smoke_check"], False)
+        self.assertEqual(
+            request.idempotency_key,
+            "odoo-preview-apply:odoo-tenant-cm-website:pr-42:destroy:run-456-attempt-2",
+        )
+
+    def test_refresh_preview_apply_request_requires_manifest(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires manifest_file"):
+            build_odoo_preview_apply_workflow_request(
+                facts=_workflow_facts(),
+                dry_run_plan_file="/tmp/dry-run.json",
+            )
+
+    def test_builder_accepts_product_profile_preview_slug_token_without_payload_authority(
+        self,
+    ) -> None:
+        facts = OdooPreviewWorkflowRequestFacts(
+            product="odoo-tenant-cm",
+            context="cm",
+            pr_number=42,
+            preview_slug="preview-42",
+            source_git_ref="abc123",
+            run_id="456",
+            run_attempt="2",
+        )
+
+        request = build_odoo_preview_apply_inputs_workflow_request(
+            facts=facts,
+            manifest_file="/tmp/preview-artifact.json",
+        )
+
+        inputs = cast(dict[str, object], request.payload["inputs"])
+        self.assertIsInstance(inputs, dict)
+        self.assertNotIn("preview_slug", inputs)
+        self.assertIn(":preview-42:", request.idempotency_key)
+
     def test_apply_inputs_reuses_discovered_preview_compose_for_refresh(self) -> None:
         requests: list[dict[str, object]] = []
 
@@ -402,9 +592,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
                 "/api/domain.byComposeId",
             ],
         )
-        self.assertEqual(
-            requests[1]["query"], {"q": "cm-odoo-preview-pr-45", "limit": 25}
-        )
+        self.assertEqual(requests[1]["query"], {"q": "cm-odoo-preview-pr-45", "limit": 25})
 
     def test_apply_inputs_ignores_compose_search_name_mismatch(self) -> None:
         def _fake_dokploy_request(**kwargs: object) -> object:


### PR DESCRIPTION
## Summary
- add Launchplane-owned Odoo preview workflow request builders for artifact publish inputs, preview apply inputs, and preview apply
- pin route paths, payload skeletons, JSON file bindings, fail-result paths, and run-scoped idempotency keys for the Odoo preview lifecycle
- keep preview slug authority out of the request payload, preserve isolated artifact publish behavior, and remove a stale blocked-result helper in the touched module
- document the Odoo preview request-shape ownership boundary for tenant workflow migrations

## Validation
- `uv run python -m py_compile control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff check --diff control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff format --check --diff control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run python -m unittest tests.test_odoo_preview_runtime tests.test_odoo_artifact_publish_inputs tests.test_http_app_driver_odoo tests.test_docs_contracts` (179 tests)
- `git diff --check`

## Plan Alignment
- advances #1529 / #898 by moving copied Odoo preview request-shape knowledge into Launchplane contract fixtures
- follows the v2 cleanup direction by removing dead code in the touched Odoo preview runtime module
- leaves tenant workflow adapter cleanup as the next consumer step once this Launchplane contract lands
