### PR TITLE
Add product expected config apply workflow

### DIFF
--- a/.github/workflows/product-expected-config.yml
+++ b/.github/workflows/product-expected-config.yml
@@ -1,0 +1,179 @@
+---
+name: Product Expected Config
+
+"on":
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Product profile key to update.
+        required: true
+        type: string
+      mode:
+        description: Plan or apply the expected config metadata change.
+        required: true
+        type: choice
+        options:
+          - dry-run
+          - apply
+      requirement_kind:
+        description: Expected config requirement type to add.
+        required: true
+        type: choice
+        options:
+          - managed_secret_binding
+          - runtime_environment_key
+      key:
+        description: Runtime env key or managed secret binding key.
+        required: true
+        type: string
+      integration:
+        description: Managed secret integration; ignored for runtime keys.
+        required: false
+        type: string
+        default: runtime_environment
+      context:
+        description: Optional requirement context.
+        required: true
+        type: string
+      instance:
+        description: Optional requirement instance; requires context.
+        required: false
+        type: string
+      source_label:
+        description: Source label recorded on apply.
+        required: false
+        type: string
+        default: product-expected-config-workflow
+      confirmation:
+        description: Type APPLY PRODUCT EXPECTED CONFIG for apply mode.
+        required: false
+        type: string
+      reason:
+        description: Operator reason for the metadata change.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: product-expected-config-${{ inputs.product }}
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      PRODUCT: ${{ inputs.product }}
+      MODE: ${{ inputs.mode }}
+      REQUIREMENT_KIND: ${{ inputs.requirement_kind }}
+      KEY: ${{ inputs.key }}
+      INTEGRATION: ${{ inputs.integration }}
+      CONTEXT_NAME: ${{ inputs.context }}
+      INSTANCE_NAME: ${{ inputs.instance }}
+      SOURCE_LABEL: ${{ inputs.source_label }}
+      CONFIRMATION: ${{ inputs.confirmation }}
+      REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate apply guard
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "$MODE" = "apply" ] && [ "$CONFIRMATION" != "APPLY PRODUCT EXPECTED CONFIG" ]; then
+            echo "Exact confirmation text is required for apply mode." >&2
+            exit 1
+          fi
+          if [ -z "$(printf '%s' "$REASON" | xargs)" ]; then
+            echo "reason is required." >&2
+            exit 1
+          fi
+          if [ -z "$(printf '%s' "$CONTEXT_NAME" | xargs)" ]; then
+            echo "context is required for this workflow." >&2
+            exit 1
+          fi
+
+      - name: Build expected config request
+        id: expected_config
+        shell: bash
+        run: |
+          set -euo pipefail
+          request_file="${RUNNER_TEMP}/product-expected-config-request.json"
+          jq -n \
+            --arg product "$PRODUCT" \
+            --arg mode "$MODE" \
+            --arg requirement_kind "$REQUIREMENT_KIND" \
+            --arg key "$KEY" \
+            --arg integration "$INTEGRATION" \
+            --arg context "$CONTEXT_NAME" \
+            --arg instance "$INSTANCE_NAME" \
+            --arg source_label "$SOURCE_LABEL" \
+            --arg reason "$REASON" \
+            '{
+              schema_version: 1,
+              product: $product,
+              mode: $mode,
+              reason: $reason,
+              source_label: $source_label,
+              runtime_environment_keys: (
+                if $requirement_kind == "runtime_environment_key" then
+                  [{key: $key, context: $context, instance: $instance}]
+                else
+                  []
+                end
+              ),
+              managed_secret_bindings: (
+                if $requirement_kind == "managed_secret_binding" then
+                  [{binding_key: $key, integration: $integration, context: $context, instance: $instance}]
+                else
+                  []
+                end
+              )
+            }' > "$request_file"
+          jq -e '.product != "" and .reason != ""' "$request_file" >/dev/null
+          {
+            echo "request_file=$request_file"
+            echo "product=$PRODUCT"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Request expected config apply
+        uses: ./.github/actions/launchplane-request
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          route-path: /v1/product-profiles/expected-config/apply
+          payload-file: ${{ steps.expected_config.outputs.request_file }}
+          idempotency-key: product-expected-config:${{ inputs.product }}:${{ inputs.mode }}:${{ github.run_id }}
+          fail-result-paths: result.status
+          response-output-file: product-expected-config.json
+
+      - name: Upload expected config evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: product-expected-config-result
+          path: product-expected-config.json
+          if-no-files-found: error
+
+      - name: Summarize expected config
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Product expected config"
+            echo
+            echo "- Product: $PRODUCT"
+            echo "- Mode: $MODE"
+            if [ -f product-expected-config.json ]; then
+              echo "- Status: $(jq -r '.status // "unknown"' product-expected-config.json)"
+              echo "- Trace: $(jq -r '.trace_id // ""' product-expected-config.json)"
+              echo "- Changed: $(jq -r '.result.changed // ""' product-expected-config.json)"
+              echo "- Runtime keys added: $(jq -r '.result.summary.runtime_environment_key_add_count // "0"' product-expected-config.json)"
+              echo "- Managed secret bindings added: $(jq -r '.result.summary.managed_secret_binding_add_count // "0"' product-expected-config.json)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -443,7 +443,12 @@ from control_plane.contracts.product_environment_read_model import (
     ProductSiteOverview,
 )
 from control_plane.contracts.product_onboarding_manifest import ProductOnboardingManifest
