### PR TITLE
Use launchplane request for product onboarding

### DIFF
--- a/.github/workflows/product-onboarding.yml
+++ b/.github/workflows/product-onboarding.yml
@@ -27,36 +27,13 @@ concurrency:
 
 jobs:
   apply:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       MANIFEST_BASE64: ${{ inputs.manifest_base64 }}
       CONFIRMATION: ${{ inputs.confirmation }}
       REASON: ${{ inputs.reason }}
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Resolve service endpoint
-        id: service
-        shell: bash
-        run: |
-          set -euo pipefail
-          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
-          origin="${LAUNCHPLANE_URL%/}"
-          without_scheme="${origin#*://}"
-          audience="${without_scheme%%/*}"
-          audience="${audience%%:*}"
-          if [ -z "$audience" ] || [ "$audience" = "$origin" ]; then
-            echo "LAUNCHPLANE_URL must be an absolute URL." >&2
-            exit 1
-          fi
-          {
-            echo "origin=$origin"
-            echo "audience=$audience"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Validate apply guard
         shell: bash
         run: |
@@ -106,42 +83,30 @@ jobs:
           {
             echo "request_file=$request_file"
             echo "product=$product"
+            echo "idempotency_key=product-onboarding:${product}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Request product onboarding apply
-        env:
-          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
-          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
-          REQUEST_FILE: ${{ steps.onboarding.outputs.request_file }}
-          PRODUCT: ${{ steps.onboarding.outputs.product }}
+        id: onboarding_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          route-path: /v1/product-onboarding/apply
+          payload-file: ${{ steps.onboarding.outputs.request_file }}
+          idempotency-key: ${{ steps.onboarding.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: product-onboarding.json
+
+      - name: Check product onboarding response
         shell: bash
+        env:
+          STATUS_CODE: ${{ steps.onboarding_request.outputs.status-code }}
         run: |
           set -euo pipefail
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
-            echo "GitHub OIDC token response did not include a token value." >&2
-            exit 1
-          fi
-
-          status_code="$({
-            curl -sS \
-              -o product-onboarding.json \
-              -w '%{http_code}' \
-              -X POST \
-              -H "Authorization: Bearer ${oidc_token}" \
-              -H 'Content-Type: application/json' \
-              -H "Idempotency-Key: product-onboarding:${PRODUCT}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
-              --data @"$REQUEST_FILE" \
-              "${SERVICE_ORIGIN%/}/v1/product-onboarding/apply"
-          })"
-          if [ "$status_code" != "202" ]; then
+          if [ "$STATUS_CODE" != "202" ]; then
             cat product-onboarding.json >&2
-            echo "Product onboarding failed with HTTP ${status_code}." >&2
+            echo "Product onboarding failed with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
           jq . product-onboarding.json
@@ -152,7 +117,7 @@ jobs:
         with:
           name: product-onboarding-result
           path: product-onboarding.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Summarize onboarding
         if: always()

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -761,6 +761,13 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "payload-file": frozenset(("dokploy-target-setup-payload.json",)),
         "response-output-file": frozenset(("dokploy-target-setup.json",)),
     },
+    ".github/workflows/product-onboarding.yml": {
+        "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
+        "fail-result-paths": frozenset(('""',)),
+        "idempotency-key": frozenset(("${{ steps.onboarding.outputs.idempotency_key }}",)),
+        "payload-file": frozenset(("${{ steps.onboarding.outputs.request_file }}",)),
+        "response-output-file": frozenset(("product-onboarding.json",)),
+    },
     ".github/workflows/provider-target-operations.yml": {
         "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
         "fail-result-paths": frozenset(("result.operation_status",)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2416,8 +2416,26 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 )
 
         for key, value in (
+            ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
+            ("fail-result-paths", '""'),
+            ("idempotency-key", "${{ steps.onboarding.outputs.idempotency_key }}"),
+            ("payload-file", "${{ steps.onboarding.outputs.request_file }}"),
+            ("response-output-file", "product-onboarding.json"),
+        ):
+            with self.subTest(product_onboarding_mechanic=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/product-onboarding.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
             ("fail-result-paths", "result.operation_status"),
             ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("idempotency-key", "${{ steps.onboarding.outputs.idempotency_key }}"),
         ):
             with self.subTest(path_scoped_provider_target_mechanic=key):
                 self.assertEqual(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1700,11 +1700,38 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_product_onboarding_workflow_calls_service_route_with_apply_guard(self) -> None:
         workflow_text = Path(".github/workflows/product-onboarding.yml").read_text(encoding="utf-8")
 
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
         self.assertIn("/v1/product-onboarding/apply", workflow_text)
+        self.assertIn("payload-file: ${{ steps.onboarding.outputs.request_file }}", workflow_text)
+        self.assertIn(
+            "idempotency-key: ${{ steps.onboarding.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn("response-output-file: product-onboarding.json", workflow_text)
+        self.assertIn(
+            "STATUS_CODE: ${{ steps.onboarding_request.outputs.status-code }}", workflow_text
+        )
+        self.assertIn('if [ "$STATUS_CODE" != "202" ]; then', workflow_text)
         self.assertIn("APPLY PRODUCT ONBOARDING", workflow_text)
         self.assertIn("manifest_base64", workflow_text)
-        self.assertIn("product-onboarding:${PRODUCT}:${GITHUB_RUN_ID}", workflow_text)
+        self.assertIn(
+            "product-onboarding:${product}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}",
+            workflow_text,
+        )
         self.assertIn("product-onboarding-result", workflow_text)
+        self.assertIn("if-no-files-found: warn", workflow_text)
+        self.assertNotIn("actions/checkout", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
 
     def test_product_expected_config_workflow_calls_service_route_with_apply_guard(
         self,


### PR DESCRIPTION
## Summary
- move Product Onboarding from inline checkout/OIDC/curl to the shared launchplane-request action
- keep the explicit HTTP 202 contract and onboarding evidence artifact behavior
- classify the new workflow mechanics in the config-authority audit and expand focused tests to guard the cleanup

## Validation
- python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/product-onboarding.yml
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_product_onboarding_workflow_calls_service_route_with_apply_guard tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- git diff --check

## Review
- read-only review agents: no findings