### PR TITLE
Use shared request for deploy rollback

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -540,8 +540,9 @@ jobs:
         env:
           LAUNCHPLANE_EXPECTED_IMAGE_REFERENCE: ${{ steps.image.outputs.image_reference }}
 
-      - name: Roll back failed Launchplane deploy
+      - name: Render Launchplane rollback request
         if: failure() && steps.self_deploy.outputs.previous_image_reference != ''
+        id: rollback_request
         shell: bash
         run: |
           set -euo pipefail
@@ -552,13 +553,6 @@ jobs:
             exit 0
           fi
 
-          oidc_token="$({
-            curl -fsSL \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
-            | jq -r '.value'
-          })"
-
           rollback_payload="$({
             jq -n \
               --arg target_type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
@@ -566,30 +560,85 @@ jobs:
               --arg image_reference "$previous_image_reference" \
               '{schema_version: 1, product: "launchplane", deploy: {target_type: $target_type, target_id: $target_id, image_reference: $image_reference, no_cache: true}}'
           })"
-          rollback_response_file="$(mktemp)"
-          rollback_status="$(curl -sS \
-            -o "$rollback_response_file" \
-            -w '%{http_code}' \
-            -X POST \
-            -H "Authorization: Bearer ${oidc_token}" \
-            -H "Content-Type: application/json" \
-            -H "Idempotency-Key: launchplane-self-deploy-rollback:${previous_image_reference}:${{ github.run_id }}:${{ github.run_attempt }}" \
-            --data "$rollback_payload" \
-            "${{ steps.service.outputs.service_url }}/v1/drivers/launchplane/self-deploy" || true)"
+
+          rollback_payload_file="$RUNNER_TEMP/launchplane-self-deploy-rollback-payload.json"
+          printf '%s\n' "$rollback_payload" > "$rollback_payload_file"
+          echo "previous_image_reference=$previous_image_reference" >> "$GITHUB_OUTPUT"
+          echo "payload_file=$rollback_payload_file" >> "$GITHUB_OUTPUT"
+
+      - name: Request Launchplane rollback through service
+        if: >-
+          failure()
+          && steps.rollback_request.outputs.payload_file != ''
+          && steps.rollback_request.outputs.previous_image_reference != ''
+        id: rollback_request_action
+        continue-on-error: true
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/drivers/launchplane/self-deploy
+          payload-file: ${{ steps.rollback_request.outputs.payload_file }}
+          idempotency-key: launchplane-self-deploy-rollback:${{ steps.rollback_request.outputs.previous_image_reference }}:${{ github.run_id }}:${{ github.run_attempt }}
+          expected-status: "200,202"
+          fail-result-paths: ""
+          timeout-ms: "30000"
+          response-output-file: ${{ runner.temp }}/launchplane-self-deploy-rollback-response.json
+          log-response-body: "false"
+
+      - name: Check Launchplane rollback request
+        if: >-
+          failure()
+          && steps.rollback_request.outputs.payload_file != ''
+          && steps.rollback_request.outputs.previous_image_reference != ''
+        shell: bash
+        env:
+          PREVIOUS_IMAGE_REFERENCE: ${{ steps.rollback_request.outputs.previous_image_reference }}
+          ROLLBACK_RESPONSE_FILE: ${{ runner.temp }}/launchplane-self-deploy-rollback-response.json
+          ROLLBACK_STATUS: ${{ steps.rollback_request_action.outputs.status-code }}
+          ROLLBACK_OUTCOME: ${{ steps.rollback_request_action.outcome }}
+        run: |
+          set -euo pipefail
+
+          rollback_status="$ROLLBACK_STATUS"
+          if [ -z "$rollback_status" ]; then
+            rollback_status="action_failed"
+          fi
           if [ "$rollback_status" != "200" ] && [ "$rollback_status" != "202" ]; then
