### PR TITLE
Use launchplane request for Odoo testing deploy poll

### DIFF
--- a/.github/workflows/reusable-product-driver-testing-deploy.yml
+++ b/.github/workflows/reusable-product-driver-testing-deploy.yml
@@ -213,29 +213,66 @@ jobs:
             poll_url=result.poll_url
 
       - name: Poll target replacement operation
-        id: poll
+        id: poll_operation
         env:
-          LAUNCHPLANE_URL: >-
-            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
-          AUDIENCE: ${{ inputs.launchplane_audience }}
           OPERATION_ID: ${{ steps.lp.outputs.operation_id }}
           POLL_URL: ${{ steps.lp.outputs.poll_url }}
         run: |
           set -euo pipefail
-          : "${LAUNCHPLANE_URL:?Missing Launchplane service URL. Set LAUNCHPLANE_PUBLIC_URL or pass launchplane_url.}"
-          if [ -z "${AUDIENCE:-}" ]; then
-            AUDIENCE="$({
-              python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
-          print(parsed.hostname)
-          PY
-            })"
+          if [ -z "$OPERATION_ID" ] || [ -z "$POLL_URL" ]; then
+            echo 'Target replacement response missing operation metadata.' >&2
+            exit 1
           fi
+          if [[ "$POLL_URL" == *\\* ]]; then
+            echo 'Target replacement poll URL must be a local Launchplane route path.' >&2
+            exit 1
+          fi
+          case "$POLL_URL" in
+            *$'\n'* | *$'\r'*)
+              echo 'Target replacement poll URL must be a single-line value.' >&2
+              exit 1
+              ;;
+            *://* | //* | *'//'* | *'?'* | *'#'* | *'%'*)
+              echo 'Target replacement poll URL must be a local Launchplane route path.' >&2
+              exit 1
+              ;;
+            /v1/drivers/odoo/target-replacement/operations/*) ;;
+            *)
+              echo "Target replacement poll URL is not an Odoo operation path: ${POLL_URL}" >&2
+              exit 1
+              ;;
+          esac
+          operation_path_id="${POLL_URL#/v1/drivers/odoo/target-replacement/operations/}"
+          case "$operation_path_id" in
+            "" | */* | *.*)
+              echo 'Target replacement poll URL operation ID must be a single path segment.' >&2
+              exit 1
+              ;;
+          esac
+
+      - name: Poll target replacement operation result
+        id: poll_result
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: >-
+            ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ inputs.launchplane_audience }}
+          method: GET
+          route-path: ${{ steps.lp.outputs.poll_url }}
+          poll-result-path: operation.status
+          poll-result-statuses: pending,running
+          poll-interval-ms: 15000
+          poll-timeout-ms: ${{ inputs['timeout-ms'] }}
+          fail-result-paths: ""
+          response-output-file: odoo-testing-target-replacement.json
+
+      - name: Read target replacement operation result
+        id: poll
+        env:
+          OPERATION_ID: ${{ steps.lp.outputs.operation_id }}
+          POLL_STATUS_CODE: ${{ steps.poll_result.outputs.status-code }}
+        run: |
+          set -euo pipefail
           write_output() {
             file="$1"
             name="$2"
@@ -247,49 +284,12 @@ jobs:
               printf '%s\n' "$delimiter"
             } >>"$file"
           }
-          write_output "$GITHUB_ENV" AUDIENCE "$AUDIENCE"
-          if [ -z "$OPERATION_ID" ] || [ -z "$POLL_URL" ]; then
-            echo 'Target replacement response missing operation metadata.' >&2
+          if [ "$POLL_STATUS_CODE" != "200" ]; then
+            echo "Target replacement poll failed with HTTP ${POLL_STATUS_CODE}." >&2
+            jq . odoo-testing-target-replacement.json >&2
             exit 1
           fi
