### PR TITLE
docs: define the post-v2 product and audit plan

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -17,6 +17,7 @@
     "productRepoContract": "docs/product-repo-contract.md",
     "newProductRepo": "docs/new-product-repo.md",
     "operatorExperience": "docs/operator-experience.md",
+    "postV2Audit": "docs/post-v2-audit.md",
     "uiStandards": "docs/ui-standards.md",
     "workGraphReadModel": "docs/work-graph-read-model.md",
     "mergeTrainPolicy": "docs/merge-train-policy.md",

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,9 @@ Use these docs as the source of truth for `launchplane`.
   review rubric.
 - [operator-experience.md](operator-experience.md) — API-first product,
   environment, settings, promotion, cleanup, and UI rebuild contract.
+- [post-v2-audit.md](post-v2-audit.md) — post-v2 product, security,
+  persistence, contract, test, and modularity audit baseline and execution
+  graph.
 - [work-graph-read-model.md](work-graph-read-model.md) — Code Plans/GitHub work
   graph snapshot and recommendation queue contract.
 - [merge-train-policy.md](merge-train-policy.md) — repository/base-branch merge

--- a/docs/operator-experience.md
+++ b/docs/operator-experience.md
@@ -13,6 +13,168 @@ The rebuilt UI should be a product operations surface, not a raw record browser.
 The first screen should show products, their stable environments, current
 operational state, and the next safe action.
 
