### PR TITLE
Use shared request for merge train controller run

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -448,7 +448,7 @@ jobs:
             }' > "$request_payload_file"
           payload_digest="$(sha256sum "$request_payload_file" | cut -d' ' -f1)"
           idempotency_key="merge-train-run-once"
-          idempotency_key="${idempotency_key}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"
+          idempotency_key="${idempotency_key}:${GITHUB_RUN_ID}"
           idempotency_key="${idempotency_key}:${payload_digest}"
           {
             echo "should_request=true"
@@ -537,7 +537,54 @@ jobs:
             exit 1
           fi
 
-      - name: Run one merge-train controller action
+      - name: Prepare merge-train controller request
+        id: controller_request
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_RUNNER_MODE == 'controller'
+        shell: bash
+        run: |
+          set -euo pipefail
+          request_payload_file="launchplane-merge-train-controller-run-once-request.json"
+          response_file="launchplane-merge-train-controller-run-once.json"
+          jq -n \
+            --arg repository "$MERGE_TRAIN_REPOSITORY" \
+            --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
+            --argjson mutate "$MERGE_TRAIN_MUTATE" \
+            '{
+              schema_version: 1,
+              repository: $repository,
+              base_branch: $base_branch,
+              mutate: $mutate
+            }' > "$request_payload_file"
+          payload_digest="$(sha256sum "$request_payload_file" | cut -d' ' -f1)"
+          idempotency_key="merge-train-controller-run-once"
+          idempotency_key="${idempotency_key}:${GITHUB_RUN_ID}"
+          idempotency_key="${idempotency_key}:${payload_digest}"
+          {
+            echo "idempotency_key=${idempotency_key}"
+            echo "payload_file=${request_payload_file}"
+            echo "response_file=${response_file}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send merge-train controller request
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_RUNNER_MODE == 'controller'
+        id: controller_run
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.admission.outputs.service_audience }}
+          method: POST
+          route-path: /v1/work-graph/merge-train/controller/run-once
+          payload-file: ${{ steps.controller_request.outputs.payload_file }}
+          idempotency-key: ${{ steps.controller_request.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: ${{ steps.controller_request.outputs.response_file }}
+          log-response-body: "false"
+
+      - name: Summarize merge-train controller response
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'controller'
@@ -545,54 +592,33 @@ jobs:
         env:
           SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
           SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
+          RESPONSE_FILE: ${{ steps.controller_request.outputs.response_file }}
+          STATUS_CODE: ${{ steps.controller_run.outputs.status-code }}
         run: |
           set -euo pipefail
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          request_payload="$({
-            jq -n \
-              --arg repository "$MERGE_TRAIN_REPOSITORY" \
-              --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
-              --argjson mutate "$MERGE_TRAIN_MUTATE" \
-              '{
-                schema_version: 1,
-                repository: $repository,
-                base_branch: $base_branch,
-                mutate: $mutate
-              }'
-          })"
-          response_file="launchplane-merge-train-controller-run-once.json"
-          controller_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train"
-          controller_url="${controller_url}/controller/run-once"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            --data "$request_payload" \
-            "$controller_url")"
-          if [ "$status_code" != "202" ]; then
-            cat "$response_file" >&2
+          if [ "$STATUS_CODE" != "202" ]; then
+            cat "$RESPONSE_FILE" >&2
             echo "Merge-train controller run-once failed" \
-              "with HTTP ${status_code}." >&2
+              "with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 
-          jq . "$response_file"
+          jq . "$RESPONSE_FILE"
           feedback_payloads="launchplane-merge-train-controller-feedback.json"
           python3 scripts/merge_train_controller_feedback.py \
-            --response-file "$response_file" \
+            --response-file "$RESPONSE_FILE" \
             > "$feedback_payloads"
           feedback_count="$(jq 'length' "$feedback_payloads")"
           if [ "$MERGE_TRAIN_MUTATE" != "true" ]; then
             feedback_count=0
           fi
           if [ "$feedback_count" -gt 0 ]; then
+            oidc_token="$({
+              curl -fsSL \
+                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
+              | jq -r '.value'
+            })"
             feedback_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train/pr-feedback"
             feedback_index=0
             while IFS= read -r feedback_payload; do
@@ -626,21 +652,21 @@ jobs:
             echo
             echo '## Launchplane merge train controller'
             echo
