### PR TITLE
Add Odoo preview request client action

### DIFF
--- a/.github/actions/setup-odoo-preview-request-client/action.yml
+++ b/.github/actions/setup-odoo-preview-request-client/action.yml
@@ -1,0 +1,17 @@
+---
+name: Setup Odoo preview request client
+description: Write Launchplane's Odoo preview request-shaping Node client.
+
+inputs:
+  output-path:
+    description: Path where the ESM client module should be written.
+    required: false
+    default: .launchplane/odoo-preview-request-client.mjs
+
+outputs:
+  client-path:
+    description: Path to the generated ESM client module.
+
+runs:
+  using: node24
+  main: dist/index.js

--- a/.github/actions/setup-odoo-preview-request-client/dist/index.js
+++ b/.github/actions/setup-odoo-preview-request-client/dist/index.js
@@ -1,0 +1,42 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+function inputNameToEnvKey(name) {
+  return `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+}
+
+function getInput(name, options = {}) {
+  const value = String(
+    process.env[inputNameToEnvKey(name)] ?? options.defaultValue ?? "",
+  ).trim();
+  if (options.required && !value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function setOutput(name, value) {
+  const outputPath = String(process.env.GITHUB_OUTPUT ?? "").trim();
+  if (!outputPath) {
+    return;
+  }
+  fs.appendFileSync(outputPath, `${name}=${value}\n`, "utf8");
+}
+
+function main() {
+  const outputPath = getInput("output-path", {
+    defaultValue: ".launchplane/odoo-preview-request-client.mjs",
+  });
+  const sourcePath = path.join(__dirname, "..", "src", "odoo-preview-request-client.mjs");
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.copyFileSync(sourcePath, outputPath);
+  setOutput("client-path", outputPath);
+  console.log(`Wrote Launchplane Odoo preview request client to ${outputPath}`);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+}

--- a/.github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs
+++ b/.github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs
@@ -1,0 +1,232 @@
+export const ODOO_PREVIEW_ARTIFACT_PUBLISH_INPUTS_ROUTE =
+  "/v1/drivers/odoo/artifact-publish-inputs";
+export const ODOO_PREVIEW_APPLY_INPUTS_ROUTE =
+  "/v1/drivers/odoo/preview-apply-inputs";
+export const ODOO_PREVIEW_APPLY_ROUTE = "/v1/drivers/odoo/preview-apply";
+
+function requiredText(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${label} is required.`);
+  }
+  return normalized;
+}
+
+function optionalText(value) {
+  return String(value ?? "").trim();
+}
+
+function parsePositiveInteger(value, label) {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} must be a positive integer.`);
+  }
+  return parsed;
+}
+
+function parseOptionalBoolean(value, defaultValue, label) {
+  if (value === undefined || value === null || value === "") {
+    return defaultValue;
+  }
+  if (typeof value === "boolean") {
+    return value;
+  }
+  const normalized = String(value).trim().toLowerCase();
+  if (["true", "1", "yes"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no"].includes(normalized)) {
+    return false;
+  }
+  throw new Error(`${label} must be a boolean.`);
+}
+
+function normalizeOperation(value = "refresh") {
+  const operation = requiredText(value, "Odoo preview operation").toLowerCase();
+  if (!["refresh", "destroy"].includes(operation)) {
+    throw new Error("Odoo preview operation must be refresh or destroy.");
+  }
+  return operation;
+}
+
+function normalizeFacts(options = {}) {
+  const product = requiredText(options.product, "Odoo preview product");
+  const context = requiredText(options.context, "Odoo preview context");
+  const instance = requiredText(options.instance ?? "testing", "Odoo preview instance");
+  const operation = normalizeOperation(options.operation);
+  const prNumber = parsePositiveInteger(options.prNumber, "Odoo preview PR number");
+  const sourceGitRef = optionalText(options.sourceGitRef);
+  if (operation === "refresh" && !sourceGitRef) {
+    throw new Error("Odoo preview refresh requires sourceGitRef.");
+  }
+  const runId = requiredText(options.runId, "Odoo preview run ID");
+  const runAttempt = requiredText(options.runAttempt, "Odoo preview run attempt");
+  const source =
+    optionalText(options.source) || `${product}-preview-apply-inputs`;
+  return {
+    product,
+    context,
+    instance,
+    operation,
+    prNumber,
+    previewSlug: optionalText(options.previewSlug),
+    sourceGitRef,
+    runId,
+    runAttempt,
+    source,
+  };
+}
+
+function previewRequestToken(facts) {
+  return facts.previewSlug || `pr-${facts.prNumber}`;
+}
+
+function previewSourceToken(facts) {
+  if (facts.operation === "destroy") {
+    return "destroy";
+  }
+  return facts.sourceGitRef;
+}
+
+function requestEnvelope({
+  routePath,
+  payload,
+  idempotencyKey,
+  payloadJsonFiles = {},
+  responseOutputPath = "",
+  failResultPaths = [],
+}) {
+  const normalizedRoutePath = requiredText(routePath, "Launchplane route path");
+  const normalizedIdempotencyKey = requiredText(
+    idempotencyKey,
+    "Launchplane idempotency key",
+  );
+  const normalizedPayloadJsonFiles = Object.fromEntries(
+    Object.entries(payloadJsonFiles).map(([payloadPath, filePath]) => [
+      requiredText(payloadPath, "Odoo preview payload JSON binding path"),
+      requiredText(filePath, "Odoo preview payload JSON binding file"),
+    ]),
+  );
+  return {
+    routePath: normalizedRoutePath,
+    payload,
+    payloadInput: JSON.stringify(payload),
+    payloadJsonFiles: normalizedPayloadJsonFiles,
+    payloadJsonFilesInput: Object.entries(normalizedPayloadJsonFiles)
+      .map(([payloadPath, filePath]) => `${payloadPath}=${filePath}`)
+      .join("\n"),
+    responseOutputPath: optionalText(responseOutputPath),
+    failResultPaths,
+    failResultPathsInput: failResultPaths
+      .map((path) => requiredText(path, "Odoo preview fail-result path"))
+      .join(","),
+    idempotencyKey: normalizedIdempotencyKey,
+  };
+}
+
+export function buildOdooPreviewArtifactPublishInputsRequest(options = {}) {
+  const facts = normalizeFacts({ ...options, operation: options.operation ?? "refresh" });
+  if (facts.operation !== "refresh") {
+    throw new Error(
+      "Odoo preview artifact publish inputs require refresh operation.",
+    );
+  }
+  return requestEnvelope({
+    routePath: ODOO_PREVIEW_ARTIFACT_PUBLISH_INPUTS_ROUTE,
+    payload: {
+      schema_version: 1,
+      product: facts.product,
+      inputs: {
+        schema_version: 1,
+        context: facts.context,
+        instance: facts.instance,
+        pr_number: facts.prNumber,
+        isolated: true,
+        source_git_ref: facts.sourceGitRef,
+      },
+    },
+    idempotencyKey:
+      "odoo-artifact-publish-inputs:" +
+      `${facts.product}:${facts.context}:${facts.instance}:` +
+      `preview-${facts.prNumber}-run-${facts.runId}-attempt-${facts.runAttempt}`,
+    failResultPaths: ["result.input_status"],
+    responseOutputPath: "result",
+  });
+}
+
+export function buildOdooPreviewApplyInputsRequest(options = {}) {
+  const facts = normalizeFacts(options);
+  const manifestFile = optionalText(options.manifestFile);
+  if (facts.operation === "refresh" && !manifestFile) {
+    throw new Error("Odoo preview refresh apply inputs require manifestFile.");
+  }
+  return requestEnvelope({
+    routePath: ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
+    payload: {
+      schema_version: 1,
+      product: facts.product,
+      inputs: {
+        schema_version: 1,
+        product: facts.product,
+        operation: facts.operation,
+        pr_number: facts.prNumber,
+        source_git_ref: facts.sourceGitRef,
+        source: facts.source,
+        timeout_seconds: 300,
+        no_cache: false,
+      },
+    },
+    payloadJsonFiles: manifestFile ? { "inputs.manifest": manifestFile } : {},
+    idempotencyKey:
+      "odoo-preview-apply-inputs:" +
+      `${facts.product}:${previewRequestToken(facts)}:` +
+      `${previewSourceToken(facts)}:` +
+      `inputs-run-${facts.runId}-attempt-${facts.runAttempt}`,
+    failResultPaths: ["result.status"],
+    responseOutputPath: "result.dry_run_plan",
+  });
+}
+
+export function buildOdooPreviewApplyRequest(options = {}) {
+  const facts = normalizeFacts(options);
+  const dryRunPlanFile = requiredText(
+    options.dryRunPlanFile,
+    "Odoo preview dry run plan file",
+  );
+  const manifestFile = optionalText(options.manifestFile);
+  if (facts.operation === "refresh" && !manifestFile) {
+    throw new Error("Odoo preview refresh apply requires manifestFile.");
+  }
+  const payloadJsonFiles = { "apply.dry_run_plan": dryRunPlanFile };
+  if (manifestFile) {
+    payloadJsonFiles["apply.manifest"] = manifestFile;
+  }
+  const waitForDeploy = parseOptionalBoolean(
+    options.waitForDeploy,
+    true,
+    "Odoo preview waitForDeploy",
+  );
+  const smokeCheck = parseOptionalBoolean(
+    options.smokeCheck,
+    facts.operation === "refresh",
+    "Odoo preview smokeCheck",
+  );
+  return requestEnvelope({
+    routePath: ODOO_PREVIEW_APPLY_ROUTE,
+    payload: {
+      schema_version: 1,
+      product: facts.product,
+      apply: {
+        timeout_seconds: 600,
+        wait_for_deploy: waitForDeploy,
+        smoke_check: smokeCheck,
+      },
+    },
+    payloadJsonFiles,
+    idempotencyKey:
+      "odoo-preview-apply:" +
+      `${facts.product}:${previewRequestToken(facts)}:${facts.operation}:` +
+      `run-${facts.runId}-attempt-${facts.runAttempt}`,
+    failResultPaths: ["result.status"],
+  });
+}

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -150,6 +150,12 @@ class OdooPreviewWorkflowRequestFacts(BaseModel):
 def build_odoo_preview_artifact_publish_inputs_workflow_request(
     *, facts: OdooPreviewWorkflowRequestFacts
 ) -> OdooPreviewWorkflowRequest:
+    if facts.operation != "refresh":
+        raise ValueError("Odoo preview artifact publish inputs request requires refresh operation.")
+    source_git_ref = _required_text(
+        facts.source_git_ref,
+        "Odoo preview artifact publish inputs request requires source_git_ref",
+    )
     return OdooPreviewWorkflowRequest(
         route_path=ODOO_PREVIEW_ARTIFACT_PUBLISH_INPUTS_ROUTE,
         payload={
@@ -161,7 +167,7 @@ def build_odoo_preview_artifact_publish_inputs_workflow_request(
                 "instance": facts.instance,
                 "pr_number": facts.pr_number,
                 "isolated": True,
-                "source_git_ref": facts.source_git_ref,
+                "source_git_ref": source_git_ref,
             },
         },
         idempotency_key=(
@@ -199,7 +205,7 @@ def build_odoo_preview_apply_inputs_workflow_request(
         payload_json_files={"inputs.manifest": manifest_file} if manifest_file else {},
         idempotency_key=(
             "odoo-preview-apply-inputs:"
-            f"{facts.product}:{_preview_request_token(facts)}:{facts.source_git_ref or 'destroy'}:"
+            f"{facts.product}:{_preview_request_token(facts)}:{_preview_source_token(facts)}:"
             f"inputs-run-{facts.run_id}-attempt-{facts.run_attempt}"
         ),
         fail_result_paths=("result.status",),
@@ -212,6 +218,8 @@ def build_odoo_preview_apply_workflow_request(
     facts: OdooPreviewWorkflowRequestFacts,
     dry_run_plan_file: str,
     manifest_file: str = "",
+    wait_for_deploy: bool = True,
+    smoke_check: bool | None = None,
 ) -> OdooPreviewWorkflowRequest:
     if facts.operation == "refresh" and not manifest_file.strip():
         raise ValueError("Odoo preview refresh apply request requires manifest_file.")
@@ -225,8 +233,8 @@ def build_odoo_preview_apply_workflow_request(
             "product": facts.product,
             "apply": {
                 "timeout_seconds": 600,
-                "wait_for_deploy": True,
-                "smoke_check": facts.operation == "refresh",
+                "wait_for_deploy": wait_for_deploy,
+                "smoke_check": facts.operation == "refresh" if smoke_check is None else smoke_check,
             },
         },
         payload_json_files=payload_json_files,
@@ -474,6 +482,12 @@ def _preview_slug(
 
 def _preview_request_token(facts: OdooPreviewWorkflowRequestFacts) -> str:
     return facts.preview_slug or f"pr-{facts.pr_number}"
+
+
+def _preview_source_token(facts: OdooPreviewWorkflowRequestFacts) -> str:
+    if facts.operation == "destroy":
+        return "destroy"
+    return facts.source_git_ref
 
 
 def resolve_odoo_preview_url(
@@ -1422,11 +1436,6 @@ def _delete_compose(*, host: str, token: str, compose_id: str, delete_volumes: b
         method="POST",
         payload={"composeId": compose_id, "deleteVolumes": delete_volumes},
     )
-
-
-def _is_compose_delete_not_found(exc: click.ClickException) -> bool:
-    message = str(exc).lower()
-    return "/api/compose.delete" in message and "404" in message
 
 
 def _rollback_created_runtime(

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -187,8 +187,14 @@ publication, runner selection, and product smoke facts, but the route paths,
 payload skeletons, JSON-file bindings, fail-result paths, and run-scoped
 idempotency keys for `artifact-publish-inputs`, `preview-apply-inputs`, and
 `preview-apply` are Launchplane contract fixtures. New or migrated tenant
-preview workflows should consume those builders through a Launchplane-owned
-reusable workflow/action instead of copying inline JSON request bodies.
+preview workflows should install
+`cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main`
+and import the generated ESM client to render `launchplane-request` inputs
+instead of copying inline route paths, JSON request bodies, file bindings, fail
+paths, or idempotency key templates. The generated request object exposes
+`payloadInput`, `payloadJsonFilesInput`, `failResultPathsInput`,
+`responseOutputPath`, and `idempotencyKey` fields shaped for direct handoff to
+the existing `launchplane-request` action.
 
 Odoo CM is the exception where Launchplane now owns both the isolated provider
 apply planning inputs and the stage-preview smoke contract after refresh. Product

--- a/tests/test_odoo_preview_request_client_action.py
+++ b/tests/test_odoo_preview_request_client_action.py
@@ -1,0 +1,324 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+
+ACTION_ENTRYPOINT = Path(".github/actions/setup-odoo-preview-request-client/dist/index.js")
+ACTION_METADATA = Path(".github/actions/setup-odoo-preview-request-client/action.yml")
+
+
+class OdooPreviewRequestClientActionTests(unittest.TestCase):
+    def test_action_metadata_uses_supported_node_runtime(self) -> None:
+        self.assertIn(
+            "using: node24",
+            ACTION_METADATA.read_text(encoding="utf-8"),
+        )
+
+    def run_setup_action(
+        self, *, output_path: Path, github_output: Path
+    ) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the Odoo preview request action")
+
+        env = os.environ.copy()
+        env["INPUT_OUTPUT-PATH"] = str(output_path)
+        env["GITHUB_OUTPUT"] = str(github_output)
+        return subprocess.run(
+            ["node", ACTION_ENTRYPOINT.as_posix()],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+    def run_client_script(
+        self, client_path: Path, script_body: str
+    ) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the Odoo preview request client")
+
+        script = f"""
+import * as client from {json.dumps(client_path.as_uri())};
+{script_body}
+"""
+        return subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_setup_action_writes_importable_client_and_output(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            client_path = temporary_root / ".launchplane" / "odoo-preview-client.mjs"
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=client_path,
+                github_output=github_output,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(client_path.exists())
+            self.assertIn(f"client-path={client_path}", github_output.read_text(encoding="utf-8"))
+
+            import_result = self.run_client_script(
+                client_path,
+                """
+console.log(Object.keys(client).sort().join(','));
+""",
+            )
+            self.assertEqual(import_result.returncode, 0, import_result.stderr)
+            self.assertIn("buildOdooPreviewArtifactPublishInputsRequest", import_result.stdout)
+            self.assertIn("buildOdooPreviewApplyInputsRequest", import_result.stdout)
+            self.assertIn("buildOdooPreviewApplyRequest", import_result.stdout)
+
+    def test_client_builds_artifact_publish_inputs_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "odoo-preview-client.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildOdooPreviewArtifactPublishInputsRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  prNumber: 42,
+  sourceGitRef: 'abc123',
+  runId: '456',
+  runAttempt: '2',
+});
+console.log(JSON.stringify(request));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        request = json.loads(result.stdout)
+        self.assertEqual(request["routePath"], "/v1/drivers/odoo/artifact-publish-inputs")
+        self.assertEqual(
+            request["payload"],
+            {
+                "schema_version": 1,
+                "product": "odoo-tenant-cm-website",
+                "inputs": {
+                    "schema_version": 1,
+                    "context": "cm_website",
+                    "instance": "testing",
+                    "pr_number": 42,
+                    "isolated": True,
+                    "source_git_ref": "abc123",
+                },
+            },
+        )
+        self.assertEqual(request["failResultPathsInput"], "result.input_status")
+        self.assertEqual(json.loads(request["payloadInput"]), request["payload"])
+        self.assertEqual(request["responseOutputPath"], "result")
+        self.assertEqual(
+            request["idempotencyKey"],
+            "odoo-artifact-publish-inputs:odoo-tenant-cm-website:cm_website:testing:preview-42-run-456-attempt-2",
+        )
+
+    def test_client_builds_apply_inputs_request_without_preview_slug_payload_authority(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "odoo-preview-client.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildOdooPreviewApplyInputsRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  prNumber: 42,
+  previewSlug: 'preview-42',
+  sourceGitRef: 'abc123',
+  manifestFile: '/tmp/preview-artifact.json',
+  runId: '456',
+  runAttempt: '2',
+});
+console.log(JSON.stringify(request));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        request = json.loads(result.stdout)
+        self.assertEqual(request["routePath"], "/v1/drivers/odoo/preview-apply-inputs")
+        self.assertNotIn("preview_slug", request["payload"]["inputs"])
+        self.assertEqual(
+            request["payloadJsonFiles"], {"inputs.manifest": "/tmp/preview-artifact.json"}
+        )
+        self.assertEqual(
+            request["payloadJsonFilesInput"], "inputs.manifest=/tmp/preview-artifact.json"
+        )
+        self.assertEqual(request["responseOutputPath"], "result.dry_run_plan")
+        self.assertEqual(request["failResultPathsInput"], "result.status")
+        self.assertEqual(
+            request["idempotencyKey"],
+            "odoo-preview-apply-inputs:odoo-tenant-cm-website:preview-42:abc123:inputs-run-456-attempt-2",
+        )
+
+    def test_client_builds_destroy_apply_request_without_manifest_or_smoke(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "odoo-preview-client.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            result = self.run_client_script(
+                client_path,
+                """
+const inputs = client.buildOdooPreviewApplyInputsRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  operation: 'destroy',
+  prNumber: 42,
+  runId: '456',
+  runAttempt: '2',
+});
+const apply = client.buildOdooPreviewApplyRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  operation: 'destroy',
+  prNumber: 42,
+  dryRunPlanFile: '/tmp/dry-run.json',
+  runId: '456',
+  runAttempt: '2',
+});
+console.log(JSON.stringify({ inputs, apply }));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["inputs"]["payloadJsonFiles"], {})
+        self.assertEqual(
+            payload["inputs"]["idempotencyKey"],
+            "odoo-preview-apply-inputs:odoo-tenant-cm-website:pr-42:destroy:inputs-run-456-attempt-2",
+        )
+        self.assertEqual(
+            payload["apply"]["payloadJsonFiles"], {"apply.dry_run_plan": "/tmp/dry-run.json"}
+        )
+        self.assertFalse(payload["apply"]["payload"]["apply"]["smoke_check"])
+        self.assertEqual(
+            payload["apply"]["idempotencyKey"],
+            "odoo-preview-apply:odoo-tenant-cm-website:pr-42:destroy:run-456-attempt-2",
+        )
+
+    def test_client_preserves_manual_apply_boolean_overrides(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "odoo-preview-client.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildOdooPreviewApplyRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  prNumber: 42,
+  sourceGitRef: 'abc123',
+  dryRunPlanFile: '/tmp/dry-run.json',
+  manifestFile: '/tmp/preview-artifact.json',
+  waitForDeploy: 'false',
+  smokeCheck: 'true',
+  runId: '456',
+  runAttempt: '2',
+});
+console.log(JSON.stringify(request.payload.apply));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            json.loads(result.stdout),
+            {
+                "timeout_seconds": 600,
+                "wait_for_deploy": False,
+                "smoke_check": True,
+            },
+        )
+
+    def test_client_rejects_invalid_apply_boolean_override(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "odoo-preview-client.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            result = self.run_client_script(
+                client_path,
+                """
+client.buildOdooPreviewApplyRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  prNumber: 42,
+  sourceGitRef: 'abc123',
+  dryRunPlanFile: '/tmp/dry-run.json',
+  manifestFile: '/tmp/preview-artifact.json',
+  waitForDeploy: 'sometimes',
+  runId: '456',
+  runAttempt: '2',
+});
+""",
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("waitForDeploy must be a boolean", result.stderr)
+
+    def test_client_rejects_refresh_requests_without_required_files(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "odoo-preview-client.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            apply_inputs = self.run_client_script(
+                client_path,
+                """
+client.buildOdooPreviewApplyInputsRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  prNumber: 42,
+  sourceGitRef: 'abc123',
+  runId: '456',
+  runAttempt: '2',
+});
+""",
+            )
+            apply = self.run_client_script(
+                client_path,
+                """
+client.buildOdooPreviewApplyRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  prNumber: 42,
+  sourceGitRef: 'abc123',
+  dryRunPlanFile: '/tmp/dry-run.json',
+  runId: '456',
+  runAttempt: '2',
+});
+""",
+            )
+
+        self.assertNotEqual(apply_inputs.returncode, 0)
+        self.assertIn("refresh apply inputs require manifestFile", apply_inputs.stderr)
+        self.assertNotEqual(apply.returncode, 0)
+        self.assertIn("refresh apply requires manifestFile", apply.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -329,6 +329,12 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(request.fail_result_paths, ("result.input_status",))
         self.assertEqual(request.response_output_path, "result")
 
+    def test_artifact_publish_inputs_builder_requires_refresh_operation(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires refresh operation"):
+            build_odoo_preview_artifact_publish_inputs_workflow_request(
+                facts=_workflow_facts(operation="destroy")
+            )
+
     def test_builds_preview_apply_inputs_workflow_request_shape(self) -> None:
         request = build_odoo_preview_apply_inputs_workflow_request(
             facts=_workflow_facts(),
@@ -375,14 +381,32 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertNotIn("preview_slug", inputs)
         self.assertEqual(
             request.idempotency_key,
-            "odoo-preview-apply-inputs:odoo-tenant-cm-website:pr-42:abc123:inputs-run-456-attempt-2",
+            "odoo-preview-apply-inputs:odoo-tenant-cm-website:pr-42:destroy:inputs-run-456-attempt-2",
         )
 
     def test_apply_inputs_destroy_without_source_ref_uses_destroy_idempotency_token(self) -> None:
-        facts = _workflow_facts(operation="destroy")
-        facts.source_git_ref = ""
+        facts = OdooPreviewWorkflowRequestFacts(
+            product="odoo-tenant-cm-website",
+            context="cm_website",
+            operation="destroy",
+            pr_number=42,
+            preview_slug="pr-42",
+            source_git_ref="",
+            run_id="456",
+            run_attempt="2",
+        )
 
         request = build_odoo_preview_apply_inputs_workflow_request(facts=facts)
+
+        self.assertEqual(
+            request.idempotency_key,
+            "odoo-preview-apply-inputs:odoo-tenant-cm-website:pr-42:destroy:inputs-run-456-attempt-2",
+        )
+
+    def test_apply_inputs_destroy_uses_stable_idempotency_token_with_source_ref(self) -> None:
+        request = build_odoo_preview_apply_inputs_workflow_request(
+            facts=_workflow_facts(operation="destroy")
+        )
 
         self.assertEqual(
             request.idempotency_key,
@@ -423,6 +447,20 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(
             request.idempotency_key,
             "odoo-preview-apply:odoo-tenant-cm-website:pr-42:refresh:run-456-attempt-2",
+        )
+
+    def test_preview_apply_workflow_request_accepts_manual_apply_overrides(self) -> None:
+        request = build_odoo_preview_apply_workflow_request(
+            facts=_workflow_facts(),
+            dry_run_plan_file="/tmp/dry-run.json",
+            manifest_file="/tmp/preview-artifact.json",
+            wait_for_deploy=False,
+            smoke_check=True,
+        )
+
+        self.assertEqual(
+            request.payload["apply"],
+            {"timeout_seconds": 600, "wait_for_deploy": False, "smoke_check": True},
         )
 
     def test_destroy_preview_apply_request_skips_manifest_and_smoke(self) -> None:


### PR DESCRIPTION
## Summary

- Add a Launchplane-owned `setup-odoo-preview-request-client` action that writes an importable ESM client for Odoo preview request envelopes.
- Cover `artifact-publish-inputs`, `preview-apply-inputs`, and `preview-apply` route paths, payload skeletons, JSON-file bindings, fail paths, response output paths, and idempotency keys for direct `launchplane-request` handoff.
- Keep `preview_slug` out of payload authority, make destroy apply-inputs idempotency stable, preserve manual apply booleans, and align the Python builders with the generated client.
- Tighten the artifact-publish builder to refresh-only and remove unused Odoo compose-delete dead code.
- Update the preview workflow contract docs so tenant repos consume this client instead of copying inline request JSON/config.

## Validation

- `uv run python -m unittest tests.test_odoo_preview_request_client_action tests.test_odoo_preview_runtime tests.test_odoo_artifact_publish_inputs tests.test_http_app_driver_odoo tests.test_docs_contracts` (190 tests)
- `node --check .github/actions/setup-odoo-preview-request-client/dist/index.js`
- `node --input-type=module -e "import('./.github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs').then((m) => console.log(Object.keys(m).length))"`
- `git diff --check`

## Review

- Agent review completed; review findings around JS/Python apply boolean parity, stable destroy idempotency, and unused helper cleanup were addressed.
- Residual smoke-check wall-clock behavior noted by review is pre-existing and outside this reusable request-client slice.

## Plan Alignment

This is the Launchplane-side contract needed for the next #1529/#898 consumer step: tenant Odoo preview workflows can install this setup action, render the request envelopes from Launchplane-owned code, and delete duplicated inline route/payload/file-binding/idempotency config as they migrate.
