### PR TITLE
Scope testing verification rerun idempotency

### DIFF
--- a/.github/workflows/reusable-product-driver-testing-verification.yml
+++ b/.github/workflows/reusable-product-driver-testing-verification.yml
@@ -87,6 +87,7 @@ jobs:
           DEPLOYMENT_RECORD_ID: ${{ inputs.deployment_record_id }}
           INSTANCE: ${{ inputs.instance }}
           MIGRATION_STATUS: ${{ inputs.migration_status }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
           OWNER_ROUTES_STATUS: ${{ inputs.owner_routes_status }}
           PRODUCT: ${{ inputs.product }}
           VERIFICATION_STATUS: ${{ inputs.verification_status }}
@@ -109,7 +110,7 @@ jobs:
           done
           {
             echo "context=$CONTEXT"
-            printf '%s=%s:%s:%s:%s:%s:%s:%s:%s\n' \
+            printf '%s=%s:%s:%s:%s:%s:%s:%s:%s:%s\n' \
               idempotency_key \
               product-driver-testing-verification \
               "$PRODUCT" \
@@ -118,7 +119,8 @@ jobs:
               "$DEPLOYMENT_RECORD_ID" \
               "$MIGRATION_STATUS" \
               "$VERIFICATION_STATUS" \
-              "$OWNER_ROUTES_STATUS"
+              "$OWNER_ROUTES_STATUS" \
+              "attempt-${RUN_ATTEMPT}"
             echo "instance=$INSTANCE"
             echo "product=$PRODUCT"
             echo "route_path=/v1/drivers/verireel/testing-verification"

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -227,6 +227,9 @@ class DocsContractsTests(TestCase):
         stable_deploy_workflow = Path(
             ".github/workflows/reusable-product-driver-stable-deploy.yml"
         ).read_text(encoding="utf-8")
+        testing_verification_workflow = Path(
+            ".github/workflows/reusable-product-driver-testing-verification.yml"
+        ).read_text(encoding="utf-8")
         prod_promotion_workflow = Path(
             ".github/workflows/reusable-product-driver-prod-promotion.yml"
         ).read_text(encoding="utf-8")
@@ -278,6 +281,19 @@ class DocsContractsTests(TestCase):
         self.assertIn("target_category=result.target_category", stable_deploy_workflow)
         self.assertNotIn("target_type=result.target_type", stable_deploy_workflow)
         self.assertNotIn("provider_target", stable_deploy_workflow)
+
+        self.assertIn("workflow_call:", testing_verification_workflow)
+        self.assertIn("product-driver-testing-verification \\", testing_verification_workflow)
+        self.assertIn("RUN_ATTEMPT: ${{ github.run_attempt }}", testing_verification_workflow)
+        self.assertIn('"attempt-${RUN_ATTEMPT}"', testing_verification_workflow)
+        self.assertIn(
+            "route_path=/v1/drivers/verireel/testing-verification",
+            testing_verification_workflow,
+        )
+        self.assertIn(
+            "deployment_health_status=result.deployment_health_status",
+            testing_verification_workflow,
+        )
 
         self.assertIn("workflow_call:", prod_promotion_workflow)
         self.assertIn("driver:", prod_promotion_workflow)


### PR DESCRIPTION
## Summary
- include GitHub run attempt in the product-driver testing verification idempotency key
- make the run-attempt dependency explicit in the reusable workflow env
- extend docs contract coverage for the testing-verification route/output shape

## Why
VeriReel's post-merge testing image rerun recovered product verification, but the reusable Launchplane report job replayed the prior failed idempotent response for the same deployment/status tuple. Reruns need a fresh report key while preserving idempotency inside a single attempt.

## Validation
- `uv run ruff check tests/test_docs_contracts.py`
- `uv run ruff format --check --diff tests/test_docs_contracts.py`
- `uv run python -m unittest tests.test_docs_contracts.DocsContractsTests.test_product_driver_reusable_workflows_keep_route_shaping_in_launchplane`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/reusable-product-driver-testing-verification.yml`
- `git diff --check`

## Review
Scoped review agents found no blockers. Low suggestions to make the run-attempt env explicit and strengthen route/output assertions were applied.