-from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductExpectedConfigProfile,
+    ProductRuntimeConfigRequirement,
+    ProductSecretConfigRequirement,
+)
 from control_plane.contracts.repo_product_mapping_read_model import RepoProductMapping
 from control_plane.contracts.preview_evidence import (
     PreviewDestroyedEvidenceEnvelope,
@@ -685,6 +690,7 @@ _INGRESS_ROUTE_APPLY_ROUTE = "/v1/drivers/ingress/route-apply"
 _INGRESS_CANARY_ROUTE_RECORD_APPLY_ROUTE = "/v1/ingress/canary-routes/records/apply"
 _INGRESS_CANARY_ROUTE_APPLY_ROUTE = "/v1/ingress/canary-routes/apply"
 _PRODUCT_PROFILES_ROUTE = "/v1/product-profiles"
+_PRODUCT_EXPECTED_CONFIG_APPLY_ROUTE = "/v1/product-profiles/expected-config/apply"
 _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/apply"
 _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
 _PRODUCT_CONFIG_APPLY_ROUTE = "/v1/product-config/apply"
@@ -1888,6 +1894,137 @@ class ProductOnboardingApplyEnvelope(BaseModel):
             raise ValueError("Product onboarding writes require product 'launchplane'.")
         self.product = "launchplane"
         return self
+
+
+class ProductExpectedConfigApplyEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    mode: Literal["dry-run", "apply"] = "dry-run"
+    reason: str
+    source_label: str = "product-expected-config"
+    runtime_environment_keys: tuple[ProductRuntimeConfigRequirement, ...] = ()
+    managed_secret_bindings: tuple[ProductSecretConfigRequirement, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "ProductExpectedConfigApplyEnvelope":
+        self.product = self.product.strip()
+        self.reason = self.reason.strip()
+        self.source_label = self.source_label.strip() or "product-expected-config"
+        if not self.product:
+            raise ValueError("Product expected config request requires product.")
+        if not self.reason:
+            raise ValueError("Product expected config request requires reason.")
+        if not self.runtime_environment_keys and not self.managed_secret_bindings:
+            raise ValueError(
+                "Product expected config request requires at least one runtime key "
+                "or managed secret binding."
+            )
+        return self
+
+
+def _runtime_config_requirement_key(
+    requirement: ProductRuntimeConfigRequirement,
+) -> tuple[str, str, str]:
+    return (requirement.context, requirement.instance, requirement.key)
+
+
+def _secret_config_requirement_key(
+    requirement: ProductSecretConfigRequirement,
+) -> tuple[str, str, str, str]:
+    return (
+        requirement.integration,
+        requirement.context,
+        requirement.instance,
+        requirement.binding_key,
+    )
+
+
+def _merge_product_expected_config(
+    *,
+    profile: LaunchplaneProductProfileRecord,
+    request: ProductExpectedConfigApplyEnvelope,
+    updated_at: str,
+) -> tuple[LaunchplaneProductProfileRecord, dict[str, object]]:
+    existing_runtime_keys = {
+        _runtime_config_requirement_key(requirement)
+        for requirement in profile.expected_config.runtime_environment_keys
+    }
+    existing_secret_keys = {
+        _secret_config_requirement_key(requirement)
+        for requirement in profile.expected_config.managed_secret_bindings
+    }
+
+    runtime_requirements = list(profile.expected_config.runtime_environment_keys)
+    secret_requirements = list(profile.expected_config.managed_secret_bindings)
+    added_runtime_requirements: list[ProductRuntimeConfigRequirement] = []
+    unchanged_runtime_requirements: list[ProductRuntimeConfigRequirement] = []
+    added_secret_requirements: list[ProductSecretConfigRequirement] = []
+    unchanged_secret_requirements: list[ProductSecretConfigRequirement] = []
+
+    for runtime_requirement in request.runtime_environment_keys:
+        runtime_key = _runtime_config_requirement_key(runtime_requirement)
+        if runtime_key in existing_runtime_keys:
+            unchanged_runtime_requirements.append(runtime_requirement)
+            continue
+        existing_runtime_keys.add(runtime_key)
+        runtime_requirements.append(runtime_requirement)
+        added_runtime_requirements.append(runtime_requirement)
+
+    for secret_requirement in request.managed_secret_bindings:
+        secret_key = _secret_config_requirement_key(secret_requirement)
+        if secret_key in existing_secret_keys:
+            unchanged_secret_requirements.append(secret_requirement)
+            continue
+        existing_secret_keys.add(secret_key)
+        secret_requirements.append(secret_requirement)
+        added_secret_requirements.append(secret_requirement)
+
+    changed = bool(added_runtime_requirements or added_secret_requirements)
+    merged_profile = profile
+    if changed:
+        merged_profile = profile.model_copy(
+            update={
+                "expected_config": ProductExpectedConfigProfile(
+                    runtime_environment_keys=tuple(runtime_requirements),
+                    managed_secret_bindings=tuple(secret_requirements),
+                ),
+                "updated_at": updated_at,
+                "source": request.source_label,
+            }
+        )
+
+    return merged_profile, {
+        "status": "ok",
+        "mode": request.mode,
+        "product": request.product,
+        "source_label": request.source_label,
+        "changed": changed,
+        "runtime_environment_keys": {
+            "added": [
+                requirement.model_dump(mode="json") for requirement in added_runtime_requirements
+            ],
+            "unchanged": [
+                requirement.model_dump(mode="json")
+                for requirement in unchanged_runtime_requirements
+            ],
+        },
+        "managed_secret_bindings": {
+            "added": [
+                requirement.model_dump(mode="json") for requirement in added_secret_requirements
+            ],
+            "unchanged": [
+                requirement.model_dump(mode="json") for requirement in unchanged_secret_requirements
+            ],
+        },
+        "summary": {
+            "runtime_environment_key_add_count": len(added_runtime_requirements),
+            "managed_secret_binding_add_count": len(added_secret_requirements),
+            "runtime_environment_key_unchanged_count": len(unchanged_runtime_requirements),
+            "managed_secret_binding_unchanged_count": len(unchanged_secret_requirements),
+        },
+    }
 
 
 class MergeTrainPolicyImportEnvelope(BaseModel):
@@ -11238,6 +11375,119 @@ def create_launchplane_fastapi_app(
         )
         return response
 
+    async def apply_product_expected_config(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_write_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Product expected config request failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Product expected config request failed validation.",
+            )
+        request_payload = cast(dict[str, object], raw_payload)
+        try:
+            expected_config_request = ProductExpectedConfigApplyEnvelope.model_validate(
+                request_payload
+            )
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Product expected config request failed validation.",
+            ) from error
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action="product_profile.expected_config.apply",
+            product=expected_config_request.product,
+            context=_LAUNCHPLANE_SERVICE_CONTEXT,
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot apply product expected config metadata.",
+            )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_PRODUCT_EXPECTED_CONFIG_APPLY_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=bool(idempotency_key.strip()),
+        )
+        if replay_response is not None:
+            return replay_response
+        try:
+            profile_read_store = require_product_profile_read_store(record_store)
+            profile = profile_read_store.read_product_profile_record(
+                expected_config_request.product
+            )
+        except TypeError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        merged_profile, result = _merge_product_expected_config(
+            profile=profile,
+            request=expected_config_request,
+            updated_at=utc_now_timestamp(),
+        )
+        if expected_config_request.mode == "apply" and result["changed"]:
+            try:
+                profile_write_store = require_product_profile_write_store(record_store)
+            except TypeError as error:
+                raise _launchplane_http_error(
+                    status_code=503,
+                    trace_id=trace_id,
+                    code="database_storage_required",
+                    message=str(error),
+                ) from error
+            profile_write_store.write_product_profile_record(merged_profile)
+        response = accepted_evidence_response(
+            trace_id=trace_id,
+            records={"product_profile": expected_config_request.product},
+            result=result,
+        )
+        store_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_PRODUCT_EXPECTED_CONFIG_APPLY_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+            response=response,
+        )
+        return response
+
     def read_product_context_cutover_audit(
         product: Annotated[str, Path(min_length=1, pattern=r"^\S+$")],
         identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
@@ -19796,6 +20046,35 @@ def create_launchplane_fastapi_app(
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _PRODUCT_EXPECTED_CONFIG_APPLY_ROUTE,
+        apply_product_expected_config,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {
+                        "schema": ProductExpectedConfigApplyEnvelope.model_json_schema()
+                    }
+                },
+            }
+        },
+        operation_id="apply_product_expected_config",
+        summary="Add product expected config metadata",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            404: {"model": LaunchplaneErrorResponse},
             409: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },

