### PR TITLE
Expose tracked Dokploy deployment logs

### DIFF
--- a/.github/workflows/tracked-target-logs.yml
+++ b/.github/workflows/tracked-target-logs.yml
@@ -17,8 +17,16 @@ name: Tracked Target Logs
         required: true
         default: "200"
         type: string
+      source:
+        description: Read current runtime logs or the latest deployment logs.
+        required: true
+        default: runtime
+        type: choice
+        options:
+          - runtime
+          - deployment
       since:
-        description: Log duration window, such as all, 5m, 2h, or 1d.
+        description: Runtime log window; deployment mode always uses all.
         required: true
         default: 1h
         type: string
@@ -43,6 +51,7 @@ jobs:
       CONTEXT: ${{ inputs.context }}
       INSTANCE: ${{ inputs.instance }}
       LINES: ${{ inputs.lines }}
+      SOURCE: ${{ inputs.source }}
       SINCE: ${{ inputs.since }}
       SEARCH: ${{ inputs.search }}
     steps:
@@ -66,6 +75,14 @@ jobs:
             echo "since must be 'all' or a duration like 5m, 2h, or 1d." >&2
             exit 1
           fi
+          if [ "$SOURCE" != "runtime" ] && [ "$SOURCE" != "deployment" ]; then
+            echo "source must be runtime or deployment." >&2
+            exit 1
+          fi
+          if [ "$SOURCE" = "deployment" ] && [ -n "$SEARCH" ]; then
+            echo "deployment logs do not support search." >&2
+            exit 1
+          fi
           if ! [[ "$SEARCH" =~ ^[a-zA-Z0-9\ ._-]{0,500}$ ]]; then
             echo 'search may contain only safe plain-text characters.' >&2
             exit 1
@@ -76,16 +93,22 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          effective_since="$SINCE"
+          if [ "$SOURCE" = "deployment" ]; then
+            effective_since="all"
+          fi
           jq -n \
             --arg context "$CONTEXT" \
             --arg instance "$INSTANCE" \
             --arg lines "$LINES" \
-            --arg since "$SINCE" \
+            --arg source "$SOURCE" \
+            --arg since "$effective_since" \
             --arg search "$SEARCH" \
             '{
               context: $context,
               instance: $instance,
               lines: $lines,
+              source: $source,
               since: $since,
               search: $search
             }' \
@@ -94,7 +117,8 @@ jobs:
             jq -r \
               '"/v1/contexts/\(.context | @uri)" +
                "/instances/\(.instance | @uri)/logs" +
-               "?lines=\(.lines | @uri)&since=\(.since | @uri)" +
+               "?lines=\(.lines | @uri)&source=\(.source | @uri)" +
+               "&since=\(.since | @uri)" +
                "&search=\(.search | @uri)"' \
               tracked-target-logs-request.json
           })"
@@ -108,6 +132,7 @@ jobs:
           method: GET
           audience: ${{ env.LAUNCHPLANE_SERVICE_AUDIENCE }}
           response-output-file: tracked-target-logs.json
+          log-response-body: false
           output-paths: >-
             trace_id=trace_id
 
@@ -122,6 +147,7 @@ jobs:
             instance,
             target,
             request,
+            deployment,
             logs: {
               line_count: .logs.line_count,
               redacted: .logs.redacted

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -386,6 +386,7 @@ WORKFLOW_INPUT_MECHANIC_DEFAULT_PATH_VALUES = {
     },
     ".github/workflows/tracked-target-logs.yml": {
         "inputs.lines.default": frozenset(("200",)),
+        "inputs.source.default": frozenset(("runtime",)),
         "inputs.since.default": frozenset(("1h",)),
     },
 }

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1386,6 +1386,7 @@ class TrackedTargetLogTargetResponse(BaseModel):
 class TrackedTargetLogRequestResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    source: Literal["runtime", "deployment"]
     line_count: int
     since: str
     search: str
@@ -1399,6 +1400,12 @@ class TrackedTargetLogLinesResponse(BaseModel):
     redacted: bool
 
 
+class TrackedTargetLogDeploymentResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    deployment_id: str
+
+
 class TrackedTargetLogsResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -1409,6 +1416,7 @@ class TrackedTargetLogsResponse(BaseModel):
     target: TrackedTargetLogTargetResponse
     request: TrackedTargetLogRequestResponse
     logs: TrackedTargetLogLinesResponse
