### PR TITLE
Add Odoo branch to product-driver prod rollback

### DIFF
--- a/.github/workflows/reusable-product-driver-prod-rollback.yml
+++ b/.github/workflows/reusable-product-driver-prod-rollback.yml
@@ -19,13 +19,35 @@ name: Reusable Product Driver Prod Rollback
         required: false
         default: prod
         type: string
+      driver:
+        description: Product driver id. Defaults to verireel for compatibility.
+        required: false
+        default: verireel
+        type: string
       promotion_record_id:
         description: Promotion record id for the failed prod-changing action.
-        required: true
+        required: false
+        default: ""
         type: string
       backup_record_id:
         description: Backup gate record id used to authorize rollback.
-        required: true
+        required: false
+        default: ""
+        type: string
+      artifact_id:
+        description: Explicit artifact ID for Odoo rollback.
+        required: false
+        default: ""
+        type: string
+      reason:
+        description: Rollback reason for Odoo rollback evidence.
+        required: false
+        default: ""
+        type: string
+      source_channel:
+        description: Source channel for Odoo rollback. Defaults to testing.
+        required: false
+        default: testing
         type: string
       snapshot_name:
         description: Backup snapshot name, when available.
@@ -74,10 +96,10 @@ name: Reusable Product Driver Prod Rollback
         description: Rollback health verification status.
         value: ${{ jobs.prod-rollback.outputs.rollback_health_status }}
       rollback_started_at:
-        description: Rollback start timestamp.
+        description: Rollback start timestamp for drivers that return one.
         value: ${{ jobs.prod-rollback.outputs.rollback_started_at }}
       rollback_finished_at:
-        description: Rollback finish timestamp.
+        description: Rollback finish timestamp for drivers that return one.
         value: ${{ jobs.prod-rollback.outputs.rollback_finished_at }}
       error_message:
         description: Rollback error message, when present.
@@ -85,6 +107,15 @@ name: Reusable Product Driver Prod Rollback
       trace_id:
         description: Launchplane trace id for request debugging.
         value: ${{ jobs.prod-rollback.outputs.trace_id }}
+      deployment_record_id:
+        description: Deployment record ID for drivers that write one.
+        value: ${{ jobs.prod-rollback.outputs.deployment_record_id }}
+      release_tuple_id:
+        description: Release tuple ID for drivers that write one.
+        value: ${{ jobs.prod-rollback.outputs.release_tuple_id }}
+      post_deploy_status:
+        description: Post-deploy status for drivers that run post-deploy after rollback.
+        value: ${{ jobs.prod-rollback.outputs.post_deploy_status }}
 
 permissions:
   contents: read
@@ -93,61 +124,90 @@ permissions:
 jobs:
   prod-rollback:
     outputs:
-      promotion_record_id: ${{ steps.lp.outputs.promotion_record_id }}
-      backup_record_id: ${{ steps.lp.outputs.backup_record_id }}
-      snapshot_name: ${{ steps.lp.outputs.snapshot_name }}
-      rollback_status: ${{ steps.lp.outputs.rollback_status }}
-      rollback_health_status: ${{ steps.lp.outputs.rollback_health_status }}
-      rollback_started_at: ${{ steps.lp.outputs.rollback_started_at }}
-      rollback_finished_at: ${{ steps.lp.outputs.rollback_finished_at }}
-      error_message: ${{ steps.lp.outputs.error_message }}
-      trace_id: ${{ steps.lp.outputs.trace_id }}
+      promotion_record_id: ${{ steps.lp_verireel.outputs.promotion_record_id || steps.lp_odoo.outputs.promotion_record_id }}
+      backup_record_id: ${{ steps.lp_verireel.outputs.backup_record_id }}
+      snapshot_name: ${{ steps.lp_verireel.outputs.snapshot_name }}
+      rollback_status: ${{ steps.lp_verireel.outputs.rollback_status || steps.lp_odoo.outputs.rollback_status }}
+      rollback_health_status: ${{ steps.lp_verireel.outputs.rollback_health_status || steps.lp_odoo.outputs.rollback_health_status }}
+      rollback_started_at: ${{ steps.lp_verireel.outputs.rollback_started_at || steps.lp_odoo.outputs.rollback_started_at }}
+      rollback_finished_at: ${{ steps.lp_verireel.outputs.rollback_finished_at || steps.lp_odoo.outputs.rollback_finished_at }}
+      error_message: ${{ steps.lp_verireel.outputs.error_message || steps.lp_odoo.outputs.error_message }}
+      trace_id: ${{ steps.lp_verireel.outputs.trace_id || steps.lp_odoo.outputs.trace_id }}
+      deployment_record_id: ${{ steps.lp_odoo.outputs.deployment_record_id }}
+      release_tuple_id: ${{ steps.lp_odoo.outputs.release_tuple_id }}
+      post_deploy_status: ${{ steps.lp_odoo.outputs.post_deploy_status }}
     runs-on: ubuntu-latest
     steps:
       - name: Resolve Launchplane prod rollback request
         id: request
         env:
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
           BACKUP_RECORD_ID: ${{ inputs.backup_record_id }}
           CONTEXT: ${{ inputs.context }}
