### PR TITLE
Add protected artifacts request client

### DIFF
--- a/.github/actions/setup-protected-artifacts-request-client/action.yml
+++ b/.github/actions/setup-protected-artifacts-request-client/action.yml
@@ -1,0 +1,44 @@
+---
+name: Setup protected artifacts request client
+description: Write Launchplane's protected artifact request-shaping Node client.
+
+inputs:
+  output-path:
+    description: Path where the ESM client module should be written.
+    required: false
+    default: .launchplane/protected-artifacts-request-client.mjs
+  render-request:
+    description: >-
+      Whether to render launchplane-request inputs for the protected artifacts
+      inventory request. When false, the action only writes the importable
+      client module and request outputs are empty.
+    required: false
+    default: "false"
+  product:
+    description: Launchplane product key. Required when render-request is true.
+    required: false
+    default: ""
+  context:
+    description: Optional Launchplane context for scoped protected inventory.
+    required: false
+    default: ""
+  response-output-file:
+    description: Optional file path where launchplane-request should write the inventory.
+    required: false
+    default: ""
+
+outputs:
+  client-path:
+    description: Path to the generated ESM client module.
+  route-path:
+    description: Launchplane route path for the rendered request; empty unless render-request is true.
+  method:
+    description: HTTP method for launchplane-request; empty unless render-request is true.
+  response-output-path:
+    description: Response output path for launchplane-request; empty unless render-request is true.
+  response-output-file:
+    description: Response output file for launchplane-request; empty unless render-request is true.
+
+runs:
+  using: node24
+  main: dist/index.js

