### PR TITLE
Authenticate saved registry on all Dokploy target servers

### DIFF
--- a/control_plane/workflows/dokploy_deploy.py
+++ b/control_plane/workflows/dokploy_deploy.py
@@ -119,24 +119,28 @@ def _prepare_saved_registry_login(
             "Dokploy saved registry does not match the Docker image registry."
         )
 
-    server_id = str(
-        target_payload.get("buildServerId") or target_payload.get("serverId") or ""
-    ).strip()
-    login_payload: control_plane_dokploy.JsonObject = {"registryId": registry_id}
-    if server_id:
-        login_payload["serverId"] = server_id
-    try:
-        control_plane_dokploy.dokploy_request(
-            host=host,
-            token=token,
-            path="/api/registry.testRegistryById",
-            method="POST",
-            payload=login_payload,
-        )
-    except click.ClickException:
-        raise click.ClickException(
-            "Dokploy saved registry login failed for the target server."
-        ) from None
+    deployment_server_id = str(target_payload.get("serverId") or "").strip()
+    build_server_id = str(target_payload.get("buildServerId") or "").strip()
+    login_server_ids: list[str | None] = [deployment_server_id or None]
+    if build_server_id and build_server_id != deployment_server_id:
+        login_server_ids.append(build_server_id)
+
+    for server_id in login_server_ids:
+        login_payload: control_plane_dokploy.JsonObject = {"registryId": registry_id}
+        if server_id is not None:
+            login_payload["serverId"] = server_id
+        try:
+            control_plane_dokploy.dokploy_request(
+                host=host,
+                token=token,
+                path="/api/registry.testRegistryById",
+                method="POST",
+                payload=login_payload,
+            )
+        except click.ClickException:
+            raise click.ClickException(
+                "Dokploy saved registry login failed for the target server."
+            ) from None
 
 
 def _docker_image_registry_host(image_reference: str) -> str:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -642,9 +642,10 @@ Current derived-state behavior:
   publish mutable prod tags as the promotion authority.
 - Docker-provider application deploys without inline pull credentials verify
   that the target's saved registry host matches the artifact host, then ask
-  Dokploy to authenticate that provider-held credential on the target server
-  before mutating the image. Registry mismatch, lookup failure, or login failure
-  blocks deployment without exposing the saved password.
+  Dokploy to authenticate that provider-held credential on every distinct
+  deployment and build server before mutating the image. Registry mismatch,
+  lookup failure, or login failure blocks deployment without exposing the saved
+  password.
 - Direct `ship` and `promote` execution fail closed when the referenced
   artifact manifest is missing.
 - Direct artifact-backed execution also fails closed when the Dokploy target

--- a/tests/test_dokploy_deploy.py
+++ b/tests/test_dokploy_deploy.py
@@ -77,6 +77,93 @@ class DokployDeployRegistryTests(unittest.TestCase):
             {"registryId": "registry-123", "serverId": "server-123"},
         )
 
