### PR TITLE
Fail closed on ambiguous Odoo preview targets

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
-from control_plane.dokploy import JsonObject
+from control_plane.dokploy import JsonObject, JsonValue
 from control_plane.contracts.artifact_identity import ArtifactIdentityManifest
 from control_plane.contracts.odoo_preview_runtime_plan import (
     OdooPreviewProviderCapabilities,
@@ -75,6 +75,10 @@ ODOO_PREVIEW_REQUIRED_ENV_KEYS = (
 ODOO_PREVIEW_ARTIFACT_PUBLISH_INPUTS_ROUTE = "/v1/drivers/odoo/artifact-publish-inputs"
 ODOO_PREVIEW_APPLY_INPUTS_ROUTE = "/v1/drivers/odoo/preview-apply-inputs"
 ODOO_PREVIEW_APPLY_ROUTE = "/v1/drivers/odoo/preview-apply"
+
+
+class OdooPreviewTargetDiscoveryAmbiguousError(click.ClickException):
+    pass
 
 
 class OdooPreviewWorkflowRequest(BaseModel):
@@ -380,6 +384,7 @@ def build_odoo_preview_apply_inputs(
     )
     target: OdooPreviewRuntimeTargetEvidence | None = None
     discovery_error = ""
+    block_discovery_error = False
     try:
         target = _discover_odoo_preview_target(
             control_plane_root=control_plane_root,
@@ -389,8 +394,12 @@ def build_odoo_preview_apply_inputs(
             compose_name=compose_name,
             database_url=database_url,
         )
+    except OdooPreviewTargetDiscoveryAmbiguousError as exc:
+        discovery_error = str(exc)
+        block_discovery_error = True
     except click.ClickException as exc:
         discovery_error = str(exc)
+        block_discovery_error = request.operation == "destroy"
     runtime_plan = plan_odoo_preview_runtime(
         request=OdooPreviewRuntimePlanRequest(
             operation=request.operation,
@@ -416,7 +425,7 @@ def build_odoo_preview_apply_inputs(
                 message=preview_url_error,
             ),
         )
-    if discovery_error and request.operation == "destroy":
+    if discovery_error and block_discovery_error:
         runtime_plan = _with_runtime_blocker(
             runtime_plan=runtime_plan,
             blocker=OdooPreviewRuntimeBlocker(
@@ -475,7 +484,11 @@ def build_odoo_preview_apply_inputs(
 
 
 def _needs_preview_environment_id(runtime_plan: OdooPreviewRuntimePlan) -> bool:
-    return runtime_plan.operation == "refresh" and runtime_plan.target is None
+    return (
+        runtime_plan.status == "ready"
+        and runtime_plan.operation == "refresh"
+        and runtime_plan.target is None
+    )
 
 
 def _preview_slug(
@@ -689,7 +702,7 @@ def _discover_odoo_preview_target(
                 token=token,
             )
     if len(matches) > 1:
-        raise click.ClickException(
+        raise OdooPreviewTargetDiscoveryAmbiguousError(
             f"Discovered multiple Odoo preview composes named {compose_name!r}; refusing to plan mutation."
         )
     if matches:
@@ -796,14 +809,20 @@ def _iter_dokploy_composes(raw_projects: object) -> tuple[JsonObject, ...]:
 
 
 def _iter_dokploy_search_composes(raw_search_matches: object) -> tuple[JsonObject, ...]:
+    search_items: list[JsonValue]
     if isinstance(raw_search_matches, list):
-        search_items = raw_search_matches
+        search_items = cast(list[JsonValue], raw_search_matches)
     elif isinstance(raw_search_matches, dict):
         search_items = []
         for key in ("composes", "items", "results", "data"):
             value = raw_search_matches.get(key)
-            if isinstance(value, list):
-                search_items.extend(value)
+            if isinstance(value, list) and value:
+                json_values = cast(list[JsonValue], value)
+                if search_items and json_values != search_items:
+                    raise OdooPreviewTargetDiscoveryAmbiguousError(
+                        "Dokploy compose search returned ambiguous result envelopes."
+                    )
+                search_items = json_values
     else:
         raise click.ClickException("Dokploy compose search returned an invalid response payload.")
 
@@ -1073,7 +1092,7 @@ def build_odoo_preview_dokploy_dry_run(
                 "Odoo preview Dokploy dry-run requires a preview URL with a hostname.",
             )
         )
-    if runtime_plan.operation == "refresh" and runtime_plan.target is None:
+    if _needs_preview_environment_id(runtime_plan):
         if not request.environment_id:
             blockers.append(
                 _blocker(

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -921,6 +921,246 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(result.dry_run_plan.rollback_operations, ())
         self.assertEqual(result.error_message, "")
 
+    def test_apply_inputs_uses_wrapped_compose_search_result_envelope(self) -> None:
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [{"environments": [{"composes": []}]}]
+            if path == "/api/compose.search":
+                compose = {
+                    "composeId": "compose-cm-pr-45",
+                    "name": "cm-odoo-preview-pr-45",
+                }
+                return {
+                    "items": [],
+                    "results": [compose],
+                    "data": [compose],
+                }
+            if path == "/api/domain.byComposeId":
+                return _preview_domain_payload()
+            raise AssertionError(path)
+
+        with _patched_apply_inputs_runtime(dokploy_side_effect=_fake_dokploy_request):
+            result = build_odoo_preview_apply_inputs(
+                control_plane_root=Path("."),
+                record_store=_OdooApplyInputsStore(),
+                profile=_profile(),
+                request=OdooPreviewApplyInputsRequest(
+                    product="odoo-tenant-cm",
+                    pr_number=45,
+                    preview_url="https://pr-45.cm-preview.example.test",
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    source_git_ref="abc123",
+                ),
+            )
+
+        self.assertEqual(result.status, "ready")
+        self.assertIsNotNone(result.runtime_plan.target)
+        target = result.runtime_plan.target
+        assert target is not None
+        self.assertEqual(target.target_id, "compose-cm-pr-45")
+        self.assertEqual(result.error_message, "")
+
+    def test_apply_inputs_refresh_reuses_compose_from_search_fallback(self) -> None:
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [{"environments": [{"composes": []}]}]
+            if path == "/api/compose.search":
+                return {
+                    "results": [
+                        {
+                            "composeId": "compose-cm-pr-45",
+                            "name": "cm-odoo-preview-pr-45",
+                        }
+                    ]
+                }
+            if path == "/api/domain.byComposeId":
+                return _preview_domain_payload()
+            raise AssertionError(path)
+
+        with _patched_apply_inputs_runtime(dokploy_side_effect=_fake_dokploy_request):
+            result = build_odoo_preview_apply_inputs(
+                control_plane_root=Path("."),
+                record_store=_OdooApplyInputsStore(),
+                profile=_profile(),
+                request=OdooPreviewApplyInputsRequest(
+                    product="odoo-tenant-cm",
+                    pr_number=45,
+                    preview_url="https://pr-45.cm-preview.example.test",
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    source_git_ref="abc123",
+                ),
+            )
+
+        self.assertEqual(result.status, "ready")
+        self.assertIsNotNone(result.runtime_plan.target)
+        target = result.runtime_plan.target
+        assert target is not None
+        self.assertEqual(target.target_id, "compose-cm-pr-45")
+        self.assertNotIn(
+            "compose_create", [operation.name for operation in result.dry_run_plan.operations]
+        )
+        self.assertEqual(result.dry_run_plan.rollback_operations, ())
+
+    def test_apply_inputs_blocks_on_ambiguous_wrapped_compose_search_envelopes(
+        self,
+    ) -> None:
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [{"environments": [{"composes": []}]}]
+            if path == "/api/compose.search":
+                return {
+                    "items": [
+                        {
+                            "composeId": "compose-cm-pr-45-a",
+                            "name": "cm-odoo-preview-pr-45",
+                        }
+                    ],
+                    "results": [
+                        {
+                            "composeId": "compose-cm-pr-45-b",
+                            "name": "cm-odoo-preview-pr-45",
+                        }
+                    ],
+                }
+            raise AssertionError(path)
+
+        with _patched_apply_inputs_runtime(dokploy_side_effect=_fake_dokploy_request):
+            result = build_odoo_preview_apply_inputs(
+                control_plane_root=Path("."),
+                record_store=_OdooApplyInputsStore(),
+                profile=_profile(),
+                request=OdooPreviewApplyInputsRequest(
+                    product="odoo-tenant-cm",
+                    pr_number=45,
+                    preview_url="https://pr-45.cm-preview.example.test",
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    source_git_ref="abc123",
+                ),
+            )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertIsNone(result.runtime_plan.target)
+        self.assertIn(
+            "runtime_target_discovery_failed",
+            {blocker.code for blocker in result.runtime_plan.blockers},
+        )
+        self.assertIn("ambiguous result envelopes", result.error_message)
+
+    def test_apply_inputs_destroy_blocks_on_ambiguous_wrapped_compose_search_envelopes(
+        self,
+    ) -> None:
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [{"environments": [{"composes": []}]}]
+            if path == "/api/compose.search":
+                return {
+                    "items": [
+                        {
+                            "composeId": "compose-cm-pr-45-a",
+                            "name": "cm-odoo-preview-pr-45",
+                        }
+                    ],
+                    "results": [
+                        {
+                            "composeId": "compose-cm-pr-45-b",
+                            "name": "cm-odoo-preview-pr-45",
+                        }
+                    ],
+                }
+            raise AssertionError(path)
+
+        with _patched_apply_inputs_runtime(dokploy_side_effect=_fake_dokploy_request):
+            result = build_odoo_preview_apply_inputs(
+                control_plane_root=Path("."),
+                record_store=_OdooApplyInputsStore(),
+                profile=_profile(),
+                request=OdooPreviewApplyInputsRequest(
+                    product="odoo-tenant-cm",
+                    operation="destroy",
+                    pr_number=45,
+                    preview_url="https://pr-45.cm-preview.example.test",
+                ),
+            )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertIsNone(result.runtime_plan.target)
+        self.assertIn(
+            "runtime_target_discovery_failed",
+            {blocker.code for blocker in result.runtime_plan.blockers},
+        )
+        self.assertIn("ambiguous result envelopes", result.error_message)
+
+    def test_apply_inputs_ambiguous_discovery_does_not_add_environment_blocker(
+        self,
+    ) -> None:
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [{"environments": [{"composes": []}]}]
+            if path == "/api/compose.search":
+                return {
+                    "items": [
+                        {
+                            "composeId": "compose-cm-pr-45-a",
+                            "name": "cm-odoo-preview-pr-45",
+                        }
+                    ],
+                    "results": [
+                        {
+                            "composeId": "compose-cm-pr-45-b",
+                            "name": "cm-odoo-preview-pr-45",
+                        }
+                    ],
+                }
+            raise AssertionError(path)
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_control_plane_dokploy_source_of_truth",
+                return_value=_source_of_truth(),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_runtime_environments.resolve_runtime_environment_values",
+                side_effect=click.ClickException(
+                    "Missing DB-backed Launchplane runtime environment records."
+                ),
+            ),
+        ):
+            result = build_odoo_preview_apply_inputs(
+                control_plane_root=Path("."),
+                record_store=_OdooApplyInputsStore(),
+                profile=_profile(),
+                request=OdooPreviewApplyInputsRequest(
+                    product="odoo-tenant-cm",
+                    pr_number=45,
+                    preview_url="https://pr-45.cm-preview.example.test",
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    source_git_ref="abc123",
+                ),
+            )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertIn(
+            "runtime_target_discovery_failed",
+            {blocker.code for blocker in result.runtime_plan.blockers},
+        )
+        self.assertNotIn(
+            "environment_id_missing", {blocker.code for blocker in result.dry_run_plan.blockers}
+        )
+        self.assertNotIn("Missing DB-backed Launchplane runtime environment", result.error_message)
+
     def test_apply_inputs_blocks_on_duplicate_discovered_preview_composes(self) -> None:
         with (
             patch(
@@ -988,6 +1228,55 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             "runtime_target_discovery_failed",
             {blocker.code for blocker in result.runtime_plan.blockers},
         )
+
+    def test_apply_inputs_refresh_blocks_on_duplicate_discovered_preview_composes(
+        self,
+    ) -> None:
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            path = kwargs["path"]
+            if path == "/api/project.all":
+                return [
+                    {
+                        "environments": [
+                            {
+                                "composes": [
+                                    {
+                                        "composeId": "compose-cm-pr-45-a",
+                                        "name": "cm-odoo-preview-pr-45",
+                                    },
+                                    {
+                                        "composeId": "compose-cm-pr-45-b",
+                                        "name": "cm-odoo-preview-pr-45",
+                                    },
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            if path == "/api/domain.byComposeId":
+                return _preview_domain_payload()
+            raise AssertionError(path)
+
+        with _patched_apply_inputs_runtime(dokploy_side_effect=_fake_dokploy_request):
+            result = build_odoo_preview_apply_inputs(
+                control_plane_root=Path("."),
+                record_store=_OdooApplyInputsStore(),
+                profile=_profile(),
+                request=OdooPreviewApplyInputsRequest(
+                    product="odoo-tenant-cm",
+                    pr_number=45,
+                    preview_url="https://pr-45.cm-preview.example.test",
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    source_git_ref="abc123",
+                ),
+            )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertIn(
+            "runtime_target_discovery_failed",
+            {blocker.code for blocker in result.runtime_plan.blockers},
+        )
+        self.assertIn("multiple Odoo preview composes", result.error_message)
 
     def test_refresh_create_dry_run_blocks_missing_create_and_delete_paths(self) -> None:
         plan = build_odoo_preview_dokploy_dry_run(


### PR DESCRIPTION
## Summary
- classify ambiguous Odoo preview target discovery separately from ordinary inventory outages
- fail closed for divergent wrapped compose-search envelopes and duplicate concrete preview composes on both refresh and destroy
- keep refresh tolerant of ordinary inventory outages, but avoid misleading environment/template blockers once the runtime plan is already blocked
- add regression coverage for search fallback reuse, divergent envelopes, duplicate compose discovery, and ambiguity plus missing environment evidence

## Validation
- `uv run python -m unittest tests.test_odoo_preview_runtime`
- `uv run ruff check --diff control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run ruff check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run ruff format --check --diff control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `git diff --check`

## Review
- Scoped review agents found and helped close the refresh fail-open ambiguity path.
- Final scoped review pass reported no blockers.
- Broad background auto-review run `545deaef-a991-43de-a6db-6c894649a88c` failed before producing findings because the checkout scope exceeded its configured cap: 152 changed paths vs limit 120. This PR is a focused two-file diff and was reviewed with scoped agents instead.

## Plan alignment
This is part of the v2 Odoo lifecycle cleanup: Launchplane owns preview target discovery and request-shape safety before tenant workflow copies are retired.