+## Primary User And Job
+
+The primary user is an operator who may also be a developer, but who is acting
+in an operations context. Their job is:
+
+> Understand what is running for one product, whether it is healthy, why it is
+> unhealthy, and what action is safe to take next without understanding or
+> bypassing Launchplane's provider plumbing.
+
+The same person may switch into engineering maintenance work, but Product Ops
+and Engineering Ops are separate jobs and must have separate navigation:
+
+- **Product Ops** owns product environments, previews, settings, secrets,
+  promotions, maintenance, activity, and diagnosis.
+- **Engineering Ops** owns the work graph, GitHub issue reconciliation, Every
+  Code queues, merge-train controls, and platform maintenance.
+
+Product Ops is the default surface. Engineering Ops may reuse the same session,
+theme, and API transport, but it must not dominate the product workspace or the
+first screen.
+
+## Representative Operator Journeys
+
+The clean-slate product model is grounded in recent Launchplane work rather than
+generic dashboard assumptions.
+
+### Recover A Product Safely
+
+In the rebuilt UI, an operator who discovers that a product profile or scoped
+workflow grant is missing must see which product record, provider target, runtime
+configuration, secret bindings, and grants are missing. The operator reviews a
+dry-run, applies only the missing authority through the service, runs an
+isolated preview canary, destroys it, and sees clean lifecycle evidence.
+
+### Diagnose A Public TLS Failure
+
+In the rebuilt UI, an operator who sees that a preview or stable environment is
+unreachable must receive an environment view that explains the bound domain,
+runtime placement, ingress termination, TLS owner, certificate observation,
+provider/runtime identity, and the evidence behind the failure. Normal
+diagnosis must not require direct Dokploy, edge-proxy, DNS-provider, or database
+inspection.
+
+### Prove Preview Apply And Destroy
+
+The rebuilt UI must let an operator compare desired and actual previews,
+refresh one through a reviewed plan, verify health and runtime identity,
+destroy it, and confirm that no provider or Launchplane inventory remains
+orphaned. Apply, destroy, and report-only reconciliation are one understandable
+journey.
+
+### Promote A Verified Release
+
+The rebuilt UI must show what artifact is in testing and production, why
+promotion is enabled or blocked, and how to run a browser-safe dry-run,
+dispatch the product-owned workflow, and follow promotion evidence without
+creating a release or mutating production during dry-run.
+
+### Change Runtime Settings Or Secrets
+
+The rebuilt UI must show expected runtime keys separately from managed-secret
+bindings and let an operator review missing/stale/disabled state, submit a
+dry-run, and apply the change without plaintext secret values remaining in the
+browser, response, logs, or activity record.
+
+## Golden Paths And Anti-Goals
+
+The primary golden paths are:
+
+1. Select a product and understand testing, production, previews, warnings, and
+   the next safe action.
+2. Open an environment and diagnose placement, domain, ingress, TLS, runtime
+   identity, configuration, and health evidence.
+3. Review and execute a supported dry-run, apply, workflow dispatch, refresh,
+   destroy, or maintenance action.
+4. Follow activity and evidence until the action reaches a clear terminal or
+   reconciliation state.
+
+The rebuilt product must not become:
+
+- a generic card dashboard
+- a raw context, route, provider-ID, or record browser
+- a fleet-wide engineering queue presented as Product Ops
+- a collection of buttons that only prepare requests or perform no operation
+- a source of inferred, fixture-backed, or reassuring placeholder state
+- a second authority for runtime configuration or provider topology
+
+## Information Architecture
+
+```text
+Launchplane
+  Product Ops
+    Products
+      Product workspace
+        Overview
+        Testing
+        Production
+        Previews
+        Runtime settings
+        Managed secrets
+        Promotions
+        Activity
+        Maintenance
+        Diagnostics
+  Engineering Ops
+    Work graph
+    Issue reconciliation
+    Every Code
+    Merge train
+    Platform maintenance
+```
+
+The product workspace is the primary object. Stable lanes and previews are
+visually distinct children of that product. Runtime settings and managed
+secrets are separate surfaces. Activity is an operator timeline. Diagnostics
+contains raw contexts, provider IDs, route paths, record IDs, and provider-only
+evidence that ordinary operation does not require.
+
+## Action Taxonomy
+
+Every visible action must declare one of these behaviors:
+
+- `inspect`: read-only navigation or evidence retrieval
+- `dry-run`: computes and records a plan without a live mutation
+- `apply`: performs a supported service mutation after required review
+- `workflow-dispatch`: starts a product-owned or operator-owned workflow
+- `destructive`: removes or disables live mutable state and requires explicit
+  confirmation plus replacement/recovery evidence
+- `unsupported`: visible only when explaining why the capability is unavailable
+
+No control may look enabled when it only prepares a request, copies a command,
+or has no execution handler. Disabled actions show exact prerequisite,
+authorization, evidence, or trust-state reasons.
+
+## First-Run And Empty States
+
+Empty states are part of the product contract:
+
+- no products: explain how a product becomes Launchplane-owned and link to the
+  supported onboarding action or documentation
+- product without stable evidence: show the profile and missing records, not an
+  empty dashboard
+- no previews: distinguish previews disabled, no desired previews, and missing
+  inventory evidence
+- missing settings/secrets: list required key or binding names and the safe
+  action that can resolve them
+- unsupported capability: name the driver limitation without presenting an
+  actionable control
+- stale or failed reads: preserve the last recorded value only with an explicit
+  trust state and timestamp
+
+Loading, empty, blocked, missing, unsupported, and error are different states
+and must not share a reassuring generic placeholder.
+
+## Responsive Product Contract
+
+Desktop layouts optimize for fast comparison across testing, production, and
+previews. Narrow layouts preserve the same hierarchy in one column: product
+identity, warnings, next action, lane state, and supporting evidence. Critical
+status, trust, timestamp, and action labels must not depend on hover or color
+alone.
+
 ## Product Model
 
 The primary operator model is:
@@ -37,6 +199,10 @@ For SellYourOutboard, the canonical product key is `sellyouroutboard`. Stable
 environments live under that product as `testing` and `prod`. Legacy names such
 as `sellyouroutboard-testing` are transition details and must not be the primary
 picker model.
+
+These names describe the current operator model. Launchplane records remain the
+authority for live product keys, lanes, contexts, repositories, domains,
+targets, and bindings.
 
 ## API Contract
 