-            cat "$rollback_response_file" >&2
+            if [ -s "$ROLLBACK_RESPONSE_FILE" ]; then
+              cat "$ROLLBACK_RESPONSE_FILE" >&2
+            fi
             {
               echo "## Launchplane rollback failed"
               echo
               echo "- Service rollback HTTP status: $rollback_status"
-              echo "- Rollback image: $previous_image_reference"
+              echo "- Rollback action outcome: ${ROLLBACK_OUTCOME:-failure}"
+              echo "- Rollback image: $PREVIOUS_IMAGE_REFERENCE"
               echo "- Direct Dokploy mutation is manual break-glass only. Run Deploy Launchplane with the exact break-glass confirmation inputs if service rollback is unavailable."
             } >>"$GITHUB_STEP_SUMMARY"
             exit 1
-          else
-            cat "$rollback_response_file"
           fi
+          {
+            echo "## Launchplane rollback requested"
+            echo
+            echo "- Service rollback HTTP status: $rollback_status"
+            echo "- Rollback image: $PREVIOUS_IMAGE_REFERENCE"
+          } >>"$GITHUB_STEP_SUMMARY"
 
+      - name: Wait for Launchplane rollback image
+        if: >-
+          failure()
+          && steps.rollback_request.outputs.payload_file != ''
+          && steps.rollback_request.outputs.previous_image_reference != ''
+          && steps.rollback_request_action.outcome == 'success'
+        shell: bash
+        env:
+          ROLLBACK_RESPONSE_FILE: ${{ runner.temp }}/launchplane-self-deploy-rollback-response.json
+          ROLLBACK_STATUS: ${{ steps.rollback_request_action.outputs.status-code }}
+        run: |
+          set -euo pipefail
+
+          previous_image_reference="${{ steps.rollback_request.outputs.previous_image_reference }}"
           deadline=$((SECONDS + ${LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600} + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
           last_report_seconds=0
           while [ "$SECONDS" -lt "$deadline" ]; do
@@ -646,6 +695,17 @@ jobs:
           done
 
           echo "Timed out waiting for Launchplane rollback image '$previous_image_reference' to become live and healthy." >&2
+          if [ -s "$ROLLBACK_RESPONSE_FILE" ]; then
+            echo "Rollback request response summary:" >&2
+            jq '{status, trace_id, error, result}' "$ROLLBACK_RESPONSE_FILE" >&2 || cat "$ROLLBACK_RESPONSE_FILE" >&2 || true
+          fi
+          {
+            echo "## Launchplane rollback timed out"
+            echo
+            echo "- Service rollback HTTP status: ${ROLLBACK_STATUS:-unknown}"
+            echo "- Rollback image: $previous_image_reference"
+            echo "- Rollback request response file: $ROLLBACK_RESPONSE_FILE"
+          } >>"$GITHUB_STEP_SUMMARY"
           exit 1
 
       - name: Render product context workflow authz grants

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -743,11 +743,27 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
     ".github/workflows/deploy-launchplane.yml": {
         "audience": frozenset(("${{ steps.service.outputs.service_audience }}",)),
         "context": frozenset((".",)),
-        "expected-status": frozenset(('"200"',)),
+        "expected-status": frozenset(('"200"', '"200,202"')),
+        "fail-result-paths": frozenset(('""',)),
+        "idempotency-key": frozenset(
+            (
+                "launchplane-self-deploy-rollback:${{ "
+                "steps.rollback_request.outputs.previous_image_reference }}:${{ "
+                "github.run_id }}:${{ github.run_attempt }}",
+            )
+        ),
         "log-response-body": frozenset(('"false"',)),
         "method": frozenset(("GET",)),
-        "response-output-file": frozenset(("${{ runner.temp }}/launchplane-runtime-smoke.json",)),
-        "route-path": frozenset(("/v1/service/runtime",)),
+        "payload-file": frozenset(("${{ steps.rollback_request.outputs.payload_file }}",)),
+        "response-output-file": frozenset(
+            (
+                "${{ runner.temp }}/launchplane-runtime-smoke.json",
+                "${{ runner.temp }}/launchplane-self-deploy-rollback-response.json",
+            )
+        ),
+        "route-path": frozenset(
+            ("/v1/service/runtime", "/v1/drivers/launchplane/self-deploy")
+        ),
         "timeout-ms": frozenset(('"30000"',)),
     },
     ".github/workflows/launchplane-config-authority.yml": {

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2931,12 +2931,26 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         for key, value in (
             ("audience", "${{ steps.service.outputs.service_audience }}"),
             ("expected-status", '"200"'),
+            ("expected-status", '"200,202"'),
+            ("fail-result-paths", '""'),
+            (
+                "idempotency-key",
+                "launchplane-self-deploy-rollback:${{ "
+                "steps.rollback_request.outputs.previous_image_reference }}:${{ "
+                "github.run_id }}:${{ github.run_attempt }}",
+            ),
             ("method", "GET"),
+            ("payload-file", "${{ steps.rollback_request.outputs.payload_file }}"),
             ("response-output-file", "${{ runner.temp }}/launchplane-runtime-smoke.json"),
+            (
+                "response-output-file",
+                "${{ runner.temp }}/launchplane-self-deploy-rollback-response.json",
+            ),
             ("route-path", "/v1/service/runtime"),
+            ("route-path", "/v1/drivers/launchplane/self-deploy"),
             ("timeout-ms", '"30000"'),
         ):
-            with self.subTest(deploy_runtime_smoke_mechanic=key):
+            with self.subTest(deploy_workflow_thin_connector_mechanic=key):
                 self.assertEqual(
                     _allow_reason(
                         path=".github/workflows/deploy-launchplane.yml",

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1916,6 +1916,58 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertNotIn("Authorization: Bearer", deployed_smoke_step)
         self.assertNotIn('--data-urlencode "audience=', deployed_smoke_step)
 
+    def test_deploy_workflow_requests_rollback_through_shared_request(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+
+        self.assertIn("Render Launchplane rollback request", workflow_text)
+        self.assertIn("id: rollback_request", workflow_text)
+        self.assertIn("Request Launchplane rollback through service", workflow_text)
+        self.assertIn("id: rollback_request_action", workflow_text)
+        self.assertIn("continue-on-error: true", workflow_text)
+        self.assertIn(
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            workflow_text,
+        )
+        self.assertIn("route-path: /v1/drivers/launchplane/self-deploy", workflow_text)
+        self.assertIn(
+            "payload-file: ${{ steps.rollback_request.outputs.payload_file }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "idempotency-key: launchplane-self-deploy-rollback:${{ "
+            "steps.rollback_request.outputs.previous_image_reference }}:${{ "
+            "github.run_id }}:${{ github.run_attempt }}",
+            workflow_text,
+        )
+        self.assertIn('expected-status: "200,202"', workflow_text)
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn('timeout-ms: "30000"', workflow_text)
+        self.assertIn(
+            "response-output-file: ${{ runner.temp }}/launchplane-self-deploy-rollback-response.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "ROLLBACK_STATUS: ${{ steps.rollback_request_action.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "ROLLBACK_OUTCOME: ${{ steps.rollback_request_action.outcome }}",
+            workflow_text,
+        )
+        self.assertIn("rollback_status=\"action_failed\"", workflow_text)
+        self.assertIn("Launchplane rollback failed", workflow_text)
+        self.assertIn("Launchplane rollback requested", workflow_text)
+        self.assertIn("Launchplane rollback timed out", workflow_text)
+        self.assertIn("Rollback request response summary", workflow_text)
+
+        rollback_request_block = workflow_text.split(
+            "- name: Render Launchplane rollback request", 1
+        )[1].split("- name: Wait for Launchplane rollback image", 1)[0]
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", rollback_request_block)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", rollback_request_block)
+        self.assertNotIn("Authorization: Bearer", rollback_request_block)
+        self.assertNotIn("curl ", rollback_request_block)
+
     def test_product_onboarding_workflow_calls_service_route_with_apply_guard(self) -> None:
         workflow_text = Path(".github/workflows/product-onboarding.yml").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- render the failed-deploy rollback payload separately and send the rollback POST through launchplane-request
- preserve rollback failure summaries and add timeout evidence for accepted-but-not-live rollback attempts
- extend path-scoped config-authority coverage and workflow assertions for the rollback connector inputs

## Validation
- uv run python -m unittest tests.test_launchplane_request_action tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_reads_deployed_runtime_through_shared_request tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_requests_rollback_through_shared_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check tests/test_product_onboarding.py tests/test_config_authority_audit.py control_plane/config_authority_audit.py
- git diff --check