### PR TITLE
Fix Odoo ownership workflow-name false positive

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -132,6 +132,7 @@
     "cbusillo/odoo-docker",
     "cbusillo/odoo-shared-addons",
     "cbusillo/odoo-tenant-cm",
+    "cbusillo/odoo-tenant-cm-website",
     "cbusillo/odoo-tenant-opw",
     "cbusillo/disable_odoo_online"
   ],

--- a/control_plane/odoo_ownership_checks.py
+++ b/control_plane/odoo_ownership_checks.py
@@ -138,6 +138,8 @@ _LAUNCHPLANE_ALLOWED_LINE_PATTERNS = (
     re.compile(r"LAUNCHPLANE_RUNTIME_IDENTITY_JSON"),
 )
 
+_YAML_NAME_LINE_PATTERN = re.compile(r"^\s*(?:-\s*)?name:\s*", re.IGNORECASE)
+
 _RULES: tuple[_Rule, ...] = (
     _Rule(
         rule_id="repo-local-oidc-client",
@@ -152,11 +154,12 @@ _RULES: tuple[_Rule, ...] = (
         rule_id="repo-local-launchplane-http-client",
         message="Repo-local Launchplane HTTP clients duplicate the shared request boundary.",
         pattern=re.compile(
-            r"\b(fetch|axios|requests\.(?:get|post|put|patch|delete)|urlopen|curl)\b.*\blaunchplane\b",
+            r"\b(fetch|axios|requests\.(?:request|get|post|put|patch|delete)|urlopen|curl)\b"
+            r".*\blaunchplane[\w-]*",
             re.IGNORECASE,
         ),
         families=("tenant", "image", "shared_addons", "devkit", "retired"),
-        allowed_line_patterns=_LAUNCHPLANE_ALLOWED_LINE_PATTERNS,
+        allowed_line_patterns=(*_LAUNCHPLANE_ALLOWED_LINE_PATTERNS, _YAML_NAME_LINE_PATTERN),
     ),
     _Rule(
         rule_id="tenant-provider-mutation",

--- a/docs/product-repo-contract.md
+++ b/docs/product-repo-contract.md
@@ -387,6 +387,9 @@ instead of introducing a second product literal. The caller must use an
 Context-specific cleanup may pass `context=` and use a matching scoped grant.
 Product repos may still own provider-specific deletion and package tokens, but
 not the protected-inventory route shape or response extraction contract.
+The Odoo ownership check treats this shared-action composition as compliant;
+it rejects executable repo-local HTTP clients, not descriptive workflow step
+names such as `Fetch Launchplane protected artifact inventory`.
 
 ## Canonical Image Deploy Connector
 

--- a/tests/test_odoo_ownership_checks.py
+++ b/tests/test_odoo_ownership_checks.py
@@ -70,6 +70,60 @@ jobs:
         self.assertEqual(result.status, "fail")
         self.assertEqual(result.findings[0].rule_id, "repo-local-oidc-client")
 
+    def test_rejects_repo_local_launchplane_http_client(self) -> None:
+        clients = (
+            "const response = await fetch(launchplaneUrl);\n",
+            "const response = await axios(launchplaneUrl, {method: 'GET'});\n",
+            "const response = await axios.request({url: launchplaneUrl});\n",
+            "response = requests.get(launchplane_url)\n",
+            "response = requests.request('GET', launchplane_url)\n",
+            "response = urlopen(launchplane_url)\n",
+            'subprocess.run(["curl", launchplane_url])\n',
+            "curl https://launchplane.example/v1/service/runtime\n",
+        )
+        for client in clients:
+            with self.subTest(client=client), TemporaryDirectory() as workspace:
+                workspace_root = Path(workspace)
+                script = workspace_root / "odoo-tenant-cm" / "scripts" / "launchplane-client.mjs"
+                script.parent.mkdir(parents=True)
+                script.write_text(client, encoding="utf-8")
+
+                result = scan_odoo_ownership_boundaries(
+                    workspace_root=workspace_root,
+                    repo_policies=(OdooOwnershipRepoPolicy("odoo-tenant-cm", "tenant"),),
+                )
+
+            self.assertEqual(result.status, "fail")
+            self.assertEqual(result.findings[0].rule_id, "repo-local-launchplane-http-client")
+
+    def test_allows_shared_request_action_with_descriptive_fetch_step_name(self) -> None:
+        with TemporaryDirectory() as workspace:
+            workspace_root = Path(workspace)
+            workflow = (
+                workspace_root / "odoo-tenant-cm" / ".github" / "workflows" / "cleanup-ghcr.yml"
+            )
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(
+                """
+jobs:
+  cleanup:
+    steps:
+      - name: Fetch Launchplane protected artifact inventory
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+      - name: Curl Launchplane protected artifact inventory
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+""".lstrip(),
+                encoding="utf-8",
+            )
+
+            result = scan_odoo_ownership_boundaries(
+                workspace_root=workspace_root,
+                repo_policies=(OdooOwnershipRepoPolicy("odoo-tenant-cm", "tenant"),),
+            )
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.findings, ())
+
     def test_rejects_tenant_provider_mutation(self) -> None:
         with TemporaryDirectory() as workspace:
             workspace_root = Path(workspace)


### PR DESCRIPTION
## Summary
- stop the Odoo ownership scanner from treating descriptive YAML `name:` lines as executable Launchplane HTTP clients
- preserve detection for direct `fetch`, `axios`, `requests`, `urlopen`, and `curl` clients, including wrapper forms
- document the approved protected-artifact shared-action composition and add the missing CM Website related-repo metadata

## Validation
- `uv run python -m unittest tests.test_odoo_ownership_checks tests.test_docs_contracts`
- `uv run launchplane odoo-ownership check --workspace-root /Users/cbusillo/Developer --format json` (7 repos, 801 files, zero findings)
- `uv run --extra dev ruff check control_plane/odoo_ownership_checks.py tests/test_odoo_ownership_checks.py`
- `uv run --extra dev ruff format --check control_plane/odoo_ownership_checks.py tests/test_odoo_ownership_checks.py`
- `uv run --extra dev mypy control_plane/odoo_ownership_checks.py tests/test_odoo_ownership_checks.py`
- `uv run launchplane service audit-config-authority --control-plane-root . --mode changed-files-gate`
- JetBrains changed-files closeout inspection: clean
- `git diff --check`

Refs #1614