### PR TITLE
Remove obsolete Dokploy deployment-log fallback

### DIFF
--- a/.github/workflows/tracked-target-logs.yml
+++ b/.github/workflows/tracked-target-logs.yml
@@ -158,8 +158,6 @@ jobs:
                 request,
                 deployment,
                 logs: {
-                  available: .logs.available,
-                  unavailable_reason: .logs.unavailable_reason,
                   line_count: .logs.line_count,
                   redacted: .logs.redacted
                 }
@@ -173,7 +171,9 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v7
         with:
-          name: tracked-target-logs-${{ inputs.context }}-${{ inputs.instance }}
+          name: >-
+            tracked-target-logs-${{ inputs.context }}-${{
+            inputs.instance }}-${{ inputs.source }}
           path: |
             tracked-target-logs-request.json
             tracked-target-logs.json

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -113,22 +113,6 @@ type JsonValue = JsonPrimitive | dict[str, "JsonValue"] | list["JsonValue"]
 type JsonObject = dict[str, JsonValue]
 
 
-class DokployHttpError(click.ClickException):
-    def __init__(
-        self,
-        *,
-        method: str,
-        path: str,
-        status_code: int,
-        error_body: str,
-    ) -> None:
-        self.method = method
-        self.path = path
-        self.status_code = status_code
-        self.error_body = error_body
-        super().__init__(f"Dokploy API {method} {path} failed ({status_code}): {error_body}")
-
-
 class DokployTargetRecordStore(Protocol):
     def list_dokploy_target_records(self) -> tuple[DokployTargetRecord, ...]: ...
 