+          DRIVER: ${{ inputs.driver }}
           INSTANCE: ${{ inputs.instance }}
           PRODUCT: ${{ inputs.product }}
           PROMOTION_RECORD_ID: ${{ inputs.promotion_record_id }}
+          REASON: ${{ inputs.reason }}
+          SOURCE_CHANNEL: ${{ inputs.source_channel }}
         run: |
           set -euo pipefail
-          if [ -z "$PRODUCT" ]; then
-            PRODUCT="${GITHUB_REPOSITORY#*/}"
-          fi
-          if [ -z "$CONTEXT" ]; then
-            CONTEXT="$PRODUCT"
-          fi
+          DRIVER="${DRIVER,,}"
           if [ -z "$INSTANCE" ]; then
             INSTANCE="prod"
           fi
-          for required in PRODUCT CONTEXT INSTANCE PROMOTION_RECORD_ID BACKUP_RECORD_ID; do
+          if [ "$DRIVER" = "verireel" ]; then
+            if [ -z "$PRODUCT" ]; then
+              PRODUCT="${GITHUB_REPOSITORY#*/}"
+            fi
+            if [ -z "$CONTEXT" ]; then
+              CONTEXT="$PRODUCT"
+            fi
+            required_inputs="PRODUCT CONTEXT INSTANCE PROMOTION_RECORD_ID BACKUP_RECORD_ID"
+            route_path="/v1/drivers/verireel/prod-rollback"
+          elif [ "$DRIVER" = "odoo" ]; then
+            required_inputs="PRODUCT CONTEXT INSTANCE ARTIFACT_ID REASON"
+            route_path="/v1/drivers/odoo/prod-rollback"
+            if [ "$INSTANCE" != "prod" ]; then
+              echo "Odoo prod rollback requires instance 'prod'." >&2
+              exit 1
+            fi
+            if [ -z "$SOURCE_CHANNEL" ]; then
+              SOURCE_CHANNEL="testing"
+            fi
+            if [ "$SOURCE_CHANNEL" != "testing" ]; then
+              echo "Odoo prod rollback requires source_channel 'testing'." >&2
+              exit 1
+            fi
+          else
+            echo "Unsupported driver: $DRIVER" >&2
+            exit 1
+          fi
+          for required in $required_inputs; do
             if [ -z "${!required}" ]; then
               echo "${required} is required." >&2
               exit 1
             fi
           done
           run_scope="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          if [ "$DRIVER" = "odoo" ]; then
