### PR TITLE
Classify VeriReel smoke maintenance secret

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -27,6 +27,15 @@ ALLOW_REASON_OPERATOR_SUPPLIED_RUNTIME_INPUT = "operator_supplied_runtime_input"
 ALLOW_REASON_PRODUCT_OWNED_ADDON = "product_owned_addon"
 ALLOW_REASON_REPO_METADATA_ERGONOMICS = "repo_metadata_ergonomics"
 
+VERIREEL_DOKPLOY_MANAGED_SECRET_BINDINGS = frozenset(
+    (
+        "BETTER_AUTH_SECRET",
+        "VERIREEL_CRON_SECRET",
+        "VERIREEL_SECRETS_MASTER_KEY",
+        "VERIREEL_SMOKE_MAINTENANCE_SECRET",
+    )
+)
+
 SCAN_MODES = ("full-audit", "changed-files-gate")
 OUTPUT_FORMATS = ("json", "markdown")
 GATE_PROFILES = ("default", "product-repo")
@@ -2248,6 +2257,12 @@ def _allow_reason(
         value=value,
     ):
         return ALLOW_REASON_OPERATOR_SUPPLIED_RUNTIME_INPUT
+    if _is_verireel_dokploy_managed_secret_binding(
+        path=normalized,
+        key=key,
+        value=value,
+    ):
+        return ALLOW_REASON_OPERATOR_SUPPLIED_RUNTIME_INPUT
     if normalized.startswith(".github/workflows/") and _is_ingress_route_option_literal(
         path=normalized,
         key=key,
@@ -2283,6 +2298,15 @@ def _allow_reason(
     if _is_click_option_metadata_key(key):
         return ALLOW_REASON_OPERATOR_SUPPLIED_RUNTIME_INPUT
     return ""
+
+
+def _is_verireel_dokploy_managed_secret_binding(*, path: str, key: str, value: object) -> bool:
+    if path != "compose.dokploy.yaml":
+        return False
+    key_text = key.strip().upper()
+    if key_text not in VERIREEL_DOKPLOY_MANAGED_SECRET_BINDINGS:
+        return False
+    return _string_value(value).strip() == f"${{{key_text}:?required}}"
 
 
 def _is_github_context_reference(value: object) -> bool:

--- a/control_plane/workflows/verireel_preview_driver.py
+++ b/control_plane/workflows/verireel_preview_driver.py
@@ -43,6 +43,7 @@ _PREVIEW_REFRESH_GENERATED_ENV_KEYS = frozenset(
         "DATABASE_URL",
         "VERIREEL_CRON_SECRET",
         "VERIREEL_SECRETS_MASTER_KEY",
+        "VERIREEL_SMOKE_MAINTENANCE_SECRET",
     }
 )
 
@@ -459,10 +460,15 @@ def _random_urlsafe_secret(byte_count: int = 32) -> str:
 
 
 def _resolve_preview_secret(
-    *, existing_env_map: dict[str, str], key: str, generate: Callable[[], str]
+    *,
+    existing_env_map: dict[str, str],
+    key: str,
+    generate: Callable[[], str],
+    template_env_map: dict[str, str] | None = None,
 ) -> str:
     existing_value = existing_env_map.get(key, "").strip()
-    if existing_value:
+    template_value = (template_env_map or {}).get(key, "").strip()
+    if existing_value and existing_value != template_value:
         return existing_value
     return generate()
 
@@ -1295,16 +1301,25 @@ def execute_verireel_preview_refresh(
                     existing_env_map=existing_env_map,
                     key="BETTER_AUTH_SECRET",
                     generate=_random_urlsafe_secret,
+                    template_env_map=template_env_map,
                 ),
                 "VERIREEL_SECRETS_MASTER_KEY": _resolve_preview_secret(
                     existing_env_map=existing_env_map,
                     key="VERIREEL_SECRETS_MASTER_KEY",
                     generate=_random_base64_secret,
+                    template_env_map=template_env_map,
                 ),
                 "VERIREEL_CRON_SECRET": _resolve_preview_secret(
                     existing_env_map=existing_env_map,
                     key="VERIREEL_CRON_SECRET",
                     generate=_random_urlsafe_secret,
+                    template_env_map=template_env_map,
+                ),
+                "VERIREEL_SMOKE_MAINTENANCE_SECRET": _resolve_preview_secret(
+                    existing_env_map=existing_env_map,
+                    key="VERIREEL_SMOKE_MAINTENANCE_SECRET",
+                    generate=_random_urlsafe_secret,
+                    template_env_map=template_env_map,
                 ),
                 **runtime_identity_env(_build_preview_runtime_identity(request=request)),
             },

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -196,8 +196,9 @@ decryption key state denies the reveal or resolution.
   managed template-lane bindings, and the active policy must allow those
   bindings for the preview target. Template values that the driver rewrites for
   each preview, such as VeriReel's generated `DATABASE_URL`,