@@ -2207,11 +2191,8 @@ def dokploy_request(
             raw_payload = response.read()
     except HTTPError as error:
         error_body = error.read().decode(errors="replace").strip()
-        raise DokployHttpError(
-            method=method,
-            path=normalized_path,
-            status_code=error.code,
-            error_body=error_body,
+        raise click.ClickException(
+            f"Dokploy API {method} {normalized_path} failed ({error.code}): {error_body}"
         ) from error
     except URLError as error:
         raise click.ClickException(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -1395,8 +1395,6 @@ class TrackedTargetLogRequestResponse(BaseModel):
 class TrackedTargetLogLinesResponse(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    available: bool
-    unavailable_reason: str
     line_count: int
     lines: tuple[str, ...]
     redacted: bool

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -19,7 +19,6 @@ TrackedTargetLogProviderOperation = Literal[
     "runtime-log-read",
 ]
 _MAX_PROVIDER_ERROR_DETAIL_LENGTH = 1000
-_DEPLOYMENT_LOG_PROVIDER_NOT_FOUND = "provider_not_found"
 
 
 class TrackedTargetLogsProviderError(RuntimeError):
@@ -104,8 +103,6 @@ def build_tracked_target_logs_payload(
     app_name = str(target_payload.get("appName") or "").strip()
     server_id = str(target_payload.get("serverId") or "").strip()
     deployment: dict[str, object] | None = None
-    logs_available = True
-    logs_unavailable_reason = ""
     if normalized_source == "deployment":
         try:
             latest_deployment = control_plane_dokploy.latest_deployment_for_target(
@@ -140,13 +137,6 @@ def build_tracked_target_logs_payload(
                 deployment_id=deployment_id,
                 line_count=normalized_line_count,
             )
-        except control_plane_dokploy.DokployHttpError as error:
-            if error.status_code == 404 and error.path == "/api/deployment.readLogs":
-                logs = ()
-                logs_available = False
-                logs_unavailable_reason = _DEPLOYMENT_LOG_PROVIDER_NOT_FOUND
-            else:
-                raise _provider_error(operation="deployment-log-read", error=error) from error
         except click.ClickException as error:
             raise _provider_error(operation="deployment-log-read", error=error) from error
     elif target_record.target_type == "application":
@@ -197,8 +187,6 @@ def build_tracked_target_logs_payload(
             "search": normalized_search,
         },
         "logs": {
-            "available": logs_available,
-            "unavailable_reason": logs_unavailable_reason,
             "line_count": len(logs),
             "lines": list(logs),
             "redacted": True,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -713,10 +713,6 @@ Current derived-state behavior:
   selected deployment is bound to the requested tracked target before reading
   its detached log id. Provider failures return a bounded redacted operation
   label/detail instead of raw credentials or unrestricted provider output.
-  When an older Dokploy release returns `404` for the deployment-log endpoint,
-  Launchplane returns the target-bound deployment status, timestamps, redacted
-  provider error, and `logs.available=false` rather than discarding the
-  diagnostic metadata.
 - The manual Tracked Target Logs workflow calls that service route with GitHub
   OIDC and uploads the redacted JSON result, so operators can inspect runtime or
   deployment failures without local Dokploy credentials. Tenant contexts need a

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1920,10 +1920,6 @@ Launchplane verifies the selected deployment belongs to the requested tracked
 target before reading its detached log id. Provider failures expose only a
 bounded redacted operation label/detail, and the manual workflow preserves the
 redacted response artifact before reporting failure.
-Older Dokploy releases that do not expose deployment-log reads return a partial
-successful response with target-bound deployment metadata and
-`logs.available=false`; Launchplane does not treat missing log transport as
-missing deployment evidence.
 
 The preview driver cut stays intentionally narrow but keeps topology in
 Launchplane: Launchplane owns preview URL derivation from the

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -1,16 +1,13 @@
 import base64
 import hashlib
-import io
 import json
 import os
 import tomllib
 import unittest
-from http.client import HTTPMessage
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
-from urllib.error import HTTPError
 
 import click
 from click.testing import CliRunner, Result
@@ -356,31 +353,6 @@ class DokployConfigTests(unittest.TestCase):
             )
 
         self.assertIn("deployment id", str(error_context.exception))
-
-    def test_dokploy_request_raises_structured_http_error(self) -> None:
-        error = HTTPError(
-            url="https://dokploy.example.com/api/deployment.readLogs",
-            code=404,
-            msg="Not Found",
-            hdrs=HTTPMessage(),
-            fp=io.BytesIO(b'{"message":"Not found"}'),
-        )
-
-        with (
-            patch("control_plane.dokploy.urlopen", side_effect=error),
-            self.assertRaises(control_plane_dokploy.DokployHttpError) as error_context,
-        ):
-            control_plane_dokploy.dokploy_request(
-                host="https://dokploy.example.com",
-                token="secret-token",
-                path="/api/deployment.readLogs",
-                query={"deploymentId": "deploy-123"},
-            )
-
-        self.assertEqual(error_context.exception.method, "GET")
-        self.assertEqual(error_context.exception.path, "/api/deployment.readLogs")
-        self.assertEqual(error_context.exception.status_code, 404)
-        self.assertEqual(error_context.exception.error_body, '{"message":"Not found"}')
 
     def test_deployment_key_from_wait_result_reads_deployment_token(self) -> None:
         self.assertEqual(

--- a/tests/test_http_app_driver_dokploy.py
+++ b/tests/test_http_app_driver_dokploy.py
@@ -11,7 +11,6 @@ from unittest.mock import patch
 
 from click import ClickException
 
-from control_plane import dokploy as control_plane_dokploy
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from control_plane.service_human_auth import (
@@ -1345,8 +1344,6 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
                 "log_path_present": True,
             },
         )
-        self.assertTrue(payload["logs"]["available"])
-        self.assertEqual(payload["logs"]["unavailable_reason"], "")
         self.assertEqual(payload["logs"]["lines"][0], "starting deployment")
         self.assertIn("SMTP_PASSWORD=[redacted]", payload["logs"]["lines"][1])
         self.assertNotIn("smtp-secret", json.dumps(payload))
@@ -1823,11 +1820,9 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 patch(
                     "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_deployment_logs",
-                    side_effect=control_plane_dokploy.DokployHttpError(
-                        method="GET",
-                        path="/api/deployment.readLogs",
-                        status_code=500,
-                        error_body=("DATABASE_URL=postgresql://user:provider-secret@example/db"),
+                    side_effect=ClickException(
+                        "Dokploy API GET /api/deployment.readLogs failed (500): "
+                        "DATABASE_URL=postgresql://user:provider-secret@example/db"
                     ),
                 ),
             ):
@@ -1855,85 +1850,6 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("deployment-log-read", payload["error"]["message"])
         self.assertIn("DATABASE_URL=[redacted]", payload["error"]["message"])
         self.assertNotIn("provider-secret", json.dumps(payload))
-
-    async def test_tracked_target_logs_returns_metadata_when_deployment_logs_are_unavailable(
-        self,
-    ) -> None:
-        with TemporaryDirectory() as temporary_directory_name:
-            root = Path(temporary_directory_name)
-            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
-            _seed_tracked_target_records(
-                database_url=database_url,
-                context="sellyouroutboard-testing",
-                instance="testing",
-                target_id="app-123",
-                target_type="application",
-                target_name="syo-testing-app",
-            )
-            app_store = PostgresRecordStore(database_url=database_url)
-            with (
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.read_dokploy_config",
-                    return_value=("https://dokploy.example.com", "secret-token"),
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_target_payload",
-                    return_value={"appName": "syo-testing-gfbiqh", "serverId": "server-1"},
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.latest_deployment_for_target",
-                    return_value={
-                        "deploymentId": "deployment-123",
-                        "applicationId": "app-123",
-                        "status": "error",
-                        "errorMessage": "REGISTRY_TOKEN=provider-secret pull denied",
-                        "createdAt": "2026-07-11T17:33:15Z",
-                        "startedAt": "2026-07-11T17:33:15Z",
-                        "finishedAt": "2026-07-11T17:33:18Z",
-                        "logPath": "/var/lib/dokploy/deployments/deployment-123.log",
-                    },
-                ),
-                patch(
-                    "control_plane.tracked_target_logs.control_plane_dokploy.fetch_dokploy_deployment_logs",
-                    side_effect=control_plane_dokploy.DokployHttpError(
-                        method="GET",
-                        path="/api/deployment.readLogs",
-                        status_code=404,
-                        error_body='{"message":"Not found"}',
-                    ),
-                ),
-            ):
-                app = create_launchplane_fastapi_app(
-                    verifier=_StubVerifier(_identity()),
-                    authz_policy=_record_read_policy(
-                        action="target_logs.read",
-                        context="sellyouroutboard-testing",
-                    ),
-                    record_store_factory=lambda: app_store,
-                    control_plane_root_path=root,
-                )
-                response = await _get_tracked_target_logs(
-                    app,
-                    "sellyouroutboard-testing",
-                    "testing",
-                    source="deployment",
-                    since="all",
-                )
-                app_store.close()
-
-        self.assertEqual(response.status_code, 200)
-        payload = response.json()
-        self.assertEqual(payload["deployment"]["deployment_id"], "deployment-123")
-        self.assertEqual(payload["deployment"]["status"], "error")
-        self.assertEqual(
-            payload["deployment"]["error_message"],
-            "REGISTRY_TOKEN=[redacted] pull denied",
-        )
-        self.assertNotIn("provider-secret", json.dumps(payload))
-        self.assertFalse(payload["logs"]["available"])
-        self.assertEqual(payload["logs"]["unavailable_reason"], "provider_not_found")
-        self.assertEqual(payload["logs"]["line_count"], 0)
-        self.assertEqual(payload["logs"]["lines"], [])
 
     async def test_tracked_target_logs_validates_query_values(self) -> None:
         app = create_launchplane_fastapi_app(


### PR DESCRIPTION
## Summary
- remove the temporary 404 metadata-only fallback now that the live Dokploy control plane is upgraded and `deployment.readLogs` is verified
- restore normal fail-closed provider errors and remove the compatibility-only availability fields from the API/workflow contract
- retain target binding, deployment status/timestamps, secret redaction, and source-qualified diagnostic artifacts

## Production evidence
- Dokploy upgraded from v0.29.4 to v0.29.11 and is healthy
- VeriReel production promotion attempt 4 passed deploy, rollout, migrations, and health
- deployment `ACjsR1ruAOKTQjlRNUitF` completed successfully and its detached logs are readable through the standard endpoint

Related: cbusillo/verireel#260

## Validation
- `uv run launchplane ci unittest-shard local` (1,837 targets, 12/12 shards)
- 99 focused Dokploy/tracked-log tests
- changed-file Ruff format/check and mypy
- `actionlint .github/workflows/tracked-target-logs.yml`
- config-authority audit
- PyCharm changed-files inspection