+            idempotency_key="opr:$CONTEXT:$run_scope"
+          else
+            idempotency_key="product-driver-prod-rollback:$PRODUCT:$CONTEXT:$INSTANCE:$PROMOTION_RECORD_ID:$BACKUP_RECORD_ID:$run_scope"
+          fi
           {
             echo "context=$CONTEXT"
-            printf '%s=%s:%s:%s:%s:%s:%s:%s\n' \
-              idempotency_key \
-              product-driver-prod-rollback \
-              "$PRODUCT" \
-              "$CONTEXT" \
-              "$INSTANCE" \
-              "$PROMOTION_RECORD_ID" \
-              "$BACKUP_RECORD_ID" \
-              "$run_scope"
+            echo "driver=$DRIVER"
+            echo "idempotency_key=$idempotency_key"
             echo "instance=$INSTANCE"
             echo "product=$PRODUCT"
-            echo "route_path=/v1/drivers/verireel/prod-rollback"
+            echo "route_path=$route_path"
+            echo "source_channel=$SOURCE_CHANNEL"
           } >>"$GITHUB_OUTPUT"
 
-      - name: Request Launchplane prod rollback
-        id: lp
+      - name: Request Launchplane VeriReel prod rollback
+        id: lp_verireel
+        if: ${{ steps.request.outputs.driver == 'verireel' }}
         uses: cbusillo/launchplane/.github/actions/launchplane-request@main
         with:
           launchplane-url: >-
@@ -182,4 +242,43 @@ jobs:
             rollback_health_status=result.rollback_health_status,
             rollback_started_at=result.rollback_started_at,
             rollback_finished_at=result.rollback_finished_at,
+            error_message=result.error_message
+
+      - name: Request Launchplane Odoo prod rollback
+        id: lp_odoo
+        if: ${{ steps.request.outputs.driver == 'odoo' }}
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
+          route-path: ${{ steps.request.outputs.route_path }}
+          payload: |-
+            {
+              "schema_version": 1,
+              "rollback": {
+                "schema_version": 1
+              }
+            }
+          payload-fields: |-
+            product=${{ steps.request.outputs.product }}
+            rollback.context=${{ steps.request.outputs.context }}
+            rollback.instance=${{ steps.request.outputs.instance }}
+            rollback.source_channel=${{ steps.request.outputs.source_channel }}
+            rollback.promotion_record_id=${{ inputs.promotion_record_id }}
+            rollback.artifact_id=${{ inputs.artifact_id }}
+            rollback.reason=${{ inputs.reason }}
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: result.rollback_status,result.rollback_health_status,result.post_deploy_status
+          output-paths: >-
+            trace_id=trace_id,
+            promotion_record_id=result.promotion_record_id,
+            deployment_record_id=result.deployment_record_id,
+            release_tuple_id=result.release_tuple_id,
+            rollback_status=result.rollback_status,
+            rollback_health_status=result.rollback_health_status,
+            rollback_started_at=result.rollback_started_at,
+            rollback_finished_at=result.rollback_finished_at,
+            post_deploy_status=result.post_deploy_status,
             error_message=result.error_message

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -331,6 +331,10 @@ WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
     ".github/workflows/reusable-product-driver-post-deploy.yml": {
         "inputs.driver.default": frozenset(("odoo",)),
     },