-  `BETTER_AUTH_SECRET`, `VERIREEL_SECRETS_MASTER_KEY`, and
-  `VERIREEL_CRON_SECRET`, are not copied template secrets.
+  `BETTER_AUTH_SECRET`, `VERIREEL_SECRETS_MASTER_KEY`,
+  `VERIREEL_CRON_SECRET`, and `VERIREEL_SMOKE_MAINTENANCE_SECRET`, are not
+  copied template secrets.
 - Delegated worker workflows that overlay managed runtime secrets into
   subprocess environments, such as VeriReel prod backup and rollback workers,
   must evaluate the managed bindings for the worker target before the worker

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2672,6 +2672,51 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         )
         self.assertEqual(product_repo_gate["status"], "pass")
 
+    def test_product_repo_gate_allows_verireel_dokploy_managed_secret_bindings(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            compose = root / "compose.dokploy.yaml"
+            compose.write_text(
+                "services:\n"
+                "  app:\n"
+                "    environment:\n"
+                "      BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:?required}\n"
+                "      VERIREEL_CRON_SECRET: ${VERIREEL_CRON_SECRET:?required}\n"
+                "      VERIREEL_SECRETS_MASTER_KEY: ${VERIREEL_SECRETS_MASTER_KEY:?required}\n"
+                "      VERIREEL_SMOKE_MAINTENANCE_SECRET: ${VERIREEL_SMOKE_MAINTENANCE_SECRET:?required}\n"
+                "      UNCLASSIFIED_API_SECRET: ${UNCLASSIFIED_API_SECRET:?required}\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            payload = build_config_authority_audit(control_plane_root=root)
+            product_repo_gate = evaluate_config_authority_gate(payload, profile="product-repo")
+
+        findings_by_key = {finding["key"]: finding for finding in _findings(payload)}
+        for key in (
+            "BETTER_AUTH_SECRET",
+            "VERIREEL_CRON_SECRET",
+            "VERIREEL_SECRETS_MASTER_KEY",
+            "VERIREEL_SMOKE_MAINTENANCE_SECRET",
+        ):
+            with self.subTest(key=key):
+                self.assertEqual(
+                    findings_by_key[key]["allow_reason"],
+                    "operator_supplied_runtime_input",
+                )
+        self.assertEqual(
+            findings_by_key["UNCLASSIFIED_API_SECRET"]["classification"],
+            "needs_classification",
+        )
+        self.assertEqual(product_repo_gate["status"], "fail")
+        self.assertEqual(
+            cast("list[dict[str, object]]", product_repo_gate["rejected_findings"])[0]["key"],
+            "UNCLASSIFIED_API_SECRET",
+        )
+
     def test_product_repo_gate_rejects_managed_secret_binding_fixtures(self) -> None:
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)

--- a/tests/test_verireel_preview_driver.py
+++ b/tests/test_verireel_preview_driver.py
@@ -24,6 +24,7 @@ from control_plane.workflows.verireel_preview_driver import (
     _enforce_verireel_preview_runtime_key_safety,
 )
 from control_plane.workflows.verireel_preview_driver import _preview_database_admin_module_source
+from control_plane.workflows.verireel_preview_driver import _resolve_preview_secret
 from control_plane.workflows.verireel_preview_driver import _resolve_preview_url
 from control_plane.workflows.verireel_preview_driver import _run_application_command_with_retries
 from control_plane.workflows.verireel_preview_driver import _verireel_template_runtime_secret_keys
@@ -279,6 +280,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                     "BETTER_AUTH_SECRET": "auth-secret",
                     "VERIREEL_SECRETS_MASTER_KEY": "master-key",
                     "VERIREEL_CRON_SECRET": "cron-secret",
+                    "VERIREEL_SMOKE_MAINTENANCE_SECRET": "smoke-secret",
                     "NEXT_PUBLIC_SITE_URL": "https://testing.example",
                 }
             ),
@@ -296,8 +298,29 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                 "BETTER_AUTH_SECRET": "auth-secret",
                 "VERIREEL_SECRETS_MASTER_KEY": "master-key",
                 "VERIREEL_CRON_SECRET": "cron-secret",
+                "VERIREEL_SMOKE_MAINTENANCE_SECRET": "smoke-secret",
             },
             request=_refresh_request(),
