### PR TITLE
Use launchplane request for product context cutover

### DIFF
--- a/.github/workflows/product-context-cutover.yml
+++ b/.github/workflows/product-context-cutover.yml
@@ -37,9 +37,7 @@ concurrency:
 
 jobs:
   cutover:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       PRODUCT: ${{ inputs.product }}
@@ -49,6 +47,7 @@ jobs:
       DRY_RUN: ${{ inputs.dry_run }}
     steps:
       - name: Request product context cutover
+        id: request
         shell: bash
         run: |
           set -euo pipefail
@@ -58,73 +57,54 @@ jobs:
           : "${TARGET_CONTEXT:?Missing target_context input}"
           : "${DISPLAY_NAME:?Missing display_name input}"
 
-          service_origin="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
-          print(f"{parsed.scheme}://{parsed.netloc}")
-          PY
-          })"
-          service_audience="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
-          print(parsed.hostname)
-          PY
-          })"
           mode="apply"
           if [ "$DRY_RUN" = "true" ]; then
             mode="dry-run"
           fi
 
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}" \
-            | jq -r '.value'
-          })"
-          request_payload="$({
-            jq -n \
-              --arg product "$PRODUCT" \
-              --arg source_context "$SOURCE_CONTEXT" \
-              --arg target_context "$TARGET_CONTEXT" \
-              --arg display_name "$DISPLAY_NAME" \
-              --arg mode "$mode" \
-              '{
-                product: $product,
-                source_context: $source_context,
-                target_context: $target_context,
-                display_name: $display_name,
-                mode: $mode,
-                source_label: "workflow:product-context-cutover"
-              }'
-          })"
+          jq -n \
+            --arg product "$PRODUCT" \
+            --arg source_context "$SOURCE_CONTEXT" \
+            --arg target_context "$TARGET_CONTEXT" \
+            --arg display_name "$DISPLAY_NAME" \
+            --arg mode "$mode" \
+            '{
+              product: $product,
+              source_context: $source_context,
+              target_context: $target_context,
+              display_name: $display_name,
+              mode: $mode,
+              source_label: "workflow:product-context-cutover"
+            }' > launchplane-product-context-cutover-payload.json
+          idempotency_key="product-context-cutover:${PRODUCT}:${SOURCE_CONTEXT}:${TARGET_CONTEXT}:${mode}:${GITHUB_RUN_ID}"
+          printf 'idempotency_key=%s\n' "$idempotency_key" >> "$GITHUB_OUTPUT"
+
+      - name: Request Launchplane product context cutover
+        id: cutover_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          route-path: /v1/product-profiles/context-cutover/apply
+          payload-file: launchplane-product-context-cutover-payload.json
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          response-output-file: launchplane-product-context-cutover.json
+
+      - name: Check cutover response
+        shell: bash
+        env:
+          CUTOVER_STATUS_CODE: ${{ steps.cutover_request.outputs.status-code }}
+        run: |
+          set -euo pipefail
           response_file="launchplane-product-context-cutover.json"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            -H "Idempotency-Key: product-context-cutover:${PRODUCT}:${SOURCE_CONTEXT}:${TARGET_CONTEXT}:${mode}:${GITHUB_RUN_ID}" \
-            --data "$request_payload" \
-            "${service_origin}/v1/product-profiles/context-cutover/apply")"
-          if [ "$status_code" != "202" ]; then
+          if [ "$CUTOVER_STATUS_CODE" != "202" ]; then
             cat "$response_file" >&2