-            echo "- Mode: $(jq -r '.result.mode' "$response_file")"
+            echo "- Mode: $(jq -r '.result.mode' "$RESPONSE_FILE")"
             controller_action="$(
-              jq -r '.result.controller_action // "unknown"' "$response_file"
+              jq -r '.result.controller_action // "unknown"' "$RESPONSE_FILE"
             )"
             candidate_record="$(
               jq -r '.records.merge_train_batch_candidate_record_id // ""' \
-                "$response_file"
+                "$RESPONSE_FILE"
             )"
             landing_record="$(
               jq -r '.records.merge_train_batch_landing_plan_record_id // ""' \
-                "$response_file"
+                "$RESPONSE_FILE"
             )"
             stack_record="$(
               jq -r '.records.merge_train_stack_collapse_plan_record_id // ""' \
-                "$response_file"
+                "$RESPONSE_FILE"
             )"
             echo "- Controller action: ${controller_action}"
             echo "- Candidate record: ${candidate_record}"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -795,19 +795,31 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
             )
         ),
         "fail-result-paths": frozenset(('""',)),
-        "idempotency-key": frozenset(("${{ steps.level1_request.outputs.idempotency_key }}",)),
+        "idempotency-key": frozenset(
+            (
+                "${{ steps.controller_request.outputs.idempotency_key }}",
+                "${{ steps.level1_request.outputs.idempotency_key }}",
+            )
+        ),
         "log-response-body": frozenset(('"false"',)),
         "method": frozenset(("GET", "POST")),
