### PR TITLE
Route VeriReel smoke maintenance through app API

### DIFF
--- a/control_plane/workflows/verireel_app_maintenance.py
+++ b/control_plane/workflows/verireel_app_maintenance.py
@@ -1,15 +1,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+import json
 import re
-import shlex
 import time
 from typing import Literal, cast
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
 
 import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane.dokploy import JsonObject
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -49,6 +53,9 @@ DEFAULT_ATTEMPTS = 4
 DEFAULT_RETRY_DELAY_SECONDS = 5.0
 PREVIEW_APPLICATION_NAME_PATTERN = re.compile(r"^ver-preview-pr-[1-9][0-9]*-app$")
 PREVIEW_SLUG_PATTERN = re.compile(r"^pr-[1-9][0-9]*$")
+SMOKE_MAINTENANCE_SECRET_KEY = "VERIREEL_SMOKE_MAINTENANCE_SECRET"
+SMOKE_MAINTENANCE_PATH = "/api/internal/smoke-maintenance"
+SMOKE_MAINTENANCE_ACTIONS = frozenset({"grant-sponsored", "promote-owner", "delete-user"})
 
 
 class VeriReelAppMaintenanceRequest(BaseModel):
@@ -142,8 +149,8 @@ def _reset_testing_command() -> str:
     return "node prisma/reset-testing-job.mjs && npx prisma migrate deploy --schema prisma/schema.prisma && node prisma/seed.mjs"
 
 
-def _remote_owner_admin_command(*, action: str, email: str) -> str:
-    return f"node scripts/ops/remote-owner-admin.mjs --action {shlex.quote(action)} --email {shlex.quote(email)}"
+def _uses_internal_smoke_maintenance_api(request: VeriReelAppMaintenanceRequest) -> bool:
+    return request.action in SMOKE_MAINTENANCE_ACTIONS
 
 
 def _command_for_request(request: VeriReelAppMaintenanceRequest) -> tuple[str, str]:
