### PR TITLE
Use shared request for runtime image waits

### DIFF
--- a/.github/actions/launchplane-request/action.yml
+++ b/.github/actions/launchplane-request/action.yml
@@ -95,6 +95,28 @@ inputs:
       Comma-separated result status values that should keep polling.
     required: false
     default: pending
+  poll-until-path:
+    description: >-
+      JSON path to inspect after each Launchplane response. When set, the action
+      repeats the request until the value equals poll-until-value.
+    required: false
+    default: ""
+  poll-until-value:
+    description: Expected string value for poll-until-path.
+    required: false
+    default: ""
+  poll-retry-on-request-error:
+    description: >-
+      When true, continue polling through Launchplane request network errors
+      until poll-timeout-ms expires.
+    required: false
+    default: "false"
+  poll-retry-on-unexpected-status:
+    description: >-
+      When true with poll-until-path, continue polling through non-2xx
+      Launchplane responses until poll-timeout-ms expires.
+    required: false
+    default: "false"
   poll-interval-ms:
     description: Delay between polling requests in milliseconds.
     required: false

--- a/.github/actions/launchplane-request/dist/index.js
+++ b/.github/actions/launchplane-request/dist/index.js
@@ -377,15 +377,48 @@ function getActionOptions() {
     expectedStatuses: parseExpectedStatuses(getInput("expected-status")),
     oidcTimeoutMs: getInput("oidc-timeout-ms", { defaultValue: "30000" }),
     pollIntervalMs: getInput("poll-interval-ms", { defaultValue: "30000" }),
+    pollRetryOnRequestError: parseBooleanInput(
+      getInput("poll-retry-on-request-error", { defaultValue: "false" }),
+      "poll-retry-on-request-error",
+    ),
+    pollRetryOnUnexpectedStatus: parseBooleanInput(
+      getInput("poll-retry-on-unexpected-status", { defaultValue: "false" }),
+      "poll-retry-on-unexpected-status",
+    ),
     pollResultPath: getInput("poll-result-path"),
     pollResultStatuses: getInput("poll-result-statuses", { defaultValue: "pending" }),
     pollTimeoutMs: getInput("poll-timeout-ms", { defaultValue: "600000" }),
+    pollUntilPath: getInput("poll-until-path"),
+    pollUntilValue: getInput("poll-until-value"),
     retryAttempts: getInput("retry-attempts", { defaultValue: "3" }),
     retryDelayMs: getInput("retry-delay-ms", { defaultValue: "250" }),
   };
 }
 
