### PR TITLE
Harden Odoo preview apply smoke contract

### DIFF
--- a/.github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs
+++ b/.github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs
@@ -206,21 +206,23 @@ export function buildOdooPreviewApplyRequest(options = {}) {
     true,
     "Odoo preview waitForDeploy",
   );
-  const smokeCheck = parseOptionalBoolean(
-    options.smokeCheck,
-    facts.operation === "refresh",
-    "Odoo preview smokeCheck",
-  );
+  const applyPayload = {
+    timeout_seconds: 600,
+    wait_for_deploy: waitForDeploy,
+  };
+  if (options.smokeCheck !== undefined && options.smokeCheck !== null && options.smokeCheck !== "") {
+    applyPayload.smoke_check = parseOptionalBoolean(
+      options.smokeCheck,
+      false,
+      "Odoo preview smokeCheck",
+    );
+  }
   return requestEnvelope({
     routePath: ODOO_PREVIEW_APPLY_ROUTE,
     payload: {
       schema_version: 1,
       product: facts.product,
-      apply: {
-        timeout_seconds: 600,
-        wait_for_deploy: waitForDeploy,
-        smoke_check: smokeCheck,
-      },
+      apply: applyPayload,
     },
     payloadJsonFiles,
     idempotencyKey:

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -221,21 +221,27 @@ def build_odoo_preview_apply_workflow_request(
     wait_for_deploy: bool = True,
     smoke_check: bool | None = None,
 ) -> OdooPreviewWorkflowRequest:
+    dry_run_plan_file = _required_text(
+        dry_run_plan_file,
+        "Odoo preview apply request requires dry_run_plan_file.",
+    )
     if facts.operation == "refresh" and not manifest_file.strip():
         raise ValueError("Odoo preview refresh apply request requires manifest_file.")
     payload_json_files = {"apply.dry_run_plan": dry_run_plan_file}
     if manifest_file.strip():
         payload_json_files["apply.manifest"] = manifest_file.strip()
+    apply_payload: dict[str, object] = {
+        "timeout_seconds": 600,
+        "wait_for_deploy": wait_for_deploy,
+    }
+    if smoke_check is not None:
+        apply_payload["smoke_check"] = smoke_check
     return OdooPreviewWorkflowRequest(
         route_path=ODOO_PREVIEW_APPLY_ROUTE,
         payload={
             "schema_version": 1,
             "product": facts.product,
-            "apply": {
-                "timeout_seconds": 600,
-                "wait_for_deploy": wait_for_deploy,
-                "smoke_check": facts.operation == "refresh" if smoke_check is None else smoke_check,
-            },
+            "apply": apply_payload,
         },
         payload_json_files=payload_json_files,
         idempotency_key=(
@@ -860,6 +866,7 @@ class OdooPreviewDokployDryRunRequest(BaseModel):
     no_cache: bool = False
     delete_volumes: bool = True
     runtime_port: int = Field(default=8069, ge=1)
+    smoke_check: bool = True
     compose_name: str = ""
     environment_id: str = ""
     template_compose_id: str = ""
@@ -985,7 +992,7 @@ class OdooPreviewDokployApplyRequest(BaseModel):
     health_path: str = DEFAULT_ODOO_RUNTIME_HEALTH_PATH
     timeout_seconds: int = Field(default=300, ge=1)
     wait_for_deploy: bool = True
-    smoke_check: bool = True
+    smoke_check: bool | None = None
 
     @model_validator(mode="after")
     def _normalize_request(self) -> "OdooPreviewDokployApplyRequest":
@@ -1007,6 +1014,10 @@ class OdooPreviewDokployApplyRequest(BaseModel):
         self.environment_values = {
             key.strip(): value for key, value in self.environment_values.items() if key.strip()
         }
+        if self.smoke_check is None:
+            self.smoke_check = any(
+                operation.name == "smoke_check" for operation in self.dry_run_plan.operations
+            )
         return self
 
 
@@ -1467,21 +1478,27 @@ def _wait_for_smoke_check(*, preview_url: str, health_path: str, timeout_seconds
         smoke_url,
         headers={"Accept": "application/json, text/plain, */*", "Cache-Control": "no-store"},
     )
-    deadline = timeout_seconds
+    deadline = time.monotonic() + timeout_seconds
     last_http_status: int | None = None
-    while deadline > 0:
+    while True:
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            break
         try:
-            with urlopen(request, timeout=min(15, deadline)) as response:
+            with urlopen(request, timeout=min(15, remaining_seconds)) as response:
                 response.read()
-            if 200 <= response.status < 400:
+                status = response.status
+            if 200 <= status < 400:
                 return
         except HTTPError as exc:
             last_http_status = exc.code
         except (TimeoutError, URLError, ValueError):
             pass
-        sleep_seconds = min(5, deadline)
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            break
+        sleep_seconds = min(5, remaining_seconds)
         time.sleep(sleep_seconds)
-        deadline -= sleep_seconds
     if last_http_status is not None:
         raise click.ClickException(f"Odoo preview smoke check returned HTTP {last_http_status}.")
     raise click.ClickException(f"Timed out waiting for Odoo preview smoke check {smoke_url}.")
@@ -1610,13 +1627,16 @@ def _operations(
                 target=compose_ref,
                 payload_keys=("composeId",),
             ),
+        )
+    )
+    if request.smoke_check:
+        operations.append(
             OdooPreviewDokployOperation(
                 name="smoke_check",
                 method="LOCAL",
                 target=runtime_plan.preview_url,
-            ),
+            )
         )
-    )
     return tuple(operations)
 
 