-          case "$POLL_URL" in
-            /v1/drivers/odoo/target-replacement/operations/*) ;;
-            *)
-              echo "Target replacement poll URL is not an Odoo operation path: ${POLL_URL}" >&2
-              exit 1
-              ;;
-          esac
-          deadline=$((SECONDS + 3600))
-          while true; do
-            token="$({
-              curl -fsSL \
-                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${AUDIENCE}" \
-              | jq -r '.value'
-            })"
-            status_code="$({
-              curl -sS \
-                -o odoo-testing-target-replacement.json \
-                -w '%{http_code}' \
-                -H "Authorization: Bearer ${token}" \
-                "${LAUNCHPLANE_URL}${POLL_URL}"
-            })"
-            if [ "$status_code" != "200" ]; then
-              echo "Target replacement poll failed: ${status_code}." >&2
-              cat odoo-testing-target-replacement.json >&2
-              exit 1
-            fi
-            operation_status="$(jq -r '.operation.status // empty' odoo-testing-target-replacement.json)"
-            if [ "$operation_status" = "pass" ] || [ "$operation_status" = "fail" ]; then
-              break
-            fi
-            if [ "$SECONDS" -ge "$deadline" ]; then
-              echo "Target replacement operation ${OPERATION_ID} timed out." >&2
-              jq . odoo-testing-target-replacement.json >&2
-              exit 1
-            fi
-            sleep 15
-          done
+          operation_status="$(jq -r '.operation.status // empty' odoo-testing-target-replacement.json)"
           result='.operation.result'
           deployment_status="$(jq -r "${result}.deploy_status // \"\"" odoo-testing-target-replacement.json)"
           post_deploy_status="$(jq -r "${result}.post_deploy_status // \"\"" odoo-testing-target-replacement.json)"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -400,9 +400,6 @@ WORKFLOW_LAUNCHPLANE_URL_REFERENCE_PATH_VALUES = {
         )
     },
     ".github/workflows/reusable-product-driver-testing-deploy.yml": {
-        "LAUNCHPLANE_URL": frozenset(
-            ("${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}",)
-        ),
         "launchplane-url": frozenset(
             ("${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}",)
         ),
@@ -505,6 +502,7 @@ PRODUCT_DRIVER_REUSABLE_PAYLOAD_FIELD_KEYS = frozenset(
 )
 PRODUCT_DRIVER_TESTING_DEPLOY_PAYLOAD_FIELD_KEYS = frozenset(
     (
+        "product",
         "replacement.artifact_id",
         "replacement.product",
         "replacement.source_git_ref",
@@ -530,7 +528,13 @@ PRODUCT_DRIVER_REUSABLE_WRAPPER_LITERAL_VALUES = {
         "INTENT": frozenset(("stable-testing-reset",)),
     },
     ".github/workflows/reusable-product-driver-testing-deploy.yml": {
-        "route-path": frozenset(("/v1/drivers/odoo/target-replacement-apply",)),
+        "fail-result-paths": frozenset(('""',)),
+        "route-path": frozenset(
+            (
+                "/v1/drivers/odoo/target-replacement-apply",
+                "${{ steps.lp.outputs.poll_url }}",
+            )
+        ),
     },
 }
 WORKFLOW_LAUNCHPLANE_BOOTSTRAP_CONTEXT_PATH_VALUES = {

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1451,19 +1451,14 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ),
             "launchplane_self_bootstrap",
         )
-        for key in ("launchplane-url", "LAUNCHPLANE_URL"):
-            with self.subTest(
+        self.assertEqual(
+            _allow_reason(
                 path=".github/workflows/reusable-product-driver-testing-deploy.yml",
-                key=key,
-            ):
-                self.assertEqual(
-                    _allow_reason(
-                        path=".github/workflows/reusable-product-driver-testing-deploy.yml",
-                        key=key,
-                        value="${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}",
-                    ),
-                    "launchplane_self_bootstrap",
-                )
+                key="launchplane-url",
+                value="${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}",
+            ),
+            "launchplane_self_bootstrap",
+        )
         for path, key in (
             (".github/workflows/odoo-driver-route-smoke.yml", "LAUNCHPLANE_URL"),
             (".github/workflows/reusable-odoo-preview.yml", "launchplane-url"),

--- a/tests/test_odoo_stable_authority.py
+++ b/tests/test_odoo_stable_authority.py
@@ -40,13 +40,19 @@ class OdooStableAuthorityTests(TestCase):
         self.assertEqual(offenders, [])
 
     def test_reusable_testing_deploy_uses_target_replacement_apply(self) -> None:
-        workflow = Path(
-            ".github/workflows/reusable-product-driver-testing-deploy.yml"
-        ).read_text(encoding="utf-8")
+        workflow = Path(".github/workflows/reusable-product-driver-testing-deploy.yml").read_text(
+            encoding="utf-8"
+        )
 
         self.assertIn("route-path: /v1/drivers/odoo/target-replacement-apply", workflow)
         self.assertIn("poll_url=result.poll_url", workflow)
-        self.assertIn('${LAUNCHPLANE_URL}${POLL_URL}', workflow)
+        self.assertIn("method: GET", workflow)
+        self.assertIn("route-path: ${{ steps.lp.outputs.poll_url }}", workflow)
+        self.assertIn("poll-result-path: operation.status", workflow)
+        self.assertIn('fail-result-paths: ""', workflow)
+        self.assertNotIn("${LAUNCHPLANE_URL}${POLL_URL}", workflow)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow)
+        self.assertNotIn("Authorization: Bearer", workflow)
         self.assertNotIn("route-path: /v1/drivers/odoo/testing-deploy", workflow)
         self.assertNotIn("odoo_testing_deploy.execute", workflow)
 
@@ -101,4 +107,6 @@ class OdooStableAuthorityTests(TestCase):
 
         self.assertIn("through the stable target replacement executor", operations_doc)
         self.assertIn("delegates the rollback deploy to stable target replacement", records_doc)
-        self.assertIn("delegates the provider mutation to\nstable target replacement", service_boundary_doc)
+        self.assertIn(
+            "delegates the provider mutation to\nstable target replacement", service_boundary_doc
+        )

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -554,6 +554,29 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             "Target replacement poll URL is not an Odoo operation path",
             workflow_text,
         )
+        self.assertIn(
+            "Target replacement poll URL must be a local Launchplane route path.",
+            workflow_text,
+        )
+        self.assertIn(
+            "Target replacement poll URL operation ID must be a single path segment.",
+            workflow_text,
+        )
+        self.assertIn("*$'\\n'* | *$'\\r'*)", workflow_text)
+        self.assertIn('[[ "$POLL_URL" == *', workflow_text)
+        self.assertIn("*'?'*", workflow_text)
+        self.assertIn("*'#'*", workflow_text)
+        self.assertIn("*'%'*", workflow_text)
+        self.assertIn("method: GET", workflow_text)
+        self.assertIn("route-path: ${{ steps.lp.outputs.poll_url }}", workflow_text)
+        self.assertIn("poll-result-path: operation.status", workflow_text)
+        self.assertIn("poll-result-statuses: pending,running", workflow_text)
+        self.assertIn("poll-timeout-ms: ${{ inputs['timeout-ms'] }}", workflow_text)
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn(
+            "response-output-file: odoo-testing-target-replacement.json",
+            workflow_text,
+        )
         self.assertIn("for required in PRODUCT ARTIFACT_ID; do", workflow_text)
         self.assertIn('echo "${required} is required."', workflow_text)
         self.assertNotIn('context_slug="${CONTEXT_NAME//_/-}"', workflow_text)
@@ -593,6 +616,9 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertNotIn('PRODUCT="${GITHUB_REPOSITORY#*/}"', workflow_text)
         self.assertNotIn("permissions:\n  contents: read\n  id-token: write", workflow_text)
         self.assertIn("permissions:\n      contents: read\n      id-token: write", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
 
     def test_reusable_odoo_workflows_use_caller_visible_runner(self) -> None:
         workflow_paths = (
@@ -1304,6 +1330,11 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn(
             "deployment_record_id: ${{ steps.poll.outputs.deployment_record_id }}", workflow_text
         )
+        self.assertIn(
+            "POLL_STATUS_CODE: ${{ steps.poll_result.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn('if [ "$POLL_STATUS_CODE" != "200" ]; then', workflow_text)
         for result_path in (
             "deploy_status",
             "post_deploy_status",


### PR DESCRIPTION
## Summary
- replace the hand-rolled OIDC/curl target-replacement poll loop in the testing deploy reusable with `launchplane-request@main`
- validate the dynamic `poll_url` as a single local Odoo operation route before delegating to the shared action
- tighten config-authority allowlists and tests so stale `LAUNCHPLANE_URL` plumbing and raw curl/OIDC polling do not return

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py tests/test_odoo_stable_authority.py`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/reusable-product-driver-testing-deploy.yml`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_product_driver_testing_deploy_requires_explicit_product_scope tests.test_product_onboarding.ProductOnboardingTests.test_product_driver_testing_deploy_requires_explicit_driver tests.test_product_onboarding.ProductOnboardingTests.test_product_driver_testing_deploy_exposes_result_outputs tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_connector_findings_are_classified_narrowly tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped tests.test_odoo_stable_authority`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_odoo_stable_authority.py`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_odoo_stable_authority.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_odoo_stable_authority.py`
- `git diff --check`

## Review Notes
- Agent review flagged the poll timeout and dynamic path guard; this revision ties the poll timeout to `inputs['timeout-ms']` and rejects CR/LF, absolute URLs, protocol-relative routes, query/fragment, percent-encoding, backslashes, multi-segment IDs, and dotted IDs before the shared action receives the route.
- Existing default-branch Dependabot moderate alerts are not introduced by this PR.