+    deployment: TrackedTargetLogDeploymentResponse | None = None
 
 
 class EdgeEndpointRecordResponse(BaseModel):
@@ -10450,6 +10458,7 @@ def create_launchplane_fastapi_app(
         lines: Annotated[str, Query()] = str(control_plane_dokploy.DEFAULT_DOKPLOY_LOG_LINE_COUNT),
         since: Annotated[str, Query()] = "all",
         search: Annotated[str, Query()] = "",
+        source: Annotated[str, Query()] = "runtime",
     ) -> TrackedTargetLogsResponse:
         trace_id = next_trace_id()
         if not resolved_authz_policy_runtime.policy.allows(
@@ -10483,7 +10492,14 @@ def create_launchplane_fastapi_app(
         try:
             normalized_since = control_plane_dokploy.normalize_dokploy_log_since(since)
             normalized_search = control_plane_dokploy.normalize_dokploy_log_search(search)
-        except click.ClickException as error:
+            normalized_source = (
+                control_plane_tracked_target_logs.normalize_tracked_target_log_source(source)
+            )
+            if normalized_source == "deployment" and normalized_since != "all":
+                raise ValueError("Tracked deployment logs require since='all'.")
+            if normalized_source == "deployment" and normalized_search:
+                raise ValueError("Tracked deployment logs do not support search.")
+        except (ValueError, click.ClickException) as error:
             raise _launchplane_http_error(
                 status_code=400,
                 trace_id=trace_id,
@@ -10500,6 +10516,7 @@ def create_launchplane_fastapi_app(
                 line_count=line_count,
                 since=normalized_since,
                 search=normalized_search,
+                source=normalized_source,
             )
         except TypeError as error:
             raise _launchplane_http_error(
@@ -10520,7 +10537,7 @@ def create_launchplane_fastapi_app(
                 status_code=503,
                 trace_id=trace_id,
                 code="target_logs_unavailable",
-                message=str(error),
+                message="Tracked target logs are unavailable from the provider.",
             ) from error
         return TrackedTargetLogsResponse.model_validate(
             {"status": "ok", "trace_id": trace_id, **logs_payload}

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol, cast
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+
+
+TrackedTargetLogSource = Literal["runtime", "deployment"]
 
 
 class TrackedTargetLogsStore(Protocol):
@@ -27,6 +30,7 @@ def build_tracked_target_logs_payload(
     line_count: int,
     since: str = "all",
     search: str = "",
+    source: str = "runtime",
 ) -> dict[str, object]:
     normalized_context = context_name.strip().lower()
     normalized_instance = instance_name.strip().lower()
@@ -54,6 +58,11 @@ def build_tracked_target_logs_payload(
     normalized_line_count = control_plane_dokploy.normalize_dokploy_log_line_count(line_count)
     normalized_since = control_plane_dokploy.normalize_dokploy_log_since(since)
     normalized_search = control_plane_dokploy.normalize_dokploy_log_search(search)
+    normalized_source = normalize_tracked_target_log_source(source)
+    if normalized_source == "deployment" and normalized_since != "all":
+        raise ValueError("Tracked deployment logs require since='all'.")
+    if normalized_source == "deployment" and normalized_search:
+        raise ValueError("Tracked deployment logs do not support search.")
     host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
     target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
         host=host,
@@ -63,7 +72,35 @@ def build_tracked_target_logs_payload(
     )
     app_name = str(target_payload.get("appName") or "").strip()
     server_id = str(target_payload.get("serverId") or "").strip()
-    if target_record.target_type == "application":
+    deployment: dict[str, object] | None = None
+    if normalized_source == "deployment":
+        latest_deployment = control_plane_dokploy.latest_deployment_for_target(
+            host=host,
+            token=token,
+            target_type=target_record.target_type,
+            target_id=target_id_record.target_id,
+        )
+        if latest_deployment is None:
+            raise ValueError("No Dokploy deployment is available for the requested target.")
+        deployment_id = control_plane_dokploy.deployment_log_id(latest_deployment)
+        if not deployment_id:
+            raise ValueError("No Dokploy deployment is available for the requested target.")
+        deployment_target_key = (
+            "applicationId" if target_record.target_type == "application" else "composeId"
+        )
+        deployment_target_id = str(latest_deployment.get(deployment_target_key) or "").strip()
+        if deployment_target_id != target_id_record.target_id:
+            raise ValueError(
+                "Latest Dokploy deployment is not bound to the requested tracked target."
+            )
+        logs = control_plane_dokploy.fetch_dokploy_deployment_logs(
+            host=host,
+            token=token,
+            deployment_id=deployment_id,
+            line_count=normalized_line_count,
+        )
+        deployment = {"deployment_id": deployment_id}
+    elif target_record.target_type == "application":
         logs = control_plane_dokploy.fetch_dokploy_application_logs(
             host=host,
             token=token,
@@ -87,7 +124,7 @@ def build_tracked_target_logs_payload(
         control_plane_dokploy.redact_dokploy_log_line(line)
         for line in logs[-normalized_line_count:]
     )
-    return {
+    result: dict[str, object] = {
         "context": normalized_context,
         "instance": normalized_instance,
         "target": {
@@ -99,6 +136,7 @@ def build_tracked_target_logs_payload(
             "source_label": target_record.source_label,
         },
         "request": {
+            "source": normalized_source,
             "line_count": normalized_line_count,
             "since": normalized_since,
             "search": normalized_search,
@@ -109,3 +147,13 @@ def build_tracked_target_logs_payload(
             "redacted": True,
         },
     }
+    if deployment is not None:
+        result["deployment"] = deployment
+    return result
+
+
+def normalize_tracked_target_log_source(value: str) -> TrackedTargetLogSource:
+    normalized_value = value.strip().lower()
+    if normalized_value not in {"runtime", "deployment"}:
+        raise ValueError("Tracked target log source must be 'runtime' or 'deployment'.")
+    return cast(TrackedTargetLogSource, normalized_value)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -701,10 +701,15 @@ Current derived-state behavior:
   `--search`, and redacts likely secret values from returned log lines.
 - `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200` exposes the
   same tracked-target log reader through a native FastAPI service route using
-  action `target_logs.read`.
+  action `target_logs.read`. The default `source=runtime` reads current
+  application or compose logs. `source=deployment` reads the latest tracked
+  target deployment log with the same line bound and redaction contract; it
+  requires `since=all` and does not accept search text. Launchplane verifies the
+  selected deployment is bound to the requested tracked target before reading
+  its detached log id, and provider failures return public-safe errors.
 - The manual Tracked Target Logs workflow calls that service route with GitHub
-  OIDC and uploads the redacted JSON result, so operators can inspect compose
-  target boot failures without local Dokploy credentials. Tenant contexts need a
+  OIDC and uploads the redacted JSON result, so operators can inspect runtime or
+  deployment failures without local Dokploy credentials. Tenant contexts need a
   matching `target_logs.read` GitHub Actions grant in
   `LAUNCHPLANE_AUTHZ_GRANTS_JSON`; do not broaden this workflow to read all
   contexts by default.

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1901,7 +1901,7 @@ read-model contract documented in [driver-descriptors.md](driver-descriptors.md)
 - `GET /v1/drivers/{driver_id}`
 - `GET /v1/contexts/{context}/driver-view`
 - `GET /v1/contexts/{context}/instances/{instance}/driver-view`
-- `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200`
+- `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200&source=runtime`
 
 The descriptor and driver-view routes use action `driver.read` and are native
 FastAPI routes. Descriptor discovery authorizes against context `launchplane`;
@@ -1912,8 +1912,13 @@ runtime-provider primitives.
 The logs route is the exception to the `driver.read` action because it reads live
 provider output. It is a native FastAPI route, uses action `target_logs.read`,
 resolves DB-backed tracked target records by context/instance, supports bounded
-Dokploy `application` and `compose` logs, validates log query parameters before
-provider access, and redacts likely secret values before returning lines.
+Dokploy `application` and `compose` runtime logs plus the latest tracked target
+deployment log, validates source-specific query parameters before provider
+access, and redacts likely secret values before returning lines. Deployment-log
+reads use `source=deployment`, require `since=all`, and reject search text.
+Launchplane verifies the selected deployment belongs to the requested tracked
+target before reading its detached log id, and provider failures remain
+public-safe.
 
 The preview driver cut stays intentionally narrow but keeps topology in
 Launchplane: Launchplane owns preview URL derivation from the

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -3965,6 +3965,7 @@ async def _get_tracked_target_logs(
     instance: str,
     *,
     lines: str = "",
+    source: str = "",
     since: str = "",
     search: str = "",
     authorization: str = "Bearer valid-token",
@@ -3976,6 +3977,8 @@ async def _get_tracked_target_logs(
     params = {}
     if lines:
         params["lines"] = lines
+    if source:
+        params["source"] = source
     if since:
         params["since"] = since
     if search:

--- a/tests/test_http_app_driver_dokploy.py
+++ b/tests/test_http_app_driver_dokploy.py
@@ -1243,10 +1243,159 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["instance"], "testing")
         self.assertEqual(payload["target"]["target_name"], "syo-testing-app")
         self.assertEqual(payload["target"]["app_name"], "syo-testing-gfbiqh")
-        self.assertEqual(payload["request"], {"line_count": 2, "since": "5m", "search": "contact"})
+        self.assertEqual(
+            payload["request"],
+            {"source": "runtime", "line_count": 2, "since": "5m", "search": "contact"},
+        )
         self.assertEqual(payload["logs"]["lines"], ["contact form submitted"])
         self.assertTrue(payload["logs"]["redacted"])
         self.assertNotIn("secret-token", json.dumps(payload))
+
+    async def test_tracked_target_logs_returns_redacted_latest_deployment_logs(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.latest_deployment_for_target",
+                    return_value={
+                        "deploymentId": "deployment-123",
+                        "applicationId": "app-123",
+                        "status": "error",
+                    },
+                ) as latest_deployment_mock,
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_deployment_logs",
+                    return_value=(
+                        "starting deployment",
+                        "SMTP_PASSWORD=smtp-secret image pull failed",
+                    ),
+                ) as deployment_logs_mock,
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_application_logs"
+                ) as runtime_logs_mock,
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="sellyouroutboard-testing",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "sellyouroutboard-testing",
+                    "testing",
+                    lines="2",
+                    source="deployment",
+                    since="all",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        latest_deployment_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            target_type="application",
+            target_id="app-123",
+        )
+        deployment_logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            deployment_id="deployment-123",
+            line_count=2,
+        )
+        runtime_logs_mock.assert_not_called()
+        payload = response.json()
+        self.assertEqual(payload["request"]["source"], "deployment")
+        self.assertEqual(payload["deployment"], {"deployment_id": "deployment-123"})
+        self.assertEqual(payload["logs"]["lines"][0], "starting deployment")
+        self.assertIn("SMTP_PASSWORD=[redacted]", payload["logs"]["lines"][1])
+        self.assertNotIn("smtp-secret", json.dumps(payload))
+        self.assertNotIn("secret-token", json.dumps(payload))
+
+    async def test_tracked_target_logs_rejects_deployment_not_bound_to_target(self) -> None:
+        for deployment in (
+            {"deploymentId": "deployment-123", "status": "error"},
+            {
+                "deploymentId": "deployment-123",
+                "applicationId": "other-app",
+                "status": "error",
+            },
+        ):
+            with self.subTest(deployment=deployment):
+                with TemporaryDirectory() as temporary_directory_name:
+                    root = Path(temporary_directory_name)
+                    database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+                    _seed_tracked_target_records(
+                        database_url=database_url,
+                        context="sellyouroutboard-testing",
+                        instance="testing",
+                        target_id="app-123",
+                        target_type="application",
+                        target_name="syo-testing-app",
+                    )
+                    app_store = PostgresRecordStore(database_url=database_url)
+                    with (
+                        patch(
+                            "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                            return_value=("https://dokploy.example.com", "secret-token"),
+                        ),
+                        patch(
+                            "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                            return_value={
+                                "appName": "syo-testing-gfbiqh",
+                                "serverId": "server-1",
+                            },
+                        ),
+                        patch(
+                            "control_plane.tracked_target_logs.control_plane_dokploy.latest_deployment_for_target",
+                            return_value=deployment,
+                        ),
+                        patch(
+                            "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_deployment_logs"
+                        ) as deployment_logs_mock,
+                    ):
+                        app = create_launchplane_fastapi_app(
+                            verifier=_StubVerifier(_identity()),
+                            authz_policy=_record_read_policy(
+                                action="target_logs.read",
+                                context="sellyouroutboard-testing",
+                            ),
+                            record_store_factory=lambda: app_store,
+                            control_plane_root_path=root,
+                        )
+                        response = await _get_tracked_target_logs(
+                            app,
+                            "sellyouroutboard-testing",
+                            "testing",
+                            source="deployment",
+                            since="all",
+                        )
+                        app_store.close()
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.json()["error"]["code"], "invalid_request")
+                deployment_logs_mock.assert_not_called()
 
     async def test_tracked_target_logs_redacts_raw_secret_values_from_provider_logs(
         self,
@@ -1471,7 +1620,12 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         payload = response.json()
         self.assertEqual(
             payload["request"],
-            {"line_count": 2, "since": "2h", "search": "website_bootstrap_applied"},
+            {
+                "source": "runtime",
+                "line_count": 2,
+                "since": "2h",
+                "search": "website_bootstrap_applied",
+            },
         )
         self.assertEqual(payload["logs"]["lines"], ["website_bootstrap_applied name=Cell Mechanic"])
 
@@ -1585,7 +1739,7 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
             app_store = PostgresRecordStore(database_url=database_url)
             with patch(
                 "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
-                side_effect=ClickException("Dokploy credentials unavailable."),
+                side_effect=ClickException("API_TOKEN=provider-secret request failed."),
             ):
                 app = create_launchplane_fastapi_app(
                     verifier=_StubVerifier(_identity()),
@@ -1607,6 +1761,11 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         payload = response.json()
         self.assertEqual(payload["status"], "rejected")
         self.assertEqual(payload["error"]["code"], "target_logs_unavailable")
+        self.assertEqual(
+            payload["error"]["message"],
+            "Tracked target logs are unavailable from the provider.",
+        )
+        self.assertNotIn("provider-secret", json.dumps(payload))
 
     async def test_tracked_target_logs_validates_query_values(self) -> None:
         app = create_launchplane_fastapi_app(
@@ -1636,13 +1795,40 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
             "testing",
             lines="1001",
         )
+        source_response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            source="build",
+        )
+        deployment_since_response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            source="deployment",
+            since="5m",
+        )
+        deployment_search_response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            source="deployment",
+            since="all",
+            search="failed",
+        )
 
         self.assertEqual(line_response.status_code, 400)
         self.assertEqual(since_response.status_code, 400)
         self.assertEqual(max_line_response.status_code, 400)
+        self.assertEqual(source_response.status_code, 400)
+        self.assertEqual(deployment_since_response.status_code, 400)
+        self.assertEqual(deployment_search_response.status_code, 400)
         self.assertEqual(line_response.json()["error"]["code"], "invalid_query")
         self.assertEqual(since_response.json()["error"]["code"], "invalid_query")
         self.assertEqual(max_line_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(source_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(deployment_since_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(deployment_search_response.json()["error"]["code"], "invalid_query")
 
     async def test_openapi_includes_tracked_target_logs_contract(self) -> None:
         app = create_launchplane_fastapi_app(


### PR DESCRIPTION
## Summary

- add `source=deployment` to the tracked-target log service route and manual workflow
- resolve the latest deployment through the authorized DB-tracked target, then fail closed unless the deployment is bound to that exact application or compose target
- keep provider failures public-safe, suppress response-body logging, and preserve bounded redacted log artifacts
- normalize manual deployment-log requests to `since=all` and reject unsupported search text
- document the new diagnostic contract and add focused API regressions

## Why

The original runtime key-safety blocker from `cbusillo/verireel#260` was fixed by #1650 and the retried Proxmox backup passed. The same promotion then exposed a separate repeatable Dokploy deployment failure. Launchplane already owns the deployment-log client, but no service-boundary route exposed those logs for diagnosis without direct Dokploy credentials.

## Validation

- `uv run python -m unittest tests.test_http_app_driver_dokploy.FastApiTrackedTargetLogsReadTests tests.test_config_authority_audit` — 108 passed
- `uv run launchplane ci unittest-shard local` — 12/12 shards passed, 1,836 targets
- changed-file `ruff check` and `ruff format --check`
- changed-file `mypy`
- `actionlint .github/workflows/tracked-target-logs.yml`
- `uv run launchplane service audit-config-authority --control-plane-root .` — status `ok`
- JetBrains changed-files inspection — green
- independent final review — clean for PR

Refs cbusillo/verireel#260
