### PR TITLE
Use shared request for live target runtime

### DIFF
--- a/.github/workflows/live-target-runtime.yml
+++ b/.github/workflows/live-target-runtime.yml
@@ -48,8 +48,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Request live target runtime sync
+        id: request
         env:
-          SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           PRODUCT: ${{ inputs.product }}
           CONTEXT: ${{ inputs.context }}
           INSTANCE: ${{ inputs.instance }}
@@ -65,27 +65,6 @@ jobs:
               echo "Deploy options require mode=apply." >&2
               exit 1
             fi
-          fi
-
-          service_audience="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["SERVICE_URL"].strip())
-          if not parsed.hostname:
-              raise SystemExit("SERVICE_URL must include a hostname.")
-          print(parsed.hostname)
-          PY
-          })"
-
-          token_json="$(curl -fsSL \
-            -H "Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${service_audience}")"
-          oidc_token="$(jq -r '.value' <<<"$token_json")"
-          if [ -z "$oidc_token" ] || [ "$oidc_token" = "null" ]; then
-            echo "GitHub OIDC token response did not include a token." >&2
-            exit 1
           fi
 
           payload="$(jq -n \
@@ -112,17 +91,37 @@ jobs:
               end')"
 
           response_file="live-target-runtime-response.json"
-          status_code="$(curl -sS -o "$response_file" -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            -H "Idempotency-Key: live-target-runtime:${MODE}:${CONTEXT}:${INSTANCE}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}" \
-            --data "$payload" \
-            "${SERVICE_URL}/v1/live-target-runtime/apply")"
-          cat "$response_file"
-          echo
-          if [ "$status_code" -lt 200 ] || [ "$status_code" -ge 300 ]; then
-            echo "Launchplane live target runtime request failed with HTTP ${status_code}." >&2
+          payload_file="live-target-runtime-request.json"
+          jq . <<<"$payload" > "$payload_file"
+          idempotency_key="live-target-runtime:${MODE}:${CONTEXT}:${INSTANCE}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          {
+            echo "payload_file=${payload_file}"
+            echo "response_file=${response_file}"
+            echo "idempotency_key=${idempotency_key}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply live target runtime sync
+        id: live_target_runtime_request
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          route-path: /v1/live-target-runtime/apply
+          payload-file: ${{ steps.request.outputs.payload_file }}
+          idempotency-key: ${{ steps.request.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: ${{ steps.request.outputs.response_file }}
+          log-response-body: "false"
+
+      - name: Summarize live target runtime sync
+        env:
+          MODE: ${{ inputs.mode }}
+          RESPONSE_FILE: ${{ steps.request.outputs.response_file }}
+          STATUS_CODE: ${{ steps.live_target_runtime_request.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          if [ "$STATUS_CODE" -lt 200 ] || [ "$STATUS_CODE" -ge 300 ]; then
+            echo "Launchplane live target runtime request failed with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 
@@ -137,11 +136,15 @@ jobs:
                 "- Runtime key-safety: \($result.runtime_key_safety.status)",
                 "- Env updated: \($result.apply.env_updated)",
                 "- Deploy triggered: \($result.deploy.triggered)"
-            ' "$response_file"
+            ' "$RESPONSE_FILE"
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload response artifact
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: live-target-runtime-response
-          path: live-target-runtime-response.json
+          path: |
+            live-target-runtime-request.json
+            live-target-runtime-response.json
+          if-no-files-found: warn

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -777,6 +777,15 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "response-output-file": frozenset(("ingress-route-audit-read-raw.json",)),
         "route-path": frozenset(("${{ steps.route.outputs.route_path }}",)),
     },
+    ".github/workflows/live-target-runtime.yml": {
+        "audience": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
+        "fail-result-paths": frozenset(('""',)),
+        "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),
+        "log-response-body": frozenset(('"false"',)),
+        "payload-file": frozenset(("${{ steps.request.outputs.payload_file }}",)),
+        "response-output-file": frozenset(("${{ steps.request.outputs.response_file }}",)),
+        "route-path": frozenset(("/v1/live-target-runtime/apply",)),
+    },
     ".github/workflows/preview-lifecycle.yml": {
         "audience": frozenset(("${{ env.LAUNCHPLANE_AUDIENCE }}",)),
         "idempotency-key": frozenset(("${{ steps.request.outputs.idempotency_key }}",)),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -761,8 +761,9 @@ Current derived-state behavior:
   by key/count metadata only, and never prints plaintext env or secret values.
   Use `mode: "dry-run"` first, confirm the returned `changed_keys` are expected,
   then use `mode: "apply"` through an authorized workflow or operator API
-  caller. The `live-target-runtime.yml` workflow wraps this route with GitHub
-  OIDC and uploads the sanitized response artifact.
+  caller. The `live-target-runtime.yml` workflow wraps this route with the
+  shared Launchplane request action and uploads sanitized request/response
+  artifacts.
 - TOML/env files are not runtime import surfaces; use DB-native
   runtime-environment records and managed secrets instead.
 - Product repos and GitHub issues must not contain product secret values. Put

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2531,6 +2531,25 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         for key, value in (
             ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
             ("fail-result-paths", '""'),
+            ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
+            ("log-response-body", '"false"'),
+            ("payload-file", "${{ steps.request.outputs.payload_file }}"),
+            ("response-output-file", "${{ steps.request.outputs.response_file }}"),
+            ("route-path", "/v1/live-target-runtime/apply"),
+        ):
+            with self.subTest(live_target_runtime_mechanic=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/live-target-runtime.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
+                )
+
+        for key, value in (
+            ("audience", "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}"),
+            ("fail-result-paths", '""'),
             ("method", "GET"),
             ("response-output-file", "launchplane-work-graph-snapshot.json"),
         ):

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1110,6 +1110,55 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertNotIn("LAUNCHPLANE_RUNNER_LABEL", workflow_text)
         self.assertNotIn("curl ", workflow_text)
 
+    def test_live_target_runtime_workflow_uses_launchplane_request(self) -> None:
+        workflow_text = Path(".github/workflows/live-target-runtime.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("runs-on: ubuntu-latest", workflow_text)
+        self.assertIn("Deploy options require mode=apply.", workflow_text)
+        self.assertIn("live-target-runtime-request.json", workflow_text)
+        self.assertIn("live-target-runtime-response.json", workflow_text)
+        self.assertIn("payload_file=${payload_file}", workflow_text)
+        self.assertIn("response_file=${response_file}", workflow_text)
+        self.assertIn("idempotency_key=${idempotency_key}", workflow_text)
+        self.assertIn(
+            "live-target-runtime:${MODE}:${CONTEXT}:${INSTANCE}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}",
+            workflow_text,
+        )
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}", workflow_text)
+        self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
+        self.assertIn("route-path: /v1/live-target-runtime/apply", workflow_text)
+        self.assertIn("payload-file: ${{ steps.request.outputs.payload_file }}", workflow_text)
+        self.assertIn(
+            "idempotency-key: ${{ steps.request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn(
+            "response-output-file: ${{ steps.request.outputs.response_file }}",
+            workflow_text,
+        )
+        self.assertIn('log-response-body: "false"', workflow_text)
+        self.assertIn(
+            "STATUS_CODE: ${{ steps.live_target_runtime_request.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn("Summarize live target runtime sync", workflow_text)
+        self.assertIn("$result.runtime_key_safety.status", workflow_text)
+        self.assertIn("if: always()", workflow_text)
+        self.assertIn("if-no-files-found: warn", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("Authorization: Bearer", workflow_text)
+        self.assertNotIn("service_audience", workflow_text)
+        self.assertNotIn("oidc_token", workflow_text)
+        self.assertNotIn("curl ", workflow_text)
+
     def test_reusable_odoo_workflows_accept_configured_service_identity(self) -> None:
         workflow_paths = (
             Path(".github/workflows/reusable-odoo-artifact-publish.yml"),


### PR DESCRIPTION
## Summary
- replace live-target-runtime bespoke OIDC/curl request plumbing with the shared `launchplane-request` action
- preserve dry-run deploy option guard, typed JSON payload generation, idempotency key, sanitized summary, and response artifacts
- update config-authority path-scoped connector allowances, workflow tests, and operator docs

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_live_target_runtime_workflow_uses_launchplane_request tests.test_product_onboarding.ProductOnboardingTests.test_dokploy_target_setup_workflow_supports_compose_domain_reconcile tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_generated_idempotency_keys_are_path_scoped`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/live-target-runtime.yml`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_product_onboarding.py tests/test_config_authority_audit.py`
- `git diff --check`

## Review
- two read-only agents reviewed the conversion; both called out preserving typed optional `deploy_timeout_seconds` via a generated JSON payload file and keeping idempotency/config-authority path-scoped
- one agent suggested local action usage plus checkout; this PR intentionally uses the remote `@main` shared action to match the other Launchplane-owned workflow callers without adding checkout