@@ -165,3 +331,7 @@ Reusable pieces from the current UI may survive only if they fit the new model:
 session/auth client, API request wrapper, status formatting, evidence formatting,
 and theme basics. The current context-picker/product-config flow should be
 hidden or removed once the new settings flow covers its use cases.
+
+The handwritten frontend contract mirror is not reusable authority. Generated
+backend contracts should replace request/response types; handwritten frontend
+types remain only for UI state and view models.

--- a/docs/post-v2-audit.md
+++ b/docs/post-v2-audit.md
@@ -1,0 +1,209 @@
+---
+title: Post-v2 Product And Engineering Audit
+---
+
+## Purpose
+
+This document records the baseline, findings, decisions, and execution order for
+the post-v2 Launchplane reset tracked by GitHub issue `#1672`. It is a recovery
+point for the workstream, not a second issue tracker. GitHub issues own current
+status, blockers, and completion evidence.
+
+## Audited Baseline
+
+The audit baseline is exact and reproducible:
+
+- repository revision: `80022f75b3a45fb38800445f96d9c1070a1a6663`
+- merged at: July 12, 2026, 20:51 UTC
+- successful CI run: `29208541146`
+- successful Security run: `29208541154`
+- successful CodeQL run: `29208541193`
+- successful deploy run: `29208862672`, July 12, 2026, 21:02–21:06 UTC
+- deployed image:
+  `ghcr.io/cbusillo/launchplane@sha256:b11599cf06937ca5a1d1729602f0b67da5e6ca08cde98632de5dd03ce6c5b9b2`
+- subsequent evidence on the same SHA included successful public-ingress,
+  preview-lifecycle, preview-TLS, target-inspection, and merge-train runs through
+  July 12, 2026, 23:35 UTC
+
+Local baseline validation on the isolated audit worktree:
+
+- `uv run launchplane ci unittest-shard local`: 1,866 targets, 12/12 shards
+  passed in 46.6 seconds
+- `pnpm --dir frontend validate`: passed after installing the locked frontend
+  dependencies
+- `uv run --with pip-audit pip-audit --ignore-vuln PYSEC-2025-183`: no known
+  third-party vulnerability found in the resolved environment
+
+## Scale And Change Context
+
+V2 landed through a high-change window. Between July 2 and the audited baseline,
+`main` received 267 commits including 135 merges.
+
+Current source shape:
+
+- production Python: 138,269 lines
+- test Python: 146,489 lines
+- frontend TypeScript/TSX/CSS: 10,782 lines
+- `control_plane/http_app.py`: 21,353 lines and 161 registered routes, including
+  101 POST/action routes
+- `control_plane/storage/postgres.py`: 5,669 lines
+- `tests/test_service.py`: 20,474 lines
+- `frontend/src/App.tsx`: 2,522 lines
+- `frontend/src/types.ts`: 1,086 lines and about 100 exported manual contracts
+
+The size is evidence of ownership pressure, not permission for mechanical file
+splitting or test deletion.
+
+## Product Decision
+
+Launchplane is a product operations control plane. The primary operator job is
+to understand one product's testing, production, previews, configuration,
+health, and next safe action without understanding provider plumbing.
+
+Product Ops and Engineering Ops remain valuable but separate surfaces. The
+current React application is placeholder scaffolding and may be discarded.
+Authentication, API transport, formatting, trust-state primitives, and theme
+tokens may survive only where they fit the product model. Handwritten API
+contracts do not survive as authority.
+
+See [operator-experience.md](operator-experience.md) for the accepted journeys,
+information architecture, action taxonomy, diagnostics boundary, empty states,
+and responsive requirements.
+
+## Confirmed Findings
+
+### Security And Trust
+
+- privileged break-glass inputs are interpolated directly into Bash while
+  provider credentials are present (`#1681`)
+- the unauthenticated GitHub webhook buffers an unbounded body, and public
+  outbound health requests do not protect resolution/redirect hops from private
+  destinations (`#1682`)
+- arbitrary text is silently derived into a managed-secret root key, while
+  per-version key selection and root rotation are not implemented (`#1683`)
+- raw child-process output can become durable worker or API detail (`#1684`)
+- cookie-authenticated mutation support and the documented CSRF/origin boundary
+  are inconsistent (`#1685`)
+- security-sensitive action/workflow references are mutable rather than pinned
+  to reviewed immutable revisions (`#1686`)
+
+Authlib `1.7.0` is affected by advisories in authorization-server grant paths
+Launchplane does not instantiate. Upgrading remains required hygiene and is
+owned by `#1681`. Cookie `Secure` defaults correctly; human sessions are
+PostgreSQL-backed in production; no direct OIDC/authz or webhook HMAC bypass was
+found in source review.
+
+### Mutation And Persistence
+
+- completed-response idempotency does not reserve execution before effects;
+  concurrent same-key requests can both execute (`#1688`)
+- managed-secret, product-config, onboarding, cutover, and cleanup writes can
+  publish partial authority graphs (`#1689`)
+- several provider mutations and workflow dispatches lack durable intent,
+  multi-instance fencing, and post-crash reconciliation (`#1690`)
+- external notifications and dispatches have send-versus-record crash windows
+  that need a transactional outbox (`#1691`)
+- production schema adoption does not verify every critical PostgreSQL
+  constraint, while most automated store tests use SQLite (`#1687`)
+- merge-train mutation lacks a repository/base controller lease and complete
+  per-step recovery state (`#1692`)
+- Every Code work requests lack lease expiry, fencing, same-key worker replay,
+  and stale recovery (`#1693`)
+
+Existing patterns to reuse include transactional preview-TLS CAS/idempotency,
+leased Odoo/VeriReel operations, bundled promotion/preview evidence writes, and
+pending notification attempts.
+
+### Runtime Topology And TLS
+
+Current product reads expose a provider target and reachability symptoms but do
+not join an environment to actual domains, runtime site/server, edge path, TLS
+terminator, or certificate state.
+
+- provider-neutral environment route authority: `#1694`
+- TLS certificate observations: `#1695`
+- product read-model projection and incident explanation: `#1696`
+
+Desired/recorded/observed facts must remain separate. Provider-specific IDs and
+addresses remain evidence and are redacted from surfaces that do not require
+them. Missing neutral authority must fail closed rather than being synthesized
+from provider records as reassuring truth.
+
+### Frontend Contracts
+
+FastAPI already emits useful typed OpenAPI, but the frontend bypasses it with a
+manual endpoint catalog and type mirror.
+
+- deterministic OpenAPI export, generated read contracts, and drift checking:
+  `#1697`
+- precise UI write-route response contracts and generated clients: `#1698`
+
+Generated contracts are backend authority. A thin handwritten adapter retains
+session behavior, cancellation, and UI normalization. View models remain
+frontend-owned.
+
+### Test Architecture
+
+The suite's main problem is coupling and production fidelity, not its current
+47-second local wall time.
+
+- decouple shared support and move ordinary HTTP tests to a lifespan-aware
+  supported client: `#1699`
+- replace brittle workflow text mirrors with semantic security/contract
+  invariants: `#1700`
+- add deterministic browser smoke after the clean-slate UI exists: `#1701`
+
+The 12-shard architecture, immutable timing snapshot, fork-hosted isolation,
+fail-closed security tests, filesystem coverage, and SQLite portability tests
+remain valuable. Real PostgreSQL proof is owned by `#1687`.
+
+### Modularity
+
+`#1048` remains the focused modularity owner. It is intentionally blocked by the
+mutation and persistence audits. The first safe extraction should follow stable
+contract boundaries: generated OpenAPI read contracts, read-only route-family
+registration, shared response/schema helpers, then one audited domain/provider
+seam. Storage and write-route extraction follows correctness proof, not file
+size.
+
+## UI Delivery Graph
+
+The clean-slate UI remains under `#1675` and is divided into reviewable slices:
+
+- `#1702`: product-first shell and workspace
+- `#1703`: environment topology, configuration, and activity
+- `#1704`: honest product actions and Engineering Ops relocation
+- `#1705`: responsive, accessible, browser-reviewed cleanup
+
+Browser smoke is tracked by `#1701`. The UI does not begin until the product
+brief, topology projection, and generated read contracts are ready.
+
+## Execution Order
+
+1. Land immediate exposed-boundary fixes (`#1681`, `#1682`, `#1684`) and the
+   real-PostgreSQL/schema proof (`#1687`).
+2. Establish generated read contracts (`#1697`) and provider-neutral route
+   authority (`#1694`).
+3. Implement mutation reservations, transactional authority bundles, durable
+   provider operations, outbox delivery, merge-train fencing, and Every Code
+   recovery (`#1688`–`#1693`).
+4. Add TLS observations and topology projection (`#1695`, `#1696`), then precise
+   generated write contracts (`#1698`).
+5. Decouple the test architecture (`#1699`, `#1700`) and perform audited
+   modularity extraction (`#1048`).
+6. Build and browser-review the clean-slate UI (`#1702`–`#1705`, `#1701`).
+7. Complete root-key rotation and immutable action pinning (`#1683`, `#1686`),
+   re-run the security, production-parity, and operator-journey reviews, and
+   close `#1672` only when every confirmed finding is fixed or explicitly
+   accepted with durable rationale.
+
+## Guardrails
+
+- Use focused PRs; do not create a post-v2 mega-branch.
+- Do not combine behavior changes with mechanical module moves.
+- Do not remove tests before mapping the behavior/security proof that replaces
+  them.
+- Do not infer runtime topology or configuration from checked-in values.
+- Prefer durable operation records, transactions, leases, reconciliation, and
+  outbox delivery over process-local locks or best-effort rollback.
+- Update the owning issue and graph whenever evidence changes sequencing.

