### PR TITLE
Use shared request for deploy authz grants

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -648,20 +648,93 @@ jobs:
           echo "Timed out waiting for Launchplane rollback image '$previous_image_reference' to become live and healthy." >&2
           exit 1
 
-      - name: Ensure product context workflow authz grants
+      - name: Render product context workflow authz grants
+        id: authz_grants
         shell: bash
         env:
-          LAUNCHPLANE_SERVICE_AUDIENCE: ${{ steps.service.outputs.service_audience }}
-          LAUNCHPLANE_SERVICE_URL: ${{ steps.service.outputs.service_url }}
           LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON: >-
             ${{ vars.LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON }}
           LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON: >-
             ${{ vars.LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON }}
+          LAUNCHPLANE_INGRESS_CANARY_ROUTE_SCOPES_JSON: >-
+            ${{ vars.LAUNCHPLANE_INGRESS_CANARY_ROUTE_SCOPES_JSON }}
           LAUNCHPLANE_AUTHZ_GRANTS_JSON: >-
             ${{ vars.LAUNCHPLANE_AUTHZ_GRANTS_JSON }}
           LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON: >-
             ${{ vars.LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON }}
         run: bash scripts/deploy/ensure-authz-grants.sh
+
+      - name: Ensure GitHub Actions authz grants
+        if: steps.authz_grants.outputs.has_github_actions_grants == 'true'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/authz-policies/github-actions/grants
+          payload-list-file: ${{ steps.authz_grants.outputs.github_actions_grants_file }}
+          idempotency-key-prefix: launchplane-authz-grant:${{ github.sha }}
+          response-output-file: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/github-actions-grants-responses.json
+          log-response-body: "false"
+
+      - name: Ensure terminal-agent authz grants
+        if: steps.authz_grants.outputs.has_terminal_agents_grants == 'true'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/authz-policies/terminal-agents/grants
+          payload-list-file: ${{ steps.authz_grants.outputs.terminal_agents_grants_file }}
+          idempotency-key-prefix: launchplane-terminal-agent-authz-grant:${{ github.sha }}
+          response-output-file: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/terminal-agents-grants-responses.json
+          log-response-body: "false"
+
+      - name: Ensure local-operator authz grants
+        if: steps.authz_grants.outputs.has_local_operators_grants == 'true'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/authz-policies/local-operators/grants
+          payload-list-file: ${{ steps.authz_grants.outputs.local_operators_grants_file }}
+          idempotency-key-prefix: launchplane-local-operator-authz-grant:${{ github.sha }}
+          response-output-file: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/local-operators-grants-responses.json
+          log-response-body: "false"
+
+      - name: Ensure local-admin authz grants
+        if: steps.authz_grants.outputs.has_local_admins_grants == 'true'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/authz-policies/local-admins/grants
+          payload-list-file: ${{ steps.authz_grants.outputs.local_admins_grants_file }}
+          idempotency-key-prefix: launchplane-local-admin-authz-grant:${{ github.sha }}
+          response-output-file: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/local-admins-grants-responses.json
+          log-response-body: "false"
+
+      - name: Ensure GitHub human authz grants
+        if: steps.authz_grants.outputs.has_github_humans_grants == 'true'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/authz-policies/github-humans/grants
+          payload-list-file: ${{ steps.authz_grants.outputs.github_humans_grants_file }}
+          idempotency-key-prefix: launchplane-product-config-human-grant:${{ github.sha }}
+          response-output-file: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/github-humans-grants-responses.json
+          log-response-body: "false"
+
+      - name: Ensure runtime key-safety policy
+        if: steps.authz_grants.outputs.has_runtime_key_safety_policy == 'true'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/runtime-key-safety/policies/apply
+          payload-file: ${{ steps.authz_grants.outputs.runtime_key_safety_policy_file }}
+          idempotency-key: ${{ steps.authz_grants.outputs.runtime_key_safety_idempotency_key }}
+          response-output-file: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/runtime-key-safety-policy-response.json
+          log-response-body: "false"
 
       - name: Capture v2 deployed smoke evidence
         shell: bash

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -237,9 +237,10 @@ grants for product-config writes. Set
 `LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_LOGINS`,
 `LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_PRODUCTS`, and
 `LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_CONTEXTS` as comma-separated repository
-variables. During deploy, `scripts/deploy/ensure-authz-grants.sh` writes
-DB-backed GitHub-human grants for `product_config.plan` and
-`product_config.apply` through `/v1/authz-policies/github-humans/grants`.
+variables. During deploy, `scripts/deploy/ensure-authz-grants.sh` renders
+GitHub-human grant payloads for `product_config.plan` and
+`product_config.apply`; the deploy workflow submits those payloads through the
+shared `launchplane-request` action to `/v1/authz-policies/github-humans/grants`.
 Leave those variables unset to skip reconciliation; do not hard-code human
 logins or product-specific operator grants in source.
 
@@ -247,9 +248,11 @@ Product-specific GitHub Actions grants are not authored in the deploy script.
 When a temporary deploy-time bridge is needed, provide
 `LAUNCHPLANE_AUTHZ_GRANTS_JSON` as an explicit operator-controlled JSON array of
 grant requests with repository, workflow file, product, context, action, source