+    ".github/workflows/reusable-product-driver-prod-rollback.yml": {
+        "inputs.driver.default": frozenset(("verireel",)),
+        "inputs.source_channel.default": frozenset(("testing",)),
+    },
     ".github/workflows/runner-host-hygiene.yml": {
         "inputs.action.default": frozenset(("prune_docker_cache",)),
         "inputs.minimum_free_disk_bytes.default": frozenset(("0",)),
@@ -450,10 +454,13 @@ PRODUCT_DRIVER_REUSABLE_PAYLOAD_FIELD_KEYS = frozenset(
         "promotion.to_instance",
         "rollback.backup_record_id",
         "rollback.context",
+        "rollback.artifact_id",
         "rollback.expected_build_revision",
         "rollback.expected_build_tag",
         "rollback.instance",
         "rollback.promotion_record_id",
+        "rollback.reason",
+        "rollback.source_channel",
         "rollback.snapshot_name",
         "verification.context",
         "verification.deployment_record_id",

--- a/control_plane/odoo_prod_rollback_http.py
+++ b/control_plane/odoo_prod_rollback_http.py
@@ -83,6 +83,8 @@ def execute_odoo_prod_rollback_result(
         "release_tuple_id": driver_result.release_tuple_id,
         "rollback_status": driver_result.rollback_status,
         "rollback_health_status": driver_result.rollback_health_status,
+        "rollback_started_at": driver_result.rollback_started_at,
+        "rollback_finished_at": driver_result.rollback_finished_at,
         "post_deploy_status": driver_result.post_deploy_status,
     }
     return records, result

--- a/control_plane/workflows/odoo_prod_rollback.py
+++ b/control_plane/workflows/odoo_prod_rollback.py
@@ -134,6 +134,8 @@ class OdooProdRollbackResult(BaseModel):
     release_tuple_id: str = ""
     rollback_status: Literal["pass", "fail"]
     rollback_health_status: Literal["pass", "fail", "skipped"] = "skipped"
+    rollback_started_at: str = ""
+    rollback_finished_at: str = ""
     post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
     error_message: str = ""
 
@@ -395,6 +397,8 @@ def execute_odoo_prod_rollback(
             deployment_record_id=deployment_record_id,
             rollback_status="fail",
             rollback_health_status=health_status,
+            rollback_started_at=started_at,
+            rollback_finished_at=finished_at,
             post_deploy_status=post_deploy_status,
             error_message=str(error),
         )
@@ -428,5 +432,7 @@ def execute_odoo_prod_rollback(
         release_tuple_id=replacement_result.release_tuple_id,
         rollback_status="pass",
         rollback_health_status=health_status,
+        rollback_started_at=started_at,
+        rollback_finished_at=finished_at,
         post_deploy_status=replacement_result.post_deploy_status,
     )

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -516,6 +516,18 @@ operations; product repos should not use it as a generic phase-aware post-deploy
 substitute. The old Odoo-specific post-deploy reusable has been retired after
 tenant callers moved to the product-driver wrapper.
 
+`reusable-product-driver-prod-rollback.yml@main` keeps the existing VeriReel
+rollback surface as its compatibility default and also supports explicit
+`driver: odoo` callers. Odoo rollback callers pass the same primitive rollback
+facts as the older Odoo-specific reusable: explicit `product`, explicit
+`context`, `artifact_id`, optional `promotion_record_id`, and `reason`. The
+wrapper keeps Odoo's source channel fixed to `testing`; callers should omit
+`source_channel` unless they are intentionally relying on that compatibility
+default. The product-driver wrapper owns the `/v1/drivers/odoo/prod-rollback`
+route, payload envelope, output mapping, fail-result paths, and legacy
+`opr:<context>:<run>` idempotency key shape so tenant repos do not keep Odoo
+rollback request construction locally.
+
 When a workflow operation has implied lane or maintenance semantics, prefer an
 operation-level reusable workflow over passing checked-in lane, action, or
 intent strings from the product repository. For example, a product repo should

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2299,6 +2299,50 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             with self.subTest(key=key, value=value):
                 self.assertEqual(_allow_reason(path=path, key=key, value=value), "")
 
+    def test_product_driver_prod_rollback_workflow_mechanics_are_thin_inputs(
+        self,
+    ) -> None:
+        path = ".github/workflows/reusable-product-driver-prod-rollback.yml"
+        for key, value in (
+            ("inputs.timeout-ms.default", "1800000"),
+            ("inputs.driver.default", "verireel"),
+            ("inputs.source_channel.default", "testing"),
+            ("route-path", "${{ steps.request.outputs.route_path }}"),
+            ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("payload-fields.rollback.context", "${{ steps.request.outputs.context }}"),
+            ("payload-fields.rollback.instance", "${{ steps.request.outputs.instance }}"),
+            (
+                "payload-fields.rollback.source_channel",
+                "${{ steps.request.outputs.source_channel }}",
+            ),
+            ("payload-fields.rollback.backup_record_id", "${{ inputs.backup_record_id }}"),
+            ("payload-fields.rollback.artifact_id", "${{ inputs.artifact_id }}"),
+            (
+                "payload-fields.rollback.promotion_record_id",
+                "${{ inputs.promotion_record_id }}",
+            ),
+            ("payload-fields.rollback.reason", "${{ inputs.reason }}"),
+            ("payload-fields.rollback.snapshot_name", "${{ inputs.snapshot_name }}"),
+        ):
+            with self.subTest(key=key, value=value):
+                self.assertEqual(
+                    _allow_reason(path=path, key=key, value=value),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
+            ("inputs.driver.default", "odoo"),
+            ("inputs.source_channel.default", "staging"),
+            ("payload-fields.rollback.context", "prod"),
+            ("payload-fields.rollback.instance", "testing"),
+            ("payload-fields.rollback.source_channel", "testing"),
+            ("payload-fields.rollback.artifact_id", "artifact-hardcoded"),
+            ("payload-fields.rollback.reason", "manual rollback"),
+            ("inputs.timeout-ms.default", "42"),
+        ):
+            with self.subTest(key=key, value=value):
+                self.assertEqual(_allow_reason(path=path, key=key, value=value), "")
+
     def test_product_driver_operation_wrapper_literals_are_exact_path_scoped(
         self,
     ) -> None:

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -237,6 +237,13 @@ class DocsContractsTests(TestCase):
         self.assertIn(
             "same explicit `product`, `context`, `instance`, and `phase`", product_repo_contract
         )
+        self.assertIn("keeps the existing VeriReel", product_repo_contract)
+        self.assertIn("also supports explicit", product_repo_contract)
+        self.assertIn("`driver: odoo` callers", product_repo_contract)
+        self.assertIn("explicit `product`, explicit", product_repo_contract)
+        self.assertIn("source channel fixed to `testing`", product_repo_contract)
+        self.assertIn("legacy", product_repo_contract)
+        self.assertIn("`opr:<context>:<run>`", product_repo_contract)
 
         self.assertIn("workflow_call:", stable_deploy_workflow)
         self.assertIn(
@@ -290,8 +297,40 @@ class DocsContractsTests(TestCase):
         self.assertIn("applied_at=result.applied_at", post_deploy_workflow)
 
         self.assertIn("workflow_call:", prod_rollback_workflow)
-        self.assertIn("route_path=/v1/drivers/verireel/prod-rollback", prod_rollback_workflow)
+        self.assertIn("driver:", prod_rollback_workflow)
+        self.assertIn("default: verireel", prod_rollback_workflow)
+        self.assertIn(
+            'route_path="/v1/drivers/verireel/prod-rollback"',
+            prod_rollback_workflow,
+        )
+        self.assertIn('route_path="/v1/drivers/odoo/prod-rollback"', prod_rollback_workflow)
+        self.assertIn(
+            "Odoo prod rollback requires source_channel 'testing'.",
+            prod_rollback_workflow,
+        )
+        self.assertIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', prod_rollback_workflow)
+        self.assertIn('CONTEXT="$PRODUCT"', prod_rollback_workflow)
+        self.assertIn(
+            'required_inputs="PRODUCT CONTEXT INSTANCE ARTIFACT_ID REASON"',
+            prod_rollback_workflow,
+        )
+        self.assertIn('echo "${required} is required."', prod_rollback_workflow)
+        self.assertIn('idempotency_key="opr:$CONTEXT:$run_scope"', prod_rollback_workflow)
         self.assertIn(
             "rollback.backup_record_id=${{ inputs.backup_record_id }}", prod_rollback_workflow
         )
+        self.assertIn("rollback.artifact_id=${{ inputs.artifact_id }}", prod_rollback_workflow)
+        self.assertIn("rollback.reason=${{ inputs.reason }}", prod_rollback_workflow)
+        self.assertIn(
+            "rollback_health_status=result.rollback_health_status", prod_rollback_workflow
+        )
+        self.assertIn("rollback_started_at=result.rollback_started_at", prod_rollback_workflow)
+        self.assertIn("rollback_finished_at=result.rollback_finished_at", prod_rollback_workflow)
+        self.assertIn(
+            "rollback.source_channel=${{ steps.request.outputs.source_channel }}",
+            prod_rollback_workflow,
+        )
         self.assertIn("rollback.snapshot_name=${{ inputs.snapshot_name }}", prod_rollback_workflow)
+        self.assertIn("deployment_record_id=result.deployment_record_id", prod_rollback_workflow)
+        self.assertIn("release_tuple_id=result.release_tuple_id", prod_rollback_workflow)
+        self.assertIn("post_deploy_status=result.post_deploy_status", prod_rollback_workflow)

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -4482,6 +4482,8 @@ class FastApiOdooProdRollbackTests(unittest.IsolatedAsyncioTestCase):
             release_tuple_id=release_tuple_id,
             rollback_status=rollback_status,
             rollback_health_status="pass" if rollback_status == "pass" else "fail",
+            rollback_started_at="2026-04-26T12:04:00Z",
+            rollback_finished_at="2026-04-26T12:05:00Z",
             post_deploy_status="pass" if rollback_status == "pass" else "skipped",
             error_message="rollback failed" if rollback_status == "fail" else "",
         )
@@ -4525,11 +4527,15 @@ class FastApiOdooProdRollbackTests(unittest.IsolatedAsyncioTestCase):
                 "release_tuple_id",
                 "rollback_status",
                 "rollback_health_status",
+                "rollback_started_at",
+                "rollback_finished_at",
                 "post_deploy_status",
             },
         )
         self.assertEqual(payload["result"]["rollback_status"], "pass")
         self.assertEqual(payload["result"]["rollback_health_status"], "pass")
