### PR TITLE
Use shared request for self deploy

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -247,226 +247,244 @@ jobs:
           fi
           echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
 
-      - name: Request Launchplane self deploy
+      - name: Read previous Launchplane runtime
+        id: previous_runtime
+        continue-on-error: true
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/service/runtime
+          method: GET
+          expected-status: "200"
+          timeout-ms: "30000"
+          response-output-file: ${{ runner.temp }}/launchplane-previous-runtime.json
+          log-response-body: "false"
+
+      - name: Render Launchplane self deploy request
         id: self_deploy
         shell: bash
+        env:
+          PREVIOUS_RUNTIME_RESPONSE_FILE: ${{ runner.temp }}/launchplane-previous-runtime.json
         run: |
           set -euo pipefail
 
-          request_deploy() {
-            local response_file="$1"
-            local request_payload=""
-            local idempotency_key=""
-            local service_env_json=""
-            local oidc_token=""
+          previous_image_reference="$(jq -r '.runtime.docker_image_reference // empty' "$PREVIOUS_RUNTIME_RESPONSE_FILE" 2>/dev/null || true)"
+          echo "previous_image_reference=$previous_image_reference" >> "$GITHUB_OUTPUT"
 
-            oidc_token="$({
-              curl -fsSL \
-                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
-              | jq -r '.value'
-            })"
-
-            previous_runtime_payload="$(curl -fsSL \
-              -H "Authorization: Bearer ${oidc_token}" \
-              "${{ steps.service.outputs.service_url }}/v1/service/runtime" 2>/dev/null || true)"
-            previous_image_reference="$(printf '%s' "$previous_runtime_payload" | jq -r '.runtime.docker_image_reference // empty' 2>/dev/null || true)"
-            echo "previous_image_reference=$previous_image_reference" >> "$GITHUB_OUTPUT"
-
-            service_env_json="$({
-              jq -n \
-                --arg github_client_id "${LAUNCHPLANE_GITHUB_CLIENT_ID:-}" \
-                --arg github_client_secret "${LAUNCHPLANE_GITHUB_CLIENT_SECRET:-}" \
-                --arg public_url "${LAUNCHPLANE_PUBLIC_URL:-}" \
-                --arg session_secret "${LAUNCHPLANE_SESSION_SECRET:-}" \
-                --arg cookie_secure "${LAUNCHPLANE_COOKIE_SECURE:-}" \
-                --arg bootstrap_admin_emails "${LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS:-}" \
-                --arg work_graph_project_owner "${LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER:-}" \
-                --arg work_graph_project_number "${LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER:-}" \
-                --arg work_graph_project_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT:-}" \
-                --arg work_graph_project_signal_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT:-}" \
-                --arg work_graph_issue_inbox_repositories "${LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES:-}" \
-                --arg work_graph_issue_inbox_limit "${LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT:-}" \
-                --arg work_graph_gh_binary "${LAUNCHPLANE_WORK_GRAPH_GH_BINARY:-}" \
-                --arg work_graph_gh_token "${LAUNCHPLANE_WORK_GRAPH_GH_TOKEN:-}" \
-                --arg public_ingress_github_token "${LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN:-}" \
-                --arg enable_every_code_runtime_secrets "${LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS:-}" \
-                --arg every_code_worker_token "${LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN:-}" \
-                --arg every_code_webhook_secret "${LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET:-}" \
-                --arg every_code_github_token "${LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN:-}" \
-                --arg every_code_github_actor "${LAUNCHPLANE_EVERY_CODE_GITHUB_ACTOR:-}" \
-                --arg terminal_agent_read_token "${LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN:-}" \
-                --arg terminal_agent_subject "${LAUNCHPLANE_TERMINAL_AGENT_SUBJECT:-}" \
-                --arg terminal_agent_token_label "${LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL:-}" \
-                --arg local_operator_token "${LAUNCHPLANE_LOCAL_OPERATOR_TOKEN:-}" \
-                --arg local_operator_subject "${LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT:-}" \
-                --arg local_operator_token_label "${LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL:-}" \
-                --arg local_admin_token "${LAUNCHPLANE_LOCAL_ADMIN_TOKEN:-}" \
-                --arg local_admin_subject "${LAUNCHPLANE_LOCAL_ADMIN_SUBJECT:-}" \
-                --arg local_admin_token_label "${LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL:-}" \
-                --arg compose_external_network "${LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK:-}" \
-                --arg npmplus_base_url "${LAUNCHPLANE_NPMPLUS_BASE_URL:-}" \
-                --arg npmplus_identity "${LAUNCHPLANE_NPMPLUS_IDENTITY:-}" \
-                --arg npmplus_secret "${LAUNCHPLANE_NPMPLUS_SECRET:-}" \
-                --argjson omit_every_code_env '${{ inputs.omit_every_code_env || false }}' \
-                --argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env || false }}' \
-                --argjson omit_owner_agent_env '${{ inputs.omit_owner_agent_env || false }}' \
-                --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
-                '(
-                  {
-                  LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
-                  LAUNCHPLANE_GITHUB_CLIENT_SECRET: $github_client_secret,
-                  LAUNCHPLANE_PUBLIC_URL: $public_url,
-                  LAUNCHPLANE_SESSION_SECRET: $session_secret,
-                  LAUNCHPLANE_COOKIE_SECURE: $cookie_secure,
-                  LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: $bootstrap_admin_emails
-                  }
-                  + (
-                    if ($omit_terminal_agent_env | not) then
-                      {
-                        LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: $terminal_agent_read_token,
-                        LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: $terminal_agent_subject,
-                        LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: $terminal_agent_token_label
-                      }
-                    else
-                      {}
-                    end
-                  )
-                  + (
-                    if ($omit_owner_agent_env | not) then
-                      {
-                        LAUNCHPLANE_LOCAL_OPERATOR_TOKEN: $local_operator_token,
-                        LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT: $local_operator_subject,
-                        LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL: $local_operator_token_label,
-                        LAUNCHPLANE_LOCAL_ADMIN_TOKEN: $local_admin_token,
-                        LAUNCHPLANE_LOCAL_ADMIN_SUBJECT: $local_admin_subject,
-                        LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL: $local_admin_token_label
-                      }
-                    else
-                      {}
-                    end
-                  )
-                  + (
-                    if (($omit_every_code_env | not)
-                      and (($enable_every_code_runtime_secrets | ascii_downcase) == "true")) then
-                      {
-                        LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN: $every_code_worker_token,
-                        LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET: $every_code_webhook_secret,
-                        LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN: $every_code_github_token,
-                        LAUNCHPLANE_EVERY_CODE_GITHUB_ACTOR: $every_code_github_actor
-                      }
-                    else
-                      {}
-                    end
-                  )
-                  + (
-                    if $compose_external_network != "" then
-                      {LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK: $compose_external_network}
-                    else
-                      {}
-                    end
-                  )
-                  + (
-                    if (($omit_npmplus_env | not) and $npmplus_base_url != "") then
-                      {LAUNCHPLANE_NPMPLUS_BASE_URL: $npmplus_base_url}
-                    else
-                      {}
-                    end
-                  )
-                  + (
-                    if (($omit_npmplus_env | not) and $npmplus_identity != "") then
-                      {LAUNCHPLANE_NPMPLUS_IDENTITY: $npmplus_identity}
-                    else
-                      {}
-                    end
-                  )
-                  + (
-                    if (($omit_npmplus_env | not) and $npmplus_secret != "") then
-                      {LAUNCHPLANE_NPMPLUS_SECRET: $npmplus_secret}
-                    else
-                      {}
-                    end
-                  )
-                  + (
-                    if $public_ingress_github_token != "" then
-                      {LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN: $public_ingress_github_token}
-                    else
-                      {}
-                    end
-                  )
-                  + (
-                    if $work_graph_gh_token != "" then
-                      {
-                        LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER: $work_graph_project_owner,
-                        LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER: $work_graph_project_number,
-                        LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT: $work_graph_project_limit,
-                        LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT: $work_graph_project_signal_limit,
-                        LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES: $work_graph_issue_inbox_repositories,
-                        LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT: $work_graph_issue_inbox_limit,
-                        LAUNCHPLANE_WORK_GRAPH_GH_BINARY: $work_graph_gh_binary,
-                        GH_TOKEN: $work_graph_gh_token
-                      }
-                    else
-                      {}
-                    end
-                  )
-                ) | with_entries(select(.value != ""))'
-            })"
-            service_env_removals_json="$({
-              jq -n \
-                --arg public_ingress_github_token "${LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN:-}" \
-                --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
-                '(
-                  if $omit_npmplus_env then
-                    [
-                      "LAUNCHPLANE_NPMPLUS_BASE_URL",
-                      "LAUNCHPLANE_NPMPLUS_IDENTITY",
-                      "LAUNCHPLANE_NPMPLUS_SECRET"
-                    ]
+          service_env_json="$({
+            jq -n \
+              --arg github_client_id "${LAUNCHPLANE_GITHUB_CLIENT_ID:-}" \
+              --arg github_client_secret "${LAUNCHPLANE_GITHUB_CLIENT_SECRET:-}" \
+              --arg public_url "${LAUNCHPLANE_PUBLIC_URL:-}" \
+              --arg session_secret "${LAUNCHPLANE_SESSION_SECRET:-}" \
+              --arg cookie_secure "${LAUNCHPLANE_COOKIE_SECURE:-}" \
+              --arg bootstrap_admin_emails "${LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS:-}" \
+              --arg work_graph_project_owner "${LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER:-}" \
+              --arg work_graph_project_number "${LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER:-}" \
+              --arg work_graph_project_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT:-}" \
+              --arg work_graph_project_signal_limit "${LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT:-}" \
+              --arg work_graph_issue_inbox_repositories "${LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES:-}" \
+              --arg work_graph_issue_inbox_limit "${LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT:-}" \
+              --arg work_graph_gh_binary "${LAUNCHPLANE_WORK_GRAPH_GH_BINARY:-}" \
+              --arg work_graph_gh_token "${LAUNCHPLANE_WORK_GRAPH_GH_TOKEN:-}" \
+              --arg public_ingress_github_token "${LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN:-}" \
+              --arg enable_every_code_runtime_secrets "${LAUNCHPLANE_ENABLE_EVERY_CODE_RUNTIME_SECRETS:-}" \
+              --arg every_code_worker_token "${LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN:-}" \
+              --arg every_code_webhook_secret "${LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET:-}" \
+              --arg every_code_github_token "${LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN:-}" \
+              --arg every_code_github_actor "${LAUNCHPLANE_EVERY_CODE_GITHUB_ACTOR:-}" \
+              --arg terminal_agent_read_token "${LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN:-}" \
+              --arg terminal_agent_subject "${LAUNCHPLANE_TERMINAL_AGENT_SUBJECT:-}" \
+              --arg terminal_agent_token_label "${LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL:-}" \
+              --arg local_operator_token "${LAUNCHPLANE_LOCAL_OPERATOR_TOKEN:-}" \
+              --arg local_operator_subject "${LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT:-}" \
+              --arg local_operator_token_label "${LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL:-}" \
+              --arg local_admin_token "${LAUNCHPLANE_LOCAL_ADMIN_TOKEN:-}" \
+              --arg local_admin_subject "${LAUNCHPLANE_LOCAL_ADMIN_SUBJECT:-}" \
+              --arg local_admin_token_label "${LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL:-}" \
+              --arg compose_external_network "${LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK:-}" \
+              --arg npmplus_base_url "${LAUNCHPLANE_NPMPLUS_BASE_URL:-}" \
+              --arg npmplus_identity "${LAUNCHPLANE_NPMPLUS_IDENTITY:-}" \
+              --arg npmplus_secret "${LAUNCHPLANE_NPMPLUS_SECRET:-}" \
+              --argjson omit_every_code_env '${{ inputs.omit_every_code_env || false }}' \
+              --argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env || false }}' \
+              --argjson omit_owner_agent_env '${{ inputs.omit_owner_agent_env || false }}' \
+              --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
+              '(
+                {
+                LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
+                LAUNCHPLANE_GITHUB_CLIENT_SECRET: $github_client_secret,
+                LAUNCHPLANE_PUBLIC_URL: $public_url,
+                LAUNCHPLANE_SESSION_SECRET: $session_secret,
+                LAUNCHPLANE_COOKIE_SECURE: $cookie_secure,
+                LAUNCHPLANE_BOOTSTRAP_ADMIN_EMAILS: $bootstrap_admin_emails
+                }
+                + (
+                  if ($omit_terminal_agent_env | not) then
+                    {
+                      LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN: $terminal_agent_read_token,
+                      LAUNCHPLANE_TERMINAL_AGENT_SUBJECT: $terminal_agent_subject,
+                      LAUNCHPLANE_TERMINAL_AGENT_TOKEN_LABEL: $terminal_agent_token_label
+                    }
                   else
-                    []
+                    {}
                   end
                 )
                 + (
-                  if $public_ingress_github_token == "" then
-                    ["LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN"]
+                  if ($omit_owner_agent_env | not) then
+                    {
+                      LAUNCHPLANE_LOCAL_OPERATOR_TOKEN: $local_operator_token,
+                      LAUNCHPLANE_LOCAL_OPERATOR_SUBJECT: $local_operator_subject,
+                      LAUNCHPLANE_LOCAL_OPERATOR_TOKEN_LABEL: $local_operator_token_label,
+                      LAUNCHPLANE_LOCAL_ADMIN_TOKEN: $local_admin_token,
+                      LAUNCHPLANE_LOCAL_ADMIN_SUBJECT: $local_admin_subject,
+                      LAUNCHPLANE_LOCAL_ADMIN_TOKEN_LABEL: $local_admin_token_label
+                    }
                   else
-                    []
+                    {}
                   end
-                )'
-            })"
-            request_payload="$({
-              jq -n \
-                --arg target_type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
-                --arg target_id "$LAUNCHPLANE_DOKPLOY_TARGET_ID" \
-                --arg image_reference "${{ steps.image.outputs.image_reference }}" \
-                --argjson service_env "$service_env_json" \
-                --argjson service_env_removals "$service_env_removals_json" \
-                '{schema_version: 1, product: "launchplane", deploy: ({target_type: $target_type, target_id: $target_id, image_reference: $image_reference} + (if ($service_env | length) > 0 then {oauth_env: $service_env} else {} end) + (if ($service_env_removals | length) > 0 then {oauth_env_removals: $service_env_removals} else {} end))}'
-            })"
-            idempotency_key="launchplane-self-deploy:${{ steps.image.outputs.image_reference }}:${{ github.run_id }}:${{ github.run_attempt }}:db-authz"
+                )
+                + (
+                  if (($omit_every_code_env | not)
+                    and (($enable_every_code_runtime_secrets | ascii_downcase) == "true")) then
+                    {
+                      LAUNCHPLANE_EVERY_CODE_WORKER_TOKEN: $every_code_worker_token,
+                      LAUNCHPLANE_EVERY_CODE_GITHUB_WEBHOOK_SECRET: $every_code_webhook_secret,
+                      LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN: $every_code_github_token,
+                      LAUNCHPLANE_EVERY_CODE_GITHUB_ACTOR: $every_code_github_actor
+                    }
+                  else
+                    {}
+                  end
+                )
+                + (
+                  if $compose_external_network != "" then
+                    {LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK: $compose_external_network}
+                  else
+                    {}
+                  end
+                )
+                + (
+                  if (($omit_npmplus_env | not) and $npmplus_base_url != "") then
+                    {LAUNCHPLANE_NPMPLUS_BASE_URL: $npmplus_base_url}
+                  else
+                    {}
+                  end
+                )
+                + (
+                  if (($omit_npmplus_env | not) and $npmplus_identity != "") then
+                    {LAUNCHPLANE_NPMPLUS_IDENTITY: $npmplus_identity}
+                  else
+                    {}
+                  end
+                )
+                + (
+                  if (($omit_npmplus_env | not) and $npmplus_secret != "") then
+                    {LAUNCHPLANE_NPMPLUS_SECRET: $npmplus_secret}
+                  else
+                    {}
+                  end
+                )
+                + (
+                  if $public_ingress_github_token != "" then
+                    {LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN: $public_ingress_github_token}
+                  else
+                    {}
+                  end
+                )
+                + (
+                  if $work_graph_gh_token != "" then
+                    {
+                      LAUNCHPLANE_WORK_GRAPH_PROJECT_OWNER: $work_graph_project_owner,
+                      LAUNCHPLANE_WORK_GRAPH_PROJECT_NUMBER: $work_graph_project_number,
+                      LAUNCHPLANE_WORK_GRAPH_PROJECT_LIMIT: $work_graph_project_limit,
+                      LAUNCHPLANE_WORK_GRAPH_PROJECT_SIGNAL_LIMIT: $work_graph_project_signal_limit,
+                      LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_REPOSITORIES: $work_graph_issue_inbox_repositories,
+                      LAUNCHPLANE_WORK_GRAPH_ISSUE_INBOX_LIMIT: $work_graph_issue_inbox_limit,
+                      LAUNCHPLANE_WORK_GRAPH_GH_BINARY: $work_graph_gh_binary,
+                      GH_TOKEN: $work_graph_gh_token
+                    }
+                  else
+                    {}
+                  end
+                )
+              ) | with_entries(select(.value != ""))'
+          })"
+          service_env_removals_json="$({
+            jq -n \
+              --arg public_ingress_github_token "${LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN:-}" \
+              --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
+              '(
+                if $omit_npmplus_env then
+                  [
+                    "LAUNCHPLANE_NPMPLUS_BASE_URL",
+                    "LAUNCHPLANE_NPMPLUS_IDENTITY",
+                    "LAUNCHPLANE_NPMPLUS_SECRET"
+                  ]
+                else
+                  []
+                end
+              )
+              + (
+                if $public_ingress_github_token == "" then
+                  ["LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN"]
+                else
+                  []
+                end
+              )'
+          })"
+          request_payload="$({
+            jq -n \
+              --arg target_type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
+              --arg target_id "$LAUNCHPLANE_DOKPLOY_TARGET_ID" \
+              --arg image_reference "${{ steps.image.outputs.image_reference }}" \
+              --argjson service_env "$service_env_json" \
+              --argjson service_env_removals "$service_env_removals_json" \
+              '{schema_version: 1, product: "launchplane", deploy: ({target_type: $target_type, target_id: $target_id, image_reference: $image_reference} + (if ($service_env | length) > 0 then {oauth_env: $service_env} else {} end) + (if ($service_env_removals | length) > 0 then {oauth_env_removals: $service_env_removals} else {} end))}'
+          })"
 