+        )
+
+    def test_resolve_preview_secret_rotates_copied_template_values(self) -> None:
+        self.assertEqual(
+            _resolve_preview_secret(
+                existing_env_map={"VERIREEL_SMOKE_MAINTENANCE_SECRET": "template"},
+                key="VERIREEL_SMOKE_MAINTENANCE_SECRET",
+                generate=lambda: "generated",
+                template_env_map={"VERIREEL_SMOKE_MAINTENANCE_SECRET": "template"},
+            ),
+            "generated",
+        )
+        self.assertEqual(
+            _resolve_preview_secret(
+                existing_env_map={"VERIREEL_SMOKE_MAINTENANCE_SECRET": "preview"},
+                key="VERIREEL_SMOKE_MAINTENANCE_SECRET",
+                generate=lambda: "generated",
+                template_env_map={"VERIREEL_SMOKE_MAINTENANCE_SECRET": "template"},
+            ),
+            "preview",
         )
 
     def test_verireel_preview_runtime_key_safety_requires_bindings_for_other_copied_secrets(
@@ -373,6 +396,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                 _runtime_binding("BETTER_AUTH_SECRET"),
                 _runtime_binding("VERIREEL_SECRETS_MASTER_KEY"),
                 _runtime_binding("VERIREEL_CRON_SECRET"),
+                _runtime_binding("VERIREEL_SMOKE_MAINTENANCE_SECRET"),
             ),
         )
 
@@ -384,6 +408,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                 "BETTER_AUTH_SECRET": "auth-secret",
                 "VERIREEL_SECRETS_MASTER_KEY": "master-key",
                 "VERIREEL_CRON_SECRET": "cron-secret",
+                "VERIREEL_SMOKE_MAINTENANCE_SECRET": "smoke-maintenance-secret",
             },
             request=_refresh_request(),
         )
@@ -544,6 +569,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
                             "BETTER_AUTH_SECRET=template-auth-secret\n"
                             f"VERIREEL_SECRETS_MASTER_KEY={template_master_key}\n"
                             "VERIREEL_CRON_SECRET=template-cron-secret\n"
+                            "VERIREEL_SMOKE_MAINTENANCE_SECRET=template-smoke-secret\n"
                         ),
                     },
                 ),
@@ -590,6 +616,10 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
         self.assertNotEqual(captured_env["BETTER_AUTH_SECRET"], "template-auth-secret")
         self.assertNotEqual(captured_env["VERIREEL_CRON_SECRET"], "template-cron-secret")
         self.assertNotEqual(
+            captured_env["VERIREEL_SMOKE_MAINTENANCE_SECRET"],
+            "template-smoke-secret",
+        )
+        self.assertNotEqual(
             captured_env["VERIREEL_SECRETS_MASTER_KEY"],
             template_master_key,
         )
@@ -611,6 +641,7 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
             + base64.b64encode(bytes(range(32))).decode("ascii")
             + "\n"
             "VERIREEL_CRON_SECRET=existing-cron-secret\n"
+            "VERIREEL_SMOKE_MAINTENANCE_SECRET=existing-smoke-secret\n"
         )
 
         with (
@@ -674,6 +705,10 @@ class VeriReelPreviewDriverTests(unittest.TestCase):
         self.assertEqual(result.refresh_status, "pass")
         self.assertEqual(captured_env["BETTER_AUTH_SECRET"], "existing-auth-secret")
         self.assertEqual(captured_env["VERIREEL_CRON_SECRET"], "existing-cron-secret")
+        self.assertEqual(
+            captured_env["VERIREEL_SMOKE_MAINTENANCE_SECRET"],
+            "existing-smoke-secret",
+        )
         self.assertEqual(
             captured_env["VERIREEL_SECRETS_MASTER_KEY"],
             base64.b64encode(bytes(range(32))).decode("ascii"),


### PR DESCRIPTION
## Summary
- Classify VeriReel Dokploy managed-secret placeholders, including `VERIREEL_SMOKE_MAINTENANCE_SECRET`, as operator-supplied runtime input in the product-repo config-authority gate.
- Generate `VERIREEL_SMOKE_MAINTENANCE_SECRET` per preview and avoid preserving copied template values for generated preview secrets.
- Update secrets docs and focused coverage for the new managed-secret contract.

## Validation
- `uv run python -m unittest tests.test_config_authority_audit tests.test_verireel_preview_driver` (105 tests)
- `python -m py_compile control_plane/config_authority_audit.py control_plane/workflows/verireel_preview_driver.py`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py control_plane/workflows/verireel_preview_driver.py tests/test_config_authority_audit.py tests/test_verireel_preview_driver.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py control_plane/workflows/verireel_preview_driver.py tests/test_config_authority_audit.py tests/test_verireel_preview_driver.py`
- `git diff --check`

## Review Notes
- Focused review found an issue where an existing preview could preserve a copied template `VERIREEL_SMOKE_MAINTENANCE_SECRET`; patched by rotating generated preview secrets when the existing value equals the template value.
- Focused re-review returned no blockers.
- Background Auto Review run `545deaef-a991-43de-a6db-6c894649a88c` is non-actionable: it failed before findings because its scope had 152 changed paths, exceeding the configured 120-path limit.

## VeriReel Follow-up
This unblocks VeriReel PR #248, where the product-repo config authority gate rejected the new smoke-maintenance secret binding as unclassified.
