### PR TITLE
Add reviewed authz grant maintenance mode

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -16,6 +16,23 @@ on:
         description: Exact image reference to deploy instead of building a new one.
         required: false
         type: string
+      authz_grants_mode:
+        description: Reconcile only operator-configured GitHub Actions authz grants without deploying Launchplane.
+        required: false
+        default: none
+        type: choice
+        options:
+          - none
+          - dry_run
+          - apply
+      authz_grants_expected_sha256:
+        description: Canonical grant-set SHA-256 reported by the reviewed dry run; required for apply.
+        required: false
+        type: string
+      authz_grants_reason:
+        description: Operator reason recorded on each grant request; required for apply.
+        required: false
+        type: string
       omit_every_code_env:
         description: Temporarily omit Every Code env for one compatibility deploy.
         required: false
@@ -66,7 +83,9 @@ jobs:
        github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_branch == 'main') ||
-      (github.event_name == 'workflow_dispatch' && inputs.break_glass_confirm == '')
+      (github.event_name == 'workflow_dispatch' &&
+       inputs.break_glass_confirm == '' &&
+       inputs.authz_grants_mode == 'none')
     runs-on:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
@@ -1144,6 +1163,147 @@ jobs:
               launchplane-v2-deployed-smoke.json
           } >> "$GITHUB_STEP_SUMMARY"
 