--- a/docs/ui-standards.md
+++ b/docs/ui-standards.md
@@ -30,6 +30,11 @@ Do not blur these into a generic set of status cards. If a slice needs multiple
 objects, make the primary object visually dominant and place supporting objects
 as evidence around it.
 
+Product Ops is the default top-level surface. Work graph, issue reconciliation,
+Every Code, merge-train control, and platform maintenance belong to a separate
+Engineering Ops navigation area. Sharing a shell does not justify mixing the
+two jobs on one first screen.
+
 The top-level picker chooses a product workspace, not a raw Launchplane context.
 Use display names such as `SellYourOutboard`, `VeriReel`, `Odoo CM`, and
 `Odoo OPW`. Context strings such as `sellyouroutboard`,
@@ -92,6 +97,11 @@ Before committing a meaningful UI slice, check it against this rubric:
   empty cards are removed?
 - Is any missing evidence shown as a real blocked/unknown state instead of a
   reassuring placeholder?
+- Does every enabled action execute a supported operation or explicit workflow
+  dispatch rather than stopping at a review-only request preview?
+- Can the operator diagnose a red environment from placement, domain, ingress,
+  TLS, runtime identity, and evidence without opening provider-native tools in
+  normal cases?
 
 ## Review Workflow
 


### PR DESCRIPTION
## Summary
- record the exact post-v2 audit baseline and verified gates
- define the primary operator, representative journeys, Product Ops/Engineering Ops boundary, IA, action taxonomy, and empty states
- publish the confirmed finding graph and focused execution order through #1705
- extend the UI review rubric and docs routing metadata

## Validation
- `uv run python -m unittest tests.test_docs_contracts tests.test_config_authority_audit`
- `uv run python -m unittest tests.test_docs_contracts`
- `git diff --check`
- independent read-only review: no blockers

Closes #1673
Related to #1672