### PR TITLE
Use shared request for merge-train feedback

### DIFF
--- a/.github/actions/launchplane-request/action.yml
+++ b/.github/actions/launchplane-request/action.yml
@@ -20,6 +20,12 @@ inputs:
       Path to a JSON request payload file. Used when payload is empty.
     required: false
     default: ""
+  payload-list-file:
+    description: >-
+      Path to a JSON array of request payload objects to send sequentially.
+      Used for bounded fan-out operations such as PR feedback.
+    required: false
+    default: ""
   payload-fields:
     description: >-
       Newline-separated JSON path assignments to overlay onto the payload after
@@ -45,6 +51,12 @@ inputs:
     default: ""
   idempotency-key:
     description: Stable idempotency key for mutation requests.
+    required: false
+    default: ""
+  idempotency-key-prefix:
+    description: >-
+      Stable prefix for payload-list-file requests. The action appends each
+      payload digest to create per-request idempotency keys.
     required: false
     default: ""
   timeout-ms:

--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -1,4 +1,5 @@
 const fs = require("node:fs");
+const crypto = require("node:crypto");
 const os = require("node:os");
 
 function inputNameToEnvKey(name) {
@@ -143,16 +144,25 @@ async function requestGitHubOidcToken(audience, options) {
 function readPayload() {
   const inlinePayload = getInput("payload");
   const payloadFile = getInput("payload-file");
-  if (inlinePayload && payloadFile) {
-    throw new Error("Use payload or payload-file, not both.");
+  const payloadListFile = getInput("payload-list-file");
+  const configuredPayloadInputs = [inlinePayload, payloadFile, payloadListFile].filter(Boolean);
+  if (configuredPayloadInputs.length > 1) {
+    throw new Error("Use only one of payload, payload-file, or payload-list-file.");
+  }
+  if (payloadListFile) {
+    const payloads = JSON.parse(fs.readFileSync(payloadListFile, "utf8"));
+    if (!Array.isArray(payloads)) {
+      throw new Error("payload-list-file must contain a JSON array.");
+    }
+    return { mode: "list", payloads };
   }
   if (inlinePayload) {
-    return JSON.parse(inlinePayload);
+    return { mode: "single", payload: JSON.parse(inlinePayload) };
   }
   if (payloadFile) {
-    return JSON.parse(fs.readFileSync(payloadFile, "utf8"));
+    return { mode: "single", payload: JSON.parse(fs.readFileSync(payloadFile, "utf8")) };
   }
-  return null;
+  return { mode: "single", payload: null };
 }
 
 function parsePayloadFieldValue(value) {
@@ -207,6 +217,19 @@ function applyPayloadFields(payload) {
     writeJsonPath(payload, path, parsePayloadFieldValue(value));
   }
   return payload;
+}
+
+function applyPayloadTransforms(payloadConfig) {
+  if (payloadConfig.mode === "list") {
+    if (getInput("payload-fields") || getInput("payload-json-files")) {
+      throw new Error("payload-list-file cannot be combined with payload-fields or payload-json-files.");
+    }
+    return payloadConfig;
+  }
+  return {
+    mode: "single",
+    payload: applyPayloadJsonFiles(applyPayloadFields(payloadConfig.payload)),
+  };
 }
 
 function applyPayloadJsonFiles(payload) {
@@ -290,6 +313,13 @@ function writeResponseOutputFile(responseBody) {
   const outputPath = getInput("response-output-path");
   const outputValue = outputPath ? readJsonPath(responseBody, outputPath) : responseBody;
   fs.writeFileSync(outputFile, `${JSON.stringify(outputValue ?? null)}\n`, "utf8");
+}
+
+function payloadDigest(payload) {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(payload))
+    .digest("hex");
 }
 
 function assertResultStatuses(responseBody) {
@@ -396,13 +426,14 @@ async function main() {
   const requestUrl = new URL(routePath, launchplaneUrl).toString();
   const audience = getInput("audience") || launchplaneUrl.host;
   const idempotencyKey = getInput("idempotency-key");
+  const idempotencyKeyPrefix = getInput("idempotency-key-prefix");
   const logResponseBody = parseBooleanInput(
     getInput("log-response-body", { defaultValue: "true" }),
     "log-response-body",
   );
-  const payload = applyPayloadJsonFiles(applyPayloadFields(readPayload()));
+  const payloadConfig = applyPayloadTransforms(readPayload());
   const options = getActionOptions();
-  async function requestInit() {
+  async function requestInit(payload, requestIdempotencyKey) {
     const token = await requestGitHubOidcToken(audience, options);
     const headers = {
       Authorization: `Bearer ${token}`,
@@ -413,8 +444,8 @@ async function main() {
       headers,
       signal: buildAbortSignal(getInput("timeout-ms", { defaultValue: "0" })),
     };
-    if (idempotencyKey) {
-      headers["Idempotency-Key"] = idempotencyKey;
+    if (requestIdempotencyKey) {
+      headers["Idempotency-Key"] = requestIdempotencyKey;
     }
     if (payload !== null) {
       headers["Content-Type"] = "application/json";
@@ -423,9 +454,83 @@ async function main() {
     return init;
   }
 
+  if (payloadConfig.mode === "list") {
+    if (idempotencyKey) {
+      throw new Error("Use idempotency-key-prefix with payload-list-file, not idempotency-key.");
+    }
+    if (!idempotencyKeyPrefix) {
+      throw new Error("idempotency-key-prefix is required when payload-list-file is set.");
+    }
+    if (payloadConfig.payloads.length === 0) {
+      setOutput("launchplane-url", requestUrl);
+      setOutput("route-path", routePath);
+      setOutput("audience", audience);
+      setOutput("status-code", "");
+      setOutput("response-body", "[]");
+      writeResponseOutputFile([]);
+      if (logResponseBody) {
+        process.stdout.write("[]\n");
+      }
+      return;
+    }
+    for (const [index, payload] of payloadConfig.payloads.entries()) {
+      if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+        throw new Error(`payload-list-file entry ${index + 1} must be a JSON object.`);
+      }
+    }
+    const responseBodies = [];
+    let lastStatus = "";
+    for (const [index, payload] of payloadConfig.payloads.entries()) {
+      const requestIdempotencyKey = `${idempotencyKeyPrefix}:${payloadDigest(payload)}`;
+      let response;
+      let responseBody;
+      let responseText;
+      try {
+        ({ response, responseBody, responseText } = await requestLaunchplaneUntilComplete(
+          requestUrl,
+          () => requestInit(payload, requestIdempotencyKey),
+          options,
+        ));
+      } catch (error) {
+        if (responseBodies.length > 0) {
+          writeResponseOutputFile(responseBodies);
+        }
+        throw error;
+      }
+      lastStatus = String(response.status);
+      responseBodies.push(responseBody);
+      if (!response.ok) {
+        writeResponseOutputFile(responseBodies);
+        const responseDetail = logResponseBody ? `: ${responseText || "empty response"}` : "";
+        throw new Error(
+          `Launchplane request ${index + 1} failed with ${response.status}${responseDetail}`,
+        );
+      }
+      try {
+        assertResultStatuses(responseBody);
+      } catch (error) {
+        writeResponseOutputFile(responseBodies);
+        throw error;
+      }
+    }
+    setOutput("launchplane-url", requestUrl);
+    setOutput("route-path", routePath);
+    setOutput("audience", audience);
+    setOutput("status-code", lastStatus);
+    setOutput("response-body", JSON.stringify(responseBodies));
+    writeMappedOutputs(responseBodies.at(-1) ?? {});
+    writeResponseOutputFile(responseBodies);
+    if (logResponseBody) {
+      process.stdout.write(`${JSON.stringify(responseBodies, null, 2)}\n`);
+    }
+    return;
+  }
+
+  const payload = payloadConfig.payload;
+
   const { response, responseBody, responseText } = await requestLaunchplaneUntilComplete(
     requestUrl,
-    requestInit,
+    () => requestInit(payload, idempotencyKey),
     options,
   );
 

--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -291,17 +291,6 @@ jobs:
           : "${MERGE_TRAIN_REPOSITORY:?Set repository input or enable one policy scheduler target}"
           : "${MERGE_TRAIN_BASE_BRANCH:?Missing base branch}"
 
-          service_origin="$({
-            python3 - <<'PY'
-          import os
-          from urllib.parse import urlsplit
-
-          parsed = urlsplit(os.environ["LAUNCHPLANE_URL"].strip())
-          if not parsed.scheme or not parsed.netloc or not parsed.hostname:
-              raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
-          print(f"{parsed.scheme}://{parsed.netloc}")
-          PY
-          })"
           service_audience="$({
             python3 - <<'PY'
           import os
@@ -327,7 +316,6 @@ jobs:
           response_file="launchplane-merge-train-admission.json"
           {
             echo "should_request=true"
-            echo "service_origin=${service_origin}"
             echo "service_audience=${service_audience}"
             echo "route_path=/v1/work-graph/merge-train/admission?${query_string}"
             echo "response_file=${response_file}"
@@ -351,7 +339,6 @@ jobs:
         shell: bash
         env:
           RESPONSE_FILE: ${{ steps.admission_request.outputs.response_file }}
-          SERVICE_ORIGIN: ${{ steps.admission_request.outputs.service_origin }}
           SERVICE_AUDIENCE: ${{ steps.admission_request.outputs.service_audience }}
           SHOULD_REQUEST: ${{ steps.admission_request.outputs.should_request }}
           STATUS_CODE: ${{ steps.admission_read.outputs.status-code }}
@@ -378,7 +365,6 @@ jobs:
             jq -r '.admission.next_allowed_at' "$RESPONSE_FILE"
           )"
           {
-            echo "service_origin=${SERVICE_ORIGIN}"
             echo "service_audience=${SERVICE_AUDIENCE}"
             echo "admission_status=${admission_status}"
             echo "reason_code=${reason_code}"
@@ -585,13 +571,12 @@ jobs:
           log-response-body: "false"
 
       - name: Summarize merge-train controller response
+        id: controller_summary
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'controller'
         shell: bash
         env:
-          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
-          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
           RESPONSE_FILE: ${{ steps.controller_request.outputs.response_file }}
           STATUS_CODE: ${{ steps.controller_run.outputs.status-code }}
         run: |
@@ -612,42 +597,15 @@ jobs:
           if [ "$MERGE_TRAIN_MUTATE" != "true" ]; then
             feedback_count=0
           fi
-          if [ "$feedback_count" -gt 0 ]; then
-            oidc_token="$({
-              curl -fsSL \
-                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-              | jq -r '.value'
-            })"
-            feedback_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train/pr-feedback"
-            feedback_index=0
-            while IFS= read -r feedback_payload; do
-              feedback_index="$((feedback_index + 1))"
-              feedback_response="launchplane-merge-train-feedback-${feedback_index}.json"
-              feedback_payload_digest="$(
-                printf '%s' "$feedback_payload" | sha256sum | cut -d' ' -f1
-              )"
-              feedback_idempotency_key="merge-train-feedback:controller"
-              feedback_idempotency_key="${feedback_idempotency_key}:${GITHUB_RUN_ID}"
-              feedback_idempotency_key="${feedback_idempotency_key}:${feedback_payload_digest}"
-              feedback_status="$(curl -sS \
-                -o "$feedback_response" \
-                -w '%{http_code}' \
-                -X POST \
-                -H "Authorization: Bearer ${oidc_token}" \
-                -H "Idempotency-Key: ${feedback_idempotency_key}" \
-                -H 'Content-Type: application/json' \
-                --data "$feedback_payload" \
-                "$feedback_url")"
-              if [ "$feedback_status" != "202" ]; then
-                cat "$feedback_response" >&2
-                echo "Merge-train PR feedback failed" \
-                  "with HTTP ${feedback_status}." >&2
-                exit 1
-              fi
-              jq . "$feedback_response"
-            done < <(jq -c '.[]' "$feedback_payloads")
-          fi
+          feedback_response="launchplane-merge-train-feedback-responses.json"
+          feedback_idempotency_key_prefix="merge-train-feedback:controller"
+          feedback_idempotency_key_prefix="${feedback_idempotency_key_prefix}:${GITHUB_RUN_ID}"
+          {
+            echo "feedback_count=${feedback_count}"
+            echo "feedback_idempotency_key_prefix=${feedback_idempotency_key_prefix}"
+            echo "feedback_payloads=${feedback_payloads}"
+            echo "feedback_response=${feedback_response}"
+          } >> "$GITHUB_OUTPUT"
           {
             echo
             echo '## Launchplane merge train controller'
@@ -674,6 +632,24 @@ jobs:
             echo "- Stack-collapse record: ${stack_record}"
             echo "- Feedback payloads: ${feedback_count}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Send merge-train controller PR feedback
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_RUNNER_MODE == 'controller' &&
+          steps.controller_summary.outputs.feedback_count != '0'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.admission.outputs.service_audience }}
+          method: POST
+          route-path: /v1/work-graph/merge-train/pr-feedback
+          payload-list-file: ${{ steps.controller_summary.outputs.feedback_payloads }}
+          idempotency-key-prefix: >-
+            ${{ steps.controller_summary.outputs.feedback_idempotency_key_prefix }}
+          fail-result-paths: ""
+          response-output-file: ${{ steps.controller_summary.outputs.feedback_response }}
+          log-response-body: "false"
 
       - name: Prepare batch-candidate phase request
         id: batch_candidate_request
@@ -1010,6 +986,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Post manual phase PR feedback
+        id: manual_phase_feedback
         if: >-
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'level1' &&
@@ -1018,8 +995,6 @@ jobs:
           steps.batch_landing.outputs.response_file != '')
         shell: bash
         env:
-          SERVICE_ORIGIN: ${{ steps.admission.outputs.service_origin }}
-          SERVICE_AUDIENCE: ${{ steps.admission.outputs.service_audience }}
           BATCH_CANDIDATE_RESPONSE: >-
             ${{ steps.batch_candidate.outputs.response_file }}
           STACK_COLLAPSE_RESPONSE: >-
@@ -1052,42 +1027,18 @@ jobs:
             --source "workflow:merge-train-runner:${phase}" \
             > "$feedback_payloads"
           feedback_count="$(jq 'length' "$feedback_payloads")"
-          if [ "$feedback_count" -gt 0 ]; then
-            oidc_token="$({
-              curl -fsSL \
-                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-              | jq -r '.value'
-            })"
-            feedback_url="${SERVICE_ORIGIN}/v1/work-graph/merge-train/pr-feedback"
-            feedback_index=0
-            while IFS= read -r feedback_payload; do
-              feedback_index="$((feedback_index + 1))"
-              feedback_response="launchplane-manual-phase-feedback-${feedback_index}.json"
-              feedback_payload_digest="$(
-                printf '%s' "$feedback_payload" | sha256sum | cut -d' ' -f1
-              )"
-              feedback_idempotency_key="merge-train-feedback:${phase}"
-              feedback_idempotency_key="${feedback_idempotency_key}:${GITHUB_RUN_ID}"
-              feedback_idempotency_key="${feedback_idempotency_key}:${feedback_payload_digest}"
-              feedback_status="$(curl -sS \
-                -o "$feedback_response" \
-                -w '%{http_code}' \
-                -X POST \
-                -H "Authorization: Bearer ${oidc_token}" \
-                -H "Idempotency-Key: ${feedback_idempotency_key}" \
-                -H 'Content-Type: application/json' \
-                --data "$feedback_payload" \
-                "$feedback_url")"
-              if [ "$feedback_status" != "202" ]; then
-                cat "$feedback_response" >&2
-                echo "Merge-train manual phase feedback failed" \
-                  "with HTTP ${feedback_status}." >&2
-                exit 1
-              fi
-              jq . "$feedback_response"
-            done < <(jq -c '.[]' "$feedback_payloads")
+          if [ "$MERGE_TRAIN_MUTATE" != "true" ]; then
+            feedback_count=0
           fi
