### PR TITLE
Support legacy Dokploy deployment diagnostics

### DIFF
--- a/.github/workflows/tracked-target-logs.yml
+++ b/.github/workflows/tracked-target-logs.yml
@@ -158,6 +158,8 @@ jobs:
                 request,
                 deployment,
                 logs: {
+                  available: .logs.available,
+                  unavailable_reason: .logs.unavailable_reason,
                   line_count: .logs.line_count,
                   redacted: .logs.redacted
                 }
@@ -171,7 +173,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: tracked-target-logs-${{ inputs.context }}-${{ inputs.instance }}-${{ inputs.source }}
+          name: tracked-target-logs-${{ inputs.context }}-${{ inputs.instance }}
           path: |
             tracked-target-logs-request.json
             tracked-target-logs.json
@@ -181,5 +183,6 @@ jobs:
         if: ${{ steps.request.outcome == 'failure' }}
         shell: bash
         run: |
-          echo 'Tracked target log request failed; inspect the uploaded redacted response.' >&2
+          echo 'Tracked target log request failed;' \
+            'inspect the uploaded redacted response.' >&2
           exit 1

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -113,6 +113,22 @@ type JsonValue = JsonPrimitive | dict[str, "JsonValue"] | list["JsonValue"]
 type JsonObject = dict[str, JsonValue]
 
 
+class DokployHttpError(click.ClickException):
+    def __init__(
+        self,
+        *,
+        method: str,
+        path: str,
+        status_code: int,
+        error_body: str,
+    ) -> None:
+        self.method = method
+        self.path = path
+        self.status_code = status_code
+        self.error_body = error_body
+        super().__init__(f"Dokploy API {method} {path} failed ({status_code}): {error_body}")
+
+
 class DokployTargetRecordStore(Protocol):
     def list_dokploy_target_records(self) -> tuple[DokployTargetRecord, ...]: ...
 
