### PR TITLE
Require explicit post-deploy driver

### DIFF
--- a/.github/workflows/reusable-product-driver-post-deploy.yml
+++ b/.github/workflows/reusable-product-driver-post-deploy.yml
@@ -9,9 +9,8 @@ name: Reusable Product Driver Post Deploy
         required: true
         type: string
       driver:
-        description: Product driver id. Defaults to odoo for migration compatibility.
-        required: false
-        default: odoo
+        description: Product driver id.
+        required: true
         type: string
       context:
         description: Runtime context.
@@ -100,7 +99,7 @@ jobs:
               ;;
             *) echo "Unsupported product driver for post-deploy: $DRIVER" >&2; exit 1 ;;
           esac
-          for required in DRIVER PRODUCT CONTEXT INSTANCE PHASE; do
+          for required in PRODUCT CONTEXT INSTANCE PHASE; do
             if [ -z "${!required}" ]; then
               echo "${required} is required." >&2
               exit 1

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -335,9 +335,6 @@ WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
     ".github/workflows/reusable-preview-feedback-status.yml": {
         "inputs.timeout-ms.default": frozenset(("300000",)),
     },
-    ".github/workflows/reusable-product-driver-post-deploy.yml": {
-        "inputs.driver.default": frozenset(("odoo",)),
-    },
     ".github/workflows/reusable-product-driver-prod-promotion.yml": {
         "inputs.driver.default": frozenset(("verireel",)),
     },

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -535,10 +535,9 @@ exists.
 
 `reusable-product-driver-post-deploy.yml@main` preserves explicit driver
 post-deploy phases for Odoo refresh, manual, promotion, and deploy callers
-while moving request shaping into Launchplane. Odoo callers do not need a driver
-input because the product-driver wrapper defaults to `driver: odoo`; they must
-still pass the same explicit `product`, `context`, `instance`, and `phase`
-inputs. App
+while moving request shaping into Launchplane. Odoo callers must pass
+`driver: odoo` plus the same explicit `product`, `context`, `instance`, and
+`phase` inputs. App
 maintenance remains the deploy-phase maintenance wrapper for stable lane
 operations; product repos should not use it as a generic phase-aware post-deploy
 substitute. The old Odoo-specific post-deploy reusable has been retired after

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2479,7 +2479,6 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         path = ".github/workflows/reusable-product-driver-post-deploy.yml"
         for key, value in (
             ("inputs.timeout-ms.default", "600000"),
-            ("inputs.driver.default", "odoo"),
             ("route-path", "${{ steps.request.outputs.route_path }}"),
             ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
             ("payload-fields.post_deploy.context", "${{ steps.request.outputs.context }}"),
@@ -2496,6 +2495,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("payload-fields.post_deploy.context", "prod"),
             ("payload-fields.post_deploy.instance", "testing"),
             ("payload-fields.post_deploy.phase", "deploy"),
+            ("inputs.driver.default", "odoo"),
             ("inputs.timeout-ms.default", "42"),
         ):
             with self.subTest(key=key, value=value):

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -257,9 +257,10 @@ class DocsContractsTests(TestCase):
         self.assertIn("should not own Launchplane route construction", product_repo_contract)
         self.assertIn("preserves explicit driver", product_repo_contract)
         self.assertIn("post-deploy phases", product_repo_contract)
-        self.assertIn("defaults to `driver: odoo`", product_repo_contract)
+        self.assertIn("must pass\n`driver: odoo`", product_repo_contract)
         self.assertIn(
-            "same explicit `product`, `context`, `instance`, and `phase`", product_repo_contract
+            "same explicit `product`, `context`, `instance`, and\n`phase`",
+            product_repo_contract,
         )
         self.assertIn("keeps the existing VeriReel", product_repo_contract)
         self.assertIn("also supports explicit", product_repo_contract)
@@ -328,8 +329,11 @@ class DocsContractsTests(TestCase):
         self.assertIn("applied_at=result.applied_at", app_maintenance_workflow)
 
         self.assertIn("workflow_call:", post_deploy_workflow)
-        self.assertIn("driver:", post_deploy_workflow)
-        self.assertIn("default: odoo", post_deploy_workflow)
+        self.assertIn(
+            "driver:\n        description: Product driver id.\n        required: true",
+            post_deploy_workflow,
+        )
+        self.assertNotIn("default: odoo", post_deploy_workflow)
         self.assertIn(
             "product:\n        description: Launchplane product key.", post_deploy_workflow
         )


### PR DESCRIPTION
## Summary
- require callers of `reusable-product-driver-post-deploy.yml` to pass an explicit product driver
- remove the temporary `driver: odoo` workflow default and its config-authority audit exception
- update the product repo contract and docs tests to reflect fail-closed caller responsibility

## Replacement-first rollout
- cbusillo/odoo-tenant-cm#99 merged and main checks passed at `542429ea71da`
- cbusillo/odoo-tenant-cm-website#48 merged and main checks passed at `4b4591163f65`
- cbusillo/odoo-tenant-opw#95 merged and main checks passed at `2d174fe30411`

## Validation
- python -m py_compile control_plane/config_authority_audit.py tests/test_docs_contracts.py tests/test_config_authority_audit.py
- uv run python -m unittest tests.test_docs_contracts tests.test_config_authority_audit
- uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_docs_contracts.py tests/test_config_authority_audit.py
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_docs_contracts.py tests/test_config_authority_audit.py
- uv run --extra dev ruff format --check --diff control_plane/config_authority_audit.py tests/test_docs_contracts.py tests/test_config_authority_audit.py
- docker run --rm -v "/Users/cbusillo/.code/worktrees/launchplane/require-post-deploy-driver:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/reusable-product-driver-post-deploy.yml
- git diff --check

## Review
- scoped review agents reported no blockers; addressed the low-severity test precision/redundant shell-check nits before commit