### PR TITLE
Use shared request for merge train phase posts

### DIFF
--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -675,15 +675,12 @@ jobs:
             echo "- Feedback payloads: ${feedback_count}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run one batch-candidate phase
-        id: batch_candidate
+      - name: Prepare batch-candidate phase request
+        id: batch_candidate_request
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none'
         shell: bash
-        env:
-          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
-          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
         run: |
           set -euo pipefail
           case "$MERGE_TRAIN_BATCH_CANDIDATE_MODE" in
@@ -702,64 +699,85 @@ jobs:
             exit 1
           fi
 
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          request_payload="$({
-            jq -n \
-              --arg repository "$MERGE_TRAIN_REPOSITORY" \
-              --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
-              --arg mode "$MERGE_TRAIN_BATCH_CANDIDATE_MODE" \
-              --arg candidate_record_id \
-                "$MERGE_TRAIN_BATCH_CANDIDATE_RECORD_ID" \
-              '{
-                schema_version: 1,
-                repository: $repository,
-                base_branch: $base_branch,
-                mode: $mode,
-                candidate_record_id: $candidate_record_id
-              }'
-          })"
+          request_payload_file="launchplane-merge-train-batch-candidate-request.json"
           response_file="launchplane-merge-train-batch-candidate.json"
-          batch_candidate_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train"
-          batch_candidate_url="${batch_candidate_url}/batch-candidate/run-once"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            --data "$request_payload" \
-            "$batch_candidate_url")"
-          if [ "$status_code" != "202" ]; then
-            cat "$response_file" >&2
+          jq -n \
+            --arg repository "$MERGE_TRAIN_REPOSITORY" \
+            --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
+            --arg mode "$MERGE_TRAIN_BATCH_CANDIDATE_MODE" \
+            --arg candidate_record_id \
+              "$MERGE_TRAIN_BATCH_CANDIDATE_RECORD_ID" \
+            '{
+              schema_version: 1,
+              repository: $repository,
+              base_branch: $base_branch,
+              mode: $mode,
+              candidate_record_id: $candidate_record_id
+            }' > "$request_payload_file"
+          payload_digest="$(sha256sum "$request_payload_file" | cut -d' ' -f1)"
+          idempotency_key="merge-train-batch-candidate-run-once"
+          idempotency_key="${idempotency_key}:${GITHUB_RUN_ID}"
+          idempotency_key="${idempotency_key}:${payload_digest}"
+          {
+            echo "idempotency_key=${idempotency_key}"
+            echo "payload_file=${request_payload_file}"
+            echo "response_file=${response_file}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send batch-candidate phase request
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none'
+        id: batch_candidate_run
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.admission.outputs.service_audience }}
+          method: POST
+          route-path: /v1/work-graph/merge-train/batch-candidate/run-once
+          payload-file: ${{ steps.batch_candidate_request.outputs.payload_file }}
+          idempotency-key: ${{ steps.batch_candidate_request.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: ${{ steps.batch_candidate_request.outputs.response_file }}
+          log-response-body: "false"
+
+      - name: Summarize batch-candidate phase response
+        id: batch_candidate
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none'
+        shell: bash
+        env:
+          RESPONSE_FILE: ${{ steps.batch_candidate_request.outputs.response_file }}
+          STATUS_CODE: ${{ steps.batch_candidate_run.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          if [ "$STATUS_CODE" != "202" ]; then
+            cat "$RESPONSE_FILE" >&2
             echo "Merge-train batch-candidate phase failed" \
-              "with HTTP ${status_code}." >&2
+              "with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 
-          jq . "$response_file"
-          echo "response_file=${response_file}" >> "$GITHUB_OUTPUT"
+          jq . "$RESPONSE_FILE"
+          echo "response_file=${RESPONSE_FILE}" >> "$GITHUB_OUTPUT"
           {
             echo
             echo '## Launchplane merge train batch candidate'
             echo
-            echo "- Mode: $(jq -r '.result.mode' "$response_file")"
+            echo "- Mode: $(jq -r '.result.mode' "$RESPONSE_FILE")"
             candidate_status="$(
-              jq -r '.result.candidate.status' "$response_file"
+              jq -r '.result.candidate.status' "$RESPONSE_FILE"
             )"
             candidate_sha="$(
-              jq -r '.result.candidate.candidate_sha // ""' "$response_file"
+              jq -r '.result.candidate.candidate_sha // ""' "$RESPONSE_FILE"
             )"
             required_checks="$(
-              jq -r '.result.candidate.required_checks_status' "$response_file"
+              jq -r '.result.candidate.required_checks_status' "$RESPONSE_FILE"
             )"
             candidate_record="$(
-              jq -r '.records.merge_train_batch_candidate_record_id' \
-                "$response_file"
+              jq -r '.records.merge_train_batch_candidate_record_id // ""' \
+                "$RESPONSE_FILE"
             )"
             echo "- Candidate status: ${candidate_status}"
             echo "- Candidate SHA: ${candidate_sha}"
@@ -767,15 +785,12 @@ jobs:
             echo "- Record: ${candidate_record}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run one stack-collapse phase
-        id: stack_collapse
+      - name: Prepare stack-collapse phase request
+        id: stack_collapse_request
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none'
         shell: bash
-        env:
-          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
-          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
         run: |
           set -euo pipefail
           case "$MERGE_TRAIN_STACK_COLLAPSE_MODE" in
@@ -793,66 +808,87 @@ jobs:
             exit 1
           fi
 
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          request_payload="$({
-            jq -n \
-              --arg repository "$MERGE_TRAIN_REPOSITORY" \
-              --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
-              --arg mode "$MERGE_TRAIN_STACK_COLLAPSE_MODE" \
-              --arg stack_collapse_plan_record_id \
-                "$MERGE_TRAIN_STACK_COLLAPSE_PLAN_RECORD_ID" \
-              '{
-                schema_version: 1,
-                repository: $repository,
-                base_branch: $base_branch,
-                mode: $mode,
-                stack_collapse_plan_record_id: $stack_collapse_plan_record_id
-              }'
-          })"
+          request_payload_file="launchplane-merge-train-stack-collapse-request.json"
           response_file="launchplane-merge-train-stack-collapse.json"