+  operator-authz-grants:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.authz_grants_mode != 'none'
+    permissions:
+      contents: read
+      id-token: write
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      LAUNCHPLANE_PUBLIC_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      LAUNCHPLANE_SERVICE_AUDIENCE: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+      LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON: >-
+        ${{ vars.LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON }}
+      LAUNCHPLANE_AUTHZ_GRANT_MODE: ${{ inputs.authz_grants_mode }}
+      LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY: "true"
+      LAUNCHPLANE_AUTHZ_GRANT_REASON: ${{ inputs.authz_grants_reason }}
+    steps:
+      - name: Validate grant-only request
+        shell: bash
+        env:
+          REVIEWED_GRANTS_SHA256: ${{ inputs.authz_grants_expected_sha256 }}
+          DEPLOY_GIT_REF: ${{ inputs.git_ref }}
+          DEPLOY_IMAGE_REFERENCE: ${{ inputs.image_reference }}
+          OMIT_EVERY_CODE_ENV: ${{ inputs.omit_every_code_env }}
+          OMIT_TERMINAL_AGENT_ENV: ${{ inputs.omit_terminal_agent_env }}
+          OMIT_OWNER_AGENT_ENV: ${{ inputs.omit_owner_agent_env }}
+          OMIT_NPMPLUS_ENV: ${{ inputs.omit_npmplus_env }}
+          BREAK_GLASS_CONFIRM: ${{ inputs.break_glass_confirm }}
+          BREAK_GLASS_IMAGE_REFERENCE: ${{ inputs.break_glass_image_reference }}
+          BREAK_GLASS_REASON: ${{ inputs.break_glass_reason }}
+        run: |
+          set -euo pipefail
+          : "${LAUNCHPLANE_PUBLIC_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
+          : "${LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON:?Missing LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON variable}"
+          if [ -n "$DEPLOY_GIT_REF" ] || [ -n "$DEPLOY_IMAGE_REFERENCE" ]; then
+            echo "Grant-only reconciliation cannot include deploy ref or image inputs." >&2
+            exit 1
+          fi
+          if [ "$OMIT_EVERY_CODE_ENV" = "true" ] ||
+            [ "$OMIT_TERMINAL_AGENT_ENV" = "true" ] ||
+            [ "$OMIT_OWNER_AGENT_ENV" = "true" ] ||
+            [ "$OMIT_NPMPLUS_ENV" = "true" ]; then
+            echo "Grant-only reconciliation cannot include deploy compatibility inputs." >&2
+            exit 1
+          fi
+          if [ -n "$BREAK_GLASS_CONFIRM" ] ||
+            [ -n "$BREAK_GLASS_IMAGE_REFERENCE" ] ||
+            [ -n "$BREAK_GLASS_REASON" ]; then
+            echo "Grant-only reconciliation cannot include break-glass rollback inputs." >&2
+            exit 1
+          fi
+          if [ "$LAUNCHPLANE_AUTHZ_GRANT_MODE" = "apply" ]; then
+            if [[ ! "$REVIEWED_GRANTS_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Apply requires the canonical SHA-256 reported by the reviewed dry run." >&2
+              exit 1
+            fi
+            if [[ -z "${LAUNCHPLANE_AUTHZ_GRANT_REASON//[[:space:]]/}" ]]; then
+              echo "Apply requires an operator reason." >&2
+              exit 1
+            fi
+          elif [ -n "$REVIEWED_GRANTS_SHA256" ]; then
+            echo "The reviewed grant-set SHA-256 input is only valid for apply." >&2
+            exit 1
+          fi
+          jq -e 'type == "array" and length > 0' \
+            <<<"$LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON" >/dev/null || {
+            echo "LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON must be a non-empty JSON array." >&2
+            exit 1
+          }
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Render operator-configured authz grants
+        id: authz_grants
+        shell: bash
+        env:
+          LAUNCHPLANE_AUTHZ_GRANTS_JSON: ${{ env.LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON }}
+        run: bash scripts/deploy/ensure-authz-grants.sh
+
+      - name: Verify reviewed authz grant set
+        if: inputs.authz_grants_mode == 'apply'
+        shell: bash
+        env:
+          REVIEWED_GRANTS_SHA256: ${{ inputs.authz_grants_expected_sha256 }}
+          RENDERED_GRANTS_SHA256: ${{ steps.authz_grants.outputs.configured_grants_sha256 }}
+        run: |
+          set -euo pipefail
+          if [ "$RENDERED_GRANTS_SHA256" != "$REVIEWED_GRANTS_SHA256" ]; then
+            echo "Configured authz grants changed after the reviewed dry run." >&2
+            echo "Reviewed: $REVIEWED_GRANTS_SHA256" >&2
+            echo "Current:  $RENDERED_GRANTS_SHA256" >&2
+            exit 1
+          fi
+
+      - name: Reconcile operator-configured authz grants
+        id: authz_grant_request
+        uses: ./.github/actions/launchplane-request
+        with:
+          launchplane-url: ${{ env.LAUNCHPLANE_PUBLIC_URL }}
+          audience: ${{ env.LAUNCHPLANE_SERVICE_AUDIENCE }}
+          route-path: /v1/authz-policies/github-actions/grants
+          payload-list-file: ${{ steps.authz_grants.outputs.github_actions_grants_file }}
+          idempotency-key-prefix: launchplane-operator-authz-grant:${{ github.run_id }}:${{ github.run_attempt }}
+          expected-status: "200,202"
+          response-output-file: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/github-actions-grants-responses.json
+          log-response-body: "false"
+
+      - name: Verify and summarize authz grant results
+        shell: bash
+        env:
+          GRANTS_FILE: ${{ steps.authz_grants.outputs.github_actions_grants_file }}
+          RESPONSES_FILE: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/github-actions-grants-responses.json
+        run: |
+          set -euo pipefail
+          request_count="$(jq 'length' "$GRANTS_FILE")"
+          response_count="$(jq 'length' "$RESPONSES_FILE")"
+          if [ "$response_count" != "$request_count" ]; then
+            echo "Launchplane returned $response_count responses for $request_count authz grants." >&2
+            exit 1
+          fi
+          jq -e --arg mode "$LAUNCHPLANE_AUTHZ_GRANT_MODE" \
+            'all(.[]; .result.mode == $mode and (.result.changed | type == "boolean"))' \
+            "$RESPONSES_FILE" >/dev/null || {
+            echo "Launchplane authz grant responses did not match the requested mode or result shape." >&2
+            exit 1
+          }
+          changed_count="$(jq '[.[] | select(.result.changed == true)] | length' "$RESPONSES_FILE")"
+          unchanged_count="$((request_count - changed_count))"
+          {
+            echo "## Operator authz grant reconciliation"
+            echo
+            echo "- Mode: $LAUNCHPLANE_AUTHZ_GRANT_MODE"
+            echo "- Requests: $request_count"
+            echo "- Changed: $changed_count"
+            echo "- Already present: $unchanged_count"
+            echo "- Canonical grant-set SHA-256: ${{ steps.authz_grants.outputs.configured_grants_sha256 }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   emergency-dokploy-rollback:
     if: github.event_name == 'workflow_dispatch' && inputs.break_glass_confirm == 'ROLL BACK LAUNCHPLANE THROUGH DIRECT DOKPLOY'
     runs-on:
@@ -1162,8 +1322,14 @@ jobs:
 
       - name: Validate manual break-glass request
         shell: bash
+        env:
+          AUTHZ_GRANTS_MODE: ${{ inputs.authz_grants_mode }}
         run: |
           set -euo pipefail
+          if [ "$AUTHZ_GRANTS_MODE" != "none" ]; then
+            echo "Break-glass rollback cannot be combined with authz grant reconciliation." >&2
+            exit 1
+          fi
           : "${LAUNCHPLANE_DOKPLOY_TARGET_TYPE:?Missing LAUNCHPLANE_DOKPLOY_TARGET_TYPE variable}"
           : "${LAUNCHPLANE_DOKPLOY_TARGET_ID:?Missing LAUNCHPLANE_DOKPLOY_TARGET_ID variable}"
           : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST secret}"

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -201,6 +201,7 @@ WORKFLOW_OPERATOR_INPUT_VALUE_KEYS = frozenset(
 )
 WORKFLOW_LAUNCHPLANE_OPERATOR_VAR_KEYS = frozenset(
     (
+        "LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON",
         "LAUNCHPLANE_CONTEXT",
         "LAUNCHPLANE_INSTANCE",
         "LAUNCHPLANE_PRODUCT",
@@ -229,6 +230,9 @@ WORKFLOW_RESPONSE_SUMMARY_PATH_VALUES = {
     },
 }
 WORKFLOW_BLOCK_MECHANIC_FIELD_PATH_VALUES = {
+    ".github/workflows/deploy-launchplane.yml": {
+        "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY": frozenset(('"true"', "true"))
+    },
     ".github/workflows/odoo-driver-route-smoke.yml": {
         "ROUTE_PATHS": frozenset(
             (
@@ -252,6 +256,7 @@ WORKFLOW_BLOCK_MECHANIC_FIELD_PATH_VALUES = {
 }
 WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
     ".github/workflows/deploy-launchplane.yml": {
+        "inputs.authz_grants_mode.default": frozenset(("none",)),
         "inputs.omit_every_code_env.default": frozenset(("false",)),
         "inputs.omit_npmplus_env.default": frozenset(("false",)),
         "inputs.omit_owner_agent_env.default": frozenset(("false",)),
@@ -587,6 +592,7 @@ WORKFLOW_LAUNCHPLANE_BOOTSTRAP_CONTEXT_PATH_VALUES = {
             ("${{ vars.LAUNCHPLANE_PRODUCT_CONFIG_OPERATOR_PRODUCTS }}",)
         ),
         "LAUNCHPLANE_PUBLIC_URL": frozenset(("${{ vars.LAUNCHPLANE_PUBLIC_URL }}",)),
+        "LAUNCHPLANE_SERVICE_AUDIENCE": frozenset(("${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",)),
         "LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN": frozenset(
             ("${{ secrets.LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN }}",)
         ),
@@ -604,6 +610,21 @@ WORKFLOW_JQ_OPERATOR_FIELD_PATH_KEYS = {
     ),
 }
 WORKFLOW_OPERATOR_INPUT_REFERENCE_PATH_VALUES = {
+    ".github/workflows/deploy-launchplane.yml": {
+        "AUTHZ_GRANTS_MODE": frozenset(("${{ inputs.authz_grants_mode }}",)),
+        "BREAK_GLASS_CONFIRM": frozenset(("${{ inputs.break_glass_confirm }}",)),
+        "BREAK_GLASS_IMAGE_REFERENCE": frozenset(("${{ inputs.break_glass_image_reference }}",)),
+        "BREAK_GLASS_REASON": frozenset(("${{ inputs.break_glass_reason }}",)),
+        "DEPLOY_GIT_REF": frozenset(("${{ inputs.git_ref }}",)),
+        "DEPLOY_IMAGE_REFERENCE": frozenset(("${{ inputs.image_reference }}",)),
+        "LAUNCHPLANE_AUTHZ_GRANT_MODE": frozenset(("${{ inputs.authz_grants_mode }}",)),
+        "LAUNCHPLANE_AUTHZ_GRANT_REASON": frozenset(("${{ inputs.authz_grants_reason }}",)),
+        "OMIT_EVERY_CODE_ENV": frozenset(("${{ inputs.omit_every_code_env }}",)),
+        "OMIT_NPMPLUS_ENV": frozenset(("${{ inputs.omit_npmplus_env }}",)),
+        "OMIT_OWNER_AGENT_ENV": frozenset(("${{ inputs.omit_owner_agent_env }}",)),
+        "OMIT_TERMINAL_AGENT_ENV": frozenset(("${{ inputs.omit_terminal_agent_env }}",)),
+        "REVIEWED_GRANTS_SHA256": frozenset(("${{ inputs.authz_grants_expected_sha256 }}",)),
+    },
     ".github/workflows/edge-endpoint-apply.yml": {
         "ENDPOINT_KEY": frozenset(("${{ inputs.endpoint_key }}",)),
         "IDEMPOTENCY_KEY": frozenset(("${{ inputs.idempotency_key }}",)),
@@ -741,7 +762,18 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         "password": frozenset(("${{ github.token }}",)),
     },
     ".github/workflows/deploy-launchplane.yml": {
-        "audience": frozenset(("${{ steps.service.outputs.service_audience }}",)),
+        "LAUNCHPLANE_AUTHZ_GRANTS_JSON": frozenset(
+            ("${{ env.LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON }}",)
+        ),
+        "RENDERED_GRANTS_SHA256": frozenset(
+            ("${{ steps.authz_grants.outputs.configured_grants_sha256 }}",)
+        ),
+        "audience": frozenset(
+            (
+                "${{ env.LAUNCHPLANE_SERVICE_AUDIENCE }}",
+                "${{ steps.service.outputs.service_audience }}",
+            )
+        ),
         "context": frozenset((".",)),
         "expected-status": frozenset(('"200"', '"200,202"')),
         "fail-result-paths": frozenset(('""',)),
@@ -754,6 +786,10 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
                 "github.run_id }}:${{ github.run_attempt }}",
             )
         ),
+        "idempotency-key-prefix": frozenset(
+            ("launchplane-operator-authz-grant:${{ github.run_id }}:${{ github.run_attempt }}",)
+        ),
+        "launchplane-url": frozenset(("${{ env.LAUNCHPLANE_PUBLIC_URL }}",)),
         "log-response-body": frozenset(('"false"',)),
         "method": frozenset(("GET",)),
         "payload-file": frozenset(
@@ -761,6 +797,9 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
                 "${{ steps.self_deploy.outputs.payload_file }}",
                 "${{ steps.rollback_request.outputs.payload_file }}",
             )
+        ),
+        "payload-list-file": frozenset(
+            ("${{ steps.authz_grants.outputs.github_actions_grants_file }}",)
         ),
         "poll-interval-ms": frozenset(('"1000"', '"5000"')),
         "poll-retry-on-request-error": frozenset(('"true"',)),
@@ -790,11 +829,11 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
                 "${{ runner.temp }}/launchplane-runtime-smoke.json",
                 "${{ runner.temp }}/launchplane-self-deploy-response.json",
                 "${{ runner.temp }}/launchplane-self-deploy-rollback-response.json",
+                "${{ steps.authz_grants.outputs.authz_grants_output_dir }}/"
+                "github-actions-grants-responses.json",
             )
         ),
-        "route-path": frozenset(
-            ("/v1/service/runtime", "/v1/drivers/launchplane/self-deploy")
-        ),
+        "route-path": frozenset(("/v1/service/runtime", "/v1/drivers/launchplane/self-deploy")),
         "timeout-ms": frozenset(('"30000"',)),
     },
     ".github/workflows/launchplane-config-authority.yml": {

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -255,6 +255,28 @@ must not become the live workflow grant catalog. Prefer the operator UI or
 service-backed authz policy
 management routes for steady-state shared and production grant changes.
 
+For grant maintenance that must use the deploy workflow's existing
+`authz_policy_grant.write` authority, manually dispatch `Deploy Launchplane`
+with `authz_grants_mode=dry_run`. Stage only the candidate batch in the temporary
+`LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON` repository variable; the normal deploy
+continues to reconcile the separate durable `LAUNCHPLANE_AUTHZ_GRANTS_JSON`
+catalog and cannot apply the maintenance batch. The grant-only path validates
+the operator-managed JSON,
+renders only its configured GitHub Actions grants, submits stateless service
+dry-runs, and reports changed versus already-present rules without building or
+deploying an image or reconciling any other runtime records. The summary includes
+a canonical SHA-256 of the normalized grant set. Review the dry-run changes, then
+dispatch `authz_grants_mode=apply` with that SHA-256, an operator reason, and the
+identical repository-variable value; apply fails before mutation when the current
+grant set no longer matches the reviewed digest. Grant-only mode rejects deploy,
+compatibility, and break-glass rollback inputs, and the rollback path independently
+rejects grant mode. The request honors `LAUNCHPLANE_SERVICE_AUDIENCE` when set and
+otherwise uses the public URL host. The default `none` mode preserves the normal
+deploy workflow. After a successful apply, merge the reviewed entries into the
+durable grant variable and remove the temporary maintenance variable. Keep real
+grant identities in operator-managed variables or service records rather than
+copying them into this workflow or the render script.
+
 The deploy workflow also reconciles its own `authz_policy_grant.write` grants
 for product/context `launchplane`, covering both manual dispatches and automatic
 CI-success deploys. Those grants keep future grant reconciliation separate from

--- a/scripts/deploy/ensure-authz-grants.sh
+++ b/scripts/deploy/ensure-authz-grants.sh
@@ -4,6 +4,40 @@ set -euo pipefail
 : "${GITHUB_REPOSITORY:?Missing GitHub repository.}"
 : "${GITHUB_SHA:?Missing GitHub SHA.}"
 
+authz_grant_mode="${LAUNCHPLANE_AUTHZ_GRANT_MODE:-apply}"
+configured_grants_only="${LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY:-false}"
+authz_grant_reason="${LAUNCHPLANE_AUTHZ_GRANT_REASON:-}"
+
+case "$authz_grant_mode" in
+	dry_run | apply) ;;
+	*)
+		echo "LAUNCHPLANE_AUTHZ_GRANT_MODE must be dry_run or apply." >&2
+		exit 1
+		;;
+esac
+case "$configured_grants_only" in
+	true | false) ;;
+	*)
+		echo "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY must be true or false." >&2
+		exit 1
+		;;
+esac
+if [ "$authz_grant_mode" = "dry_run" ] && [ "$configured_grants_only" != "true" ]; then
+	echo "Dry-run authz reconciliation requires configured-only mode." >&2
+	exit 1
+fi
+if [ "$configured_grants_only" = "true" ]; then
+	if [ "$authz_grant_mode" = "apply" ] && [[ -z "${authz_grant_reason//[[:space:]]/}" ]]; then
+		echo "Configured-only authz apply requires LAUNCHPLANE_AUTHZ_GRANT_REASON." >&2
+		exit 1
+	fi
+	if [[ -z "${authz_grant_reason//[[:space:]]/}" ]]; then
+		authz_grant_reason="Grant-only workflow reviewing authz grant"
+	fi
+elif [[ -z "${authz_grant_reason//[[:space:]]/}" ]]; then
+	authz_grant_reason="Deploy workflow ensuring authz grant"
+fi
+
 authz_grants_output_dir="${LAUNCHPLANE_AUTHZ_GRANTS_OUTPUT_DIR:-${RUNNER_TEMP:-.}/launchplane-authz-grants}"
 github_actions_grants_file="${authz_grants_output_dir}/github-actions-grants.json"
 terminal_agents_grants_file="${authz_grants_output_dir}/terminal-agents-grants.json"
