### PR TITLE
Expose Odoo app maintenance workflow outputs

### DIFF
--- a/.github/workflows/reusable-product-driver-app-maintenance.yml
+++ b/.github/workflows/reusable-product-driver-app-maintenance.yml
@@ -80,6 +80,24 @@ name: Reusable Product Driver App Maintenance
       schedule_name:
         description: Schedule name used by the maintenance action.
         value: ${{ jobs.app-maintenance.outputs.schedule_name }}
+      post_deploy_status:
+        description: Odoo post-deploy status, when returned by the selected driver.
+        value: ${{ jobs.app-maintenance.outputs.post_deploy_status }}
+      override_status:
+        description: Odoo override apply status, when returned by the selected driver.
+        value: ${{ jobs.app-maintenance.outputs.override_status }}
+      override_record_found:
+        description: Whether an Odoo override record existed, when returned.
+        value: ${{ jobs.app-maintenance.outputs.override_record_found }}
+      override_payload_rendered:
+        description: Whether an Odoo override payload was rendered, when returned.
+        value: ${{ jobs.app-maintenance.outputs.override_payload_rendered }}
+      website_bootstrap_included:
+        description: Whether Odoo website bootstrap was included, when returned.
+        value: ${{ jobs.app-maintenance.outputs.website_bootstrap_included }}
+      applied_at:
+        description: Odoo override apply timestamp, when returned.
+        value: ${{ jobs.app-maintenance.outputs.applied_at }}
       error_message:
         description: Maintenance error message, when present.
         value: ${{ jobs.app-maintenance.outputs.error_message }}
@@ -98,6 +116,12 @@ jobs:
       application_name: ${{ steps.lp.outputs.application_name }}
       application_id: ${{ steps.lp.outputs.application_id }}
       schedule_name: ${{ steps.lp.outputs.schedule_name }}
+      post_deploy_status: ${{ steps.lp.outputs.post_deploy_status }}
+      override_status: ${{ steps.lp.outputs.override_status }}
+      override_record_found: ${{ steps.lp.outputs.override_record_found }}
+      override_payload_rendered: ${{ steps.lp.outputs.override_payload_rendered }}
+      website_bootstrap_included: ${{ steps.lp.outputs.website_bootstrap_included }}
+      applied_at: ${{ steps.lp.outputs.applied_at }}
       error_message: ${{ steps.lp.outputs.error_message }}
       trace_id: ${{ steps.lp.outputs.trace_id }}
     runs-on: ubuntu-latest
@@ -194,4 +218,10 @@ jobs:
             application_name=result.application_name,
             application_id=result.application_id,
             schedule_name=result.schedule_name,
+            post_deploy_status=result.post_deploy_status,
+            override_status=result.override_status,
+            override_record_found=result.override_record_found,
+            override_payload_rendered=result.override_payload_rendered,
+            website_bootstrap_included=result.website_bootstrap_included,
+            applied_at=result.applied_at,
             error_message=result.error_message

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -258,6 +258,9 @@ class DocsContractsTests(TestCase):
         self.assertIn('route_path="/v1/drivers/verireel/app-maintenance"', app_maintenance_workflow)
         self.assertIn('route_path="/v1/drivers/odoo/app-maintenance"', app_maintenance_workflow)
         self.assertIn("maintenance.intent=${{ inputs.intent }}", app_maintenance_workflow)
+        self.assertIn("post_deploy_status=result.post_deploy_status", app_maintenance_workflow)
+        self.assertIn("override_status=result.override_status", app_maintenance_workflow)
+        self.assertIn("applied_at=result.applied_at", app_maintenance_workflow)
 
         self.assertIn("workflow_call:", prod_rollback_workflow)
         self.assertIn("route_path=/v1/drivers/verireel/prod-rollback", prod_rollback_workflow)


### PR DESCRIPTION
## Summary
- expose Odoo post-deploy evidence outputs from the shared product-driver app-maintenance reusable workflow
- keep the Odoo app-maintenance route deploy-phase-only and leave the multi-phase Odoo post-deploy reusable untouched
- add docs-contract coverage for the new output mappings

## Plan alignment
This prepares deploy-phase Odoo callers to adopt `reusable-product-driver-app-maintenance.yml@main` with `driver: odoo` without losing post-deploy evidence outputs. It deliberately does not migrate tenant workflows that still expose `manual` or `promotion` phases.

## Validation
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/reusable-product-driver-app-maintenance.yml`
- `uv run python -m unittest tests.test_docs_contracts.DocsContractsTests`
- `git diff --check`
- `uv run --extra dev ruff check tests/test_docs_contracts.py`
- `uv run --extra dev ruff format --check tests/test_docs_contracts.py`
