### PR TITLE
Use shared request for ingress audit reads

### DIFF
--- a/.github/actions/launchplane-request/action.yml
+++ b/.github/actions/launchplane-request/action.yml
@@ -112,6 +112,10 @@ inputs:
       JSON path to write to response-output-file. Defaults to the full response.
     required: false
     default: ""
+  log-response-body:
+    description: Write the Launchplane response body to stdout.
+    required: false
+    default: "true"
 
 outputs:
   launchplane-url:

--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -31,6 +31,17 @@ function parseNonNegativeInteger(value, label) {
   return parsed;
 }
 
+function parseBooleanInput(value, label) {
+  const normalizedValue = String(value ?? "").trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(normalizedValue)) {
+    return true;
+  }
+  if (["false", "0", "no", "off"].includes(normalizedValue)) {
+    return false;
+  }
+  throw new Error(`${label} must be true or false.`);
+}
+
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -385,6 +396,10 @@ async function main() {
   const requestUrl = new URL(routePath, launchplaneUrl).toString();
   const audience = getInput("audience") || launchplaneUrl.host;
   const idempotencyKey = getInput("idempotency-key");
+  const logResponseBody = parseBooleanInput(
+    getInput("log-response-body", { defaultValue: "true" }),
+    "log-response-body",
+  );
   const payload = applyPayloadJsonFiles(applyPayloadFields(readPayload()));
   const options = getActionOptions();
   async function requestInit() {
@@ -422,10 +437,13 @@ async function main() {
   writeMappedOutputs(responseBody);
   writeResponseOutputFile(responseBody);
 
-  process.stdout.write(`${JSON.stringify(responseBody, null, 2)}\n`);
+  if (logResponseBody) {
+    process.stdout.write(`${JSON.stringify(responseBody, null, 2)}\n`);
+  }
   if (!response.ok) {
+    const responseDetail = logResponseBody ? `: ${responseText || "empty response"}` : "";
     throw new Error(
-      `Launchplane request failed with ${response.status}: ${responseText || "empty response"}`,
+      `Launchplane request failed with ${response.status}${responseDetail}`,
     );
   }
   assertResultStatuses(responseBody);

--- a/.github/workflows/ingress-route-audit-read.yml
+++ b/.github/workflows/ingress-route-audit-read.yml
@@ -50,11 +50,8 @@ concurrency:
 
 jobs:
   read:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
-      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       PRODUCT: ${{ inputs.product }}
       CONTEXT: ${{ inputs.context }}
       RECORD_ID: ${{ inputs.record_id }}
@@ -63,7 +60,7 @@ jobs:
       TRACE_ID: ${{ inputs.trace_id }}
       LIMIT: ${{ inputs.limit }}
     steps:
-      - name: Request redacted audit records
+      - name: Build audit read request
         id: route
         shell: bash
         run: |
@@ -73,12 +70,8 @@ jobs:
           read_url="$({
             python3 - <<'PY'
           import os
-          from urllib.parse import urlencode, quote, urlsplit
+          from urllib.parse import urlencode, quote
 
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL")
-          origin = f"{parsed.scheme}://{parsed.netloc}"
           product = os.environ["PRODUCT"].strip()
           context = os.environ["CONTEXT"].strip()
           record_id = os.environ["RECORD_ID"].strip()
@@ -112,41 +105,40 @@ jobs:
                   if value:
                       query[query_name] = value
               route_path = f"/v1/ingress/route-audits/records?{urlencode(query)}"
-          print(f"{origin}{route_path}")
+          print(route_path)
           PY
           })"
+          echo "route_path=${read_url}" >> "$GITHUB_OUTPUT"
 
-          service_audience="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
+      - name: Request redacted audit records
+        id: audit_read_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          method: GET
+          route-path: ${{ steps.route.outputs.route_path }}
+          fail-result-paths: ""
+          response-output-file: ingress-route-audit-read-raw.json
+          log-response-body: "false"
 
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must include a hostname")
-          print(parsed.hostname)
-          PY
-          })"
-
-          oidc_response="$(curl -fsS \
-            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}")"
-          oidc_token="$(jq -r '.value // empty' <<< "$oidc_response")"
-          if [ -z "$oidc_token" ]; then
-            echo 'GitHub OIDC token response did not include a token value.' >&2
+      - name: Redact audit read response
+        if: always()
+        shell: bash
+        env:
+          STATUS_CODE: ${{ steps.audit_read_request.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          raw_response="ingress-route-audit-read-raw.json"
+          if [ ! -f "$raw_response" ]; then
+            echo 'Launchplane ingress route audit read did not produce a response file.' >&2
             exit 1
           fi
-
-          raw_response="$RUNNER_TEMP/ingress-route-audit-read-raw.json"
-          status_code="$(curl -sS \
-            -o "$raw_response" \
-            -w '%{http_code}' \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Accept: application/json' \
-            "$read_url")"
-          if [ "$status_code" != '200' ]; then
-            jq '{status, trace_id, error}' "$raw_response" >&2 || cat "$raw_response" >&2
-            echo "Launchplane ingress route audit read failed with HTTP ${status_code}." >&2
+          if [ "$STATUS_CODE" != '200' ]; then
+            if ! jq '{status, trace_id, error}' "$raw_response" >&2; then
+              echo 'Launchplane ingress route audit read returned a non-JSON error response.' >&2
+            fi
+            echo "Launchplane ingress route audit read failed with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 
@@ -182,8 +174,6 @@ jobs:
             end
           ' "$raw_response" >ingress-route-audit-read.json
 
-          jq . ingress-route-audit-read.json
-
       - name: Summarize audit read
         shell: bash
         run: |
@@ -209,8 +199,9 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload audit read response
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: ingress-route-audit-read
           path: ingress-route-audit-read.json
-          if-no-files-found: error
+          if-no-files-found: warn

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -768,6 +768,14 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "response-output-file": frozenset(("dokploy-target-inspect-response.json",)),
         "route-path": frozenset(("${{ steps.request.outputs.route_path }}",)),
     },
+    ".github/workflows/ingress-route-audit-read.yml": {
+        "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
+        "fail-result-paths": frozenset(('""',)),
+        "log-response-body": frozenset(('"false"',)),
+        "method": frozenset(("GET",)),
+        "response-output-file": frozenset(("ingress-route-audit-read-raw.json",)),
+        "route-path": frozenset(("${{ steps.route.outputs.route_path }}",)),
+    },
     ".github/workflows/product-onboarding.yml": {
         "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
         "fail-result-paths": frozenset(('""',)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2452,6 +2452,24 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         for key, value in (
             ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
             ("fail-result-paths", '""'),
+            ("log-response-body", '"false"'),
+            ("method", "GET"),
+            ("response-output-file", "ingress-route-audit-read-raw.json"),
+            ("route-path", "${{ steps.route.outputs.route_path }}"),
+        ):
+            with self.subTest(ingress_route_audit_read_mechanic=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/ingress-route-audit-read.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
+            ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
+            ("fail-result-paths", '""'),
             ("method", "GET"),
             ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):
@@ -2469,7 +2487,9 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("fail-result-paths", "result.operation_status"),
             ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
             ("idempotency-key", "${{ steps.onboarding.outputs.idempotency_key }}"),
+            ("log-response-body", '"false"'),
             ("response-output-file", "dokploy-target-inspect-response.json"),
+            ("response-output-file", "ingress-route-audit-read-raw.json"),
             ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):
             with self.subTest(path_scoped_provider_target_mechanic=key):

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -13,10 +13,10 @@ ACTION_METADATA = Path(".github/actions/launchplane-request/action.yml")
 
 class LaunchplaneRequestActionTests(unittest.TestCase):
     def test_action_metadata_uses_supported_node_runtime(self) -> None:
-        self.assertIn(
-            "using: node24",
-            ACTION_METADATA.read_text(encoding="utf-8"),
-        )
+        metadata = ACTION_METADATA.read_text(encoding="utf-8")
+        self.assertIn("using: node24", metadata)
+        self.assertIn("log-response-body:", metadata)
+        self.assertIn('default: "true"', metadata)
 
     def run_action(
         self,
@@ -142,8 +142,7 @@ process.on('beforeExit', () => {{
         launchplane_calls = [
             call
             for call in calls
-            if call["url"]
-            == "https://launchplane.example/v1/drivers/odoo/prod-promotion-run"
+            if call["url"] == "https://launchplane.example/v1/drivers/odoo/prod-promotion-run"
         ]
         self.assertEqual(len(launchplane_calls), 2)
         self.assertEqual(
@@ -172,6 +171,66 @@ process.on('beforeExit', () => {{
                     "error_message": "",
                     "application_id": "app-123",
                 },
+            )
+
+    def test_can_write_response_file_without_logging_response_body(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            response_output_path = Path(temporary_directory) / "result.json"
+            result = self.run_action(
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/ingress/route-audits/records?product=demo&context=dev",
+                    "method": "GET",
+                    "response-output-file": str(response_output_path),
+                    "log-response-body": "false",
+                },
+                environment={"TEST_ERROR_MESSAGE": "sensitive-audit-payload"},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertNotIn("sensitive-audit-payload", result.stdout)
+            self.assertIn(
+                "sensitive-audit-payload",
+                response_output_path.read_text(encoding="utf-8"),
+            )
+
+    def test_logs_response_body_by_default(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/drivers/generic-web/preview-refresh",
+                "payload": '{"schema_version":1,"product":"sellyouroutboard"}',
+            },
+            environment={"TEST_ERROR_MESSAGE": "default-log-marker"},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("default-log-marker", result.stdout)
+
+    def test_omits_non_ok_response_body_from_error_when_logging_disabled(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            response_output_path = Path(temporary_directory) / "result.json"
+            result = self.run_action(
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/ingress/route-audits/records?product=demo&context=dev",
+                    "method": "GET",
+                    "response-output-file": str(response_output_path),
+                    "log-response-body": "false",
+                },
+                environment={
+                    "TEST_ERROR_MESSAGE": "sensitive-audit-error",
+                    "TEST_STATUS": "500",
+                },
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("Launchplane request failed with 500", result.stderr)
+            self.assertNotIn("sensitive-audit-error", result.stdout)
+            self.assertNotIn("sensitive-audit-error", result.stderr)
+            self.assertIn(
+                "sensitive-audit-error",
+                response_output_path.read_text(encoding="utf-8"),
             )
 
     def test_overlays_payload_fields_before_request(self) -> None:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1307,20 +1307,42 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             encoding="utf-8"
         )
 
-        self.assertIn("curl -sS", workflow_text)
-        self.assertIn("-w '%{http_code}'", workflow_text)
-        self.assertIn('"$read_url"', workflow_text)
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
+        self.assertIn("method: GET", workflow_text)
+        self.assertIn("route-path: ${{ steps.route.outputs.route_path }}", workflow_text)
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn("response-output-file: ingress-route-audit-read-raw.json", workflow_text)
+        self.assertIn('log-response-body: "false"', workflow_text)
+        self.assertIn(
+            "STATUS_CODE: ${{ steps.audit_read_request.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn("Launchplane ingress route audit read did not produce", workflow_text)
+        self.assertIn("if [ \"$STATUS_CODE\" != '200' ]; then", workflow_text)
+        self.assertIn("non-JSON error response", workflow_text)
+        self.assertNotIn('cat "$raw_response"', workflow_text)
+        self.assertIn('echo "route_path=${read_url}"', workflow_text)
         self.assertIn("/v1/ingress/route-audits/records", workflow_text)
         self.assertIn("product", workflow_text)
         self.assertIn("context", workflow_text)
         self.assertIn("record_id", workflow_text)
         self.assertIn("limit must be between 1 and 100", workflow_text)
-        self.assertIn(
-            'raw_response="$RUNNER_TEMP/ingress-route-audit-read-raw.json"', workflow_text
-        )
+        self.assertIn('raw_response="ingress-route-audit-read-raw.json"', workflow_text)
         self.assertIn("redacted", workflow_text)
         self.assertIn("operation_count", workflow_text)
-        self.assertNotIn("launchplane-request", workflow_text)
+        self.assertIn("if: always()", workflow_text)
+        self.assertIn("path: ingress-route-audit-read.json", workflow_text)
+        self.assertIn("if-no-files-found: warn", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
         self.assertNotIn("ingress_route.apply", workflow_text)
         self.assertNotIn("provider_host_id:", workflow_text)
         self.assertNotIn("idempotency-key:", workflow_text)


### PR DESCRIPTION
## Summary
- move `ingress-route-audit-read` from bespoke OIDC/curl to the shared Launchplane request action on GitHub-hosted runners
- add `log-response-body` to the shared action, defaulting to current body logging while allowing redacted audit reads to keep raw responses out of logs
- tighten non-JSON audit error handling so malformed responses do not fall back to printing raw bodies
- extend config-authority classification and focused regression tests for the new thin connector mechanics

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py tests/test_launchplane_request_action.py`
- `uv run python -m unittest tests.test_launchplane_request_action tests.test_product_onboarding.ProductOnboardingTests.test_ingress_route_audit_read_workflow_is_plan_scoped_get tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/ingress-route-audit-read.yml`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py tests/test_launchplane_request_action.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py tests/test_launchplane_request_action.py`
- `git diff --check`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`

## Review
- Review agents used for privacy/logging and workflow behavior.
- Fixed review finding: removed raw-body `cat "$raw_response"` fallback on non-JSON HTTP errors.
- Added explicit compatibility coverage that `log-response-body` defaults to true.
