### PR TITLE
Use launchplane request for Odoo operator workflows

### DIFF
--- a/.github/workflows/odoo-target-replacement-plan.yml
+++ b/.github/workflows/odoo-target-replacement-plan.yml
@@ -49,9 +49,7 @@ concurrency:
 
 jobs:
   plan:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
       PRODUCT: ${{ inputs.product }}
       INSTANCE: ${{ inputs.instance }}
@@ -59,8 +57,6 @@ jobs:
       ALLOW_EMPTY_DATA: ${{ inputs.allow_empty_data }}
       DATA_SOURCE_MODE: ${{ inputs.data_source_mode }}
       CONFIRMATION: ${{ inputs.confirmation }}
-      LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
     steps:
       - name: Validate runtime inputs
         shell: bash
@@ -69,83 +65,74 @@ jobs:
           : "${PRODUCT:?Missing product input}"
           : "${INSTANCE:?Missing instance input}"
           : "${STRATEGY:?Missing strategy input}"
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
-            echo \
-              'Missing Launchplane service URL variable.' \
-              >&2
-            exit 1
-          fi
-          if [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
-            LAUNCHPLANE_SERVICE_AUDIENCE="$({
-              python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
+          for scalar in PRODUCT INSTANCE STRATEGY DATA_SOURCE_MODE CONFIRMATION; do
+            case "${!scalar}" in
+              *$'\n'*)
+                echo "${scalar} must be a single-line value." >&2
+                exit 1
+                ;;
+            esac
+          done
 
-          parsed = urlsplit(os.environ["LAUNCHPLANE_SERVICE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_SERVICE_URL must include a hostname.")
-          print(parsed.hostname)
-          PY
-            })"
-          fi
-          echo "LAUNCHPLANE_SERVICE_AUDIENCE=${LAUNCHPLANE_SERVICE_AUDIENCE}" >>"$GITHUB_ENV"
-
-      - name: Build replacement plan
+      - name: Write target replacement plan payload
+        id: request
         shell: bash
         run: |
           set -euo pipefail
-          oidc_token="$({
-            token_url="${ACTIONS_ID_TOKEN_REQUEST_URL}"
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${token_url}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          payload="$({
-            jq -n \
-              --arg product "$PRODUCT" \
-              --arg instance "$INSTANCE" \
-              --arg strategy "$STRATEGY" \
-              --arg data_source_mode "$DATA_SOURCE_MODE" \
-              --arg confirmation "$CONFIRMATION" \
-              --argjson allow_empty_data "$ALLOW_EMPTY_DATA" \
-              '{
+          mkdir -p .launchplane
+          jq -n \
+            --arg product "$PRODUCT" \
+            --arg instance "$INSTANCE" \
+            --arg strategy "$STRATEGY" \
+            --arg data_source_mode "$DATA_SOURCE_MODE" \
+            --arg confirmation "$CONFIRMATION" \
+            --argjson allow_empty_data "$ALLOW_EMPTY_DATA" \
+            '{
+              schema_version: 1,
+              product: $product,
+              replacement: {
                 schema_version: 1,
                 product: $product,
-                replacement: {
-                  schema_version: 1,
-                  product: $product,
-                  instance: $instance,
-                  strategy: $strategy,
-                  allow_empty_data: $allow_empty_data,
-                  data_source_mode: $data_source_mode,
-                  confirmation: $confirmation
-                }
-              }'
-          })"
+                instance: $instance,
+                strategy: $strategy,
+                allow_empty_data: $allow_empty_data,
+                data_source_mode: $data_source_mode,
+                confirmation: $confirmation
+              }
+            }' > .launchplane/odoo-target-replacement-plan-payload.json
+
           idempotency_key="$({
             printf '%s' \
               "odoo-target-replacement-plan:${PRODUCT}:${INSTANCE}:" \
               "${STRATEGY}:${ALLOW_EMPTY_DATA}:${DATA_SOURCE_MODE}:" \
               "${CONFIRMATION}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
           })"
