### PR TITLE
Prevalidate Odoo website bootstrap workflow payloads

### DIFF
--- a/.github/workflows/odoo-website-bootstrap-override.yml
+++ b/.github/workflows/odoo-website-bootstrap-override.yml
@@ -20,7 +20,7 @@ name: Odoo Website Bootstrap Override
           - testing
           - prod
       website_bootstrap_payload:
-        description: Website bootstrap JSON object rendered from the tenant bootstrap settings.
+        description: Website bootstrap JSON object rendered from tenant bootstrap settings; homepage and route URLs must be local Odoo route paths.
         required: true
         type: string
 
@@ -71,7 +71,28 @@ jobs:
             })"
           fi
           echo "LAUNCHPLANE_SERVICE_AUDIENCE=${LAUNCHPLANE_SERVICE_AUDIENCE}" >>"$GITHUB_ENV"
-          jq -e 'type == "object"' <<< "$WEBSITE_BOOTSTRAP_PAYLOAD" >/dev/null
+          if ! jq -e 'type == "object"' <<< "$WEBSITE_BOOTSTRAP_PAYLOAD" >/dev/null; then
+            echo 'website_bootstrap_payload must be a JSON object.' >&2
+            exit 1
+          fi
+          if ! jq -e '
+            def local_route_path:
+              type == "string" and
+              (. == "" or (startswith("/") and (startswith("//") | not)));
+            (.homepage_url // "") | local_route_path
+          ' <<< "$WEBSITE_BOOTSTRAP_PAYLOAD" >/dev/null; then
+            echo 'website_bootstrap.homepage_url must be empty or a local Odoo route path.' >&2
+            exit 1
+          fi
+          if ! jq -e '
+            def local_route_path:
+              type == "string" and
+              (. == "" or (startswith("/") and (startswith("//") | not)));
+            all((.routes // [])[]?; (.url // "") | local_route_path)
+          ' <<< "$WEBSITE_BOOTSTRAP_PAYLOAD" >/dev/null; then
+            echo 'website_bootstrap.routes[].url values must be empty or local Odoo route paths.' >&2
+            exit 1
+          fi
 
       - name: Write website bootstrap override
         shell: bash

--- a/docs/records.md
+++ b/docs/records.md
@@ -871,11 +871,14 @@ run` is the foreground loop intended for an external process supervisor, and
   including site identity, canonical URL, logo path, source metadata, and route
   definitions. Product repos remain the source of that intent; Launchplane
   persists the typed payload and renders it during Odoo post-deploy.
-- New website-bootstrap writes through the CLI or service route enforce the
-  devkit-safe contract: homepage and route URLs are local Odoo route paths,
+- New website-bootstrap writes through the service route enforce the devkit-safe
+  contract: homepage and route URLs are local Odoo route paths,
   `primary_page_xmlid` is a dotted XML ID, and at most one route can be marked
-  as the homepage. Persisted record reads remain tolerant so older records can
-  be inspected and repaired instead of becoming unreadable after validation
+  as the homepage. The reusable service workflow prevalidates the local-route
+  portion of that contract for fast operator feedback, while the service remains
+  the write authority. The local CLI applies the same validation for explicit
+  repair writes only. Persisted record reads remain tolerant so older records
+  can be inspected and repaired instead of becoming unreadable after validation
   hardening.
 - Stable bootstrap normalizes the persisted `website_bootstrap.canonical_url`
   to the Launchplane-resolved stable target base URL before post-deploy renders

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -589,6 +589,17 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertNotIn("odoo-tenant-opw:opw:prod", workflow_text)
         self.assertNotIn("writes only cm/testing", workflow_text)
 
+    def test_odoo_website_bootstrap_override_prevalidates_route_paths(self) -> None:
+        workflow_text = Path(".github/workflows/odoo-website-bootstrap-override.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("website_bootstrap_payload must be a JSON object", workflow_text)
+        self.assertIn("homepage_url must be empty or a local Odoo route path", workflow_text)
+        self.assertIn("routes[].url values must be empty or local Odoo route paths", workflow_text)
+        self.assertIn('startswith("/")', workflow_text)
+        self.assertIn('startswith("//") | not', workflow_text)
+
     def test_launchplane_workflows_do_not_hardcode_public_service_defaults(self) -> None:
         workflow_dir = Path(".github/workflows")
         forbidden_literals = (


### PR DESCRIPTION
## Summary
- add fast-fail JSON object and local-route validation to the Odoo website-bootstrap override workflow
- document that the service remains the write authority while the workflow only prevalidates the local-route subset for operator feedback
- keep the local CLI documented as explicit repair-only and add workflow text coverage

## Validation
- python -m py_compile tests/test_product_onboarding.py
- uv run python -m unittest tests.test_product_onboarding tests.test_docs_contracts
- uv run --extra dev ruff check --diff tests/test_product_onboarding.py
- uv run --extra dev ruff format --check --diff tests/test_product_onboarding.py
- uv run --extra dev ruff check tests/test_product_onboarding.py
- docker run --rm -v "/Users/cbusillo/.code/worktrees/launchplane/odoo-preview-request-builders-v2:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/odoo-website-bootstrap-override.yml
- git diff --check

## Review
- Read-only bounded review reported no blockers.
- Low finding fixed: non-object payloads now emit a clear workflow error before exiting.

Note: background Auto Review run 545deaef-a991-43de-a6db-6c894649a88c failed before findings because its broad snapshot had 152 changed paths over the 120-path limit; it produced no code findings and is not applicable to this three-file branch.