### PR TITLE
Add Odoo app maintenance driver route

### DIFF
--- a/.github/workflows/reusable-product-driver-app-maintenance.yml
+++ b/.github/workflows/reusable-product-driver-app-maintenance.yml
@@ -9,6 +9,11 @@ name: Reusable Product Driver App Maintenance
         required: false
         default: ""
         type: string
+      driver:
+        description: Product driver id. Defaults to verireel for backward compatibility.
+        required: false
+        default: verireel
+        type: string
       context:
         description: Runtime context. Defaults to the product key.
         required: false
@@ -103,6 +108,7 @@ jobs:
           ACTION: ${{ inputs.action }}
           APPLICATION_NAME: ${{ inputs.application_name }}
           CONTEXT: ${{ inputs.context }}
+          DRIVER: ${{ inputs.driver }}
           EMAIL: ${{ inputs.email }}
           INSTANCE: ${{ inputs.instance }}
           INTENT: ${{ inputs.intent }}
@@ -117,7 +123,12 @@ jobs:
           if [ -z "$CONTEXT" ]; then
             CONTEXT="$PRODUCT"
           fi
-          for required in PRODUCT CONTEXT INSTANCE ACTION INTENT TIMEOUT_SECONDS; do
+          case "$DRIVER" in
+            verireel) route_path="/v1/drivers/verireel/app-maintenance" ;;
+            odoo) route_path="/v1/drivers/odoo/app-maintenance" ;;
+            *) echo "Unsupported product driver for app maintenance: $DRIVER" >&2; exit 1 ;;
+          esac
+          for required in DRIVER PRODUCT CONTEXT INSTANCE ACTION INTENT TIMEOUT_SECONDS; do
             if [ -z "${!required}" ]; then
               echo "${required} is required." >&2
               exit 1