--- a/docs/records.md
+++ b/docs/records.md
@@ -416,6 +416,19 @@ The service exposes product profile records through `GET /v1/product-profiles`,
 require the `product_profile.write` action for the target product in the
 Launchplane service context; reads use `product_profile.read`.
 
+Additive expected-config metadata changes use
+`POST /v1/product-profiles/expected-config/apply`. The request carries
+`mode: "dry-run"` or `mode: "apply"`, a product key, a reason, and runtime key
+or managed secret binding requirements to append if absent. It does not accept
+secret plaintext, runtime values, repositories, lanes, domains, or promotion
+settings, and it never removes existing expected-config entries. The manual
+`Product Expected Config` workflow is the operator path for shared/runtime
+metadata changes; real product, context, instance, and binding values are
+workflow inputs, not checked-in defaults. Because the route authorizes against
+the target product in the Launchplane service context, product-specific workflow
+grants must come from explicit operator-supplied authz grant input such as
+`LAUNCHPLANE_AUTHZ_GRANTS_JSON`, not a checked-in product catalog.
+
 For initial seed or repair work, operators can write the same DB-backed record
 directly with
 `uv run launchplane product-profiles upsert --database-url ... --allow-direct-db-mutation`.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1192,6 +1192,7 @@ refresh/destroy flow.
 - `GET /v1/product-profiles`
 - `GET /v1/product-profiles/{product}`
 - `POST /v1/product-profiles`