+    def test_saved_matching_registry_logs_in_on_each_distinct_required_server(self) -> None:
+        cases: tuple[
+            tuple[str, dict[str, object], list[dict[str, str]]],
+            ...,
+        ] = (
+            (
+                "distinct servers",
+                {
+                    "serverId": "deploy-server-123",
+                    "buildServerId": "build-server-123",
+                },
+                [
+                    {"registryId": "registry-123", "serverId": "deploy-server-123"},
+                    {"registryId": "registry-123", "serverId": "build-server-123"},
+                ],
+            ),
+            (
+                "shared server",
+                {"serverId": "server-123", "buildServerId": "server-123"},
+                [{"registryId": "registry-123", "serverId": "server-123"}],
+            ),
+            (
+                "default deployment and remote build servers",
+                {"serverId": None, "buildServerId": "build-server-123"},
+                [
+                    {"registryId": "registry-123"},
+                    {"registryId": "registry-123", "serverId": "build-server-123"},
+                ],
+            ),
+            (
+                "default server only",
+                {"serverId": None, "buildServerId": None},
+                [{"registryId": "registry-123"}],
+            ),
+        )
+
+        for case_name, server_fields, expected_login_payloads in cases:
+            with self.subTest(case=case_name):
+                requests: list[dict[str, object]] = []
+
+                def request(**kwargs: object) -> object:
+                    requests.append(kwargs)
+                    if kwargs["path"] == "/api/registry.one":
+                        return {
+                            "registryId": "registry-123",
+                            "registryUrl": "https://ghcr.io",
+                            "username": "every",
+                        }
+                    return True
+
+                with (
+                    patch(
+                        "control_plane.workflows.dokploy_deploy.control_plane_dokploy.fetch_dokploy_target_payload",
+                        return_value={
+                            "applicationId": "app-123",
+                            "dockerImage": "ghcr.io/every/example:old",
+                            "username": None,
+                            "password": None,
+                            "registryUrl": None,
+                            "registryId": "registry-123",
+                            **server_fields,
+                        },
+                    ),
+                    patch(
+                        "control_plane.workflows.dokploy_deploy.control_plane_dokploy.dokploy_request",
+                        side_effect=request,
+                    ),
+                ):
+                    update_dokploy_target_artifact(
+                        host="https://dokploy.example.com",
+                        token="secret-token",
+                        target_type="application",
+                        target_id="app-123",
+                        artifact_id="ghcr.io/every/example:new",
+                    )
+
+                self.assertEqual(
+                    [request["path"] for request in requests],
+                    ["/api/registry.one"]
+                    + ["/api/registry.testRegistryById"] * len(expected_login_payloads)
+                    + ["/api/application.saveDockerProvider"],
+                )
+                self.assertEqual(
+                    [request["payload"] for request in requests[1:-1]],
+                    expected_login_payloads,
+                )
+
     def test_saved_mismatched_registry_blocks_provider_update(self) -> None:
         requests: list[dict[str, object]] = []
 
@@ -127,6 +214,11 @@ class DokployDeployRegistryTests(unittest.TestCase):
             requests.append(kwargs)
             if kwargs["path"] == "/api/registry.one":
                 return {"registryId": "registry-123", "registryUrl": "ghcr.io"}
+            if kwargs["payload"] == {
+                "registryId": "registry-123",
+                "serverId": "deploy-server-123",
+            }:
+                return True
             raise click.ClickException("Registry login failed with provider-secret.")
 
         with (
@@ -135,7 +227,8 @@ class DokployDeployRegistryTests(unittest.TestCase):
                 return_value={
                     "applicationId": "app-123",
                     "registryId": "registry-123",
-                    "serverId": "server-123",
+                    "serverId": "deploy-server-123",
+                    "buildServerId": "build-server-123",
                 },
             ),
             patch(
@@ -160,7 +253,11 @@ class DokployDeployRegistryTests(unittest.TestCase):
         self.assertTrue(error_context.exception.__suppress_context__)
         self.assertEqual(
             [request["path"] for request in requests],
-            ["/api/registry.one", "/api/registry.testRegistryById"],
+            [
+                "/api/registry.one",
+                "/api/registry.testRegistryById",
+                "/api/registry.testRegistryById",
+            ],
         )
 
     def test_inline_credentials_skip_saved_registry_login(self) -> None:


### PR DESCRIPTION
## Summary

- authenticate the deployment/default Dokploy server before Docker-provider mutation
- authenticate a distinct build server as a second required target
- deduplicate shared server IDs and preserve inline-credential behavior
- fail closed before `application.saveDockerProvider` when any login fails
- document the multi-server saved-registry behavior

## Validation

- `uv run python -m unittest tests.test_dokploy_deploy tests.test_verireel_testing_deploy tests.test_generic_web_preview`
- `uv run launchplane ci unittest-shard local` — 1,837 targets passed
- changed-file Ruff check and format check
- `uv run --extra dev mypy control_plane tests`
- config-authority audit
- changed-file JetBrains inspection — green
- two independent agent reviews; one default-server edge finding fixed, final re-review clean

Fixes #1656