### PR TITLE
Validate Odoo website bootstrap write contract

### DIFF
--- a/control_plane/cli_odoo.py
+++ b/control_plane/cli_odoo.py
@@ -22,6 +22,9 @@ from control_plane.contracts.odoo_instance_override_record import OdooInstanceOv
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideApplyResult
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideValue
 from control_plane.contracts.odoo_instance_override_record import OdooWebsiteBootstrapPayload
+from control_plane.contracts.odoo_instance_override_record import (
+    validate_odoo_website_bootstrap_contract,
+)
 from control_plane.contracts.odoo_stable_target_replacement import (
     OdooStableTargetReplacementRequest,
 )
@@ -828,10 +831,12 @@ def odoo_overrides_put_website_bootstrap(
     _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     try:
         raw_payload = json.loads(payload_file.read_text(encoding="utf-8"))
-        website_bootstrap = OdooWebsiteBootstrapPayload.model_validate(raw_payload)
+        website_bootstrap = validate_odoo_website_bootstrap_contract(
+            OdooWebsiteBootstrapPayload.model_validate(raw_payload)
+        )
     except JSONDecodeError as error:
         raise click.ClickException("Odoo website bootstrap payload must be valid JSON.") from error
-    except ValidationError as error:
+    except (ValidationError, ValueError) as error:
         raise click.ClickException(f"Invalid Odoo website bootstrap payload: {error}") from error
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()

--- a/control_plane/contracts/odoo_instance_override_record.py
+++ b/control_plane/contracts/odoo_instance_override_record.py
@@ -1,5 +1,6 @@
 from typing import Literal
 import json
+import re
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -8,6 +9,40 @@ from control_plane.contracts.runtime_environment_record import ScalarValue
 OdooOverrideApplyPhase = Literal["restore", "deploy", "promotion", "preview", "manual"]
 OdooOverrideApplyStatus = Literal["skipped", "pending", "pass", "fail"]
 OdooOverrideValueSource = Literal["literal", "secret_binding"]
+_ODOO_XMLID_RE = re.compile(r"^[A-Za-z0-9_]+(?:\.[A-Za-z0-9_-]+)+$")
+
+
+def _validate_local_route_path(value: str, *, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+    if not normalized.startswith("/") or normalized.startswith("//"):
+        raise ValueError(f"Odoo website bootstrap {label} must be a local route path")
+    if any(character in normalized for character in "\r\n\t"):
+        raise ValueError(f"Odoo website bootstrap {label} must be a single-line route path")
+    return normalized
+
+
+def validate_odoo_website_bootstrap_contract(
+    payload: "OdooWebsiteBootstrapPayload",
+) -> "OdooWebsiteBootstrapPayload":
+    # Payload model construction strips text; this helper only enforces
+    # write-path shape so persisted record reads remain repairable.
+    _validate_local_route_path(payload.homepage_url, label="homepage_url")
+    if payload.primary_page_xmlid and _ODOO_XMLID_RE.fullmatch(payload.primary_page_xmlid) is None:
+        raise ValueError("Odoo website bootstrap primary_page_xmlid must be a dotted XML ID")
+    route_urls = [route.url for route in payload.routes]
+    if len(route_urls) != len(set(route_urls)):
+        raise ValueError("Odoo website bootstrap has duplicate route urls")
+    route_names = [route.name for route in payload.routes]
+    if len(route_names) != len(set(route_names)):
+        raise ValueError("Odoo website bootstrap has duplicate route names")
+    homepage_routes = [route for route in payload.routes if route.homepage]
+    if len(homepage_routes) > 1:
+        raise ValueError("Odoo website bootstrap must not define multiple homepage routes")
+    for route in payload.routes:
+        _validate_local_route_path(route.url, label="route url")
+    return payload
 
 
 class OdooOverrideValue(BaseModel):
@@ -142,12 +177,6 @@ class OdooWebsiteBootstrapPayload(BaseModel):
     def _validate_payload(self) -> "OdooWebsiteBootstrapPayload":
         if not self.name:
             raise ValueError("Odoo website bootstrap requires name")
-        route_urls = [route.url for route in self.routes]
-        if len(route_urls) != len(set(route_urls)):
-            raise ValueError("Odoo website bootstrap has duplicate route urls")
-        route_names = [route.name for route in self.routes]
-        if len(route_names) != len(set(route_names)):
-            raise ValueError("Odoo website bootstrap has duplicate route names")
         return self
 
 
@@ -200,7 +229,11 @@ class OdooInstanceOverrideRecord(BaseModel):
             raise ValueError("Odoo instance override record requires instance")
         if not self.updated_at:
             raise ValueError("Odoo instance override record requires updated_at")
-        if not self.config_parameters and not self.addon_settings and self.website_bootstrap is None:
+        if (
+            not self.config_parameters
+            and not self.addon_settings
+            and self.website_bootstrap is None
+        ):
             raise ValueError("Odoo instance override record requires at least one override")
         if not self.apply_on:
             raise ValueError("Odoo instance override record requires at least one apply phase")

--- a/control_plane/odoo_post_deploy_http.py
+++ b/control_plane/odoo_post_deploy_http.py
@@ -9,6 +9,7 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooInstanceOverrideRecord,
     OdooOverrideValue,
     OdooWebsiteBootstrapPayload,
+    validate_odoo_website_bootstrap_contract,
 )
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.drivers.dispatch import (
@@ -104,6 +105,7 @@ class OdooWebsiteBootstrapOverrideRequest(BaseModel):
             raise ValueError("Odoo website-bootstrap override requires context.")
         if not self.instance:
             raise ValueError("Odoo website-bootstrap override requires instance.")
+        self.website_bootstrap = validate_odoo_website_bootstrap_contract(self.website_bootstrap)
         return self
 
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -871,6 +871,12 @@ run` is the foreground loop intended for an external process supervisor, and
   including site identity, canonical URL, logo path, source metadata, and route
   definitions. Product repos remain the source of that intent; Launchplane
   persists the typed payload and renders it during Odoo post-deploy.
+- New website-bootstrap writes through the CLI or service route enforce the
+  devkit-safe contract: homepage and route URLs are local Odoo route paths,
+  `primary_page_xmlid` is a dotted XML ID, and at most one route can be marked
+  as the homepage. Persisted record reads remain tolerant so older records can
+  be inspected and repaired instead of becoming unreadable after validation
+  hardening.
 - Stable bootstrap normalizes the persisted `website_bootstrap.canonical_url`
   to the Launchplane-resolved stable target base URL before post-deploy renders
   the payload, so local tenant bootstrap defaults do not become stable lane URL

--- a/tests/test_odoo_instance_overrides.py
+++ b/tests/test_odoo_instance_overrides.py
@@ -11,6 +11,7 @@ from control_plane.odoo_instance_overrides import LAUNCHPLANE_WEBSITE_BOOTSTRAP_
 from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
 from control_plane.odoo_instance_overrides import build_post_deploy_environment
 from control_plane.odoo_instance_overrides import render_post_deploy_payload
+from control_plane.odoo_post_deploy_http import OdooWebsiteBootstrapOverrideRequest
 from click.testing import CliRunner, Result
 from pydantic import ValidationError
 
@@ -28,6 +29,8 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooOverrideApplyResult,
     OdooOverrideValue,
     OdooWebsiteBootstrapPayload,
+    OdooWebsiteBootstrapRoute,
+    validate_odoo_website_bootstrap_contract,
 )
 from control_plane.contracts.secret_record import SecretBinding, SecretRecord, SecretVersion
 from control_plane.contracts.ship_request import ShipRequest
@@ -64,6 +67,165 @@ def _assert_direct_db_mutation_rejected(test_case: unittest.TestCase, result: Re
 
 
 class OdooInstanceOverrideTests(unittest.TestCase):
+    def test_website_bootstrap_payload_accepts_devkit_route_shape(self) -> None:
+        payload = validate_odoo_website_bootstrap_contract(
+            OdooWebsiteBootstrapPayload(
+                tenant=" opw ",
+                name=" OPW ",
+                canonical_url=" https://opw-testing.example.com/ ",
+                homepage_url=" /shop ",
+                primary_page_xmlid="website_sale.shop",
+                routes=(
+                    OdooWebsiteBootstrapRoute(
+                        name=" Shop ",
+                        url=" /shop ",
+                        module=" website_sale ",
+                        published=True,
+                        homepage=True,
+                    ),
+                ),
+            )
+        )
+
+        self.assertEqual(payload.tenant, "opw")
+        self.assertEqual(payload.name, "OPW")
+        self.assertEqual(payload.homepage_url, "/shop")
+        self.assertEqual(payload.primary_page_xmlid, "website_sale.shop")
+        self.assertEqual(payload.routes[0].url, "/shop")
+        self.assertEqual(payload.routes[0].module, "website_sale")
+
+    def test_website_bootstrap_payload_load_remains_tolerant_for_stored_records(self) -> None:
+        payload = OdooWebsiteBootstrapPayload(
+            name="OPW",
+            homepage_url="https://opw-testing.example.com/shop",
+            primary_page_xmlid="legacy_page",
+            routes=(
+                OdooWebsiteBootstrapRoute(name="Shop", url="shop", homepage=True),
+                OdooWebsiteBootstrapRoute(name="Home", url="/", homepage=True),
+                OdooWebsiteBootstrapRoute(name="Shop", url="shop"),
+            ),
+        )
+
+        self.assertEqual(payload.homepage_url, "https://opw-testing.example.com/shop")
+        self.assertEqual(payload.primary_page_xmlid, "legacy_page")
+        self.assertEqual(payload.routes[0].url, "shop")
+        self.assertEqual(payload.routes[2].name, "Shop")
+
+    def test_website_bootstrap_contract_rejects_non_local_homepage_url(self) -> None:
+        with self.assertRaisesRegex(ValueError, "homepage_url.*local route path"):
+            validate_odoo_website_bootstrap_contract(
+                OdooWebsiteBootstrapPayload(
+                    name="OPW",
+                    homepage_url="https://opw-testing.example.com/shop",
+                )
+            )
+
+    def test_website_bootstrap_contract_rejects_protocol_relative_homepage_url(self) -> None:
+        with self.assertRaisesRegex(ValueError, "homepage_url.*local route path"):
+            validate_odoo_website_bootstrap_contract(
+                OdooWebsiteBootstrapPayload(
+                    name="OPW",
+                    homepage_url="//example.com/shop",
+                )
+            )
+
+    def test_website_bootstrap_contract_rejects_non_local_route_url(self) -> None:
+        with self.assertRaisesRegex(ValueError, "route url.*local route path"):
+            validate_odoo_website_bootstrap_contract(
+                OdooWebsiteBootstrapPayload(
+                    name="OPW",
+                    routes=(OdooWebsiteBootstrapRoute(name="Shop", url="shop"),),
+                )
+            )
+
+    def test_website_bootstrap_contract_rejects_protocol_relative_route_url(self) -> None:
+        with self.assertRaisesRegex(ValueError, "route url.*local route path"):
+            validate_odoo_website_bootstrap_contract(
+                OdooWebsiteBootstrapPayload(
+                    name="OPW",
+                    routes=(OdooWebsiteBootstrapRoute(name="Shop", url="//example.com/shop"),),
+                )
+            )
+
+    def test_website_bootstrap_contract_accepts_root_route(self) -> None:
+        payload = validate_odoo_website_bootstrap_contract(
+            OdooWebsiteBootstrapPayload(
+                name="OPW",
+                homepage_url="/",
+                routes=(OdooWebsiteBootstrapRoute(name="Home", url="/", homepage=True),),
+            )
+        )
+
+        self.assertEqual(payload.homepage_url, "/")
+        self.assertEqual(payload.routes[0].url, "/")
+
+    def test_website_bootstrap_contract_rejects_bad_primary_page_xmlid(self) -> None:
+        with self.assertRaisesRegex(ValueError, "primary_page_xmlid.*dotted XML ID"):
+            validate_odoo_website_bootstrap_contract(
+                OdooWebsiteBootstrapPayload(
+                    name="Cell Mechanic",
+                    primary_page_xmlid="bad xml id",
+                )
+            )
+
+    def test_website_bootstrap_contract_accepts_hyphenated_record_xmlid(self) -> None:
+        payload = validate_odoo_website_bootstrap_contract(
+            OdooWebsiteBootstrapPayload(
+                name="Cell Mechanic",
+                primary_page_xmlid="cm_website.website-page-cell-mechanic",
+            )
+        )
+
+        self.assertEqual(payload.primary_page_xmlid, "cm_website.website-page-cell-mechanic")
+
+    def test_website_bootstrap_contract_rejects_multiple_homepage_routes(self) -> None:
+        with self.assertRaisesRegex(ValueError, "multiple homepage routes"):
+            validate_odoo_website_bootstrap_contract(
+                OdooWebsiteBootstrapPayload(
+                    name="OPW",
+                    routes=(
+                        OdooWebsiteBootstrapRoute(name="Shop", url="/shop", homepage=True),
+                        OdooWebsiteBootstrapRoute(name="Home", url="/", homepage=True),
+                    ),
+                )
+            )
+
+    def test_website_bootstrap_contract_rejects_duplicate_route_names(self) -> None:
+        with self.assertRaisesRegex(ValueError, "duplicate route names"):
+            validate_odoo_website_bootstrap_contract(
+                OdooWebsiteBootstrapPayload(
+                    name="OPW",
+                    routes=(
+                        OdooWebsiteBootstrapRoute(name="Shop", url="/shop"),
+                        OdooWebsiteBootstrapRoute(name="Shop", url="/store"),
+                    ),
+                )
+            )
+
+    def test_website_bootstrap_contract_rejects_duplicate_route_urls(self) -> None:
+        with self.assertRaisesRegex(ValueError, "duplicate route urls"):
+            validate_odoo_website_bootstrap_contract(
+                OdooWebsiteBootstrapPayload(
+                    name="OPW",
+                    routes=(
+                        OdooWebsiteBootstrapRoute(name="Shop", url="/shop"),
+                        OdooWebsiteBootstrapRoute(name="Store", url="/shop"),
+                    ),
+                )
+            )
+
+    def test_website_bootstrap_override_request_enforces_write_contract(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "homepage_url.*local route path"):
+            OdooWebsiteBootstrapOverrideRequest(
+                product="odoo",
+                context="opw",
+                instance="testing",
+                website_bootstrap=OdooWebsiteBootstrapPayload(
+                    name="OPW",
+                    homepage_url="//example.com/shop",
+                ),
+            )
+
     def test_record_rejects_duplicate_config_parameter_keys(self) -> None:
         with self.assertRaisesRegex(ValidationError, "duplicate config parameter keys"):
             OdooInstanceOverrideRecord(
@@ -633,9 +795,7 @@ class OdooInstanceOverrideTests(unittest.TestCase):
             temp_dir = Path(temporary_directory_name)
             database_url = _sqlite_database_url(temp_dir / "launchplane.sqlite3")
             payload_file = temp_dir / "website-bootstrap.json"
-            payload_file.write_text(
-                json.dumps({"tenant": "opw", "name": "OPW"}), encoding="utf-8"
-            )
+            payload_file.write_text(json.dumps({"tenant": "opw", "name": "OPW"}), encoding="utf-8")
             result = CliRunner().invoke(
                 main,
                 [
@@ -681,6 +841,37 @@ class OdooInstanceOverrideTests(unittest.TestCase):
         self.assertNotEqual(put_bootstrap_result.exit_code, 0)
         self.assertIn("Invalid Odoo website bootstrap payload", put_bootstrap_result.output)
         self.assertIn("name", put_bootstrap_result.output)
+
+    def test_cli_put_website_bootstrap_reports_contract_errors(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temp_dir = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(temp_dir / "launchplane.sqlite3")
+            payload_file = temp_dir / "website-bootstrap.json"
+            payload_file.write_text(
+                json.dumps({"tenant": "opw", "name": "OPW", "homepage_url": "//example.com"}),
+                encoding="utf-8",
+            )
+            runner = CliRunner()
+            put_bootstrap_result = runner.invoke(
+                main,
+                [
+                    "odoo-overrides",
+                    "put-website-bootstrap",
+                    "--database-url",
+                    database_url,
+                    "--context",
+                    "opw",
+                    "--instance",
+                    "testing",
+                    "--payload-file",
+                    str(payload_file),
+                    *_allow_direct_db_mutation_argument(),
+                ],
+            )
+
+        self.assertNotEqual(put_bootstrap_result.exit_code, 0)
+        self.assertIn("Invalid Odoo website bootstrap payload", put_bootstrap_result.output)
+        self.assertIn("homepage_url", put_bootstrap_result.output)
 
     def test_cli_mark_apply_updates_result_metadata(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add strict devkit-safe validation for Odoo website-bootstrap write paths
- keep persisted website-bootstrap payload reads tolerant so older records can still be inspected and repaired
- document the CLI/service strict-write boundary and add focused tests for route paths, XML IDs, homepage selection, duplicate routes, API request validation, and CLI contract failures

## Validation
- python -m py_compile control_plane/contracts/odoo_instance_override_record.py control_plane/cli_odoo.py control_plane/odoo_post_deploy_http.py tests/test_odoo_instance_overrides.py
- uv run python -m unittest tests.test_odoo_instance_overrides tests.test_docs_contracts
- uv run --extra dev ruff check --diff control_plane/contracts/odoo_instance_override_record.py control_plane/cli_odoo.py control_plane/odoo_post_deploy_http.py tests/test_odoo_instance_overrides.py
- uv run --extra dev ruff format --check --diff control_plane/contracts/odoo_instance_override_record.py control_plane/cli_odoo.py control_plane/odoo_post_deploy_http.py tests/test_odoo_instance_overrides.py
- uv run --extra dev ruff check control_plane/contracts/odoo_instance_override_record.py control_plane/cli_odoo.py control_plane/odoo_post_deploy_http.py tests/test_odoo_instance_overrides.py
- git diff --check

## Review
- Targeted final review found a model-level duplicate route tolerance issue; fixed by moving duplicate route enforcement fully into the strict write-path helper.
- Post-fix targeted review reported no blockers.

Note: attempted JetBrains changed-files inspection via PyCharm offline inspection, but the local IDE instance lock prevented a non-interactive run. The repo's targeted unittest/Ruff/diff gates and bounded review agents are clean.