### PR TITLE
Use shared request for merge train level1 run

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -418,70 +418,88 @@ jobs:
           env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none')
         uses: actions/checkout@v6
 
-      - name: Run one merge-train pass
+      - name: Prepare merge-train run-once request
+        id: level1_request
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'level1'
         shell: bash
-        env:
-          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
-          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
         run: |
           set -euo pipefail
           if [ "${MERGE_TRAIN_BATCH_CANDIDATE_MODE}" != "none" ] || \
              [ "${MERGE_TRAIN_BATCH_LANDING_MODE}" != "none" ] || \
              [ "${MERGE_TRAIN_STACK_COLLAPSE_MODE}" != "none" ]; then
             echo "Batch mode selected; skipping Level 1 worker pass."
+            echo "should_request=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          request_payload="$({
-            jq -n \
-              --arg repository "$MERGE_TRAIN_REPOSITORY" \
-              --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
-              --argjson mutate "$MERGE_TRAIN_MUTATE" \
-              '{
-                schema_version: 1,
-                repository: $repository,
-                base_branch: $base_branch,
-                mutate: $mutate
-              }'
-          })"
+          request_payload_file="launchplane-merge-train-run-once-request.json"
           response_file="launchplane-merge-train-run-once.json"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            --data "$request_payload" \