+- `POST /v1/product-profiles/expected-config/apply`
 
 Product profiles are Launchplane-owned product/driver bindings. They are written
 through native FastAPI authenticated service ingress and stored in Launchplane
@@ -1199,6 +1200,18 @@ records; product repos do not carry repo-local Launchplane lifecycle manifests.
 Writes require `product_profile.write` for the profile product in the
 Launchplane service context, validate the profile write contract before storage,
 and preserve optional `Idempotency-Key` replay/conflict behavior.
+
+Expected-config apply is a narrower metadata mutation for runtime contract
+requirements already owned by product profiles. It requires
+`product_profile.expected_config.apply` for the target product in the
+Launchplane service context, loads the existing DB-backed product profile, and
+appends supplied runtime keys or managed secret binding requirements only when
+absent. Dry-run returns the same redacted added/unchanged summary without
+writing. Apply updates only the profile `expected_config`, `updated_at`, and
+`source` fields; callers must use the live-target-runtime workflow afterward to
+sync live provider environment. The route does not accept secret plaintext,
+runtime values, or checked-in product catalogs, and workflow authority for real
+products must be granted through operator-supplied authz input.
 
 Public ingress notification policy writes use
 `POST /v1/public-ingress/notification-policies/apply`. The request carries

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -2424,6 +2424,25 @@ def _product_profile_write_policy(*, product: str) -> LaunchplaneAuthzPolicy:
     )
 
 