-          route="${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo"
-          status_code="$({
-            curl -sS \
-              -o odoo-target-replacement-plan.json \
-              -w '%{http_code}' \
-              -X POST \
-              -H "Authorization: Bearer ${oidc_token}" \
-              -H 'Content-Type: application/json' \
-              -H "Idempotency-Key: ${idempotency_key}" \
-              --data "$payload" \
-              "${route}/target-replacement-plan"
-          })"
+          echo "idempotency_key=${idempotency_key}" >>"$GITHUB_OUTPUT"
+
+      - name: Build replacement plan
+        id: launchplane
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          route-path: /v1/drivers/odoo/target-replacement-plan
+          payload-file: .launchplane/odoo-target-replacement-plan-payload.json
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          response-output-file: odoo-target-replacement-plan.json
+
+      - name: Verify replacement plan response
+        shell: bash
+        run: |
+          set -euo pipefail
           jq . odoo-target-replacement-plan.json
-          if [ "$status_code" != "202" ]; then
+          if [ "${{ steps.launchplane.outputs.status-code }}" != "202" ]; then
             echo \
-              "Odoo replacement plan failed: ${status_code}." \
+              "Odoo replacement plan failed: ${{ steps.launchplane.outputs.status-code }}." \
               >&2
+            exit 1
+          fi
+          if [ "$(jq -r '.status' odoo-target-replacement-plan.json)" != "accepted" ]; then
+            echo 'Launchplane Odoo target replacement plan was not accepted.' >&2
             exit 1
           fi
 

--- a/.github/workflows/odoo-website-bootstrap-override.yml
+++ b/.github/workflows/odoo-website-bootstrap-override.yml
@@ -34,16 +34,12 @@ concurrency:
 
 jobs:
   write:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
       PRODUCT: ${{ inputs.product }}
       CONTEXT_NAME: ${{ inputs.context }}
       INSTANCE: ${{ inputs.instance }}
       WEBSITE_BOOTSTRAP_PAYLOAD: ${{ inputs.website_bootstrap_payload }}
-      LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
-      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
     steps:
       - name: Validate runtime inputs
         shell: bash
@@ -53,24 +49,14 @@ jobs:
           : "${CONTEXT_NAME:?Missing context input}"
           : "${INSTANCE:?Missing instance input}"
           : "${WEBSITE_BOOTSTRAP_PAYLOAD:?Missing website bootstrap payload input}"
-          if [ -z "${LAUNCHPLANE_SERVICE_URL:-}" ]; then
-            echo 'Missing Launchplane service URL repository variable.' >&2
-            exit 1
-          fi
-          if [ -z "${LAUNCHPLANE_SERVICE_AUDIENCE:-}" ]; then
-            LAUNCHPLANE_SERVICE_AUDIENCE="$({
-              python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_SERVICE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_SERVICE_URL must include a hostname.")
-          print(parsed.hostname)
-          PY
-            })"
-          fi
-          echo "LAUNCHPLANE_SERVICE_AUDIENCE=${LAUNCHPLANE_SERVICE_AUDIENCE}" >>"$GITHUB_ENV"
+          for scalar in PRODUCT CONTEXT_NAME INSTANCE; do
+            case "${!scalar}" in
+              *$'\n'*)
+                echo "${scalar} must be a single-line value." >&2
+                exit 1
+                ;;
+            esac
+          done
           if ! jq -e 'type == "object"' <<< "$WEBSITE_BOOTSTRAP_PAYLOAD" >/dev/null; then
             echo 'website_bootstrap_payload must be a JSON object.' >&2
             exit 1
@@ -94,52 +80,57 @@ jobs:
             exit 1
           fi
 
-      - name: Write website bootstrap override
+      - name: Write website bootstrap override payload
+        id: request
         shell: bash
         run: |
           set -euo pipefail
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
+          mkdir -p .launchplane
           website_bootstrap="$({
             jq -c . <<< "$WEBSITE_BOOTSTRAP_PAYLOAD"
           })"
