### PR TITLE
Add Odoo preview request render mode

### DIFF
--- a/.github/actions/setup-odoo-preview-request-client/action.yml
+++ b/.github/actions/setup-odoo-preview-request-client/action.yml
@@ -7,10 +7,85 @@ inputs:
     description: Path where the ESM client module should be written.
     required: false
     default: .launchplane/odoo-preview-request-client.mjs
+  request-kind:
+    description: >-
+      Optional request to render: artifact-publish-inputs,
+      preview-apply-inputs, or preview-apply. When omitted, the action only
+      writes the importable client module.
+    required: false
+    default: ""
+  product:
+    description: Launchplane product key for rendered requests.
+    required: false
+    default: ""
+  context:
+    description: Launchplane Odoo preview context for rendered requests.
+    required: false
+    default: ""
+  instance:
+    description: Launchplane runtime instance for artifact publish inputs.
+    required: false
+    default: testing
+  operation:
+    description: Odoo preview operation, refresh or destroy.
+    required: false
+    default: refresh
+  pr-number:
+    description: Pull request number for rendered requests.
+    required: false
+    default: ""
+  preview-slug:
+    description: Optional preview slug token for idempotency only.
+    required: false
+    default: ""
+  source-git-ref:
+    description: Source git ref or SHA for rendered requests.
+    required: false
+    default: ""
+  source:
+    description: Optional request source for preview apply inputs.
+    required: false
+    default: ""
+  manifest-file:
+    description: Artifact manifest file path for refresh requests.
+    required: false
+    default: ""
+  dry-run-plan-file:
+    description: Dry-run plan file path for preview apply requests.
+    required: false
+    default: ""
+  wait-for-deploy:
+    description: Whether preview apply should wait for deploy completion.
+    required: false
+    default: ""
+  smoke-check:
+    description: Optional preview apply smoke-check override.
+    required: false
+    default: ""
+  run-id:
+    description: GitHub run ID for rendered request idempotency.
+    required: false
+    default: ${{ github.run_id }}
+  run-attempt:
+    description: GitHub run attempt for rendered request idempotency.
+    required: false
+    default: ${{ github.run_attempt }}
 
 outputs:
   client-path:
     description: Path to the generated ESM client module.
+  route-path:
+    description: Launchplane route path for the rendered request.
+  payload:
+    description: JSON payload for the rendered request.
+  payload-json-files:
+    description: Newline-separated payload path to JSON file bindings.
+  idempotency-key:
+    description: Idempotency key for the rendered request.
+  fail-result-paths:
+    description: Comma-separated fail-result paths for launchplane-request.
+  response-output-path:
+    description: Response output path for launchplane-request.
 
 runs:
   using: node24