-            echo "Launchplane product context cutover failed with HTTP ${status_code}." >&2
+            echo "Launchplane product context cutover failed with HTTP ${CUTOVER_STATUS_CODE}." >&2
             exit 1
           fi
           jq . "$response_file"
 
       - name: Upload cutover artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: launchplane-product-context-cutover-${{ inputs.product }}

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -592,12 +592,6 @@ WORKFLOW_LAUNCHPLANE_BOOTSTRAP_CONTEXT_PATH_VALUES = {
 WORKFLOW_JQ_OPERATOR_FIELD_PATH_KEYS = {
     ".github/workflows/edge-endpoint-apply.yml": frozenset(("endpoint_key",)),
     ".github/workflows/odoo-config-parameter-override.yml": frozenset(("key",)),
-    ".github/workflows/product-context-cutover.yml": frozenset(
-        ("source_context", "target_context")
-    ),
-    ".github/workflows/product-legacy-context-cleanup.yml": frozenset(
-        ("source_context", "target_context")
-    ),
     ".github/workflows/provider-target-operations.yml": frozenset(
         ("context", "instance", "provider_id")
     ),
@@ -773,6 +767,10 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
     ".github/workflows/odoo-website-bootstrap-override.yml": {
         "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
         "payload-file": frozenset((".launchplane/odoo-website-bootstrap-override-payload.json",)),
+    },
+    ".github/workflows/product-context-cutover.yml": {
+        "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "payload-file": frozenset(("launchplane-product-context-cutover-payload.json",)),
     },
     ".github/workflows/product-legacy-context-cleanup.yml": {
         "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2138,6 +2138,23 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                         "",
                     )
 
+        for path, key, value in (
+            (".github/workflows/product-context-cutover.yml", "source_context", "$source_context,"),
+            (".github/workflows/product-context-cutover.yml", "target_context", "$target_context,"),
+            (
+                ".github/workflows/product-legacy-context-cleanup.yml",
+                "source_context",
+                "$source_context,",
+            ),
+            (
+                ".github/workflows/product-legacy-context-cleanup.yml",
+                "target_context",
+                "$target_context,",
+            ),
+        ):
+            with self.subTest(path=path, key=key, value=value):
+                self.assertEqual(_allow_reason(path=path, key=key, value=value), "")
+
     def test_remaining_workflow_aliases_are_path_scoped(self) -> None:
         workflow_aliases = (
             (
@@ -2258,18 +2275,6 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 )
 
         for path, key, value in (
-            (".github/workflows/product-context-cutover.yml", "source_context", "$source_context,"),
-            (".github/workflows/product-context-cutover.yml", "target_context", "$target_context,"),
-            (
-                ".github/workflows/product-legacy-context-cleanup.yml",
-                "source_context",
-                "$source_context,",
-            ),
-            (
-                ".github/workflows/product-legacy-context-cleanup.yml",
-                "target_context",
-                "$target_context,",
-            ),
             (".github/workflows/provider-target-operations.yml", "provider_id", "$provider_id,"),
             (".github/workflows/provider-target-operations.yml", "context", "$context,"),
             (".github/workflows/provider-target-operations.yml", "instance", "$instance,"),
@@ -2530,6 +2535,28 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         for key, value in (
             ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
             ("payload-file", "launchplane-product-legacy-context-cleanup-payload.json"),
+        ):
+            with self.subTest(key=key, value=value):
+                self.assertEqual(
+                    _allow_reason(path=path, key=key, value=value),
+                    "thin_connector_input",
+                )
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/generic-workflow.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "",
+                )
+
+    def test_product_context_cutover_request_mechanics_are_path_scoped(
+        self,
+    ) -> None:
+        path = ".github/workflows/product-context-cutover.yml"
+        for key, value in (
+            ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("payload-file", "launchplane-product-context-cutover-payload.json"),
         ):
             with self.subTest(key=key, value=value):
                 self.assertEqual(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1305,6 +1305,56 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         inputs_section = workflow_text.split("permissions:", maxsplit=1)[0]
         self.assertEqual(inputs_section.count("        description:"), 6)
 
+    def test_product_context_cutover_uses_launchplane_request(self) -> None:
+        workflow_text = Path(".github/workflows/product-context-cutover.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn(
+            "route-path: /v1/product-profiles/context-cutover/apply",
+            workflow_text,
+        )
+        self.assertIn(
+            "payload-file: launchplane-product-context-cutover-payload.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "idempotency-key: ${{ steps.request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: launchplane-product-context-cutover.json",
+            workflow_text,
+        )
+        self.assertIn('mode="apply"', workflow_text)
+        self.assertIn('mode="dry-run"', workflow_text)
+        self.assertIn('--arg product "$PRODUCT"', workflow_text)
+        self.assertIn('--arg source_context "$SOURCE_CONTEXT"', workflow_text)
+        self.assertIn('--arg target_context "$TARGET_CONTEXT"', workflow_text)
+        self.assertIn('--arg display_name "$DISPLAY_NAME"', workflow_text)
+        self.assertIn('--arg mode "$mode"', workflow_text)
+        self.assertIn("product: $product", workflow_text)
+        self.assertIn("source_context: $source_context", workflow_text)
+        self.assertIn("target_context: $target_context", workflow_text)
+        self.assertIn("display_name: $display_name", workflow_text)
+        self.assertIn("mode: $mode", workflow_text)
+        self.assertIn('source_label: "workflow:product-context-cutover"', workflow_text)
+        self.assertIn("if: always()", workflow_text)
+        self.assertIn(
+            "CUTOVER_STATUS_CODE: ${{ steps.cutover_request.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn('if [ "$CUTOVER_STATUS_CODE" != "202" ]; then', workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
+
     def test_product_legacy_context_cleanup_uses_launchplane_request(self) -> None:
         workflow_text = Path(".github/workflows/product-legacy-context-cleanup.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- convert product-context-cutover to the shared launchplane-request action
- preserve payload/idempotency shape and 202 response handling
- retain failure artifacts and remove stale lowercase jq-field audit allowances

## Validation
- python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/product-context-cutover.yml
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_product_context_cutover_uses_launchplane_request tests.test_product_onboarding.ProductOnboardingTests.test_product_legacy_context_cleanup_uses_launchplane_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_product_context_cutover_request_mechanics_are_path_scoped tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_product_legacy_context_cleanup_request_mechanics_are_path_scoped tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_product_context_workflow_aliases_are_path_scoped tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- git diff --check

## Review
- code-gpt-5.5 read-only review: no findings
- claude-sonnet-4.6 read-only review: patched dead audit allowlist entries and strengthened payload tests; remaining artifact-upload note matches existing converted workflow pattern