-          stack_collapse_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train"
-          stack_collapse_url="${stack_collapse_url}/stack-collapse/run-once"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            --data "$request_payload" \
-            "$stack_collapse_url")"
-          if [ "$status_code" != "202" ]; then
-            cat "$response_file" >&2
+          jq -n \
+            --arg repository "$MERGE_TRAIN_REPOSITORY" \
+            --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
+            --arg mode "$MERGE_TRAIN_STACK_COLLAPSE_MODE" \
+            --arg stack_collapse_plan_record_id \
+              "$MERGE_TRAIN_STACK_COLLAPSE_PLAN_RECORD_ID" \
+            '{
+              schema_version: 1,
+              repository: $repository,
+              base_branch: $base_branch,
+              mode: $mode,
+              stack_collapse_plan_record_id: $stack_collapse_plan_record_id
+            }' > "$request_payload_file"
+          payload_digest="$(sha256sum "$request_payload_file" | cut -d' ' -f1)"
+          idempotency_key="merge-train-stack-collapse-run-once"
+          idempotency_key="${idempotency_key}:${GITHUB_RUN_ID}"
+          idempotency_key="${idempotency_key}:${payload_digest}"
+          {
+            echo "idempotency_key=${idempotency_key}"
+            echo "payload_file=${request_payload_file}"
+            echo "response_file=${response_file}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send stack-collapse phase request
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none'
+        id: stack_collapse_run
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.admission.outputs.service_audience }}
+          method: POST
+          route-path: /v1/work-graph/merge-train/stack-collapse/run-once
+          payload-file: ${{ steps.stack_collapse_request.outputs.payload_file }}
+          idempotency-key: ${{ steps.stack_collapse_request.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: ${{ steps.stack_collapse_request.outputs.response_file }}
+          log-response-body: "false"
+
+      - name: Summarize stack-collapse phase response
+        id: stack_collapse
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none'
+        shell: bash
+        env:
+          RESPONSE_FILE: ${{ steps.stack_collapse_request.outputs.response_file }}
+          STATUS_CODE: ${{ steps.stack_collapse_run.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          if [ "$STATUS_CODE" != "202" ]; then
+            cat "$RESPONSE_FILE" >&2
             echo "Merge-train stack-collapse phase failed" \
-              "with HTTP ${status_code}." >&2
+              "with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 
-          jq . "$response_file"
-          echo "response_file=${response_file}" >> "$GITHUB_OUTPUT"
+          jq . "$RESPONSE_FILE"
+          echo "response_file=${RESPONSE_FILE}" >> "$GITHUB_OUTPUT"
           {
             echo
             echo '## Launchplane merge train stack collapse'
             echo
-            echo "- Mode: $(jq -r '.result.mode' "$response_file")"
+            echo "- Mode: $(jq -r '.result.mode' "$RESPONSE_FILE")"
             stack_record="$(
               jq -r '.records.merge_train_stack_collapse_plan_record_id // ""' \
-                "$response_file"
+                "$RESPONSE_FILE"
             )"
             candidate_record="$(
               jq -r '.records.merge_train_batch_candidate_record_id // ""' \
-                "$response_file"
+                "$RESPONSE_FILE"
             )"
             stack_status="$(
               jq -r '.result.stack_collapse_plan.status // ""' \
-                "$response_file"
+                "$RESPONSE_FILE"
             )"
             candidate_status="$(
-              jq -r '.result.candidate.status // ""' "$response_file"
+              jq -r '.result.candidate.status // ""' "$RESPONSE_FILE"
             )"
             echo "- Stack-collapse record: ${stack_record}"
             echo "- Stack status: ${stack_status}"
@@ -860,15 +896,12 @@ jobs:
             echo "- Candidate status: ${candidate_status}"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run one batch-landing phase
-        id: batch_landing
+      - name: Prepare batch-landing phase request
+        id: batch_landing_request
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none'
         shell: bash
-        env:
-          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
-          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
         run: |
           set -euo pipefail
           case "$MERGE_TRAIN_BATCH_LANDING_MODE" in
@@ -894,62 +927,83 @@ jobs:
             exit 1
           fi
 
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          request_payload="$({
-            jq -n \
-              --arg repository "$MERGE_TRAIN_REPOSITORY" \
-              --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
-              --arg mode "$MERGE_TRAIN_BATCH_LANDING_MODE" \
-              --arg candidate_record_id \
-                "$MERGE_TRAIN_BATCH_LANDING_CANDIDATE_RECORD_ID" \
-              --arg landing_plan_record_id \
-                "$MERGE_TRAIN_BATCH_LANDING_PLAN_RECORD_ID" \
-              '{
-                schema_version: 1,
-                repository: $repository,
-                base_branch: $base_branch,
-                mode: $mode,
-                candidate_record_id: $candidate_record_id,
-                landing_plan_record_id: $landing_plan_record_id
-              }'
-          })"
+          request_payload_file="launchplane-merge-train-batch-landing-request.json"
           response_file="launchplane-merge-train-batch-landing.json"
