### PR TITLE
Use shared request for cutover audit

### DIFF
--- a/.github/workflows/product-context-cutover-audit.yml
+++ b/.github/workflows/product-context-cutover-audit.yml
@@ -32,11 +32,8 @@ concurrency:
 
 jobs:
   audit:
-    runs-on:
-      - self-hosted
-      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    runs-on: ubuntu-latest
     env:
-      LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
       PRODUCT: ${{ inputs.product }}
       SOURCE_CONTEXT: ${{ inputs.source_context }}
       TARGET_CONTEXT: ${{ inputs.target_context }}
@@ -46,7 +43,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          : "${LAUNCHPLANE_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
           : "${PRODUCT:?Missing product input}"
           : "${SOURCE_CONTEXT:?Missing source_context input}"
           : "${TARGET_CONTEXT:?Missing target_context input}"
@@ -55,76 +51,16 @@ jobs:
             exit 1
           fi
 
-      - name: Request redacted cutover audit
-        id: audit
+      - name: Build cutover audit request
+        id: request
         shell: bash
         run: |
           set -euo pipefail
-
-          service_origin="$({
+          route_path="$({
             python3 - <<'PY'
           import os
-          from urllib.parse import urlsplit
+          from urllib.parse import quote, urlencode
 
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
-          print(f"{parsed.scheme}://{parsed.netloc}")
-          PY
-          })"
-          service_audience="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must include a hostname.")
-          print(parsed.hostname)
-          PY
-          })"
-
-          oidc_response="$(curl -fsS \
-            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}")"
-          oidc_token="$(jq -r '.value // empty' <<< "$oidc_response")"
-          if [ -z "$oidc_token" ]; then
-            echo 'GitHub OIDC token response did not include a token value.' >&2
-            exit 1
-          fi
-          python3 - "$oidc_token" <<'PY'
-          import base64
-          import json
-          import sys
-
-          token = sys.argv[1]
-          payload = token.split(".")[1]
-          payload += "=" * (-len(payload) % 4)
-          claims = json.loads(base64.urlsafe_b64decode(payload))
-          safe_claims = {
-              key: claims.get(key, "")
-              for key in (
-                  "repository",
-                  "repository_owner",
-                  "workflow_ref",
-                  "job_workflow_ref",
-                  "event_name",
-                  "ref",
-                  "ref_type",
-                  "environment",
-                  "aud",
-                  "sub",
-              )
-          }
-          print(json.dumps({"oidc_claims": safe_claims}, sort_keys=True))
-          PY
-
-          audit_url="$({
-            SERVICE_ORIGIN="$service_origin" python3 - <<'PY'
-          import os
-          from urllib.parse import urlencode
-
-          origin = os.environ["SERVICE_ORIGIN"].rstrip("/")
           product = os.environ["PRODUCT"].strip()
           query = {
               "source_context": os.environ["SOURCE_CONTEXT"].strip(),
@@ -134,23 +70,36 @@ jobs:
           if preview_context:
               query["preview_context"] = preview_context
           print(
-              f"{origin}/v1/product-profiles/{product}"
+              f"/v1/product-profiles/{quote(product, safe='')}"
               f"/context-cutover-audit?{urlencode(query)}"
           )
           PY
           })"
+          echo "route_path=${route_path}" >> "$GITHUB_OUTPUT"
 
+      - name: Request redacted cutover audit
+        id: audit_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          method: GET
+          route-path: ${{ steps.request.outputs.route_path }}
+          fail-result-paths: ""
+          response-output-file: launchplane-context-cutover-audit.json
+
+      - name: Check cutover audit response
+        id: audit
+        shell: bash
+        env:
+          STATUS_CODE: ${{ steps.audit_request.outputs.status-code }}
+        run: |
+          set -euo pipefail
           response_file="launchplane-context-cutover-audit.json"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Accept: application/json' \
-            "$audit_url")"
-          if [ "$status_code" != '200' ]; then
-            cat "$response_file" >&2
+          if [ "$STATUS_CODE" != '200' ]; then
+            jq '{status, trace_id, error}' "$response_file" >&2 || true
             echo 'Launchplane context cutover audit failed' \
-              "with HTTP ${status_code}." >&2
+              "with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -236,9 +236,6 @@ WORKFLOW_BLOCK_MECHANIC_FIELD_PATH_VALUES = {
             )
         )
     },