-label, and idempotency suffix fields. The script only submits that configured
-payload through the service; checked-in shell tuples must not become the live
-workflow grant catalog. Prefer the operator UI or service-backed authz policy
+label, optional event/ref override fields, and optional legacy idempotency suffix
+fields. The script only renders that configured payload for the deploy workflow
+to submit through the shared Launchplane request action; checked-in shell tuples
+must not become the live workflow grant catalog. Prefer the operator UI or
+service-backed authz policy
 management routes for steady-state shared and production grant changes.
 
 The deploy workflow also reconciles its own `authz_policy_grant.write` grants

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-: "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:?Missing GitHub Actions OIDC request token.}"
-: "${ACTIONS_ID_TOKEN_REQUEST_URL:?Missing GitHub Actions OIDC request URL.}"
 : "${GITHUB_REPOSITORY:?Missing GitHub repository.}"
 : "${GITHUB_SHA:?Missing GitHub SHA.}"
-: "${LAUNCHPLANE_SERVICE_AUDIENCE:?Missing Launchplane service audience.}"
-: "${LAUNCHPLANE_SERVICE_URL:?Missing Launchplane service URL.}"
 
-oidc_token="$({
-	curl -fsSL \
-		-H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-		"${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" |
-		jq -r '.value'
-})"
+authz_grants_output_dir="${LAUNCHPLANE_AUTHZ_GRANTS_OUTPUT_DIR:-${RUNNER_TEMP:-.}/launchplane-authz-grants}"
+github_actions_grants_file="${authz_grants_output_dir}/github-actions-grants.json"
+terminal_agents_grants_file="${authz_grants_output_dir}/terminal-agents-grants.json"
+local_operators_grants_file="${authz_grants_output_dir}/local-operators-grants.json"
+local_admins_grants_file="${authz_grants_output_dir}/local-admins-grants.json"
+github_humans_grants_file="${authz_grants_output_dir}/github-humans-grants.json"
+runtime_key_safety_policy_file="${authz_grants_output_dir}/runtime-key-safety-policy.json"
+runtime_key_safety_idempotency_key=""
+
+mkdir -p "$authz_grants_output_dir"
+printf '[]\n' >"$github_actions_grants_file"
+printf '[]\n' >"$terminal_agents_grants_file"
+printf '[]\n' >"$local_operators_grants_file"
+printf '[]\n' >"$local_admins_grants_file"
+printf '[]\n' >"$github_humans_grants_file"
+rm -f "$runtime_key_safety_policy_file"
 
 require_non_empty() {
 	local value="$1"
@@ -47,30 +53,57 @@ sha256_stdin() {
 	fi
 }
 
-post_payload() {
+append_payload() {
+	local payload_file="$1"
+	local request_payload="$2"
+	local temporary_file
+
+	temporary_file="$(mktemp)"
+	jq --argjson request_payload "$request_payload" '. + [$request_payload]' \
+		"$payload_file" >"$temporary_file"
+	mv "$temporary_file" "$payload_file"
+}
+
+write_output() {
+	local output_name="$1"
+	local output_value="$2"
+
+	if [ -n "${GITHUB_OUTPUT:-}" ]; then
+		printf '%s=%s\n' "$output_name" "$output_value" >>"$GITHUB_OUTPUT"
+	fi
+}
+
+write_payload() {
 	local route_path="$1"
 	local idempotency_key="$2"
 	local request_payload="$3"
-	local failure_message="$4"
-	local response_file status_code
+	local _failure_message="${4:-}"
 
-	response_file="$(mktemp)"
-	status_code="$(curl -sS \
-		-o "$response_file" \
-		-w '%{http_code}' \
-		-X POST \
-		-H "Authorization: Bearer ${oidc_token}" \
-		-H 'Content-Type: application/json' \
-		-H "Idempotency-Key: ${idempotency_key}" \
-		--data "$request_payload" \
-		"${LAUNCHPLANE_SERVICE_URL}${route_path}")"
-	if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
-		cat "$response_file"
-		return 0
-	fi
-	cat "$response_file" >&2
-	echo "${failure_message} HTTP ${status_code}." >&2
-	return 1
+	case "$route_path" in
+		/v1/authz-policies/github-actions/grants)
+			append_payload "$github_actions_grants_file" "$request_payload"
+			;;
+		/v1/authz-policies/terminal-agents/grants)
+			append_payload "$terminal_agents_grants_file" "$request_payload"
+			;;
+		/v1/authz-policies/local-operators/grants)
+			append_payload "$local_operators_grants_file" "$request_payload"
+			;;
+		/v1/authz-policies/local-admins/grants)
+			append_payload "$local_admins_grants_file" "$request_payload"
+			;;
+		/v1/authz-policies/github-humans/grants)
+			append_payload "$github_humans_grants_file" "$request_payload"
+			;;
+		/v1/runtime-key-safety/policies/apply)
+			printf '%s\n' "$request_payload" >"$runtime_key_safety_policy_file"
+			runtime_key_safety_idempotency_key="$idempotency_key"
+			;;
+		*)
+			echo "Unsupported Launchplane authz payload route ${route_path}." >&2
+			return 1
+			;;
+	esac
 }
 
 post_grant() {
@@ -114,7 +147,7 @@ post_grant() {
         }
       }'
 	})"
-	post_payload \
+	write_payload \
 		/v1/authz-policies/github-actions/grants \
 		"launchplane-authz-grant:${idempotency_suffix}:${GITHUB_SHA}" \
 		"$request_payload" \
@@ -158,7 +191,7 @@ post_terminal_agent_grant() {
         }
       }'
 	})"
-	post_payload \
+	write_payload \
 		/v1/authz-policies/terminal-agents/grants \
 		"launchplane-terminal-agent-authz-grant:${idempotency_suffix}:${GITHUB_SHA}" \
 		"$request_payload" \