@@ -12,6 +46,7 @@ local_admins_grants_file="${authz_grants_output_dir}/local-admins-grants.json"
 github_humans_grants_file="${authz_grants_output_dir}/github-humans-grants.json"
 runtime_key_safety_policy_file="${authz_grants_output_dir}/runtime-key-safety-policy.json"
 runtime_key_safety_idempotency_key=""
+configured_grants_sha256=""
 
 mkdir -p "$authz_grants_output_dir"
 printf '[]\n' >"$github_actions_grants_file"
@@ -128,12 +163,14 @@ post_grant() {
 			--arg context_name "$context_name" \
 			--arg action_name "$action_name" \
 			--arg source_label "$source_label" \
+			--arg mode "$authz_grant_mode" \
+			--arg reason "$authz_grant_reason" \
 			--arg job_workflow_ref "$job_workflow_ref" \
 			'{
         schema_version: 1,
         product: "launchplane",
-        mode: "apply",
-        reason: ("Deploy workflow ensuring authz grant " + $source_label),
+        mode: $mode,
+        reason: ($reason + " " + $source_label),
         related_issue: "cbusillo/launchplane#83",
         grant: {
           repository: $repository,
@@ -459,6 +496,23 @@ configured_github_action_grants_json() {
 		return 1
 }
 
+configured_github_action_grants_sha256() {
+	configured_github_action_grants_json |
+		jq -cS 'sort_by([
+      .repository,
+      .workflow_file,
+      .product,
+      .context,
+      .action,
+      .source_label,
+      .idempotency_suffix,
+      .event_name,
+      .workflow_ref_suffix,
+      .job_workflow_ref
+    ])' |
+		sha256_stdin
+}
+
 post_configured_github_action_grants() {
 	local grants_json grant_count grant_json repository workflow_file product_name
 	local context_name action_name source_label idempotency_suffix event_name
@@ -580,7 +634,11 @@ post_runtime_key_safety_rules() {
 		"Launchplane runtime key-safety policy request failed with"
 }
 
-preflight_owner_authz_env
+if [ "$configured_grants_only" = "true" ]; then
+	post_configured_github_action_grants
+	configured_grants_sha256="$(configured_github_action_grants_sha256)"
+else
+	preflight_owner_authz_env
 
 post_launchplane_service_grant \
 	public-ingress-monitor.yml \
@@ -863,6 +921,7 @@ post_product_config_human_grant \
 	product-config-human-apply
 post_configured_github_action_grants
 post_runtime_key_safety_rules
+fi
 
 github_actions_grant_count="$(jq 'length' "$github_actions_grants_file")"
 terminal_agents_grant_count="$(jq 'length' "$terminal_agents_grants_file")"
@@ -870,10 +929,16 @@ local_operators_grant_count="$(jq 'length' "$local_operators_grants_file")"
 local_admins_grant_count="$(jq 'length' "$local_admins_grants_file")"
 github_humans_grant_count="$(jq 'length' "$github_humans_grants_file")"
 
+if [ "$configured_grants_only" = "true" ] && [ "$github_actions_grant_count" = "0" ]; then
+	echo "Configured-only authz reconciliation requires at least one GitHub Actions grant." >&2
+	exit 1
+fi
+
 write_output authz_grants_output_dir "$authz_grants_output_dir"
 write_output github_actions_grants_file "$github_actions_grants_file"
 write_output github_actions_grant_count "$github_actions_grant_count"
 write_output has_github_actions_grants "$([ "$github_actions_grant_count" -gt 0 ] && echo true || echo false)"
+write_output configured_grants_sha256 "$configured_grants_sha256"
 write_output terminal_agents_grants_file "$terminal_agents_grants_file"
 write_output terminal_agents_grant_count "$terminal_agents_grant_count"
 write_output has_terminal_agents_grants "$([ "$terminal_agents_grant_count" -gt 0 ] && echo true || echo false)"

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1859,14 +1859,6 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                     ),
                     "",
                 )