-            "${SERVICE_ORIGIN}/v1/work-graph/merge-train/run-once")"
-          if [ "$status_code" != "202" ]; then
-            cat "$response_file" >&2
-            echo "Merge-train run-once failed with HTTP ${status_code}." >&2
+          jq -n \
+            --arg repository "$MERGE_TRAIN_REPOSITORY" \
+            --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
+            --argjson mutate "$MERGE_TRAIN_MUTATE" \
+            '{
+              schema_version: 1,
+              repository: $repository,
+              base_branch: $base_branch,
+              mutate: $mutate
+            }' > "$request_payload_file"
+          payload_digest="$(sha256sum "$request_payload_file" | cut -d' ' -f1)"
+          idempotency_key="merge-train-run-once"
+          idempotency_key="${idempotency_key}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          idempotency_key="${idempotency_key}:${payload_digest}"
+          {
+            echo "should_request=true"
+            echo "idempotency_key=${idempotency_key}"
+            echo "payload_file=${request_payload_file}"
+            echo "response_file=${response_file}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send merge-train run-once request
+        if: steps.level1_request.outputs.should_request == 'true'
+        id: level1_run
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.admission.outputs.service_audience }}
+          method: POST
+          route-path: /v1/work-graph/merge-train/run-once
+          payload-file: ${{ steps.level1_request.outputs.payload_file }}
+          idempotency-key: ${{ steps.level1_request.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: ${{ steps.level1_request.outputs.response_file }}
+          log-response-body: "false"
+
+      - name: Summarize merge-train run-once response
+        if: steps.level1_request.outputs.should_request == 'true'
+        shell: bash
+        env:
+          RESPONSE_FILE: ${{ steps.level1_request.outputs.response_file }}
+          STATUS_CODE: ${{ steps.level1_run.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          if [ "$STATUS_CODE" != "202" ]; then
+            cat "$RESPONSE_FILE" >&2
+            echo "Merge-train run-once failed with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 
-          jq . "$response_file"
+          jq . "$RESPONSE_FILE"
           {
             echo
             echo '## Launchplane merge train run-once'
             echo
-            echo "- Mode: $(jq -r '.result.mode' "$response_file")"
+            echo "- Mode: $(jq -r '.result.mode' "$RESPONSE_FILE")"
             run_record="$(
-              jq -r '.records.merge_train_run_id // ""' "$response_file"
+              jq -r '.records.merge_train_run_id // ""' "$RESPONSE_FILE"
             )"
             next_action="$({
               jq -r \
                 '.result.dry_run_result.intended_next_action //
                  .result.intended_next_action // "unknown"' \
-                "$response_file"
+                "$RESPONSE_FILE"
             })"
             echo "- Run record: ${run_record}"
             echo "- Next action: ${next_action}"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -791,19 +791,24 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
             (
                 "${{ steps.admission_request.outputs.service_audience }}",
                 "${{ steps.scheduled_target_request.outputs.service_audience }}",
+                "${{ steps.admission.outputs.service_audience }}",
             )
         ),
         "fail-result-paths": frozenset(('""',)),
+        "idempotency-key": frozenset(("${{ steps.level1_request.outputs.idempotency_key }}",)),
         "log-response-body": frozenset(('"false"',)),
-        "method": frozenset(("GET",)),
+        "method": frozenset(("GET", "POST")),
+        "payload-file": frozenset(("${{ steps.level1_request.outputs.payload_file }}",)),
         "response-output-file": frozenset(
             (
                 "${{ steps.admission_request.outputs.response_file }}",
+                "${{ steps.level1_request.outputs.response_file }}",
                 "${{ steps.scheduled_target_request.outputs.response_file }}",
             )
         ),
         "route-path": frozenset(
             (
+                "/v1/work-graph/merge-train/run-once",
                 "/v1/work-graph/merge-train/policy-targets",
                 "${{ steps.admission_request.outputs.route_path }}",
             )

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -55,12 +55,15 @@ def _gaps(payload: dict[str, object]) -> list[dict[str, object]]:
 
 
 class ConfigAuthorityAuditTest(unittest.TestCase):
-    def test_merge_train_runner_uses_policy_targets_for_scheduled_authority(self) -> None:
+    def test_merge_train_runner_uses_shared_request_for_reads_and_level1_post(self) -> None:
         workflow_text = Path(".github/workflows/merge-train-runner.yml").read_text(encoding="utf-8")
 
         self.assertIn("/v1/work-graph/merge-train/policy-targets", workflow_text)
         self.assertIn("Read scheduled merge-train targets", workflow_text)
         self.assertIn("Read merge-train admission", workflow_text)
+        self.assertIn("Prepare merge-train run-once request", workflow_text)
+        self.assertIn("Send merge-train run-once request", workflow_text)
+        self.assertIn("Summarize merge-train run-once response", workflow_text)
         self.assertIn(
             "uses: cbusillo/launchplane/.github/actions/launchplane-request@main", workflow_text
         )
@@ -71,10 +74,20 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn(
             "audience: ${{ steps.admission_request.outputs.service_audience }}", workflow_text
         )
+        self.assertIn("audience: ${{ steps.admission.outputs.service_audience }}", workflow_text)
         self.assertIn("method: GET", workflow_text)
+        self.assertIn("method: POST", workflow_text)
         self.assertIn("route-path: /v1/work-graph/merge-train/policy-targets", workflow_text)
         self.assertIn(
             "route-path: ${{ steps.admission_request.outputs.route_path }}", workflow_text
+        )
+        self.assertIn("route-path: /v1/work-graph/merge-train/run-once", workflow_text)
+        self.assertIn(
+            "payload-file: ${{ steps.level1_request.outputs.payload_file }}", workflow_text
+        )
+        self.assertIn(
+            "idempotency-key: ${{ steps.level1_request.outputs.idempotency_key }}",
+            workflow_text,
         )
         self.assertIn(
             "response-output-file: ${{ steps.scheduled_target_request.outputs.response_file }}",
@@ -84,10 +97,22 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "response-output-file: ${{ steps.admission_request.outputs.response_file }}",
             workflow_text,
         )
+        self.assertIn(
+            "response-output-file: ${{ steps.level1_request.outputs.response_file }}", workflow_text
+        )
         self.assertIn('fail-result-paths: ""', workflow_text)
         self.assertIn('log-response-body: "false"', workflow_text)
         self.assertIn("launchplane-merge-train-policy-targets.json", workflow_text)
         self.assertIn("launchplane-merge-train-admission.json", workflow_text)
+        self.assertIn("launchplane-merge-train-run-once-request.json", workflow_text)
+        self.assertIn("launchplane-merge-train-run-once.json", workflow_text)
+        self.assertIn('idempotency_key="merge-train-run-once"', workflow_text)
+        self.assertRegex(
+            workflow_text,
+            r"(?s)Send merge-train run-once request.*idempotency-key: "
+            r"\$\{\{ steps\.level1_request\.outputs\.idempotency_key \}\}.*"
+            r"log-response-body: \"false\"",
+        )
         self.assertNotIn(
             '"${service_origin}/v1/work-graph/merge-train/policy-targets"', workflow_text
         )
@@ -95,6 +120,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             '"${service_origin}/v1/work-graph/merge-train/admission?${query_string}"',
             workflow_text,
         )
+        self.assertNotIn('"${SERVICE_ORIGIN}/v1/work-graph/merge-train/run-once"', workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_REPOSITORY", workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_BASE_BRANCH", workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_MUTATE", workflow_text)
@@ -2585,10 +2611,14 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
 
         for key, value in (
             ("audience", "${{ steps.admission_request.outputs.service_audience }}"),
+            ("audience", "${{ steps.admission.outputs.service_audience }}"),
             ("audience", "${{ steps.scheduled_target_request.outputs.service_audience }}"),
             ("fail-result-paths", '""'),
+            ("idempotency-key", "${{ steps.level1_request.outputs.idempotency_key }}"),
             ("log-response-body", '"false"'),
             ("method", "GET"),
+            ("method", "POST"),
+            ("payload-file", "${{ steps.level1_request.outputs.payload_file }}"),
             (
                 "response-output-file",
                 "${{ steps.scheduled_target_request.outputs.response_file }}",
@@ -2597,7 +2627,12 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 "response-output-file",
                 "${{ steps.admission_request.outputs.response_file }}",
             ),
+            (
+                "response-output-file",
+                "${{ steps.level1_request.outputs.response_file }}",
+            ),
             ("route-path", "/v1/work-graph/merge-train/policy-targets"),
+            ("route-path", "/v1/work-graph/merge-train/run-once"),
             ("route-path", "${{ steps.admission_request.outputs.route_path }}"),
         ):
             with self.subTest(merge_train_runner_get_mechanic=key):


### PR DESCRIPTION
## Summary
- move the merge-train runner Level 1 `run-once` POST from inline OIDC/curl to the shared `launchplane-request` action
- keep the existing payload shape and response summary, with a run-attempt/payload-scoped idempotency key for retry-safe mutation semantics
- update config-authority audit allowlists and focused tests for the new thin-connector POST inputs

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run python -m unittest tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_merge_train_runner_uses_shared_request_for_reads_and_level1_post tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-runner.yml`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `git diff --check`

## Review
- agent review flagged default action retries on a mutating POST; fixed by adding a stable `Idempotency-Key` for the Level 1 request
- agent review flagged duplicate response-body logging; fixed by setting `log-response-body: "false"` and keeping the existing summary step as the output owner
- controller, phase, and PR-feedback write loops remain raw in this slice for separate, smaller conversions
