### PR TITLE
Preserve tracked log failure diagnostics

### DIFF
--- a/.github/workflows/tracked-target-logs.yml
+++ b/.github/workflows/tracked-target-logs.yml
@@ -125,6 +125,8 @@ jobs:
           echo "route_path=${route_path}" >>"$GITHUB_OUTPUT"
 
       - name: Read tracked target logs
+        id: request
+        continue-on-error: true
         uses: ./.github/actions/launchplane-request
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_SERVICE_URL }}
@@ -137,29 +139,47 @@ jobs:
             trace_id=trace_id
 
       - name: Show redacted log summary
+        if: ${{ always() }}
         shell: bash
         run: |
           set -euo pipefail
-          jq '{
-            status,
-            trace_id,
-            context,
-            instance,
-            target,
-            request,
-            deployment,
-            logs: {
-              line_count: .logs.line_count,
-              redacted: .logs.redacted
-            }
-          }' \
-            tracked-target-logs.json
+          if [ ! -f tracked-target-logs.json ]; then
+            echo 'Tracked target log response file was not created.'
+            exit 0
+          fi
+          jq '
+            if .status == "ok" then
+              {
+                status,
+                trace_id,
+                context,
+                instance,
+                target,
+                request,
+                deployment,
+                logs: {
+                  line_count: .logs.line_count,
+                  redacted: .logs.redacted
+                }
+              }
+            else
+              {status, trace_id, error}
+            end
+          ' tracked-target-logs.json
 
       - name: Upload tracked target logs
+        if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: tracked-target-logs-${{ inputs.context }}-${{ inputs.instance }}
+          name: tracked-target-logs-${{ inputs.context }}-${{ inputs.instance }}-${{ inputs.source }}
           path: |
             tracked-target-logs-request.json
             tracked-target-logs.json
           if-no-files-found: error
+
+      - name: Fail when tracked target log read failed
+        if: ${{ steps.request.outcome == 'failure' }}
+        shell: bash
+        run: |
+          echo 'Tracked target log request failed; inspect the uploaded redacted response.' >&2
+          exit 1

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -10532,6 +10532,15 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message=str(error),
             ) from error
+        except control_plane_tracked_target_logs.TrackedTargetLogsProviderError as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="target_logs_unavailable",
+                message=(
+                    f"Tracked target logs are unavailable during {error.operation}: {error.detail}"
+                ),
+            ) from error
         except click.ClickException as error:
             raise _launchplane_http_error(
                 status_code=503,

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -3,12 +3,34 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Literal, Protocol, cast
 
+import click
+
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 
 
 TrackedTargetLogSource = Literal["runtime", "deployment"]
+TrackedTargetLogProviderOperation = Literal[
+    "provider-config",
+    "target-inspect",
+    "deployment-list",
+    "deployment-log-read",
+    "runtime-log-read",
+]
+_MAX_PROVIDER_ERROR_DETAIL_LENGTH = 1000
+
+
+class TrackedTargetLogsProviderError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        operation: TrackedTargetLogProviderOperation,
+        detail: str,
+    ) -> None:
+        self.operation = operation
+        self.detail = detail
+        super().__init__(f"{operation}: {detail}")
 
 
 class TrackedTargetLogsStore(Protocol):
@@ -63,23 +85,34 @@ def build_tracked_target_logs_payload(
         raise ValueError("Tracked deployment logs require since='all'.")
     if normalized_source == "deployment" and normalized_search:
         raise ValueError("Tracked deployment logs do not support search.")
-    host, token = control_plane_dokploy.read_dokploy_config(control_plane_root=control_plane_root)
-    target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
-        host=host,
-        token=token,
-        target_type=target_record.target_type,
-        target_id=target_id_record.target_id,
-    )
-    app_name = str(target_payload.get("appName") or "").strip()
-    server_id = str(target_payload.get("serverId") or "").strip()
-    deployment: dict[str, object] | None = None
-    if normalized_source == "deployment":
-        latest_deployment = control_plane_dokploy.latest_deployment_for_target(
+    try:
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
+    except click.ClickException as error:
+        raise _provider_error(operation="provider-config", error=error) from error
+    try:
+        target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
             host=host,
             token=token,
             target_type=target_record.target_type,
             target_id=target_id_record.target_id,
         )
+    except click.ClickException as error:
+        raise _provider_error(operation="target-inspect", error=error) from error
+    app_name = str(target_payload.get("appName") or "").strip()
+    server_id = str(target_payload.get("serverId") or "").strip()
+    deployment: dict[str, object] | None = None
+    if normalized_source == "deployment":
+        try:
+            latest_deployment = control_plane_dokploy.latest_deployment_for_target(
+                host=host,
+                token=token,
+                target_type=target_record.target_type,
+                target_id=target_id_record.target_id,
+            )
+        except click.ClickException as error:
+            raise _provider_error(operation="deployment-list", error=error) from error
         if latest_deployment is None:
             raise ValueError("No Dokploy deployment is available for the requested target.")
         deployment_id = control_plane_dokploy.deployment_log_id(latest_deployment)
@@ -93,33 +126,42 @@ def build_tracked_target_logs_payload(
             raise ValueError(
                 "Latest Dokploy deployment is not bound to the requested tracked target."
             )
-        logs = control_plane_dokploy.fetch_dokploy_deployment_logs(
-            host=host,
-            token=token,
-            deployment_id=deployment_id,
-            line_count=normalized_line_count,
-        )
+        try:
+            logs = control_plane_dokploy.fetch_dokploy_deployment_logs(
+                host=host,
+                token=token,
+                deployment_id=deployment_id,
+                line_count=normalized_line_count,
+            )
+        except click.ClickException as error:
+            raise _provider_error(operation="deployment-log-read", error=error) from error
         deployment = {"deployment_id": deployment_id}
     elif target_record.target_type == "application":
-        logs = control_plane_dokploy.fetch_dokploy_application_logs(
-            host=host,
-            token=token,
-            application_id=target_id_record.target_id,
-            line_count=normalized_line_count,
-            since=normalized_since,
-            search=normalized_search,
-        )
+        try:
+            logs = control_plane_dokploy.fetch_dokploy_application_logs(
+                host=host,
+                token=token,
+                application_id=target_id_record.target_id,
+                line_count=normalized_line_count,
+                since=normalized_since,
+                search=normalized_search,
+            )
+        except click.ClickException as error:
+            raise _provider_error(operation="runtime-log-read", error=error) from error
     else:
-        logs = control_plane_dokploy.fetch_dokploy_compose_logs(
-            host=host,
-            token=token,
-            compose_id=target_id_record.target_id,
-            app_name=app_name,
-            server_id=server_id,
-            line_count=normalized_line_count,
-            since=normalized_since,
-            search=normalized_search,
-        )
+        try:
+            logs = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host=host,
+                token=token,
+                compose_id=target_id_record.target_id,
+                app_name=app_name,
+                server_id=server_id,
+                line_count=normalized_line_count,
+                since=normalized_since,
+                search=normalized_search,
+            )
+        except click.ClickException as error:
+            raise _provider_error(operation="runtime-log-read", error=error) from error
     logs = tuple(
         control_plane_dokploy.redact_dokploy_log_line(line)
         for line in logs[-normalized_line_count:]
@@ -157,3 +199,17 @@ def normalize_tracked_target_log_source(value: str) -> TrackedTargetLogSource:
     if normalized_value not in {"runtime", "deployment"}:
         raise ValueError("Tracked target log source must be 'runtime' or 'deployment'.")
     return cast(TrackedTargetLogSource, normalized_value)
+
+
+def _provider_error(
+    *,
+    operation: TrackedTargetLogProviderOperation,
+    error: click.ClickException,
+) -> TrackedTargetLogsProviderError:
+    redacted_detail = control_plane_dokploy.redact_dokploy_log_line(str(error)).strip()
+    if not redacted_detail:
+        redacted_detail = "Provider request failed."
+    return TrackedTargetLogsProviderError(
+        operation=operation,
+        detail=redacted_detail[:_MAX_PROVIDER_ERROR_DETAIL_LENGTH],
+    )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -706,13 +706,16 @@ Current derived-state behavior:
   target deployment log with the same line bound and redaction contract; it
   requires `since=all` and does not accept search text. Launchplane verifies the
   selected deployment is bound to the requested tracked target before reading
-  its detached log id, and provider failures return public-safe errors.
+  its detached log id. Provider failures return a bounded redacted operation
+  label/detail instead of raw credentials or unrestricted provider output.
 - The manual Tracked Target Logs workflow calls that service route with GitHub
   OIDC and uploads the redacted JSON result, so operators can inspect runtime or
   deployment failures without local Dokploy credentials. Tenant contexts need a
   matching `target_logs.read` GitHub Actions grant in
   `LAUNCHPLANE_AUTHZ_GRANTS_JSON`; do not broaden this workflow to read all
-  contexts by default.
+  contexts by default. The workflow uploads the redacted response artifact even
+  when the provider request fails, then fails the job after preserving that
+  diagnostic evidence.
 
 ## Runtime Environment Contracts
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1917,8 +1917,9 @@ deployment log, validates source-specific query parameters before provider
 access, and redacts likely secret values before returning lines. Deployment-log
 reads use `source=deployment`, require `since=all`, and reject search text.
 Launchplane verifies the selected deployment belongs to the requested tracked
-target before reading its detached log id, and provider failures remain
-public-safe.
+target before reading its detached log id. Provider failures expose only a
+bounded redacted operation label/detail, and the manual workflow preserves the
+redacted response artifact before reporting failure.
 
 The preview driver cut stays intentionally narrow but keeps topology in
 Launchplane: Launchplane owns preview URL derivation from the

--- a/tests/test_http_app_driver_dokploy.py
+++ b/tests/test_http_app_driver_dokploy.py
@@ -1763,8 +1763,72 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["error"]["code"], "target_logs_unavailable")
         self.assertEqual(
             payload["error"]["message"],
-            "Tracked target logs are unavailable from the provider.",
+            "Tracked target logs are unavailable during provider-config: "
+            "API_TOKEN=[redacted] request failed.",
         )