-                self.assertEqual(
-                    _allow_reason(
-                        path=".github/workflows/deploy-launchplane.yml",
-                        key=key,
-                        value="$unexpected_source,",
-                    ),
-                    "",
-                )
 
         thin_connectors = (
             (
@@ -2323,6 +2315,75 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             ),
             "",
         )
+
+    def test_deploy_authz_grant_workflow_mechanics_are_classified(self) -> None:
+        cases = (
+            (
+                "inputs.authz_grants_mode.default",
+                "none",
+                "thin_connector_input",
+            ),
+            (
+                "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY",
+                "true",
+                "thin_connector_input",
+            ),
+            (
+                "LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON",
+                "${{ vars.LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON }}",
+                "operator_supplied_runtime_input",
+            ),
+            (
+                "LAUNCHPLANE_AUTHZ_GRANTS_JSON",
+                "${{ env.LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON }}",
+                "thin_connector_input",
+            ),
+            (
+                "LAUNCHPLANE_SERVICE_AUDIENCE",
+                "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",
+                "launchplane_self_bootstrap",
+            ),
+            (
+                "LAUNCHPLANE_AUTHZ_GRANT_MODE",
+                "${{ inputs.authz_grants_mode }}",
+                "operator_supplied_runtime_input",
+            ),
+            (
+                "LAUNCHPLANE_AUTHZ_GRANT_REASON",
+                "${{ inputs.authz_grants_reason }}",
+                "operator_supplied_runtime_input",
+            ),
+            (
+                "REVIEWED_GRANTS_SHA256",
+                "${{ inputs.authz_grants_expected_sha256 }}",
+                "operator_supplied_runtime_input",
+            ),
+            (
+                "audience",
+                "${{ env.LAUNCHPLANE_SERVICE_AUDIENCE }}",
+                "thin_connector_input",
+            ),
+            (
+                "idempotency-key-prefix",
+                "launchplane-operator-authz-grant:${{ github.run_id }}:${{ github.run_attempt }}",
+                "thin_connector_input",
+            ),
+            (
+                "payload-list-file",
+                "${{ steps.authz_grants.outputs.github_actions_grants_file }}",
+                "thin_connector_input",
+            ),
+        )
+        for key, value, expected_reason in cases:
+            with self.subTest(key=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/deploy-launchplane.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    expected_reason,
+                )
 
     def test_reusable_odoo_workflow_aliases_are_path_scoped(self) -> None:
         reusable_workflow_cases = (
@@ -3033,8 +3094,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "github.run_id }}:${{ github.run_attempt }}"
         )
         preview_apply_key = (
-            "odoo-driver-route-smoke:preview-apply:${{ "
-            "github.run_id }}:${{ github.run_attempt }}"
+            "odoo-driver-route-smoke:preview-apply:${{ github.run_id }}:${{ github.run_attempt }}"
         )
         preview_pr_feedback_key = (
             "odoo-driver-route-smoke:preview-pr-feedback:${{ "

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -399,6 +399,108 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertEqual(grant["actions"], ["example_action.execute"])
         self.assertEqual(grant["source_label"], "operator-config:example-product-deploy")
 
+    def test_deploy_authz_grants_support_configured_only_dry_run(self) -> None:
+        configured_grants = [
+            {
+                "repository": "cbusillo/launchplane",
+                "workflow_file": "preview-lifecycle.yml",
+                "product": "example-product",
+                "context": "example-context",
+                "action": "preview_lifecycle.plan",
+                "source_label": "operator-config:example-preview-plan",
+            }
+        ]
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_directory = Path(temporary_directory_name)
+            result = _run_authz_grants_generator(
+                temporary_directory,
+                owner_authz_env={},
+                extra_env={
+                    "LAUNCHPLANE_AUTHZ_GRANT_MODE": "dry_run",
+                    "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY": "true",
+                    "LAUNCHPLANE_AUTHZ_GRANTS_JSON": json.dumps(configured_grants),
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payloads = _read_authz_grant_payloads(temporary_directory, "github-actions-grants.json")
+            outputs = _read_github_outputs(temporary_directory)
+            self.assertEqual(
+                _read_authz_grant_payloads(temporary_directory, "terminal-agents-grants.json"),
+                [],
+            )
+            self.assertEqual(
+                _read_authz_grant_payloads(temporary_directory, "local-operators-grants.json"),
+                [],
+            )
+            self.assertFalse(
+                (temporary_directory / "authz-grants" / "runtime-key-safety-policy.json").exists()
+            )
+
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(payloads[0]["mode"], "dry_run")
+        self.assertEqual(outputs["github_actions_grant_count"], "1")
+        self.assertEqual(outputs["has_github_actions_grants"], "true")
+        self.assertRegex(outputs["configured_grants_sha256"], r"^[0-9a-f]{64}$")
+
+        with TemporaryDirectory() as temporary_directory_name:
+            apply_directory = Path(temporary_directory_name)
+            apply_result = _run_authz_grants_generator(
+                apply_directory,
+                owner_authz_env={},
+                extra_env={
+                    "LAUNCHPLANE_AUTHZ_GRANT_MODE": "apply",
+                    "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY": "true",
+                    "LAUNCHPLANE_AUTHZ_GRANT_REASON": "Resolve reviewed authz gaps.",
+                    "LAUNCHPLANE_AUTHZ_GRANTS_JSON": json.dumps(configured_grants),
+                },
+            )
+
+            self.assertEqual(apply_result.returncode, 0, apply_result.stderr)
+            apply_payloads = _read_authz_grant_payloads(
+                apply_directory, "github-actions-grants.json"
+            )
+            apply_outputs = _read_github_outputs(apply_directory)
+
+        self.assertEqual(apply_payloads[0]["mode"], "apply")
+        self.assertTrue(
+            cast(str, apply_payloads[0]["reason"]).startswith("Resolve reviewed authz gaps.")
+        )
+        self.assertEqual(
+            apply_outputs["configured_grants_sha256"], outputs["configured_grants_sha256"]
+        )
+
+    def test_deploy_authz_grants_reject_dry_run_without_configured_only(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            result = _run_authz_grants_generator(
+                Path(temporary_directory_name),
+                extra_env={"LAUNCHPLANE_AUTHZ_GRANT_MODE": "dry_run"},
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Dry-run authz reconciliation requires configured-only mode.",
+            result.stderr,
+        )
+
+    def test_deploy_authz_grants_require_reason_for_configured_only_apply(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            result = _run_authz_grants_generator(
+                Path(temporary_directory_name),
+                owner_authz_env={},
+                extra_env={
+                    "LAUNCHPLANE_AUTHZ_GRANT_MODE": "apply",
+                    "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY": "true",
+                    "LAUNCHPLANE_AUTHZ_GRANTS_JSON": "[]",
+                },
+            )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "Configured-only authz apply requires LAUNCHPLANE_AUTHZ_GRANT_REASON.",
+            result.stderr,
+        )
+
     def test_deploy_authz_grants_require_configured_owner_identities(
         self,
     ) -> None:
@@ -1918,6 +2020,43 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", script_text)
         self.assertNotIn("Authorization: Bearer", script_text)
         self.assertNotIn("curl ", script_text)
+
+    def test_deploy_workflow_supports_grant_only_dry_run_and_apply(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+        grant_only_job = workflow_text.split("  operator-authz-grants:\n", 1)[1].split(
+            "  emergency-dokploy-rollback:\n", 1
+        )[0]
+
+        self.assertIn("authz_grants_mode:", workflow_text)
+        self.assertIn("- dry_run", workflow_text)
+        self.assertIn("- apply", workflow_text)
+        self.assertIn("inputs.authz_grants_mode == 'none'", workflow_text)
+        self.assertIn("authz_grants_expected_sha256:", workflow_text)
+        self.assertIn("authz_grants_reason:", workflow_text)
+        self.assertIn("LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON", grant_only_job)
+        self.assertNotIn("vars.LAUNCHPLANE_AUTHZ_GRANTS_JSON", grant_only_job)
+        self.assertIn('LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY: "true"', grant_only_job)
+        self.assertIn("LAUNCHPLANE_SERVICE_AUDIENCE", grant_only_job)
+        self.assertIn("Verify reviewed authz grant set", grant_only_job)
+        self.assertIn("Configured authz grants changed after the reviewed dry run.", grant_only_job)
+        self.assertIn(
+            "Grant-only reconciliation cannot include break-glass rollback inputs.", grant_only_job
+        )
+        self.assertIn("uses: ./.github/actions/launchplane-request", grant_only_job)
+        self.assertIn("audience: ${{ env.LAUNCHPLANE_SERVICE_AUDIENCE }}", grant_only_job)
+        self.assertIn("route-path: /v1/authz-policies/github-actions/grants", grant_only_job)
+        self.assertIn("Verify and summarize authz grant results", grant_only_job)
+        self.assertIn("Canonical grant-set SHA-256", grant_only_job)
+        self.assertNotIn("Build and push Launchplane image", grant_only_job)
+        self.assertNotIn("Request Launchplane self deploy", grant_only_job)
+        self.assertNotIn("runtime-key-safety/policies/apply", grant_only_job)
+
+        emergency_job = workflow_text.split("  emergency-dokploy-rollback:\n", 1)[1]
+        self.assertIn("AUTHZ_GRANTS_MODE: ${{ inputs.authz_grants_mode }}", emergency_job)
+        self.assertIn(
+            "Break-glass rollback cannot be combined with authz grant reconciliation.",
+            emergency_job,
+        )
 
     def test_deploy_workflow_reads_deployed_runtime_through_shared_request(self) -> None:
         workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add an authz-grant-only dry-run/apply mode to the already-authorized deploy workflow
- isolate candidate grants in a temporary operator variable so normal deploys cannot apply them
- bind apply to the canonical SHA-256 from the reviewed dry run and require an operator reason
- fail closed on deploy/break-glass input conflicts and honor the configured OIDC audience
- classify the workflow mechanics in the config-authority audit and document the operator sequence

## Validation
- `uv run python -m unittest tests.test_product_onboarding tests.test_config_authority_audit tests.test_docs_contracts` (203 tests)
- `uv run launchplane service audit-config-authority --control-plane-root .`
- changed-files config-authority gate for `.github/workflows/deploy-launchplane.yml`
- `actionlint -config-file .github/actionlint.yaml .github/workflows/deploy-launchplane.yml`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_product_onboarding.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_product_onboarding.py`
- `bash -n scripts/deploy/ensure-authz-grants.sh`

Supports #1240 and #1621.