@@ -132,9 +143,10 @@ jobs:
           fi
           {
             echo "context=$CONTEXT"
-            printf '%s=%s:%s:%s:%s:%s:%s:%s:%s:%s\n' \
+            printf '%s=%s:%s:%s:%s:%s:%s:%s:%s:%s:%s\n' \
               idempotency_key \
               product-driver-app-maintenance \
+              "$DRIVER" \
               "$PRODUCT" \
               "$CONTEXT" \
               "$INSTANCE" \
@@ -145,7 +157,7 @@ jobs:
               "$PREVIEW_SLUG"
             echo "instance=$INSTANCE"
             echo "product=$PRODUCT"
-            echo "route_path=/v1/drivers/verireel/app-maintenance"
+            echo "route_path=$route_path"
           } >>"$GITHUB_OUTPUT"
 
       - name: Request Launchplane app maintenance

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -500,7 +500,7 @@ ODOO_DRIVER = DriverDescriptor(
             capability_id="post_deploy_settings",
             label="Post-deploy settings",
             description="Apply typed Odoo instance settings and managed secret bindings after deploy.",
-            actions=("post_deploy", "stable_bootstrap"),
+            actions=("app_maintenance", "post_deploy", "stable_bootstrap"),
             panels=("settings", "secret_bindings", "audit"),
         ),
         DriverCapabilityDescriptor(
@@ -554,6 +554,16 @@ ODOO_DRIVER = DriverDescriptor(
             route_path="/v1/drivers/odoo/artifact-publish",
             authz_action="odoo_artifact_publish.write",
             writes_records=("artifact_manifest",),
+        ),
+        _action(
+            "app_maintenance",
+            "Run app maintenance",
+            "Run narrow Odoo app maintenance through the product-driver reusable surface.",
+            safety="mutation",
+            scope="instance",
+            route_path="/v1/drivers/odoo/app-maintenance",
+            authz_action="odoo_app_maintenance.execute",
+            writes_records=("odoo_instance_override",),
         ),
         _action(
             "post_deploy",

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -349,6 +349,15 @@ from control_plane.odoo_post_deploy_http import (
     write_odoo_config_parameter_override_result,
     write_odoo_website_bootstrap_override_result,
 )
+from control_plane.odoo_app_maintenance_http import (
+    ODOO_APP_MAINTENANCE_ACTION,
+    ODOO_APP_MAINTENANCE_ROUTE as _ODOO_APP_MAINTENANCE_ROUTE,
+    OdooAppMaintenanceEnvelope,
+    OdooAppMaintenanceProductMismatchError,
+    OdooAppMaintenanceRouteDependencyError,
+    execute_odoo_app_maintenance_result,
+    resolve_odoo_app_maintenance_product_route,
+)
 from control_plane.odoo_prod_backup_gate_http import (
     ODOO_PROD_BACKUP_GATE_ACTION,
     ODOO_PROD_BACKUP_GATE_ROUTE as _ODOO_PROD_BACKUP_GATE_ROUTE,
@@ -6488,6 +6497,137 @@ def create_launchplane_fastapi_app(
             record_store=record_store,
             identity=identity,
             route_path=_ODOO_POST_DEPLOY_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
+    async def write_odoo_app_maintenance(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse | JSONResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            )
+        try:
+            maintenance_request = OdooAppMaintenanceEnvelope.model_validate(raw_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request payload failed validation.",
+            ) from error
+        try:
+            product_profile = resolve_odoo_app_maintenance_product_route(
+                record_store=record_store,
+                product=maintenance_request.product,
+                context=maintenance_request.maintenance.context,
+                instance=maintenance_request.maintenance.instance,
+            )
+        except OdooAppMaintenanceRouteDependencyError:
+            return driver_route_dependency_not_found_response(
+                trace_id=trace_id,
+                route_path=_ODOO_APP_MAINTENANCE_ROUTE,
+            )
+        except OdooAppMaintenanceProductMismatchError as error:
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="product_driver_mismatch",
+                message="Product is not configured for the requested driver route.",
+            ) from error
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+
+        authorization_product = (
+            product_profile.product if product_profile is not None else maintenance_request.product
+        )
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=ODOO_APP_MAINTENANCE_ACTION,
+            product=authorization_product,
+            context=maintenance_request.maintenance.context,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message=(
+                    "Workflow cannot execute the Odoo app maintenance driver"
+                    " for the requested product/context."
+                ),
+            )
+
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_ODOO_APP_MAINTENANCE_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+
+        try:
+            records, driver_result = execute_odoo_app_maintenance_result(
+                control_plane_root=resolved_control_plane_root,
+                record_store=record_store,
+                request=maintenance_request,
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=f"No Launchplane route for {_ODOO_APP_MAINTENANCE_ROUTE}.",
+            ) from error
+        except (ValueError, click.ClickException) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
+
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={key: str(value) for key, value in records.items()},
+            result=driver_result,
+        )
+        store_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_ODOO_APP_MAINTENANCE_ROUTE,
             idempotency_key=normalized_idempotency_key,
             request_fingerprint_value=payload_fingerprint,
             trace_id=trace_id,
@@ -18572,6 +18712,33 @@ def create_launchplane_fastapi_app(
         },
         operation_id="write_odoo_post_deploy",
         summary="Execute Odoo post-deploy maintenance",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _ODOO_APP_MAINTENANCE_ROUTE,
+        write_odoo_app_maintenance,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {"schema": OdooAppMaintenanceEnvelope.model_json_schema()}
+                },
+            }
+        },
+        operation_id="write_odoo_app_maintenance",
+        summary="Execute Odoo app maintenance",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -357,6 +357,7 @@ from control_plane.odoo_app_maintenance_http import (
     OdooAppMaintenanceRouteDependencyError,
     execute_odoo_app_maintenance_result,
     resolve_odoo_app_maintenance_product_route,
+    should_store_odoo_app_maintenance_idempotency,
 )
 from control_plane.odoo_prod_backup_gate_http import (
     ODOO_PROD_BACKUP_GATE_ACTION,
@@ -6624,15 +6625,16 @@ def create_launchplane_fastapi_app(
             records={key: str(value) for key, value in records.items()},
             result=driver_result,
         )
-        store_apply_idempotency(
-            record_store=record_store,
-            identity=identity,
-            route_path=_ODOO_APP_MAINTENANCE_ROUTE,
-            idempotency_key=normalized_idempotency_key,
-            request_fingerprint_value=payload_fingerprint,
-            trace_id=trace_id,
-            response=response,
-        )
+        if should_store_odoo_app_maintenance_idempotency(driver_result):
+            store_apply_idempotency(
+                record_store=record_store,
+                identity=identity,
+                route_path=_ODOO_APP_MAINTENANCE_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=response,
+            )
         return response
 
     async def write_odoo_config_parameter_override(

--- a/control_plane/odoo_app_maintenance_http.py
+++ b/control_plane/odoo_app_maintenance_http.py
@@ -79,3 +79,9 @@ def execute_odoo_app_maintenance_result(
         )
     }
     return records, driver_result.model_dump(mode="json")
+
+
+def should_store_odoo_app_maintenance_idempotency(
+    driver_result: dict[str, object],
+) -> bool:
+    return driver_result.get("maintenance_status") == "pass"

--- a/control_plane/odoo_app_maintenance_http.py
+++ b/control_plane/odoo_app_maintenance_http.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pydantic import Field, model_validator
+
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.drivers.dispatch import (
+    _ProductRouteEnvelope,
+    _validate_driver_envelope_product,
+)
+from control_plane.odoo_product_driver_http import (
+    OdooProductMismatchError,
+    OdooRouteDependencyError,
+    resolve_odoo_product_route,
+)
+from control_plane.workflows.odoo_app_maintenance import (
+    OdooAppMaintenanceRequest,
+    execute_odoo_app_maintenance,
+)
+
+
+ODOO_APP_MAINTENANCE_ROUTE = "/v1/drivers/odoo/app-maintenance"
+ODOO_APP_MAINTENANCE_ACTION = "odoo_app_maintenance.execute"
+
+
+class OdooAppMaintenanceProductMismatchError(OdooProductMismatchError):
+    pass
+
+
+class OdooAppMaintenanceRouteDependencyError(OdooRouteDependencyError):
+    pass
+
+
+class OdooAppMaintenanceEnvelope(_ProductRouteEnvelope):
+    schema_version: int = Field(default=1, ge=1)
+    maintenance: OdooAppMaintenanceRequest
+
+    @model_validator(mode="after")
+    def _validate_alignment(self) -> "OdooAppMaintenanceEnvelope":
+        _validate_driver_envelope_product(self.product, label="Odoo app maintenance")
+        return self
+
+
+def resolve_odoo_app_maintenance_product_route(
+    *,
+    record_store: object,
+    product: str,
+    context: str,
+    instance: str,
+) -> LaunchplaneProductProfileRecord | None:
+    try:
+        return resolve_odoo_product_route(
+            record_store=record_store,
+            product=product,
+            context=context,
+            instance=instance,
+        )
+    except OdooRouteDependencyError as error:
+        raise OdooAppMaintenanceRouteDependencyError from error
+    except OdooProductMismatchError as error:
+        raise OdooAppMaintenanceProductMismatchError from error
+
+
+def execute_odoo_app_maintenance_result(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: OdooAppMaintenanceEnvelope,
+) -> tuple[dict[str, object], dict[str, object]]:
+    driver_result = execute_odoo_app_maintenance(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=request.maintenance,
+    )
+    records: dict[str, object] = {
+        "transition": (
+            f"odoo-app-maintenance:{driver_result.context}:{driver_result.instance}:deploy"
+        )
+    }
+    return records, driver_result.model_dump(mode="json")

--- a/control_plane/service.py
+++ b/control_plane/service.py
@@ -150,6 +150,10 @@ from control_plane.odoo_artifact_publish_http import (
     ODOO_ARTIFACT_PUBLISH_ROUTE,
     OdooArtifactPublishEnvelope as OdooArtifactPublishEnvelope,
 )
+from control_plane.odoo_app_maintenance_http import (
+    ODOO_APP_MAINTENANCE_ROUTE,
+    OdooAppMaintenanceEnvelope as OdooAppMaintenanceEnvelope,
+)
 from control_plane.odoo_post_deploy_http import (
     ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE,
     ODOO_POST_DEPLOY_ROUTE,
@@ -253,6 +257,7 @@ _NATIVE_FASTAPI_DRIVER_ROUTE_PATHS = frozenset(
         _VERIREEL_PROD_ROLLBACK_ROUTE.route_path,
         "/v1/drivers/ingress/route-apply",
         ODOO_ARTIFACT_PUBLISH_ROUTE,
+        ODOO_APP_MAINTENANCE_ROUTE,
         "/v1/drivers/odoo/artifact-publish-inputs",
         ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE,
         ODOO_POST_DEPLOY_ROUTE,
@@ -347,6 +352,15 @@ _ODOO_POST_DEPLOY_ROUTE = _DriverRouteExecutionMetadata(
     envelope_model=OdooPostDeployEnvelope,
     denial_message=(
         "Workflow cannot execute the Odoo post-deploy driver for the requested product/context."
+    ),
+)
+
+
+_ODOO_APP_MAINTENANCE_ROUTE = _DriverRouteExecutionMetadata(
+    route_path=ODOO_APP_MAINTENANCE_ROUTE,
+    envelope_model=OdooAppMaintenanceEnvelope,
+    denial_message=(
+        "Workflow cannot execute the Odoo app maintenance driver for the requested product/context."
     ),
 )
 

--- a/control_plane/workflows/odoo_app_maintenance.py
+++ b/control_plane/workflows/odoo_app_maintenance.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.odoo_instance_override_record import OdooOverrideApplyPhase
+from control_plane.workflows.odoo_post_deploy import (
+    OdooPostDeployRequest,
+    execute_odoo_post_deploy,
+)
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+OdooAppMaintenanceAction = Literal["post-deploy"]
+OdooAppMaintenanceIntent = Literal["stable-post-deploy"]
+
+
+class OdooAppMaintenanceRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str = "testing"
+    action: OdooAppMaintenanceAction
+    intent: OdooAppMaintenanceIntent
+    phase: OdooOverrideApplyPhase = "deploy"
+    email: str = ""
+    application_name: str = ""
+    preview_slug: str = ""
+    timeout_seconds: int = Field(default=300, ge=1)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "OdooAppMaintenanceRequest":
+        self.context = self.context.strip().lower()
+        self.instance = self.instance.strip().lower()
+        self.email = self.email.strip()
+        self.application_name = self.application_name.strip()
+        self.preview_slug = self.preview_slug.strip()
+        if not self.context:
+            raise ValueError("Odoo app maintenance requires context.")
+        if not self.instance:
+            raise ValueError("Odoo app maintenance requires instance.")
+        if self.email or self.application_name or self.preview_slug:
+            raise ValueError("Odoo app maintenance does not accept user or preview-scoped fields.")
+        if self.action != "post-deploy" or self.intent != "stable-post-deploy":
+            raise ValueError(
+                "Odoo app maintenance currently supports only post-deploy / stable-post-deploy."
+            )
+        if self.phase != "deploy":
+            raise ValueError("Odoo app maintenance currently supports only the deploy phase.")
+        return self
+
+
+class OdooAppMaintenanceResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    maintenance_status: Literal["pass", "fail"]
+    action: OdooAppMaintenanceAction
+    intent: str
+    context: str
+    instance: str
+    application_name: str = ""
+    application_id: str = ""
+    schedule_name: str = "odoo-post-deploy"
+    post_deploy_status: Literal["pass", "fail"]
+    override_status: str = "skipped"
+    override_record_found: bool = False
+    override_payload_rendered: bool = False
+    website_bootstrap_included: bool = False
+    applied_at: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+    error_message: str = ""
+
+
+def execute_odoo_app_maintenance(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: OdooAppMaintenanceRequest,
+) -> OdooAppMaintenanceResult:
+    started_at = utc_now_timestamp()
+    post_deploy_result = execute_odoo_post_deploy(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=OdooPostDeployRequest(
+            context=request.context,
+            instance=request.instance,
+            phase=request.phase,
+        ),
+    )
+    finished_at = utc_now_timestamp()
+    return OdooAppMaintenanceResult(
+        maintenance_status=post_deploy_result.post_deploy_status,
+        action=request.action,
+        intent=request.intent,
+        context=post_deploy_result.context,
+        instance=post_deploy_result.instance,
+        post_deploy_status=post_deploy_result.post_deploy_status,
+        override_status=post_deploy_result.override_status,
+        override_record_found=post_deploy_result.override_record_found,
+        override_payload_rendered=post_deploy_result.override_payload_rendered,
+        website_bootstrap_included=post_deploy_result.website_bootstrap_included,
+        applied_at=post_deploy_result.applied_at,
+        started_at=started_at,
+        finished_at=finished_at,
+        error_message=post_deploy_result.error_message,
+    )

--- a/control_plane/workflows/odoo_app_maintenance.py
+++ b/control_plane/workflows/odoo_app_maintenance.py
@@ -44,10 +44,6 @@ class OdooAppMaintenanceRequest(BaseModel):
             raise ValueError("Odoo app maintenance requires instance.")
         if self.email or self.application_name or self.preview_slug:
             raise ValueError("Odoo app maintenance does not accept user or preview-scoped fields.")
-        if self.action != "post-deploy" or self.intent != "stable-post-deploy":
-            raise ValueError(
-                "Odoo app maintenance currently supports only post-deploy / stable-post-deploy."
-            )
         if self.phase != "deploy":
             raise ValueError("Odoo app maintenance currently supports only the deploy phase.")
         return self

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -475,6 +475,9 @@ The product-driver workflow surface for stable deploy, stable environment, and
 app-maintenance defaults to the `testing` lane so a testing publish workflow can
 pass only the primitive facts it owns, such as immutable artifact identity,
 tested source git ref, and operation-level maintenance intent.
+The app-maintenance connector defaults to the VeriReel driver for compatibility,
+and callers can pass `driver: odoo` for the narrow Odoo post-deploy maintenance
+adapter backed by `/v1/drivers/odoo/app-maintenance`.
 Product repos should pass an explicit `instance` only for a workflow whose
 operator input or job purpose genuinely selects a different lane.
 Production readiness wrappers may also accept expected runtime build identity

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -302,6 +302,7 @@ VeriReel product paths:
   - `GET /v1/drivers/odoo/target-replacement/operations/{operation_id}`
     (native FastAPI)
   - `POST /v1/drivers/odoo/post-deploy` (native FastAPI)
+  - `POST /v1/drivers/odoo/app-maintenance` (native FastAPI)
   - `POST /v1/drivers/odoo/config-parameter-override` (native FastAPI)
   - `POST /v1/drivers/odoo/website-bootstrap-override` (native FastAPI)
   - `POST /v1/drivers/odoo/target-replacement-plan` (native FastAPI)

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -3518,6 +3518,28 @@ async def _post_odoo_post_deploy(
     )
 
 
+async def _post_odoo_app_maintenance(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/drivers/odoo/app-maintenance",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
 async def _post_odoo_config_parameter_override(
     app: FastAPI,
     payload: dict[str, object],

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -209,6 +209,9 @@ class DocsContractsTests(TestCase):
         prod_promotion_workflow = Path(
             ".github/workflows/reusable-product-driver-prod-promotion.yml"
         ).read_text(encoding="utf-8")
+        app_maintenance_workflow = Path(
+            ".github/workflows/reusable-product-driver-app-maintenance.yml"
+        ).read_text(encoding="utf-8")
         prod_rollback_workflow = Path(
             ".github/workflows/reusable-product-driver-prod-rollback.yml"
         ).read_text(encoding="utf-8")
@@ -226,7 +229,9 @@ class DocsContractsTests(TestCase):
         self.assertIn("should not own Launchplane route construction", product_repo_contract)
 
         self.assertIn("workflow_call:", stable_deploy_workflow)
-        self.assertIn("Stable lane instance to deploy. Defaults to testing.", stable_deploy_workflow)
+        self.assertIn(
+            "Stable lane instance to deploy. Defaults to testing.", stable_deploy_workflow
+        )
         self.assertIn('default: "testing"', stable_deploy_workflow)
         self.assertIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', stable_deploy_workflow)
         self.assertIn("route_path=/v1/drivers/verireel/$INSTANCE-deploy", stable_deploy_workflow)
@@ -247,6 +252,12 @@ class DocsContractsTests(TestCase):
         )
         self.assertIn("target_category=result.target_category", prod_promotion_workflow)
         self.assertNotIn("target_type=result.target_type", prod_promotion_workflow)
+
+        self.assertIn("workflow_call:", app_maintenance_workflow)
+        self.assertIn("driver:", app_maintenance_workflow)
+        self.assertIn('route_path="/v1/drivers/verireel/app-maintenance"', app_maintenance_workflow)
+        self.assertIn('route_path="/v1/drivers/odoo/app-maintenance"', app_maintenance_workflow)
+        self.assertIn("maintenance.intent=${{ inputs.intent }}", app_maintenance_workflow)
 
         self.assertIn("workflow_call:", prod_rollback_workflow)
         self.assertIn("route_path=/v1/drivers/verireel/prod-rollback", prod_rollback_workflow)

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -584,6 +584,11 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
                     control_plane_service.OdooPostDeployEnvelope,
                     "post-deploy driver",
                 ),
+                "app_maintenance": (
+                    control_plane_service._ODOO_APP_MAINTENANCE_ROUTE,
+                    control_plane_service.OdooAppMaintenanceEnvelope,
+                    "app maintenance driver",
+                ),
                 "stable_bootstrap": (
                     control_plane_service._ODOO_STABLE_BOOTSTRAP_ROUTE,
                     control_plane_service.OdooStableBootstrapEnvelope,

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -4928,6 +4928,71 @@ class FastApiOdooPostDeployOverrideTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["result"]["maintenance_status"], "pass")
         self.assertEqual(payload["result"]["post_deploy_status"], "pass")
 
+    async def test_odoo_app_maintenance_does_not_replay_failed_result(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._store_with_tenant_profile(root / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(self._tenant_identity(workflow_name="deploy-odoo.yml")),
+                authz_policy=self._tenant_policy(
+                    action="odoo_app_maintenance.execute",
+                    workflow_name="deploy-odoo.yml",
+                ),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            request_payload: dict[str, object] = {
+                "product": "odoo-tenant-cm",
+                "maintenance": {
+                    "context": "cm",
+                    "instance": "testing",
+                    "action": "post-deploy",
+                    "intent": "stable-post-deploy",
+                },
+            }
+            with patch(
+                "control_plane.odoo_app_maintenance_http.execute_odoo_app_maintenance",
+                side_effect=(
+                    OdooAppMaintenanceResult(
+                        maintenance_status="fail",
+                        action="post-deploy",
+                        intent="stable-post-deploy",
+                        context="cm",
+                        instance="testing",
+                        post_deploy_status="fail",
+                        override_status="fail",
+                        error_message="temporary Odoo maintenance failure",
+                    ),
+                    OdooAppMaintenanceResult(
+                        maintenance_status="pass",
+                        action="post-deploy",
+                        intent="stable-post-deploy",
+                        context="cm",
+                        instance="testing",
+                        post_deploy_status="pass",
+                        override_status="pass",
+                    ),
+                ),
+            ) as execute_mock:
+                first_response = await _post_odoo_app_maintenance(
+                    app,
+                    request_payload,
+                    idempotency_key="odoo-app-maintenance:retry-after-failure",
+                )
+                retry_response = await _post_odoo_app_maintenance(
+                    app,
+                    request_payload,
+                    idempotency_key="odoo-app-maintenance:retry-after-failure",
+                )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(first_response.json()["result"]["maintenance_status"], "fail")
+        self.assertEqual(retry_response.status_code, 202)
+        self.assertFalse(retry_response.json().get("replayed", False))
+        self.assertEqual(retry_response.json()["result"]["maintenance_status"], "pass")
+        self.assertEqual(execute_mock.call_count, 2)
+
     async def test_odoo_app_maintenance_rejects_non_deploy_phase(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -21,6 +21,7 @@ from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPo
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.odoo_artifact_publish import OdooArtifactPublishResult
+from control_plane.workflows.odoo_app_maintenance import OdooAppMaintenanceResult
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
 from control_plane.workflows.odoo_preview_runtime import OdooPreviewDokployApplyResult
 from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResult
@@ -34,6 +35,7 @@ from control_plane.workflows.odoo_stable_target_replacement import (
 from tests.http_app_test_support import (
     _asgi_get,
     _MissingProductReadStore,
+    _post_odoo_app_maintenance,
     _post_odoo_artifact_publish,
     _post_odoo_artifact_publish_inputs,
     _post_odoo_config_parameter_override,
@@ -4872,6 +4874,121 @@ class FastApiOdooPostDeployOverrideTests(unittest.IsolatedAsyncioTestCase):
             },
         }
 
+    async def test_odoo_app_maintenance_executes_authorized_post_deploy(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(self._tenant_identity(workflow_name="deploy-odoo.yml")),
+                authz_policy=self._tenant_policy(
+                    action="odoo_app_maintenance.execute",
+                    workflow_name="deploy-odoo.yml",
+                ),
+                record_store_factory=lambda: self._store_with_tenant_profile(root / "state"),
+                control_plane_root_path=root,
+            )
+
+            with patch(
+                "control_plane.odoo_app_maintenance_http.execute_odoo_app_maintenance",
+                return_value=OdooAppMaintenanceResult(
+                    maintenance_status="pass",
+                    action="post-deploy",
+                    intent="stable-post-deploy",
+                    context="cm",
+                    instance="testing",
+                    post_deploy_status="pass",
+                    override_status="pass",
+                    override_record_found=True,
+                    override_payload_rendered=True,
+                    applied_at="2026-04-26T12:05:00Z",
+                    started_at="2026-04-26T12:04:00Z",
+                    finished_at="2026-04-26T12:05:00Z",
+                ),
+            ):
+                response = await _post_odoo_app_maintenance(
+                    app,
+                    {
+                        "product": "odoo-tenant-cm",
+                        "maintenance": {
+                            "context": "cm",
+                            "instance": "testing",
+                            "action": "post-deploy",
+                            "intent": "stable-post-deploy",
+                        },
+                    },
+                    idempotency_key="odoo-app-maintenance:cm-testing-post-deploy",
+                )
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["status"], "accepted")
+        self.assertEqual(
+            payload["records"]["transition"],
+            "odoo-app-maintenance:cm:testing:deploy",
+        )
+        self.assertEqual(payload["result"]["maintenance_status"], "pass")
+        self.assertEqual(payload["result"]["post_deploy_status"], "pass")
+
+    async def test_odoo_app_maintenance_rejects_non_deploy_phase(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(self._tenant_identity(workflow_name="deploy-odoo.yml")),
+                authz_policy=self._tenant_policy(
+                    action="odoo_app_maintenance.execute",
+                    workflow_name="deploy-odoo.yml",
+                ),
+                record_store_factory=lambda: self._store_with_tenant_profile(root / "state"),
+                control_plane_root_path=root,
+            )
+
+            response = await _post_odoo_app_maintenance(
+                app,
+                {
+                    "product": "odoo-tenant-cm",
+                    "maintenance": {
+                        "context": "cm",
+                        "instance": "testing",
+                        "action": "post-deploy",
+                        "intent": "stable-post-deploy",
+                        "phase": "promotion",
+                    },
+                },
+                idempotency_key="odoo-app-maintenance:unsupported-phase",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    async def test_odoo_app_maintenance_rejects_unsupported_action(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(self._tenant_identity(workflow_name="deploy-odoo.yml")),
+                authz_policy=self._tenant_policy(
+                    action="odoo_app_maintenance.execute",
+                    workflow_name="deploy-odoo.yml",
+                ),
+                record_store_factory=lambda: self._store_with_tenant_profile(root / "state"),
+                control_plane_root_path=root,
+            )
+
+            response = await _post_odoo_app_maintenance(
+                app,
+                {
+                    "product": "odoo-tenant-cm",
+                    "maintenance": {
+                        "context": "cm",
+                        "instance": "testing",
+                        "action": "reset-testing",
+                        "intent": "stable-post-deploy",
+                    },
+                },
+                idempotency_key="odoo-app-maintenance:unsupported-action",
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
     async def test_odoo_post_deploy_executes_authorized_workflow(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -5351,6 +5468,10 @@ class FastApiOdooPostDeployOverrideTests(unittest.IsolatedAsyncioTestCase):
             "/v1/drivers/odoo/post-deploy": (
                 "write_odoo_post_deploy",
                 "OdooPostDeployEnvelope",
+            ),
+            "/v1/drivers/odoo/app-maintenance": (
+                "write_odoo_app_maintenance",
+                "OdooAppMaintenanceEnvelope",
             ),
             "/v1/drivers/odoo/config-parameter-override": (
                 "write_odoo_config_parameter_override",


### PR DESCRIPTION
## Summary
- add a native Odoo app-maintenance route backed by the existing Odoo post-deploy executor
- let the product-driver app-maintenance reusable workflow select `verireel` or `odoo` while keeping `verireel` as the compatibility default
- register descriptor/service metadata and update docs/tests for the new route

## Review fixes
- reject non-deploy phases for the narrow Odoo app-maintenance adapter
- include transition evidence in accepted responses and idempotency replays

## Validation
- `uv run python -m py_compile control_plane/workflows/odoo_app_maintenance.py control_plane/odoo_app_maintenance_http.py control_plane/http_app.py control_plane/service.py control_plane/drivers/registry.py tests/http_app_test_support.py tests/test_http_app_driver_odoo.py tests/test_driver_descriptors.py tests/test_docs_contracts.py`
- `uv run python -m unittest tests.test_http_app_driver_odoo.FastApiOdooPostDeployOverrideTests tests.test_driver_descriptors.DriverDescriptorRegistryTests tests.test_docs_contracts.DocsContractsTests`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/reusable-product-driver-app-maintenance.yml`
- `git diff --check`
- `uv run --extra dev ruff check control_plane/workflows/odoo_app_maintenance.py control_plane/odoo_app_maintenance_http.py control_plane/drivers/registry.py control_plane/http_app.py control_plane/service.py tests/http_app_test_support.py tests/test_docs_contracts.py tests/test_driver_descriptors.py tests/test_http_app_driver_odoo.py`
- `uv run --extra dev ruff format --check control_plane/workflows/odoo_app_maintenance.py control_plane/odoo_app_maintenance_http.py control_plane/drivers/registry.py control_plane/http_app.py control_plane/service.py tests/http_app_test_support.py tests/test_docs_contracts.py tests/test_driver_descriptors.py tests/test_http_app_driver_odoo.py`

Review agent: code-gpt-5.5 found phase/evidence issues; both are fixed and covered by tests.
