### PR TITLE
Use launchplane request for legacy context cleanup

### DIFF
--- a/.github/workflows/product-legacy-context-cleanup.yml
+++ b/.github/workflows/product-legacy-context-cleanup.yml
@@ -34,9 +34,7 @@ concurrency:
 
 jobs:
   cleanup:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       PRODUCT: ${{ inputs.product }}
@@ -45,6 +43,7 @@ jobs:
       DRY_RUN: ${{ inputs.dry_run }}
     steps:
       - name: Request legacy context cleanup
+        id: request
         shell: bash
         run: |
           set -euo pipefail
@@ -53,57 +52,26 @@ jobs:
           : "${SOURCE_CONTEXT:?Missing source_context input}"
           : "${TARGET_CONTEXT:?Missing target_context input}"
 
-          service_origin="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
-          print(f"{parsed.scheme}://{parsed.netloc}")
-          PY
-          })"
-          service_audience="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
-          print(parsed.hostname)
-          PY
-          })"
           mode="apply"
           if [ "$DRY_RUN" = "true" ]; then
             mode="dry-run"
           fi
 
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}" \
-            | jq -r '.value'
-          })"
-          request_payload="$({
-            actor="github-actions:${GITHUB_REPOSITORY}:${GITHUB_RUN_ID}"
-            jq -n \
-              --arg product "$PRODUCT" \
-              --arg source_context "$SOURCE_CONTEXT" \
-              --arg target_context "$TARGET_CONTEXT" \
-              --arg mode "$mode" \
-              --arg actor "$actor" \
-              '{
-                product: $product,
-                source_context: $source_context,
-                target_context: $target_context,
-                mode: $mode,
-                actor: $actor,
-                source_label: "workflow:product-legacy-context-cleanup"
-              }'
-          })"
-          response_file="launchplane-product-legacy-context-cleanup.json"
+          actor="github-actions:${GITHUB_REPOSITORY}:${GITHUB_RUN_ID}"
+          jq -n \
+            --arg product "$PRODUCT" \
+            --arg source_context "$SOURCE_CONTEXT" \
+            --arg target_context "$TARGET_CONTEXT" \
+            --arg mode "$mode" \
+            --arg actor "$actor" \
+            '{
+              product: $product,
+              source_context: $source_context,
+              target_context: $target_context,
+              mode: $mode,
+              actor: $actor,
+              source_label: "workflow:product-legacy-context-cleanup"
+            }' > launchplane-product-legacy-context-cleanup-payload.json
           idempotency_key="$({
             printf 'product-legacy-context-cleanup:%s:%s:%s:%s:%s' \
               "$PRODUCT" \