@@ -151,27 +158,21 @@ def _command_for_request(request: VeriReelAppMaintenanceRequest) -> tuple[str, s
         return "ver-apply-prisma-migrations", _migration_command()
     if request.action == "reset-testing":
         return "ver-testing-reset", _reset_testing_command()
-    if request.action == "grant-sponsored":
-        return "ver-remote-e2e-grant-sponsored", _remote_owner_admin_command(
-            action=request.action,
-            email=request.email,
-        )
-    if request.action == "promote-owner":
-        return "ver-owner-route-promote-owner", _remote_owner_admin_command(
-            action=request.action,
-            email=request.email,
-        )
-    if request.action == "delete-user":
-        schedule_name = (
-            "ver-owner-route-delete-user"
-            if request.context == "verireel"
-            else "ver-remote-e2e-delete-user"
-        )
-        return schedule_name, _remote_owner_admin_command(
-            action=request.action,
-            email=request.email,
+    if _uses_internal_smoke_maintenance_api(request):
+        raise click.ClickException(
+            f"VeriReel app maintenance action '{request.action}' uses the internal smoke maintenance API."
         )
     raise click.ClickException(f"Unsupported VeriReel app maintenance action '{request.action}'.")
+
+
+def _smoke_maintenance_operation_name(request: VeriReelAppMaintenanceRequest) -> str:
+    if request.action == "grant-sponsored":
+        return "ver-internal-smoke-grant-sponsored"
+    if request.action == "promote-owner":
+        return "ver-internal-smoke-promote-owner"
+    if request.action == "delete-user":
+        return "ver-internal-smoke-delete-user"
+    raise click.ClickException(f"Unsupported VeriReel smoke maintenance action '{request.action}'.")
 
 
 def _resolve_stable_testing_application(
@@ -227,9 +228,108 @@ def _find_application_by_name(*, host: str, token: str, application_name: str) -
     return None
 
 
-def _resolve_preview_application(
-    *, host: str, token: str, application_name: str
-) -> tuple[str, str]:
+def _preview_application_name(preview_slug: str) -> str:
+    return f"ver-preview-{preview_slug}-app"
+
+
+def _validate_base_url(raw_base_url: str, *, label: str) -> str:
+    base_url = raw_base_url.strip().rstrip("/")
+    if not base_url:
+        raise click.ClickException(f"{label} requires a base URL.")
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise click.ClickException(f"{label} requires an http or https base URL.")
+    if parsed.path not in {"", "/"} or parsed.params or parsed.query or parsed.fragment:
+        raise click.ClickException(
+            f"{label} requires a root base URL without path, query, or fragment."
+        )
+    return base_url
+
+
+def _first_application_base_url(application: JsonObject) -> str:
+    raw_domains = application.get("domains")
+    domains = raw_domains if isinstance(raw_domains, list) else []
+    for raw_domain in domains:
+        domain = control_plane_dokploy.as_json_object(raw_domain)
+        if domain is None:
+            continue
+        raw_host = str(domain.get("host") or "").strip()
+        if not raw_host:
+            continue
+        return _validate_base_url(
+            raw_host if urlparse(raw_host).scheme else f"https://{raw_host}",
+            label="VeriReel preview smoke maintenance",
+        )
+    raise click.ClickException("VeriReel preview smoke maintenance requires a Dokploy domain.")
+
+
+def _resolve_application_base_url(*, host: str, token: str, application_id: str) -> str:
+    raw_domains = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/domain.byApplicationId",
+        query={"applicationId": application_id},
+    )
+    application: JsonObject = {"domains": raw_domains if isinstance(raw_domains, list) else []}
+    return _first_application_base_url(application)
+
+
+def _fetch_application_by_id(*, host: str, token: str, application_id: str) -> JsonObject:
+    return control_plane_dokploy.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type="application",
+        target_id=application_id,
+    )
+
+
+def _resolve_stable_testing_base_url(*, control_plane_root: Path) -> str:
+    source_of_truth = control_plane_dokploy.read_control_plane_dokploy_source_of_truth(
+        control_plane_root=control_plane_root,
+    )
+    target_definition = control_plane_dokploy.find_dokploy_target_definition(
+        source_of_truth,
+        context_name="verireel",
+        instance_name="testing",
+    )
+    if target_definition is None:
+        raise click.ClickException("No Dokploy target definition found for verireel/testing.")
+    base_urls = control_plane_dokploy.resolve_healthcheck_base_urls(
+        target_definition=target_definition,
+        environment_values={},
+    )
+    if not base_urls:
+        raise click.ClickException("No base URL configured for verireel/testing.")
+    return _validate_base_url(
+        base_urls[0],
+        label="VeriReel stable smoke maintenance",
+    )
+
+
+def _resolve_stable_testing_smoke_maintenance_secret(*, control_plane_root: Path) -> str:
+    environment_values = control_plane_runtime_environments.resolve_runtime_environment_values(
+        control_plane_root=control_plane_root,
+        context_name="verireel",
+        instance_name="testing",
+    )
+    secret = str(environment_values.get(SMOKE_MAINTENANCE_SECRET_KEY) or "").strip()
+    if not secret:
+        raise click.ClickException(
+            f"VeriReel stable smoke maintenance requires {SMOKE_MAINTENANCE_SECRET_KEY}."
+        )
+    return secret
+
+
+def _preview_application_environment_map(application: JsonObject) -> dict[str, str]:
+    return control_plane_dokploy.parse_dokploy_env_text(str(application.get("env") or ""))
+
+
+def _resolve_preview_smoke_maintenance_target(
+    *,
+    host: str,
+    token: str,
+    application_name: str,
+) -> tuple[str, str, str, str]:
     application = _find_application_by_name(
         host=host,
         token=token,
@@ -244,11 +344,59 @@ def _resolve_preview_application(
         raise click.ClickException(
             f"Preview app {application_name!r} did not expose an application id."
         )
-    return application_name, application_id
+    base_url = _resolve_application_base_url(
+        host=host,
+        token=token,
+        application_id=application_id,
+    )
+    resolved_application = _fetch_application_by_id(
+        host=host,
+        token=token,
+        application_id=application_id,
+    )
+    environment_map = _preview_application_environment_map(resolved_application)
+    secret = str(environment_map.get(SMOKE_MAINTENANCE_SECRET_KEY) or "").strip()
+    if not secret:
+        raise click.ClickException(
+            f"VeriReel preview smoke maintenance requires {SMOKE_MAINTENANCE_SECRET_KEY}."
+        )
+    return application_name, application_id, base_url, secret
 
 
-def _preview_application_name(preview_slug: str) -> str:
-    return f"ver-preview-{preview_slug}-app"
+def _request_internal_smoke_maintenance_api(
+    *,
+    base_url: str,
+    secret: str,
+    request: VeriReelAppMaintenanceRequest,
+) -> None:
+    endpoint = f"{_validate_base_url(base_url, label='VeriReel smoke maintenance')}{SMOKE_MAINTENANCE_PATH}"
+    body = json.dumps(
+        {
+            "action": request.action,
+            "email": request.email,
+        }
+    ).encode("utf-8")
+    http_request = Request(
+        endpoint,
+        data=body,
+        method="POST",
+        headers={
+            "Accept": "application/json",
+            "Authorization": f"Bearer {secret}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urlopen(http_request, timeout=request.timeout_seconds) as response:
+            response.read()
+    except HTTPError as error:
+        raise click.ClickException(
+            f"VeriReel smoke maintenance API returned HTTP {error.code}."
+        ) from error
+    except URLError as error:
+        raise click.ClickException(
+            f"VeriReel smoke maintenance API request failed: {error.reason}"
+        ) from error
 
 
 def _find_application_schedule(
@@ -392,35 +540,57 @@ def execute_verireel_app_maintenance(
     application_id = ""
     schedule_name = ""
     try:
-        host, token = control_plane_dokploy.read_dokploy_config(
-            control_plane_root=control_plane_root
-        )
-        if request.context == "verireel":
+        if _uses_internal_smoke_maintenance_api(request):
+            schedule_name = _smoke_maintenance_operation_name(request)
+            if request.context == "verireel":
+                application_name, application_id = _resolve_stable_testing_application(
+                    control_plane_root=control_plane_root,
+                )
+                base_url = _resolve_stable_testing_base_url(
+                    control_plane_root=control_plane_root,
+                )
+                secret = _resolve_stable_testing_smoke_maintenance_secret(
+                    control_plane_root=control_plane_root,
+                )
+            else:
+                host, token = control_plane_dokploy.read_dokploy_config(
+                    control_plane_root=control_plane_root
+                )
+                application_name, application_id, base_url, secret = (
+                    _resolve_preview_smoke_maintenance_target(
+                        host=host,
+                        token=token,
+                        application_name=request.application_name
+                        or _preview_application_name(request.preview_slug),
+                    )
+                )
+            _request_internal_smoke_maintenance_api(
+                base_url=base_url,
+                secret=secret,
+                request=request,
+            )
+        else:
+            host, token = control_plane_dokploy.read_dokploy_config(
+                control_plane_root=control_plane_root
+            )
             application_name, application_id = _resolve_stable_testing_application(
                 control_plane_root=control_plane_root,
             )
-        else:
-            application_name, application_id = _resolve_preview_application(
-                host=host,
-                token=token,
-                application_name=request.application_name
-                or _preview_application_name(request.preview_slug),
-            )
-        schedule_name, command = _command_for_request(request)
-        _run_application_command_with_retries(
-            host=host,
-            token=token,
-            application_id=application_id,
-            schedule_name=schedule_name,
-            command=command,
-            timeout_seconds=request.timeout_seconds,
-        )
-        if request.action == "reset-testing":
-            _trigger_application_deploy(
+            schedule_name, command = _command_for_request(request)
+            _run_application_command_with_retries(
                 host=host,
                 token=token,
                 application_id=application_id,
+                schedule_name=schedule_name,
+                command=command,
+                timeout_seconds=request.timeout_seconds,
             )
+            if request.action == "reset-testing":
+                _trigger_application_deploy(
+                    host=host,
+                    token=token,
+                    application_id=application_id,
+                )
         return VeriReelAppMaintenanceResult(
             maintenance_status="pass",
             action=request.action,

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -197,7 +197,10 @@ instance, preview slug, and timeout. The client derives the Launchplane driver
 intent for supported smoke actions. The product script should not own
 Launchplane route paths, request envelopes, driver intent strings,
 idempotency-key recipes, GitHub OIDC token exchange, retry behavior, or
-driver-result failure rules.
+driver-result failure rules. Launchplane resolves the target app URL and
+maintenance secret, then calls the app-owned internal maintenance endpoint for
+generated-user setup and cleanup; product images must not remain the long-term
+home for generated-user admin helper scripts.
 
 ## What Launchplane Owns
 

--- a/tests/test_verireel_app_maintenance.py
+++ b/tests/test_verireel_app_maintenance.py
@@ -1,13 +1,18 @@
+import json
 import unittest
+from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
+from urllib.error import HTTPError
 
 import click
 
 from control_plane.workflows.verireel_app_maintenance import (
     VeriReelAppMaintenanceRequest,
+    _request_internal_smoke_maintenance_api,
     _command_for_request,
+    _resolve_stable_testing_smoke_maintenance_secret,
     execute_verireel_app_maintenance,
 )
 
@@ -35,7 +40,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         self.assertEqual(schedule_name, "ver-apply-prisma-migrations")
         self.assertEqual(command, "npx prisma migrate deploy --config prisma.config.ts")
 
-    def test_builds_shell_quoted_remote_owner_command(self) -> None:
+    def test_owner_admin_actions_no_longer_build_product_image_script_command(self) -> None:
         request = VeriReelAppMaintenanceRequest(
             context="verireel-testing",
             instance="preview",
@@ -45,13 +50,8 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
             preview_slug="pr-42",
         )
 
-        schedule_name, command = _command_for_request(request)
-
-        self.assertEqual(schedule_name, "ver-remote-e2e-grant-sponsored")
-        self.assertEqual(
-            command,
-            "node scripts/ops/remote-owner-admin.mjs --action grant-sponsored --email creator+e2e@example.com",
-        )
+        with self.assertRaisesRegex(click.ClickException, "internal smoke maintenance API"):
+            _command_for_request(request)
 
     def test_rejects_preview_request_with_invalid_preview_application_name(self) -> None:
         with self.assertRaises(ValueError):
@@ -114,7 +114,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
 
         self.assertEqual(request.intent, "stable-testing-remote-e2e-grant-sponsored")
 
-    def test_executes_stable_testing_remote_e2e_grant_through_stable_app(self) -> None:
+    def test_executes_stable_testing_remote_e2e_grant_through_internal_api(self) -> None:
         request = VeriReelAppMaintenanceRequest(
             context="verireel",
             instance="testing",
@@ -126,23 +126,20 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             with (
                 patch(
-                    "control_plane.workflows.verireel_app_maintenance.control_plane_dokploy.read_dokploy_config",
-                    return_value=("https://dokploy.example.test", "managed-token"),
-                ),
-                patch(
                     "control_plane.workflows.verireel_app_maintenance._resolve_stable_testing_application",
                     return_value=("ver-testing-app", "app-123"),
                 ) as stable_resolve_mock,
                 patch(
-                    "control_plane.workflows.verireel_app_maintenance._resolve_preview_application",
-                    return_value=("ver-preview-pr-42-app", "app-preview-42"),
-                ) as preview_resolve_mock,
+                    "control_plane.workflows.verireel_app_maintenance._resolve_stable_testing_base_url",
+                    return_value="https://testing.verireel.example",
+                ),
                 patch(
-                    "control_plane.workflows.verireel_app_maintenance._run_application_command_with_retries"
-                ) as run_mock,
+                    "control_plane.workflows.verireel_app_maintenance._resolve_stable_testing_smoke_maintenance_secret",
+                    return_value="managed-secret",
+                ),
                 patch(
-                    "control_plane.workflows.verireel_app_maintenance._trigger_application_deploy"
-                ) as deploy_mock,
+                    "control_plane.workflows.verireel_app_maintenance._request_internal_smoke_maintenance_api"
+                ) as api_mock,
             ):
                 result = execute_verireel_app_maintenance(
                     control_plane_root=Path(temporary_directory_name),
@@ -152,17 +149,137 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         self.assertEqual(result.maintenance_status, "pass")
         self.assertEqual(result.application_id, "app-123")
         self.assertEqual(result.intent, "stable-testing-remote-e2e-grant-sponsored")
+        self.assertEqual(result.schedule_name, "ver-internal-smoke-grant-sponsored")
         stable_resolve_mock.assert_called_once()
-        preview_resolve_mock.assert_not_called()
-        run_mock.assert_called_once_with(
+        api_mock.assert_called_once_with(
+            base_url="https://testing.verireel.example",
+            secret="managed-secret",
+            request=request,
+        )
+
+    def test_executes_preview_remote_e2e_delete_through_internal_api(self) -> None:
+        request = VeriReelAppMaintenanceRequest(
+            context="verireel-testing",
+            instance="preview",
+            action="delete-user",
+            intent="remote-e2e-delete-user",
+            email="creator+e2e@example.com",
+            preview_slug="pr-42",
+        )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            with (
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.test", "managed-token"),
+                ),
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._resolve_preview_smoke_maintenance_target",
+                    return_value=(
+                        "ver-preview-pr-42-app",
+                        "app-preview-42",
+                        "https://pr-42.verireel.example",
+                        "preview-secret",
+                    ),
+                ) as preview_resolve_mock,
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._request_internal_smoke_maintenance_api"
+                ) as api_mock,
+            ):
+                result = execute_verireel_app_maintenance(
+                    control_plane_root=Path(temporary_directory_name),
+                    request=request,
+                )
+
+        self.assertEqual(result.maintenance_status, "pass")
+        self.assertEqual(result.application_name, "ver-preview-pr-42-app")
+        self.assertEqual(result.application_id, "app-preview-42")
+        self.assertEqual(result.schedule_name, "ver-internal-smoke-delete-user")
+        preview_resolve_mock.assert_called_once_with(
             host="https://dokploy.example.test",
             token="managed-token",
-            application_id="app-123",
-            schedule_name="ver-remote-e2e-grant-sponsored",
-            command="node scripts/ops/remote-owner-admin.mjs --action grant-sponsored --email creator+e2e@example.com",
-            timeout_seconds=300,
+            application_name="ver-preview-pr-42-app",
         )
-        deploy_mock.assert_not_called()
+        api_mock.assert_called_once_with(
+            base_url="https://pr-42.verireel.example",
+            secret="preview-secret",
+            request=request,
+        )
+
+    def test_internal_api_request_posts_json_with_bearer_secret(self) -> None:
+        class FakeResponse:
+            status = 200
+
+            def __enter__(self) -> "FakeResponse":
+                return self
+
+            def __exit__(self, *args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return b'{"ok":true}'
+
+        request = VeriReelAppMaintenanceRequest(
+            action="promote-owner",
+            intent="owner-route-promote-owner",
+            email="owner-e2e@example.com",
+        )
+
+        with patch(
+            "control_plane.workflows.verireel_app_maintenance.urlopen",
+            return_value=FakeResponse(),
+        ) as urlopen_mock:
+            _request_internal_smoke_maintenance_api(
+                base_url="https://testing.verireel.example/",
+                secret="managed-secret",
+                request=request,
+            )
+
+        http_request = urlopen_mock.call_args.args[0]
+        self.assertEqual(
+            http_request.full_url,
+            "https://testing.verireel.example/api/internal/smoke-maintenance",
+        )
+        self.assertEqual(http_request.get_method(), "POST")
+        self.assertEqual(http_request.get_header("Authorization"), "Bearer managed-secret")
+        self.assertEqual(http_request.get_header("Content-type"), "application/json")
+        self.assertEqual(
+            json.loads(http_request.data.decode("utf-8")),
+            {"action": "promote-owner", "email": "owner-e2e@example.com"},
+        )
+
+    def test_internal_api_request_redacts_http_error_body(self) -> None:
+        request = VeriReelAppMaintenanceRequest(
+            action="promote-owner",
+            intent="owner-route-promote-owner",
+            email="owner-e2e@example.com",
+        )
+        http_error = HTTPError(
+            "https://testing.verireel.example/api/internal/smoke-maintenance",
+            403,
+            "Forbidden",
+            hdrs={},
+            fp=BytesIO(b"not allowed"),
+        )
+
+        with patch(
+            "control_plane.workflows.verireel_app_maintenance.urlopen",
+            side_effect=http_error,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "HTTP 403\\."):
+                _request_internal_smoke_maintenance_api(
+                    base_url="https://testing.verireel.example",
+                    secret="managed-secret",
+                    request=request,
+                )
+
+    def test_stable_secret_resolution_fails_closed_when_missing(self) -> None:
+        with patch(
+            "control_plane.workflows.verireel_app_maintenance.control_plane_runtime_environments.resolve_runtime_environment_values",
+            return_value={},
+        ):
+            with self.assertRaisesRegex(click.ClickException, "VERIREEL_SMOKE_MAINTENANCE_SECRET"):
+                _resolve_stable_testing_smoke_maintenance_secret(control_plane_root=Path("."))
 
     def test_rejects_intent_that_does_not_match_action_and_context(self) -> None:
         with self.assertRaises(ValueError):
@@ -183,6 +300,57 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
         self.assertEqual(
             command,
             "node prisma/reset-testing-job.mjs && npx prisma migrate deploy --schema prisma/schema.prisma && node prisma/seed.mjs",
+        )
+
+    def test_preview_target_reads_secret_from_application_one_payload(self) -> None:
+        from control_plane.workflows.verireel_app_maintenance import (
+            _resolve_preview_smoke_maintenance_target,
+        )
+
+        def fake_dokploy_request(**kwargs: object) -> object:
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [
+                    {
+                        "environments": [
+                            {
+                                "applications": [
+                                    {
+                                        "name": "ver-preview-pr-42-app",
+                                        "applicationId": "app-preview-42",
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            if path == "/api/domain.byApplicationId":
+                return [{"host": "pr-42.verireel.example"}]
+            if path == "/api/application.one":
+                return {
+                    "applicationId": "app-preview-42",
+                    "env": "VERIREEL_SMOKE_MAINTENANCE_SECRET=preview-secret\n",
+                }
+            raise AssertionError(f"unexpected path {path!r}")
+
+        with patch(
+            "control_plane.workflows.verireel_app_maintenance.control_plane_dokploy.dokploy_request",
+            side_effect=fake_dokploy_request,
+        ):
+            result = _resolve_preview_smoke_maintenance_target(
+                host="https://dokploy.example.test",
+                token="managed-token",
+                application_name="ver-preview-pr-42-app",
+            )
+
+        self.assertEqual(
+            result,
+            (
+                "ver-preview-pr-42-app",
+                "app-preview-42",
+                "https://pr-42.verireel.example",
+                "preview-secret",
+            ),
         )
 
     def test_executes_stable_testing_command_through_launchplane_dokploy_config(self) -> None:
@@ -282,6 +450,48 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
 
         self.assertEqual(result.maintenance_status, "fail")
         self.assertIn("schedule failed", result.error_message)
+
+    def test_reports_failed_internal_api_without_leaking_response_body(self) -> None:
+        request = VeriReelAppMaintenanceRequest(
+            context="verireel",
+            instance="testing",
+            action="promote-owner",
+            intent="owner-route-promote-owner",
+            email="owner-e2e@example.com",
+        )
+
+        with TemporaryDirectory() as temporary_directory_name:
+            with (
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._resolve_stable_testing_application",
+                    return_value=("ver-testing-app", "app-123"),
+                ),
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._resolve_stable_testing_base_url",
+                    return_value="https://testing.verireel.example",
+                ),
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._resolve_stable_testing_smoke_maintenance_secret",
+                    return_value="managed-secret",
+                ),
+                patch(
+                    "control_plane.workflows.verireel_app_maintenance._request_internal_smoke_maintenance_api",
+                    side_effect=click.ClickException(
+                        "VeriReel smoke maintenance API returned HTTP 500."
+                    ),
+                ),
+            ):
+                result = execute_verireel_app_maintenance(
+                    control_plane_root=Path(temporary_directory_name),
+                    request=request,
+                )
+
+        self.assertEqual(result.maintenance_status, "fail")
+        self.assertEqual(
+            result.error_message,
+            "VeriReel smoke maintenance API returned HTTP 500.",
+        )
+        self.assertEqual(result.schedule_name, "ver-internal-smoke-promote-owner")
 
 
 if __name__ == "__main__":

--- a/tests/test_verireel_app_maintenance.py
+++ b/tests/test_verireel_app_maintenance.py
@@ -1,5 +1,6 @@
 import json
 import unittest
+from email.message import Message
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -258,7 +259,7 @@ class VeriReelAppMaintenanceTests(unittest.TestCase):
             "https://testing.verireel.example/api/internal/smoke-maintenance",
             403,
             "Forbidden",
-            hdrs={},
+            hdrs=Message(),
             fp=BytesIO(b"not allowed"),
         )
 


### PR DESCRIPTION
## Summary
- Route VeriReel generated-user smoke maintenance actions (`grant-sponsored`, `promote-owner`, `delete-user`) through the app-owned `/api/internal/smoke-maintenance` endpoint instead of the product-image `remote-owner-admin.mjs` script.
- Resolve stable secrets from Launchplane runtime environment/managed secret plumbing and preview secrets from the live preview application env via `application.one`.
- Keep Prisma migrate/reset-testing on the existing Dokploy schedule path and document the new ownership boundary.

## Validation
- `python -m py_compile control_plane/workflows/verireel_app_maintenance.py tests/test_verireel_app_maintenance.py`
- `uv run --extra dev ruff format control_plane/workflows/verireel_app_maintenance.py tests/test_verireel_app_maintenance.py`
- `uv run --extra dev ruff check control_plane/workflows/verireel_app_maintenance.py tests/test_verireel_app_maintenance.py`
- `uv run python -m unittest tests.test_verireel_app_maintenance`
- `uv run python -m unittest tests.test_docs_contracts tests.test_verireel_app_maintenance`
- `git diff --check`

## Review
- Focused review agents found and we fixed: preview secret resolution now fetches `application.one`; API error bodies are redacted/bounded to HTTP status; dead preview resolver/dead HTTP branch removed; API failure path covered.
- Auto Review run `545deaef-a991-43de-a6db-6c894649a88c` is non-actionable: it failed before findings because the background scope has 152 changed paths, above its 120-path limit.

Refs #1526
Refs #1530