--- a/.github/actions/setup-odoo-preview-request-client/dist/index.js
+++ b/.github/actions/setup-odoo-preview-request-client/dist/index.js
@@ -1,5 +1,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
+const { randomUUID } = require("node:crypto");
+const { pathToFileURL } = require("node:url");
 
 function inputNameToEnvKey(name) {
   return `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
@@ -23,7 +25,74 @@ function setOutput(name, value) {
   fs.appendFileSync(outputPath, `${name}=${value}\n`, "utf8");
 }
 
-function main() {
+function setMultilineOutput(name, value) {
+  const outputPath = String(process.env.GITHUB_OUTPUT ?? "").trim();
+  if (!outputPath) {
+    return;
+  }
+  let delimiter = `odoo_preview_request_${randomUUID()}`;
+  while (String(value).includes(delimiter)) {
+    delimiter = `odoo_preview_request_${randomUUID()}`;
+  }
+  fs.appendFileSync(outputPath, `${name}<<${delimiter}\n${value}\n${delimiter}\n`, "utf8");
+}
+
+function normalizeRequestKind(value) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (
+    normalized &&
+    !["artifact-publish-inputs", "preview-apply-inputs", "preview-apply"].includes(normalized)
+  ) {
+    throw new Error(
+      "request-kind must be artifact-publish-inputs, preview-apply-inputs, or preview-apply.",
+    );
+  }
+  return normalized;
+}
+
+function requestOptions() {
+  return {
+    product: getInput("product"),
+    context: getInput("context"),
+    instance: getInput("instance", { defaultValue: "testing" }),
+    operation: getInput("operation", { defaultValue: "refresh" }),
+    prNumber: getInput("pr-number"),
+    previewSlug: getInput("preview-slug"),
+    sourceGitRef: getInput("source-git-ref"),
+    source: getInput("source"),
+    manifestFile: getInput("manifest-file"),
+    dryRunPlanFile: getInput("dry-run-plan-file"),
+    waitForDeploy: getInput("wait-for-deploy"),
+    smokeCheck: getInput("smoke-check"),
+    runId: getInput("run-id", { defaultValue: process.env.GITHUB_RUN_ID ?? "" }),
+    runAttempt: getInput("run-attempt", {
+      defaultValue: process.env.GITHUB_RUN_ATTEMPT ?? "",
+    }),
+  };
+}
+
+async function renderRequest(kind, clientPath) {
+  const client = await import(pathToFileURL(clientPath).href);
+  const options = requestOptions();
+  if (kind === "artifact-publish-inputs") {
+    return client.buildOdooPreviewArtifactPublishInputsRequest(options);
+  }
+  if (kind === "preview-apply-inputs") {
+    return client.buildOdooPreviewApplyInputsRequest(options);
+  }
+  return client.buildOdooPreviewApplyRequest(options);
+}
+
+function writeRequestOutputs(request) {
+  setOutput("route-path", request.routePath);
+  setMultilineOutput("payload", request.payloadInput);
+  setMultilineOutput("payload-json-files", request.payloadJsonFilesInput);
+  setOutput("idempotency-key", request.idempotencyKey);
+  setOutput("fail-result-paths", request.failResultPathsInput);
+  setOutput("response-output-path", request.responseOutputPath);
+}
+
+async function main() {
   const outputPath = getInput("output-path", {
     defaultValue: ".launchplane/odoo-preview-request-client.mjs",
   });
@@ -32,11 +101,15 @@ function main() {
   fs.copyFileSync(sourcePath, outputPath);
   setOutput("client-path", outputPath);
   console.log(`Wrote Launchplane Odoo preview request client to ${outputPath}`);
+
+  const requestKind = normalizeRequestKind(getInput("request-kind"));
+  if (requestKind) {
+    writeRequestOutputs(await renderRequest(requestKind, outputPath));
+    console.log(`Rendered Launchplane Odoo preview ${requestKind} request`);
+  }
 }
 
-try {
-  main();
-} catch (error) {
+main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
-}
+});

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -198,12 +198,15 @@ idempotency keys for `artifact-publish-inputs`, `preview-apply-inputs`, and
 `preview-apply` are Launchplane contract fixtures. New or migrated tenant
 preview workflows should install
 `cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main`
-and import the generated ESM client to render `launchplane-request` inputs
-instead of copying inline route paths, JSON request bodies, file bindings, fail
-paths, or idempotency key templates. The generated request object exposes
-`payloadInput`, `payloadJsonFilesInput`, `failResultPathsInput`,
-`responseOutputPath`, and `idempotencyKey` fields shaped for direct handoff to
-the existing `launchplane-request` action.
+and either use its `request-kind` render mode or import the generated ESM client
+to render `launchplane-request` inputs instead of copying inline route paths,
+JSON request bodies, file bindings, fail paths, or idempotency key templates.
+Render mode accepts primitive workflow facts and emits `route-path`, `payload`,
+`payload-json-files`, `fail-result-paths`, `response-output-path`, and
+`idempotency-key` outputs shaped for direct handoff to the existing
+`launchplane-request` action. The generated request object exposes the same
+contract as `routePath`, `payloadInput`, `payloadJsonFilesInput`,
+`failResultPathsInput`, `responseOutputPath`, and `idempotencyKey` fields.
 
 Odoo CM is the exception where Launchplane now owns both the isolated provider
 apply planning inputs and the stage-preview smoke contract after refresh. Product

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -462,6 +462,14 @@ summaries, derives the canonical `ready`, `failed`, `destroyed`, or
 feedback workflow. Product repos should not copy status selection, feedback
 route payloads, feedback markers, or idempotency-key logic.
 
+Odoo tenant preview workflows that still call Odoo driver routes directly should
+use `setup-odoo-preview-request-client@main` with `request-kind` set to
+`artifact-publish-inputs`, `preview-apply-inputs`, or `preview-apply` before
+calling `launchplane-request`. The action owns the route path, JSON payload
+shape, JSON-file binding list, fail-result paths, response output path, and
+run-scoped idempotency key. Tenant workflows supply only primitive product,
+context, PR, source, manifest, dry-run plan, and smoke/wait facts.
+
 These reusable workflows intentionally do not accept provider targets, target
 ids, health URLs, preview URLs, feedback markdown, record ids, managed secrets,
 runtime environment values, or idempotency keys. Launchplane derives or records

--- a/tests/test_odoo_preview_request_client_action.py
+++ b/tests/test_odoo_preview_request_client_action.py
@@ -19,7 +19,11 @@ class OdooPreviewRequestClientActionTests(unittest.TestCase):
         )
 
     def run_setup_action(
-        self, *, output_path: Path, github_output: Path
+        self,
+        *,
+        output_path: Path,
+        github_output: Path,
+        inputs: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         if shutil.which("node") is None:
             self.skipTest("node is required to test the Odoo preview request action")
@@ -27,6 +31,8 @@ class OdooPreviewRequestClientActionTests(unittest.TestCase):
         env = os.environ.copy()
         env["INPUT_OUTPUT-PATH"] = str(output_path)
         env["GITHUB_OUTPUT"] = str(github_output)
+        for name, value in (inputs or {}).items():
+            env[f"INPUT_{name.replace(' ', '_').upper()}"] = value
         return subprocess.run(
             ["node", ACTION_ENTRYPOINT.as_posix()],
             check=False,
@@ -34,6 +40,26 @@ class OdooPreviewRequestClientActionTests(unittest.TestCase):
             env=env,
             text=True,
         )
+
+    def read_outputs(self, github_output: Path) -> dict[str, str]:
+        outputs: dict[str, str] = {}
+        lines = github_output.read_text(encoding="utf-8").splitlines()
+        index = 0
+        while index < len(lines):
+            line = lines[index]
+            if "<<" in line:
+                name, delimiter = line.split("<<", 1)
+                index += 1
+                values: list[str] = []
+                while index < len(lines) and lines[index] != delimiter:
+                    values.append(lines[index])
+                    index += 1
+                outputs[name] = "\n".join(values)
+            elif "=" in line:
+                name, value = line.split("=", 1)
+                outputs[name] = value
+            index += 1
+        return outputs
 
     def run_client_script(
         self, client_path: Path, script_body: str
@@ -77,6 +103,202 @@ console.log(Object.keys(client).sort().join(','));
             self.assertIn("buildOdooPreviewArtifactPublishInputsRequest", import_result.stdout)
             self.assertIn("buildOdooPreviewApplyInputsRequest", import_result.stdout)
             self.assertIn("buildOdooPreviewApplyRequest", import_result.stdout)
+
+    def test_setup_action_renders_artifact_publish_request_outputs(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            client_path = temporary_root / "odoo-preview-client.mjs"
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=client_path,
+                github_output=github_output,
+                inputs={
+                    "REQUEST-KIND": "artifact-publish-inputs",
+                    "PRODUCT": "odoo-tenant-cm-website",
+                    "CONTEXT": "cm_website",
+                    "PR-NUMBER": "42",
+                    "SOURCE-GIT-REF": "abc123",
+                    "RUN-ID": "456",
+                    "RUN-ATTEMPT": "2",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            outputs = self.read_outputs(github_output)
+            self.assertEqual(outputs["client-path"], str(client_path))
+            self.assertEqual(outputs["route-path"], "/v1/drivers/odoo/artifact-publish-inputs")
+            self.assertEqual(outputs["fail-result-paths"], "result.input_status")
+            self.assertEqual(outputs["response-output-path"], "result")
+            self.assertEqual(
+                outputs["idempotency-key"],
+                "odoo-artifact-publish-inputs:odoo-tenant-cm-website:cm_website:testing:preview-42-run-456-attempt-2",
+            )
+            self.assertEqual(outputs["payload-json-files"], "")
+            self.assertEqual(
+                json.loads(outputs["payload"]),
+                {
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm-website",
+                    "inputs": {
+                        "schema_version": 1,
+                        "context": "cm_website",
+                        "instance": "testing",
+                        "pr_number": 42,
+                        "isolated": True,
+                        "source_git_ref": "abc123",
+                    },
+                },
+            )
+
+    def test_setup_action_renders_preview_apply_inputs_request_outputs(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=temporary_root / "odoo-preview-client.mjs",
+                github_output=github_output,
+                inputs={
+                    "REQUEST-KIND": "preview-apply-inputs",
+                    "PRODUCT": "odoo-tenant-cm-website",
+                    "CONTEXT": "cm_website",
+                    "PR-NUMBER": "42",
+                    "PREVIEW-SLUG": "preview-42",
+                    "SOURCE-GIT-REF": "abc123",
+                    "MANIFEST-FILE": "/tmp/preview-artifact.json",
+                    "RUN-ID": "456",
+                    "RUN-ATTEMPT": "2",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            outputs = self.read_outputs(github_output)
+            self.assertEqual(outputs["route-path"], "/v1/drivers/odoo/preview-apply-inputs")
+            self.assertEqual(
+                outputs["payload-json-files"], "inputs.manifest=/tmp/preview-artifact.json"
+            )
+            self.assertEqual(outputs["fail-result-paths"], "result.status")
+            self.assertEqual(outputs["response-output-path"], "result.dry_run_plan")
+            self.assertEqual(
+                outputs["idempotency-key"],
+                "odoo-preview-apply-inputs:odoo-tenant-cm-website:preview-42:abc123:inputs-run-456-attempt-2",
+            )
+            payload = json.loads(outputs["payload"])
+            self.assertNotIn("preview_slug", payload["inputs"])
+
+    def test_setup_action_renders_destroy_apply_request_outputs(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=temporary_root / "odoo-preview-client.mjs",
+                github_output=github_output,
+                inputs={
+                    "REQUEST-KIND": "preview-apply",
+                    "PRODUCT": "odoo-tenant-cm-website",
+                    "CONTEXT": "cm_website",
+                    "OPERATION": "destroy",
+                    "PR-NUMBER": "42",
+                    "DRY-RUN-PLAN-FILE": "/tmp/destroy-dry-run.json",
+                    "WAIT-FOR-DEPLOY": "false",
+                    "SMOKE-CHECK": "false",
+                    "RUN-ID": "456",
+                    "RUN-ATTEMPT": "2",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            outputs = self.read_outputs(github_output)
+            self.assertEqual(outputs["route-path"], "/v1/drivers/odoo/preview-apply")
+            self.assertEqual(
+                outputs["payload-json-files"], "apply.dry_run_plan=/tmp/destroy-dry-run.json"
+            )
+            self.assertEqual(outputs["fail-result-paths"], "result.status")
+            self.assertEqual(outputs["response-output-path"], "")
+            self.assertEqual(
+                outputs["idempotency-key"],
+                "odoo-preview-apply:odoo-tenant-cm-website:pr-42:destroy:run-456-attempt-2",
+            )
+            self.assertEqual(
+                json.loads(outputs["payload"])["apply"],
+                {"timeout_seconds": 600, "wait_for_deploy": False, "smoke_check": False},
+            )
+
+    def test_setup_action_renders_refresh_apply_request_outputs(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=temporary_root / "odoo-preview-client.mjs",
+                github_output=github_output,
+                inputs={
+                    "REQUEST-KIND": "preview-apply",
+                    "PRODUCT": "odoo-tenant-cm-website",
+                    "CONTEXT": "cm_website",
+                    "PR-NUMBER": "42",
+                    "PREVIEW-SLUG": "preview-42",
+                    "SOURCE-GIT-REF": "abc123",
+                    "DRY-RUN-PLAN-FILE": "/tmp/dry-run.json",
+                    "MANIFEST-FILE": "/tmp/preview-artifact.json",
+                    "RUN-ID": "456",
+                    "RUN-ATTEMPT": "2",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            outputs = self.read_outputs(github_output)
+            self.assertEqual(outputs["route-path"], "/v1/drivers/odoo/preview-apply")
+            self.assertEqual(
+                outputs["payload-json-files"],
+                "apply.dry_run_plan=/tmp/dry-run.json\napply.manifest=/tmp/preview-artifact.json",
+            )
+            self.assertEqual(outputs["fail-result-paths"], "result.status")
+            self.assertEqual(outputs["response-output-path"], "")
+            self.assertEqual(
+                outputs["idempotency-key"],
+                "odoo-preview-apply:odoo-tenant-cm-website:preview-42:refresh:run-456-attempt-2",
+            )
+            self.assertEqual(
+                json.loads(outputs["payload"]),
+                {
+                    "schema_version": 1,
+                    "product": "odoo-tenant-cm-website",
+                    "apply": {"timeout_seconds": 600, "wait_for_deploy": True},
+                },
+            )
+
+    def test_setup_action_rejects_unknown_request_kind(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            result = self.run_setup_action(
+                output_path=Path(temporary_directory) / "odoo-preview-client.mjs",
+                github_output=Path(temporary_directory) / "out",
+                inputs={"REQUEST-KIND": "preview-url"},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("request-kind must be", result.stderr)
+
+    def test_setup_action_render_mode_rejects_missing_required_facts(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            result = self.run_setup_action(
+                output_path=Path(temporary_directory) / "odoo-preview-client.mjs",
+                github_output=Path(temporary_directory) / "out",
+                inputs={
+                    "REQUEST-KIND": "preview-apply-inputs",
+                    "PRODUCT": "odoo-tenant-cm-website",
+                    "CONTEXT": "cm_website",
+                    "PR-NUMBER": "42",
+                    "SOURCE-GIT-REF": "abc123",
+                    "RUN-ID": "456",
+                    "RUN-ATTEMPT": "2",
+                },
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("refresh apply inputs require manifestFile", result.stderr)
 
     def test_client_builds_artifact_publish_inputs_request(self) -> None:
         with TemporaryDirectory() as temporary_directory:


### PR DESCRIPTION
## Summary
- Add optional request-kind render mode to setup-odoo-preview-request-client.
- Preserve existing client-path output/importable ESM client behavior while emitting launchplane-request inputs for artifact-publish-inputs, preview-apply-inputs, and preview-apply.
- Document render mode as the tenant migration path away from copied inline Node request-rendering blocks.

## Validation
- node --check .github/actions/setup-odoo-preview-request-client/dist/index.js
- node --check .github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs
- uv run python -m unittest tests.test_odoo_preview_request_client_action tests.test_docs_contracts
- uv run ruff check --diff tests/test_odoo_preview_request_client_action.py
- uv run ruff format --check --diff tests/test_odoo_preview_request_client_action.py

## Review
- Targeted two-agent review found no blockers.
- Patched review follow-ups: added action-level refresh preview-apply render test, randomized multiline output delimiters, and removed dead async try/catch.

## Notes
- Background Auto Review currently fails before findings because the broad snapshot has 152 changed paths over its 120-path cap; no actionable finding was produced.