### PR TITLE
Restore driver-owned generic preview transport

### DIFF
--- a/control_plane/drivers/generic_web_preview_extensions.py
+++ b/control_plane/drivers/generic_web_preview_extensions.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.drivers.generic_web_preview_dispatch import (
+    _generic_web_preview_anchor_head_sha,
+    _generic_web_preview_anchor_pr_number,
+    _generic_web_preview_anchor_pr_url,
+    _generic_web_preview_anchor_repo,
+)
+from control_plane.verireel_read_http import (
+    VeriReelPreviewDestroyEnvelope,
+    VeriReelPreviewRefreshEnvelope,
+    apply_verireel_preview_destroy_result,
+    apply_verireel_preview_refresh_result,
+)
+from control_plane.workflows.generic_web_preview import (
+    GenericWebPreviewDestroyRequest,
+    GenericWebPreviewDestroyResult,
+    GenericWebPreviewRefreshRequest,
+    GenericWebPreviewRefreshResult,
+    preview_pr_number_from_slug,
+    resolve_generic_web_preview_slug,
+)
+from control_plane.workflows.verireel_preview_driver import (
+    VeriReelPreviewDestroyRequest,
+    VeriReelPreviewRefreshRequest,
+)
+
+
+def apply_generic_web_preview_driver_refresh(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebPreviewRefreshRequest,
+    profile: LaunchplaneProductProfileRecord,
+) -> tuple[dict[str, object], dict[str, object]] | None:
+    if profile.preview.data_transport_mode != "driver":
+        return None
+    if profile.driver_id != "verireel":
+        raise click.ClickException(
+            f"Driver {profile.driver_id!r} does not register a generic-web preview refresh extension."
+        )
+
+    anchor_pr_number = _generic_web_preview_anchor_pr_number(
+        request=request,
+        profile=profile,
+    )
+    preview_slug = resolve_generic_web_preview_slug(
+        profile=profile,
+        preview_slug=request.preview_slug,
+        anchor_pr_number=anchor_pr_number,
+        label="Generic web preview refresh",
+    )
+    records, result = apply_verireel_preview_refresh_result(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=VeriReelPreviewRefreshEnvelope(
+            product=profile.product,
+            refresh=VeriReelPreviewRefreshRequest(
+                context=profile.preview.context,
+                anchor_repo=_generic_web_preview_anchor_repo(profile),
+                anchor_pr_number=anchor_pr_number,
+                anchor_pr_url=_generic_web_preview_anchor_pr_url(
+                    request=request,
+                    profile=profile,
+                    anchor_pr_number=anchor_pr_number,
+                ),
+                anchor_head_sha=_generic_web_preview_anchor_head_sha(request),
+                preview_slug=preview_slug,
+                preview_url=request.preview_url,
+                image_reference=request.image_reference,
+                timeout_seconds=request.timeout_seconds,
+            ),
+        ),
+    )
+    generic_result = GenericWebPreviewRefreshResult.model_validate(
+        {
+            **result,
+            "product": profile.product,
+            "context": profile.preview.context,
+            "preview_slug": preview_slug,
+        }
+    )
+    return records, generic_result.model_dump(mode="json")
+
+
+def apply_generic_web_preview_driver_destroy(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    request: GenericWebPreviewDestroyRequest,
+    profile: LaunchplaneProductProfileRecord,
+) -> tuple[dict[str, object], dict[str, object]] | None:
+    if profile.preview.data_transport_mode != "driver":
+        return None
+    if profile.driver_id != "verireel":
+        raise click.ClickException(
+            f"Driver {profile.driver_id!r} does not register a generic-web preview destroy extension."
+        )
+
+    anchor_pr_number = request.anchor_pr_number or preview_pr_number_from_slug(
+        preview_slug=request.preview_slug,
+        slug_template=profile.preview.slug_template,
+    )
+    if anchor_pr_number is None:
+        raise click.ClickException(
+            "Generic web preview destroy requires anchor_pr_number when preview_slug does not match the profile slug_template."
+        )
+    preview_slug = resolve_generic_web_preview_slug(
+        profile=profile,
+        preview_slug=request.preview_slug,
+        anchor_pr_number=anchor_pr_number,
+        label="Generic web preview destroy",
+    )
+    records, result = apply_verireel_preview_destroy_result(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=VeriReelPreviewDestroyEnvelope(
+            product=profile.product,
+            destroy=VeriReelPreviewDestroyRequest(
+                context=profile.preview.context,
+                anchor_repo=_generic_web_preview_anchor_repo(profile),
+                anchor_pr_number=anchor_pr_number,
+                preview_slug=preview_slug,
+                destroy_reason=request.destroy_reason,
+                timeout_seconds=request.timeout_seconds,
+            ),
+        ),
+    )
+    generic_result = GenericWebPreviewDestroyResult.model_validate(
+        {
+            "destroy_status": result["destroy_status"],
+            "destroy_started_at": result["destroy_started_at"],
+            "destroy_finished_at": result["destroy_finished_at"],
+            "product": profile.product,
+            "context": profile.preview.context,
+            "preview_slug": preview_slug,
+            "application_name": result["application_name"],
+            "application_id": result["application_id"],
+            "error_message": result.get("error_message", ""),
+        }
+    )
+    return records, generic_result.model_dump(mode="json")