+        self.assertEqual(payload["result"]["rollback_started_at"], "2026-04-26T12:04:00Z")
+        self.assertEqual(payload["result"]["rollback_finished_at"], "2026-04-26T12:05:00Z")
         self.assertEqual(payload["result"]["post_deploy_status"], "pass")
         execute_mock.assert_called_once()
 


### PR DESCRIPTION
## Summary

- Extend `reusable-product-driver-prod-rollback.yml` with an explicit `driver: odoo` branch while preserving the existing `verireel` default.
- Keep Odoo rollback fail-closed: explicit product/context/artifact/reason, prod-only instance, testing-only source channel, and the legacy `opr:<context>:<run>` idempotency shape.
- Expose Odoo rollback start/finish timestamps through the HTTP result so product-driver rollback outputs are populated for both drivers.
- Update config-authority allowlists, docs, and contract tests for the new wrapper shape.

## Validation

- `uv run python -m py_compile control_plane/config_authority_audit.py control_plane/odoo_prod_rollback_http.py control_plane/workflows/odoo_prod_rollback.py tests/test_config_authority_audit.py tests/test_docs_contracts.py tests/test_http_app_driver_odoo.py`
- `uv run python -m unittest tests.test_odoo_prod_rollback tests.test_http_app_driver_odoo.FastApiOdooProdRollbackTests tests.test_docs_contracts tests.test_config_authority_audit`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 .github/workflows/reusable-product-driver-prod-rollback.yml`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py control_plane/odoo_prod_rollback_http.py control_plane/workflows/odoo_prod_rollback.py tests/test_config_authority_audit.py tests/test_docs_contracts.py tests/test_http_app_driver_odoo.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py control_plane/odoo_prod_rollback_http.py control_plane/workflows/odoo_prod_rollback.py tests/test_config_authority_audit.py tests/test_docs_contracts.py tests/test_http_app_driver_odoo.py`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate --fail-on-findings`

## Review

Read-only review agents covered workflow compatibility, Odoo fail-closed behavior, output mapping, config authority, and docs/tests. Findings addressed before opening: explicit Odoo product/context requirement, non-retired wording for the older Odoo-specific reusable, source-channel docs, and Odoo rollback timestamp outputs.

Refs #1529
Refs #898