@@ -217,7 +250,7 @@ post_local_owner_grant() {
         }
       }'
 	})"
-	post_payload \
+	write_payload \
 		"$route_path" \
 		"launchplane-${principal}-authz-grant:${idempotency_suffix}:${GITHUB_SHA}" \
 		"$request_payload" \
@@ -395,7 +428,7 @@ post_product_config_human_grant() {
         }
       }'
 	})"
-	post_payload \
+	write_payload \
 		/v1/authz-policies/github-humans/grants \
 		"launchplane-product-config-human-grant:${idempotency_suffix}:${GITHUB_SHA}" \
 		"$request_payload" \
@@ -417,7 +450,7 @@ configured_github_action_grants_json() {
         context: (.context // ""),
         action: (.action // ""),
         source_label: (.source_label // ""),
-        idempotency_suffix: (.idempotency_suffix // ""),
+        idempotency_suffix: (.idempotency_suffix // .source_label // ""),
         event_name: (.event_name // "workflow_dispatch"),
         workflow_ref_suffix: (.workflow_ref_suffix // "refs/heads/main"),
         job_workflow_ref: (.job_workflow_ref // "")
@@ -456,7 +489,6 @@ post_configured_github_action_grants() {
 		require_non_empty "$context_name" context
 		require_non_empty "$action_name" action
 		require_non_empty "$source_label" source_label
-		require_non_empty "$idempotency_suffix" idempotency_suffix
 		require_non_empty "$event_name" event_name
 		require_non_empty "$workflow_ref_suffix" workflow_ref_suffix
 
@@ -541,7 +573,7 @@ post_runtime_key_safety_rules() {
       }'
 	})"
 	payload_sha256="$(printf '%s' "$request_payload" | sha256_stdin)"
-	post_payload \
+	write_payload \
 		/v1/runtime-key-safety/policies/apply \
 		"launchplane-runtime-key-safety-rules:${GITHUB_SHA}:${payload_sha256}" \
 		"$request_payload" \
@@ -831,3 +863,31 @@ post_product_config_human_grant \
 	product-config-human-apply
 post_configured_github_action_grants
 post_runtime_key_safety_rules
+
+github_actions_grant_count="$(jq 'length' "$github_actions_grants_file")"
+terminal_agents_grant_count="$(jq 'length' "$terminal_agents_grants_file")"
+local_operators_grant_count="$(jq 'length' "$local_operators_grants_file")"
+local_admins_grant_count="$(jq 'length' "$local_admins_grants_file")"
+github_humans_grant_count="$(jq 'length' "$github_humans_grants_file")"
+
+write_output authz_grants_output_dir "$authz_grants_output_dir"
+write_output github_actions_grants_file "$github_actions_grants_file"
+write_output github_actions_grant_count "$github_actions_grant_count"
+write_output has_github_actions_grants "$([ "$github_actions_grant_count" -gt 0 ] && echo true || echo false)"
+write_output terminal_agents_grants_file "$terminal_agents_grants_file"
+write_output terminal_agents_grant_count "$terminal_agents_grant_count"
+write_output has_terminal_agents_grants "$([ "$terminal_agents_grant_count" -gt 0 ] && echo true || echo false)"
+write_output local_operators_grants_file "$local_operators_grants_file"
+write_output local_operators_grant_count "$local_operators_grant_count"
+write_output has_local_operators_grants "$([ "$local_operators_grant_count" -gt 0 ] && echo true || echo false)"
+write_output local_admins_grants_file "$local_admins_grants_file"
+write_output local_admins_grant_count "$local_admins_grant_count"
+write_output has_local_admins_grants "$([ "$local_admins_grant_count" -gt 0 ] && echo true || echo false)"
+write_output github_humans_grants_file "$github_humans_grants_file"
+write_output github_humans_grant_count "$github_humans_grant_count"
+write_output has_github_humans_grants "$([ "$github_humans_grant_count" -gt 0 ] && echo true || echo false)"
+write_output runtime_key_safety_policy_file "$runtime_key_safety_policy_file"
+write_output runtime_key_safety_idempotency_key "$runtime_key_safety_idempotency_key"
+write_output has_runtime_key_safety_policy "$([ -f "$runtime_key_safety_policy_file" ] && echo true || echo false)"
+
+echo "Rendered Launchplane authz grant payloads: github-actions=${github_actions_grant_count} terminal-agents=${terminal_agents_grant_count} local-operators=${local_operators_grant_count} local-admins=${local_admins_grant_count} github-humans=${github_humans_grant_count} runtime-key-safety=$([ -f "$runtime_key_safety_policy_file" ] && echo 1 || echo 0)."

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -56,6 +56,73 @@ OWNER_AUTHZ_ENV = {
 }
 
 
+def _run_authz_grants_generator(
+    temporary_directory: Path,
+    *,
+    extra_env: dict[str, str] | None = None,
+    owner_authz_env: dict[str, str] | None = OWNER_AUTHZ_ENV,
+) -> subprocess.CompletedProcess[str]:
+    output_directory = temporary_directory / "authz-grants"
+    github_output = temporary_directory / "github-output.txt"
+    env = {**os.environ}
+    for key in OWNER_AUTHZ_ENV:
+        env.pop(key, None)
+    if owner_authz_env is not None:
+        env.update(owner_authz_env)
+    env.update(
+        {
+            "GITHUB_REPOSITORY": "cbusillo/launchplane",
+            "GITHUB_SHA": "test-sha",
+            "GITHUB_OUTPUT": str(github_output),
+            "LAUNCHPLANE_AUTHZ_GRANTS_OUTPUT_DIR": str(output_directory),
+        }
+    )
+    if extra_env:
+        env.update(extra_env)
+
+    return subprocess.run(
+        ["bash", "scripts/deploy/ensure-authz-grants.sh"],
+        check=False,
+        cwd=Path.cwd(),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _read_authz_grant_payloads(temporary_directory: Path, filename: str) -> list[dict[str, object]]:
+    payload_path = temporary_directory / "authz-grants" / filename
+    return cast(list[dict[str, object]], json.loads(payload_path.read_text(encoding="utf-8")))
+
+
+def _read_authz_grants(temporary_directory: Path, filename: str) -> list[dict[str, object]]:
+    return [
+        cast(dict[str, object], payload["grant"])
+        for payload in _read_authz_grant_payloads(temporary_directory, filename)
+    ]
+
+
+def _grant_string(grant: dict[str, object], key: str) -> str:
+    return cast(str, grant[key])
+
+
+def _grant_string_list(grant: dict[str, object], key: str) -> list[str]:
+    return cast(list[str], grant[key])
+
+
+def _read_github_outputs(temporary_directory: Path) -> dict[str, str]:
+    output_path = temporary_directory / "github-output.txt"
+    outputs: dict[str, str] = {}
+    if not output_path.exists():
+        return outputs
+    for line in output_path.read_text(encoding="utf-8").splitlines():
+        if "=" not in line:
+            continue
+        name, value = line.split("=", 1)
+        outputs[name] = value
+    return outputs
+
+
 def _load_health_monitoring_migration() -> object:
     spec = importlib.util.spec_from_file_location(
         "launchplane_health_monitoring_migration", _HEALTH_MONITORING_MIGRATION_PATH
@@ -285,11 +352,6 @@ class ProductOnboardingTests(unittest.TestCase):
     def test_deploy_authz_grants_accept_configured_github_action_grants(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         configured_grants = [
             {
                 "repository": "example-org/example-product",
@@ -298,7 +360,6 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
                 "context": "example-context",
                 "action": "example_action.execute",
                 "source_label": "operator-config:example-product-deploy",
-                "idempotency_suffix": "example-product-deploy",
                 "event_name": "push",
                 "workflow_ref_suffix": "refs/heads/release",
                 "job_workflow_ref": (
@@ -308,70 +369,16 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         ]
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                '    printf \'%s\\n\' "$*" >> "$CAPTURED_GRANT_ATTEMPTS"\n'
-                "    output_file=''\n"
-                "    request_payload=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                '        --data) shift; request_payload="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                "    if printf '%s' \"$request_payload\" | grep -q 'example-product-deploy'; then\n"
-                "      printf '%s\\n%s\\n' \"$request_payload\" '---END-GRANT---' >> \"$CAPTURED_GRANTS\"\n"
-                "    fi\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_grants = temporary_directory / "grants.jsonl"
-            captured_grants.touch()
-            captured_response_file = temporary_directory / "response.json"
-            env = {
-                **os.environ,
-                **OWNER_AUTHZ_ENV,
-                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                "GITHUB_SHA": "test-sha",
-                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
-                "LAUNCHPLANE_AUTHZ_GRANTS_JSON": json.dumps(configured_grants),
-                "CAPTURED_GRANTS": str(captured_grants),
-                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                "CAPTURED_BIN_DIR": str(captured_bin_directory),
-            }
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                extra_env={"LAUNCHPLANE_AUTHZ_GRANTS_JSON": json.dumps(configured_grants)},
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
             grants = [
-                json.loads(grant_text)["grant"]
-                for grant_text in captured_grants.read_text().split("---END-GRANT---")
-                if grant_text.strip()
+                grant
+                for grant in _read_authz_grants(temporary_directory, "github-actions-grants.json")
+                if grant["source_label"] == "operator-config:example-product-deploy"
             ]
 
         self.assertEqual(len(grants), 1)
@@ -394,72 +401,15 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_require_configured_owner_identities(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                '    printf \'%s\\n\' "$*" >> "$CAPTURED_GRANT_ATTEMPTS"\n'
-                "    output_file=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_response_file = temporary_directory / "response.json"
-            captured_grant_attempts = temporary_directory / "grant-attempts.txt"
-            env = {key: value for key, value in os.environ.items() if key not in OWNER_AUTHZ_ENV}
-            env.update(
-                {
-                    "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                    "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                    "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                    "GITHUB_SHA": "test-sha",
-                    "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                    "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
-                    "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                    "CAPTURED_GRANT_ATTEMPTS": str(captured_grant_attempts),
-                    "CAPTURED_BIN_DIR": str(captured_bin_directory),
-                }
-            )
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
-            )
+            result = _run_authz_grants_generator(temporary_directory, owner_authz_env={})
 
         self.assertNotEqual(result.returncode, 0)
         self.assertIn(
-            "Configured authz grant is missing LAUNCHPLANE_TERMINAL_AGENT_SUBJECT.",
+            "Configured authz grant is missing LAUNCHPLANE_",
             result.stderr,
         )
-        self.assertFalse(captured_grant_attempts.exists())
 
     def test_reusable_odoo_artifact_publish_standardizes_request_shape(self) -> None:
         workflow_text = Path(".github/workflows/reusable-odoo-artifact-publish.yml").read_text(
@@ -1904,6 +1854,27 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         self.assertIn("LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON", workflow_text)
         self.assertIn("vars.LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON", workflow_text)
 
+    def test_deploy_workflow_sends_authz_grants_through_shared_request(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+        script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
+
+        self.assertIn("id: authz_grants", workflow_text)
+        self.assertIn("LAUNCHPLANE_INGRESS_CANARY_ROUTE_SCOPES_JSON", workflow_text)
+        self.assertIn("vars.LAUNCHPLANE_INGRESS_CANARY_ROUTE_SCOPES_JSON", workflow_text)
+        self.assertIn("payload-list-file: ${{ steps.authz_grants.outputs.github_actions_grants_file }}", workflow_text)
+        self.assertIn("payload-list-file: ${{ steps.authz_grants.outputs.terminal_agents_grants_file }}", workflow_text)
+        self.assertIn("payload-list-file: ${{ steps.authz_grants.outputs.local_operators_grants_file }}", workflow_text)
+        self.assertIn("payload-list-file: ${{ steps.authz_grants.outputs.local_admins_grants_file }}", workflow_text)
+        self.assertIn("payload-list-file: ${{ steps.authz_grants.outputs.github_humans_grants_file }}", workflow_text)
+        self.assertIn("payload-file: ${{ steps.authz_grants.outputs.runtime_key_safety_policy_file }}", workflow_text)
+        self.assertIn("idempotency-key: ${{ steps.authz_grants.outputs.runtime_key_safety_idempotency_key }}", workflow_text)
+        self.assertIn("route-path: /v1/authz-policies/github-actions/grants", workflow_text)
+        self.assertIn("route-path: /v1/runtime-key-safety/policies/apply", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", script_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", script_text)
+        self.assertNotIn("Authorization: Bearer", script_text)
+        self.assertNotIn("curl ", script_text)
+
     def test_product_onboarding_workflow_calls_service_route_with_apply_guard(self) -> None:
         workflow_text = Path(".github/workflows/product-onboarding.yml").read_text(encoding="utf-8")
 
@@ -2073,11 +2044,6 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_accept_configured_runtime_key_safety_rules(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         configured_rules = [
             {
                 "binding_key": "EXAMPLE_API_TOKEN",
@@ -2088,80 +2054,28 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
         ]
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'all_args="$*"\n'
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                "    idempotency_header=''\n"
-                "    request_payload=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                '        -H) shift; case "$1" in Idempotency-Key:*) idempotency_header="$1" ;; esac ;;\n'
-                '        --data) shift; request_payload="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                '    case "$all_args" in\n'
-                "      */v1/runtime-key-safety/policies/apply*)\n"
-                '      printf \'%s\\n\' "$request_payload" > "$CAPTURED_POLICY"\n'
-                '      printf \'%s\\n\' "$idempotency_header" > "$CAPTURED_POLICY_IDEMPOTENCY"\n'
-                "        ;;\n"
-                "    esac\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_policy = temporary_directory / "policy.json"
-            captured_policy_idempotency = temporary_directory / "policy-idempotency.txt"
-            captured_response_file = temporary_directory / "response.json"
-            env = {
-                **os.environ,
-                **OWNER_AUTHZ_ENV,
-                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                "GITHUB_SHA": "test-sha",
-                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
-                "LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON": json.dumps(configured_rules),
-                "CAPTURED_POLICY": str(captured_policy),
-                "CAPTURED_POLICY_IDEMPOTENCY": str(captured_policy_idempotency),
-                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                "CAPTURED_BIN_DIR": str(captured_bin_directory),
-            }
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                extra_env={
+                    "LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON": json.dumps(configured_rules)
+                },
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            policy_payload = json.loads(captured_policy.read_text(encoding="utf-8"))
-            policy_idempotency = captured_policy_idempotency.read_text(encoding="utf-8")
+            policy_payload = json.loads(
+                (temporary_directory / "authz-grants" / "runtime-key-safety-policy.json").read_text(
+                    encoding="utf-8"
+                )
+            )
+            policy_idempotency = _read_github_outputs(temporary_directory)[
+                "runtime_key_safety_idempotency_key"
+            ]
 
         self.assertEqual(policy_payload["product"], "launchplane")
         self.assertEqual(policy_payload["source_label"], "deploy:runtime-key-safety-rules")
         self.assertRegex(
             policy_idempotency,
-            r"Idempotency-Key: launchplane-runtime-key-safety-rules:test-sha:[0-9a-f]{64}",
+            r"launchplane-runtime-key-safety-rules:test-sha:[0-9a-f]{64}",
         )
         self.assertNotIn("EXAMPLE_API_TOKEN", policy_idempotency)
         self.assertEqual(policy_payload["rules"][0]["binding_key"], "EXAMPLE_API_TOKEN")
@@ -2175,52 +2089,13 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_reject_incomplete_runtime_key_safety_rules(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      if [ "$1" = "-o" ]; then shift; output_file="$1"; fi\n'
-                "      shift || true\n"
-                "    done\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-
-            result = subprocess.run(
-                ["bash", "scripts/deploy/ensure-authz-grants.sh"],
-                check=False,
-                cwd=Path.cwd(),
-                env={
-                    **os.environ,
-                    **OWNER_AUTHZ_ENV,
-                    "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                    "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                    "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                    "GITHUB_SHA": "test-sha",
-                    "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                    "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                extra_env={
                     "LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON": json.dumps(
                         [{"binding_key": "EXAMPLE_API_TOKEN"}]
-                    ),
-                    "CAPTURED_RESPONSE_FILE": str(temporary_directory / "response.json"),
-                    "PATH": f"{captured_bin_directory}:{os.environ['PATH']}",
+                    )
                 },
-                capture_output=True,
-                text=True,
             )
 
         self.assertNotEqual(result.returncode, 0)
@@ -2231,52 +2106,13 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      if [ "$1" = "-o" ]; then shift; output_file="$1"; fi\n'
-                "      shift || true\n"
-                "    done\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-
-            result = subprocess.run(
-                ["bash", "scripts/deploy/ensure-authz-grants.sh"],
-                check=False,
-                cwd=Path.cwd(),
-                env={
-                    **os.environ,
-                    **OWNER_AUTHZ_ENV,
-                    "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                    "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                    "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                    "GITHUB_SHA": "test-sha",
-                    "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                    "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                extra_env={
                     "LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON": json.dumps(
                         [{"binding_key": "EXAMPLE_API_TOKEN", "secret_class": "production"}]
-                    ),
-                    "CAPTURED_RESPONSE_FILE": str(temporary_directory / "response.json"),
-                    "PATH": f"{captured_bin_directory}:{os.environ['PATH']}",
+                    )
                 },
-                capture_output=True,
-                text=True,
             )
 
         self.assertNotEqual(result.returncode, 0)
@@ -2305,84 +2141,21 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_scope_public_ingress_monitor_to_launchplane(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                "    request_payload=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                '        --data) shift; request_payload="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                "    if printf '%s' \"$request_payload\" | grep -q 'public-ingress-monitor.yml'; then\n"
-                "      printf '%s\\n%s\\n' \"$request_payload\" '---END-GRANT---' >> \"$CAPTURED_GRANTS\"\n"
-                "    fi\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_grants = temporary_directory / "grants.jsonl"
-            captured_grants.touch()
-            captured_response_file = temporary_directory / "response.json"
-            env = {
-                **os.environ,
-                **OWNER_AUTHZ_ENV,
-                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                "GITHUB_SHA": "test-sha",
-                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
-                "DISCORD_BLUE_DOKPLOY_TARGET_ID": "app-discord-blue",
-                "ODOO_CM_TESTING_DOKPLOY_TARGET_ID": "compose-cm-testing",
-                "ODOO_CM_PROD_DOKPLOY_TARGET_ID": "compose-cm-prod",
-                "ODOO_OPW_TESTING_DOKPLOY_TARGET_ID": "compose-opw-testing",
-                "ODOO_OPW_PROD_DOKPLOY_TARGET_ID": "compose-opw-prod",
-                "CAPTURED_GRANTS": str(captured_grants),
-                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                "CAPTURED_BIN_DIR": str(captured_bin_directory),
-            }
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
-            )
+            result = _run_authz_grants_generator(temporary_directory)
 
             self.assertEqual(result.returncode, 0, result.stderr)
             grants = [
-                json.loads(grant_text)["grant"]
-                for grant_text in captured_grants.read_text().split("---END-GRANT---")
-                if grant_text.strip()
+                grant
+                for grant in _read_authz_grants(temporary_directory, "github-actions-grants.json")
+                if _grant_string_list(grant, "workflow_refs")[0].endswith(
+                    "/.github/workflows/public-ingress-monitor.yml@refs/heads/main"
+                )
             ]
 
         self.assertEqual(len(grants), 2)
-        grant_index = {grant["event_names"][0]: grant for grant in grants}
+        grant_index = {_grant_string_list(grant, "event_names")[0]: grant for grant in grants}
         self.assertEqual(set(grant_index), {"schedule", "workflow_dispatch"})
         for grant in grants:
             self.assertEqual(grant["repository"], "cbusillo/launchplane")
@@ -2491,88 +2264,24 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_skip_local_operator_product_config_without_scopes(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                "    request_payload=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                '        --data) shift; request_payload="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                "    if printf '%s' \"$request_payload\" | grep -q '\"grant\"'; then\n"
-                "      printf '%s\\n%s\\n' \"$request_payload\" '---END-GRANT---' >> \"$CAPTURED_GRANTS\"\n"
-                "    fi\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_grants = temporary_directory / "grants.jsonl"
-            captured_grants.touch()
-            captured_response_file = temporary_directory / "response.json"
-            env = {
-                **os.environ,
-                **OWNER_AUTHZ_ENV,
-                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                "GITHUB_SHA": "test-sha",
-                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
-                "CAPTURED_GRANTS": str(captured_grants),
-                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                "CAPTURED_BIN_DIR": str(captured_bin_directory),
-            }
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
-            )
+            result = _run_authz_grants_generator(temporary_directory)
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            grants = [
-                json.loads(grant_text)["grant"]
-                for grant_text in captured_grants.read_text().split("---END-GRANT---")
-                if grant_text.strip()
-            ]
+            grants = _read_authz_grants(temporary_directory, "local-operators-grants.json")
 
         product_config_grants = [
             grant
             for grant in grants
-            if grant["actions"][0].startswith("product_config.")
+            if _grant_string_list(grant, "actions")[0].startswith("product_config.")
             and "subjects" in grant
             and "token_labels" in grant
         ]
         private_health_endpoint_grants = [
             grant
             for grant in grants
-            if grant["actions"][0].startswith("private_health_endpoint.")
+            if _grant_string_list(grant, "actions")[0].startswith("private_health_endpoint.")
             and "subjects" in grant
             and "token_labels" in grant
         ]
@@ -2598,61 +2307,13 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_fail_on_malformed_local_operator_product_config_scopes(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_response_file = temporary_directory / "response.json"
-            env = {
-                **os.environ,
-                **OWNER_AUTHZ_ENV,
-                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                "GITHUB_SHA": "test-sha",
-                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                extra_env={
                 "LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON": "not-json",
-                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                "CAPTURED_BIN_DIR": str(captured_bin_directory),
-            }
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
+                },
             )
 
         self.assertNotEqual(result.returncode, 0)
@@ -2661,61 +2322,13 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_fail_on_malformed_private_health_endpoint_scopes(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_response_file = temporary_directory / "response.json"
-            env = {
-                **os.environ,
-                **OWNER_AUTHZ_ENV,
-                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                "GITHUB_SHA": "test-sha",
-                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                extra_env={
                 "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON": "not-json",
-                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                "CAPTURED_BIN_DIR": str(captured_bin_directory),
-            }
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
+                },
             )
 
         self.assertNotEqual(result.returncode, 0)
@@ -2724,63 +2337,15 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_reject_private_health_endpoint_wildcard_scopes(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_response_file = temporary_directory / "response.json"
-            env = {
-                **os.environ,
-                **OWNER_AUTHZ_ENV,
-                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                "GITHUB_SHA": "test-sha",
-                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                extra_env={
                 "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON": json.dumps(
                     [{"product": "*", "context": "*"}]
                 ),
-                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                "CAPTURED_BIN_DIR": str(captured_bin_directory),
-            }
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
+                },
             )
 
         self.assertNotEqual(result.returncode, 0)
@@ -2792,114 +2357,62 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
     def test_deploy_authz_grants_scope_configured_local_operator_product_config(
         self,
     ) -> None:
-        script_path = Path("scripts/deploy/ensure-authz-grants.sh")
-        extractor = """
-set -euo pipefail
-PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
-"""
         with TemporaryDirectory() as temporary_directory_name:
             temporary_directory = Path(temporary_directory_name)
-            captured_bin_directory = temporary_directory / "bin"
-            captured_bin_directory.mkdir()
-            (captured_bin_directory / "curl").write_text(
-                "#!/usr/bin/env bash\n"
-                'case "$*" in\n'
-                '  *github.invalid/oidc*) printf \'{"value":"oidc-token"}\' ;;\n'
-                "  *)\n"
-                "    output_file=''\n"
-                "    request_payload=''\n"
-                '    while [ "$#" -gt 0 ]; do\n'
-                '      case "$1" in\n'
-                '        -o) shift; output_file="$1" ;;\n'
-                '        --data) shift; request_payload="$1" ;;\n'
-                "      esac\n"
-                "      shift || true\n"
-                "    done\n"
-                "    if printf '%s' \"$request_payload\" | grep -q '\"grant\"'; then\n"
-                "      printf '%s\\n%s\\n' \"$request_payload\" '---END-GRANT---' >> \"$CAPTURED_GRANTS\"\n"
-                "    fi\n"
-                '    if [ -n "$output_file" ]; then\n'
-                '      printf \'{"status":"ok"}\' > "$output_file"\n'
-                "    fi\n"
-                "    printf '200'\n"
-                "    ;;\n"
-                "esac\n"
-            )
-            (captured_bin_directory / "mktemp").write_text(
-                "#!/usr/bin/env bash\nprintf '%s\\n' \"$CAPTURED_RESPONSE_FILE\"\n"
-            )
-            (captured_bin_directory / "curl").chmod(0o755)
-            (captured_bin_directory / "mktemp").chmod(0o755)
-            captured_grants = temporary_directory / "grants.jsonl"
-            captured_grants.touch()
-            captured_response_file = temporary_directory / "response.json"
             configured_scopes = json.dumps(
                 [
                     {"product": "discord-blue", "context": "discord-blue"},
                     {"product": "verireel", "context": "verireel"},
                 ]
             )
-            env = {
-                **os.environ,
-                **OWNER_AUTHZ_ENV,
-                "ACTIONS_ID_TOKEN_REQUEST_TOKEN": "request-token",
-                "ACTIONS_ID_TOKEN_REQUEST_URL": "https://github.invalid/oidc",
-                "GITHUB_REPOSITORY": "cbusillo/launchplane",
-                "GITHUB_SHA": "test-sha",
-                "LAUNCHPLANE_SERVICE_AUDIENCE": "launchplane-service",
-                "LAUNCHPLANE_SERVICE_URL": "https://launchplane.example.invalid",
-                "LAUNCHPLANE_INGRESS_CANARY_ROUTE_SCOPES_JSON": configured_scopes,
-                "LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON": configured_scopes,
-                "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON": configured_scopes,
-                "CAPTURED_GRANTS": str(captured_grants),
-                "CAPTURED_RESPONSE_FILE": str(captured_response_file),
-                "CAPTURED_BIN_DIR": str(captured_bin_directory),
-            }
-
-            result = subprocess.run(
-                ["bash", "-c", extractor],
-                check=False,
-                cwd=script_path.parent.parent.parent,
-                env=env,
-                capture_output=True,
-                text=True,
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                extra_env={
+                    "LAUNCHPLANE_INGRESS_CANARY_ROUTE_SCOPES_JSON": configured_scopes,
+                    "LAUNCHPLANE_LOCAL_OPERATOR_PRODUCT_CONFIG_SCOPES_JSON": configured_scopes,
+                    "LAUNCHPLANE_PRIVATE_HEALTH_ENDPOINT_SCOPES_JSON": configured_scopes,
+                },
             )
 
             self.assertEqual(result.returncode, 0, result.stderr)
-            grants = [
-                json.loads(grant_text)["grant"]
-                for grant_text in captured_grants.read_text().split("---END-GRANT---")
-                if grant_text.strip()
-            ]
+            grants = _read_authz_grants(
+                temporary_directory,
+                "local-operators-grants.json",
+            ) + _read_authz_grants(temporary_directory, "github-actions-grants.json")
 
         product_config_grants = [
             grant
             for grant in grants
-            if grant["actions"][0].startswith("product_config.")
+            if _grant_string_list(grant, "actions")[0].startswith("product_config.")
             and "subjects" in grant
             and "token_labels" in grant
         ]
         private_health_endpoint_grants = [
             grant
             for grant in grants
-            if grant["actions"][0].startswith("private_health_endpoint.")
+            if _grant_string_list(grant, "actions")[0].startswith("private_health_endpoint.")
             and "subjects" in grant
             and "token_labels" in grant
         ]
         scoped_grants = {
-            (grant["products"][0], grant["contexts"][0], grant["actions"][0])
+            (
+                _grant_string_list(grant, "products")[0],
+                _grant_string_list(grant, "contexts")[0],
+                _grant_string_list(grant, "actions")[0],
+            )
             for grant in product_config_grants + private_health_endpoint_grants
         }
         canary_workflow_grants = [
             grant
             for grant in grants
-            if grant["actions"] == ["ingress_route.apply"]
-            and grant["workflow_refs"][0].endswith(
+            if _grant_string_list(grant, "actions") == ["ingress_route.apply"]
+            and _grant_string_list(grant, "workflow_refs")[0].endswith(
                 "/.github/workflows/ingress-route-canary-apply.yml@refs/heads/main"
             )
         ]
         canary_scoped_grants = {
-            (grant["products"][0], grant["contexts"][0]) for grant in canary_workflow_grants
+            (_grant_string_list(grant, "products")[0], _grant_string_list(grant, "contexts")[0])
+            for grant in canary_workflow_grants
         }
         expected_scopes = {
             ("discord-blue", "discord-blue"),
@@ -2924,19 +2437,23 @@ PATH="$CAPTURED_BIN_DIR:$PATH" bash scripts/deploy/ensure-authz-grants.sh
             self.assertNotEqual(grant["products"], ["*"])
             self.assertNotEqual(grant["contexts"], ["*"])
             self.assertTrue(
-                grant["source_label"].startswith("deploy:local-operator-product-config-")
+                _grant_string(grant, "source_label").startswith("deploy:local-operator-product-config-")
             )
         for grant in private_health_endpoint_grants:
             self.assertNotEqual(grant["products"], ["*"])
             self.assertNotEqual(grant["contexts"], ["*"])
             self.assertTrue(
-                grant["source_label"].startswith("deploy:local-operator-private-health-endpoint-")
+                _grant_string(grant, "source_label").startswith(
+                    "deploy:local-operator-private-health-endpoint-"
+                )
             )
         for grant in canary_workflow_grants:
             self.assertNotEqual(grant["products"], ["*"])
             self.assertNotEqual(grant["contexts"], ["*"])
             self.assertTrue(
-                grant["source_label"].startswith("deploy:ingress-route-canary-apply-workflow-")
+                _grant_string(grant, "source_label").startswith(
+                    "deploy:ingress-route-canary-apply-workflow-"
+                )
             )
 
     def test_apply_product_onboarding_manifest_writes_canonical_records(self) -> None:


### PR DESCRIPTION
## Summary
- Convert scripts/deploy/ensure-authz-grants.sh from raw GitHub OIDC/curl POSTs into a route-grouped payload generator.
- Wire deploy-launchplane.yml to send generated authz grant and runtime key-safety payloads through the shared launchplane-request action.
- Update operations docs and authz grant tests for the render-then-shared-request contract.

## Review
- Read-only review agent completed; fixed findings for ingress canary scope env wiring and stale configured-grant idempotency suffix requirements.

## Validation
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_scheduled_merge_train_runner tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_runner_registration_audit_writer tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_accept_configured_github_action_grants tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_require_configured_owner_identities tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_seed_local_admin_self_deploy_authority tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_stage_dedicated_policy_grant_authority tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_stage_runtime_key_safety_policy_authority tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_sends_authz_grants_through_shared_request tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_product_onboarding_apply tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_do_not_hard_code_product_expected_config_apply tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_do_not_restore_stale_import_self_deploy_rules tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_do_not_carry_product_grant_catalog tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_accept_configured_runtime_key_safety_rules tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_reject_incomplete_runtime_key_safety_rules tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_reject_unknown_runtime_key_safety_secret_class tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_scope_public_ingress_monitor_to_launchplane tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_terminal_agent_product_profile_read tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_local_operator_notification_apply tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_local_operator_service_read tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_local_operator_odoo_worker_reconcile tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_edge_endpoint_authority tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_private_health_endpoint_authority tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_include_ingress_canary_route_authority tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_skip_local_operator_product_config_without_scopes tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_fail_on_malformed_local_operator_product_config_scopes tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_fail_on_malformed_private_health_endpoint_scopes tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_reject_private_health_endpoint_wildcard_scopes tests.test_product_onboarding.ProductOnboardingTests.test_deploy_authz_grants_scope_configured_local_operator_product_config
- bash -n scripts/deploy/ensure-authz-grants.sh
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml
- uv run --extra dev ruff check tests/test_product_onboarding.py
- git diff --check
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate