### PR TITLE
Use shared request for preview lifecycle

### DIFF
--- a/.github/workflows/preview-lifecycle.yml
+++ b/.github/workflows/preview-lifecycle.yml
@@ -22,9 +22,7 @@ concurrency:
 
 jobs:
   preview_lifecycle:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
       APPLY: ${{ github.event_name == 'workflow_dispatch' && inputs.apply || false }}
       LAUNCHPLANE_AUDIENCE: ${{ vars.LAUNCHPLANE_PREVIEW_LIFECYCLE_AUDIENCE }}
@@ -38,33 +36,10 @@ jobs:
           : "${LAUNCHPLANE_AUDIENCE:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_AUDIENCE variable}"
           : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PREVIEW_LIFECYCLE_URL variable}"
 
-      - name: Run Launchplane-owned preview lifecycle
+      - name: Build preview lifecycle request
+        id: request
         run: |
           set -euo pipefail
-
-          oidc_response="$(curl -fsS \
-            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${LAUNCHPLANE_AUDIENCE}")"
-          oidc_token="$(jq -r '.value // empty' <<< "$oidc_response")"
-          if [ -z "$oidc_token" ]; then
-            echo 'GitHub OIDC token response did not include a token value.' >&2
-            exit 1
-          fi
-
-          post_launchplane_json() {
-            local route="$1"
-            local idempotency_key="$2"
-            local payload="$3"
-            curl -fsS \
-              -X POST \
-              -H "Authorization: Bearer ${oidc_token}" \
-              -H 'Accept: application/json' \
-              -H 'Content-Type: application/json' \
-              -H "Idempotency-Key: ${idempotency_key}" \
-              --data "$payload" \
-              "${LAUNCHPLANE_URL}${route}"
-          }
-
           run_identity="${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
           apply_json='false'
           if [ "$APPLY" = 'true' ]; then
@@ -75,18 +50,37 @@ jobs:
             --arg source "$SOURCE" \
             --argjson apply "$apply_json" \
             '{schema_version: 1, source: $source, apply: $apply, destroy_reason: "launchplane_preview_lifecycle_cleanup", timeout_seconds: 300}')"
-          sweep_response="$(post_launchplane_json \
-            '/v1/previews/lifecycle-sweep' \
-            "preview-lifecycle-sweep:${run_identity}:${apply_json}" \
-            "$sweep_payload")"
-          echo "$sweep_response" | jq .
+          request_file="launchplane-preview-lifecycle-sweep.json"
+          printf '%s\n' "$sweep_payload" > "$request_file"
+          {
+            echo "apply_json=${apply_json}"
+            echo "idempotency_key=preview-lifecycle-sweep:${run_identity}:${apply_json}"
+            echo "request_file=${request_file}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Launchplane-owned preview lifecycle
+        id: preview_lifecycle_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ env.LAUNCHPLANE_AUDIENCE }}
+          route-path: /v1/previews/lifecycle-sweep
+          payload-file: ${{ steps.request.outputs.request_file }}
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          response-output-file: launchplane-preview-lifecycle-sweep-response.json
+
+      - name: Summarize preview lifecycle
+        run: |
+          set -euo pipefail
+          response_file="launchplane-preview-lifecycle-sweep-response.json"
+          jq . "$response_file"
 
           {
             echo '## Launchplane preview lifecycle'
             echo
-            echo "- Apply: ${apply_json}"
-            echo "- Sweep status: $(jq -r '.result.status // empty' <<< "$sweep_response")"
-            echo "- Profiles: $(jq -r '.result.profile_count // 0' <<< "$sweep_response")"
+            echo "- Apply: ${{ steps.request.outputs.apply_json }}"
+            echo "- Sweep status: $(jq -r '.result.status // empty' "$response_file")"
+            echo "- Profiles: $(jq -r '.result.profile_count // 0' "$response_file")"
             echo
-            jq -r '.result.profiles[]? | "- \(.product) / \(.context): \(.status) (orphaned: \((.orphaned_slugs // []) | length), destroyed: \((.destroyed_slugs // []) | length), failed: \((.failed_slugs // []) | length))"' <<< "$sweep_response"
+            jq -r '.result.profiles[]? | "- \(.product) / \(.context): \(.status) (orphaned: \((.orphaned_slugs // []) | length), destroyed: \((.destroyed_slugs // []) | length), failed: \((.failed_slugs // []) | length))"' "$response_file"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -776,6 +776,13 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "response-output-file": frozenset(("ingress-route-audit-read-raw.json",)),
         "route-path": frozenset(("${{ steps.route.outputs.route_path }}",)),
     },