@@ -2191,8 +2207,11 @@ def dokploy_request(
             raw_payload = response.read()
     except HTTPError as error:
         error_body = error.read().decode(errors="replace").strip()
-        raise click.ClickException(
-            f"Dokploy API {method} {normalized_path} failed ({error.code}): {error_body}"
+        raise DokployHttpError(
+            method=method,
+            path=normalized_path,
+            status_code=error.code,
+            error_body=error_body,
         ) from error
     except URLError as error:
         raise click.ClickException(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1395,6 +1395,8 @@ class TrackedTargetLogRequestResponse(BaseModel):
 class TrackedTargetLogLinesResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    available: bool
+    unavailable_reason: str
     line_count: int
     lines: tuple[str, ...]
     redacted: bool
@@ -1404,6 +1406,12 @@ class TrackedTargetLogDeploymentResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     deployment_id: str
+    status: str
+    error_message: str
+    created_at: str
+    started_at: str
+    finished_at: str
+    log_path_present: bool
 
 
 class TrackedTargetLogsResponse(BaseModel):

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -19,6 +19,7 @@ TrackedTargetLogProviderOperation = Literal[
     "runtime-log-read",
 ]
 _MAX_PROVIDER_ERROR_DETAIL_LENGTH = 1000
+_DEPLOYMENT_LOG_PROVIDER_NOT_FOUND = "provider_not_found"
 
 
 class TrackedTargetLogsProviderError(RuntimeError):
@@ -103,6 +104,8 @@ def build_tracked_target_logs_payload(
     app_name = str(target_payload.get("appName") or "").strip()
     server_id = str(target_payload.get("serverId") or "").strip()
     deployment: dict[str, object] | None = None
+    logs_available = True
+    logs_unavailable_reason = ""
     if normalized_source == "deployment":
         try:
             latest_deployment = control_plane_dokploy.latest_deployment_for_target(
@@ -126,6 +129,10 @@ def build_tracked_target_logs_payload(
             raise ValueError(
                 "Latest Dokploy deployment is not bound to the requested tracked target."
             )
+        deployment = _deployment_metadata(
+            deployment=latest_deployment,
+            deployment_id=deployment_id,
+        )
         try:
             logs = control_plane_dokploy.fetch_dokploy_deployment_logs(
                 host=host,
@@ -133,9 +140,15 @@ def build_tracked_target_logs_payload(
                 deployment_id=deployment_id,
                 line_count=normalized_line_count,
             )
+        except control_plane_dokploy.DokployHttpError as error:
+            if error.status_code == 404 and error.path == "/api/deployment.readLogs":
+                logs = ()
+                logs_available = False
+                logs_unavailable_reason = _DEPLOYMENT_LOG_PROVIDER_NOT_FOUND
+            else:
+                raise _provider_error(operation="deployment-log-read", error=error) from error
         except click.ClickException as error:
             raise _provider_error(operation="deployment-log-read", error=error) from error
-        deployment = {"deployment_id": deployment_id}
     elif target_record.target_type == "application":
         try:
             logs = control_plane_dokploy.fetch_dokploy_application_logs(
@@ -184,6 +197,8 @@ def build_tracked_target_logs_payload(
             "search": normalized_search,
         },
         "logs": {
+            "available": logs_available,
+            "unavailable_reason": logs_unavailable_reason,
             "line_count": len(logs),
             "lines": list(logs),
             "redacted": True,
@@ -201,15 +216,48 @@ def normalize_tracked_target_log_source(value: str) -> TrackedTargetLogSource:
     return cast(TrackedTargetLogSource, normalized_value)
 
 
+def _deployment_metadata(
+    *,
+    deployment: dict[str, control_plane_dokploy.JsonValue],
+    deployment_id: str,
+) -> dict[str, object]:
+    return {
+        "deployment_id": deployment_id,
+        "status": _deployment_text(deployment, "status", "state", "deploymentStatus").lower(),
+        "error_message": _redacted_text(
+            _deployment_text(deployment, "errorMessage", "error_message")
+        ),
+        "created_at": _deployment_text(deployment, "createdAt", "created_at"),
+        "started_at": _deployment_text(deployment, "startedAt", "started_at"),
+        "finished_at": _deployment_text(deployment, "finishedAt", "finished_at"),
+        "log_path_present": bool(_deployment_text(deployment, "logPath", "log_path")),
+    }
+
+
+def _deployment_text(
+    deployment: dict[str, control_plane_dokploy.JsonValue],
+    *key_names: str,
+) -> str:
+    for key_name in key_names:
+        value = deployment.get(key_name)
+        if value is not None:
+            return str(value).strip()
+    return ""
+
+
 def _provider_error(
     *,
     operation: TrackedTargetLogProviderOperation,
     error: click.ClickException,
 ) -> TrackedTargetLogsProviderError:
-    redacted_detail = control_plane_dokploy.redact_dokploy_log_line(str(error)).strip()
-    if not redacted_detail:
-        redacted_detail = "Provider request failed."
+    redacted_detail = _redacted_text(str(error)) or "Provider request failed."
     return TrackedTargetLogsProviderError(
         operation=operation,
-        detail=redacted_detail[:_MAX_PROVIDER_ERROR_DETAIL_LENGTH],
+        detail=redacted_detail,
     )
+
+
+def _redacted_text(value: str) -> str:
+    return control_plane_dokploy.redact_dokploy_log_line(value).strip()[
+        :_MAX_PROVIDER_ERROR_DETAIL_LENGTH
+    ]

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -708,6 +708,10 @@ Current derived-state behavior:
   selected deployment is bound to the requested tracked target before reading
   its detached log id. Provider failures return a bounded redacted operation
   label/detail instead of raw credentials or unrestricted provider output.
+  When an older Dokploy release returns `404` for the deployment-log endpoint,
+  Launchplane returns the target-bound deployment status, timestamps, redacted
+  provider error, and `logs.available=false` rather than discarding the
+  diagnostic metadata.
 - The manual Tracked Target Logs workflow calls that service route with GitHub
   OIDC and uploads the redacted JSON result, so operators can inspect runtime or
   deployment failures without local Dokploy credentials. Tenant contexts need a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1920,6 +1920,10 @@ Launchplane verifies the selected deployment belongs to the requested tracked
 target before reading its detached log id. Provider failures expose only a
 bounded redacted operation label/detail, and the manual workflow preserves the
 redacted response artifact before reporting failure.
+Older Dokploy releases that do not expose deployment-log reads return a partial
+successful response with target-bound deployment metadata and
+`logs.available=false`; Launchplane does not treat missing log transport as
+missing deployment evidence.
 
 The preview driver cut stays intentionally narrow but keeps topology in
 Launchplane: Launchplane owns preview URL derivation from the

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -1,13 +1,16 @@
 import base64
 import hashlib
+import io
 import json
 import os
 import tomllib
 import unittest
+from http.client import HTTPMessage
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
+from urllib.error import HTTPError
 
 import click
 from click.testing import CliRunner, Result
@@ -353,6 +356,31 @@ class DokployConfigTests(unittest.TestCase):
             )
 
         self.assertIn("deployment id", str(error_context.exception))
+
+    def test_dokploy_request_raises_structured_http_error(self) -> None:
+        error = HTTPError(
+            url="https://dokploy.example.com/api/deployment.readLogs",
+            code=404,
+            msg="Not Found",
+            hdrs=HTTPMessage(),
+            fp=io.BytesIO(b'{"message":"Not found"}'),
+        )
+
+        with (
+            patch("control_plane.dokploy.urlopen", side_effect=error),
+            self.assertRaises(control_plane_dokploy.DokployHttpError) as error_context,
+        ):
+            control_plane_dokploy.dokploy_request(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                path="/api/deployment.readLogs",
+                query={"deploymentId": "deploy-123"},
+            )
+
+        self.assertEqual(error_context.exception.method, "GET")
+        self.assertEqual(error_context.exception.path, "/api/deployment.readLogs")
+        self.assertEqual(error_context.exception.status_code, 404)
+        self.assertEqual(error_context.exception.error_body, '{"message":"Not found"}')
 
     def test_deployment_key_from_wait_result_reads_deployment_token(self) -> None:
         self.assertEqual(

--- a/tests/test_http_app_driver_dokploy.py
+++ b/tests/test_http_app_driver_dokploy.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from click import ClickException
 
+from control_plane import dokploy as control_plane_dokploy
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from control_plane.service_human_auth import (
@@ -1278,14 +1279,19 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
                     return_value={
                         "deploymentId": "deployment-123",
                         "applicationId": "app-123",
-                        "status": "error",
+                        "status": "done",
+                        "errorMessage": "",
+                        "createdAt": "2026-07-11T17:33:15Z",
+                        "startedAt": "2026-07-11T17:33:15Z",
+                        "finishedAt": "2026-07-11T17:33:18Z",
+                        "logPath": "/var/lib/dokploy/deployments/deployment-123.log",
                     },
                 ) as latest_deployment_mock,
                 patch(
                     "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_deployment_logs",
                     return_value=(
                         "starting deployment",
-                        "SMTP_PASSWORD=smtp-secret image pull failed",
+                        "SMTP_PASSWORD=smtp-secret deployment complete",
                     ),
                 ) as deployment_logs_mock,
                 patch(
@@ -1327,7 +1333,20 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         runtime_logs_mock.assert_not_called()
         payload = response.json()
         self.assertEqual(payload["request"]["source"], "deployment")
-        self.assertEqual(payload["deployment"], {"deployment_id": "deployment-123"})
+        self.assertEqual(
+            payload["deployment"],
+            {
+                "deployment_id": "deployment-123",
+                "status": "done",
+                "error_message": "",
+                "created_at": "2026-07-11T17:33:15Z",
+                "started_at": "2026-07-11T17:33:15Z",
+                "finished_at": "2026-07-11T17:33:18Z",
+                "log_path_present": True,
+            },
+        )
+        self.assertTrue(payload["logs"]["available"])
+        self.assertEqual(payload["logs"]["unavailable_reason"], "")
         self.assertEqual(payload["logs"]["lines"][0], "starting deployment")
         self.assertIn("SMTP_PASSWORD=[redacted]", payload["logs"]["lines"][1])
         self.assertNotIn("smtp-secret", json.dumps(payload))
@@ -1804,9 +1823,11 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 patch(
                     "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_deployment_logs",
-                    side_effect=ClickException(
-                        "Dokploy API GET /api/deployment.readLogs failed (500): "
-                        "DATABASE_URL=postgresql://user:provider-secret@example/db"
+                    side_effect=control_plane_dokploy.DokployHttpError(
+                        method="GET",
+                        path="/api/deployment.readLogs",
+                        status_code=500,
+                        error_body=("DATABASE_URL=postgresql://user:provider-secret@example/db"),
                     ),
                 ),
             ):
@@ -1834,6 +1855,85 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("deployment-log-read", payload["error"]["message"])
         self.assertIn("DATABASE_URL=[redacted]", payload["error"]["message"])
         self.assertNotIn("provider-secret", json.dumps(payload))
+
+    async def test_tracked_target_logs_returns_metadata_when_deployment_logs_are_unavailable(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
+                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.latest_deployment_for_target",
+                    return_value={
+                        "deploymentId": "deployment-123",
+                        "applicationId": "app-123",
+                        "status": "error",
+                        "errorMessage": "REGISTRY_TOKEN=provider-secret pull denied",
+                        "createdAt": "2026-07-11T17:33:15Z",
+                        "startedAt": "2026-07-11T17:33:15Z",
+                        "finishedAt": "2026-07-11T17:33:18Z",
+                        "logPath": "/var/lib/dokploy/deployments/deployment-123.log",
+                    },
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_deployment_logs",
+                    side_effect=control_plane_dokploy.DokployHttpError(
+                        method="GET",
+                        path="/api/deployment.readLogs",
+                        status_code=404,
+                        error_body='{"message":"Not found"}',
+                    ),
+                ),
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="sellyouroutboard-testing",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "sellyouroutboard-testing",
+                    "testing",
+                    source="deployment",
+                    since="all",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(payload["deployment"]["deployment_id"], "deployment-123")
+        self.assertEqual(payload["deployment"]["status"], "error")
+        self.assertEqual(
+            payload["deployment"]["error_message"],
+            "REGISTRY_TOKEN=[redacted] pull denied",
+        )
+        self.assertNotIn("provider-secret", json.dumps(payload))
+        self.assertFalse(payload["logs"]["available"])
+        self.assertEqual(payload["logs"]["unavailable_reason"], "provider_not_found")
+        self.assertEqual(payload["logs"]["line_count"], 0)
+        self.assertEqual(payload["logs"]["lines"], [])
 
     async def test_tracked_target_logs_validates_query_values(self) -> None:
         app = create_launchplane_fastapi_app(


### PR DESCRIPTION
## Summary
- preserve target-bound deployment metadata when older Dokploy versions return 404 for `deployment.readLogs`
- expose explicit log availability while retaining bounded secret redaction and fail-closed handling for other provider failures
- add structured Dokploy HTTP errors, API/workflow coverage, and operator documentation

## Incident context
VeriReel production promotion diagnostics reached Dokploy deployment `18V7t8Xn4SaOK8eJ35I4E`, but the deployed Dokploy version predates the `deployment.readLogs` endpoint. The existing 404 discarded the already-authorized deployment metadata needed to identify the root failure.

Related: cbusillo/verireel#260

## Validation
- `uv run launchplane ci unittest-shard local` (1,837 targets, 12/12 shards)
- focused tracked-target log tests
- changed-file Ruff format/check and mypy
- `actionlint .github/workflows/tracked-target-logs.yml`
- config-authority audit
- PyCharm changed-files inspection