### PR TITLE
Lock Odoo preview generated binding evidence

### DIFF
--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -75,6 +75,12 @@ ODOO_PREVIEW_REQUIRED_ENV_KEYS = (
 ODOO_PREVIEW_ARTIFACT_PUBLISH_INPUTS_ROUTE = "/v1/drivers/odoo/artifact-publish-inputs"
 ODOO_PREVIEW_APPLY_INPUTS_ROUTE = "/v1/drivers/odoo/preview-apply-inputs"
 ODOO_PREVIEW_APPLY_ROUTE = "/v1/drivers/odoo/preview-apply"
+ODOO_PREVIEW_GENERATED_ENV_KEYS = (
+    "ODOO_DB_NAME",
+    "ODOO_DATA_VOLUME",
+    "ODOO_LOG_VOLUME",
+    "ODOO_DB_VOLUME",
+)
 
 
 class OdooPreviewTargetDiscoveryAmbiguousError(click.ClickException):
@@ -562,12 +568,7 @@ def _preview_runtime_bindings(
     )
     bindings.extend(
         OdooPreviewRuntimeBindingEvidence(key=key, source="generated")
-        for key in (
-            "ODOO_DB_NAME",
-            "ODOO_DATA_VOLUME",
-            "ODOO_LOG_VOLUME",
-            "ODOO_DB_VOLUME",
-        )
+        for key in ODOO_PREVIEW_GENERATED_ENV_KEYS
     )
     return tuple({binding.key: binding for binding in bindings}.values())
 

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -38,6 +38,7 @@ from control_plane.workflows.odoo_preview_runtime import (
     build_odoo_preview_apply_workflow_request,
     build_odoo_preview_artifact_publish_inputs_workflow_request,
     execute_odoo_preview_dokploy_apply,
+    _preview_runtime_bindings,
     _wait_for_smoke_check,
 )
 
@@ -185,6 +186,38 @@ class _OdooApplyInputsStore:
         if limit is not None:
             return filtered[:limit]
         return filtered
+
+
+class _OdooApplyInputsStoreWithConfiguredGeneratedKey(_OdooApplyInputsStore):
+    @staticmethod
+    def list_secret_bindings(
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        bindings = (
+            *_OdooApplyInputsStore.list_secret_bindings(
+                integration=integration,
+                context_name=context_name,
+                instance_name=instance_name,
+                limit=None,
+            ),
+            SecretBinding(
+                binding_id="secret-odoo-db-name-binding",
+                secret_id="secret-odoo-db-name",
+                integration=RUNTIME_ENVIRONMENT_SECRET_INTEGRATION,
+                context="cm-preview",
+                instance="testing",
+                binding_key="ODOO_DB_NAME",
+                created_at="2026-05-10T05:32:00Z",
+                updated_at="2026-05-10T05:32:00Z",
+            ),
+        )
+        if limit is not None:
+            return bindings[:limit]
+        return bindings
 
 
 def _workflow_facts(
@@ -528,6 +561,19 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertIsInstance(inputs, dict)
         self.assertNotIn("preview_slug", inputs)
         self.assertIn(":preview-42:", request.idempotency_key)
+
+    def test_runtime_binding_evidence_keeps_preview_identity_keys_generated(self) -> None:
+        bindings = _preview_runtime_bindings(
+            record_store=_OdooApplyInputsStoreWithConfiguredGeneratedKey(),
+            context_name="cm-preview",
+            instance_name="testing",
+        )
+
+        binding_sources = {binding.key: binding.source for binding in bindings}
+        self.assertEqual(binding_sources["ODOO_DB_NAME"], "generated")
+        self.assertEqual(binding_sources["ODOO_DATA_VOLUME"], "generated")
+        self.assertEqual(binding_sources["ODOO_LOG_VOLUME"], "generated")
+        self.assertEqual(binding_sources["ODOO_DB_VOLUME"], "generated")
 
     def test_apply_inputs_reuses_discovered_preview_compose_for_refresh(self) -> None:
         requests: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary
- name the generated Odoo preview DB/volume binding keys as an explicit runtime contract
- add coverage proving preview identity keys remain `generated` evidence even if a managed secret binding collides with one of those names

## Validation
- `python -m py_compile control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run python -m unittest tests.test_odoo_preview_runtime.OdooPreviewDokployDryRunTests.test_runtime_binding_evidence_keeps_preview_identity_keys_generated`
- `uv run python -m unittest tests.test_odoo_preview_runtime`
- `uv run --extra dev ruff check --diff control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff format --check --diff control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `uv run --extra dev ruff format --check control_plane/workflows/odoo_preview_runtime.py tests/test_odoo_preview_runtime.py`
- `git diff --check`

## Review
- Targeted agent review: one reviewer reported no blockers.
- A second reviewer caught that an earlier draft incorrectly preserved configured evidence for isolation-critical generated keys; the patch was corrected before commit so generated preview DB/volume identity remains authoritative.
- Background Auto Review run `545deaef-a991-43de-a6db-6c894649a88c` failed before findings because the broad workspace scope had 152 changed paths over the 120-path limit; it produced no code findings and is not applicable to this scoped two-file PR.

Refs #1529