+          feedback_response="launchplane-merge-train-${phase}-feedback-responses.json"
+          feedback_idempotency_key_prefix="merge-train-feedback:${phase}"
+          feedback_idempotency_key_prefix="${feedback_idempotency_key_prefix}:${GITHUB_RUN_ID}"
+          {
+            echo "feedback_count=${feedback_count}"
+            echo "feedback_idempotency_key_prefix=${feedback_idempotency_key_prefix}"
+            echo "feedback_payloads=${feedback_payloads}"
+            echo "feedback_response=${feedback_response}"
+          } >> "$GITHUB_OUTPUT"
           {
             echo
             echo '## Launchplane merge train manual phase feedback'
@@ -1095,6 +1046,24 @@ jobs:
             echo "- Phase: ${phase}"
             echo "- Feedback payloads: ${feedback_count}"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Send manual phase PR feedback
+        if: >-
+          steps.admission.outputs.admission_status == 'admitted' &&
+          env.MERGE_TRAIN_RUNNER_MODE == 'level1' &&
+          steps.manual_phase_feedback.outputs.feedback_count != '0'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.admission.outputs.service_audience }}
+          method: POST
+          route-path: /v1/work-graph/merge-train/pr-feedback
+          payload-list-file: ${{ steps.manual_phase_feedback.outputs.feedback_payloads }}
+          idempotency-key-prefix: >-
+            ${{ steps.manual_phase_feedback.outputs.feedback_idempotency_key_prefix }}
+          fail-result-paths: ""
+          response-output-file: ${{ steps.manual_phase_feedback.outputs.feedback_response }}
+          log-response-body: "false"
 
       - name: Record deferred decision
         if: steps.admission.outputs.admission_status != 'admitted'

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -804,6 +804,12 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
                 "${{ steps.stack_collapse_request.outputs.idempotency_key }}",
             )
         ),
