### PR TITLE
Use launchplane request for work graph snapshot

### DIFF
--- a/.github/workflows/work-graph-snapshot-validate.yml
+++ b/.github/workflows/work-graph-snapshot-validate.yml
@@ -14,66 +14,40 @@ concurrency:
 
 jobs:
   validate:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
-    env:
-      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+    runs-on: ubuntu-latest
     steps:
       - name: Request work graph snapshot
+        id: snapshot_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          method: GET
+          route-path: /v1/work-graph/snapshot
+          fail-result-paths: ""
+          response-output-file: launchplane-work-graph-snapshot.json
+
+      - name: Check work graph snapshot response
         shell: bash
+        env:
+          STATUS_CODE: ${{ steps.snapshot_request.outputs.status-code }}
         run: |
           set -euo pipefail
-          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
-
-          service_origin="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
-          print(f"{parsed.scheme}://{parsed.netloc}")
-          PY
-          })"
-          service_audience="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
-          print(parsed.hostname)
-          PY
-          })"
-
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}" \
-            | jq -r '.value'
-          })"
           response_file="launchplane-work-graph-snapshot.json"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -H "Authorization: Bearer ${oidc_token}" \
-            "${service_origin}/v1/work-graph/snapshot")"
-          if [ "$status_code" != "200" ]; then
+          if [ "$STATUS_CODE" != "200" ]; then
             cat "$response_file" >&2
-            echo "Launchplane work graph snapshot failed with HTTP ${status_code}." >&2
+            echo "Launchplane work graph snapshot failed with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
           jq . "$response_file"
 
       - name: Upload snapshot artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: launchplane-work-graph-snapshot
           path: launchplane-work-graph-snapshot.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Summarize snapshot
         shell: bash

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -775,6 +775,12 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "payload-file": frozenset(("${{ steps.request.outputs.payload_file }}",)),
         "response-output-file": frozenset(("${{ steps.request.outputs.response_file }}",)),
     },
+    ".github/workflows/work-graph-snapshot-validate.yml": {
+        "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
+        "fail-result-paths": frozenset(('""',)),
+        "method": frozenset(("GET",)),
+        "response-output-file": frozenset(("launchplane-work-graph-snapshot.json",)),
+    },
     ".github/workflows/odoo-config-parameter-override.yml": {
         "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
         "payload-file": frozenset((".launchplane/odoo-config-parameter-override-payload.json",)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2433,9 +2433,26 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 )
 
         for key, value in (
+            ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
+            ("fail-result-paths", '""'),
+            ("method", "GET"),
+            ("response-output-file", "launchplane-work-graph-snapshot.json"),
+        ):
+            with self.subTest(work_graph_snapshot_mechanic=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/work-graph-snapshot-validate.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
             ("fail-result-paths", "result.operation_status"),
             ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
             ("idempotency-key", "${{ steps.onboarding.outputs.idempotency_key }}"),
+            ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):
             with self.subTest(path_scoped_provider_target_mechanic=key):
                 self.assertEqual(

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1733,6 +1733,37 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
         self.assertNotIn("curl ", workflow_text)
 
+    def test_work_graph_snapshot_validate_uses_shared_launchplane_request(self) -> None:
+        workflow_text = Path(".github/workflows/work-graph-snapshot-validate.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
+        self.assertIn("method: GET", workflow_text)
+        self.assertIn("route-path: /v1/work-graph/snapshot", workflow_text)
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn(
+            "response-output-file: launchplane-work-graph-snapshot.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "STATUS_CODE: ${{ steps.snapshot_request.outputs.status-code }}", workflow_text
+        )
+        self.assertIn('if [ "$STATUS_CODE" != "200" ]; then', workflow_text)
+        self.assertIn("name: launchplane-work-graph-snapshot", workflow_text)
+        self.assertIn("if: always()", workflow_text)
+        self.assertIn("if-no-files-found: warn", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
+
     def test_product_expected_config_workflow_calls_service_route_with_apply_guard(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- move Work Graph Snapshot Validate from inline URL parsing/OIDC/curl to the shared launchplane-request action
- preserve explicit HTTP 200 validation and snapshot artifact evidence
- classify the new workflow mechanics in config-authority audit and add focused workflow tests

## Validation
- python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/work-graph-snapshot-validate.yml
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_work_graph_snapshot_validate_uses_shared_launchplane_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- git diff --check

## Review
- read-only review agents: one no findings; one low-severity cleanup feedback, patched and revalidated