-          payload="$({
-            jq -n \
-              --arg product "$PRODUCT" \
-              --arg context "$CONTEXT_NAME" \
-              --arg instance "$INSTANCE" \
-              --argjson website_bootstrap "$website_bootstrap" \
-              '{
+          jq -n \
+            --arg product "$PRODUCT" \
+            --arg context "$CONTEXT_NAME" \
+            --arg instance "$INSTANCE" \
+            --argjson website_bootstrap "$website_bootstrap" \
+            '{
+              schema_version: 1,
+              product: $product,
+              override: {
                 schema_version: 1,
                 product: $product,
-                override: {
-                  schema_version: 1,
-                  product: $product,
-                  context: $context,
-                  instance: $instance,
-                  website_bootstrap: $website_bootstrap,
-                  source_label: "github-actions:odoo-website-bootstrap-override"
-                }
-              }'
-          })"
-          status_code="$({
-            curl -sS \
-              -o odoo-website-bootstrap-override.json \
-              -w '%{http_code}' \
-              -X POST \
-              -H "Authorization: Bearer ${oidc_token}" \
-              -H 'Content-Type: application/json' \
-              -H "Idempotency-Key: odoo-website-bootstrap-override:${PRODUCT}:${CONTEXT_NAME}:${INSTANCE}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
-              --data "$payload" \
-              "${LAUNCHPLANE_SERVICE_URL}/v1/drivers/odoo/website-bootstrap-override"
-          })"
+                context: $context,
+                instance: $instance,
+                website_bootstrap: $website_bootstrap,
+                source_label: "github-actions:odoo-website-bootstrap-override"
+              }
+            }' > .launchplane/odoo-website-bootstrap-override-payload.json
+
+          printf 'idempotency_key=%s\n' \
+            "odoo-website-bootstrap-override:${PRODUCT}:${CONTEXT_NAME}:${INSTANCE}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
+            >>"$GITHUB_OUTPUT"
+
+      - name: Write website bootstrap override
+        id: launchplane
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          route-path: /v1/drivers/odoo/website-bootstrap-override
+          payload-file: .launchplane/odoo-website-bootstrap-override-payload.json
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          response-output-file: odoo-website-bootstrap-override.json
+
+      - name: Verify website bootstrap override response
+        shell: bash
+        run: |
+          set -euo pipefail
           jq . odoo-website-bootstrap-override.json
-          if [ "$status_code" != "202" ]; then
-            echo "Launchplane Odoo website-bootstrap override failed with HTTP ${status_code}." >&2
+          if [ "${{ steps.launchplane.outputs.status-code }}" != "202" ]; then
+            echo \
+              "Launchplane Odoo website-bootstrap override failed with HTTP ${{ steps.launchplane.outputs.status-code }}." \
+              >&2
             exit 1
           fi
           if [ "$(jq -r '.status' odoo-website-bootstrap-override.json)" != "accepted" ]; then

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -746,6 +746,18 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
             )
         ),
     },
