### PR TITLE
Allow dedicated GHCR cleanup delete credential

### DIFF
--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -230,7 +230,10 @@ WORKFLOW_RESPONSE_SUMMARY_PATH_VALUES = {
     },
 }
 WORKFLOW_BLOCK_MECHANIC_FIELD_PATH_VALUES = {
-    ".github/workflows/cleanup-ghcr.yml": {"GITHUB_TOKEN": frozenset(("${{ github.token }}",))},
+    ".github/workflows/cleanup-ghcr.yml": {
+        "GITHUB_DELETE_TOKEN": frozenset(("${{ secrets.ODOO_GHCR_CLEANUP_TOKEN }}",)),
+        "GITHUB_TOKEN": frozenset(("${{ github.token }}",)),
+    },
     ".github/workflows/deploy-launchplane.yml": {
         "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY": frozenset(('"true"', "true"))
     },

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -1316,6 +1316,32 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
             "",
         )
 
+    def test_cleanup_ghcr_delete_token_is_thin_connector_input(self) -> None:
+        self.assertEqual(
+            _allow_reason(
+                path=".github/workflows/cleanup-ghcr.yml",
+                key="GITHUB_DELETE_TOKEN",
+                value="${{ secrets.ODOO_GHCR_CLEANUP_TOKEN }}",
+            ),
+            "thin_connector_input",
+        )
+        self.assertEqual(
+            _allow_reason(
+                path=".github/workflows/cleanup-ghcr.yml",
+                key="GITHUB_DELETE_TOKEN",
+                value="${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}",
+            ),
+            "",
+        )
+        self.assertEqual(
+            _allow_reason(
+                path=".github/workflows/other.yml",
+                key="GITHUB_DELETE_TOKEN",
+                value="${{ secrets.ODOO_GHCR_CLEANUP_TOKEN }}",
+            ),
+            "",
+        )
+
     def test_workflow_block_scalar_runtime_values_are_scanned(self) -> None:
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- classify the dedicated GHCR cleanup delete secret as an allowed thin connector input
- keep the publish credential rejected in cleanup workflows
- cover path and exact-secret restrictions

## Validation
- `uv run python -m unittest tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cleanup_ghcr_repository_token_is_thin_connector_input tests.test_config_authority_audit.ConfigAuthorityAuditTest.test_cleanup_ghcr_delete_token_is_thin_connector_input`
- `uv run --extra dev ruff format --check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py`
- `uv run launchplane service audit-config-authority --control-plane-root .`

Related to #1620.