### PR TITLE
Use shared request for merge train policy import

### DIFF
--- a/.github/workflows/merge-train-policy-import.yml
+++ b/.github/workflows/merge-train-policy-import.yml
@@ -20,6 +20,10 @@ name: Merge Train Policy Import
         description: Label Launchplane applies when a pull request blocks
         required: true
         type: string
+      stack_child_disposition_label:
+        description: Label Launchplane applies to stacked child pull requests
+        required: true
+        type: string
       merge_method:
         description: GitHub merge method
         required: true
@@ -54,7 +58,8 @@ permissions:
   id-token: write
 
 concurrency:
-  group: merge-train-policy-import
+  group: >-
+    merge-train-policy-import:${{ inputs.repository }}:${{ inputs.base_branch }}
   cancel-in-progress: false
 
 jobs:
@@ -69,6 +74,7 @@ jobs:
       POLICY_BASE_BRANCH: ${{ inputs.base_branch }}
       POLICY_ENQUEUE_LABEL: ${{ inputs.enqueue_label }}
       POLICY_BLOCKED_LABEL: ${{ inputs.blocked_label }}
+      POLICY_STACK_CHILD_DISPOSITION_LABEL: ${{ inputs.stack_child_disposition_label }}
       POLICY_MERGE_METHOD: ${{ inputs.merge_method }}
       POLICY_FAILURE_POLICY: ${{ inputs.failure_policy }}
       POLICY_SOURCE_LABEL: ${{ inputs.source_label }}
@@ -90,7 +96,6 @@ jobs:
               raise SystemExit("LAUNCHPLANE_URL must be an absolute URL.")
           output_path = os.environ["GITHUB_OUTPUT"]
           with open(output_path, "a", encoding="utf-8") as handle:
-              handle.write(f"origin={parsed.scheme}://{parsed.netloc}\n")
               handle.write(f"audience={parsed.hostname}\n")
           PY
 
@@ -111,12 +116,16 @@ jobs:
           policy_file="${RUNNER_TEMP}/merge-train-policy.toml"
           python3 - <<'PY' > "$policy_file"
           import os
+          import json
 
           values = {
               "repository": os.environ["POLICY_REPOSITORY"].strip(),
               "base_branch": os.environ["POLICY_BASE_BRANCH"].strip(),
               "enqueue_label": os.environ["POLICY_ENQUEUE_LABEL"].strip(),
               "blocked_label": os.environ["POLICY_BLOCKED_LABEL"].strip(),
+              "stack_child_disposition_label": os.environ[
+                  "POLICY_STACK_CHILD_DISPOSITION_LABEL"
+              ].strip(),
               "merge_method": os.environ["POLICY_MERGE_METHOD"].strip(),
               "failure_policy": os.environ["POLICY_FAILURE_POLICY"].strip(),
           }
@@ -129,6 +138,14 @@ jobs:
               raise SystemExit("repository must be owner/name")
           if values["enqueue_label"] == values["blocked_label"]:
               raise SystemExit("enqueue_label and blocked_label must differ")
+          if values["stack_child_disposition_label"] in {
+              values["enqueue_label"],
+              values["blocked_label"],
+          }:
+              raise SystemExit(
+                  "stack_child_disposition_label must differ from enqueue_label "
+                  "and blocked_label"
+              )
           print("schema_version = 1")
           print()
           print("[[policies]]")
@@ -137,10 +154,11 @@ jobs:
               "base_branch",
               "enqueue_label",
               "blocked_label",
+              "stack_child_disposition_label",
               "merge_method",
               "failure_policy",
           ):
-              print(f'{key} = "{values[key]}"')
+              print(f"{key} = {json.dumps(values[key])}")
           print()
           print("[policies.enqueue]")
           print("label_required = true")
@@ -168,36 +186,32 @@ jobs:
           )"
           echo "file=${policy_file}" >> "$GITHUB_OUTPUT"
           echo "sha256=${policy_sha256}" >> "$GITHUB_OUTPUT"
