### PR TITLE
Update Go builder for CVE-2026-39822

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN pnpm install --frozen-lockfile
 COPY frontend /app/frontend
 RUN pnpm build
 
-FROM mirror.gcr.io/library/golang:1.26.4-bookworm AS github-cli-build
+FROM mirror.gcr.io/library/golang:1.26.5-bookworm AS github-cli-build
 
 ENV CGO_ENABLED=0 \
     GOTOOLCHAIN=local


### PR DESCRIPTION
## Summary
- update the GitHub CLI builder from Go 1.26.4 to 1.26.5
- remove the fixed HIGH-severity CVE-2026-39822 finding from the runtime image
- keep the container vulnerability gate strict

## Evidence
- Trivy failure reproduced in PR #1640 run 29124764491 and PR #1636
- `mirror.gcr.io/library/golang:1.26.5-bookworm` manifest exists for supported platforms
- `docker build --target github-cli-build -t launchplane-gh-builder:go-1.26.5-test .`
- built `/go/bin/gh` reports `go1.26.5`
- full runtime image builds successfully
- Trivy 0.70.0 reports zero HIGH/CRITICAL findings, including `usr/local/bin/gh`
- JetBrains changed-files inspection: GREEN

Refs #1629
Refs #1640