-            curl -sS \
-              -o "$response_file" \
-              -w '%{http_code}' \
-              -X POST \
-              -H "Authorization: Bearer ${oidc_token}" \
-              -H "Content-Type: application/json" \
-              -H "Idempotency-Key: ${idempotency_key}" \
-              --data "$request_payload" \
-              "${{ steps.service.outputs.service_url }}/v1/drivers/launchplane/self-deploy"
-          }
+          request_payload_file="$RUNNER_TEMP/launchplane-self-deploy-payload.json"
+          printf '%s\n' "$request_payload" > "$request_payload_file"
+          echo "payload_file=$request_payload_file" >> "$GITHUB_OUTPUT"
 
-          response_file="$(mktemp)"
-          status_code="$(request_deploy "$response_file")"
-          if [ "$status_code" = "200" ] || [ "$status_code" = "202" ]; then
-            cat "$response_file"
-            exit 0
+      - name: Request Launchplane self deploy
+        id: self_deploy_request
+        continue-on-error: true
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/drivers/launchplane/self-deploy
+          payload-file: ${{ steps.self_deploy.outputs.payload_file }}
+          idempotency-key: launchplane-self-deploy:${{ steps.image.outputs.image_reference }}:${{ github.run_id }}:${{ github.run_attempt }}:db-authz
+          expected-status: "200,202"
+          fail-result-paths: ""
+          timeout-ms: "30000"
+          response-output-file: ${{ runner.temp }}/launchplane-self-deploy-response.json
+          log-response-body: "false"
+
+      - name: Check Launchplane self deploy request
+        shell: bash
+        env:
+          SELF_DEPLOY_RESPONSE_FILE: ${{ runner.temp }}/launchplane-self-deploy-response.json
+          SELF_DEPLOY_STATUS: ${{ steps.self_deploy_request.outputs.status-code }}
+          SELF_DEPLOY_OUTCOME: ${{ steps.self_deploy_request.outcome }}
+        run: |
+          set -euo pipefail
+
+          status_code="$SELF_DEPLOY_STATUS"
+          if [ -z "$status_code" ]; then
+            status_code="action_failed"
           fi