+function assertCanContinuePolling({ deadline, lastPollValue, options, pollIntervalMs, pollPath }) {
+  const pollTimeoutMs = parseNonNegativeInteger(
+    options.pollTimeoutMs,
+    "poll-timeout-ms",
+  );
+  if (!pollTimeoutMs || Date.now() + pollIntervalMs > deadline) {
+    throw new Error(
+      options.pollUntilPath
+        ? `Timed out waiting for Launchplane result ${pollPath} to become ` +
+            `${options.pollUntilValue} after ${pollTimeoutMs}ms. Last value: ` +
+            `${lastPollValue || "missing"}.`
+        : `Timed out waiting for Launchplane result ${pollPath} to leave ` +
+            `${lastPollValue || "the polling status"} after ${pollTimeoutMs}ms.`,
+    );
+  }
+}
+
 function shouldPollResponse(responseBody, options) {
+  const pollUntilPath = String(options.pollUntilPath ?? "").trim();
+  if (pollUntilPath) {
+    const value = readJsonPath(responseBody, pollUntilPath);
+    return String(value ?? "").trim() !== String(options.pollUntilValue ?? "");
+  }
+
   const pollResultPath = String(options.pollResultPath ?? "").trim();
   if (!pollResultPath) {
     return false;
@@ -404,7 +437,7 @@ function shouldPollResponse(responseBody, options) {
 }
 
 async function requestLaunchplaneUntilComplete(requestUrl, requestInit, options) {
-  const pollResultPath = String(options.pollResultPath ?? "").trim();
+  const pollPath = String(options.pollUntilPath || options.pollResultPath || "").trim();
   const pollTimeoutMs = parseNonNegativeInteger(
     options.pollTimeoutMs,
     "poll-timeout-ms",
@@ -419,24 +452,55 @@ async function requestLaunchplaneUntilComplete(requestUrl, requestInit, options)
 
   while (true) {
     attempt += 1;
-    const response = await fetchWithRetry(requestUrl, requestInit, {
-      ...options,
-      label: "Launchplane request",
-    });
-    const { responseBody, responseText } = await readJsonResponse(response);
-    if (!response.ok || !shouldPollResponse(responseBody, options)) {
+    let response;
+    let responseBody;
+    let responseText;
+    try {
+      response = await fetchWithRetry(requestUrl, requestInit, {
+        ...options,
+        label: "Launchplane request",
+      });
+      ({ responseBody, responseText } = await readJsonResponse(response));
+    } catch (error) {
+      if (!options.pollUntilPath || !options.pollRetryOnRequestError) {
+        throw error;
+      }
+      lastPollValue = describeError(error);
+      assertCanContinuePolling({
+        deadline,
+        lastPollValue,
+        options,
+        pollIntervalMs,
+        pollPath,
+      });
+      process.stderr.write(
+        `Launchplane request failed while waiting for ${pollPath}: ${lastPollValue}; ` +
+          `polling again in ${pollIntervalMs}ms.\n`,
+      );
+      await sleep(pollIntervalMs);
+      continue;
+    }
+    if (!response.ok && (!options.pollUntilPath || !options.pollRetryOnUnexpectedStatus)) {
       return { response, responseBody, responseText };
     }
-
-    lastPollValue = String(readJsonPath(responseBody, pollResultPath) ?? "").trim();
-    if (!pollTimeoutMs || Date.now() + pollIntervalMs > deadline) {
-      throw new Error(
-        `Timed out waiting for Launchplane result ${pollResultPath} to leave ` +
-          `${lastPollValue || "the polling status"} after ${pollTimeoutMs}ms.`,
-      );
+    lastPollValue = String(readJsonPath(responseBody, pollPath) ?? "").trim();
+    if (!response.ok && options.pollUntilPath) {
+      lastPollValue = `HTTP ${response.status}`;
+    } else if (!shouldPollResponse(responseBody, options)) {
+      return { response, responseBody, responseText };
     }
+    assertCanContinuePolling({
+      deadline,
+      lastPollValue,
+      options,
+      pollIntervalMs,
+      pollPath,
+    });
     process.stderr.write(
-      `Launchplane result ${pollResultPath} is ${lastPollValue}; polling again in ${pollIntervalMs}ms.\n`,
+      options.pollUntilPath
+        ? `Launchplane result ${pollPath} is ${lastPollValue || "missing"}; ` +
+            `waiting for ${options.pollUntilValue}, polling again in ${pollIntervalMs}ms.\n`
+        : `Launchplane result ${pollPath} is ${lastPollValue}; polling again in ${pollIntervalMs}ms.\n`,
     );
     await sleep(pollIntervalMs);
   }
@@ -456,6 +520,15 @@ async function main() {
   );
   const payloadConfig = applyPayloadTransforms(readPayload());
   const options = getActionOptions();
+  if (options.pollUntilPath && !String(options.pollUntilValue ?? "")) {
+    throw new Error("poll-until-value is required when poll-until-path is set.");
+  }
+  if (options.pollUntilValue && !options.pollUntilPath) {
+    throw new Error("poll-until-path is required when poll-until-value is set.");
+  }
+  if (options.pollUntilPath && options.pollResultPath) {
+    throw new Error("Use either poll-until-path or poll-result-path, not both.");
+  }
   async function requestInit(payload, requestIdempotencyKey) {
     const token = await requestGitHubOidcToken(audience, options);
     const headers = {

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -486,15 +486,48 @@ jobs:
             exit 1
           fi
 
-      - name: Wait for deployed Launchplane image
+      - name: Resolve Launchplane deploy wait timeout
+        id: deploy_wait_timeout
         shell: bash
         run: |
           set -euo pipefail
 
-          deadline=$((SECONDS + ${LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600} + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
-          expected_image_reference="${{ steps.image.outputs.image_reference }}"
+          wait_timeout_seconds=$((${LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600} + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
+          {
+            echo "timeout_seconds=$wait_timeout_seconds"
+            echo "timeout_ms=$((wait_timeout_seconds * 1000))"
+            echo "deadline_epoch=$(($(date +%s) + wait_timeout_seconds))"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Wait for deployed Launchplane runtime image
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/service/runtime
+          method: GET
+          expected-status: "200"
+          timeout-ms: "30000"
+          poll-until-path: runtime.docker_image_reference
+          poll-until-value: ${{ steps.image.outputs.image_reference }}
+          poll-retry-on-request-error: "true"
+          poll-retry-on-unexpected-status: "true"
+          poll-interval-ms: "5000"
+          poll-timeout-ms: ${{ steps.deploy_wait_timeout.outputs.timeout_ms }}
+          response-output-file: ${{ runner.temp }}/launchplane-deployed-runtime-wait.json
+          log-response-body: "false"
+
+      - name: Wait for deployed Launchplane health URLs
+        id: deployed_health
+        shell: bash
+        env:
+          WAIT_DEADLINE_EPOCH: ${{ steps.deploy_wait_timeout.outputs.deadline_epoch }}
+        run: |
+          set -euo pipefail
+
+          deadline_epoch="${WAIT_DEADLINE_EPOCH:?}"
           last_report_seconds=0
-          while [ "$SECONDS" -lt "$deadline" ]; do
+          while [ "$(date +%s)" -lt "$deadline_epoch" ]; do
             all_healthy=1
             health_report=""
             while IFS= read -r raw_url; do
@@ -518,36 +551,43 @@ jobs:
               rm -f "$health_response_file"
             done < <(printf '%s\n' "$LAUNCHPLANE_DEPLOY_HEALTH_URLS" | tr ',' '\n')
 
-            oidc_token="$({
-              curl -fsSL \
-                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
-              | jq -r '.value'
-            })"
-
-            runtime_response_file="$(mktemp)"
-            runtime_status_code="$(curl -sS \
-              -o "$runtime_response_file" \
-              -w '%{http_code}' \
-              -H "Authorization: Bearer ${oidc_token}" \
-              "${{ steps.service.outputs.service_url }}/v1/service/runtime" 2>/dev/null || true)"
-            actual_image_reference="$(jq -r '.runtime.docker_image_reference // empty' "$runtime_response_file" 2>/dev/null || true)"
-            runtime_error_code="$(jq -r '.error.code // empty' "$runtime_response_file" 2>/dev/null || true)"
-
-            if [ "$all_healthy" -eq 1 ] && [ "$runtime_status_code" = "200" ] && [ "$actual_image_reference" = "$expected_image_reference" ]; then
-              rm -f "$runtime_response_file"
+            if [ "$all_healthy" -eq 1 ]; then
+              remaining_seconds=$((deadline_epoch - $(date +%s)))
+              if [ "$remaining_seconds" -lt 0 ]; then
+                remaining_seconds=0
+              fi
+              remaining_timeout_ms=$((remaining_seconds * 1000))
+              if [ "$remaining_timeout_ms" -lt 1 ]; then
+                remaining_timeout_ms=1
+              fi
+              echo "remaining_timeout_ms=$remaining_timeout_ms" >>"$GITHUB_OUTPUT"
               exit 0
             fi
             if [ "$((SECONDS - last_report_seconds))" -ge 30 ]; then
-              echo "Waiting for Launchplane image. health=${health_report:-none} runtime_http=${runtime_status_code:-curl_failed} runtime_image=${actual_image_reference:-none} runtime_error=${runtime_error_code:-none}"
+              echo "Waiting for Launchplane health URLs. health=${health_report:-none}"
               last_report_seconds=$SECONDS
             fi
-            rm -f "$runtime_response_file"
             sleep 5
           done
 
-          echo "Timed out waiting for Launchplane image '$expected_image_reference' to become live and healthy." >&2
+          echo "Timed out waiting for Launchplane health URLs to become healthy." >&2
           exit 1
+
+      - name: Verify deployed Launchplane runtime image after health
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/service/runtime
+          method: GET
+          expected-status: "200"
+          timeout-ms: "30000"
+          poll-until-path: runtime.docker_image_reference
+          poll-until-value: ${{ steps.image.outputs.image_reference }}
+          poll-interval-ms: "1000"
+          poll-timeout-ms: ${{ steps.deployed_health.outputs.remaining_timeout_ms }}
+          response-output-file: ${{ runner.temp }}/launchplane-deployed-runtime-final.json
+          log-response-body: "false"
 
       - name: Capture failed Launchplane deploy diagnostics
         if: failure()
@@ -643,7 +683,50 @@ jobs:
             echo "- Rollback image: $PREVIOUS_IMAGE_REFERENCE"
           } >>"$GITHUB_STEP_SUMMARY"
 
-      - name: Wait for Launchplane rollback image
+      - name: Resolve Launchplane rollback wait timeout
+        if: >-
+          failure()
+          && steps.rollback_request.outputs.payload_file != ''
+          && steps.rollback_request.outputs.previous_image_reference != ''
+          && steps.rollback_request_action.outcome == 'success'
+        id: rollback_wait_timeout
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          wait_timeout_seconds=$((${LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600} + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
+          {
+            echo "timeout_seconds=$wait_timeout_seconds"
+            echo "timeout_ms=$((wait_timeout_seconds * 1000))"
+            echo "deadline_epoch=$(($(date +%s) + wait_timeout_seconds))"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Wait for Launchplane rollback runtime image
+        if: >-
+          failure()
+          && steps.rollback_request.outputs.payload_file != ''
+          && steps.rollback_request.outputs.previous_image_reference != ''
+          && steps.rollback_request_action.outcome == 'success'
+        id: rollback_runtime
+        continue-on-error: true
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/service/runtime
+          method: GET
+          expected-status: "200"
+          timeout-ms: "30000"
+          poll-until-path: runtime.docker_image_reference
+          poll-until-value: ${{ steps.rollback_request.outputs.previous_image_reference }}
+          poll-retry-on-request-error: "true"
+          poll-retry-on-unexpected-status: "true"
+          poll-interval-ms: "5000"
+          poll-timeout-ms: ${{ steps.rollback_wait_timeout.outputs.timeout_ms }}
+          response-output-file: ${{ runner.temp }}/launchplane-rollback-runtime-wait.json
+          log-response-body: "false"
+
+      - name: Check Launchplane rollback runtime image
         if: >-
           failure()
           && steps.rollback_request.outputs.payload_file != ''
@@ -651,15 +734,56 @@ jobs:
           && steps.rollback_request_action.outcome == 'success'
         shell: bash
         env:
+          PREVIOUS_IMAGE_REFERENCE: ${{ steps.rollback_request.outputs.previous_image_reference }}
           ROLLBACK_RESPONSE_FILE: ${{ runner.temp }}/launchplane-self-deploy-rollback-response.json
+          ROLLBACK_RUNTIME_RESPONSE_FILE: ${{ runner.temp }}/launchplane-rollback-runtime-wait.json
+          ROLLBACK_RUNTIME_OUTCOME: ${{ steps.rollback_runtime.outcome }}
           ROLLBACK_STATUS: ${{ steps.rollback_request_action.outputs.status-code }}
         run: |
           set -euo pipefail
 
-          previous_image_reference="${{ steps.rollback_request.outputs.previous_image_reference }}"
-          deadline=$((SECONDS + ${LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS:-600} + ${LAUNCHPLANE_DEPLOY_HEALTH_TIMEOUT_SECONDS:-180}))
+          if [ "${ROLLBACK_RUNTIME_OUTCOME:-failure}" = "success" ]; then
+            echo "Rolled Launchplane back to $PREVIOUS_IMAGE_REFERENCE."
+            exit 0
+          fi
+          echo "Timed out waiting for Launchplane rollback image '$PREVIOUS_IMAGE_REFERENCE' to become live." >&2
+          if [ -s "$ROLLBACK_RUNTIME_RESPONSE_FILE" ]; then
+            echo "Rollback runtime response summary:" >&2
+            jq '{runtime, error}' "$ROLLBACK_RUNTIME_RESPONSE_FILE" >&2 || cat "$ROLLBACK_RUNTIME_RESPONSE_FILE" >&2 || true
+          fi
+          if [ -s "$ROLLBACK_RESPONSE_FILE" ]; then
+            echo "Rollback request response summary:" >&2
+            jq '{status, trace_id, error, result}' "$ROLLBACK_RESPONSE_FILE" >&2 || cat "$ROLLBACK_RESPONSE_FILE" >&2 || true
+          fi
+          {
+            echo "## Launchplane rollback timed out"
+            echo
+            echo "- Service rollback HTTP status: ${ROLLBACK_STATUS:-unknown}"
+            echo "- Rollback image: $PREVIOUS_IMAGE_REFERENCE"
+            echo "- Rollback runtime action outcome: ${ROLLBACK_RUNTIME_OUTCOME:-failure}"
+          } >>"$GITHUB_STEP_SUMMARY"
+          exit 1
+
+      - name: Wait for Launchplane rollback health URLs
+        if: >-
+          failure()
+          && steps.rollback_request.outputs.payload_file != ''
+          && steps.rollback_request.outputs.previous_image_reference != ''
+          && steps.rollback_request_action.outcome == 'success'
+          && steps.rollback_runtime.outcome == 'success'
+        id: rollback_health
+        shell: bash
+        env:
+          PREVIOUS_IMAGE_REFERENCE: ${{ steps.rollback_request.outputs.previous_image_reference }}
+          ROLLBACK_RESPONSE_FILE: ${{ runner.temp }}/launchplane-self-deploy-rollback-response.json
+          ROLLBACK_STATUS: ${{ steps.rollback_request_action.outputs.status-code }}
+          WAIT_DEADLINE_EPOCH: ${{ steps.rollback_wait_timeout.outputs.deadline_epoch }}
+        run: |
+          set -euo pipefail
+
+          deadline_epoch="${WAIT_DEADLINE_EPOCH:?}"
           last_report_seconds=0
-          while [ "$SECONDS" -lt "$deadline" ]; do
+          while [ "$(date +%s)" -lt "$deadline_epoch" ]; do
             all_healthy=1
             health_report=""
             while IFS= read -r raw_url; do
@@ -683,36 +807,26 @@ jobs:
               rm -f "$health_response_file"
             done < <(printf '%s\n' "$LAUNCHPLANE_DEPLOY_HEALTH_URLS" | tr ',' '\n')
 
-            oidc_token="$({
-              curl -fsSL \
-                -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=${{ steps.service.outputs.service_audience }}" \
-              | jq -r '.value'
-            })"
-
-            runtime_response_file="$(mktemp)"
-            runtime_status_code="$(curl -sS \
-              -o "$runtime_response_file" \
-              -w '%{http_code}' \
-              -H "Authorization: Bearer ${oidc_token}" \
-              "${{ steps.service.outputs.service_url }}/v1/service/runtime" 2>/dev/null || true)"
-            actual_image_reference="$(jq -r '.runtime.docker_image_reference // empty' "$runtime_response_file" 2>/dev/null || true)"
-            runtime_error_code="$(jq -r '.error.code // empty' "$runtime_response_file" 2>/dev/null || true)"
-
-            if [ "$all_healthy" -eq 1 ] && [ "$runtime_status_code" = "200" ] && [ "$actual_image_reference" = "$previous_image_reference" ]; then
-              echo "Rolled Launchplane back to $previous_image_reference."
-              rm -f "$runtime_response_file"
+            if [ "$all_healthy" -eq 1 ]; then
+              remaining_seconds=$((deadline_epoch - $(date +%s)))
+              if [ "$remaining_seconds" -lt 0 ]; then
+                remaining_seconds=0
+              fi
+              remaining_timeout_ms=$((remaining_seconds * 1000))
+              if [ "$remaining_timeout_ms" -lt 1 ]; then
+                remaining_timeout_ms=1
+              fi
+              echo "remaining_timeout_ms=$remaining_timeout_ms" >>"$GITHUB_OUTPUT"
               exit 0
             fi
             if [ "$((SECONDS - last_report_seconds))" -ge 30 ]; then
-              echo "Waiting for Launchplane rollback image. health=${health_report:-none} runtime_http=${runtime_status_code:-curl_failed} runtime_image=${actual_image_reference:-none} runtime_error=${runtime_error_code:-none}"
+              echo "Waiting for Launchplane rollback health URLs. health=${health_report:-none}"
               last_report_seconds=$SECONDS
             fi
-            rm -f "$runtime_response_file"
             sleep 5
           done
 
-          echo "Timed out waiting for Launchplane rollback image '$previous_image_reference' to become live and healthy." >&2
+          echo "Timed out waiting for Launchplane rollback health URLs to become healthy." >&2
           if [ -s "$ROLLBACK_RESPONSE_FILE" ]; then
             echo "Rollback request response summary:" >&2
             jq '{status, trace_id, error, result}' "$ROLLBACK_RESPONSE_FILE" >&2 || cat "$ROLLBACK_RESPONSE_FILE" >&2 || true
@@ -721,10 +835,33 @@ jobs:
             echo "## Launchplane rollback timed out"
             echo
             echo "- Service rollback HTTP status: ${ROLLBACK_STATUS:-unknown}"
-            echo "- Rollback image: $previous_image_reference"
+            echo "- Rollback image: $PREVIOUS_IMAGE_REFERENCE"
             echo "- Rollback request response file: $ROLLBACK_RESPONSE_FILE"
           } >>"$GITHUB_STEP_SUMMARY"
           exit 1
+
+      - name: Verify Launchplane rollback runtime image after health
+        if: >-
+          failure()
+          && steps.rollback_request.outputs.payload_file != ''
+          && steps.rollback_request.outputs.previous_image_reference != ''
+          && steps.rollback_request_action.outcome == 'success'
+          && steps.rollback_runtime.outcome == 'success'
+          && steps.rollback_health.outcome == 'success'
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        with:
+          launchplane-url: ${{ steps.service.outputs.service_url }}
+          audience: ${{ steps.service.outputs.service_audience }}
+          route-path: /v1/service/runtime
+          method: GET
+          expected-status: "200"
+          timeout-ms: "30000"
+          poll-until-path: runtime.docker_image_reference
+          poll-until-value: ${{ steps.rollback_request.outputs.previous_image_reference }}
+          poll-interval-ms: "1000"
+          poll-timeout-ms: ${{ steps.rollback_health.outputs.remaining_timeout_ms }}
+          response-output-file: ${{ runner.temp }}/launchplane-rollback-runtime-final.json
+          log-response-body: "false"
 
       - name: Render product context workflow authz grants
         id: authz_grants

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -762,9 +762,31 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
                 "${{ steps.rollback_request.outputs.payload_file }}",
             )
         ),
+        "poll-interval-ms": frozenset(('"1000"', '"5000"')),
+        "poll-retry-on-request-error": frozenset(('"true"',)),
+        "poll-retry-on-unexpected-status": frozenset(('"true"',)),
+        "poll-timeout-ms": frozenset(
+            (
+                "${{ steps.deploy_wait_timeout.outputs.timeout_ms }}",
+                "${{ steps.deployed_health.outputs.remaining_timeout_ms }}",
+                "${{ steps.rollback_wait_timeout.outputs.timeout_ms }}",
+                "${{ steps.rollback_health.outputs.remaining_timeout_ms }}",
+            )
+        ),
+        "poll-until-path": frozenset(("runtime.docker_image_reference",)),
+        "poll-until-value": frozenset(
+            (
+                "${{ steps.image.outputs.image_reference }}",
+                "${{ steps.rollback_request.outputs.previous_image_reference }}",
+            )
+        ),
         "response-output-file": frozenset(
             (
+                "${{ runner.temp }}/launchplane-deployed-runtime-wait.json",
+                "${{ runner.temp }}/launchplane-deployed-runtime-final.json",
                 "${{ runner.temp }}/launchplane-previous-runtime.json",
+                "${{ runner.temp }}/launchplane-rollback-runtime-final.json",
+                "${{ runner.temp }}/launchplane-rollback-runtime-wait.json",
                 "${{ runner.temp }}/launchplane-runtime-smoke.json",
                 "${{ runner.temp }}/launchplane-self-deploy-response.json",
                 "${{ runner.temp }}/launchplane-self-deploy-rollback-response.json",

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2947,7 +2947,49 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ("method", "GET"),
             ("payload-file", "${{ steps.self_deploy.outputs.payload_file }}"),
             ("payload-file", "${{ steps.rollback_request.outputs.payload_file }}"),
+            ("poll-interval-ms", '"1000"'),
+            ("poll-interval-ms", '"5000"'),
+            ("poll-retry-on-request-error", '"true"'),
+            ("poll-retry-on-unexpected-status", '"true"'),
+            (
+                "poll-timeout-ms",
+                "${{ steps.deploy_wait_timeout.outputs.timeout_ms }}",
+            ),
+            (
+                "poll-timeout-ms",
+                "${{ steps.deployed_health.outputs.remaining_timeout_ms }}",
+            ),
+            (
+                "poll-timeout-ms",
+                "${{ steps.rollback_wait_timeout.outputs.timeout_ms }}",
+            ),
+            (
+                "poll-timeout-ms",
+                "${{ steps.rollback_health.outputs.remaining_timeout_ms }}",
+            ),
+            ("poll-until-path", "runtime.docker_image_reference"),
+            ("poll-until-value", "${{ steps.image.outputs.image_reference }}"),
+            (
+                "poll-until-value",
+                "${{ steps.rollback_request.outputs.previous_image_reference }}",
+            ),
+            (
+                "response-output-file",
+                "${{ runner.temp }}/launchplane-deployed-runtime-wait.json",
+            ),
+            (
+                "response-output-file",
+                "${{ runner.temp }}/launchplane-deployed-runtime-final.json",
+            ),
             ("response-output-file", "${{ runner.temp }}/launchplane-previous-runtime.json"),
+            (
+                "response-output-file",
+                "${{ runner.temp }}/launchplane-rollback-runtime-final.json",
+            ),
+            (
+                "response-output-file",
+                "${{ runner.temp }}/launchplane-rollback-runtime-wait.json",
+            ),
             ("response-output-file", "${{ runner.temp }}/launchplane-runtime-smoke.json"),
             (
                 "response-output-file",

--- a/tests/test_launchplane_request_action.py
+++ b/tests/test_launchplane_request_action.py
@@ -60,6 +60,15 @@ global.fetch = async (url, init) => {{
   if (failureAttempts.includes(launchplaneRequestCount)) {{
     throw new TypeError('simulated Launchplane network failure');
   }}
+  const configuredStatusCodes = String(process.env.TEST_STATUS_SEQUENCE || '').split(',').filter(Boolean);
+  const statusCode = Number(configuredStatusCodes[launchplaneRequestCount - 1] || process.env.TEST_STATUS || '200');
+  const configuredRuntimeImages = String(process.env.TEST_RUNTIME_IMAGES || '').split(',').filter(Boolean);
+  if (configuredRuntimeImages.length > 0) {{
+    const imageReference = configuredRuntimeImages[launchplaneRequestCount - 1] || configuredRuntimeImages.at(-1);
+    return new Response(JSON.stringify({{
+      runtime: {{ docker_image_reference: imageReference }}
+    }}), {{status: statusCode}});
+  }}
   const configuredStatuses = String(process.env.TEST_REFRESH_STATUSES || '').split(',').filter(Boolean);
   const refreshStatus = configuredStatuses[launchplaneRequestCount - 1] || process.env.TEST_REFRESH_STATUS || 'pass';
   return new Response(JSON.stringify({{
@@ -68,8 +77,8 @@ global.fetch = async (url, init) => {{
       refresh_status: refreshStatus,
       error_message: process.env.TEST_ERROR_MESSAGE || '',
       application_id: 'app-123'
-    }}
-  }}), {{status: Number(process.env.TEST_STATUS || '200')}});
+      }}
+  }}), {{status: statusCode}});
 }};
 require('./{ACTION_ENTRYPOINT.as_posix()}');
 process.on('beforeExit', () => {{
@@ -292,6 +301,181 @@ process.on('beforeExit', () => {{
             self.assertEqual(json.loads(launchplane_calls[0]["body"]), payloads[0])
             self.assertEqual(json.loads(launchplane_calls[1]["body"]), payloads[1])
             self.assertEqual(result.stdout, "")
+
+    def test_get_request_polls_until_json_path_matches_expected_value(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            response_output_path = Path(temporary_directory) / "runtime.json"
+            result = self.run_action(
+                inputs={
+                    "launchplane-url": "https://launchplane.example",
+                    "route-path": "/v1/service/runtime",
+                    "method": "GET",
+                    "poll-until-path": "runtime.docker_image_reference",
+                    "poll-until-value": "registry.example/launchplane@sha256:new",
+                    "poll-interval-ms": "1",
+                    "poll-timeout-ms": "1000",
+                    "response-output-file": str(response_output_path),
+                    "log-response-body": "false",
+                },
+                environment={
+                    "TEST_RUNTIME_IMAGES": (
+                        "registry.example/launchplane@sha256:old,"
+                        "registry.example/launchplane@sha256:new"
+                    )
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            calls = json.loads(result.stderr.strip().splitlines()[-1])
+            launchplane_calls = [
+                call
+                for call in calls
+                if call["url"] == "https://launchplane.example/v1/service/runtime"
+            ]
+            self.assertEqual(len(launchplane_calls), 2)
+            self.assertEqual(
+                [call["headers"]["Authorization"] for call in launchplane_calls],
+                ["Bearer oidc-token-1", "Bearer oidc-token-2"],
+            )
+            self.assertEqual(
+                json.loads(response_output_path.read_text(encoding="utf-8"))["runtime"][
+                    "docker_image_reference"
+                ],
+                "registry.example/launchplane@sha256:new",
+            )
+            self.assertIn(
+                "waiting for registry.example/launchplane@sha256:new",
+                result.stderr,
+            )
+
+    def test_poll_until_can_retry_launchplane_request_error(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/service/runtime",
+                "method": "GET",
+                "poll-until-path": "runtime.docker_image_reference",
+                "poll-until-value": "registry.example/launchplane@sha256:new",
+                "poll-retry-on-request-error": "true",
+                "poll-interval-ms": "1",
+                "poll-timeout-ms": "1000",
+                "retry-attempts": "1",
+                "log-response-body": "false",
+            },
+            environment={
+                "TEST_LAUNCHPLANE_NETWORK_FAILURE_ATTEMPTS": "1",
+                "TEST_RUNTIME_IMAGES": "registry.example/launchplane@sha256:new",
+            },
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = json.loads(result.stderr.strip().splitlines()[-1])
+        launchplane_calls = [
+            call
+            for call in calls
+            if call["url"] == "https://launchplane.example/v1/service/runtime"
+        ]
+        self.assertEqual(len(launchplane_calls), 2)
+        self.assertIn(
+            "Launchplane request failed while waiting for runtime.docker_image_reference",
+            result.stderr,
+        )
+
+    def test_poll_until_rejects_unexpected_status_by_default(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/service/runtime",
+                "method": "GET",
+                "expected-status": "200",
+                "poll-until-path": "runtime.docker_image_reference",
+                "poll-until-value": "registry.example/launchplane@sha256:new",
+                "poll-interval-ms": "1",
+                "poll-timeout-ms": "1000",
+                "log-response-body": "false",
+            },
+            environment={
+                "TEST_RUNTIME_IMAGES": "registry.example/launchplane@sha256:new",
+                "TEST_STATUS": "503",
+            },
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Launchplane request failed with 503", result.stderr)
+        calls = json.loads(result.stderr.strip().splitlines()[-1])
+        launchplane_calls = [
+            call
+            for call in calls
+            if call["url"] == "https://launchplane.example/v1/service/runtime"
+        ]
+        self.assertEqual(len(launchplane_calls), 1)
+
+    def test_poll_until_can_retry_unexpected_status_when_enabled(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/service/runtime",
+                "method": "GET",
+                "expected-status": "200",
+                "poll-until-path": "runtime.docker_image_reference",
+                "poll-until-value": "registry.example/launchplane@sha256:new",
+                "poll-retry-on-unexpected-status": "true",
+                "poll-interval-ms": "1",
+                "poll-timeout-ms": "1000",
+                "log-response-body": "false",
+            },
+            environment={
+                "TEST_RUNTIME_IMAGES": (
+                    "registry.example/launchplane@sha256:old,"
+                    "registry.example/launchplane@sha256:new"
+                ),
+                "TEST_STATUS_SEQUENCE": "503,200",
+            },
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = json.loads(result.stderr.strip().splitlines()[-1])
+        launchplane_calls = [
+            call
+            for call in calls
+            if call["url"] == "https://launchplane.example/v1/service/runtime"
+        ]
+        self.assertEqual(len(launchplane_calls), 2)
+        self.assertIn("Launchplane result runtime.docker_image_reference is HTTP 503", result.stderr)
+
+    def test_poll_until_requires_expected_value(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/service/runtime",
+                "method": "GET",
+                "poll-until-path": "runtime.docker_image_reference",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "poll-until-value is required when poll-until-path is set",
+            result.stderr,
+        )
+
+    def test_poll_until_and_poll_result_are_mutually_exclusive(self) -> None:
+        result = self.run_action(
+            inputs={
+                "launchplane-url": "https://launchplane.example",
+                "route-path": "/v1/service/runtime",
+                "method": "GET",
+                "poll-until-path": "runtime.docker_image_reference",
+                "poll-until-value": "registry.example/launchplane@sha256:new",
+                "poll-result-path": "result.refresh_status",
+            }
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Use either poll-until-path or poll-result-path, not both",
+            result.stderr,
+        )
 
     def test_payload_list_requires_idempotency_prefix(self) -> None:
         with TemporaryDirectory() as temporary_directory:

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1915,6 +1915,8 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("RUNTIME_OUTCOME: ${{ steps.deployed_runtime.outcome }}", workflow_text)
         self.assertIn("runtime_status_code=\"action_failed\"", workflow_text)
         self.assertIn("Launchplane runtime smoke failed.", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", workflow_text)
+        self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", workflow_text)
 
         deployed_smoke_step = workflow_text.split(
             "- name: Capture v2 deployed smoke evidence", 1
@@ -1965,14 +1967,51 @@ class ProductOnboardingTests(unittest.TestCase):
         )
         self.assertIn("status_code=\"action_failed\"", workflow_text)
         self.assertIn("Launchplane self deploy request failed with HTTP", workflow_text)
+        self.assertIn("Resolve Launchplane deploy wait timeout", workflow_text)
+        self.assertIn("id: deploy_wait_timeout", workflow_text)
+        self.assertIn("timeout_ms=$((wait_timeout_seconds * 1000))", workflow_text)
+        self.assertIn("deadline_epoch=$(($(date +%s) + wait_timeout_seconds))", workflow_text)
+        self.assertIn("Wait for deployed Launchplane runtime image", workflow_text)
+        self.assertLess(
+            workflow_text.index("Wait for deployed Launchplane runtime image"),
+            workflow_text.index("Wait for deployed Launchplane health URLs"),
+        )
+        self.assertLess(
+            workflow_text.index("Wait for deployed Launchplane health URLs"),
+            workflow_text.index("Verify deployed Launchplane runtime image after health"),
+        )
+        self.assertIn("poll-until-path: runtime.docker_image_reference", workflow_text)
+        self.assertIn(
+            "poll-until-value: ${{ steps.image.outputs.image_reference }}",
+            workflow_text,
+        )
+        self.assertIn('poll-retry-on-request-error: "true"', workflow_text)
+        self.assertIn('poll-retry-on-unexpected-status: "true"', workflow_text)
+        self.assertIn('poll-interval-ms: "5000"', workflow_text)
+        self.assertIn(
+            "poll-timeout-ms: ${{ steps.deploy_wait_timeout.outputs.timeout_ms }}",
+            workflow_text,
+        )
+        self.assertIn("remaining_timeout_ms=$((remaining_seconds * 1000))", workflow_text)
+        self.assertIn(
+            "poll-timeout-ms: ${{ steps.deployed_health.outputs.remaining_timeout_ms }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: ${{ runner.temp }}/launchplane-deployed-runtime-wait.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: ${{ runner.temp }}/launchplane-deployed-runtime-final.json",
+            workflow_text,
+        )
 
         self_deploy_block = workflow_text.split(
             "- name: Read previous Launchplane runtime", 1
-        )[1].split("- name: Wait for deployed Launchplane image", 1)[0]
+        )[1].split("- name: Capture failed Launchplane deploy diagnostics", 1)[0]
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", self_deploy_block)
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", self_deploy_block)
         self.assertNotIn("Authorization: Bearer", self_deploy_block)
-        self.assertNotIn("curl ", self_deploy_block)
 
     def test_deploy_workflow_requests_rollback_through_shared_request(self) -> None:
         workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
@@ -2017,14 +2056,50 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("Launchplane rollback requested", workflow_text)
         self.assertIn("Launchplane rollback timed out", workflow_text)
         self.assertIn("Rollback request response summary", workflow_text)
+        self.assertIn("Resolve Launchplane rollback wait timeout", workflow_text)
+        self.assertIn("id: rollback_wait_timeout", workflow_text)
+        self.assertIn("Wait for Launchplane rollback health URLs", workflow_text)
+        self.assertIn("id: rollback_health", workflow_text)
+        self.assertIn("Wait for Launchplane rollback runtime image", workflow_text)
+        self.assertIn("id: rollback_runtime", workflow_text)
+        self.assertLess(
+            workflow_text.index("Wait for Launchplane rollback runtime image"),
+            workflow_text.index("Wait for Launchplane rollback health URLs"),
+        )
+        self.assertLess(
+            workflow_text.index("Wait for Launchplane rollback health URLs"),
+            workflow_text.index("Verify Launchplane rollback runtime image after health"),
+        )
+        self.assertIn(
+            "poll-until-value: ${{ steps.rollback_request.outputs.previous_image_reference }}",
+            workflow_text,
+        )
+        self.assertIn('poll-retry-on-unexpected-status: "true"', workflow_text)
+        self.assertIn(
+            "poll-timeout-ms: ${{ steps.rollback_wait_timeout.outputs.timeout_ms }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "poll-timeout-ms: ${{ steps.rollback_health.outputs.remaining_timeout_ms }}",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: ${{ runner.temp }}/launchplane-rollback-runtime-wait.json",
+            workflow_text,
+        )
+        self.assertIn(
+            "response-output-file: ${{ runner.temp }}/launchplane-rollback-runtime-final.json",
+            workflow_text,
+        )
+        self.assertIn("Rollback runtime response summary", workflow_text)
+        self.assertIn("ROLLBACK_RUNTIME_OUTCOME", workflow_text)
 
         rollback_request_block = workflow_text.split(
             "- name: Render Launchplane rollback request", 1
-        )[1].split("- name: Wait for Launchplane rollback image", 1)[0]
+        )[1].split("- name: Render product context workflow authz grants", 1)[0]
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", rollback_request_block)
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", rollback_request_block)
         self.assertNotIn("Authorization: Bearer", rollback_request_block)
-        self.assertNotIn("curl ", rollback_request_block)
 
     def test_product_onboarding_workflow_calls_service_route_with_apply_guard(self) -> None:
         workflow_text = Path(".github/workflows/product-onboarding.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a narrow poll-until mode to the shared launchplane-request action, with explicit opt-in retries for transient request errors and unexpected statuses
- replace authenticated raw OIDC/curl runtime image polling in deploy and rollback with shared action calls
- preserve public health URL shell checks while sharing one deadline and verifying the runtime image again after health succeeds

## Tests
- uv run python -m unittest tests.test_launchplane_request_action
- uv run python -m unittest tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_reads_deployed_runtime_through_shared_request tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_requests_self_deploy_through_shared_request tests.test_product_onboarding.ProductOnboardingTests.test_deploy_workflow_requests_rollback_through_shared_request tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_workflow_block_fields_are_classified_by_path_only tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_remaining_workflow_aliases_are_path_scoped
- uv run python -m unittest tests.test_product_onboarding
- uv run python -m unittest tests.test_config_authority_audit
- docker run --rm -v "/Users/cbusillo/.code/worktrees/launchplane/raw-request-cleanup-self-deploy-post:/repo" -w /repo rhysd/actionlint:1.7.12 -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml
- uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate
- uv run --extra dev ruff check --diff tests/test_launchplane_request_action.py tests/test_product_onboarding.py tests/test_config_authority_audit.py control_plane/config_authority_audit.py
- uv run --extra dev ruff check tests/test_launchplane_request_action.py tests/test_product_onboarding.py tests/test_config_authority_audit.py control_plane/config_authority_audit.py
- git diff --check

## Review Notes
- addressed review-agent findings by preserving a shared deploy/rollback wait deadline and adding final post-health runtime-image verification
- made unexpected HTTP status retry explicit via poll-retry-on-unexpected-status instead of changing shared action defaults

Auto Review: current matching-head run 94773b18 failed before producing findings, so there were no Auto Review findings to apply.