### PR TITLE
Add product-driver post-deploy reusable

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -100,6 +100,7 @@
     "Reusable Product Driver Runtime Verification",
     "Reusable Product Driver Stable Deploy",
     "Reusable Product Driver App Maintenance",
+    "Reusable Product Driver Post Deploy",
     "Reusable Product Driver Testing Verification",
     "Reusable Product Driver Testing Reset",
     "Reusable Product Driver Prod Backup Gate",

--- a/.github/workflows/reusable-product-driver-post-deploy.yml
+++ b/.github/workflows/reusable-product-driver-post-deploy.yml
@@ -1,0 +1,162 @@
+---
+name: Reusable Product Driver Post Deploy
+
+"on":
+  workflow_call:
+    inputs:
+      product:
+        description: Launchplane product key.
+        required: true
+        type: string
+      driver:
+        description: Product driver id. Defaults to odoo for migration compatibility.
+        required: false
+        default: odoo
+        type: string
+      context:
+        description: Runtime context.
+        required: true
+        type: string
+      instance:
+        description: Runtime instance to run post-deploy against.
+        required: true
+        type: string
+      phase:
+        description: Driver post-deploy phase.
+        required: true
+        type: string
+      timeout-ms:
+        description: Launchplane request timeout in milliseconds.
+        required: false
+        default: "600000"
+        type: string
+      launchplane_url:
+        description: Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
+    outputs:
+      post_deploy_status:
+        description: Driver post-deploy status.
+        value: ${{ jobs.post-deploy.outputs.post_deploy_status }}
+      override_status:
+        description: Odoo override apply status, when returned by the selected driver.
+        value: ${{ jobs.post-deploy.outputs.override_status }}
+      override_record_found:
+        description: Whether an Odoo override record existed, when returned.
+        value: ${{ jobs.post-deploy.outputs.override_record_found }}
+      override_payload_rendered:
+        description: Whether an Odoo override payload was rendered, when returned.
+        value: ${{ jobs.post-deploy.outputs.override_payload_rendered }}
+      website_bootstrap_included:
+        description: Whether Odoo website bootstrap was included, when returned.
+        value: ${{ jobs.post-deploy.outputs.website_bootstrap_included }}
+      applied_at:
+        description: Driver apply timestamp, when returned.
+        value: ${{ jobs.post-deploy.outputs.applied_at }}
+      error_message:
+        description: Launchplane driver error message, when present.
+        value: ${{ jobs.post-deploy.outputs.error_message }}
+      trace_id:
+        description: Launchplane trace id for request debugging.
+        value: ${{ jobs.post-deploy.outputs.trace_id }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  post-deploy:
+    outputs:
+      post_deploy_status: ${{ steps.lp.outputs.post_deploy_status }}
+      override_status: ${{ steps.lp.outputs.override_status }}
+      override_record_found: ${{ steps.lp.outputs.override_record_found }}
+      override_payload_rendered: ${{ steps.lp.outputs.override_payload_rendered }}
+      website_bootstrap_included: ${{ steps.lp.outputs.website_bootstrap_included }}
+      applied_at: ${{ steps.lp.outputs.applied_at }}
+      error_message: ${{ steps.lp.outputs.error_message }}
+      trace_id: ${{ steps.lp.outputs.trace_id }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve Launchplane post-deploy request
+        id: request
+        env:
+          CONTEXT: ${{ inputs.context }}
+          DRIVER: ${{ inputs.driver }}
+          INSTANCE: ${{ inputs.instance }}
+          PHASE: ${{ inputs.phase }}
+          PRODUCT: ${{ inputs.product }}
+        run: |
+          set -euo pipefail
+          case "$DRIVER" in
+            odoo)
+              route_path="/v1/drivers/odoo/post-deploy"
+              idempotency_prefix="odp"
+              ;;
+            *) echo "Unsupported product driver for post-deploy: $DRIVER" >&2; exit 1 ;;
+          esac
+          for required in DRIVER PRODUCT CONTEXT INSTANCE PHASE; do
+            if [ -z "${!required}" ]; then
+              echo "${required} is required." >&2
+              exit 1
+            fi
+          done
+          {
+            echo "context=$CONTEXT"
+            printf '%s=%s:%s:%s\n' \
+              idempotency_key \
+              "$idempotency_prefix" \
+              "$CONTEXT" \
+              "${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+            echo "instance=$INSTANCE"
+            echo "phase=$PHASE"
+            echo "product=$PRODUCT"
+            echo "route_path=$route_path"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Request Launchplane post-deploy driver
+        id: lp
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
+          route-path: ${{ steps.request.outputs.route_path }}
+          payload: >-
+            {"schema_version":1,"post_deploy":{"schema_version":1}}
+          payload-fields: |-
+            product=${{ steps.request.outputs.product }}
+            post_deploy.context=${{ steps.request.outputs.context }}
+            post_deploy.instance=${{ steps.request.outputs.instance }}
+            post_deploy.phase=${{ steps.request.outputs.phase }}
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: result.post_deploy_status
+          output-paths: >-
+            trace_id=trace_id,
+            post_deploy_status=result.post_deploy_status,
+            override_status=result.override_status,
+            override_record_found=result.override_record_found,
+            override_payload_rendered=result.override_payload_rendered,
+            website_bootstrap_included=result.website_bootstrap_included,
+            applied_at=result.applied_at,
+            error_message=result.error_message
+
+      - name: Report result
+        env:
+          POST_DEPLOY_STATUS: ${{ steps.lp.outputs.post_deploy_status }}
+          OVERRIDE_STATUS: ${{ steps.lp.outputs.override_status }}
+          OVERRIDE_RECORD_FOUND: ${{ steps.lp.outputs.override_record_found }}
+          OVERRIDE_PAYLOAD_RENDERED: ${{ steps.lp.outputs.override_payload_rendered }}
+          WEBSITE_BOOTSTRAP_INCLUDED: ${{ steps.lp.outputs.website_bootstrap_included }}
+        run: |
+          echo "post_deploy_status=$POST_DEPLOY_STATUS"
+          echo "override_status=$OVERRIDE_STATUS"
+          echo "override_record_found=$OVERRIDE_RECORD_FOUND"
+          echo "override_payload_rendered=$OVERRIDE_PAYLOAD_RENDERED"
+          echo "website_bootstrap_included=$WEBSITE_BOOTSTRAP_INCLUDED"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -331,6 +331,9 @@ WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
         "inputs.timeout-ms.default": frozenset(("300000",)),
         "inputs.timeout-seconds.default": frozenset(("null",)),
     },
