### PR TITLE
Freeze unittest timing input per CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,13 +278,54 @@ jobs:
       - name: Validate frontend
         run: pnpm --dir frontend validate
 
+  test_timing_snapshot:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    env:
+      UNITTEST_TIMINGS_CACHE: .ci-cache/unittest-timings/history.json
+    steps:
+      - name: Restore unittest timings
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.UNITTEST_TIMINGS_CACHE }}
+          key: >-
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-
+            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-
+            ${{ runner.os }}-python-3.13-unittest-timings-
+
+      - name: Freeze unittest timing snapshot
+        run: |
+          set -euo pipefail
+          snapshot_directory="${RUNNER_TEMP}/unittest-timing-snapshot"
+          mkdir -p "${snapshot_directory}"
+          if [ -f "${UNITTEST_TIMINGS_CACHE}" ]; then
+            cp "${UNITTEST_TIMINGS_CACHE}" "${snapshot_directory}/history.json"
+          fi
+          printf '%s:%s\n' "${GITHUB_RUN_ID}" "${GITHUB_RUN_ATTEMPT}" \
+            > "${snapshot_directory}/snapshot-id"
+
+      - name: Upload unittest timing snapshot
+        uses: actions/upload-artifact@v7
+        with:
+          name: unittest-timing-snapshot
+          path: ${{ runner.temp }}/unittest-timing-snapshot
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 30
+
   test_shards:
+    needs: test_timing_snapshot
     if: >-
       github.event_name != 'pull_request' ||
       github.event.pull_request.head.repo.full_name == github.repository
     name: test_shard (${{ matrix.shard_index }})
     env:
-      UNITTEST_TIMINGS_CACHE: .ci-cache/unittest-timings/history.json
       UNITTEST_SHARD_COUNT: "12"
       UNITTEST_MAX_TESTS_PER_TARGET: "20"
       UNITTEST_MAX_SECONDS_PER_TARGET: "30"
@@ -308,22 +349,17 @@ jobs:
       - name: Install Python
         run: uv python install 3.13
 
-      - name: Restore unittest timings
-        uses: actions/cache/restore@v4
+      - name: Download unittest timing snapshot
+        uses: actions/download-artifact@v7
         with:
-          path: ${{ env.UNITTEST_TIMINGS_CACHE }}
-          key: >-
-            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-
-            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-
-            ${{ runner.os }}-python-3.13-unittest-timings-
+          name: unittest-timing-snapshot
+          path: ${{ runner.temp }}/unittest-timing-snapshot
 
       - name: Show unit test shard plan
         run: >-
           uv run launchplane ci unittest-shard plan
           --shard-count "${UNITTEST_SHARD_COUNT}"
-          --timings-file "${UNITTEST_TIMINGS_CACHE}"
+          --timings-file "${RUNNER_TEMP}/unittest-timing-snapshot/history.json"
           --max-tests-per-target "${UNITTEST_MAX_TESTS_PER_TARGET}"
           --max-seconds-per-target "${UNITTEST_MAX_SECONDS_PER_TARGET}"
 
@@ -332,7 +368,7 @@ jobs:
           uv run launchplane ci unittest-shard run
           --shard-count "${UNITTEST_SHARD_COUNT}"
           --shard-index ${{ matrix.shard_index }}
-          --timings-file "${UNITTEST_TIMINGS_CACHE}"
+          --timings-file "${RUNNER_TEMP}/unittest-timing-snapshot/history.json"
           --max-tests-per-target "${UNITTEST_MAX_TESTS_PER_TARGET}"
           --max-seconds-per-target "${UNITTEST_MAX_SECONDS_PER_TARGET}"
           --timings-output "${RUNNER_TEMP}/unittest-timings/shard-${{ matrix.shard_index }}.json"
@@ -344,10 +380,11 @@ jobs:
           name: unittest-timings-${{ matrix.shard_index }}
           path: ${{ runner.temp }}/unittest-timings/shard-${{ matrix.shard_index }}.json
           if-no-files-found: error
-          retention-days: 7
+          overwrite: true
+          retention-days: 30
 
   test:
-    needs: test_shards
+    needs: [test_timing_snapshot, test_shards]
     if: >-
       always() &&
       (github.event_name != 'pull_request' ||
@@ -373,23 +410,22 @@ jobs:
       - name: Install Python
         run: uv python install 3.13
 
-      - name: Restore unittest timings
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.UNITTEST_TIMINGS_CACHE }}
-          key: >-
-            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-${{ github.run_attempt }}
-          restore-keys: |
-            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-${{ github.run_id }}-
-            ${{ runner.os }}-python-3.13-unittest-timings-${{ github.ref_name }}-
-            ${{ runner.os }}-python-3.13-unittest-timings-
-
       - name: Require successful test shards
         run: |