+    ".github/workflows/odoo-target-replacement-plan.yml": {
+        "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "payload-file": frozenset(
+            (".launchplane/odoo-target-replacement-plan-payload.json",)
+        ),
+    },
+    ".github/workflows/odoo-website-bootstrap-override.yml": {
+        "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "payload-file": frozenset(
+            (".launchplane/odoo-website-bootstrap-override-payload.json",)
+        ),
+    },
     ".github/workflows/reusable-odoo-artifact-publish.yml": {
         "DEFAULT_REPOSITORY": frozenset(("${{ github.repository }}",)),
         "GITHUB_TOKEN": frozenset(("${{ github.token }}",)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1787,6 +1787,26 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 "${{ env.PRODUCT }}:${{",
             ),
             (
+                ".github/workflows/odoo-target-replacement-plan.yml",
+                "idempotency-key",
+                "${{ steps.request.outputs.idempotency_key }}",
+            ),
+            (
+                ".github/workflows/odoo-target-replacement-plan.yml",
+                "payload-file",
+                ".launchplane/odoo-target-replacement-plan-payload.json",
+            ),
+            (
+                ".github/workflows/odoo-website-bootstrap-override.yml",
+                "idempotency-key",
+                "${{ steps.request.outputs.idempotency_key }}",
+            ),
+            (
+                ".github/workflows/odoo-website-bootstrap-override.yml",
+                "payload-file",
+                ".launchplane/odoo-website-bootstrap-override-payload.json",
+            ),
+            (
                 ".github/workflows/launchplane-config-authority.yml",
                 "checkout.repository[1]",
                 "${{ github.repository_owner }}/launchplane",
@@ -1857,6 +1877,16 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 ".github/workflows/launchplane-deploy.yml",
                 "uses",
                 "cbusillo/not-launchplane/.github/workflows/reusable-generic-web-stable-deploy.yml@main",
+            ),
+            (
+                ".github/workflows/unrelated.yml",
+                "payload-file",
+                ".launchplane/odoo-target-replacement-plan-payload.json",
+            ),
+            (
+                ".github/workflows/unrelated.yml",
+                "payload-file",
+                ".launchplane/odoo-website-bootstrap-override-payload.json",
             ),
             (
                 ".github/workflows/launchplane-deploy.yml",

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -642,6 +642,41 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn('startswith("/")', workflow_text)
         self.assertIn('startswith("//") | not', workflow_text)
 
+    def test_odoo_operator_workflows_use_launchplane_request_action(self) -> None:
+        workflow_expectations = {
+            "odoo-target-replacement-plan.yml": (
+                "/v1/drivers/odoo/target-replacement-plan",
+                ".launchplane/odoo-target-replacement-plan-payload.json",
+                "odoo-target-replacement-plan.json",
+            ),
+            "odoo-website-bootstrap-override.yml": (
+                "/v1/drivers/odoo/website-bootstrap-override",
+                ".launchplane/odoo-website-bootstrap-override-payload.json",
+                "odoo-website-bootstrap-override.json",
+            ),
+        }
+
+        for workflow_name, (route_path, payload_file, response_file) in workflow_expectations.items():
+            with self.subTest(workflow=workflow_name):
+                workflow_text = Path(f".github/workflows/{workflow_name}").read_text(
+                    encoding="utf-8"
+                )
+
+                self.assertIn("runs-on: ubuntu-latest", workflow_text)
+                self.assertIn(
+                    "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+                    workflow_text,
+                )
+                self.assertIn(f"route-path: {route_path}", workflow_text)
+                self.assertIn(f"payload-file: {payload_file}", workflow_text)
+                self.assertIn(f"response-output-file: {response_file}", workflow_text)
+                self.assertIn("idempotency-key: ${{ steps.request.outputs.idempotency_key }}", workflow_text)
+                self.assertIn('steps.launchplane.outputs.status-code }}" != "202"', workflow_text)
+                self.assertIn('!= "accepted"', workflow_text)
+                self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+                self.assertNotIn("Authorization: Bearer", workflow_text)
+                self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
+
     def test_launchplane_workflows_do_not_hardcode_public_service_defaults(self) -> None:
         workflow_dir = Path(".github/workflows")
         forbidden_literals = (


### PR DESCRIPTION
## Summary
- Replace hand-rolled GitHub OIDC token exchange and raw Launchplane `curl` calls in Odoo target replacement plan and website-bootstrap override workflows with the shared `launchplane-request` action.
- Preserve request payload shapes, run-scoped idempotency keys, response artifact uploads, and fail-closed HTTP `202` plus `accepted` response validation.
- Add scoped config-authority classifications and workflow contract tests for the new payload-file/idempotency mechanics.

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_product_onboarding.py tests/test_odoo_stable_authority.py`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_odoo_website_bootstrap_override_requires_explicit_target_inputs tests.test_product_onboarding.ProductOnboardingTests.test_odoo_website_bootstrap_override_prevalidates_route_paths tests.test_product_onboarding.ProductOnboardingTests.test_odoo_operator_workflows_use_launchplane_request_action tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_connector_findings_are_classified_narrowly tests.test_odoo_stable_authority`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/odoo-target-replacement-plan.yml .github/workflows/odoo-website-bootstrap-override.yml`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `git diff --check`
- `uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_product_onboarding.py`

## Review
- Read-only review agents flagged preserving exact HTTP `202` checks and asserting accepted-status guards in tests; both fixed before PR.
- Auto Review ledger had no active target-applicable findings.

Refs #1526
Refs #1529