+        self.assertNotIn("provider-secret", json.dumps(payload))
+
+    async def test_tracked_target_logs_redacts_deployment_log_provider_error(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.latest_deployment_for_target",
+                    return_value={
+                        "deploymentId": "deployment-123",
+                        "applicationId": "app-123",
+                        "status": "error",
+                    },
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_deployment_logs",
+                    side_effect=ClickException(
+                        "Dokploy API GET /api/deployment.readLogs failed (500): "
+                        "DATABASE_URL=postgresql://user:provider-secret@example/db"
+                    ),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="sellyouroutboard-testing",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "sellyouroutboard-testing",
+                    "testing",
+                    source="deployment",
+                    since="all",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 503)
+        payload = response.json()
+        self.assertEqual(payload["error"]["code"], "target_logs_unavailable")
+        self.assertIn("deployment-log-read", payload["error"]["message"])
+        self.assertIn("DATABASE_URL=[redacted]", payload["error"]["message"])
         self.assertNotIn("provider-secret", json.dumps(payload))
 
     async def test_tracked_target_logs_validates_query_values(self) -> None:

--- a/tests/test_http_app_driver_dokploy.py
+++ b/tests/test_http_app_driver_dokploy.py
@@ -1739,7 +1739,9 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
             app_store = PostgresRecordStore(database_url=database_url)
             with patch(
                 "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
-                side_effect=ClickException("API_TOKEN=provider-secret request failed."),
+                side_effect=ClickException(
+                    f"API_TOKEN=provider-secret request failed. {'x' * 2000}"
+                ),
             ):
                 app = create_launchplane_fastapi_app(
                     verifier=_StubVerifier(_identity()),
@@ -1761,11 +1763,13 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         payload = response.json()
         self.assertEqual(payload["status"], "rejected")
         self.assertEqual(payload["error"]["code"], "target_logs_unavailable")
-        self.assertEqual(
-            payload["error"]["message"],
-            "Tracked target logs are unavailable during provider-config: "
-            "API_TOKEN=[redacted] request failed.",
+        self.assertTrue(
+            payload["error"]["message"].startswith(
+                "Tracked target logs are unavailable during provider-config: "
+                "API_TOKEN=[redacted] request failed."
+            )
         )
+        self.assertLessEqual(len(payload["error"]["message"]), 1060)
         self.assertNotIn("provider-secret", json.dumps(payload))
 
     async def test_tracked_target_logs_redacts_deployment_log_provider_error(self) -> None:


### PR DESCRIPTION
## Summary

- classify tracked-target provider failures by bounded operation stage and return only redacted, length-limited detail
- preserve the response artifact even when the service request fails, while still failing the workflow after upload
- keep response-body logging disabled and print only the redacted response summary
- cover provider-config and deployment-log failures with secret-bearing regression fixtures
- document failure-evidence handling for operators

## Why

After #1651 deployed, the first `verireel/prod` deployment-log read reached the new service route but returned `503`. The workflow correctly suppressed the body, but it failed before uploading the response, leaving no safe evidence to distinguish provider configuration, target inspection, deployment listing, or detached log retrieval failure.

This follow-up preserves redacted failure evidence without restoring raw provider output to Actions logs.

## Validation

- `uv run python -m unittest tests.test_http_app_driver_dokploy.FastApiTrackedTargetLogsReadTests tests.test_config_authority_audit` — 109 passed
- `uv run launchplane ci unittest-shard local` — 12/12 shards passed, 1,836 targets
- changed-file `ruff check`, `ruff format --check`, and `mypy`
- `actionlint .github/workflows/tracked-target-logs.yml`
- `uv run launchplane service audit-config-authority --control-plane-root .` — status `ok`
- JetBrains changed-files inspection — green
- independent review — clean for PR
- branch workflow run `29165844703` proved failed responses are uploaded before the final failure step; its auth denial was expected because the production grant is restricted to `refs/heads/main`

Refs cbusillo/verireel#260