+          dry_run_payload="merge-train-policy-dry-run-request.json"
+          uv run launchplane merge-train-policies build-import-request \
+            --policy-file "$policy_file" \
+            --source-label "$POLICY_SOURCE_LABEL" \
+            --dry-run \
+            > "$dry_run_payload"
+          echo "dry_run_payload=${dry_run_payload}" >> "$GITHUB_OUTPUT"
 
       - name: Request policy import dry-run
         id: dry_run
-        shell: bash
-        env:
-          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
-          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
-          POLICY_FILE: ${{ steps.policy.outputs.file }}
-        run: |
-          set -euo pipefail
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
-          })"
-          LAUNCHPLANE_SERVICE_TOKEN="$oidc_token" \
-            uv run launchplane merge-train-policies import-policy \
-              --service-url "$SERVICE_ORIGIN" \
-              --policy-file "$POLICY_FILE" \
-              --source-label "$POLICY_SOURCE_LABEL" \
-              --dry-run \
-              | tee merge-train-policy-dry-run.json
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.service.outputs.audience }}
+          method: POST
+          route-path: /v1/merge-train/policies/import
+          payload-file: ${{ steps.policy.outputs.dry_run_payload }}
+          fail-result-paths: ""
+          response-output-file: merge-train-policy-dry-run.json
+          log-response-body: "false"
 
-      - name: Apply policy import
+      - name: Build policy apply payload
+        id: apply_policy
         if: env.APPLY_POLICY == 'true'
         shell: bash
         env:
-          SERVICE_ORIGIN: ${{ steps.service.outputs.origin }}
-          SERVICE_AUDIENCE: ${{ steps.service.outputs.audience }}
           POLICY_FILE: ${{ steps.policy.outputs.file }}
         run: |
           set -euo pipefail
@@ -206,28 +220,39 @@ jobs:
             echo "reason is required when apply is true" >&2
             exit 1
           fi
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${SERVICE_AUDIENCE}" \
-            | jq -r '.value'
+          apply_payload="merge-train-policy-apply-request.json"
+          idempotency_key="$({
+            printf 'merge-train-policy-import:%s:%s:%s:%s:%s' \
+              "$POLICY_REPOSITORY" \
+              "$POLICY_BASE_BRANCH" \
+              '${{ steps.policy.outputs.sha256 }}' \
+              "$GITHUB_RUN_ID" \
+              "$GITHUB_RUN_ATTEMPT"
           })"
-          LAUNCHPLANE_SERVICE_TOKEN="$oidc_token" \
-            uv run launchplane merge-train-policies import-policy \
-              --service-url "$SERVICE_ORIGIN" \
-              --policy-file "$POLICY_FILE" \
-              --source-label "$POLICY_SOURCE_LABEL" \
-              --reason "$reason" \
-              --idempotency-key "$({
-                printf 'merge-train-policy-import:%s:%s:%s:%s:%s' \
-                  "$POLICY_REPOSITORY" \
-                  "$POLICY_BASE_BRANCH" \
-                  '${{ steps.policy.outputs.sha256 }}' \
-                  "$GITHUB_RUN_ID" \
-                  "$GITHUB_RUN_ATTEMPT"
-              })" \
-              --apply \
-              | tee merge-train-policy-apply.json
+          uv run launchplane merge-train-policies build-import-request \
+            --policy-file "$POLICY_FILE" \
+            --source-label "$POLICY_SOURCE_LABEL" \
+            --reason "$reason" \
+            --apply \
+            > "$apply_payload"
+          {
+            echo "idempotency_key=${idempotency_key}"
+            echo "payload=${apply_payload}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Apply policy import
+        if: env.APPLY_POLICY == 'true'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_URL }}
+          audience: ${{ steps.service.outputs.audience }}
+          method: POST
+          route-path: /v1/merge-train/policies/import
+          payload-file: ${{ steps.apply_policy.outputs.payload }}
+          idempotency-key: ${{ steps.apply_policy.outputs.idempotency_key }}
+          fail-result-paths: ""
+          response-output-file: merge-train-policy-apply.json
+          log-response-body: "false"
 
       - name: Summarize
         shell: bash

