### PR TITLE
Use launchplane request for Dokploy target inspect

### DIFF
--- a/.github/workflows/dokploy-target-inspect.yml
+++ b/.github/workflows/dokploy-target-inspect.yml
@@ -35,37 +35,13 @@ concurrency:
 
 jobs:
   inspect:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
-      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       CONTEXT: ${{ inputs.context }}
       INSTANCE: ${{ inputs.instance }}
       TARGET_TYPE: ${{ inputs.target_type }}
       TARGET_ID: ${{ inputs.target_id }}
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Resolve service endpoint
-        id: service
-        shell: bash
-        run: |
-          set -euo pipefail
-          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
-          origin="${LAUNCHPLANE_URL%/}"
-          without_scheme="${origin#*://}"
-          audience="${without_scheme%%/*}"
-          audience="${audience%%:*}"
-          if [ -z "$audience" ] || [ "$audience" = "$origin" ]; then
-            echo "LAUNCHPLANE_URL must be an absolute URL." >&2
-            exit 1
-          fi
-          {
-            echo "origin=$origin"
-            echo "audience=$audience"
-          } >> "$GITHUB_OUTPUT"
-
       - name: Validate inspect inputs
         shell: bash
         run: |
@@ -99,24 +75,11 @@ jobs:
             exit 1
           fi
 
-      - name: Inspect target
-        env:
-          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
-          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
+      - name: Build inspect request
+        id: request
         shell: bash
         run: |
           set -euo pipefail
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
-            echo "GitHub OIDC token response did not include a token value." >&2
-            exit 1
-          fi
-
           query="$(jq -rn \
             --arg context "$CONTEXT" \
             --arg instance "$INSTANCE" \
@@ -130,16 +93,29 @@ jobs:
               encpair("target_type"; $target_type),
               encpair("target_id"; $target_id)
             ] | join("&")')"
+          echo "route_path=/v1/dokploy-targets/inspect?${query}" >> "$GITHUB_OUTPUT"
+
+      - name: Inspect target
+        id: inspect_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          method: GET
+          route-path: ${{ steps.request.outputs.route_path }}
+          fail-result-paths: ""
+          response-output-file: dokploy-target-inspect-response.json
+
+      - name: Check inspect response
+        shell: bash
+        env:
+          STATUS_CODE: ${{ steps.inspect_request.outputs.status-code }}
+        run: |
+          set -euo pipefail
           response_file="dokploy-target-inspect-response.json"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Accept: application/json' \
-            "${SERVICE_ORIGIN%/}/v1/dokploy-targets/inspect?${query}")"
           jq . "$response_file"
-          if [ "$status_code" != "200" ]; then
-            echo "Dokploy target inspect failed with HTTP ${status_code}." >&2
+          if [ "$STATUS_CODE" != "200" ]; then
+            echo "Dokploy target inspect failed with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 
@@ -149,7 +125,7 @@ jobs:
         with:
           name: dokploy-target-inspect
           path: dokploy-target-inspect-response.json
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Summarize inspect
         if: always()

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -761,6 +761,13 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "payload-file": frozenset(("dokploy-target-setup-payload.json",)),
         "response-output-file": frozenset(("dokploy-target-setup.json",)),
     },
+    ".github/workflows/dokploy-target-inspect.yml": {
+        "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
+        "fail-result-paths": frozenset(('""',)),
+        "method": frozenset(("GET",)),
+        "response-output-file": frozenset(("dokploy-target-inspect-response.json",)),
+        "route-path": frozenset(("${{ steps.request.outputs.route_path }}",)),
+    },
     ".github/workflows/product-onboarding.yml": {
         "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
         "fail-result-paths": frozenset(('""',)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2436,6 +2436,23 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
             ("fail-result-paths", '""'),
             ("method", "GET"),
+            ("response-output-file", "dokploy-target-inspect-response.json"),
+            ("route-path", "${{ steps.request.outputs.route_path }}"),
+        ):
+            with self.subTest(dokploy_target_inspect_mechanic=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/dokploy-target-inspect.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
+            ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
+            ("fail-result-paths", '""'),
+            ("method", "GET"),
             ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):
             with self.subTest(work_graph_snapshot_mechanic=key):
@@ -2452,6 +2469,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("fail-result-paths", "result.operation_status"),
             ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
             ("idempotency-key", "${{ steps.onboarding.outputs.idempotency_key }}"),
+            ("response-output-file", "dokploy-target-inspect-response.json"),
             ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):
             with self.subTest(path_scoped_provider_target_mechanic=key):

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1764,6 +1764,45 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
         self.assertNotIn("curl ", workflow_text)
 
+    def test_dokploy_target_inspect_uses_shared_launchplane_request(self) -> None:
+        workflow_text = Path(".github/workflows/dokploy-target-inspect.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn("Use context/instance or target_type/target_id, not both.", workflow_text)
+        self.assertIn("context and instance are both required for tracked inspect.", workflow_text)
+        self.assertIn(
+            "target_type and target_id are both required for explicit inspect.", workflow_text
+        )
+        self.assertIn("context/instance or target_type/target_id is required.", workflow_text)
+        self.assertIn('echo "route_path=/v1/dokploy-targets/inspect?${query}"', workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
+        self.assertIn("method: GET", workflow_text)
+        self.assertIn("route-path: ${{ steps.request.outputs.route_path }}", workflow_text)
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn(
+            "response-output-file: dokploy-target-inspect-response.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "STATUS_CODE: ${{ steps.inspect_request.outputs.status-code }}", workflow_text
+        )
+        self.assertIn('if [ "$STATUS_CODE" != "200" ]; then', workflow_text)
+        self.assertIn("name: dokploy-target-inspect", workflow_text)
+        self.assertIn("if: always()", workflow_text)
+        self.assertIn("if-no-files-found: warn", workflow_text)
+        self.assertNotIn("actions/checkout", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
+
     def test_product_expected_config_workflow_calls_service_route_with_apply_guard(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary
- move Dokploy Target Inspect from inline checkout/URL parsing/OIDC/curl to the shared launchplane-request action
- preserve input validation, dynamic inspect query construction, explicit HTTP 200 validation, and evidence artifacts
- classify the new workflow mechanics in config-authority audit and add focused workflow tests

## Validation
- python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/dokploy-target-inspect.yml
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_dokploy_target_inspect_uses_shared_launchplane_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- git diff --check

## Review
- read-only review agents: no findings