### PR TITLE
Use shared request for deployed runtime smoke

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -736,12 +736,28 @@ jobs:
           response-output-file: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/runtime-key-safety-policy-response.json
           log-response-body: "false"
 
+      - name: Read deployed Launchplane runtime
+        id: deployed_runtime
+        continue-on-error: true
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/service/runtime
+          method: GET
+          expected-status: "200"
+          timeout-ms: "30000"
+          response-output-file: ${{ runner.temp }}/launchplane-runtime-smoke.json
+          log-response-body: "false"
+
       - name: Capture v2 deployed smoke evidence
         shell: bash
         env:
           DEPLOYED_IMAGE_REFERENCE: ${{ steps.image.outputs.image_reference }}
-          LAUNCHPLANE_SERVICE_AUDIENCE: ${{ steps.service.outputs.service_audience }}
           LAUNCHPLANE_SERVICE_URL: ${{ steps.service.outputs.service_url }}
+          RUNTIME_RESPONSE_FILE: ${{ runner.temp }}/launchplane-runtime-smoke.json
+          RUNTIME_STATUS_CODE: ${{ steps.deployed_runtime.outputs.status-code }}
+          RUNTIME_OUTCOME: ${{ steps.deployed_runtime.outcome }}
         run: |
           set -euo pipefail
 
@@ -809,22 +825,12 @@ jobs:
           fi
           rm -f "$health_response_file"
 
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              -G \
-              --data-urlencode "audience=${LAUNCHPLANE_SERVICE_AUDIENCE}" \
-              "$ACTIONS_ID_TOKEN_REQUEST_URL" \
-            | jq -r '.value'
-          })"
-          runtime_response_file="$(mktemp)"
-          runtime_status_code="$(curl -sS \
-            -o "$runtime_response_file" \
-            -w '%{http_code}' \
-            -H "Authorization: Bearer ${oidc_token}" \
-            "${LAUNCHPLANE_SERVICE_URL}/v1/service/runtime")"
-          actual_image_reference="$(jq -r '.runtime.docker_image_reference // empty' "$runtime_response_file" 2>/dev/null || true)"
-          runtime_trace_id="$(jq -r '.trace_id // empty' "$runtime_response_file" 2>/dev/null || true)"
+          runtime_status_code="$RUNTIME_STATUS_CODE"
+          if [ -z "$runtime_status_code" ]; then
+            runtime_status_code="action_failed"
+          fi
+          actual_image_reference="$(jq -r '.runtime.docker_image_reference // empty' "$RUNTIME_RESPONSE_FILE" 2>/dev/null || true)"
+          runtime_trace_id="$(jq -r '.trace_id // empty' "$RUNTIME_RESPONSE_FILE" 2>/dev/null || true)"
           append_result \
             "/v1/service/runtime" \
             "GET" \
@@ -834,12 +840,13 @@ jobs:
             "$runtime_trace_id" \
             "200 matching image" \
             "$([ "$runtime_status_code" = "200" ] && [ "$actual_image_reference" = "$DEPLOYED_IMAGE_REFERENCE" ] && echo true || echo false)"
-          if [ "$runtime_status_code" != "200" ] || [ "$actual_image_reference" != "$DEPLOYED_IMAGE_REFERENCE" ]; then
-            jq '{status, trace_id, error, runtime: {docker_image_reference: .runtime.docker_image_reference}}' "$runtime_response_file" >&2 || cat "$runtime_response_file" >&2
+          if [ "${RUNTIME_OUTCOME:-failure}" != "success" ] \
+            || [ "$runtime_status_code" != "200" ] \
+            || [ "$actual_image_reference" != "$DEPLOYED_IMAGE_REFERENCE" ]; then
+            jq '{status, trace_id, error, runtime: {docker_image_reference: .runtime.docker_image_reference}}' "$RUNTIME_RESPONSE_FILE" >&2 || cat "$RUNTIME_RESPONSE_FILE" >&2 || true
             echo "Launchplane runtime smoke failed." >&2
             exit 1
           fi
-          rm -f "$runtime_response_file"
 
           openapi_response_file="$(mktemp)"
           openapi_status_code="$(curl -sS \

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -740,7 +740,16 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "context": frozenset((".",)),
         "password": frozenset(("${{ github.token }}",)),
     },