--- a/control_plane/cli_policy_profiles.py
+++ b/control_plane/cli_policy_profiles.py
@@ -826,6 +826,48 @@ def merge_train_policies_list(database_url: str, status_filter: str) -> None:
     )
 
 
+@merge_train_policies.command("build-import-request")
+@click.option(
+    "--policy-file",
+    type=click.Path(exists=True, path_type=Path),
+    required=True,
+    help="TOML policy file containing merge-train repository policies.",
+)
+@click.option("--status", type=click.Choice(["active", "superseded"]), default="active")
+@click.option("--source-label", default="cli:import-policy", show_default=True)
+@click.option("--reason", default="", help="Required audit reason when --apply is used.")
+@click.option("--dry-run", "mode", flag_value="dry_run", default="dry_run")
+@click.option("--apply", "mode", flag_value="apply")
+def merge_train_policies_build_import_request(
+    policy_file: Path,
+    status: MergeTrainPolicyRecordStatus,
+    source_label: str,
+    reason: str,
+    mode: str,
+) -> None:
+    normalized_reason = reason.strip()
+    if mode == "apply" and not normalized_reason:
+        raise click.ClickException("reason is required when apply is true")
+    record = _build_merge_train_policy_record(
+        policy_file=policy_file,
+        source_label=source_label,
+        status=status,
+    )
+    click.echo(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "product": "launchplane",
+                "mode": mode,
+                "reason": normalized_reason,
+                "record": _merge_train_policy_record_payload(record),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+
+
 @merge_train_policies.command("import-policy")
 @click.option(
     "--database-url",

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -618,8 +618,17 @@ WORKFLOW_OPERATOR_INPUT_REFERENCE_PATH_VALUES = {
         "idempotency-key": frozenset(("${{ inputs.idempotency_key }}",)),
     },
     ".github/workflows/merge-train-policy-import.yml": {
+        "POLICY_BLOCKED_LABEL": frozenset(("${{ inputs.blocked_label }}",)),
         "POLICY_BASE_BRANCH": frozenset(("${{ inputs.base_branch }}",)),
+        "POLICY_ENQUEUE_LABEL": frozenset(("${{ inputs.enqueue_label }}",)),
+        "POLICY_FAILURE_POLICY": frozenset(("${{ inputs.failure_policy }}",)),
+        "POLICY_MERGE_METHOD": frozenset(("${{ inputs.merge_method }}",)),
+        "POLICY_REASON": frozenset(("${{ inputs.reason }}",)),
         "POLICY_REPOSITORY": frozenset(("${{ inputs.repository }}",)),
+        "POLICY_SOURCE_LABEL": frozenset(("${{ inputs.source_label }}",)),
+        "POLICY_STACK_CHILD_DISPOSITION_LABEL": frozenset(
+            ("${{ inputs.stack_child_disposition_label }}",)
+        ),
     },
     ".github/workflows/merge-train-runner.yml": {
         "REQUESTED_REPOSITORY": frozenset(("${{ inputs.repository }}",)),
@@ -785,6 +794,23 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "payload-file": frozenset(("${{ steps.request.outputs.payload_file }}",)),
         "response-output-file": frozenset(("${{ steps.request.outputs.response_file }}",)),
         "route-path": frozenset(("/v1/live-target-runtime/apply",)),
+    },
+    ".github/workflows/merge-train-policy-import.yml": {
+        "audience": frozenset(("${{ steps.service.outputs.audience }}",)),
+        "fail-result-paths": frozenset(('""',)),
+        "idempotency-key": frozenset(("${{ steps.apply_policy.outputs.idempotency_key }}",)),
+        "log-response-body": frozenset(('"false"',)),
+        "method": frozenset(("POST",)),
+        "payload-file": frozenset(
+            (
+                "${{ steps.apply_policy.outputs.payload }}",
+                "${{ steps.policy.outputs.dry_run_payload }}",
+            )
+        ),
+        "response-output-file": frozenset(
+            ("merge-train-policy-apply.json", "merge-train-policy-dry-run.json")
+        ),
+        "route-path": frozenset(("/v1/merge-train/policies/import",)),
     },
     ".github/workflows/merge-train-runner.yml": {
         "audience": frozenset(

--- a/docs/merge-train-policy.md
+++ b/docs/merge-train-policy.md
@@ -238,7 +238,31 @@ closed.
 
 Prepare a TOML payload with every repository/base policy the service should
 support, store it outside the repo or generate it from operator automation, then
-import it through the deployed service API:
+import it through the deployed service API. GitHub Actions operator workflows
+should build the JSON request with Launchplane's typed CLI and call the shared
+`launchplane-request` action rather than fetching GitHub OIDC tokens in shell:
+
+```sh
+uv run launchplane merge-train-policies build-import-request \
+  --policy-file path/to/merge-train-policy.toml \
+  --source-label operator:update \
+  --reason "Configure merge train repositories" \
+  --apply \
+  > merge-train-policy-import-request.json
+```
+
+```yaml
+- uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+  with:
+    launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+    route-path: /v1/merge-train/policies/import
+    payload-file: merge-train-policy-import-request.json
+    idempotency-key: merge-train-policy-import:${{ github.run_id }}
+```
+
+For local operator terminals, the compatibility CLI import path still reads the
+bearer token from `LAUNCHPLANE_SERVICE_TOKEN` unless a browser
+`--session-cookie` is supplied:
 
 ```sh
 uv run launchplane merge-train-policies import-policy \
@@ -249,9 +273,7 @@ uv run launchplane merge-train-policies import-policy \
   --apply
 ```
 
-The command reads the bearer token from `LAUNCHPLANE_SERVICE_TOKEN` unless a
-browser `--session-cookie` is supplied. Direct `--database-url --apply` import is
-reserved for local development and DB repair, requires
+Direct `--database-url --apply` import is reserved for local development and DB repair, requires
 `--allow-direct-db-mutation`, and is not for shared or production live mutation.
 
 For local development or DB repair only:

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -55,6 +55,44 @@ def _gaps(payload: dict[str, object]) -> list[dict[str, object]]:
 
 
 class ConfigAuthorityAuditTest(unittest.TestCase):
+    def test_merge_train_policy_import_uses_shared_request(self) -> None:
+        workflow_text = Path(".github/workflows/merge-train-policy-import.yml").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("Resolve service endpoint", workflow_text)
+        self.assertIn("Build policy payload", workflow_text)
+        self.assertIn("Request policy import dry-run", workflow_text)
+        self.assertIn("Build policy apply payload", workflow_text)
+        self.assertIn("Apply policy import", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("route-path: /v1/merge-train/policies/import", workflow_text)
+        self.assertIn("payload-file: ${{ steps.policy.outputs.dry_run_payload }}", workflow_text)
+        self.assertIn("payload-file: ${{ steps.apply_policy.outputs.payload }}", workflow_text)
+        self.assertIn(
+            "idempotency-key: ${{ steps.apply_policy.outputs.idempotency_key }}",
+            workflow_text,
+        )
+        self.assertIn("response-output-file: merge-train-policy-dry-run.json", workflow_text)
+        self.assertIn("response-output-file: merge-train-policy-apply.json", workflow_text)
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn('log-response-body: "false"', workflow_text)
+        self.assertIn("build-import-request", workflow_text)
+        self.assertIn("merge-train-policy-dry-run-request.json", workflow_text)
+        self.assertIn("merge-train-policy-apply-request.json", workflow_text)
+        self.assertIn("stack_child_disposition_label:", workflow_text)
+        self.assertIn("POLICY_STACK_CHILD_DISPOSITION_LABEL", workflow_text)
+        self.assertIn('print(f"{key} = {json.dumps(values[key])}")', workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_SERVICE_TOKEN", workflow_text)
+        self.assertNotIn("import-policy \\", workflow_text)
+        self.assertNotIn("SERVICE_ORIGIN", workflow_text)
+        self.assertNotIn("curl -fsSL", workflow_text)
+
     def test_merge_train_runner_uses_shared_request_for_reads_worker_and_feedback_posts(
         self,
     ) -> None:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -2609,6 +2609,7 @@ repository = "cbusillo/codex-skills"
 base_branch = "main"
 enqueue_label = "ready-to-merge"
 blocked_label = "merge-blocked"
+stack_child_disposition_label = "stack-landed"
 merge_method = "merge"
 failure_policy = "pause_train"
 [policies.enqueue]
@@ -2657,6 +2658,78 @@ env_var = "GH_TOKEN"
         self.assertEqual(list_result.exit_code, 0, list_result.output)
         self.assertIn('"count": 1', list_result.output)
         self.assertIn('"cbusillo/codex-skills:main"', list_result.output)
+
+    def test_merge_train_policy_cli_builds_service_import_request(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy_file = Path(temporary_directory_name) / "merge-train-policy.toml"
+            policy_file.write_text(
+                """
+schema_version = 1
+
+[[policies]]
+repository = "cbusillo/codex-skills"
+base_branch = "main"
+enqueue_label = "ready-to-merge"
+blocked_label = "merge-blocked"
+stack_child_disposition_label = "stack-landed"
+merge_method = "merge"
+failure_policy = "pause_train"
+[policies.enqueue]
+label_required = true
+allowed_actor_roles = ["repo_owner", "repo_admin"]
+[policies.merge_identity]
+kind = "github_actions_oidc"
+name = "launchplane-merge-train"
+[policies.github_token]
+env_var = "GH_TOKEN"
+""".strip(),
+                encoding="utf-8",
+            )
+            result = CliRunner().invoke(
+                main,
+                [
+                    "merge-train-policies",
+                    "build-import-request",
+                    "--policy-file",
+                    str(policy_file),
+                    "--source-label",
+                    "workflow:merge-train-policy-import",
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["product"], "launchplane")
+        self.assertEqual(payload["mode"], "dry_run")
+        self.assertEqual(payload["reason"], "")
+        record = payload["record"]
+        self.assertEqual(record["source"], "workflow:merge-train-policy-import")
+        self.assertEqual(record["status"], "active")
+        self.assertEqual(record["policy"]["policies"][0]["repository"], "cbusillo/codex-skills")
+        self.assertEqual(record["policy"]["policies"][0]["base_branch"], "main")
+        self.assertEqual(
+            record["policy"]["policies"][0]["stack_child_disposition_label"],
+            "stack-landed",
+        )
+
+    def test_merge_train_policy_build_import_request_apply_requires_reason(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            policy_file = Path(temporary_directory_name) / "merge-train-policy.toml"
+            policy_file.write_text("schema_version = 1\n", encoding="utf-8")
+            result = CliRunner().invoke(
+                main,
+                [
+                    "merge-train-policies",
+                    "build-import-request",
+                    "--policy-file",
+                    str(policy_file),
+                    "--apply",
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("reason is required when apply is true", result.output)
 
     def test_merge_train_policy_direct_import_requires_direct_db_acknowledgement(
         self,


### PR DESCRIPTION
## Summary

- add `merge-train-policies build-import-request` to generate the validated service import envelope without doing HTTP/DB mutation
- convert `merge-train-policy-import.yml` from raw GitHub OIDC curl + CLI service import to `launchplane-request` calls
- include `stack_child_disposition_label`, escape generated TOML strings, and scope workflow concurrency by repository/base branch
- update config-authority allowlists, merge-train policy docs, and focused tests

## Validation

- `python -m py_compile control_plane/cli_policy_profiles.py control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_postgres_store.py`
- `docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/merge-train-policy-import.yml`
- `uv run python -m unittest tests.test_postgres_store.PostgresRecordStoreTests.test_merge_train_policy_cli_builds_service_import_request tests.test_postgres_store.PostgresRecordStoreTests.test_merge_train_policy_build_import_request_apply_requires_reason tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_merge_train_policy_import_uses_shared_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped`
- `uv run --extra dev ruff check --diff control_plane/cli_policy_profiles.py control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_postgres_store.py`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- `git diff --check`

## Review

- Agent CLI review found no blockers.
- Agent workflow review found TOML escaping, missing stack-child label support, operator input allowlist gaps, and broader concurrency scope; all fixed.
- Verified upstream tags exist for existing `actions/checkout@v6` and `astral-sh/setup-uv@v7` references.