-          batch_landing_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train"
-          batch_landing_url="${batch_landing_url}/batch-landing/run-once"
-          status_code="$(curl -sS \
-            -o "$response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H 'Content-Type: application/json' \
-            --data "$request_payload" \
-            "$batch_landing_url")"
-          if [ "$status_code" != "202" ]; then
-            cat "$response_file" >&2
+          jq -n \
+            --arg repository "$MERGE_TRAIN_REPOSITORY" \
+            --arg base_branch "$MERGE_TRAIN_BASE_BRANCH" \
+            --arg mode "$MERGE_TRAIN_BATCH_LANDING_MODE" \
+            --arg candidate_record_id \
+              "$MERGE_TRAIN_BATCH_LANDING_CANDIDATE_RECORD_ID" \
+            --arg landing_plan_record_id \
+              "$MERGE_TRAIN_BATCH_LANDING_PLAN_RECORD_ID" \
+            '{
+              schema_version: 1,
+              repository: $repository,
+              base_branch: $base_branch,
+              mode: $mode,
+              candidate_record_id: $candidate_record_id,
+              landing_plan_record_id: $landing_plan_record_id
+            }' > "$request_payload_file"
+          payload_digest="$(sha256sum "$request_payload_file" | cut -d' ' -f1)"
+          idempotency_key="merge-train-batch-landing-run-once"
+          idempotency_key="${idempotency_key}:${GITHUB_RUN_ID}"
+          idempotency_key="${idempotency_key}:${payload_digest}"
+          {
+            echo "idempotency_key=${idempotency_key}"
+            echo "payload_file=${request_payload_file}"
+            echo "response_file=${response_file}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Send batch-landing phase request
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none'
+        id: batch_landing_run
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.admission.outputs.service_audience }}
+          method: POST
+          route-path: /v1/work-graph/merge-train/batch-landing/run-once
+          payload-file: ${{ steps.batch_landing_request.outputs.payload_file }}
+          idempotency-key: ${{ steps.batch_landing_request.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: ${{ steps.batch_landing_request.outputs.response_file }}
+          log-response-body: "false"
+
+      - name: Summarize batch-landing phase response
+        id: batch_landing
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none'
+        shell: bash
+        env:
+          RESPONSE_FILE: ${{ steps.batch_landing_request.outputs.response_file }}
+          STATUS_CODE: ${{ steps.batch_landing_run.outputs.status-code }}
+        run: |
+          set -euo pipefail
+          if [ "$STATUS_CODE" != "202" ]; then
+            cat "$RESPONSE_FILE" >&2
             echo "Merge-train batch-landing phase failed" \
-              "with HTTP ${status_code}." >&2
+              "with HTTP ${STATUS_CODE}." >&2
             exit 1
           fi
 
-          jq . "$response_file"
-          echo "response_file=${response_file}" >> "$GITHUB_OUTPUT"
+          jq . "$RESPONSE_FILE"
+          echo "response_file=${RESPONSE_FILE}" >> "$GITHUB_OUTPUT"
           {
             echo
             echo '## Launchplane merge train batch landing'
             echo
-            echo "- Mode: $(jq -r '.result.mode' "$response_file")"
+            echo "- Mode: $(jq -r '.result.mode' "$RESPONSE_FILE")"
             plan_record="$(
-              jq -r '.records.merge_train_batch_landing_plan_record_id' \
-                "$response_file"
+              jq -r '.records.merge_train_batch_landing_plan_record_id // ""' \
+                "$RESPONSE_FILE"
             )"
             entry_statuses="$(
               jq -r '[.result.landing_plan.entries[].status] | join(",")' \
-                "$response_file"
+                "$RESPONSE_FILE"
             )"
             echo "- Landing-plan record: ${plan_record}"
             echo "- Entry statuses: ${entry_statuses}"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -797,31 +797,43 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "fail-result-paths": frozenset(('""',)),
         "idempotency-key": frozenset(
             (
+                "${{ steps.batch_candidate_request.outputs.idempotency_key }}",
+                "${{ steps.batch_landing_request.outputs.idempotency_key }}",
                 "${{ steps.controller_request.outputs.idempotency_key }}",
                 "${{ steps.level1_request.outputs.idempotency_key }}",
+                "${{ steps.stack_collapse_request.outputs.idempotency_key }}",
             )
         ),
         "log-response-body": frozenset(('"false"',)),
         "method": frozenset(("GET", "POST")),
         "payload-file": frozenset(
             (
+                "${{ steps.batch_candidate_request.outputs.payload_file }}",
+                "${{ steps.batch_landing_request.outputs.payload_file }}",
                 "${{ steps.controller_request.outputs.payload_file }}",
                 "${{ steps.level1_request.outputs.payload_file }}",
+                "${{ steps.stack_collapse_request.outputs.payload_file }}",
             )
         ),
         "response-output-file": frozenset(
             (
                 "${{ steps.admission_request.outputs.response_file }}",
+                "${{ steps.batch_candidate_request.outputs.response_file }}",
+                "${{ steps.batch_landing_request.outputs.response_file }}",
                 "${{ steps.controller_request.outputs.response_file }}",
                 "${{ steps.level1_request.outputs.response_file }}",
                 "${{ steps.scheduled_target_request.outputs.response_file }}",
+                "${{ steps.stack_collapse_request.outputs.response_file }}",
             )
         ),
         "route-path": frozenset(
             (
+                "/v1/work-graph/merge-train/batch-candidate/run-once",
+                "/v1/work-graph/merge-train/batch-landing/run-once",
                 "/v1/work-graph/merge-train/controller/run-once",
                 "/v1/work-graph/merge-train/run-once",
                 "/v1/work-graph/merge-train/policy-targets",
+                "/v1/work-graph/merge-train/stack-collapse/run-once",
                 "${{ steps.admission_request.outputs.route_path }}",
             )
         ),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -67,6 +67,14 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("Prepare merge-train controller request", workflow_text)
         self.assertIn("Send merge-train controller request", workflow_text)
         self.assertIn("Summarize merge-train controller response", workflow_text)
+        for phase_name in (
+            "batch-candidate",
+            "stack-collapse",
+            "batch-landing",
+        ):
+            self.assertIn(f"Prepare {phase_name} phase request", workflow_text)
+            self.assertIn(f"Send {phase_name} phase request", workflow_text)
+            self.assertIn(f"Summarize {phase_name} phase response", workflow_text)
         self.assertIn(
             "uses: cbusillo/launchplane/.github/actions/launchplane-request@main", workflow_text
         )
@@ -87,10 +95,34 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("route-path: /v1/work-graph/merge-train/run-once", workflow_text)
         self.assertIn("route-path: /v1/work-graph/merge-train/controller/run-once", workflow_text)
         self.assertIn(
+            "route-path: /v1/work-graph/merge-train/batch-candidate/run-once",
+            workflow_text,
+        )
+        self.assertIn(
+            "route-path: /v1/work-graph/merge-train/stack-collapse/run-once",
+            workflow_text,
+        )
+        self.assertIn(
+            "route-path: /v1/work-graph/merge-train/batch-landing/run-once",
+            workflow_text,
+        )
+        self.assertIn(
             "payload-file: ${{ steps.level1_request.outputs.payload_file }}", workflow_text
         )
         self.assertIn(
             "payload-file: ${{ steps.controller_request.outputs.payload_file }}", workflow_text
+        )
+        self.assertIn(
+            "payload-file: ${{ steps.batch_candidate_request.outputs.payload_file }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "payload-file: ${{ steps.stack_collapse_request.outputs.payload_file }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "payload-file: ${{ steps.batch_landing_request.outputs.payload_file }}",
+            workflow_text,
         )
         self.assertIn(
             "idempotency-key: ${{ steps.level1_request.outputs.idempotency_key }}",
@@ -98,6 +130,18 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         )
         self.assertIn(
             "idempotency-key: ${{ steps.controller_request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "idempotency-key: ${{ steps.batch_candidate_request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "idempotency-key: ${{ steps.stack_collapse_request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "idempotency-key: ${{ steps.batch_landing_request.outputs.idempotency_key }}",
             workflow_text,
         )
         self.assertIn(
@@ -115,6 +159,18 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "response-output-file: ${{ steps.controller_request.outputs.response_file }}",
             workflow_text,
         )
+        self.assertIn(
+            "response-output-file: ${{ steps.batch_candidate_request.outputs.response_file }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: ${{ steps.stack_collapse_request.outputs.response_file }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: ${{ steps.batch_landing_request.outputs.response_file }}",
+            workflow_text,
+        )
         self.assertIn('fail-result-paths: ""', workflow_text)
         self.assertIn('log-response-body: "false"', workflow_text)
         self.assertIn("launchplane-merge-train-policy-targets.json", workflow_text)
@@ -123,8 +179,17 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("launchplane-merge-train-run-once.json", workflow_text)
         self.assertIn("launchplane-merge-train-controller-run-once-request.json", workflow_text)
         self.assertIn("launchplane-merge-train-controller-run-once.json", workflow_text)
+        self.assertIn("launchplane-merge-train-batch-candidate-request.json", workflow_text)
+        self.assertIn("launchplane-merge-train-batch-candidate.json", workflow_text)
+        self.assertIn("launchplane-merge-train-stack-collapse-request.json", workflow_text)
+        self.assertIn("launchplane-merge-train-stack-collapse.json", workflow_text)
+        self.assertIn("launchplane-merge-train-batch-landing-request.json", workflow_text)
+        self.assertIn("launchplane-merge-train-batch-landing.json", workflow_text)
         self.assertIn('idempotency_key="merge-train-run-once"', workflow_text)
         self.assertIn('idempotency_key="merge-train-controller-run-once"', workflow_text)
+        self.assertIn('idempotency_key="merge-train-batch-candidate-run-once"', workflow_text)
+        self.assertIn('idempotency_key="merge-train-stack-collapse-run-once"', workflow_text)
+        self.assertIn('idempotency_key="merge-train-batch-landing-run-once"', workflow_text)
         self.assertNotIn("${GITHUB_RUN_ATTEMPT}:${payload_digest}", workflow_text)
         self.assertRegex(
             workflow_text,
@@ -138,6 +203,24 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             r"\$\{\{ steps\.controller_request\.outputs\.idempotency_key \}\}.*"
             r"log-response-body: \"false\"",
         )
+        self.assertRegex(
+            workflow_text,
+            r"(?s)Send batch-candidate phase request.*idempotency-key: "
+            r"\$\{\{ steps\.batch_candidate_request\.outputs\.idempotency_key \}\}.*"
+            r"log-response-body: \"false\"",
+        )
+        self.assertRegex(
+            workflow_text,
+            r"(?s)Send stack-collapse phase request.*idempotency-key: "
+            r"\$\{\{ steps\.stack_collapse_request\.outputs\.idempotency_key \}\}.*"
+            r"log-response-body: \"false\"",
+        )
+        self.assertRegex(
+            workflow_text,
+            r"(?s)Send batch-landing phase request.*idempotency-key: "
+            r"\$\{\{ steps\.batch_landing_request\.outputs\.idempotency_key \}\}.*"
+            r"log-response-body: \"false\"",
+        )
         self.assertNotIn(
             '"${service_origin}/v1/work-graph/merge-train/policy-targets"', workflow_text
         )
@@ -146,6 +229,9 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             workflow_text,
         )
         self.assertNotIn('"${SERVICE_ORIGIN}/v1/work-graph/merge-train/run-once"', workflow_text)
+        self.assertNotIn("batch_candidate_url=", workflow_text)
+        self.assertNotIn("stack_collapse_url=", workflow_text)
+        self.assertNotIn("batch_landing_url=", workflow_text)
         self.assertNotIn('"$controller_url"', workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_REPOSITORY", workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_BASE_BRANCH", workflow_text)
@@ -2640,13 +2726,28 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("audience", "${{ steps.admission.outputs.service_audience }}"),
             ("audience", "${{ steps.scheduled_target_request.outputs.service_audience }}"),
             ("fail-result-paths", '""'),
+            (
+                "idempotency-key",
+                "${{ steps.batch_candidate_request.outputs.idempotency_key }}",
+            ),
+            (
+                "idempotency-key",
+                "${{ steps.batch_landing_request.outputs.idempotency_key }}",
+            ),
             ("idempotency-key", "${{ steps.controller_request.outputs.idempotency_key }}"),
             ("idempotency-key", "${{ steps.level1_request.outputs.idempotency_key }}"),
+            (
+                "idempotency-key",
+                "${{ steps.stack_collapse_request.outputs.idempotency_key }}",
+            ),
             ("log-response-body", '"false"'),
             ("method", "GET"),
             ("method", "POST"),
+            ("payload-file", "${{ steps.batch_candidate_request.outputs.payload_file }}"),
+            ("payload-file", "${{ steps.batch_landing_request.outputs.payload_file }}"),
             ("payload-file", "${{ steps.controller_request.outputs.payload_file }}"),
             ("payload-file", "${{ steps.level1_request.outputs.payload_file }}"),
+            ("payload-file", "${{ steps.stack_collapse_request.outputs.payload_file }}"),
             (
                 "response-output-file",
                 "${{ steps.scheduled_target_request.outputs.response_file }}",
@@ -2657,15 +2758,30 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ),
             (
                 "response-output-file",
+                "${{ steps.batch_candidate_request.outputs.response_file }}",
+            ),
+            (
+                "response-output-file",
+                "${{ steps.batch_landing_request.outputs.response_file }}",
+            ),
+            (
+                "response-output-file",
                 "${{ steps.level1_request.outputs.response_file }}",
             ),
             (
                 "response-output-file",
                 "${{ steps.controller_request.outputs.response_file }}",
             ),
+            (
+                "response-output-file",
+                "${{ steps.stack_collapse_request.outputs.response_file }}",
+            ),
             ("route-path", "/v1/work-graph/merge-train/policy-targets"),
+            ("route-path", "/v1/work-graph/merge-train/batch-candidate/run-once"),
+            ("route-path", "/v1/work-graph/merge-train/batch-landing/run-once"),
             ("route-path", "/v1/work-graph/merge-train/controller/run-once"),
             ("route-path", "/v1/work-graph/merge-train/run-once"),
+            ("route-path", "/v1/work-graph/merge-train/stack-collapse/run-once"),
             ("route-path", "${{ steps.admission_request.outputs.route_path }}"),
         ):
             with self.subTest(merge_train_runner_get_mechanic=key):


### PR DESCRIPTION
## Summary
- convert merge-train batch-candidate, stack-collapse, and batch-landing run-once POSTs to the shared `launchplane-request` action
- keep phase validation and summary output local while moving OIDC/request/idempotency handling into the shared action
- extend config-authority allowlist/tests for the new exact shared-action inputs and preserve manual PR feedback curls for a later slice

## Validation
- `python -m py_compile control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run python -m unittest tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_merge_train_runner_uses_shared_request_for_reads_and_worker_posts tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-runner.yml`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `git diff --check`

## Review
- Review agents checked the workflow conversion. One reported no blockers. One flagged preserved optional empty-string payload fields and validation ordering as non-blocking, plus suggested summary null coalescing; summary fallback was patched. Feedback-loop raw curls remain intentionally out of scope for the next slice.