### PR TITLE
Use launchplane request for Dokploy target setup

### DIFF
--- a/.github/workflows/dokploy-target-setup.yml
+++ b/.github/workflows/dokploy-target-setup.yml
@@ -142,9 +142,7 @@ concurrency:
 
 jobs:
   setup:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       MODE: ${{ inputs.mode }}
@@ -173,27 +171,6 @@ jobs:
       CONFIRMATION: ${{ inputs.confirmation }}
       REASON: ${{ inputs.reason }}
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Resolve service endpoint
-        id: service
-        shell: bash
-        run: |
-          set -euo pipefail
-          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
-          origin="${LAUNCHPLANE_URL%/}"
-          without_scheme="${origin#*://}"
-          audience="${without_scheme%%/*}"
-          audience="${audience%%:*}"
-          if [ -z "$audience" ] || [ "$audience" = "$origin" ]; then
-            echo "LAUNCHPLANE_URL must be an absolute URL." >&2
-            exit 1
-          fi
-          {
-            echo "origin=$origin"
-            echo "audience=$audience"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Validate apply guard
         if: env.MODE == 'apply'
         shell: bash
@@ -241,24 +218,11 @@ jobs:
             exit 1
           fi
 
-      - name: Request target setup
-        env:
-          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
-          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
+      - name: Prepare target setup request
+        id: request
         shell: bash
         run: |
           set -euo pipefail
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
-            echo "GitHub OIDC token response did not include a token value." >&2
-            exit 1
-          fi
-
           domains_json="$({
             jq -Rsc '
               split(",")
@@ -320,8 +284,13 @@ jobs:
             )"
           fi
           if [ -n "$(printf '%s' "$DEPLOY_TIMEOUT_SECONDS" | xargs)" ]; then
+            deploy_timeout_seconds="$(printf '%s' "$DEPLOY_TIMEOUT_SECONDS" | xargs)"
+            if ! [[ "$deploy_timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
+              echo "deploy_timeout_seconds must be a positive integer." >&2
+              exit 1
+            fi
             payload="$(
-              jq --argjson timeout "$DEPLOY_TIMEOUT_SECONDS" \
+              jq --argjson timeout "$deploy_timeout_seconds" \
                 '.deploy_timeout_seconds = $timeout' <<< "$payload"
             )"
           fi
@@ -341,20 +310,30 @@ jobs:
           idempotency_key="dokploy-target-setup:${OPERATION}:"
           idempotency_key+="${CONTEXT}:${INSTANCE}:"
           idempotency_key+="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
-          status_code="$({
-            curl -sS \
-              -o dokploy-target-setup.json \
-              -w '%{http_code}' \
-              -X POST \
-              -H "Authorization: Bearer ${oidc_token}" \
-              -H 'Content-Type: application/json' \
-              -H "Idempotency-Key: ${idempotency_key}" \
-              --data "$payload" \
-              "${SERVICE_ORIGIN%/}/v1/dokploy-targets/setup"
-          })"
+          printf '%s\n' "$payload" > dokploy-target-setup-payload.json
+          printf 'idempotency_key=%s\n' "$idempotency_key" >> "$GITHUB_OUTPUT"
+
+      - name: Request Launchplane target setup
+        id: target_setup_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          route-path: /v1/dokploy-targets/setup
+          payload-file: dokploy-target-setup-payload.json
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: dokploy-target-setup.json
+
+      - name: Check target setup response
+        shell: bash
+        env:
+          SETUP_STATUS_CODE: ${{ steps.target_setup_request.outputs.status-code }}
+        run: |
+          set -euo pipefail
           jq . dokploy-target-setup.json
-          if [ "$status_code" != "202" ]; then
-            echo "Dokploy target setup failed with HTTP ${status_code}." >&2
+          if [ "$SETUP_STATUS_CODE" != "202" ]; then
+            echo "Dokploy target setup failed with HTTP ${SETUP_STATUS_CODE}." >&2
             exit 1
           fi
 
@@ -364,7 +343,7 @@ jobs:
         with:
           name: dokploy-target-setup-result
           path: dokploy-target-setup.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Summarize setup
         if: always()

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -177,6 +177,7 @@ WORKFLOW_OPERATOR_INPUT_VALUE_KEYS = frozenset(
         "EDGE_ENDPOINT_KEY",
         "ENVIRONMENT_ID",
         "ENVIRONMENT_NAME",
+        "EXPECTED_CURRENT_PROVIDER_TARGET_JSON",
         "HEALTHCHECK_PATH",
         "INSTANCE",
         "MODE",
@@ -743,6 +744,13 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
                 "${{ env.PRODUCT }}:${{ env.CONTEXT_NAME }}",
             )
         ),
