### PR TITLE
Fix Dependabot config and add fork-aware merge gates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     open-pull-requests-limit: 5
     schedule:
       interval: weekly
-    cooldown:
-      semver-major-days: 30
     labels:
       - dependencies
       - github-actions

--- a/.github/github.json
+++ b/.github/github.json
@@ -123,7 +123,14 @@
     "Work Graph Snapshot Validate",
     "Dependency Graph"
   ],
-  "requiredStatusChecks": ["test"],
+  "requiredStatusChecks": [
+    "test",
+    "static_checks",
+    "container_scan",
+    "frontend_validate",
+    "workflow_lint",
+    "secret_scan"
+  ],
   "codeScanningMergeProtection": {
     "ruleset": "Require code scanning results",
     "tool": "CodeQL",

--- a/.github/github.json
+++ b/.github/github.json
@@ -123,14 +123,7 @@
     "Work Graph Snapshot Validate",
     "Dependency Graph"
   ],
-  "requiredStatusChecks": [
-    "test",
-    "static_checks",
-    "container_scan",
-    "frontend_validate",
-    "workflow_lint",
-    "secret_scan"
-  ],
+  "requiredStatusChecks": ["ci-gate", "security-gate"],
   "codeScanningMergeProtection": {
     "ruleset": "Require code scanning results",
     "tool": "CodeQL",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,64 @@ jobs:
         if: always()
         run: docker image rm "$LAUNCHPLANE_CI_IMAGE_TAG" || true
 
+  container_scan_fork:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      LAUNCHPLANE_CI_IMAGE_TAG: >-
+        launchplane-ci:${{ github.run_id }}-${{ github.run_attempt }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v4
+        with:
+          name: launchplane-ci-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Build runtime image
+        uses: docker/build-push-action@v7
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          context: .
+          load: true
+          tags: ${{ env.LAUNCHPLANE_CI_IMAGE_TAG }}
+          cache-from: >-
+            type=gha,scope=launchplane-ci
+
+      - name: Restore Trivy cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/trivy-cache
+          key: ${{ runner.os }}-trivy-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-trivy-
+
+      - name: Scan runtime image
+        env:
+          LAUNCHPLANE_TRIVY_CACHE_DIR: ${{ runner.temp }}/trivy-cache
+        run: |
+          mkdir -p "$LAUNCHPLANE_TRIVY_CACHE_DIR"
+          docker run --rm \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "${LAUNCHPLANE_TRIVY_CACHE_DIR}:/root/.cache" \
+            ghcr.io/aquasecurity/trivy:0.70.0 \
+            image \
+            --scanners vulnerability \
+            --ignore-unfixed \
+            --severity HIGH,CRITICAL \
+            --exit-code 1 \
+            "$LAUNCHPLANE_CI_IMAGE_TAG"
+
+      - name: Remove scanned runtime image
+        if: always()
+        run: docker image rm "$LAUNCHPLANE_CI_IMAGE_TAG" || true
+
   frontend_validate:
     if: >-
       github.event_name != 'pull_request' ||
@@ -378,3 +436,55 @@ jobs:
 
       - name: Run unit tests
         run: uv run python -m unittest
+
+  ci_gate:
+    name: ci-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - static_checks
+      - static_checks_fork
+      - container_scan
+      - container_scan_fork
+      - frontend_validate
+      - frontend_validate_fork
+      - test
+      - test_fork
+    if: always() && github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Require successful CI path
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          STATIC_CHECKS_RESULT: ${{ needs.static_checks.result }}
+          STATIC_CHECKS_FORK_RESULT: ${{ needs.static_checks_fork.result }}
+          CONTAINER_SCAN_RESULT: ${{ needs.container_scan.result }}
+          CONTAINER_SCAN_FORK_RESULT: ${{ needs.container_scan_fork.result }}
+          FRONTEND_VALIDATE_RESULT: ${{ needs.frontend_validate.result }}
+          FRONTEND_VALIDATE_FORK_RESULT: ${{ needs.frontend_validate_fork.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          TEST_FORK_RESULT: ${{ needs.test_fork.result }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            check_name="$1"
+            check_result="$2"
+            if [ "${check_result}" != "success" ]; then
+              echo "${check_name} concluded with: ${check_result}" >&2
+              exit 1
+            fi
+          }
+
+          if [ "${HEAD_REPOSITORY}" = "${BASE_REPOSITORY}" ]; then
+            require_success static_checks "${STATIC_CHECKS_RESULT}"
+            require_success container_scan "${CONTAINER_SCAN_RESULT}"
+            require_success frontend_validate "${FRONTEND_VALIDATE_RESULT}"
+            require_success test "${TEST_RESULT}"
+          else
+            require_success static_checks_fork "${STATIC_CHECKS_FORK_RESULT}"
+            require_success container_scan_fork "${CONTAINER_SCAN_FORK_RESULT}"
+            require_success frontend_validate_fork "${FRONTEND_VALIDATE_FORK_RESULT}"
+            require_success test_fork "${TEST_FORK_RESULT}"
+          fi

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -36,6 +36,26 @@ jobs:
             rhysd/actionlint:1.7.12 \
             -config-file .github/actionlint.yaml
 
+  workflow_lint_fork:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Lint GitHub Actions workflows
+        run: |
+          docker run --rm \
+            -v "${PWD}:/repo" \
+            -w /repo \
+            rhysd/actionlint:1.7.12 \
+            -config-file .github/actionlint.yaml
+
   secret_scan:
     if: >-
       github.event_name != 'pull_request' ||
@@ -65,3 +85,71 @@ jobs:
             --no-git \
             --redact \
             --verbose
+
+  secret_scan_fork:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Scan current tree for committed secrets
+        run: |
+          scan_path="${RUNNER_TEMP}/gitleaks-source"
+          rm -rf "${scan_path}"
+          mkdir -p "${scan_path}"
+          git ls-files -z | rsync -a --files-from=- --from0 ./ "${scan_path}/"
+
+          docker run --rm \
+            -v "${scan_path}:/repo:ro" \
+            -w /repo \
+            ghcr.io/gitleaks/gitleaks:v8.30.1 detect \
+            --source . \
+            --no-git \
+            --redact \
+            --verbose
+
+  security_gate:
+    name: security-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+      - workflow_lint
+      - workflow_lint_fork
+      - secret_scan
+      - secret_scan_fork
+    if: always() && github.event_name == 'pull_request'
+    permissions:
+      contents: read
+    steps:
+      - name: Require successful security path
+        env:
+          BASE_REPOSITORY: ${{ github.repository }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          WORKFLOW_LINT_RESULT: ${{ needs.workflow_lint.result }}
+          WORKFLOW_LINT_FORK_RESULT: ${{ needs.workflow_lint_fork.result }}
+          SECRET_SCAN_RESULT: ${{ needs.secret_scan.result }}
+          SECRET_SCAN_FORK_RESULT: ${{ needs.secret_scan_fork.result }}
+        run: |
+          set -euo pipefail
+          require_success() {
+            check_name="$1"
+            check_result="$2"
+            if [ "${check_result}" != "success" ]; then
+              echo "${check_name} concluded with: ${check_result}" >&2
+              exit 1
+            fi
+          }
+
+          if [ "${HEAD_REPOSITORY}" = "${BASE_REPOSITORY}" ]; then
+            require_success workflow_lint "${WORKFLOW_LINT_RESULT}"
+            require_success secret_scan "${SECRET_SCAN_RESULT}"
+          else
+            require_success workflow_lint_fork "${WORKFLOW_LINT_FORK_RESULT}"
+            require_success secret_scan_fork "${SECRET_SCAN_FORK_RESULT}"
+          fi

--- a/docs/policies/coding-standards.md
+++ b/docs/policies/coding-standards.md
@@ -29,9 +29,9 @@ title: Coding Standards
 ## Dependency Updates
 
 - Group routine minor and patch updates when they share a validation surface.
-- Keep semantic-version major updates independently reviewable and delay them
-  with a bounded cooldown so newly released majors do not poison routine groups
-  before adjacent tools declare compatibility.
+- Keep semantic-version major updates independently reviewable. Where the
+  package ecosystem supports cooldowns, delay newly released majors so they do
+  not poison routine groups before adjacent tools declare compatibility.
 - Keep security updates ungrouped and independently mergeable; version-update
   grouping and cooldown policy must not delay them.
 - Fix compatibility findings in code or dependency constraints. Do not weaken

--- a/docs/policies/coding-standards.md
+++ b/docs/policies/coding-standards.md
@@ -25,6 +25,9 @@ title: Coding Standards
   needed to reach DB-backed records and managed secrets.
 - Preserve minimal diffs and readable history.
 - Update docs whenever behavior or repo ownership changes.
+- Protect pull-request merges with stable aggregate status checks that fail
+  closed over the validation path selected for same-repository or fork work.
+  Do not rely on skipped conditional jobs as proof that an alternate path ran.
 
 ## Dependency Updates
 

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -1,8 +1,27 @@
+import json
 from pathlib import Path
 from unittest import TestCase
 
 
 class DocsContractsTests(TestCase):
+    def test_required_status_checks_use_fork_aware_aggregate_gates(self) -> None:
+        metadata = json.loads(Path(".github/github.json").read_text(encoding="utf-8"))
+        ci_workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        security_workflow = Path(".github/workflows/security.yml").read_text(encoding="utf-8")
+
+        self.assertEqual(["ci-gate", "security-gate"], metadata["requiredStatusChecks"])
+        self.assertIn("  container_scan_fork:", ci_workflow)
+        self.assertIn("  ci_gate:\n    name: ci-gate", ci_workflow)
+        self.assertIn("STATIC_CHECKS_FORK_RESULT", ci_workflow)
+        self.assertIn("CONTAINER_SCAN_FORK_RESULT", ci_workflow)
+        self.assertIn("FRONTEND_VALIDATE_FORK_RESULT", ci_workflow)
+        self.assertIn("TEST_FORK_RESULT", ci_workflow)
+        self.assertIn("  workflow_lint_fork:", security_workflow)
+        self.assertIn("  secret_scan_fork:", security_workflow)
+        self.assertIn("  security_gate:\n    name: security-gate", security_workflow)
+        self.assertIn("WORKFLOW_LINT_FORK_RESULT", security_workflow)
+        self.assertIn("SECRET_SCAN_FORK_RESULT", security_workflow)
+
     def test_post_v2_transition_plans_are_issue_backed(self) -> None:
         docs_index = Path("docs/README.md").read_text(encoding="utf-8")
         service_boundary = Path("docs/service-boundary.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- remove the unsupported `github-actions` cooldown that caused Dependabot's own config check to fail
- retain the supported uv major-version cooldown and independent major review policy
- replace conditional per-job branch requirements with stable `ci-gate` and `security-gate` contexts
- run fork-safe validation on GitHub-hosted runners while keeping trusted same-repository work on self-hosted runners
- fail closed when the selected CI or security path fails, cancels, or skips

## Validation
- Dependabot's `.github/dependabot.yml` check passes on the corrected configuration
- targeted docs contract tests pass
- Ruff check/format and targeted mypy pass
- Actionlint passes for both changed workflows
- `.github/github.json`, Markdown, and diff checks pass
- independent gate review found no merge-protection bypass; the generic cooldown concern is superseded by Dependabot's live ecosystem-specific parser result

Related to #1632