+          if [ "${{ needs.test_timing_snapshot.result }}" != "success" ]; then
+            echo "test_timing_snapshot result: ${{ needs.test_timing_snapshot.result }}" >&2
+            exit 1
+          fi
           if [ "${{ needs.test_shards.result }}" != "success" ]; then
             echo "test_shards result: ${{ needs.test_shards.result }}" >&2
             exit 1
           fi
+
+      - name: Download unittest timing snapshot
+        uses: actions/download-artifact@v7
+        with:
+          name: unittest-timing-snapshot
+          path: ${{ runner.temp }}/unittest-timing-snapshot
 
       - name: Download unittest timings
         uses: actions/download-artifact@v7
@@ -403,7 +439,7 @@ jobs:
           uv run launchplane ci unittest-shard aggregate
           --shard-count "${UNITTEST_SHARD_COUNT}"
           --results-dir "${RUNNER_TEMP}/unittest-timings"
-          --timings-file "${UNITTEST_TIMINGS_CACHE}"
+          --timings-file "${RUNNER_TEMP}/unittest-timing-snapshot/history.json"
           --max-tests-per-target "${UNITTEST_MAX_TESTS_PER_TARGET}"
           --max-seconds-per-target "${UNITTEST_MAX_SECONDS_PER_TARGET}"
           --timings-output "${UNITTEST_TIMINGS_CACHE}"

--- a/docs/style/testing.md
+++ b/docs/style/testing.md
@@ -35,7 +35,12 @@ of truth.
 
 Same-repo CI currently uses 12 unittest shards with a 20-test/30-second split
 threshold to keep large app and service targets under the tool wall-clock
-ceiling. The shard plan includes per-target timing-source diagnostics:
+ceiling. CI restores timing history once per workflow run and distributes that
+immutable snapshot to every shard and the aggregate job. Shards must not restore
+timing caches independently because timing-dependent target splitting requires
+one shared plan input. Snapshot and shard artifacts remain available for the
+full workflow rerun window and may be overwritten safely by rerun jobs. The
+shard plan includes per-target timing-source diagnostics:
 
 - `exact`: the timing file has a direct record for that unittest target.
 - `parent`: the estimate is derived from the parent module timing and spread

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -22,6 +22,24 @@ class DocsContractsTests(TestCase):
         self.assertIn("WORKFLOW_LINT_FORK_RESULT", security_workflow)
         self.assertIn("SECRET_SCAN_FORK_RESULT", security_workflow)
 
+    def test_ci_shards_share_one_unittest_timing_snapshot(self) -> None:
+        ci_workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+
+        self.assertIn("  test_timing_snapshot:", ci_workflow)
+        self.assertIn("name: unittest-timing-snapshot", ci_workflow)
+        self.assertEqual(1, ci_workflow.count("name: Restore unittest timings"))
+        self.assertEqual(2, ci_workflow.count("name: Download unittest timing snapshot"))
+        self.assertEqual(2, ci_workflow.count("overwrite: true"))
+        self.assertEqual(2, ci_workflow.count("retention-days: 30"))
+        self.assertIn("needs: test_timing_snapshot", ci_workflow)
+        self.assertIn("needs: [test_timing_snapshot, test_shards]", ci_workflow)
+        self.assertEqual(
+            3,
+            ci_workflow.count(
+                '--timings-file "${RUNNER_TEMP}/unittest-timing-snapshot/history.json"'
+            ),
+        )
+
     def test_post_v2_transition_plans_are_issue_backed(self) -> None:
         docs_index = Path("docs/README.md").read_text(encoding="utf-8")
         service_boundary = Path("docs/service-boundary.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- restore unittest timing history once per CI workflow run
- publish one immutable timing snapshot for every shard and the aggregate job
- remove independent fallback cache restores that could derive incompatible shard assignments
- document and contract-test the shared snapshot topology

## Root cause
PR #1634 run 29119807297 produced 1,840 timing records but only 1,698 unique targets. Exactly 142 targets were duplicated and every duplicate involved shard 2, proving one shard derived a different assignment after restoring a different fallback cache revision.

## Validation
- `actionlint -oneline .github/workflows/ci.yml`
- `uv run python -m unittest tests.test_docs_contracts`
- `uv run --extra dev ruff check tests/test_docs_contracts.py`
- `uv run --extra dev ruff format --check tests/test_docs_contracts.py`
- `uv run --extra dev mypy tests/test_docs_contracts.py`
- `git diff --check`
- JetBrains changed-files inspection: GREEN
- markdownlint reports two pre-existing MD013 violations in the unchanged command examples at `docs/style/testing.md:24-25`

Refs #1629
Refs #1499