--- a/tests/test_odoo_preview_request_client_action.py
+++ b/tests/test_odoo_preview_request_client_action.py
@@ -210,7 +210,7 @@ console.log(JSON.stringify({ inputs, apply }));
         self.assertEqual(
             payload["apply"]["payloadJsonFiles"], {"apply.dry_run_plan": "/tmp/dry-run.json"}
         )
-        self.assertFalse(payload["apply"]["payload"]["apply"]["smoke_check"])
+        self.assertNotIn("smoke_check", payload["apply"]["payload"]["apply"])
         self.assertEqual(
             payload["apply"]["idempotencyKey"],
             "odoo-preview-apply:odoo-tenant-cm-website:pr-42:destroy:run-456-attempt-2",
@@ -249,6 +249,40 @@ console.log(JSON.stringify(request.payload.apply));
                 "timeout_seconds": 600,
                 "wait_for_deploy": False,
                 "smoke_check": True,
+            },
+        )
+
+    def test_client_omits_refresh_smoke_check_without_override(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "odoo-preview-client.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildOdooPreviewApplyRequest({
+  product: 'odoo-tenant-cm-website',
+  context: 'cm_website',
+  prNumber: 42,
+  sourceGitRef: 'abc123',
+  dryRunPlanFile: '/tmp/dry-run.json',
+  manifestFile: '/tmp/preview-artifact.json',
+  runId: '456',
+  runAttempt: '2',
+});
+console.log(JSON.stringify(request.payload.apply));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        apply = json.loads(result.stdout)
+        self.assertEqual(
+            apply,
+            {
+                "timeout_seconds": 600,
+                "wait_for_deploy": True,
             },
         )
 

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -4,7 +4,7 @@ from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import Iterator, Literal, cast
 from unittest.mock import ANY, patch
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 
 import click
 
@@ -433,7 +433,6 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
                 "apply": {
                     "timeout_seconds": 600,
                     "wait_for_deploy": True,
-                    "smoke_check": True,
                 },
             },
         )
@@ -463,6 +462,18 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             {"timeout_seconds": 600, "wait_for_deploy": False, "smoke_check": True},
         )
 