+        "idempotency-key-prefix": frozenset(
+            (
+                "${{ steps.controller_summary.outputs.feedback_idempotency_key_prefix }}",
+                "${{ steps.manual_phase_feedback.outputs.feedback_idempotency_key_prefix }}",
+            )
+        ),
         "log-response-body": frozenset(('"false"',)),
         "method": frozenset(("GET", "POST")),
         "payload-file": frozenset(
@@ -815,13 +821,21 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
                 "${{ steps.stack_collapse_request.outputs.payload_file }}",
             )
         ),
+        "payload-list-file": frozenset(
+            (
+                "${{ steps.controller_summary.outputs.feedback_payloads }}",
+                "${{ steps.manual_phase_feedback.outputs.feedback_payloads }}",
+            )
+        ),
         "response-output-file": frozenset(
             (
                 "${{ steps.admission_request.outputs.response_file }}",
                 "${{ steps.batch_candidate_request.outputs.response_file }}",
                 "${{ steps.batch_landing_request.outputs.response_file }}",
                 "${{ steps.controller_request.outputs.response_file }}",
+                "${{ steps.controller_summary.outputs.feedback_response }}",
                 "${{ steps.level1_request.outputs.response_file }}",
+                "${{ steps.manual_phase_feedback.outputs.feedback_response }}",
                 "${{ steps.scheduled_target_request.outputs.response_file }}",
                 "${{ steps.stack_collapse_request.outputs.response_file }}",
             )
@@ -831,6 +845,7 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
                 "/v1/work-graph/merge-train/batch-candidate/run-once",
                 "/v1/work-graph/merge-train/batch-landing/run-once",
                 "/v1/work-graph/merge-train/controller/run-once",
+                "/v1/work-graph/merge-train/pr-feedback",
                 "/v1/work-graph/merge-train/run-once",
                 "/v1/work-graph/merge-train/policy-targets",
                 "/v1/work-graph/merge-train/stack-collapse/run-once",

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -321,6 +321,13 @@ For an existing repo, classify each workflow and script before deleting code:
   keep only dispatch inputs, confirmation text, and product-owned build or test
   facts locally.
 
+`launchplane-request` also supports `payload-list-file` with
+`idempotency-key-prefix` for bounded fan-out where Launchplane has already
+generated a JSON array of public-safe request payloads, such as merge-train PR
+feedback delivery. The action appends a stable digest for each payload, requests
+GitHub OIDC per POST, and writes a JSON response array. Do not use shell loops
+or repo-local OIDC clients for those remaining connector calls.
+
 Odoo artifact publication now follows the reusable workflow shape: tenant repos
 own the manual dispatch confirmation and the source workspace, while
 `reusable-odoo-artifact-publish.yml` owns the Launchplane publish-input request,

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -55,7 +55,9 @@ def _gaps(payload: dict[str, object]) -> list[dict[str, object]]:
 
 
 class ConfigAuthorityAuditTest(unittest.TestCase):
-    def test_merge_train_runner_uses_shared_request_for_reads_and_worker_posts(self) -> None:
+    def test_merge_train_runner_uses_shared_request_for_reads_worker_and_feedback_posts(
+        self,
+    ) -> None:
         workflow_text = Path(".github/workflows/merge-train-runner.yml").read_text(encoding="utf-8")
 
         self.assertIn("/v1/work-graph/merge-train/policy-targets", workflow_text)
@@ -67,6 +69,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("Prepare merge-train controller request", workflow_text)
         self.assertIn("Send merge-train controller request", workflow_text)
         self.assertIn("Summarize merge-train controller response", workflow_text)
+        self.assertIn("Send merge-train controller PR feedback", workflow_text)
         for phase_name in (
             "batch-candidate",
             "stack-collapse",
@@ -75,6 +78,8 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             self.assertIn(f"Prepare {phase_name} phase request", workflow_text)
             self.assertIn(f"Send {phase_name} phase request", workflow_text)
             self.assertIn(f"Summarize {phase_name} phase response", workflow_text)
+        self.assertIn("Post manual phase PR feedback", workflow_text)
+        self.assertIn("Send manual phase PR feedback", workflow_text)
         self.assertIn(
             "uses: cbusillo/launchplane/.github/actions/launchplane-request@main", workflow_text
         )
@@ -94,6 +99,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         )
         self.assertIn("route-path: /v1/work-graph/merge-train/run-once", workflow_text)
         self.assertIn("route-path: /v1/work-graph/merge-train/controller/run-once", workflow_text)
+        self.assertIn("route-path: /v1/work-graph/merge-train/pr-feedback", workflow_text)
         self.assertIn(
             "route-path: /v1/work-graph/merge-train/batch-candidate/run-once",
             workflow_text,
@@ -125,6 +131,14 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             workflow_text,
         )
         self.assertIn(
+            "payload-list-file: ${{ steps.controller_summary.outputs.feedback_payloads }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "payload-list-file: ${{ steps.manual_phase_feedback.outputs.feedback_payloads }}",
+            workflow_text,
+        )
+        self.assertIn(
             "idempotency-key: ${{ steps.level1_request.outputs.idempotency_key }}",
             workflow_text,
         )
@@ -142,6 +156,14 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         )
         self.assertIn(
             "idempotency-key: ${{ steps.batch_landing_request.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "${{ steps.controller_summary.outputs.feedback_idempotency_key_prefix }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "${{ steps.manual_phase_feedback.outputs.feedback_idempotency_key_prefix }}",
             workflow_text,
         )
         self.assertIn(
@@ -171,6 +193,14 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "response-output-file: ${{ steps.batch_landing_request.outputs.response_file }}",
             workflow_text,
         )
+        self.assertIn(
+            "response-output-file: ${{ steps.controller_summary.outputs.feedback_response }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: ${{ steps.manual_phase_feedback.outputs.feedback_response }}",
+            workflow_text,
+        )
         self.assertIn('fail-result-paths: ""', workflow_text)
         self.assertIn('log-response-body: "false"', workflow_text)
         self.assertIn("launchplane-merge-train-policy-targets.json", workflow_text)
@@ -185,11 +215,23 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("launchplane-merge-train-stack-collapse.json", workflow_text)
         self.assertIn("launchplane-merge-train-batch-landing-request.json", workflow_text)
         self.assertIn("launchplane-merge-train-batch-landing.json", workflow_text)
+        self.assertIn("launchplane-merge-train-controller-feedback.json", workflow_text)
+        self.assertIn("launchplane-merge-train-feedback-responses.json", workflow_text)
+        self.assertIn("launchplane-merge-train-${phase}-feedback.json", workflow_text)
+        self.assertIn("launchplane-merge-train-${phase}-feedback-responses.json", workflow_text)
         self.assertIn('idempotency_key="merge-train-run-once"', workflow_text)
         self.assertIn('idempotency_key="merge-train-controller-run-once"', workflow_text)
         self.assertIn('idempotency_key="merge-train-batch-candidate-run-once"', workflow_text)
         self.assertIn('idempotency_key="merge-train-stack-collapse-run-once"', workflow_text)
         self.assertIn('idempotency_key="merge-train-batch-landing-run-once"', workflow_text)
+        self.assertIn(
+            'feedback_idempotency_key_prefix="merge-train-feedback:controller"',
+            workflow_text,
+        )
+        self.assertIn(
+            'feedback_idempotency_key_prefix="merge-train-feedback:${phase}"',
+            workflow_text,
+        )
         self.assertNotIn("${GITHUB_RUN_ATTEMPT}:${payload_digest}", workflow_text)
         self.assertRegex(
             workflow_text,
@@ -221,6 +263,18 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             r"\$\{\{ steps\.batch_landing_request\.outputs\.idempotency_key \}\}.*"
             r"log-response-body: \"false\"",
         )
+        self.assertRegex(
+            workflow_text,
+            r"(?s)Send merge-train controller PR feedback.*payload-list-file: "
+            r"\$\{\{ steps\.controller_summary\.outputs\.feedback_payloads \}\}.*"
+            r"log-response-body: \"false\"",
+        )
+        self.assertRegex(
+            workflow_text,
+            r"(?s)Send manual phase PR feedback.*payload-list-file: "
+            r"\$\{\{ steps\.manual_phase_feedback\.outputs\.feedback_payloads \}\}.*"
+            r"log-response-body: \"false\"",
+        )
         self.assertNotIn(
             '"${service_origin}/v1/work-graph/merge-train/policy-targets"', workflow_text
         )
@@ -233,6 +287,10 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertNotIn("stack_collapse_url=", workflow_text)
         self.assertNotIn("batch_landing_url=", workflow_text)
         self.assertNotIn('"$controller_url"', workflow_text)
+        self.assertNotIn("feedback_url=", workflow_text)
+        self.assertNotIn('"$feedback_url"', workflow_text)
+        self.assertNotIn("feedback_status=", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_REPOSITORY", workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_BASE_BRANCH", workflow_text)
         self.assertNotIn("LAUNCHPLANE_MERGE_TRAIN_MUTATE", workflow_text)

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -125,6 +125,160 @@ process.on('beforeExit', () => {{
             self.assertEqual(json.loads(calls[1]["body"])["product"], "sellyouroutboard")
             self.assertIn("application_id<<", output_path.read_text(encoding="utf-8"))
 
+    def test_posts_payload_list_with_per_payload_idempotency_keys(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            payload_list_path = Path(temporary_directory) / "payloads.json"
+            response_output_path = Path(temporary_directory) / "responses.json"
+            payloads = [
+                {
+                    "schema_version": 1,
+                    "repository": "example/repo",
+                    "pull_request_number": 1,
+                },
+                {
+                    "schema_version": 1,
+                    "repository": "example/repo",
+                    "pull_request_number": 2,
+                },
+            ]
+            payload_list_path.write_text(json.dumps(payloads), encoding="utf-8")
+            result = self.run_action(
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/work-graph/merge-train/pr-feedback",
+                    "payload-list-file": str(payload_list_path),
+                    "idempotency-key-prefix": "merge-train-feedback:controller:run-1",
+                    "response-output-file": str(response_output_path),
+                    "log-response-body": "false",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(json.loads(response_output_path.read_text(encoding="utf-8")), [
+                {
+                    "ok": True,
+                    "result": {
+                        "refresh_status": "pass",
+                        "error_message": "",
+                        "application_id": "app-123",
+                    },
+                },
+                {
+                    "ok": True,
+                    "result": {
+                        "refresh_status": "pass",
+                        "error_message": "",
+                        "application_id": "app-123",
+                    },
+                },
+            ])
+            calls = json.loads(result.stderr.strip().splitlines()[-1])
+            launchplane_calls = [
+                call
+                for call in calls
+                if call["url"]
+                == "https://launchplane.example/v1/work-graph/merge-train/pr-feedback"
+            ]
+            self.assertEqual(len(launchplane_calls), 2)
+            self.assertEqual(
+                [call["headers"]["Authorization"] for call in launchplane_calls],
+                ["Bearer oidc-token-1", "Bearer oidc-token-2"],
+            )
+            self.assertTrue(
+                all(
+                    call["headers"]["Idempotency-Key"].startswith(
+                        "merge-train-feedback:controller:run-1:"
+                    )
+                    for call in launchplane_calls
+                )
+            )
+            self.assertNotEqual(
+                launchplane_calls[0]["headers"]["Idempotency-Key"],
+                launchplane_calls[1]["headers"]["Idempotency-Key"],
+            )
+            self.assertEqual(json.loads(launchplane_calls[0]["body"]), payloads[0])
+            self.assertEqual(json.loads(launchplane_calls[1]["body"]), payloads[1])
+            self.assertEqual(result.stdout, "")
+
+    def test_payload_list_requires_idempotency_prefix(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            payload_list_path = Path(temporary_directory) / "payloads.json"
+            payload_list_path.write_text("[]", encoding="utf-8")
+            result = self.run_action(
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/work-graph/merge-train/pr-feedback",
+                    "payload-list-file": str(payload_list_path),
+                },
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("idempotency-key-prefix is required", result.stderr)
+
+    def test_payload_list_validates_all_entries_before_posting(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            payload_list_path = Path(temporary_directory) / "payloads.json"
+            payload_list_path.write_text(
+                json.dumps(
+                    [
+                        {"schema_version": 1, "pull_request_number": 1},
+                        ["not", "an", "object"],
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_action(
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/work-graph/merge-train/pr-feedback",
+                    "payload-list-file": str(payload_list_path),
+                    "idempotency-key-prefix": "merge-train-feedback:controller:run-1",
+                },
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("payload-list-file entry 2 must be a JSON object", result.stderr)
+        self.assertEqual(json.loads(result.stderr.strip().splitlines()[-1]), [])
+
+    def test_payload_list_writes_prior_responses_when_later_request_throws(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            payload_list_path = Path(temporary_directory) / "payloads.json"
+            response_output_path = Path(temporary_directory) / "responses.json"
+            payload_list_path.write_text(
+                json.dumps(
+                    [
+                        {"schema_version": 1, "pull_request_number": 1},
+                        {"schema_version": 1, "pull_request_number": 2},
+                    ]
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_action(
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/work-graph/merge-train/pr-feedback",
+                    "payload-list-file": str(payload_list_path),
+                    "idempotency-key-prefix": "merge-train-feedback:controller:run-1",
+                    "response-output-file": str(response_output_path),
+                    "retry-attempts": "1",
+                    "log-response-body": "false",
+                },
+                environment={"TEST_LAUNCHPLANE_NETWORK_FAILURE_ATTEMPTS": "2"},
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("simulated Launchplane network failure", result.stderr)
+            self.assertEqual(json.loads(response_output_path.read_text(encoding="utf-8")), [
+                {
+                    "ok": True,
+                    "result": {
+                        "refresh_status": "pass",
+                        "error_message": "",
+                        "application_id": "app-123",
+                    },
+                }
+            ])
+
     def test_retries_launchplane_request_with_fresh_oidc_token(self) -> None:
         result = self.run_action(
             inputs={


### PR DESCRIPTION
## Summary

- add bounded `payload-list-file` fan-out support to `launchplane-request` with per-payload idempotency keys and response-array output
- replace merge-train PR-feedback raw OIDC/curl loops with the shared request action
- clean unused merge-train service-origin threading and keep feedback disabled for dry-run/manual phase flows
- update config-authority allowlists, product-repo contract docs, and focused tests

## Validation

- `node --check .github/actions/launchplane-request/dist/index.js`
- `python -m py_compile tests/test_launchplane_request_action.py control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-runner.yml`
- `uv run python -m unittest tests.test_launchplane_request_action tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_merge_train_runner_uses_shared_request_for_reads_worker_and_feedback_posts tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `uv run --extra dev ruff check --diff control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_launchplane_request_action.py`
- `git diff --check`

## Review

- Agent review caught list-mode preflight validation/partial-response evidence gaps; fixed with tests.
- Agent review caught manual feedback dry-run asymmetry and unused service-origin output; fixed.
- Verified `actions/checkout@v6` tag exists upstream before leaving the existing workflow reference untouched.
