### PR TITLE
Add product-driver testing deploy reusable

### DIFF
--- a/.github/workflows/reusable-product-driver-testing-deploy.yml
+++ b/.github/workflows/reusable-product-driver-testing-deploy.yml
@@ -1,0 +1,146 @@
+---
+name: Reusable Product Driver Testing Deploy
+
+"on":
+  workflow_call:
+    inputs:
+      product:
+        description: Launchplane product key.
+        required: true
+        type: string
+      driver:
+        description: Product driver id.
+        required: true
+        type: string
+      context:
+        description: Runtime context.
+        required: true
+        type: string
+      artifact_id:
+        description: Stored Launchplane artifact ID to deploy to testing.
+        required: true
+        type: string
+      source_git_ref:
+        description: Source git ref attached to deployment evidence.
+        required: true
+        type: string
+      timeout-ms:
+        description: Launchplane request timeout in milliseconds.
+        required: false
+        default: "2700000"
+        type: string
+      launchplane_url:
+        description: >-
+          Launchplane service URL. Defaults to LAUNCHPLANE_PUBLIC_URL.
+        required: false
+        default: ""
+        type: string
+      launchplane_audience:
+        description: >-
+          Optional GitHub OIDC audience. Defaults to the service URL host.
+        required: false
+        default: ""
+        type: string
+    outputs:
+      operation_id:
+        description: Launchplane target replacement operation ID.
+        value: ${{ jobs.odoo_testing_deploy.outputs.operation_id }}
+      deployment_record_id:
+        description: Launchplane deployment record ID.
+        value: ${{ jobs.odoo_testing_deploy.outputs.deployment_record_id }}
+      release_tuple_id:
+        description: Minted testing release tuple ID.
+        value: ${{ jobs.odoo_testing_deploy.outputs.release_tuple_id }}
+      deployment_status:
+        description: Target replacement deploy status.
+        value: ${{ jobs.odoo_testing_deploy.outputs.deployment_status }}
+      post_deploy_status:
+        description: Driver post-deploy status.
+        value: ${{ jobs.odoo_testing_deploy.outputs.post_deploy_status }}
+      destination_health_status:
+        description: Stable destination health status.
+        value: ${{ jobs.odoo_testing_deploy.outputs.destination_health_status }}
+      canonical_status:
+        description: Stable canonical URL verification status.
+        value: ${{ jobs.odoo_testing_deploy.outputs.canonical_status }}
+      logo_status:
+        description: Stable logo verification status.
+        value: ${{ jobs.odoo_testing_deploy.outputs.logo_status }}
+      error_message:
+        description: Launchplane driver error message, when present.
+        value: ${{ jobs.odoo_testing_deploy.outputs.error_message }}
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  resolve:
+    outputs:
+      artifact_id: ${{ steps.request.outputs.artifact_id }}
+      context: ${{ steps.request.outputs.context }}
+      driver: ${{ steps.request.outputs.driver }}
+      product: ${{ steps.request.outputs.product }}
+      source_git_ref: ${{ steps.request.outputs.source_git_ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve product-driver testing deploy request
+        id: request
+        env:
+          ARTIFACT_ID: ${{ inputs.artifact_id }}
+          CONTEXT: ${{ inputs.context }}
+          DRIVER: ${{ inputs.driver }}
+          PRODUCT: ${{ inputs.product }}
+          SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
+        run: |
+          set -euo pipefail
+          for required in PRODUCT DRIVER CONTEXT ARTIFACT_ID SOURCE_GIT_REF; do
+            if [ -z "${!required}" ]; then
+              echo "${required} is required." >&2
+              exit 1
+            fi
+          done
+          write_output() {
+            name="$1"
+            value="$2"
+            delimiter="launchplane_output_$(uuidgen | tr '[:upper:]' '[:lower:]')"
+            {
+              printf '%s<<%s\n' "$name" "$delimiter"
+              printf '%s\n' "$value"
+              printf '%s\n' "$delimiter"
+            } >>"$GITHUB_OUTPUT"
+          }
+          write_output artifact_id "$ARTIFACT_ID"
+          write_output context "$CONTEXT"
+          write_output driver "$DRIVER"
+          write_output product "$PRODUCT"
+          write_output source_git_ref "$SOURCE_GIT_REF"
+
+  unsupported_driver:
+    needs: resolve
+    if: ${{ needs.resolve.outputs.driver != 'odoo' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject unsupported product driver
+        env:
+          DRIVER: ${{ needs.resolve.outputs.driver }}
+        run: |
+          set -euo pipefail
+          echo "Unsupported product driver for testing deploy: ${DRIVER}" >&2
+          exit 1
+
+  odoo_testing_deploy:
+    needs: resolve
+    if: ${{ needs.resolve.outputs.driver == 'odoo' }}
+    permissions:
+      contents: read
+      id-token: write
+    uses: cbusillo/launchplane/.github/workflows/reusable-odoo-testing-deploy.yml@main
+    with:
+      product: ${{ needs.resolve.outputs.product }}
+      context: ${{ needs.resolve.outputs.context }}
+      artifact_id: ${{ needs.resolve.outputs.artifact_id }}
+      source_git_ref: ${{ needs.resolve.outputs.source_git_ref }}
+      timeout-ms: ${{ inputs['timeout-ms'] }}
+      launchplane_url: ${{ inputs.launchplane_url }}
+      launchplane_audience: ${{ inputs.launchplane_audience }}

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -159,7 +159,7 @@ GITHUB_INPUT_REFERENCE_PATTERN = re.compile(
     r"^(?:inputs|github\.event\.inputs)\.(?P<input_name>[A-Za-z0-9_.-]+)$"
 )
 LAUNCHPLANE_REUSABLE_WORKFLOW_PATTERN = re.compile(
-    r"^[A-Za-z0-9_.-]+/launchplane/\.github/workflows/[A-Za-z0-9_.-]+\.yml@main$"
+    r"^cbusillo/launchplane/\.github/workflows/[A-Za-z0-9_.-]+\.yml@main$"
 )
 WORKFLOW_RUNTIME_AUTHORITY_KEYS = frozenset(
     ("GITHUB_TOKEN", "ID_TOKEN", "LAUNCHPLANE_PRODUCT", "LAUNCHPLANE_URL")
@@ -323,6 +323,9 @@ WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
     ".github/workflows/reusable-odoo-testing-deploy.yml": {
         "inputs.timeout-ms.default": frozenset(("2700000",)),
     },
+    ".github/workflows/reusable-product-driver-testing-deploy.yml": {
+        "inputs.timeout-ms.default": frozenset(("2700000",)),
+    },
     ".github/workflows/reusable-generic-web-preview-lifecycle.yml": {
         "inputs.feedback_status.default": frozenset(("unsupported",)),
         "inputs.timeout-ms.default": frozenset(("1800000",)),
@@ -478,6 +481,16 @@ PRODUCT_DRIVER_REUSABLE_PAYLOAD_FIELD_KEYS = frozenset(
         "verification.verification_status",
     )
 )
+PRODUCT_DRIVER_REUSABLE_WITH_INPUT_KEYS = frozenset(
+    (
+        "artifact_id",
+        "context",
+        "launchplane_audience",
+        "launchplane_url",
+        "product",
+        "source_git_ref",
+    )
+)
 PRODUCT_DRIVER_REUSABLE_WRAPPER_LITERAL_VALUES = {
     ".github/workflows/reusable-product-driver-prod-launch-readiness.yml": {
         "INSTANCE": frozenset(("prod",)),
@@ -486,6 +499,14 @@ PRODUCT_DRIVER_REUSABLE_WRAPPER_LITERAL_VALUES = {
         "ACTION": frozenset(("reset-testing",)),
         "INSTANCE": frozenset(("testing",)),
         "INTENT": frozenset(("stable-testing-reset",)),
+    },
+    ".github/workflows/reusable-product-driver-testing-deploy.yml": {
+        "uses": frozenset(
+            (
+                "cbusillo/launchplane/.github/workflows/"
+                "reusable-odoo-testing-deploy.yml@main",
+            )
+        ),
     },
 }
 WORKFLOW_LAUNCHPLANE_BOOTSTRAP_CONTEXT_PATH_VALUES = {
@@ -2650,7 +2671,11 @@ def _is_github_step_output_reference(value_text: str) -> bool:
     match = GITHUB_EXPRESSION_PATTERN.match(value_text)
     if match is None:
         return False
-    return bool(GITHUB_STEP_OUTPUT_REFERENCE_PATTERN.match(match.group("body").strip()))
+    body = match.group("body").strip()
+    return bool(
+        GITHUB_STEP_OUTPUT_REFERENCE_PATTERN.match(body)
+        or GITHUB_NEEDS_OUTPUT_REFERENCE_PATTERN.match(body)
+    )
 
 
 def _is_workflow_read_model_output_forward(*, key: str, value: object) -> bool:
@@ -2722,6 +2747,12 @@ def _is_product_driver_reusable_workflow_mechanic(*, path: str, key: str, value:
         key_text, frozenset()
     ):
         return True
+    if key in PRODUCT_DRIVER_REUSABLE_WITH_INPUT_KEYS:
+        return (
+            _is_github_step_output_reference(value_text)
+            or _is_github_direct_input_reference(value)
+            or _is_github_bracket_input_reference(value_text)
+        )
     if key.startswith("payload-fields."):
         if key.removeprefix("payload-fields.") not in PRODUCT_DRIVER_REUSABLE_PAYLOAD_FIELD_KEYS:
             return False

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -340,13 +340,16 @@ because they call the deployed Launchplane service over HTTPS; product repos do
 not need direct access to Launchplane self-hosted runners, and privileged
 provider mutations still run inside the Launchplane service boundary.
 
-Odoo testing deploys follow the same ownership shape. Tenant repos own the
-manual dispatch confirmation and pass an explicit stored `artifact_id` plus
-`source_git_ref` into `reusable-odoo-testing-deploy.yml`; the reusable workflow
-calls `/v1/drivers/odoo/target-replacement-apply` with the explicit product key
-provided by the caller. The Launchplane service owns the provider mutation,
+Product-driver testing deploys follow the same ownership shape. Tenant repos own
+the manual dispatch confirmation and pass explicit `product`, `context`,
+`driver`, stored `artifact_id`, and `source_git_ref` into
+`reusable-product-driver-testing-deploy.yml@main`; Odoo callers must pass
+`driver: odoo`. The reusable workflow preserves the explicit product and context
+from the caller, dispatches Odoo requests to
+`/v1/drivers/odoo/target-replacement-apply`, and leaves the provider mutation,
 runtime identity injection, Odoo post-deploy extension, stable readiness checks,
-deployment and inventory records, and the testing release tuple.
+deployment and inventory records, and the testing release tuple inside the
+Launchplane service boundary.
 
 Start with low-risk deletions and documentation, then replace active workflow
 behavior in small slices. Do not remove active backup, promotion, rollback,
@@ -519,6 +522,7 @@ The product-driver reusable surface is:
 - `reusable-product-driver-stable-deploy.yml@main`
 - `reusable-product-driver-app-maintenance.yml@main`
 - `reusable-product-driver-post-deploy.yml@main`
+- `reusable-product-driver-testing-deploy.yml@main`
 - `reusable-product-driver-testing-verification.yml@main`
 - `reusable-product-driver-testing-reset.yml@main`
 - `reusable-product-driver-prod-backup-gate.yml@main`

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1840,6 +1840,11 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 "cbusillo/launchplane/.github/workflows/reusable-generic-web-stable-deploy.yml@feature",
             ),
             (
+                ".github/workflows/launchplane-deploy.yml",
+                "uses",
+                "someone/launchplane/.github/workflows/reusable-generic-web-stable-deploy.yml@main",
+            ),
+            (
                 ".github/workflows/preview.yml",
                 "uses",
                 "cbusillo/not-launchplane/.github/workflows/reusable-generic-web-preview-lifecycle.yml@main",

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -230,6 +230,9 @@ class DocsContractsTests(TestCase):
         testing_verification_workflow = Path(
             ".github/workflows/reusable-product-driver-testing-verification.yml"
         ).read_text(encoding="utf-8")
+        testing_deploy_workflow = Path(
+            ".github/workflows/reusable-product-driver-testing-deploy.yml"
+        ).read_text(encoding="utf-8")
         prod_promotion_workflow = Path(
             ".github/workflows/reusable-product-driver-prod-promotion.yml"
         ).read_text(encoding="utf-8")
@@ -249,6 +252,7 @@ class DocsContractsTests(TestCase):
             product_repo_contract,
         )
         self.assertIn("reusable-product-driver-stable-deploy.yml@main", product_repo_contract)
+        self.assertIn("reusable-product-driver-testing-deploy.yml@main", product_repo_contract)
         self.assertIn("reusable-product-driver-prod-promotion.yml@main", product_repo_contract)
         self.assertIn("reusable-product-driver-post-deploy.yml@main", product_repo_contract)
         self.assertIn("reusable-product-driver-prod-rollback.yml@main", product_repo_contract)
@@ -266,6 +270,10 @@ class DocsContractsTests(TestCase):
         self.assertIn("also supports explicit", product_repo_contract)
         self.assertIn("`driver: odoo` callers", product_repo_contract)
         self.assertIn("explicit `product`, explicit", product_repo_contract)
+        self.assertIn(
+            "pass explicit `product`, `context`,\n`driver`, stored `artifact_id`, and `source_git_ref`",
+            product_repo_contract,
+        )
         self.assertIn("source channel fixed to `testing`", product_repo_contract)
         self.assertIn("legacy", product_repo_contract)
         self.assertIn("`opr:<context>:<run>`", product_repo_contract)
@@ -295,6 +303,24 @@ class DocsContractsTests(TestCase):
             "deployment_health_status=result.deployment_health_status",
             testing_verification_workflow,
         )
+
+        self.assertIn("workflow_call:", testing_deploy_workflow)
+        self.assertIn(
+            "driver:\n        description: Product driver id.\n        required: true",
+            testing_deploy_workflow,
+        )
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/workflows/"
+            "reusable-odoo-testing-deploy.yml@main",
+            testing_deploy_workflow,
+        )
+        self.assertIn(
+            "if: ${{ needs.resolve.outputs.driver == 'odoo' }}",
+            testing_deploy_workflow,
+        )
+        self.assertIn("Unsupported product driver for testing deploy", testing_deploy_workflow)
+        self.assertIn("artifact_id: ${{ needs.resolve.outputs.artifact_id }}", testing_deploy_workflow)
+        self.assertNotIn("default: odoo", testing_deploy_workflow)
 
         self.assertIn("workflow_call:", prod_promotion_workflow)
         self.assertIn("driver:", prod_promotion_workflow)

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -554,6 +554,38 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("replacement.artifact_id=${{ inputs.artifact_id }}", workflow_text)
         self.assertIn("${{ steps.product.outputs.idempotency_key }}", workflow_text)
 
+    def test_product_driver_testing_deploy_requires_explicit_driver(self) -> None:
+        workflow_text = Path(
+            ".github/workflows/reusable-product-driver-testing-deploy.yml"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("name: Reusable Product Driver Testing Deploy", workflow_text)
+        self.assertIn(
+            "driver:\n        description: Product driver id.\n        required: true",
+            workflow_text,
+        )
+        self.assertIn("Unsupported product driver for testing deploy", workflow_text)
+        self.assertIn(
+            "if: ${{ needs.resolve.outputs.driver == 'odoo' }}", workflow_text
+        )
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/workflows/"
+            "reusable-odoo-testing-deploy.yml@main",
+            workflow_text,
+        )
+        self.assertIn("product: ${{ needs.resolve.outputs.product }}", workflow_text)
+        self.assertIn("context: ${{ needs.resolve.outputs.context }}", workflow_text)
+        self.assertIn("artifact_id: ${{ needs.resolve.outputs.artifact_id }}", workflow_text)
+        self.assertIn(
+            "source_git_ref: ${{ needs.resolve.outputs.source_git_ref }}",
+            workflow_text,
+        )
+        self.assertIn("write_output()", workflow_text)
+        self.assertIn("printf '%s<<%s\\n'", workflow_text)
+        self.assertNotIn('echo "driver=$DRIVER"', workflow_text)
+        self.assertNotIn("default: odoo", workflow_text)
+        self.assertNotIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', workflow_text)
+
     def test_reusable_odoo_workflows_use_caller_visible_runner(self) -> None:
         workflow_paths = (
             Path(".github/workflows/reusable-odoo-artifact-publish.yml"),


### PR DESCRIPTION
## Summary
- add reusable-product-driver-testing-deploy.yml as the replacement-first testing deploy surface
- require explicit driver/product/context/artifact/source inputs and dispatch Odoo callers to the existing Odoo reusable
- update product repo contract and config-authority tests for the new thin connector

## Validation
- python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_docs_contracts.py tests/test_config_authority_audit.py
- uv run python -m unittest tests.test_product_onboarding tests.test_docs_contracts tests.test_config_authority_audit
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_docs_contracts.py tests/test_config_authority_audit.py
- docker run --rm -v "/Users/cbusillo/.code/worktrees/launchplane/odoo-app-maintenance-driver:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/reusable-product-driver-testing-deploy.yml
- git diff --check

## Review
- scoped agents reviewed the wrapper/config-authority changes
- fixed review findings for multiline GITHUB_OUTPUT injection and trusted reusable owner matching
- verified the reported output-name concern was already covered by the existing Odoo reusable outputs
