### PR TITLE
Allow repository token for GHCR cleanup

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -230,6 +230,7 @@ WORKFLOW_RESPONSE_SUMMARY_PATH_VALUES = {
     },
 }
 WORKFLOW_BLOCK_MECHANIC_FIELD_PATH_VALUES = {
+    ".github/workflows/cleanup-ghcr.yml": {"GITHUB_TOKEN": frozenset(("${{ github.token }}",))},
     ".github/workflows/deploy-launchplane.yml": {
         "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY": frozenset(('"true"', "true"))
     },

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1298,6 +1298,24 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "",
         )
 
+    def test_cleanup_ghcr_repository_token_is_thin_connector_input(self) -> None:
+        self.assertEqual(
+            _allow_reason(
+                path=".github/workflows/cleanup-ghcr.yml",
+                key="GITHUB_TOKEN",
+                value="${{ github.token }}",
+            ),
+            "thin_connector_input",
+        )
+        self.assertEqual(
+            _allow_reason(
+                path=".github/workflows/other.yml",
+                key="GITHUB_TOKEN",
+                value="${{ github.token }}",
+            ),
+            "",
+        )
+
     def test_workflow_block_scalar_runtime_values_are_scanned(self) -> None:
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- classify `${{ github.token }}` as the approved path-scoped credential for `.github/workflows/cleanup-ghcr.yml`
- keep the allowance limited to the cleanup workflow and `GITHUB_TOKEN` field
- add positive and negative classification coverage

## Validation
- `uv run python -m unittest tests.test_config_authority_audit` (93 tests)
- `uv run launchplane service audit-config-authority --control-plane-root .`
- product-repo changed-files gate passes against the pending CM Website cleanup change
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`

Supports #1620.