### PR TITLE
Authenticate saved registry before Dokploy image pulls

### DIFF
--- a/control_plane/workflows/dokploy_deploy.py
+++ b/control_plane/workflows/dokploy_deploy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from urllib.parse import urlsplit
+
 import click
 
 from control_plane import dokploy as control_plane_dokploy
@@ -24,6 +26,12 @@ def update_dokploy_target_artifact(
         target_id=target_id,
     )
     if target_type == "application":
+        _prepare_saved_registry_login(
+            host=host,
+            token=token,
+            artifact_id=artifact_id,
+            target_payload=target_payload,
+        )
         if runtime_identity is not None:
             env_text = control_plane_dokploy.render_dokploy_env_text_with_overrides(
                 str(target_payload.get("env") or ""),
@@ -71,6 +79,86 @@ def update_dokploy_target_artifact(
         return
 
     raise click.ClickException(f"Unsupported Dokploy target type: {target_type}")
+
+
+def _prepare_saved_registry_login(
+    *,
+    host: str,
+    token: str,
+    artifact_id: str,
+    target_payload: control_plane_dokploy.JsonObject,
+) -> None:
+    username = str(target_payload.get("username") or "").strip()
+    password = str(target_payload.get("password") or "").strip()
+    if username and password:
+        return
+
+    registry_id = str(target_payload.get("registryId") or "").strip()
+    if not registry_id:
+        return
+    try:
+        registry_payload = control_plane_dokploy.as_json_object(
+            control_plane_dokploy.dokploy_request(
+                host=host,
+                token=token,
+                path="/api/registry.one",
+                query={"registryId": registry_id},
+            )
+        )
+    except click.ClickException:
+        raise click.ClickException("Dokploy saved registry lookup failed.") from None
+    if registry_payload is None:
+        raise click.ClickException("Dokploy saved registry lookup returned an invalid payload.")
+    returned_registry_id = str(registry_payload.get("registryId") or "").strip()
+    if returned_registry_id != registry_id:
+        raise click.ClickException("Dokploy saved registry lookup returned the wrong registry.")
+
+    registry_host = _canonical_registry_host(str(registry_payload.get("registryUrl") or ""))
+    if registry_host != _docker_image_registry_host(artifact_id):
+        raise click.ClickException(
+            "Dokploy saved registry does not match the Docker image registry."
+        )
+
+    server_id = str(
+        target_payload.get("buildServerId") or target_payload.get("serverId") or ""
+    ).strip()
+    login_payload: control_plane_dokploy.JsonObject = {"registryId": registry_id}
+    if server_id:
+        login_payload["serverId"] = server_id
+    try:
+        control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/registry.testRegistryById",
+            method="POST",
+            payload=login_payload,
+        )
+    except click.ClickException:
+        raise click.ClickException(
+            "Dokploy saved registry login failed for the target server."
+        ) from None
+
+
+def _docker_image_registry_host(image_reference: str) -> str:
+    normalized_reference = image_reference.strip()
+    first_component = normalized_reference.split("/", 1)[0]
+    if "/" not in normalized_reference or not (
+        "." in first_component or ":" in first_component or first_component == "localhost"
+    ):
+        return "docker.io"
+    return _canonical_registry_host(first_component)
+
+
+def _canonical_registry_host(registry_url: str) -> str:
+    normalized_url = registry_url.strip()
+    if not normalized_url:
+        return "docker.io"
+    parsed_url = urlsplit(normalized_url if "://" in normalized_url else f"//{normalized_url}")
+    registry_host = (parsed_url.netloc or parsed_url.path.split("/", 1)[0]).lower()
+    registry_host = registry_host.rsplit("@", 1)[-1]
+    if registry_host in {"index.docker.io", "registry-1.docker.io"}:
+        return "docker.io"
+    return registry_host
 
 
 def execute_dokploy_artifact_deploy(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -640,6 +640,11 @@ Current derived-state behavior:
 - VeriReel stable deploys update the Dokploy Application docker provider to the
   exact immutable artifact id before triggering deploy; product workflows do not
   publish mutable prod tags as the promotion authority.
+- Docker-provider application deploys without inline pull credentials verify
+  that the target's saved registry host matches the artifact host, then ask
+  Dokploy to authenticate that provider-held credential on the target server
+  before mutating the image. Registry mismatch, lookup failure, or login failure
+  blocks deployment without exposing the saved password.
 - Direct `ship` and `promote` execution fail closed when the referenced
   artifact manifest is missing.
 - Direct artifact-backed execution also fails closed when the Dokploy target

--- a/tests/test_dokploy_deploy.py
+++ b/tests/test_dokploy_deploy.py
@@ -1,0 +1,201 @@
+import unittest
+from unittest.mock import patch
+
+import click
+
+from control_plane.workflows.dokploy_deploy import (
+    _canonical_registry_host,
+    _docker_image_registry_host,
+    update_dokploy_target_artifact,
+)
+
+
+class DokployDeployRegistryTests(unittest.TestCase):
+    def test_registry_host_normalization_matches_docker_image_rules(self) -> None:
+        self.assertEqual(_docker_image_registry_host("ubuntu:24.04"), "docker.io")
+        self.assertEqual(_docker_image_registry_host("library/postgres:16"), "docker.io")
+        self.assertEqual(
+            _docker_image_registry_host("ghcr.io/every/example@sha256:abc"),
+            "ghcr.io",
+        )
+        self.assertEqual(
+            _docker_image_registry_host("localhost:5000/every/example:latest"),
+            "localhost:5000",
+        )
+        self.assertEqual(_canonical_registry_host("https://USER@GHCR.IO/v2/"), "ghcr.io")
+        self.assertEqual(_canonical_registry_host("registry-1.docker.io"), "docker.io")
+
+    def test_saved_matching_registry_logs_in_before_provider_update(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/registry.one":
+                return {
+                    "registryId": "registry-123",
+                    "registryUrl": "https://ghcr.io",
+                    "username": "every",
+                }
+            return True
+
+        with (
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "applicationId": "app-123",
+                    "dockerImage": "ghcr.io/every/example:old",
+                    "username": None,
+                    "password": None,
+                    "registryUrl": None,
+                    "registryId": "registry-123",
+                    "serverId": "server-123",
+                },
+            ),
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.dokploy_request",
+                side_effect=request,
+            ),
+        ):
+            update_dokploy_target_artifact(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_type="application",
+                target_id="app-123",
+                artifact_id="ghcr.io/every/example:new",
+            )
+
+        self.assertEqual(
+            [request["path"] for request in requests],
+            [
+                "/api/registry.one",
+                "/api/registry.testRegistryById",
+                "/api/application.saveDockerProvider",
+            ],
+        )
+        self.assertEqual(
+            requests[1]["payload"],
+            {"registryId": "registry-123", "serverId": "server-123"},
+        )
+
+    def test_saved_mismatched_registry_blocks_provider_update(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/registry.one":
+                return {
+                    "registryId": "registry-123",
+                    "registryUrl": "registry.example.com",
+                }
+            return True
+
+        with (
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "applicationId": "app-123",
+                    "registryId": "registry-123",
+                    "serverId": "server-123",
+                },
+            ),
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.dokploy_request",
+                side_effect=request,
+            ),
+            self.assertRaisesRegex(
+                click.ClickException,
+                "saved registry does not match",
+            ),
+        ):
+            update_dokploy_target_artifact(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_type="application",
+                target_id="app-123",
+                artifact_id="ghcr.io/every/example:new",
+            )
+
+        self.assertEqual(
+            [request["path"] for request in requests],
+            ["/api/registry.one"],
+        )
+
+    def test_saved_registry_login_failure_blocks_provider_update(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/registry.one":
+                return {"registryId": "registry-123", "registryUrl": "ghcr.io"}
+            raise click.ClickException("Registry login failed with provider-secret.")
+
+        with (
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "applicationId": "app-123",
+                    "registryId": "registry-123",
+                    "serverId": "server-123",
+                },
+            ),
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.dokploy_request",
+                side_effect=request,
+            ),
+            self.assertRaisesRegex(
+                click.ClickException,
+                "Dokploy saved registry login failed for the target server",
+            ) as error_context,
+        ):
+            update_dokploy_target_artifact(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_type="application",
+                target_id="app-123",
+                artifact_id="ghcr.io/every/example:new",
+            )
+
+        self.assertNotIn("provider-secret", str(error_context.exception))
+        self.assertIsNone(error_context.exception.__cause__)
+        self.assertTrue(error_context.exception.__suppress_context__)
+        self.assertEqual(
+            [request["path"] for request in requests],
+            ["/api/registry.one", "/api/registry.testRegistryById"],
+        )
+
+    def test_inline_credentials_skip_saved_registry_login(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        with (
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={
+                    "applicationId": "app-123",
+                    "username": "every",
+                    "password": "secret-password",
+                    "registryUrl": "ghcr.io",
+                    "registryId": "registry-123",
+                    "serverId": "server-123",
+                },
+            ),
+            patch(
+                "control_plane.workflows.dokploy_deploy.control_plane_dokploy.dokploy_request",
+                side_effect=lambda **kwargs: requests.append(kwargs),
+            ),
+        ):
+            update_dokploy_target_artifact(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                target_type="application",
+                target_id="app-123",
+                artifact_id="ghcr.io/every/example:new",
+            )
+
+        self.assertEqual(
+            [request["path"] for request in requests],
+            ["/api/application.saveDockerProvider"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- authenticate Dokploy's provider-held saved registry on the target/build server before Docker-provider image mutation when inline pull credentials are absent
- require the saved registry host to match the immutable artifact host and fail before deployment on lookup, mismatch, or login errors
- keep registry passwords inside Dokploy and suppress provider exception chains from persisted deployment diagnostics

## Incident context
VeriReel production deployment `18V7t8Xn4SaOK8eJ35I4E` failed before startup because the target server received `unauthorized` while pulling the private GHCR artifact. The application had a valid saved GHCR registry binding but no inline Docker-provider credentials, so Dokploy skipped login and relied on stale/missing host credentials.

Related: cbusillo/verireel#260

## Validation
- `uv run launchplane ci unittest-shard local` (1,838 targets, 12/12 shards)
- 39 focused Dokploy/VeriReel/generic-web deploy tests
- changed-file Ruff format/check and mypy
- config-authority audit
- PyCharm changed-files inspection