### PR TITLE
Require explicit Odoo replacement product

### DIFF
--- a/control_plane/cli_odoo.py
+++ b/control_plane/cli_odoo.py
@@ -623,7 +623,7 @@ def odoo_ownership_check(workspace_root: Path | None, output_format: str) -> Non
     required=True,
     help="Postgres connection string for Launchplane Odoo target records.",
 )
-@click.option("--product", default="odoo-tenant-cm", show_default=True)
+@click.option("--product", required=True)
 @click.option("--instance", "instance_name", required=True)
 @click.option(
     "--strategy",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1032,7 +1032,8 @@ behind pre-existing DNS/nginx routing and are intended to make the client-visibl
 Odoo system usable before full ephemeral preview infrastructure exists.
 
 For stable Odoo target replacement planning, use the read-only dry-run command
-before considering any provider mutation:
+before considering any provider mutation. Product identity is always explicit;
+the CLI does not select a tenant default:
 
 ```sh
 uv run launchplane odoo-targets replacement-plan \

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -41,9 +41,7 @@ def _allow_direct_db_mutation_argument() -> list[str]:
     return ["--allow-direct-db-mutation"]
 
 
-def _assert_direct_db_mutation_rejected(
-    test_case: unittest.TestCase, result: Result
-) -> None:
+def _assert_direct_db_mutation_rejected(test_case: unittest.TestCase, result: Result) -> None:
     test_case.assertNotEqual(result.exit_code, 0)
     test_case.assertIn("Direct local DB mutation is restricted", result.output)
     test_case.assertIn("--allow-direct-db-mutation", result.output)
@@ -140,6 +138,22 @@ class _FakeDokployTargetStore:
 
 
 class DokployConfigTests(unittest.TestCase):
+    def test_odoo_target_replacement_plan_cli_requires_product(self) -> None:
+        result = CliRunner().invoke(
+            main,
+            [
+                "odoo-targets",
+                "replacement-plan",
+                "--database-url",
+                "postgresql://launchplane.example/launchplane",
+                "--instance",
+                "testing",
+            ],
+        )
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertIn("Missing option '--product'", result.output)
+
     def test_load_optional_source_of_truth_uses_structural_store_boundary(self) -> None:
         target = control_plane_dokploy.DokployTargetDefinition(
             context="verireel",


### PR DESCRIPTION
## Summary
- remove the real tenant fallback from the Odoo target replacement CLI
- require operators to name the Launchplane product explicitly
- document and test the fail-closed CLI contract

## Validation
- `uv run python -m unittest tests.test_dokploy` (84 passed)
- `uv run --extra dev ruff check control_plane/cli_odoo.py tests/test_dokploy.py`
- `uv run --extra dev ruff format --check control_plane/cli_odoo.py tests/test_dokploy.py`
- `uv run --extra dev mypy control_plane/cli_odoo.py tests/test_dokploy.py`
- `uv run launchplane service audit-config-authority --control-plane-root .` (status ok)

Refs #1529