+    def test_preview_apply_workflow_request_accepts_refresh_smoke_disabled(self) -> None:
+        request = build_odoo_preview_apply_workflow_request(
+            facts=_workflow_facts(),
+            dry_run_plan_file="/tmp/dry-run.json",
+            manifest_file="/tmp/preview-artifact.json",
+            smoke_check=False,
+        )
+
+        apply = cast(dict[str, object], request.payload["apply"])
+        self.assertIsInstance(apply, dict)
+        self.assertEqual(apply["smoke_check"], False)
+
     def test_destroy_preview_apply_request_skips_manifest_and_smoke(self) -> None:
         request = build_odoo_preview_apply_workflow_request(
             facts=_workflow_facts(operation="destroy"),
@@ -474,7 +485,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         )
         apply = cast(dict[str, object], request.payload["apply"])
         self.assertIsInstance(apply, dict)
-        self.assertEqual(apply["smoke_check"], False)
+        self.assertNotIn("smoke_check", apply)
         self.assertEqual(
             request.idempotency_key,
             "odoo-preview-apply:odoo-tenant-cm-website:pr-42:destroy:run-456-attempt-2",
@@ -485,6 +496,14 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             build_odoo_preview_apply_workflow_request(
                 facts=_workflow_facts(),
                 dry_run_plan_file="/tmp/dry-run.json",
+            )
+
+    def test_preview_apply_workflow_request_requires_dry_run_plan_file(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires dry_run_plan_file"):
+            build_odoo_preview_apply_workflow_request(
+                facts=_workflow_facts(),
+                dry_run_plan_file=" ",
+                manifest_file="/tmp/preview-artifact.json",
             )
 
     def test_builder_accepts_product_profile_preview_slug_token_without_payload_authority(
@@ -1060,6 +1079,59 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             )
         )
 
+    def test_refresh_dry_run_omits_smoke_check_when_disabled(self) -> None:
+        plan = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(),
+                endpoint_spec=_endpoint_spec(),
+                environment_id="env-cm-preview",
+                template_compose_id="compose-template",
+                smoke_check=False,
+            )
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertNotIn("smoke_check", [operation.name for operation in plan.operations])
+
+    def test_apply_inherits_smoke_check_disabled_from_dry_run_plan(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(),
+                endpoint_spec=_endpoint_spec(),
+                environment_id="env-cm-preview",
+                template_compose_id="compose-template",
+                smoke_check=False,
+            )
+        )
+
+        request = OdooPreviewDokployApplyRequest(
+            dry_run_plan=dry_run,
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            environment_values=_environment_values(),
+        )
+
+        self.assertFalse(request.smoke_check)
+
+    def test_apply_allows_explicit_smoke_check_override(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(),
+                endpoint_spec=_endpoint_spec(),
+                environment_id="env-cm-preview",
+                template_compose_id="compose-template",
+                smoke_check=False,
+            )
+        )
+
+        request = OdooPreviewDokployApplyRequest(
+            dry_run_plan=dry_run,
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            environment_values=_environment_values(),
+            smoke_check=True,
+        )
+
+        self.assertTrue(request.smoke_check)
+
     def test_refresh_existing_runtime_does_not_plan_delete_rollback(self) -> None:
         plan = build_odoo_preview_dokploy_dry_run(
             request=OdooPreviewDokployDryRunRequest(
@@ -1358,6 +1430,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(result.compose_id, "compose-cm-pr-45")
         self.assertEqual(result.domain_id, "domain-cm-pr-45")
         self.assertFalse(result.created_compose)
+        self.assertNotIn("smoke_check", [step.name for step in result.steps])
         delete_domain.assert_not_called()
         delete_compose.assert_not_called()
 
@@ -1543,8 +1616,8 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             ["/api/domain.byComposeId", "/api/domain.delete", "/api/compose.delete"],
         )
 
-    @staticmethod
-    def test_smoke_check_retries_transient_http_404() -> None:
+    def test_smoke_check_retries_transient_http_404(self) -> None:
+        clock = _FakeClock(start=0)
         responses: list[HTTPError | _SmokeResponse] = [
             HTTPError(
                 "https://pr-45.cm-preview.example.test/launchplane/health",
@@ -1566,8 +1639,13 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             patch(
                 "control_plane.workflows.odoo_preview_runtime.urlopen", side_effect=_fake_urlopen
             ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.time.monotonic",
+                side_effect=clock.monotonic,
+            ),
             patch("control_plane.workflows.odoo_preview_runtime.time.sleep") as sleep,
         ):
+            sleep.side_effect = clock.sleep
             _wait_for_smoke_check(
                 preview_url="https://pr-45.cm-preview.example.test/",
                 health_path="/launchplane/health",
@@ -1576,15 +1654,71 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
 
         sleep.assert_called_once_with(5)
 
+    def test_smoke_check_uses_status_before_response_closes(self) -> None:
+        clock = _FakeClock(start=0)
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.urlopen",
+                return_value=_SmokeResponse(status=204, clear_status_on_exit=True),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.time.monotonic",
+                side_effect=clock.monotonic,
+            ),
+            patch("control_plane.workflows.odoo_preview_runtime.time.sleep") as sleep,
+        ):
+            _wait_for_smoke_check(
+                preview_url="https://pr-45.cm-preview.example.test/",
+                health_path="/launchplane/health",
+                timeout_seconds=10,
+            )
+
+        sleep.assert_not_called()
+
+    def test_smoke_check_raises_timeout_when_attempts_are_exhausted(self) -> None:
+        clock = _FakeClock(start=0)
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.urlopen",
+                side_effect=URLError("not ready"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.time.monotonic",
+                side_effect=clock.monotonic,
+            ),
+            patch("control_plane.workflows.odoo_preview_runtime.time.sleep") as sleep,
+            self.assertRaisesRegex(click.ClickException, "Timed out waiting"),
+        ):
+            sleep.side_effect = clock.sleep
+            _wait_for_smoke_check(
+                preview_url="https://pr-45.cm-preview.example.test/",
+                health_path="/launchplane/health",
+                timeout_seconds=2,
+            )
+
+
+class _FakeClock:
+    def __init__(self, *, start: float = 0) -> None:
+        self.now = start
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
 
 class _SmokeResponse:
-    def __init__(self, *, status: int) -> None:
+    def __init__(self, *, status: int, clear_status_on_exit: bool = False) -> None:
         self.status = status
+        self._clear_status_on_exit = clear_status_on_exit
 
     def __enter__(self) -> "_SmokeResponse":
         return self
 
     def __exit__(self, *_args: object) -> None:
+        if self._clear_status_on_exit:
+            self.status = 0
         return None
 
     @staticmethod


### PR DESCRIPTION
## Summary
- make Odoo preview dry-run plans the default source of smoke_check intent
- omit apply smoke_check from Python and action request builders unless explicitly overridden
- tighten apply workflow inputs and smoke-check timeout/status handling
- add Python and action-client coverage for default inheritance and explicit overrides

## Validation
- node --check .github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs
- node --check .github/actions/setup-odoo-preview-request-client/dist/index.js
- python -m py_compile control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py tests/test_odoo_preview_request_client_action.py
- uv run python -m unittest tests.test_odoo_preview_runtime tests.test_odoo_preview_request_client_action tests.test_odoo_artifact_publish_inputs tests.test_http_app_driver_odoo tests.test_docs_contracts
- uv run --extra dev ruff check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py tests/test_odoo_preview_request_client_action.py
- uv run --extra dev ruff format --check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py tests/test_odoo_preview_request_client_action.py
- git diff --check
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate --fail-on-findings (pass; report-only preexisting findings, .mjs scanner coverage gap covered by JS syntax/action tests)
- JetBrains changed-files inspection: green

## Review
- Review agents checked smoke_check inheritance, Python/JS parity, timeout handling, and config-authority risk. Findings were patched before this PR.