-    ".github/workflows/product-context-cutover-audit.yml": {
-        "key": frozenset(('claims.get(key, "")',))
-    },
     ".github/workflows/provider-target-operations.yml": {
         "path": frozenset(
             (
@@ -782,6 +779,13 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "payload-file": frozenset(("${{ steps.request.outputs.request_file }}",)),
         "response-output-file": frozenset(("launchplane-preview-lifecycle-sweep-response.json",)),
         "route-path": frozenset(("/v1/previews/lifecycle-sweep",)),
+    },
+    ".github/workflows/product-context-cutover-audit.yml": {
+        "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
+        "fail-result-paths": frozenset(('""',)),
+        "method": frozenset(("GET",)),
+        "response-output-file": frozenset(("launchplane-context-cutover-audit.json",)),
+        "route-path": frozenset(("${{ steps.request.outputs.route_path }}",)),
     },
     ".github/workflows/product-onboarding.yml": {
         "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2360,11 +2360,6 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 "/v1/drivers/odoo/preview-apply /v1/previews/pr-feedback",
             ),
             (
-                ".github/workflows/product-context-cutover-audit.yml",
-                "key",
-                'claims.get(key, "")',
-            ),
-            (
                 ".github/workflows/provider-target-operations.yml",
                 "path",
                 "provider-target-routes.json",
@@ -2491,6 +2486,23 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
             ("fail-result-paths", '""'),
             ("method", "GET"),
+            ("response-output-file", "launchplane-context-cutover-audit.json"),
+            ("route-path", "${{ steps.request.outputs.route_path }}"),
+        ):
+            with self.subTest(product_context_cutover_audit_mechanic=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/product-context-cutover-audit.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
+            ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
+            ("fail-result-paths", '""'),
+            ("method", "GET"),
             ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):
             with self.subTest(work_graph_snapshot_mechanic=key):
@@ -2510,6 +2522,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("log-response-body", '"false"'),
             ("response-output-file", "dokploy-target-inspect-response.json"),
             ("response-output-file", "ingress-route-audit-read-raw.json"),
+            ("response-output-file", "launchplane-context-cutover-audit.json"),
             ("response-output-file", "launchplane-preview-lifecycle-sweep-response.json"),
             ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1461,6 +1461,39 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertNotIn("Authorization: Bearer", workflow_text)
         self.assertNotIn("curl ", workflow_text)
 
+    def test_product_context_cutover_audit_uses_launchplane_request(self) -> None:
+        workflow_text = Path(".github/workflows/product-context-cutover-audit.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}", workflow_text)
+        self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
+        self.assertIn("method: GET", workflow_text)
+        self.assertIn("route-path: ${{ steps.request.outputs.route_path }}", workflow_text)
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn("response-output-file: launchplane-context-cutover-audit.json", workflow_text)
+        self.assertIn("/v1/product-profiles/{quote(product, safe='')}", workflow_text)
+        self.assertIn("/context-cutover-audit?", workflow_text)
+        self.assertIn('echo "route_path=${route_path}"', workflow_text)
+        self.assertIn(
+            "STATUS_CODE: ${{ steps.audit_request.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn("if [ \"$STATUS_CODE\" != '200' ]; then", workflow_text)
+        self.assertIn('jq "{status, trace_id, error}"', workflow_text.replace("'", '"'))
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
+        self.assertNotIn("oidc_claims", workflow_text)
+        self.assertNotIn("claims.get", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
+
     def test_preview_lifecycle_uses_launchplane_request(self) -> None:
         workflow_text = Path(".github/workflows/preview-lifecycle.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- move product context cutover audit to the shared launchplane-request action on GitHub-hosted runners
- build the audit route path with URL encoding and let the shared action handle OIDC/request mechanics
- remove the stale decoded-claims config-authority allowlist and add workflow contract coverage

## Validation
- python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_product_context_cutover_audit_uses_launchplane_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_product_context_workflow_aliases_are_path_scoped
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/product-context-cutover-audit.yml
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py
- git diff --check

## Review notes
- Read-only review agents initially inspected a stale checkout and flagged raw OIDC/curl/claims still present. I checked those findings against this worktree: the live diff removes raw OIDC/curl, route-encodes product/query values, avoids raw response dumping, and removes the stale claims allowlist.