-
-          cat "$response_file" >&2
-          echo "Launchplane self deploy request failed with HTTP ${status_code}." >&2
-          exit 1
+          if [ "${SELF_DEPLOY_OUTCOME:-failure}" != "success" ] \
+            || { [ "$status_code" != "200" ] && [ "$status_code" != "202" ]; }; then
+            if [ -s "$SELF_DEPLOY_RESPONSE_FILE" ]; then
+              cat "$SELF_DEPLOY_RESPONSE_FILE" >&2
+            fi
+            echo "Launchplane self deploy request failed with HTTP ${status_code}." >&2
+            exit 1
+          fi
 
       - name: Wait for deployed Launchplane image
         shell: bash

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -747,6 +747,8 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "fail-result-paths": frozenset(('""',)),
         "idempotency-key": frozenset(
             (
+                "launchplane-self-deploy:${{ steps.image.outputs.image_reference }}:${{ "
+                "github.run_id }}:${{ github.run_attempt }}:db-authz",
                 "launchplane-self-deploy-rollback:${{ "
                 "steps.rollback_request.outputs.previous_image_reference }}:${{ "
                 "github.run_id }}:${{ github.run_attempt }}",
@@ -754,10 +756,17 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         ),
         "log-response-body": frozenset(('"false"',)),
         "method": frozenset(("GET",)),
-        "payload-file": frozenset(("${{ steps.rollback_request.outputs.payload_file }}",)),
+        "payload-file": frozenset(
+            (
+                "${{ steps.self_deploy.outputs.payload_file }}",
+                "${{ steps.rollback_request.outputs.payload_file }}",
+            )
+        ),
         "response-output-file": frozenset(
             (
+                "${{ runner.temp }}/launchplane-previous-runtime.json",
                 "${{ runner.temp }}/launchplane-runtime-smoke.json",
+                "${{ runner.temp }}/launchplane-self-deploy-response.json",
                 "${{ runner.temp }}/launchplane-self-deploy-rollback-response.json",
             )
         ),

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2935,13 +2935,24 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("fail-result-paths", '""'),
             (
                 "idempotency-key",
+                "launchplane-self-deploy:${{ steps.image.outputs.image_reference }}:${{ "
+                "github.run_id }}:${{ github.run_attempt }}:db-authz",
+            ),
+            (
+                "idempotency-key",
                 "launchplane-self-deploy-rollback:${{ "
                 "steps.rollback_request.outputs.previous_image_reference }}:${{ "
                 "github.run_id }}:${{ github.run_attempt }}",
             ),
             ("method", "GET"),
+            ("payload-file", "${{ steps.self_deploy.outputs.payload_file }}"),
             ("payload-file", "${{ steps.rollback_request.outputs.payload_file }}"),
+            ("response-output-file", "${{ runner.temp }}/launchplane-previous-runtime.json"),
             ("response-output-file", "${{ runner.temp }}/launchplane-runtime-smoke.json"),
+            (
+                "response-output-file",
+                "${{ runner.temp }}/launchplane-self-deploy-response.json",
+            ),
             (
                 "response-output-file",
                 "${{ runner.temp }}/launchplane-self-deploy-rollback-response.json",

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1916,6 +1916,56 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertNotIn("Authorization: Bearer", deployed_smoke_step)
         self.assertNotIn('--data-urlencode "audience=', deployed_smoke_step)
 
+    def test_deploy_workflow_requests_self_deploy_through_shared_request(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+
+        self.assertIn("Read previous Launchplane runtime", workflow_text)
+        self.assertIn("id: previous_runtime", workflow_text)
+        self.assertIn("Render Launchplane self deploy request", workflow_text)
+        self.assertIn("id: self_deploy", workflow_text)
+        self.assertIn("Request Launchplane self deploy", workflow_text)
+        self.assertIn("id: self_deploy_request", workflow_text)
+        self.assertIn("continue-on-error: true", workflow_text)
+        self.assertIn(
+            "response-output-file: ${{ runner.temp }}/launchplane-previous-runtime.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "payload-file: ${{ steps.self_deploy.outputs.payload_file }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "idempotency-key: launchplane-self-deploy:${{ "
+            "steps.image.outputs.image_reference }}:${{ github.run_id }}:${{ "
+            "github.run_attempt }}:db-authz",
+            workflow_text,
+        )
+        self.assertIn('expected-status: "200,202"', workflow_text)
+        self.assertIn('fail-result-paths: ""', workflow_text)
+        self.assertIn('timeout-ms: "30000"', workflow_text)
+        self.assertIn(
+            "response-output-file: ${{ runner.temp }}/launchplane-self-deploy-response.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "SELF_DEPLOY_STATUS: ${{ steps.self_deploy_request.outputs.status-code }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "SELF_DEPLOY_OUTCOME: ${{ steps.self_deploy_request.outcome }}",
+            workflow_text,
+        )
+        self.assertIn("status_code=\"action_failed\"", workflow_text)
+        self.assertIn("Launchplane self deploy request failed with HTTP", workflow_text)
+
+        self_deploy_block = workflow_text.split(
+            "- name: Read previous Launchplane runtime", 1
+        )[1].split("- name: Wait for deployed Launchplane image", 1)[0]
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", self_deploy_block)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", self_deploy_block)
+        self.assertNotIn("Authorization: Bearer", self_deploy_block)
+        self.assertNotIn("curl ", self_deploy_block)
+
     def test_deploy_workflow_requests_rollback_through_shared_request(self) -> None:
         workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
 

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -3,6 +3,7 @@ import json
 import os
 from pathlib import Path
 import subprocess
+import textwrap
 from tempfile import TemporaryDirectory
 from typing import Callable, cast
 import unittest
@@ -1713,9 +1714,9 @@ class ProductOnboardingTests(unittest.TestCase):
             "Missing LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK variable",
             workflow_text,
         )
+        self.assertIn('if $compose_external_network != "" then', workflow_text)
         self.assertIn(
-            'if $compose_external_network != "" then\n'
-            "                      {LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK: $compose_external_network}",
+            "{LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK: $compose_external_network}",
             workflow_text,
         )
         self.assertNotIn("omit_compose_external_network_env", workflow_text)
@@ -1756,9 +1757,16 @@ class ProductOnboardingTests(unittest.TestCase):
         )
 
         removals_block = workflow_text.split("service_env_removals_json=", 1)[1].split(
-            '            })"', 1
+            '          })"', 1
         )[0]
-        jq_filter = removals_block.split("                '", 1)[1].rsplit("'", 1)[0]
+        removal_lines = removals_block.splitlines()
+        start = next(index for index, line in enumerate(removal_lines) if line.strip() == "'(")
+        end = next(
+            index for index, line in enumerate(removal_lines[start + 1 :], start + 1) if line.strip() == ")'"
+        )
+        removal_lines[start] = removal_lines[start].split("'", 1)[1]
+        removal_lines[end] = removal_lines[end].rsplit("'", 1)[0]
+        jq_filter = textwrap.dedent("\n".join(removal_lines[start : end + 1]))
         self.assertIn("$public_ingress_github_token", jq_filter)
         self.assertIn("LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN", jq_filter)
 


### PR DESCRIPTION
## Summary
- move the previous Launchplane runtime read to the shared launchplane-request action
- render the self-deploy payload separately and POST it through launchplane-request
- preserve previous_image_reference rollback wiring and update config-authority/test coverage

## Validation
- uv run python -m unittest tests.test_launchplane_request_action tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_reads_deployed_runtime_through_shared_request tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_requests_self_deploy_through_shared_request tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_requests_rollback_through_shared_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only
- docker run --rm -v "${PWD}:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check --diff tests/test_product_onboarding.py tests/test_config_authority_audit.py control_plane/config_authority_audit.py
- git diff --check