### PR TITLE
Classify protected artifacts cleanup connector input

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -1833,17 +1833,21 @@ def _yaml_block_scalar_assignment_candidates(
 def _allow_context_for_candidates(
     *, path: str, candidates: Sequence[tuple[int, str, object]]
 ) -> Mapping[str, object]:
-    if path != ".github/workflows/launchplane-config-authority.yml":
-        return {}
-    pinned_checkout_blocks = {
-        _checkout_candidate_block(key)
-        for _, key, value in candidates
-        if key.startswith("checkout.ref[")
-        and GIT_COMMIT_SHA_PATTERN.fullmatch(_string_value(value).strip()) is not None
-    }
-    return {
-        "launchplane_tool_checkout_pinned_blocks": pinned_checkout_blocks,
-    }
+    allow_context: dict[str, object] = {}
+    if path == ".github/workflows/launchplane-config-authority.yml":
+        allow_context["launchplane_tool_checkout_pinned_blocks"] = {
+            _checkout_candidate_block(key)
+            for _, key, value in candidates
+            if key.startswith("checkout.ref[")
+            and GIT_COMMIT_SHA_PATTERN.fullmatch(_string_value(value).strip()) is not None
+        }
+    if path == ".github/workflows/cleanup-ghcr.yml":
+        allow_context["cleanup_ghcr_launchplane_products"] = {
+            _string_value(value).strip().rstrip(",")
+            for _, key, value in candidates
+            if key == "LAUNCHPLANE_PRODUCT"
+        }
+    return allow_context
 
 
 def _checkout_candidate_block(key: str) -> str:
@@ -2193,6 +2197,13 @@ def _allow_reason(
         path=normalized,
         key=key,
         value=value,
+    ):
+        return ALLOW_REASON_THIN_CONNECTOR_INPUT
+    if normalized.startswith(".github/workflows/") and _is_cleanup_ghcr_product_forward(
+        path=normalized,
+        key=key,
+        value=value,
+        allow_context=allow_context,
     ):
         return ALLOW_REASON_THIN_CONNECTOR_INPUT
     if normalized.startswith(".github/workflows/") and _is_workflow_read_model_output_forward(
@@ -2731,6 +2742,18 @@ def _is_workflow_thin_connector_key_value(*, path: str, key: str, value: object)
         return False
     value_text = _string_value(value).strip().rstrip(",")
     return value_text in allowed_values
+
+
+def _is_cleanup_ghcr_product_forward(
+    *, path: str, key: str, value: object, allow_context: Mapping[str, object]
+) -> bool:
+    if path != ".github/workflows/cleanup-ghcr.yml" or key != "product":
+        return False
+    value_text = _string_value(value).strip().rstrip(",")
+    if value_text == "${{ env.LAUNCHPLANE_PRODUCT }}":
+        return True
+    existing_products = allow_context.get("cleanup_ghcr_launchplane_products")
+    return isinstance(existing_products, set) and value_text in existing_products
 
 
 def _is_launchplane_reusable_workflow(*, key: str, value: object) -> bool:

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -370,12 +370,13 @@ product cleanup callers should use
 `cbusillo/launchplane/.github/actions/setup-protected-artifacts-request-client@main`
 with `render-request: true` to render the
 `GET /v1/artifacts/protected?product=...` route, `GET` method, and
-`protected_artifacts` response extraction for `launchplane-request`; the caller
-must use an `artifact_protection.read` grant that allows wildcard context for
-that product. Context-specific cleanup may pass `context=` and use a matching
-scoped grant. Product repos may still own provider-specific deletion and package
-tokens, but not the protected-inventory route shape or response extraction
-contract.
+`protected_artifacts` response extraction for `launchplane-request`. Product
+repos should forward the workflow's existing product value into that action
+instead of introducing a second product literal. The caller must use an
+`artifact_protection.read` grant that allows wildcard context for that product.
+Context-specific cleanup may pass `context=` and use a matching scoped grant.
+Product repos may still own provider-specific deletion and package tokens, but
+not the protected-inventory route shape or response extraction contract.
 
 ## Canonical Image Deploy Connector
 

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -959,6 +959,75 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertEqual(route_path["classification"], "allowed")
         self.assertEqual(route_path["allow_reason"], "thin_connector_input")
 
+    def test_cleanup_ghcr_protected_artifacts_product_match_is_thin_connector_input(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            workflow = root / ".github" / "workflows" / "cleanup-ghcr.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(
+                "name: Cleanup GHCR Images\n"
+                "jobs:\n"
+                "  cleanup:\n"
+                "    steps:\n"
+                "      - name: Render Launchplane protected artifact request\n"
+                "        uses: cbusillo/launchplane/.github/actions/"
+                "setup-protected-artifacts-request-client@main\n"
+                "        with:\n"
+                "          product: verireel\n"
+                "      - name: Run GHCR cleanup\n"
+                "        env:\n"
+                "          LAUNCHPLANE_PRODUCT: verireel\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            payload = build_config_authority_audit(control_plane_root=root)
+
+        product = next(finding for finding in _findings(payload) if finding["key"] == "product")
+        self.assertEqual(product["classification"], "allowed")
+        self.assertEqual(product["allow_reason"], "thin_connector_input")
+
+    def test_cleanup_ghcr_protected_artifacts_product_forward_is_thin_connector_input(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            _init_repo(root)
+            workflow = root / ".github" / "workflows" / "cleanup-ghcr.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(
+                "name: Cleanup GHCR Images\n"
+                "jobs:\n"
+                "  cleanup:\n"
+                "    steps:\n"
+                "      - name: Render Launchplane protected artifact request\n"
+                "        uses: cbusillo/launchplane/.github/actions/"
+                "setup-protected-artifacts-request-client@main\n"
+                "        with:\n"
+                "          product: ${{ env.LAUNCHPLANE_PRODUCT }}\n",
+                encoding="utf-8",
+            )
+            _commit_all(root)
+
+            payload = build_config_authority_audit(control_plane_root=root)
+
+        product = next(finding for finding in _findings(payload) if finding["key"] == "product")
+        self.assertEqual(product["classification"], "allowed")
+        self.assertEqual(product["allow_reason"], "thin_connector_input")
+
+    def test_cleanup_ghcr_literal_product_still_needs_classification(self) -> None:
+        self.assertEqual(
+            _allow_reason(
+                path=".github/workflows/cleanup-ghcr.yml",
+                key="product",
+                value="verireel",
+            ),
+            "",
+        )
+
     def test_workflow_block_scalar_runtime_values_are_scanned(self) -> None:
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- classify cleanup-ghcr protected-artifacts request-client product forwarding as a thin connector input
- keep standalone literal product values unclassified unless they match the workflow's existing LAUNCHPLANE_PRODUCT
- document forwarding the existing product value into setup-protected-artifacts-request-client

## Validation
- uv run python -m unittest tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cleanup_ghcr_protected_artifacts_product_match_is_thin_connector_input tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cleanup_ghcr_protected_artifacts_product_forward_is_thin_connector_input tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cleanup_ghcr_literal_product_still_needs_classification tests.test_docs_contracts
- uv run ruff check tests/test_config_authority_audit.py
- uv run ruff format --check --diff tests/test_config_authority_audit.py
- git diff --check
- uv run launchplane service audit-config-authority --control-plane-root /Users/cbusillo/.code/worktrees/verireel/protected-artifacts-request-client --mode changed-files-gate --fail-on-findings --gate-profile product-repo

## Review
- scoped validation models the exact VeriReel config-authority failure from PR #250 and now passes with zero rejected findings
- repo auto-review background run is currently blocked by the known 152-path scope limit before findings