+def _product_expected_config_policy(*, product: str = "sellyouroutboard") -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/product-expected-config.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": [product],
+                    "contexts": ["launchplane"],
+                    "actions": ["product_profile.expected_config.apply"],
+                }
+            ]
+        }
+    )
+
+
 def _product_config_policy(
     *,
     action: str,
@@ -4302,6 +4321,28 @@ async def _post_product_profile(
         app,
         "POST",
         "/v1/product-profiles",
+        headers=request_headers,
+        payload=payload,
+    )
+
+
+async def _post_product_expected_config(
+    app: FastAPI,
+    payload: dict[str, object],
+    *,
+    authorization: str = "Bearer valid-token",
+    idempotency_key: str = "",
+    headers: dict[str, str] | None = None,
+) -> _AsgiResponse:
+    request_headers = dict(headers or {})
+    if authorization:
+        request_headers["Authorization"] = authorization
+    if idempotency_key:
+        request_headers["Idempotency-Key"] = idempotency_key
+    return await _asgi_request(
+        app,
+        "POST",
+        "/v1/product-profiles/expected-config/apply",
         headers=request_headers,
         payload=payload,
     )

--- a/tests/test_http_app_product.py
+++ b/tests/test_http_app_product.py
@@ -11,6 +11,7 @@ from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssue
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import (
     BearerIdentityConfig,
+    GitHubActionsIdentity,
     LaunchplaneAuthzPolicy,
 )
 from control_plane.service_human_auth import (
@@ -49,10 +50,12 @@ from tests.http_app_test_support import (
     _local_operator_product_environment_read_policy,
     _local_operator_work_graph_rank_policy,
     _MissingProductReadStore,
+    _post_product_expected_config,
     _post_product_profile,
     _post_work_graph_issue_inbox_reconcile,
     _post_work_graph_rank,
     _product_environment_read_policy,
+    _product_expected_config_policy,
     _product_profile_read_policy,
     _product_profile_write_policy,
     _ProductProfileReplayOnlyStore,
@@ -74,6 +77,31 @@ from tests.test_service import (
     _StubVerifier,
     _work_graph_snapshot_payload,
 )
+
+
+def _product_expected_config_payload() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": "sellyouroutboard",
+        "mode": "dry-run",
+        "reason": "Test expected config metadata update.",
+        "source_label": "product-expected-config-test",
+        "managed_secret_bindings": [
+            {
+                "binding_key": "SMTP_PASSWORD",
+                "integration": "runtime_environment",
+                "context": "sellyouroutboard-prod",
+                "instance": "prod",
+            }
+        ],
+    }
+
+
+def _product_expected_config_identity() -> GitHubActionsIdentity:
+    return _identity(
+        workflow_ref="every/verireel/.github/workflows/product-expected-config.yml@refs/heads/main",
+        event_name="workflow_dispatch",
+    )
 
 
 class FastApiProductEnvironmentConfigStatusTests(unittest.IsolatedAsyncioTestCase):
@@ -1774,6 +1802,252 @@ class FastApiProductProfileTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["status"], "rejected")
         self.assertEqual(payload["error"]["code"], "database_storage_required")
         self.assertIn("write_product_profile_record", payload["error"]["message"])
+
+    async def test_apply_product_expected_config_dry_run_reports_additions_without_write(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            profile = LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            record_store.write_product_profile_record(profile)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_product_expected_config_identity()),
+                authz_policy=_product_expected_config_policy(),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _post_product_expected_config(
+                app,
+                _product_expected_config_payload(),
+                idempotency_key="expected-config-dry-run",
+            )
+            stored_profile = record_store.read_product_profile_record("sellyouroutboard")
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["records"], {"product_profile": "sellyouroutboard"})
+        self.assertEqual(payload["result"]["mode"], "dry-run")
+        self.assertTrue(payload["result"]["changed"])
+        self.assertEqual(
+            payload["result"]["managed_secret_bindings"]["added"],
+            [
+                {
+                    "binding_key": "SMTP_PASSWORD",
+                    "integration": "runtime_environment",
+                    "context": "sellyouroutboard-prod",
+                    "instance": "prod",
+                }
+            ],
+        )
+        self.assertEqual(stored_profile.expected_config.managed_secret_bindings, ())
+
+    async def test_apply_product_expected_config_persists_additive_binding(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_product_expected_config_identity()),
+                authz_policy=_product_expected_config_policy(),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _post_product_expected_config(
+                app,
+                {**_product_expected_config_payload(), "mode": "apply"},
+                idempotency_key="expected-config-apply",
+            )
+            stored_profile = record_store.read_product_profile_record("sellyouroutboard")
+
+        self.assertEqual(response.status_code, 202)
+        payload = response.json()
+        self.assertEqual(payload["result"]["summary"]["managed_secret_binding_add_count"], 1)
+        self.assertEqual(
+            [
+                requirement.binding_key
+                for requirement in stored_profile.expected_config.managed_secret_bindings
+            ],
+            ["SMTP_PASSWORD"],
+        )
+        self.assertEqual(stored_profile.source, "product-expected-config-test")
+
+    async def test_apply_product_expected_config_replays_idempotent_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_product_expected_config_identity()),
+                authz_policy=_product_expected_config_policy(),
+                record_store_factory=lambda: record_store,
+            )
+            payload = {**_product_expected_config_payload(), "mode": "apply"}
+
+            first_response = await _post_product_expected_config(
+                app,
+                payload,
+                idempotency_key="expected-config-replay",
+            )
+            second_response = await _post_product_expected_config(
+                app,
+                payload,
+                idempotency_key="expected-config-replay",
+            )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(second_response.status_code, 202)
+        self.assertTrue(second_response.json()["replayed"])
+        self.assertEqual(
+            second_response.json()["original_trace_id"], first_response.json()["trace_id"]
+        )
+
+    async def test_apply_product_expected_config_rejects_reused_idempotency_key(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_product_expected_config_identity()),
+                authz_policy=_product_expected_config_policy(),
+                record_store_factory=lambda: record_store,
+            )
+
+            await _post_product_expected_config(
+                app,
+                _product_expected_config_payload(),
+                idempotency_key="expected-config-conflict",
+            )
+            response = await _post_product_expected_config(
+                app,
+                {
+                    **_product_expected_config_payload(),
+                    "managed_secret_bindings": [
+                        {
+                            "binding_key": "API_TOKEN",
+                            "integration": "runtime_environment",
+                            "context": "sellyouroutboard-prod",
+                            "instance": "prod",
+                        }
+                    ],
+                },
+                idempotency_key="expected-config-conflict",
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "idempotency_key_reused")
+
+    async def test_apply_product_expected_config_rejects_dry_run_key_for_apply(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_product_expected_config_identity()),
+                authz_policy=_product_expected_config_policy(),
+                record_store_factory=lambda: record_store,
+            )
+
+            await _post_product_expected_config(
+                app,
+                _product_expected_config_payload(),
+                idempotency_key="expected-config-cross-mode",
+            )
+            response = await _post_product_expected_config(
+                app,
+                {**_product_expected_config_payload(), "mode": "apply"},
+                idempotency_key="expected-config-cross-mode",
+            )
+            stored_profile = record_store.read_product_profile_record("sellyouroutboard")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "idempotency_key_reused")
+        self.assertEqual(stored_profile.expected_config.managed_secret_bindings, ())
+
+    async def test_apply_product_expected_config_rejects_unauthorized_workflow(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_product_profile_write_policy(product="sellyouroutboard"),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_product_expected_config(
+            app,
+            _product_expected_config_payload(),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_apply_product_expected_config_reports_missing_profile(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_product_expected_config_identity()),
+                authz_policy=_product_expected_config_policy(),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _post_product_expected_config(
+                app,
+                _product_expected_config_payload(),
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_apply_product_expected_config_rejects_empty_change(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_product_expected_config_identity()),
+            authz_policy=_product_expected_config_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_product_expected_config(
+            app,
+            {
+                "schema_version": 1,
+                "product": "sellyouroutboard",
+                "mode": "dry-run",
+                "reason": "Test empty request.",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+
+    async def test_apply_product_expected_config_rejects_instance_without_context(
+        self,
+    ) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_product_expected_config_identity()),
+            authz_policy=_product_expected_config_policy(),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _post_product_expected_config(
+            app,
+            {
+                **_product_expected_config_payload(),
+                "managed_secret_bindings": [
+                    {
+                        "binding_key": "SMTP_PASSWORD",
+                        "integration": "runtime_environment",
+                        "instance": "prod",
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
 
     async def test_list_product_profiles_accepts_every_code_worker_token(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1123,12 +1123,40 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("product-onboarding:${PRODUCT}:${GITHUB_RUN_ID}", workflow_text)
         self.assertIn("product-onboarding-result", workflow_text)
 
+    def test_product_expected_config_workflow_calls_service_route_with_apply_guard(
+        self,
+    ) -> None:
+        workflow_text = Path(".github/workflows/product-expected-config.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("/v1/product-profiles/expected-config/apply", workflow_text)
+        self.assertIn("APPLY PRODUCT EXPECTED CONFIG", workflow_text)
+        self.assertIn("context is required for this workflow", workflow_text)
+        self.assertIn("requirement_kind", workflow_text)
+        self.assertIn("managed_secret_binding", workflow_text)
+        self.assertIn("runtime_environment_key", workflow_text)
+        self.assertIn(
+            "product-expected-config:${{ inputs.product }}:${{ inputs.mode }}:${{ github.run_id }}",
+            workflow_text,
+        )
+        self.assertNotIn("github.run_attempt", workflow_text)
+        self.assertIn("product-expected-config-result", workflow_text)
+
     def test_deploy_authz_grants_include_product_onboarding_apply(self) -> None:
         script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
 
         self.assertIn("product-onboarding.yml", script_text)
         self.assertIn("product_onboarding.apply", script_text)
         self.assertIn("deploy:product-onboarding-grant", script_text)
+
+    def test_deploy_authz_grants_do_not_hard_code_product_expected_config_apply(
+        self,
+    ) -> None:
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
+
+        self.assertNotIn("deploy:product-expected-config-grant", script_text)
+        self.assertIn("LAUNCHPLANE_AUTHZ_GRANTS_JSON", script_text)
 
     def test_deploy_authz_grants_do_not_restore_stale_import_self_deploy_rules(
         self,


### PR DESCRIPTION
## Summary

- add `POST /v1/product-profiles/expected-config/apply` for additive product-profile expected-config metadata updates
- add the manual `Product Expected Config` workflow for OIDC-authenticated dry-run/apply calls with runtime operator inputs
- document the product-scoped authz boundary and add focused route/workflow tests

## Review Notes

- Background Auto Review run `545deaef-a991-43de-a6db-6c894649a88c` produced no findings because the scope exceeded the configured background review limit: 152 changed paths over the 120-path limit.
- Focused review agents found authz/idempotency/context concerns; patched before PR:
  - target-product authz for `product_profile.expected_config.apply`
  - no checked-in generic grant for product-specific workflow authority
  - stable workflow idempotency key across reruns
  - required workflow context to avoid accidental global expected-config entries
  - dry-run idempotency key reused for apply now returns 409 and leaves profile unchanged

## Validation

- `uv run python -m unittest tests.test_http_app_product.FastApiProductProfileTests tests.test_product_onboarding.ProductOnboardingTests.test_product_expected_config_workflow_calls_service_route_with_apply_guard tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_do_not_hard_code_product_expected_config_apply`
- `uv run python -m unittest tests.test_http_app_product tests.test_product_onboarding tests.test_docs_contracts`
- `uv run python -m py_compile control_plane/http_app.py tests/test_http_app_product.py tests/http_app_test_support.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff check --diff control_plane/http_app.py tests/test_http_app_product.py tests/http_app_test_support.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff format --check --diff control_plane/http_app.py tests/test_http_app_product.py tests/http_app_test_support.py tests/test_product_onboarding.py`
- `actionlint -oneline .github/workflows/product-expected-config.yml .github/workflows/deploy-launchplane.yml`
- `bash -n scripts/deploy/ensure-authz-grants.sh`
- `shfmt -d scripts/deploy/ensure-authz-grants.sh`
- `git diff --check`