@@ -112,23 +80,34 @@ jobs:
               "$mode" \
               "$GITHUB_RUN_ID"
           })"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            -H "Idempotency-Key: ${idempotency_key}" \
-            --data "$request_payload" \
-            "${service_origin}/v1/product-profiles/legacy-context-cleanup/apply")"
-          if [ "$status_code" != "202" ]; then
+          printf 'idempotency_key=%s\n' "$idempotency_key" >> "$GITHUB_OUTPUT"
+
+      - name: Request Launchplane legacy context cleanup
+        id: cleanup_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          route-path: /v1/product-profiles/legacy-context-cleanup/apply
+          payload-file: launchplane-product-legacy-context-cleanup-payload.json
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          response-output-file: launchplane-product-legacy-context-cleanup.json
+
+      - name: Check cleanup response
+        shell: bash
+        env:
+          CLEANUP_STATUS_CODE: ${{ steps.cleanup_request.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          response_file="launchplane-product-legacy-context-cleanup.json"
+          if [ "$CLEANUP_STATUS_CODE" != "202" ]; then
             cat "$response_file" >&2
-            echo "Cleanup failed with HTTP ${status_code}." >&2
+            echo "Cleanup failed with HTTP ${CLEANUP_STATUS_CODE}." >&2
             exit 1
           fi
           jq . "$response_file"
 
       - name: Upload cleanup artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: launchplane-product-legacy-context-cleanup-${{ inputs.product }}

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -774,6 +774,10 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
         "payload-file": frozenset((".launchplane/odoo-website-bootstrap-override-payload.json",)),
     },
+    ".github/workflows/product-legacy-context-cleanup.yml": {
+        "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "payload-file": frozenset(("launchplane-product-legacy-context-cleanup-payload.json",)),
+    },
     ".github/workflows/reusable-odoo-artifact-publish.yml": {
         "DEFAULT_REPOSITORY": frozenset(("${{ github.repository }}",)),
         "GITHUB_TOKEN": frozenset(("${{ github.token }}",)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2523,6 +2523,28 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             with self.subTest(key=key, value=value):
                 self.assertEqual(_allow_reason(path=path, key=key, value=value), "")
 
+    def test_product_legacy_context_cleanup_request_mechanics_are_path_scoped(
+        self,
+    ) -> None:
+        path = ".github/workflows/product-legacy-context-cleanup.yml"
+        for key, value in (
+            ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("payload-file", "launchplane-product-legacy-context-cleanup-payload.json"),
+        ):
+            with self.subTest(key=key, value=value):
+                self.assertEqual(
+                    _allow_reason(path=path, key=key, value=value),
+                    "thin_connector_input",
+                )
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/generic-workflow.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "",
+                )
+
     def test_product_driver_reusable_workflow_mechanics_are_path_scoped(
         self,
     ) -> None:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1305,6 +1305,43 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         inputs_section = workflow_text.split("permissions:", maxsplit=1)[0]
         self.assertEqual(inputs_section.count("        description:"), 6)
 
+    def test_product_legacy_context_cleanup_uses_launchplane_request(self) -> None:
+        workflow_text = Path(".github/workflows/product-legacy-context-cleanup.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn(
+            "route-path: /v1/product-profiles/legacy-context-cleanup/apply",
+            workflow_text,
+        )
+        self.assertIn(
+            "payload-file: launchplane-product-legacy-context-cleanup-payload.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "idempotency-key: ${{ steps.request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: launchplane-product-legacy-context-cleanup.json",
+            workflow_text,
+        )
+        self.assertIn("if: always()", workflow_text)
+        self.assertIn(
+            "CLEANUP_STATUS_CODE: ${{ steps.cleanup_request.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn('if [ "$CLEANUP_STATUS_CODE" != "202" ]; then', workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
+
     def test_github_metadata_prefers_repository_merge_method(self) -> None:
         metadata = json.loads(Path(".github/github.json").read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## Summary
- replace the hand-rolled OIDC/curl POST in `product-legacy-context-cleanup.yml` with `launchplane-request@main`
- keep the existing operator intent payload, idempotency key shape, response JSON artifact, and summary behavior
- move the workflow off the self-hosted runner because the local request transport is gone
- add path-scoped config-authority/test coverage so the shared-action handoff is allowed without reviving raw token/curl plumbing

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/product-legacy-context-cleanup.yml`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_product_legacy_context_cleanup_uses_launchplane_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_product_legacy_context_cleanup_request_mechanics_are_path_scoped tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_product_context_workflow_aliases_are_path_scoped tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `git diff --check`

## Review Notes
- Read-only agents reviewed the workflow conversion. One agent reported no blockers.
- The second agent flagged that failed responses could lose the cleanup artifact; fixed by adding `if: always()` to the upload step and pinning it in `tests/test_product_onboarding.py`.
- The same review noted a possible `blocked: true` response gate; the service apply path raises for blocked cleanup plans, so non-cleanable apply requests should not return a green 202.
- Auto Review ledger had no in-flight or target-applicable findings during this slice.
- Existing default-branch Dependabot moderate alerts are not introduced by this PR.