+    ".github/workflows/preview-lifecycle.yml": {
+        "audience": frozenset(("${{ env.LAUNCHPLANE_AUDIENCE }}",)),
+        "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "payload-file": frozenset(("${{ steps.request.outputs.request_file }}",)),
+        "response-output-file": frozenset(("launchplane-preview-lifecycle-sweep-response.json",)),
+        "route-path": frozenset(("/v1/previews/lifecycle-sweep",)),
+    },
     ".github/workflows/product-onboarding.yml": {
         "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
         "fail-result-paths": frozenset(('""',)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2468,6 +2468,26 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 )
 
         for key, value in (
+            ("audience", "${{ env.LAUNCHPLANE_AUDIENCE }}"),
+            ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("payload-file", "${{ steps.request.outputs.request_file }}"),
+            (
+                "response-output-file",
+                "launchplane-preview-lifecycle-sweep-response.json",
+            ),
+            ("route-path", "/v1/previews/lifecycle-sweep"),
+        ):
+            with self.subTest(preview_lifecycle_mechanic=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/preview-lifecycle.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
             ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
             ("fail-result-paths", '""'),
             ("method", "GET"),
@@ -2490,6 +2510,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("log-response-body", '"false"'),
             ("response-output-file", "dokploy-target-inspect-response.json"),
             ("response-output-file", "ingress-route-audit-read-raw.json"),
+            ("response-output-file", "launchplane-preview-lifecycle-sweep-response.json"),
             ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):
             with self.subTest(path_scoped_provider_target_mechanic=key):

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1461,6 +1461,37 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertNotIn("Authorization: Bearer", workflow_text)
         self.assertNotIn("curl ", workflow_text)
 
+    def test_preview_lifecycle_uses_launchplane_request(self) -> None:
+        workflow_text = Path(".github/workflows/preview-lifecycle.yml").read_text(encoding="utf-8")
+
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("launchplane-url: ${{ env.LAUNCHPLANE_URL }}", workflow_text)
+        self.assertIn("audience: ${{ env.LAUNCHPLANE_AUDIENCE }}", workflow_text)
+        self.assertIn("route-path: /v1/previews/lifecycle-sweep", workflow_text)
+        self.assertIn("payload-file: ${{ steps.request.outputs.request_file }}", workflow_text)
+        self.assertIn(
+            "idempotency-key: ${{ steps.request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: launchplane-preview-lifecycle-sweep-response.json",
+            workflow_text,
+        )
+        self.assertIn("request_file=", workflow_text)
+        self.assertIn("launchplane-preview-lifecycle-sweep.json", workflow_text)
+        self.assertIn("launchplane-preview-lifecycle-sweep-response.json", workflow_text)
+        self.assertIn("steps.request.outputs.apply_json", workflow_text)
+        self.assertNotIn("post_launchplane_json", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
+
     def test_product_legacy_context_cleanup_uses_launchplane_request(self) -> None:
         workflow_text = Path(".github/workflows/product-legacy-context-cleanup.yml").read_text(
             encoding="utf-8"


### PR DESCRIPTION
## Summary
- move `preview-lifecycle` from hand-rolled OIDC/curl to the shared Launchplane request action
- keep the sweep payload and idempotency key shape unchanged while writing/reading the action response file for summaries
- run the workflow on GitHub-hosted runners and remove the self-hosted runner label dependency
- extend config-authority classification and focused workflow regression tests for the new shared-action mechanics

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_preview_lifecycle_uses_launchplane_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/preview-lifecycle.yml`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `git diff --check`

## Review
- Review agents used for workflow/action behavior. Stale findings from agents reading the main checkout were checked against this worktree; live diff has shared action use, explicit audience forwarding, response-file summary, and focused tests.