--- a/.github/actions/setup-protected-artifacts-request-client/dist/index.js
+++ b/.github/actions/setup-protected-artifacts-request-client/dist/index.js
@@ -1,0 +1,88 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const { pathToFileURL } = require("node:url");
+
+function inputNameToEnvKey(name) {
+  return `INPUT_${name.replace(/ /g, "_").toUpperCase()}`;
+}
+
+function getInput(name, options = {}) {
+  const value = String(
+    process.env[inputNameToEnvKey(name)] ?? options.defaultValue ?? "",
+  ).trim();
+  if (options.required && !value) {
+    throw new Error(`${name} is required.`);
+  }
+  return value;
+}
+
+function parseBooleanInput(name, options = {}) {
+  const value = getInput(name, options);
+  if (!value) {
+    return false;
+  }
+  const normalized = value.toLowerCase();
+  if (["true", "1", "yes"].includes(normalized)) {
+    return true;
+  }
+  if (["false", "0", "no"].includes(normalized)) {
+    return false;
+  }
+  throw new Error(`${name} must be a boolean.`);
+}
+
+function setOutput(name, value) {
+  const outputPath = String(process.env.GITHUB_OUTPUT ?? "").trim();
+  if (!outputPath) {
+    console.warn(`GITHUB_OUTPUT is not set; skipped ${name} output.`);
+    return;
+  }
+  fs.appendFileSync(outputPath, `${name}=${value}\n`, "utf8");
+}
+
+async function renderRequest(clientPath) {
+  const client = await import(pathToFileURL(clientPath).href);
+  return client.buildProtectedArtifactsRequest({
+    product: getInput("product", { required: true }),
+    context: getInput("context"),
+    responseOutputFile: getInput("response-output-file"),
+  });
+}
+
+function writeRequestOutputs(request) {
+  setOutput("route-path", request.routePath);
+  setOutput("method", request.method);
+  setOutput("response-output-path", request.responseOutputPath);
+  setOutput("response-output-file", request.responseOutputFile);
+}
+
+async function main() {
+  const outputPath = getInput("output-path", {
+    defaultValue: ".launchplane/protected-artifacts-request-client.mjs",
+  });
+  const sourcePath = path.join(
+    __dirname,
+    "..",
+    "src",
+    "protected-artifacts-request-client.mjs",
+  );
+  if (!fs.existsSync(sourcePath)) {
+    throw new Error(
+      `Protected artifacts request client source is missing at ${sourcePath}.`,
+    );
+  }
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.copyFileSync(sourcePath, outputPath);
+  setOutput("client-path", outputPath);
+  console.log(`Wrote Launchplane protected artifacts request client to ${outputPath}`);
+
+  if (parseBooleanInput("render-request", { defaultValue: "false" })) {
+    writeRequestOutputs(await renderRequest(outputPath));
+    console.log("Rendered Launchplane protected artifacts request");
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/.github/actions/setup-protected-artifacts-request-client/src/protected-artifacts-request-client.mjs
+++ b/.github/actions/setup-protected-artifacts-request-client/src/protected-artifacts-request-client.mjs
@@ -1,0 +1,37 @@
+export const PROTECTED_ARTIFACTS_ROUTE = "/v1/artifacts/protected";
+export const PROTECTED_ARTIFACTS_RESPONSE_OUTPUT_PATH = "protected_artifacts";
+
+function requiredText(value, label) {
+  const normalized = String(value ?? "").trim();
+  if (!normalized) {
+    throw new Error(`${label} is required.`);
+  }
+  return normalized;
+}
+
+function optionalText(value) {
+  return String(value ?? "").trim();
+}
+
+function queryParameter(name, value) {
+  return `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
+}
+
+export function buildProtectedArtifactsRoutePath(options = {}) {
+  const product = requiredText(options.product, "Protected artifacts product");
+  const context = optionalText(options.context);
+  const parameters = [queryParameter("product", product)];
+  if (context) {
+    parameters.push(queryParameter("context", context));
+  }
+  return `${PROTECTED_ARTIFACTS_ROUTE}?${parameters.join("&")}`;
+}
+
+export function buildProtectedArtifactsRequest(options = {}) {
+  return {
+    routePath: buildProtectedArtifactsRoutePath(options),
+    method: "GET",
+    responseOutputPath: PROTECTED_ARTIFACTS_RESPONSE_OUTPUT_PATH,
+    responseOutputFile: optionalText(options.responseOutputFile),
+  };
+}

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -366,10 +366,16 @@ Cleanup consumers must check both `artifact_ids` and `image_references` from the
 protected inventory. Some active-preview protections come from ready PR feedback
 records that carry immutable and refresh image references but no artifact id, so
 an artifact-id-only cleanup filter can still delete a live preview tag. Whole-
-product cleanup callers should request `GET /v1/artifacts/protected?product=...`
-with an `artifact_protection.read` grant that allows wildcard context for that
-product; context-specific cleanup may pass `context=` and use a matching scoped
-grant.
+product cleanup callers should use
+`cbusillo/launchplane/.github/actions/setup-protected-artifacts-request-client@main`
+with `render-request: true` to render the
+`GET /v1/artifacts/protected?product=...` route, `GET` method, and
+`protected_artifacts` response extraction for `launchplane-request`; the caller
+must use an `artifact_protection.read` grant that allows wildcard context for
+that product. Context-specific cleanup may pass `context=` and use a matching
+scoped grant. Product repos may still own provider-specific deletion and package
+tokens, but not the protected-inventory route shape or response extraction
+contract.
 
 ## Canonical Image Deploy Connector
 

--- a/tests/test_protected_artifacts_request_client_action.py
+++ b/tests/test_protected_artifacts_request_client_action.py
@@ -1,0 +1,213 @@
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+
+ACTION_ENTRYPOINT = Path(".github/actions/setup-protected-artifacts-request-client/dist/index.js")
+ACTION_METADATA = Path(".github/actions/setup-protected-artifacts-request-client/action.yml")
+
+
+class ProtectedArtifactsRequestClientActionTests(unittest.TestCase):
+    def test_action_metadata_uses_supported_node_runtime(self) -> None:
+        self.assertIn(
+            "using: node24",
+            ACTION_METADATA.read_text(encoding="utf-8"),
+        )
+
+    def run_setup_action(
+        self,
+        *,
+        output_path: Path,
+        github_output: Path,
+        inputs: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the protected artifacts request action")
+
+        env = os.environ.copy()
+        env["INPUT_OUTPUT-PATH"] = str(output_path)
+        env["GITHUB_OUTPUT"] = str(github_output)
+        for name, value in (inputs or {}).items():
+            env[f"INPUT_{name.replace(' ', '_').upper()}"] = value
+        return subprocess.run(
+            ["node", ACTION_ENTRYPOINT.as_posix()],
+            check=False,
+            capture_output=True,
+            env=env,
+            text=True,
+        )
+
+    def read_outputs(self, github_output: Path) -> dict[str, str]:
+        outputs: dict[str, str] = {}
+        for line in github_output.read_text(encoding="utf-8").splitlines():
+            name, value = line.split("=", 1)
+            outputs[name] = value
+        return outputs
+
+    def run_client_script(
+        self, client_path: Path, script_body: str
+    ) -> subprocess.CompletedProcess[str]:
+        if shutil.which("node") is None:
+            self.skipTest("node is required to test the protected artifacts request client")
+
+        script = f"""
+import * as client from {json.dumps(client_path.as_uri())};
+{script_body}
+"""
+        return subprocess.run(
+            ["node", "--input-type=module", "-e", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_setup_action_writes_importable_client_and_output(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            client_path = temporary_root / ".launchplane" / "protected-artifacts.mjs"
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=client_path,
+                github_output=github_output,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertTrue(client_path.exists())
+            outputs = self.read_outputs(github_output)
+            self.assertEqual(outputs, {"client-path": str(client_path)})
+
+            import_result = self.run_client_script(
+                client_path,
+                """
+console.log(Object.keys(client).sort().join(','));
+""",
+            )
+            self.assertEqual(import_result.returncode, 0, import_result.stderr)
+            self.assertIn("buildProtectedArtifactsRequest", import_result.stdout)
+            self.assertIn("buildProtectedArtifactsRoutePath", import_result.stdout)
+
+    def test_setup_action_renders_request_outputs(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            client_path = temporary_root / "protected-artifacts.mjs"
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=client_path,
+                github_output=github_output,
+                inputs={
+                    "RENDER-REQUEST": "true",
+                    "PRODUCT": "odoo tenant/cm",
+                    "CONTEXT": "cm website",
+                    "RESPONSE-OUTPUT-FILE": "protected-artifacts.json",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            outputs = self.read_outputs(github_output)
+            self.assertEqual(outputs["client-path"], str(client_path))
+            self.assertEqual(
+                outputs["route-path"],
+                "/v1/artifacts/protected?product=odoo%20tenant%2Fcm&context=cm%20website",
+            )
+            self.assertEqual(outputs["method"], "GET")
+            self.assertEqual(outputs["response-output-path"], "protected_artifacts")
+            self.assertEqual(outputs["response-output-file"], "protected-artifacts.json")
+
+    def test_setup_action_renders_whole_product_request_outputs(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            temporary_root = Path(temporary_directory)
+            client_path = temporary_root / "protected-artifacts.mjs"
+            github_output = temporary_root / "github-output.txt"
+
+            result = self.run_setup_action(
+                output_path=client_path,
+                github_output=github_output,
+                inputs={
+                    "RENDER-REQUEST": "true",
+                    "PRODUCT": "verireel",
+                    "RESPONSE-OUTPUT-FILE": "protected-artifacts.json",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            outputs = self.read_outputs(github_output)
+            self.assertEqual(outputs["client-path"], str(client_path))
+            self.assertEqual(outputs["route-path"], "/v1/artifacts/protected?product=verireel")
+            self.assertEqual(outputs["method"], "GET")
+            self.assertEqual(outputs["response-output-path"], "protected_artifacts")
+            self.assertEqual(outputs["response-output-file"], "protected-artifacts.json")
+
+    def test_setup_action_render_mode_rejects_missing_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            result = self.run_setup_action(
+                output_path=Path(temporary_directory) / "protected-artifacts.mjs",
+                github_output=Path(temporary_directory) / "out",
+                inputs={"RENDER-REQUEST": "true"},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("product is required", result.stderr)
+
+    def test_setup_action_rejects_invalid_render_request_boolean(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            result = self.run_setup_action(
+                output_path=Path(temporary_directory) / "protected-artifacts.mjs",
+                github_output=Path(temporary_directory) / "out",
+                inputs={"RENDER-REQUEST": "sometimes"},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("render-request must be a boolean", result.stderr)
+
+    def test_client_builds_whole_product_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "protected-artifacts.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            result = self.run_client_script(
+                client_path,
+                """
+const request = client.buildProtectedArtifactsRequest({
+  product: 'verireel',
+  responseOutputFile: 'protected-artifacts.json',
+});
+console.log(JSON.stringify(request));
+""",
+            )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        request = json.loads(result.stdout)
+        self.assertEqual(request["routePath"], "/v1/artifacts/protected?product=verireel")
+        self.assertEqual(request["method"], "GET")
+        self.assertEqual(request["responseOutputPath"], "protected_artifacts")
+        self.assertEqual(request["responseOutputFile"], "protected-artifacts.json")
+
+    def test_client_rejects_blank_product(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            client_path = Path(temporary_directory) / "protected-artifacts.mjs"
+            self.run_setup_action(
+                output_path=client_path, github_output=Path(temporary_directory) / "out"
+            )
+
+            result = self.run_client_script(
+                client_path,
+                """
+try {
+  client.buildProtectedArtifactsRequest({ product: '   ' });
+} catch (error) {
+  console.error(error.message);
+  process.exit(2);
+}
+""",
+            )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("Protected artifacts product is required", result.stderr)


### PR DESCRIPTION
## Summary
- add a Launchplane-owned protected artifacts request client action
- render GET /v1/artifacts/protected request inputs for launchplane-request without tenant workflow route hard-coding
- document the protected-inventory cleanup boundary for product repos

## Validation
- node --check .github/actions/setup-protected-artifacts-request-client/dist/index.js
- node --check .github/actions/setup-protected-artifacts-request-client/src/protected-artifacts-request-client.mjs
- uv run python -m unittest tests.test_protected_artifacts_request_client_action tests.test_docs_contracts
- uv run ruff check tests/test_protected_artifacts_request_client_action.py
- uv run ruff format --check --diff tests/test_protected_artifacts_request_client_action.py
- git diff --check

## Review
- scoped review agents checked the new action, docs, and tests
- accepted review follow-ups for whole-product render coverage, render-output absence, metadata wording, and friendly missing-source failure
- repo auto-review background run is currently blocked by the known 152-path scope limit before findings