--- a/control_plane/generic_web_preview_http.py
+++ b/control_plane/generic_web_preview_http.py
@@ -19,6 +19,10 @@ from control_plane.drivers.generic_web_preview_dispatch import (
     _generic_web_preview_anchor_pr_number,
     _write_preview_inventory_scan_if_supported,
 )
+from control_plane.drivers.generic_web_preview_extensions import (
+    apply_generic_web_preview_driver_destroy,
+    apply_generic_web_preview_driver_refresh,
+)
 from control_plane.workflows.generic_web_deploy import product_profile_uses_generic_web_base
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDestroyResult,
@@ -151,6 +155,15 @@ def apply_generic_web_preview_refresh_result(
     request: GenericWebPreviewRefreshEnvelope,
     profile: LaunchplaneProductProfileRecord,
 ) -> tuple[dict[str, object], dict[str, object]]:
+    driver_extension_result = apply_generic_web_preview_driver_refresh(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=request.refresh,
+        profile=profile,
+    )
+    if driver_extension_result is not None:
+        return driver_extension_result
+
     _generic_web_preview_anchor_pr_number(request=request.refresh, profile=profile)
     driver_result = execute_generic_web_preview_refresh(
         control_plane_root=control_plane_root,
@@ -176,6 +189,15 @@ def apply_generic_web_preview_destroy_result(
     request: GenericWebPreviewDestroyEnvelope,
     profile: LaunchplaneProductProfileRecord,
 ) -> tuple[dict[str, object], dict[str, object]]:
+    driver_extension_result = apply_generic_web_preview_driver_destroy(
+        control_plane_root=control_plane_root,
+        record_store=record_store,
+        request=request.destroy,
+        profile=profile,
+    )
+    if driver_extension_result is not None:
+        return driver_extension_result
+
     driver_result = execute_generic_web_preview_destroy(
         control_plane_root=control_plane_root,
         record_store=cast(GenericWebPreviewProfileStore, record_store),

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -108,6 +108,12 @@ destroy status, or feedback status as job outputs. Callers should omit preview
 context so Launchplane can derive it from the product profile before
 authorization and recording. It does not accept `preview_slug`, `preview_url`,
 provider target ids, feedback markdown, or idempotency keys as caller inputs.
+When the stored product profile declares `preview.data_transport_mode="driver"`,
+the generic-web lifecycle route delegates refresh and destroy execution to the
+registered product-driver extension. This keeps product-specific database,
+secret, migration, seed, and cleanup behavior inside Launchplane while the
+product workflow remains a thin reusable-workflow caller. Missing driver
+extensions fail closed instead of falling back to generic environment copying.
 
 Preview comment updates that are not part of the lifecycle workflow use
 `cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main`.

--- a/tests/test_generic_web_preview_extensions.py
+++ b/tests/test_generic_web_preview_extensions.py
@@ -1,0 +1,170 @@
+from pathlib import Path
+import unittest
+from unittest.mock import MagicMock, patch
+
+import click
+
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+    ProductLaneProfile,
+    ProductPreviewProfile,
+)
+from control_plane.drivers.generic_web_preview_extensions import (
+    apply_generic_web_preview_driver_refresh,
+)
+from control_plane.drivers.generic_web_preview_dispatch import (
+    GenericWebPreviewDestroyEnvelope,
+    GenericWebPreviewRefreshEnvelope,
+)
+from control_plane.generic_web_preview_http import (
+    apply_generic_web_preview_destroy_result,
+    apply_generic_web_preview_refresh_result,
+)
+from control_plane.workflows.generic_web_preview import (
+    GenericWebPreviewDestroyRequest,
+    GenericWebPreviewRefreshRequest,
+)
+
+
+def _driver_profile(*, driver_id: str = "verireel") -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="verireel",
+        display_name="VeriReel",
+        repository="cbusillo/verireel",
+        driver_id=driver_id,
+        image=ProductImageProfile(repository="ghcr.io/cbusillo/verireel-app"),
+        runtime_port=3000,
+        health_path="/api/health",
+        lanes=(
+            ProductLaneProfile(
+                instance="testing",
+                context="verireel",
+                base_url="https://testing.example.test",
+            ),
+        ),
+        preview=ProductPreviewProfile(
+            enabled=True,
+            context="verireel-testing",
+            slug_template="pr-{number}",
+            app_name_prefix="ver-preview",
+            template_instance="testing",
+            data_transport_mode="driver",
+        ),
+        updated_at="2026-07-12T03:00:00Z",
+        source="test",
+    )
+
+
+class GenericWebPreviewExtensionTests(unittest.TestCase):
+    @patch(
+        "control_plane.drivers.generic_web_preview_extensions.apply_verireel_preview_refresh_result"
+    )
+    def test_verireel_refresh_delegates_driver_owned_transport(
+        self, apply_refresh: MagicMock
+    ) -> None:
+        apply_refresh.return_value = (
+            {"preview_id": "preview-verireel-testing-verireel-pr-42"},
+            {
+                "refresh_status": "pass",
+                "refresh_started_at": "2026-07-12T03:00:00Z",
+                "refresh_finished_at": "2026-07-12T03:01:00Z",
+                "application_name": "ver-preview-pr-42",
+                "application_id": "app-pr-42",
+                "preview_url": "https://pr-42.preview.example.test",
+                "error_message": "",
+            },
+        )
+        request = GenericWebPreviewRefreshRequest(
+            product="verireel",
+            anchor_pr_number=42,
+            anchor_pr_url="https://github.com/cbusillo/verireel/pull/42",
+            anchor_head_sha="a1b2c3d4",
+            image_reference="ghcr.io/cbusillo/verireel-app:pr-42-a1b2c3d4",
+            timeout_seconds=240,
+        )
+
+        records, result = apply_generic_web_preview_refresh_result(
+            control_plane_root=Path("."),
+            record_store=object(),
+            request=GenericWebPreviewRefreshEnvelope(
+                product="verireel",
+                refresh=request,
+            ),
+            profile=_driver_profile(),
+        )
+
+        self.assertEqual(records["preview_id"], "preview-verireel-testing-verireel-pr-42")
+        self.assertEqual(result["product"], "verireel")
+        self.assertEqual(result["context"], "verireel-testing")
+        self.assertEqual(result["preview_slug"], "pr-42")
+        delegated = apply_refresh.call_args.kwargs["request"].refresh
+        self.assertEqual(delegated.context, "verireel-testing")
+        self.assertEqual(delegated.anchor_repo, "verireel")
+        self.assertEqual(delegated.preview_slug, "pr-42")
+        self.assertEqual(delegated.anchor_head_sha, "a1b2c3d4")
+        self.assertEqual(delegated.timeout_seconds, 240)
+
+    @patch(
+        "control_plane.drivers.generic_web_preview_extensions.apply_verireel_preview_destroy_result"
+    )
+    def test_verireel_destroy_delegates_database_cleanup(self, apply_destroy: MagicMock) -> None:
+        apply_destroy.return_value = (
+            {"transition": "destroyed"},
+            {
+                "destroy_status": "pass",
+                "destroy_started_at": "2026-07-12T03:00:00Z",
+                "destroy_finished_at": "2026-07-12T03:01:00Z",
+                "application_name": "ver-preview-pr-42",
+                "application_id": "app-pr-42",
+                "preview_url": "https://pr-42.preview.example.test",
+                "error_message": "",
+            },
+        )
+        request = GenericWebPreviewDestroyRequest(
+            product="verireel",
+            anchor_pr_number=42,
+            destroy_reason="pull_request_closed",
+            timeout_seconds=240,
+        )
+
+        records, result = apply_generic_web_preview_destroy_result(
+            control_plane_root=Path("."),
+            record_store=object(),
+            request=GenericWebPreviewDestroyEnvelope(
+                product="verireel",
+                destroy=request,
+            ),
+            profile=_driver_profile(),
+        )
+
+        self.assertEqual(records["transition"], "destroyed")
+        self.assertEqual(result["product"], "verireel")
+        self.assertEqual(result["context"], "verireel-testing")
+        self.assertEqual(result["preview_slug"], "pr-42")
+        delegated = apply_destroy.call_args.kwargs["request"].destroy
+        self.assertEqual(delegated.context, "verireel-testing")
+        self.assertEqual(delegated.anchor_repo, "verireel")
+        self.assertEqual(delegated.preview_slug, "pr-42")
+        self.assertEqual(delegated.destroy_reason, "pull_request_closed")
+
+    def test_unknown_driver_owned_transport_fails_closed(self) -> None:
+        with self.assertRaisesRegex(
+            click.ClickException,
+            "does not register a generic-web preview refresh extension",
+        ):
+            apply_generic_web_preview_driver_refresh(
+                control_plane_root=Path("."),
+                record_store=object(),
+                request=GenericWebPreviewRefreshRequest(
+                    product="verireel",
+                    anchor_pr_number=42,
+                    anchor_head_sha="a1b2c3d4",
+                    image_reference="ghcr.io/cbusillo/verireel-app:pr-42-a1b2c3d4",
+                ),
+                profile=_driver_profile(driver_id="odoo"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- delegate generic preview refresh and destroy requests to the registered product-driver extension when the stored profile uses `preview.data_transport_mode="driver"`
- preserve the generic reusable-workflow result contract while keeping VeriReel database bootstrap, generated secrets, migrations, seeding, evidence, and cleanup in its existing driver
- fail closed when a driver-owned transport mode has no registered extension

## Incident evidence
VeriReel preview runs for app PRs cbusillo/verireel#265 and cbusillo/verireel#266 entered Launchplane after the missing authz grants were repaired, but timed out during provisioning. Live Dokploy evidence showed:
- the immutable private GHCR image pulled successfully
- the preview app started with only generic copied URL/runtime-identity keys
- runtime logs repeatedly reported `Missing required environment variable: DATABASE_URL`
- `/api/health` returned 502 until Launchplane rolled the transient app back

The stored VeriReel profile uses `preview.data_transport_mode="driver"`; its existing driver owns per-preview database roles/databases, generated secrets, migrations, seed, health, and cleanup. The generic route was bypassing that driver.

## Validation
- `uv run launchplane ci unittest-shard local` (1,838 targets, 12/12 shards)
- `uv run --extra dev mypy control_plane tests`
- focused generic-preview, VeriReel-driver, service-route, and docs contract tests
- changed-file Ruff check and format check
- changed-files config-authority gate
- PyCharm changed-files inspection: 0 findings
- `git diff --check`

Related: cbusillo/verireel#262, cbusillo/verireel#263, cbusillo/verireel#264