-        "payload-file": frozenset(("${{ steps.level1_request.outputs.payload_file }}",)),
+        "payload-file": frozenset(
+            (
+                "${{ steps.controller_request.outputs.payload_file }}",
+                "${{ steps.level1_request.outputs.payload_file }}",
+            )
+        ),
         "response-output-file": frozenset(
             (
                 "${{ steps.admission_request.outputs.response_file }}",
+                "${{ steps.controller_request.outputs.response_file }}",
                 "${{ steps.level1_request.outputs.response_file }}",
                 "${{ steps.scheduled_target_request.outputs.response_file }}",
             )
         ),
         "route-path": frozenset(
             (
+                "/v1/work-graph/merge-train/controller/run-once",
                 "/v1/work-graph/merge-train/run-once",
                 "/v1/work-graph/merge-train/policy-targets",
                 "${{ steps.admission_request.outputs.route_path }}",

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -55,7 +55,7 @@ def _gaps(payload: dict[str, object]) -> list[dict[str, object]]:
 
 
 class ConfigAuthorityAuditTest(unittest.TestCase):
-    def test_merge_train_runner_uses_shared_request_for_reads_and_level1_post(self) -> None:
+    def test_merge_train_runner_uses_shared_request_for_reads_and_worker_posts(self) -> None:
         workflow_text = Path(".github/workflows/merge-train-runner.yml").read_text(encoding="utf-8")
 
         self.assertIn("/v1/work-graph/merge-train/policy-targets", workflow_text)
@@ -64,6 +64,9 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("Prepare merge-train run-once request", workflow_text)
         self.assertIn("Send merge-train run-once request", workflow_text)
         self.assertIn("Summarize merge-train run-once response", workflow_text)
+        self.assertIn("Prepare merge-train controller request", workflow_text)
+        self.assertIn("Send merge-train controller request", workflow_text)
+        self.assertIn("Summarize merge-train controller response", workflow_text)
         self.assertIn(
             "uses: cbusillo/launchplane/.github/actions/launchplane-request@main", workflow_text
         )
@@ -82,11 +85,19 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "route-path: ${{ steps.admission_request.outputs.route_path }}", workflow_text
         )
         self.assertIn("route-path: /v1/work-graph/merge-train/run-once", workflow_text)
+        self.assertIn("route-path: /v1/work-graph/merge-train/controller/run-once", workflow_text)
         self.assertIn(
             "payload-file: ${{ steps.level1_request.outputs.payload_file }}", workflow_text
         )
         self.assertIn(
+            "payload-file: ${{ steps.controller_request.outputs.payload_file }}", workflow_text
+        )
+        self.assertIn(
             "idempotency-key: ${{ steps.level1_request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "idempotency-key: ${{ steps.controller_request.outputs.idempotency_key }}",
             workflow_text,
         )
         self.assertIn(
@@ -100,17 +111,31 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn(
             "response-output-file: ${{ steps.level1_request.outputs.response_file }}", workflow_text
         )
+        self.assertIn(
+            "response-output-file: ${{ steps.controller_request.outputs.response_file }}",
+            workflow_text,
+        )
         self.assertIn('fail-result-paths: ""', workflow_text)
         self.assertIn('log-response-body: "false"', workflow_text)
         self.assertIn("launchplane-merge-train-policy-targets.json", workflow_text)
         self.assertIn("launchplane-merge-train-admission.json", workflow_text)
         self.assertIn("launchplane-merge-train-run-once-request.json", workflow_text)
         self.assertIn("launchplane-merge-train-run-once.json", workflow_text)
+        self.assertIn("launchplane-merge-train-controller-run-once-request.json", workflow_text)
+        self.assertIn("launchplane-merge-train-controller-run-once.json", workflow_text)
         self.assertIn('idempotency_key="merge-train-run-once"', workflow_text)
+        self.assertIn('idempotency_key="merge-train-controller-run-once"', workflow_text)
+        self.assertNotIn("${GITHUB_RUN_ATTEMPT}:${payload_digest}", workflow_text)
         self.assertRegex(
             workflow_text,
             r"(?s)Send merge-train run-once request.*idempotency-key: "
             r"\$\{\{ steps\.level1_request\.outputs\.idempotency_key \}\}.*"
+            r"log-response-body: \"false\"",
+        )
+        self.assertRegex(
+            workflow_text,
+            r"(?s)Send merge-train controller request.*idempotency-key: "
+            r"\$\{\{ steps\.controller_request\.outputs\.idempotency_key \}\}.*"
             r"log-response-body: \"false\"",
         )
         self.assertNotIn(
@@ -121,6 +146,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             workflow_text,
         )
         self.assertNotIn('"${SERVICE_ORIGIN}/v1/work-graph/merge-train/run-once"', workflow_text)
+        self.assertNotIn('"$controller_url"', workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_REPOSITORY", workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_BASE_BRANCH", workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_MUTATE", workflow_text)
@@ -2614,10 +2640,12 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("audience", "${{ steps.admission.outputs.service_audience }}"),
             ("audience", "${{ steps.scheduled_target_request.outputs.service_audience }}"),
             ("fail-result-paths", '""'),
+            ("idempotency-key", "${{ steps.controller_request.outputs.idempotency_key }}"),
             ("idempotency-key", "${{ steps.level1_request.outputs.idempotency_key }}"),
             ("log-response-body", '"false"'),
             ("method", "GET"),
             ("method", "POST"),
+            ("payload-file", "${{ steps.controller_request.outputs.payload_file }}"),
             ("payload-file", "${{ steps.level1_request.outputs.payload_file }}"),
             (
                 "response-output-file",
@@ -2631,7 +2659,12 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                 "response-output-file",
                 "${{ steps.level1_request.outputs.response_file }}",
             ),
+            (
+                "response-output-file",
+                "${{ steps.controller_request.outputs.response_file }}",
+            ),
             ("route-path", "/v1/work-graph/merge-train/policy-targets"),
+            ("route-path", "/v1/work-graph/merge-train/controller/run-once"),
             ("route-path", "/v1/work-graph/merge-train/run-once"),
             ("route-path", "${{ steps.admission_request.outputs.route_path }}"),
         ):


### PR DESCRIPTION
## Summary
- move the merge-train controller `run-once` POST to the shared `launchplane-request` action
- preserve controller payload/summary behavior and keep the PR feedback loop in shell for this slice
- add workflow-run/payload-scoped idempotency keys for Level 1 and controller POSTs so action retries and GitHub job reruns replay safely
- update config-authority allowlists and focused workflow contract tests for the controller POST inputs

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run python -m unittest tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_merge_train_runner_uses_shared_request_for_reads_and_worker_posts tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-runner.yml`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `git diff --check`

## Review
- agent review confirmed the controller action wiring and feedback loop preservation
- agent review flagged rerun-idempotency weakness when the key included `GITHUB_RUN_ATTEMPT`; fixed by keying these run-once mutations to `GITHUB_RUN_ID` plus payload digest instead
- PR-feedback loop and manual phase write paths remain separate cleanup slices