+    },
+    ".github/workflows/dokploy-target-setup.yml": {
+        "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
+        "fail-result-paths": frozenset(('""',)),
+        "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "payload-file": frozenset(("dokploy-target-setup-payload.json",)),
+        "response-output-file": frozenset(("dokploy-target-setup.json",)),
     },
     ".github/workflows/odoo-config-parameter-override.yml": {
         "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1279,6 +1279,10 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("target_id", "${{ inputs.target_id }}"),
             ("target_id", "${{ github.event.inputs.target_id }}"),
             ("environment_name", "${{ inputs.environment_name }}"),
+            (
+                "EXPECTED_CURRENT_PROVIDER_TARGET_JSON",
+                "${{ inputs.expected_current_provider_target_json }}",
+            ),
             ("compose_path", "${{ inputs.compose_path }}"),
             ("edge_endpoint_key", "${{ inputs.edge_endpoint_key }}"),
             ("healthcheck_path", "${{ inputs.healthcheck_path }}"),
@@ -1319,8 +1323,13 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 )
 
         mechanics = (
+            ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
+            ("fail-result-paths", '""'),
             ("id-token", "write"),
             ("group", "dokploy-target-setup-${{ inputs.context }}-${{ inputs.instance }}"),
+            ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("payload-file", "dokploy-target-setup-payload.json"),
+            ("response-output-file", "dokploy-target-setup.json"),
             ("path", "dokploy-target-setup.json"),
         )
         for key, value in mechanics:
@@ -1332,6 +1341,21 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                         value=value,
                     ),
                     "thin_connector_input",
+                )
+
+        for key, value in (
+            ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("payload-file", "dokploy-target-setup-payload.json"),
+            ("response-output-file", "dokploy-target-setup.json"),
+        ):
+            with self.subTest(path_scoped_key=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/generic-workflow.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "",
                 )
 
     def test_workflow_operator_input_allow_reasons_stay_narrow(self) -> None:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -943,16 +943,45 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             encoding="utf-8"
         )
 
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
+        self.assertIn("route-path: /v1/dokploy-targets/setup", workflow_text)
+        self.assertIn("payload-file: dokploy-target-setup-payload.json", workflow_text)
+        self.assertIn(
+            "idempotency-key: ${{ steps.request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn("response-output-file: dokploy-target-setup.json", workflow_text)
+        self.assertIn(
+            "SETUP_STATUS_CODE: ${{ steps.target_setup_request.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn('if [ "$SETUP_STATUS_CODE" != "202" ]; then', workflow_text)
         self.assertIn("- reconcile-compose-domain", workflow_text)
         self.assertIn("DOMAIN: ${{ inputs.domain }}", workflow_text)
         self.assertIn("RUNTIME_PORT: ${{ inputs.runtime_port }}", workflow_text)
         self.assertIn("Validate reconcile compose domain inputs", workflow_text)
         self.assertIn("domain is required for compose domain reconcile/prune", workflow_text)
         self.assertIn("runtime_port is required for reconcile-compose-domain", workflow_text)
+        self.assertIn("deploy_timeout_seconds must be a positive integer.", workflow_text)
         self.assertIn("expected_current_provider_target_json:", workflow_text)
         self.assertIn("EXPECTED_CURRENT_PROVIDER_TARGET_JSON", workflow_text)
         self.assertIn("expected_current_provider_target", workflow_text)
         self.assertIn("APPLY DOKPLOY TARGET SETUP", workflow_text)
+        self.assertIn("dokploy-target-setup-payload.json", workflow_text)
+        self.assertIn("dokploy-target-setup:${OPERATION}:", workflow_text)
+        self.assertIn("if-no-files-found: warn", workflow_text)
+        self.assertNotIn("actions/checkout", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
 
     def test_reusable_odoo_workflows_accept_configured_service_identity(self) -> None:
         workflow_paths = (


### PR DESCRIPTION
## Summary
- Convert Dokploy Target Setup from local checkout/OIDC/curl plumbing to the shared `launchplane-request` action.
- Preserve the setup payload, idempotency key, explicit `202` response check, and operator-supplied expected-provider-target guard.
- Add explicit service audience wiring, positive-integer deploy timeout validation, pre-response artifact tolerance, and config-authority/test coverage.

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/dokploy-target-setup.yml`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_dokploy_target_setup_workflow_supports_compose_domain_reconcile tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_operator_inputs_and_mechanics_are_classified`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `git diff --check`

## Review Notes
- GPT reviewer finding: explicit service audience required so the shared action does not derive a different OIDC audience than the old workflow path. Fixed.
- Claude reviewer findings: missing expected-provider-target audit classification, missing deploy timeout validation, and artifact upload masking pre-response failures. Fixed.
- Antigravity reviewer findings: artifact behavior and explicit `fail-result-paths` handling. Fixed; stale manifest-test note was verified absent from the live diff.
- Final post-patch reviewer finding: over-quoted empty `fail-result-paths` input. Fixed to match the existing `fail-result-paths: ""` contract.