+    ".github/workflows/reusable-product-driver-post-deploy.yml": {
+        "inputs.driver.default": frozenset(("odoo",)),
+    },
     ".github/workflows/runner-host-hygiene.yml": {
         "inputs.action.default": frozenset(("prune_docker_cache",)),
         "inputs.minimum_free_disk_bytes.default": frozenset(("0",)),
@@ -411,6 +414,7 @@ PRODUCT_DRIVER_REUSABLE_INPUT_DEFAULT_VALUES = frozenset(
         "300",
         "30000",
         "300000",
+        "600000",
         "1800000",
         "2400000",
         "2700000",
@@ -438,6 +442,9 @@ PRODUCT_DRIVER_REUSABLE_PAYLOAD_FIELD_KEYS = frozenset(
         "maintenance.intent",
         "maintenance.preview_slug",
         "maintenance.timeout_seconds",
+        "post_deploy.context",
+        "post_deploy.instance",
+        "post_deploy.phase",
         "product",
         "promotion.artifact_id",
         "promotion.backup_record_id",
@@ -2530,10 +2537,13 @@ def _is_github_action_metadata_mechanic(*, path: str, key: str, value: object) -
     if key_text == "MAIN":
         return re.fullmatch(r"[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\.js", value_text) is not None
     if key_text == "DEFAULT":
-        return re.fullmatch(
-            r"\.[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\.mjs",
-            value_text,
-        ) is not None
+        return (
+            re.fullmatch(
+                r"\.[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)*\.mjs",
+                value_text,
+            )
+            is not None
+        )
     return False
 
 

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -490,6 +490,7 @@ The product-driver reusable surface is:
 - `reusable-product-driver-runtime-verification.yml@main`
 - `reusable-product-driver-stable-deploy.yml@main`
 - `reusable-product-driver-app-maintenance.yml@main`
+- `reusable-product-driver-post-deploy.yml@main`
 - `reusable-product-driver-testing-verification.yml@main`
 - `reusable-product-driver-testing-reset.yml@main`
 - `reusable-product-driver-prod-backup-gate.yml@main`
@@ -503,6 +504,16 @@ build/publish, release tagging, and product-specific browser checks, but it
 should not own Launchplane route construction, request envelopes, idempotency
 recipes, polling behavior, or record-output extraction once a reusable workflow
 exists.
+
+`reusable-product-driver-post-deploy.yml@main` preserves explicit driver
+post-deploy phases for existing Odoo refresh, manual, promotion, and deploy
+callers while moving request shaping into Launchplane. Odoo callers can migrate
+from `reusable-odoo-post-deploy.yml@main` without adding a driver input because
+the product-driver wrapper defaults to `driver: odoo`; they must still pass the
+same explicit `product`, `context`, `instance`, and `phase` inputs. App
+maintenance remains the deploy-phase maintenance wrapper for stable lane
+operations; product repos should not use it as a generic phase-aware post-deploy
+substitute.
 
 When a workflow operation has implied lane or maintenance semantics, prefer an
 operation-level reusable workflow over passing checked-in lane, action, or

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -494,7 +494,9 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
 
             payload = build_config_authority_audit(control_plane_root=root)
 
-        default_findings = [finding for finding in _findings(payload) if finding["key"] == "default"]
+        default_findings = [
+            finding for finding in _findings(payload) if finding["key"] == "default"
+        ]
         output_default = next(finding for finding in default_findings if finding["line"] == 5)
         product_path_default = next(finding for finding in default_findings if finding["line"] == 7)
         findings_by_key = {finding["key"]: finding for finding in _findings(payload)}
@@ -2277,6 +2279,34 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("launchplane_url", "https://example.test"),
             ("TO_INSTANCE", "${{ github.token }}"),
             ("inputs.to_instance.default", "production"),
+        ):
+            with self.subTest(key=key, value=value):
+                self.assertEqual(_allow_reason(path=path, key=key, value=value), "")
+
+    def test_product_driver_post_deploy_workflow_mechanics_are_thin_inputs(
+        self,
+    ) -> None:
+        path = ".github/workflows/reusable-product-driver-post-deploy.yml"
+        for key, value in (
+            ("inputs.timeout-ms.default", "600000"),
+            ("inputs.driver.default", "odoo"),
+            ("route-path", "${{ steps.request.outputs.route_path }}"),
+            ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("payload-fields.post_deploy.context", "${{ steps.request.outputs.context }}"),
+            ("payload-fields.post_deploy.instance", "${{ steps.request.outputs.instance }}"),
+            ("payload-fields.post_deploy.phase", "${{ steps.request.outputs.phase }}"),
+        ):
+            with self.subTest(key=key, value=value):
+                self.assertEqual(
+                    _allow_reason(path=path, key=key, value=value),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
+            ("payload-fields.post_deploy.context", "prod"),
+            ("payload-fields.post_deploy.instance", "testing"),
+            ("payload-fields.post_deploy.phase", "deploy"),
+            ("inputs.timeout-ms.default", "42"),
         ):
             with self.subTest(key=key, value=value):
                 self.assertEqual(_allow_reason(path=path, key=key, value=value), "")

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -212,6 +212,9 @@ class DocsContractsTests(TestCase):
         app_maintenance_workflow = Path(
             ".github/workflows/reusable-product-driver-app-maintenance.yml"
         ).read_text(encoding="utf-8")
+        post_deploy_workflow = Path(
+            ".github/workflows/reusable-product-driver-post-deploy.yml"
+        ).read_text(encoding="utf-8")
         prod_rollback_workflow = Path(
             ".github/workflows/reusable-product-driver-prod-rollback.yml"
         ).read_text(encoding="utf-8")
@@ -223,10 +226,17 @@ class DocsContractsTests(TestCase):
         )
         self.assertIn("reusable-product-driver-stable-deploy.yml@main", product_repo_contract)
         self.assertIn("reusable-product-driver-prod-promotion.yml@main", product_repo_contract)
+        self.assertIn("reusable-product-driver-post-deploy.yml@main", product_repo_contract)
         self.assertIn("reusable-product-driver-prod-rollback.yml@main", product_repo_contract)
         self.assertIn("route path, envelope JSON, output mapping", product_repo_contract)
         self.assertIn("transitional connectors", product_repo_contract)
         self.assertIn("should not own Launchplane route construction", product_repo_contract)
+        self.assertIn("preserves explicit driver", product_repo_contract)
+        self.assertIn("post-deploy phases", product_repo_contract)
+        self.assertIn("defaults to `driver: odoo`", product_repo_contract)
+        self.assertIn(
+            "same explicit `product`, `context`, `instance`, and `phase`", product_repo_contract
+        )
 
         self.assertIn("workflow_call:", stable_deploy_workflow)
         self.assertIn(
@@ -261,6 +271,23 @@ class DocsContractsTests(TestCase):
         self.assertIn("post_deploy_status=result.post_deploy_status", app_maintenance_workflow)
         self.assertIn("override_status=result.override_status", app_maintenance_workflow)
         self.assertIn("applied_at=result.applied_at", app_maintenance_workflow)
+
+        self.assertIn("workflow_call:", post_deploy_workflow)
+        self.assertIn("driver:", post_deploy_workflow)
+        self.assertIn("default: odoo", post_deploy_workflow)
+        self.assertIn(
+            "product:\n        description: Launchplane product key.", post_deploy_workflow
+        )
+        self.assertIn("context:\n        description: Runtime context.", post_deploy_workflow)
+        self.assertIn('route_path="/v1/drivers/odoo/post-deploy"', post_deploy_workflow)
+        self.assertIn('idempotency_prefix="odp"', post_deploy_workflow)
+        self.assertIn(
+            "post_deploy.phase=${{ steps.request.outputs.phase }}",
+            post_deploy_workflow,
+        )
+        self.assertIn("post_deploy_status=result.post_deploy_status", post_deploy_workflow)
+        self.assertIn("override_status=result.override_status", post_deploy_workflow)
+        self.assertIn("applied_at=result.applied_at", post_deploy_workflow)
 
         self.assertIn("workflow_call:", prod_rollback_workflow)
         self.assertIn("route_path=/v1/drivers/verireel/prod-rollback", prod_rollback_workflow)


### PR DESCRIPTION
## Summary
- add a product-driver post-deploy reusable workflow that currently routes Odoo callers to /v1/drivers/odoo/post-deploy
- preserve legacy Odoo migration behavior: explicit product/context/instance/phase inputs, default driver odoo, and legacy odp idempotency prefix
- document the new product-driver surface and teach the config-authority audit about the exact thin connector mechanics

## Validation
- uv run python -m unittest tests.test_docs_contracts.DocsContractsTests.test_product_driver_reusable_workflows_keep_route_shaping_in_launchplane tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_product_driver_reusable_workflow_mechanics_are_path_scoped tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_product_driver_post_deploy_workflow_mechanics_are_thin_inputs
- docker run --rm -v "/Users/cbusillo/.code/worktrees/launchplane/odoo-post-deploy-shared-contract:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/reusable-product-driver-post-deploy.yml
- uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_docs_contracts.py
- uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_docs_contracts.py
- git diff --check
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate --fail-on-findings

Review agents flagged migration risks around optional product/context and required driver; this patch keeps product/context required and defaults driver to odoo for compatibility.