-    ".github/workflows/deploy-launchplane.yml": {"context": frozenset((".",))},
+    ".github/workflows/deploy-launchplane.yml": {
+        "audience": frozenset(("${{ steps.service.outputs.service_audience }}",)),
+        "context": frozenset((".",)),
+        "expected-status": frozenset(('"200"',)),
+        "log-response-body": frozenset(('"false"',)),
+        "method": frozenset(("GET",)),
+        "response-output-file": frozenset(("${{ runner.temp }}/launchplane-runtime-smoke.json",)),
+        "route-path": frozenset(("/v1/service/runtime",)),
+        "timeout-ms": frozenset(('"30000"',)),
+    },
     ".github/workflows/launchplane-config-authority.yml": {
         "uses": frozenset(
             (

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2911,6 +2911,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("idempotency-key", "${{ steps.request.outputs.idempotency_key }}"),
             ("idempotency-key", "${{ steps.onboarding.outputs.idempotency_key }}"),
             ("log-response-body", '"false"'),
+            ("method", "GET"),
             ("response-output-file", "dokploy-target-inspect-response.json"),
             ("response-output-file", "ingress-route-audit-read-raw.json"),
             ("response-output-file", "launchplane-context-cutover-audit.json"),
@@ -2925,6 +2926,24 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                         value=value,
                     ),
                     "",
+                )
+
+        for key, value in (
+            ("audience", "${{ steps.service.outputs.service_audience }}"),
+            ("expected-status", '"200"'),
+            ("method", "GET"),
+            ("response-output-file", "${{ runner.temp }}/launchplane-runtime-smoke.json"),
+            ("route-path", "/v1/service/runtime"),
+            ("timeout-ms", '"30000"'),
+        ):
+            with self.subTest(deploy_runtime_smoke_mechanic=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/deploy-launchplane.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    "thin_connector_input",
                 )
         self.assertEqual(
             _allow_reason(

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -125,6 +125,40 @@ process.on('beforeExit', () => {{
             self.assertEqual(json.loads(calls[1]["body"])["product"], "sellyouroutboard")
             self.assertIn("application_id<<", output_path.read_text(encoding="utf-8"))
 
+    def test_get_request_omits_payload_and_idempotency_header(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            response_output_path = Path(temporary_directory) / "response.json"
+            output_path = Path(temporary_directory) / "github-output.txt"
+            result = self.run_action(
+                output_path=output_path,
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/service/runtime",
+                    "method": "GET",
+                    "response-output-file": str(response_output_path),
+                    "log-response-body": "false",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            calls = json.loads(result.stderr.strip().splitlines()[-1])
+            self.assertEqual(calls[1]["method"], "GET")
+            self.assertEqual(
+                calls[1]["url"],
+                "https://launchplane.example/v1/service/runtime",
+            )
+            self.assertEqual(calls[1]["headers"]["Authorization"], "Bearer oidc-token-1")
+            self.assertNotIn("Idempotency-Key", calls[1]["headers"])
+            self.assertNotIn("Content-Type", calls[1]["headers"])
+            self.assertEqual(calls[1]["body"], "")
+            self.assertIn("status-code<<", output_path.read_text(encoding="utf-8"))
+            self.assertEqual(
+                json.loads(response_output_path.read_text(encoding="utf-8"))["result"][
+                    "refresh_status"
+                ],
+                "pass",
+            )
+
     def test_accepts_configured_non_2xx_status(self) -> None:
         with TemporaryDirectory() as temporary_directory:
             response_output_path = Path(temporary_directory) / "response.json"

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1882,6 +1882,40 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertNotIn("Authorization: Bearer", script_text)
         self.assertNotIn("curl ", script_text)
 
+    def test_deploy_workflow_reads_deployed_runtime_through_shared_request(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+
+        self.assertIn("Read deployed Launchplane runtime", workflow_text)
+        self.assertIn("id: deployed_runtime", workflow_text)
+        self.assertIn("continue-on-error: true", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("route-path: /v1/service/runtime", workflow_text)
+        self.assertIn("method: GET", workflow_text)
+        self.assertIn('expected-status: "200"', workflow_text)
+        self.assertIn('timeout-ms: "30000"', workflow_text)
+        self.assertIn(
+            "response-output-file: ${{ runner.temp }}/launchplane-runtime-smoke.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "RUNTIME_STATUS_CODE: ${{ steps.deployed_runtime.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn("RUNTIME_OUTCOME: ${{ steps.deployed_runtime.outcome }}", workflow_text)
+        self.assertIn("runtime_status_code=\"action_failed\"", workflow_text)
+        self.assertIn("Launchplane runtime smoke failed.", workflow_text)
+
+        deployed_smoke_step = workflow_text.split(
+            "- name: Capture v2 deployed smoke evidence", 1
+        )[1].split("- name: Upload v2 deployed smoke evidence", 1)[0]
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", deployed_smoke_step)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", deployed_smoke_step)
+        self.assertNotIn("Authorization: Bearer", deployed_smoke_step)
+        self.assertNotIn('--data-urlencode "audience=', deployed_smoke_step)
+
     def test_product_onboarding_workflow_calls_service_route_with_apply_guard(self) -> None:
         workflow_text = Path(".github/workflows/product-onboarding.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- move the post-deploy /v1/service/runtime smoke read to the shared launchplane-request action
- preserve launchplane-v2-deployed-smoke.jsonl evidence when the authenticated runtime read fails
- pin the request action's GET/no-payload behavior and classify the new thin connector mechanics

## Validation
- uv run python -m unittest tests.test_launchplane_request_action tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_reads_deployed_runtime_through_shared_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check tests/test_launchplane_request_action.py tests/test_product_onboarding.py tests/test_config_authority_audit.py control_plane/config_authority_audit.py
- git diff --check

## Review
- Read-only review agent found no issues.