### PR TITLE
Harden privileged deploy workflow inputs

### DIFF
--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -8,12 +8,8 @@ on:
       - completed
   workflow_dispatch:
     inputs:
-      git_ref:
-        description: Git ref to build when deploying a new Launchplane image.
-        required: false
-        type: string
       image_reference:
-        description: Exact image reference to deploy instead of building a new one.
+        description: Exact immutable Launchplane image digest to deploy instead of building a new one.
         required: false
         type: string
       authz_grants_mode:
@@ -58,11 +54,11 @@ on:
         required: false
         type: string
       break_glass_image_reference:
-        description: Exact previous Launchplane image reference for manual direct Dokploy rollback.
+        description: Exact previous immutable Launchplane image digest for manual direct Dokploy rollback.
         required: false
         type: string
       break_glass_reason:
-        description: Operator reason for manual direct Dokploy rollback.
+        description: Single-line 8-500 character operator reason for manual direct Dokploy rollback.
         required: false
         type: string
 
@@ -84,6 +80,8 @@ jobs:
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_branch == 'main') ||
       (github.event_name == 'workflow_dispatch' &&
+       github.ref_type == 'branch' &&
+       github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
        inputs.break_glass_confirm == '' &&
        inputs.authz_grants_mode == 'none')
     runs-on:
@@ -134,40 +132,90 @@ jobs:
       LAUNCHPLANE_AUTHZ_GRANTS_JSON: ${{ vars.LAUNCHPLANE_AUTHZ_GRANTS_JSON }}
       LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON: ${{ vars.LAUNCHPLANE_RUNTIME_KEY_SAFETY_RULES_JSON }}
       LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK: ${{ vars.LAUNCHPLANE_COMPOSE_EXTERNAL_NETWORK }}
-      LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
-      LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
+      OMIT_EVERY_CODE_ENV: ${{ inputs.omit_every_code_env || false }}
+      OMIT_TERMINAL_AGENT_ENV: ${{ inputs.omit_terminal_agent_env || false }}
+      OMIT_OWNER_AGENT_ENV: ${{ inputs.omit_owner_agent_env || false }}
+      OMIT_NPMPLUS_ENV: ${{ inputs.omit_npmplus_env || false }}
     steps:
       - name: Resolve deploy inputs
         id: prep
         shell: bash
+        env:
+          DISPATCH_IMAGE_REFERENCE: ${{ inputs.image_reference }}
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
 
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            checkout_ref="${{ github.event.workflow_run.head_sha }}"
-          elif [ -n "${{ inputs.git_ref }}" ]; then
-            checkout_ref="${{ inputs.git_ref }}"
+          validate_single_line_value() {
+            local name="$1"
+            local value="$2"
+            if [[ "$value" =~ [[:cntrl:]] ]]; then
+              echo "${name} must not contain control characters." >&2
+              exit 1
+            fi
+          }
+
+          validate_immutable_image_reference() {
+            local image_reference="$1"
+            local image_repository="$2"
+            local expected_image_prefix="${image_repository}@sha256:"
+            local image_digest=""
+
+            if [[ "$image_reference" != "$expected_image_prefix"* ]]; then
+              echo "image_reference must use the configured Launchplane image repository and an immutable sha256 digest." >&2
+              exit 1
+            fi
+            image_digest="${image_reference#"$expected_image_prefix"}"
+            if [[ ! "$image_digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "image_reference must end with a lowercase sha256 digest." >&2
+              exit 1
+            fi
+          }
+
+          if [ "$EVENT_NAME" = "workflow_run" ]; then
+            checkout_ref="$WORKFLOW_RUN_HEAD_SHA"
           else
-            checkout_ref="${{ github.sha }}"
+            checkout_ref="$WORKFLOW_SHA"
           fi
+          if [ -z "$checkout_ref" ]; then
+            echo "Could not resolve a checkout ref." >&2
+            exit 1
+          fi
+          validate_single_line_value "checkout ref" "$checkout_ref"
 
           image_repository="${LAUNCHPLANE_IMAGE_REPOSITORY}"
           if [ -z "$image_repository" ]; then
             image_repository="ghcr.io/${GITHUB_REPOSITORY,,}"
           fi
+          validate_single_line_value "Launchplane image repository" "$image_repository"
 
-          deploy_image_reference="${{ inputs.image_reference }}"
+          deploy_image_reference="$DISPATCH_IMAGE_REFERENCE"
           if [ -n "$deploy_image_reference" ]; then
+            validate_immutable_image_reference "$deploy_image_reference" "$image_repository"
             should_build="false"
           else
             should_build="true"
           fi
 
+          for omit_environment_variable in \
+            OMIT_EVERY_CODE_ENV \
+            OMIT_TERMINAL_AGENT_ENV \
+            OMIT_OWNER_AGENT_ENV \
+            OMIT_NPMPLUS_ENV; do
+            omit_environment_value="${!omit_environment_variable}"
+            if [ "$omit_environment_value" != "true" ] && [ "$omit_environment_value" != "false" ]; then
+              echo "${omit_environment_variable} must be true or false." >&2
+              exit 1
+            fi
+          done
+
           {
-            echo "checkout_ref=$checkout_ref"
-            echo "image_repository=$image_repository"
-            echo "should_build=$should_build"
-            echo "deploy_image_reference=$deploy_image_reference"
+            printf 'checkout_ref=%s\n' "$checkout_ref"
+            printf 'image_repository=%s\n' "$image_repository"
+            printf 'should_build=%s\n' "$should_build"
+            printf 'deploy_image_reference=%s\n' "$deploy_image_reference"
           } >> "$GITHUB_OUTPUT"
 
       - name: Validate deploy configuration
@@ -258,13 +306,17 @@ jobs:
       - name: Resolve image reference
         id: image
         shell: bash
+        env:
+          BUILT_IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
+          DEPLOY_IMAGE_REFERENCE: ${{ steps.prep.outputs.deploy_image_reference }}
+          IMAGE_REPOSITORY: ${{ steps.prep.outputs.image_repository }}
         run: |
           set -euo pipefail
-          image_reference="${{ steps.prep.outputs.deploy_image_reference }}"
+          image_reference="$DEPLOY_IMAGE_REFERENCE"
           if [ -z "$image_reference" ]; then
-            image_reference="${{ steps.prep.outputs.image_repository }}@${{ steps.build.outputs.digest }}"
+            image_reference="${IMAGE_REPOSITORY}@${BUILT_IMAGE_DIGEST}"
           fi
-          echo "image_reference=$image_reference" >> "$GITHUB_OUTPUT"
+          printf 'image_reference=%s\n' "$image_reference" >> "$GITHUB_OUTPUT"
 
       - name: Read previous Launchplane runtime
         id: previous_runtime
@@ -284,12 +336,27 @@ jobs:
         id: self_deploy
         shell: bash
         env:
+          DEPLOY_IMAGE_REFERENCE: ${{ steps.image.outputs.image_reference }}
+          IMAGE_REPOSITORY: ${{ steps.prep.outputs.image_repository }}
           PREVIOUS_RUNTIME_RESPONSE_FILE: ${{ runner.temp }}/launchplane-previous-runtime.json
         run: |
           set -euo pipefail
 
           previous_image_reference="$(jq -r '.runtime.docker_image_reference // empty' "$PREVIOUS_RUNTIME_RESPONSE_FILE" 2>/dev/null || true)"
-          echo "previous_image_reference=$previous_image_reference" >> "$GITHUB_OUTPUT"
+          if [[ "$previous_image_reference" =~ [[:cntrl:]] ]]; then
+            echo "Previous Launchplane image reference must not contain control characters." >&2
+            exit 1
+          fi
+          if [ -n "$previous_image_reference" ]; then
+            expected_image_prefix="${IMAGE_REPOSITORY}@sha256:"
+            image_digest="${previous_image_reference#"$expected_image_prefix"}"
+            if [[ "$previous_image_reference" != "$expected_image_prefix"* ]] ||
+              [[ ! "$image_digest" =~ ^[0-9a-f]{64}$ ]]; then
+              echo "Previous Launchplane image reference must use the configured repository and an immutable sha256 digest." >&2
+              exit 1
+            fi
+          fi
+          printf 'previous_image_reference=%s\n' "$previous_image_reference" >> "$GITHUB_OUTPUT"
 
           service_env_json="$({
             jq -n \
@@ -326,10 +393,10 @@ jobs:
               --arg npmplus_base_url "${LAUNCHPLANE_NPMPLUS_BASE_URL:-}" \
               --arg npmplus_identity "${LAUNCHPLANE_NPMPLUS_IDENTITY:-}" \
               --arg npmplus_secret "${LAUNCHPLANE_NPMPLUS_SECRET:-}" \
-              --argjson omit_every_code_env '${{ inputs.omit_every_code_env || false }}' \
-              --argjson omit_terminal_agent_env '${{ inputs.omit_terminal_agent_env || false }}' \
-              --argjson omit_owner_agent_env '${{ inputs.omit_owner_agent_env || false }}' \
-              --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
+              --argjson omit_every_code_env "$OMIT_EVERY_CODE_ENV" \
+              --argjson omit_terminal_agent_env "$OMIT_TERMINAL_AGENT_ENV" \
+              --argjson omit_owner_agent_env "$OMIT_OWNER_AGENT_ENV" \
+              --argjson omit_npmplus_env "$OMIT_NPMPLUS_ENV" \
               '(
                 {
                 LAUNCHPLANE_GITHUB_CLIENT_ID: $github_client_id,
@@ -433,7 +500,7 @@ jobs:
           service_env_removals_json="$({
             jq -n \
               --arg public_ingress_github_token "${LAUNCHPLANE_PUBLIC_INGRESS_GITHUB_TOKEN:-}" \
-              --argjson omit_npmplus_env '${{ inputs.omit_npmplus_env || false }}' \
+              --argjson omit_npmplus_env "$OMIT_NPMPLUS_ENV" \
               '(
                 if $omit_npmplus_env then
                   [
@@ -457,7 +524,7 @@ jobs:
             jq -n \
               --arg target_type "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE" \
               --arg target_id "$LAUNCHPLANE_DOKPLOY_TARGET_ID" \
-              --arg image_reference "${{ steps.image.outputs.image_reference }}" \
+              --arg image_reference "$DEPLOY_IMAGE_REFERENCE" \
               --argjson service_env "$service_env_json" \
               --argjson service_env_removals "$service_env_removals_json" \
               '{schema_version: 1, product: "launchplane", deploy: ({target_type: $target_type, target_id: $target_id, image_reference: $image_reference} + (if ($service_env | length) > 0 then {oauth_env: $service_env} else {} end) + (if ($service_env_removals | length) > 0 then {oauth_env_removals: $service_env_removals} else {} end))}'
@@ -608,24 +675,18 @@ jobs:
           response-output-file: ${{ runner.temp }}/launchplane-deployed-runtime-final.json
           log-response-body: "false"
 
-      - name: Capture failed Launchplane deploy diagnostics
-        if: failure()
-        shell: bash
-        run: |
-          set -euo pipefail
-          uv run python scripts/deploy/capture-launchplane-deploy-diagnostics.py || true
-        env:
-          LAUNCHPLANE_EXPECTED_IMAGE_REFERENCE: ${{ steps.image.outputs.image_reference }}
-
       - name: Render Launchplane rollback request
         if: failure() && steps.self_deploy.outputs.previous_image_reference != ''
         id: rollback_request
         shell: bash
+        env:
+          DEPLOYED_IMAGE_REFERENCE: ${{ steps.image.outputs.image_reference }}
+          PREVIOUS_IMAGE_REFERENCE: ${{ steps.self_deploy.outputs.previous_image_reference }}
         run: |
           set -euo pipefail
 
-          previous_image_reference="${{ steps.self_deploy.outputs.previous_image_reference }}"
-          if [ -z "$previous_image_reference" ] || [ "$previous_image_reference" = "${{ steps.image.outputs.image_reference }}" ]; then
+          previous_image_reference="$PREVIOUS_IMAGE_REFERENCE"
+          if [ -z "$previous_image_reference" ] || [ "$previous_image_reference" = "$DEPLOYED_IMAGE_REFERENCE" ]; then
             echo "No distinct previous Launchplane image reference is available for rollback."
             exit 0
           fi
@@ -640,8 +701,8 @@ jobs:
 
           rollback_payload_file="$RUNNER_TEMP/launchplane-self-deploy-rollback-payload.json"
           printf '%s\n' "$rollback_payload" > "$rollback_payload_file"
-          echo "previous_image_reference=$previous_image_reference" >> "$GITHUB_OUTPUT"
-          echo "payload_file=$rollback_payload_file" >> "$GITHUB_OUTPUT"
+          printf 'previous_image_reference=%s\n' "$previous_image_reference" >> "$GITHUB_OUTPUT"
+          printf 'payload_file=%s\n' "$rollback_payload_file" >> "$GITHUB_OUTPUT"
 
       - name: Request Launchplane rollback through service
         if: >-
@@ -1166,6 +1227,8 @@ jobs:
   operator-authz-grants:
     if: >-
       github.event_name == 'workflow_dispatch' &&
+      github.ref_type == 'branch' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
       inputs.authz_grants_mode != 'none'
     permissions:
       contents: read
@@ -1186,7 +1249,6 @@ jobs:
         shell: bash
         env:
           REVIEWED_GRANTS_SHA256: ${{ inputs.authz_grants_expected_sha256 }}
-          DEPLOY_GIT_REF: ${{ inputs.git_ref }}
           DEPLOY_IMAGE_REFERENCE: ${{ inputs.image_reference }}
           OMIT_EVERY_CODE_ENV: ${{ inputs.omit_every_code_env }}
           OMIT_TERMINAL_AGENT_ENV: ${{ inputs.omit_terminal_agent_env }}
@@ -1199,8 +1261,8 @@ jobs:
           set -euo pipefail
           : "${LAUNCHPLANE_PUBLIC_URL:?Missing LAUNCHPLANE_PUBLIC_URL variable}"
           : "${LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON:?Missing LAUNCHPLANE_AUTHZ_GRANT_MAINTENANCE_JSON variable}"
-          if [ -n "$DEPLOY_GIT_REF" ] || [ -n "$DEPLOY_IMAGE_REFERENCE" ]; then
-            echo "Grant-only reconciliation cannot include deploy ref or image inputs." >&2
+          if [ -n "$DEPLOY_IMAGE_REFERENCE" ]; then
+            echo "Grant-only reconciliation cannot include a deploy image input." >&2
             exit 1
           fi
           if [ "$OMIT_EVERY_CODE_ENV" = "true" ] ||
@@ -1276,6 +1338,7 @@ jobs:
       - name: Verify and summarize authz grant results
         shell: bash
         env:
+          CONFIGURED_GRANTS_SHA256: ${{ steps.authz_grants.outputs.configured_grants_sha256 }}
           GRANTS_FILE: ${{ steps.authz_grants.outputs.github_actions_grants_file }}
           RESPONSES_FILE: ${{ steps.authz_grants.outputs.authz_grants_output_dir }}/github-actions-grants-responses.json
         run: |
@@ -1301,11 +1364,18 @@ jobs:
             echo "- Requests: $request_count"
             echo "- Changed: $changed_count"
             echo "- Already present: $unchanged_count"
-            echo "- Canonical grant-set SHA-256: ${{ steps.authz_grants.outputs.configured_grants_sha256 }}"
+            printf '%s\n' "- Canonical grant-set SHA-256: $CONFIGURED_GRANTS_SHA256"
           } >> "$GITHUB_STEP_SUMMARY"
 
   emergency-dokploy-rollback:
-    if: github.event_name == 'workflow_dispatch' && inputs.break_glass_confirm == 'ROLL BACK LAUNCHPLANE THROUGH DIRECT DOKPLOY'
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref_type == 'branch' &&
+      github.ref == format('refs/heads/{0}', github.event.repository.default_branch) &&
+      inputs.break_glass_confirm == 'ROLL BACK LAUNCHPLANE THROUGH DIRECT DOKPLOY'
+    environment: launchplane-break-glass
+    permissions:
+      contents: read
     runs-on:
       - self-hosted
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
@@ -1313,8 +1383,7 @@ jobs:
       LAUNCHPLANE_DOKPLOY_TARGET_ID: ${{ vars.LAUNCHPLANE_DOKPLOY_TARGET_ID }}
       LAUNCHPLANE_DOKPLOY_TARGET_TYPE: ${{ vars.LAUNCHPLANE_DOKPLOY_TARGET_TYPE }}
       LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS: ${{ vars.LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS }}
-      LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
-      LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
+      LAUNCHPLANE_IMAGE_REPOSITORY: ${{ vars.LAUNCHPLANE_IMAGE_REPOSITORY }}
     steps:
       - uses: actions/checkout@v7
 
@@ -1324,6 +1393,8 @@ jobs:
         shell: bash
         env:
           AUTHZ_GRANTS_MODE: ${{ inputs.authz_grants_mode }}
+          BREAK_GLASS_IMAGE_REFERENCE: ${{ inputs.break_glass_image_reference }}
+          BREAK_GLASS_REASON: ${{ inputs.break_glass_reason }}
         run: |
           set -euo pipefail
           if [ "$AUTHZ_GRANTS_MODE" != "none" ]; then
@@ -1332,39 +1403,69 @@ jobs:
           fi
           : "${LAUNCHPLANE_DOKPLOY_TARGET_TYPE:?Missing LAUNCHPLANE_DOKPLOY_TARGET_TYPE variable}"
           : "${LAUNCHPLANE_DOKPLOY_TARGET_ID:?Missing LAUNCHPLANE_DOKPLOY_TARGET_ID variable}"
-          : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST secret}"
-          : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN secret}"
-          break_glass_image_reference="${{ inputs.break_glass_image_reference }}"
-          break_glass_reason="${{ inputs.break_glass_reason }}"
-          if [ -z "$break_glass_image_reference" ]; then
+          if [ -z "$BREAK_GLASS_IMAGE_REFERENCE" ]; then
             echo "break_glass_image_reference is required for direct Dokploy rollback." >&2
             exit 1
           fi
-          if [ -z "$break_glass_reason" ]; then
+          if [ -z "$BREAK_GLASS_REASON" ]; then
             echo "break_glass_reason is required for direct Dokploy rollback." >&2
+            exit 1
+          fi
+
+          image_repository="${LAUNCHPLANE_IMAGE_REPOSITORY:-}"
+          if [ -z "$image_repository" ]; then
+            image_repository="ghcr.io/${GITHUB_REPOSITORY,,}"
+          fi
+          if [[ "$image_repository" =~ [[:cntrl:]] ]]; then
+            echo "Launchplane image repository must not contain control characters." >&2
+            exit 1
+          fi
+
+          expected_image_prefix="${image_repository}@sha256:"
+          if [[ "$BREAK_GLASS_IMAGE_REFERENCE" != "$expected_image_prefix"* ]]; then
+            echo "break_glass_image_reference must use the configured Launchplane image repository and an immutable sha256 digest." >&2
+            exit 1
+          fi
+          image_digest="${BREAK_GLASS_IMAGE_REFERENCE#"$expected_image_prefix"}"
+          if [[ ! "$image_digest" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "break_glass_image_reference must end with a lowercase sha256 digest." >&2
+            exit 1
+          fi
+
+          if [ "${#BREAK_GLASS_REASON}" -lt 8 ] || [ "${#BREAK_GLASS_REASON}" -gt 500 ]; then
+            echo "break_glass_reason must be between 8 and 500 printable characters." >&2
+            exit 1
+          fi
+          if [[ "$BREAK_GLASS_REASON" =~ [[:cntrl:]] ]] || [[ ! "$BREAK_GLASS_REASON" =~ [^[:space:]] ]]; then
+            echo "break_glass_reason must be single-line, printable, and contain non-whitespace text." >&2
             exit 1
           fi
 
       - name: Run manual direct Dokploy rollback
         shell: bash
+        env:
+          LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST }}
+          LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN: ${{ secrets.LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN }}
+          LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE: ${{ inputs.break_glass_image_reference }}
+          LAUNCHPLANE_ROLLBACK_REASON: ${{ inputs.break_glass_reason }}
         run: |
           set -euo pipefail
+          : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST secret}"
+          : "${LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN:?Missing LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN secret}"
           evidence_file="$RUNNER_TEMP/launchplane-break-glass-rollback.json"
           LAUNCHPLANE_ALLOW_DIRECT_DOKPLOY_FALLBACK=true \
-            LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE="${{ inputs.break_glass_image_reference }}" \
-            LAUNCHPLANE_ROLLBACK_REASON="${{ inputs.break_glass_reason }}" \
             LAUNCHPLANE_ROLLBACK_REQUEST_STATUS="manual-break-glass" \
             uv run python scripts/deploy/emergency-dokploy-rollback.py | tee "$evidence_file"
 
           {
-            echo "## Launchplane break-glass rollback"
-            echo
-            echo "- Fallback: direct Dokploy"
-            echo "- Reason: ${{ inputs.break_glass_reason }}"
-            echo "- Target type: $LAUNCHPLANE_DOKPLOY_TARGET_TYPE"
-            echo "- Target id: $LAUNCHPLANE_DOKPLOY_TARGET_ID"
-            echo "- Rollback image: ${{ inputs.break_glass_image_reference }}"
-            echo "- Evidence artifact: launchplane-break-glass-rollback"
+            printf '%s\n' "## Launchplane break-glass rollback"
+            printf '\n'
+            printf '%s\n' "- Fallback: direct Dokploy"
+            printf -- "- Reason: %s\n" "$LAUNCHPLANE_ROLLBACK_REASON"
+            printf -- "- Target type: %s\n" "$LAUNCHPLANE_DOKPLOY_TARGET_TYPE"
+            printf -- "- Target id: %s\n" "$LAUNCHPLANE_DOKPLOY_TARGET_ID"
+            printf -- "- Rollback image: %s\n" "$LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE"
+            printf '%s\n' "- Evidence artifact: launchplane-break-glass-rollback"
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload break-glass rollback evidence

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -235,7 +235,8 @@ WORKFLOW_BLOCK_MECHANIC_FIELD_PATH_VALUES = {
         "GITHUB_TOKEN": frozenset(("${{ github.token }}",)),
     },
     ".github/workflows/deploy-launchplane.yml": {
-        "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY": frozenset(('"true"', "true"))
+        "LAUNCHPLANE_AUTHZ_GRANTS_CONFIGURED_ONLY": frozenset(('"true"', "true")),
+        "environment": frozenset(("launchplane-break-glass",)),
     },
     ".github/workflows/odoo-driver-route-smoke.yml": {
         "ROUTE_PATHS": frozenset(
@@ -624,10 +625,30 @@ WORKFLOW_OPERATOR_INPUT_REFERENCE_PATH_VALUES = {
         "DEPLOY_IMAGE_REFERENCE": frozenset(("${{ inputs.image_reference }}",)),
         "LAUNCHPLANE_AUTHZ_GRANT_MODE": frozenset(("${{ inputs.authz_grants_mode }}",)),
         "LAUNCHPLANE_AUTHZ_GRANT_REASON": frozenset(("${{ inputs.authz_grants_reason }}",)),
-        "OMIT_EVERY_CODE_ENV": frozenset(("${{ inputs.omit_every_code_env }}",)),
-        "OMIT_NPMPLUS_ENV": frozenset(("${{ inputs.omit_npmplus_env }}",)),
-        "OMIT_OWNER_AGENT_ENV": frozenset(("${{ inputs.omit_owner_agent_env }}",)),
-        "OMIT_TERMINAL_AGENT_ENV": frozenset(("${{ inputs.omit_terminal_agent_env }}",)),
+        "OMIT_EVERY_CODE_ENV": frozenset(
+            (
+                "${{ inputs.omit_every_code_env }}",
+                "${{ inputs.omit_every_code_env || false }}",
+            )
+        ),
+        "OMIT_NPMPLUS_ENV": frozenset(
+            (
+                "${{ inputs.omit_npmplus_env }}",
+                "${{ inputs.omit_npmplus_env || false }}",
+            )
+        ),
+        "OMIT_OWNER_AGENT_ENV": frozenset(
+            (
+                "${{ inputs.omit_owner_agent_env }}",
+                "${{ inputs.omit_owner_agent_env || false }}",
+            )
+        ),
+        "OMIT_TERMINAL_AGENT_ENV": frozenset(
+            (
+                "${{ inputs.omit_terminal_agent_env }}",
+                "${{ inputs.omit_terminal_agent_env || false }}",
+            )
+        ),
         "REVIEWED_GRANTS_SHA256": frozenset(("${{ inputs.authz_grants_expected_sha256 }}",)),
     },
     ".github/workflows/edge-endpoint-apply.yml": {
@@ -3021,7 +3042,10 @@ def _is_github_action_metadata_mechanic(*, path: str, key: str, value: object) -
 
 
 def _is_workflow_image_artifact_mechanic(*, path: str, key: str, value: object) -> bool:
-    if path != ".github/workflows/launchplane-deploy.yml":
+    if path not in {
+        ".github/workflows/deploy-launchplane.yml",
+        ".github/workflows/launchplane-deploy.yml",
+    }:
         return False
     key_text = key.upper().replace(".", "_").replace("-", "_")
     value_text = _string_value(value).strip()

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -492,16 +492,21 @@ repository secrets for normal deploy execution. Automatic rollback also uses the
 Launchplane service route. If a failed rollout makes that route unable to accept
 its own rollback request, direct Dokploy rollback is available only through the
 manual break-glass inputs on the Deploy Launchplane workflow: provide the exact
-confirmation text, previous image reference, and operator reason.
+confirmation text, a previous immutable `@sha256` image reference from the
+configured Launchplane image repository, and an operator reason. The reason
+must be a single printable line from 8 to 500 characters and contain
+non-whitespace text. Configure the `launchplane-break-glass` GitHub environment
+with required reviewers and protected-branch deployment rules before enabling
+this path: its approval gate completes before the job receives the emergency
+Dokploy credentials, the workflow accepts manual dispatches only from the
+repository default branch, and the job validates the request before the
+credentials are scoped to the rollback step.
 Keep the workflow configured with break-glass
 `LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST` and
 `LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN` repository secrets for that manual
 emergency path. When direct Dokploy break-glass rollback runs, the workflow
 writes a redacted `launchplane-break-glass-rollback` artifact and summary so the
 provider mutation remains reviewable after the emergency.
-Before rollback, the workflow uses those same break-glass credentials to capture
-redacted Dokploy target, container, and recent log diagnostics for the failed
-rollout. Diagnostics failures are non-blocking so rollback remains the priority.
 
 Product onboarding manifests and runtime key-safety policies are DB-backed
 Launchplane records. Create or repair them through the Launchplane service API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "Launchplane control-plane contracts and workflows for deployment truth and promotion"
 requires-python = ">=3.13"
 dependencies = [
-    "Authlib>=1.7.0",
+    "Authlib>=1.7.2",
     "click>=8.4.2",
     "fastapi>=0.139.0",
     "pydantic>=2.13.4",

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -2429,6 +2429,32 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
                     expected_reason,
                 )
 
+    def test_deploy_launchplane_hardening_mechanics_are_classified(self) -> None:
+        cases = (
+            (
+                "IMAGE_REPOSITORY",
+                "${{ steps.prep.outputs.image_repository }}",
+                "thin_connector_input",
+            ),
+            (
+                "OMIT_NPMPLUS_ENV",
+                "${{ inputs.omit_npmplus_env || false }}",
+                "operator_supplied_runtime_input",
+            ),
+            ("environment", "launchplane-break-glass", "thin_connector_input"),
+        )
+
+        for key, value, expected_reason in cases:
+            with self.subTest(key=key):
+                self.assertEqual(
+                    _allow_reason(
+                        path=".github/workflows/deploy-launchplane.yml",
+                        key=key,
+                        value=value,
+                    ),
+                    expected_reason,
+                )
+
     def test_reusable_odoo_workflow_aliases_are_path_scoped(self) -> None:
         reusable_workflow_cases = (
             (

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -2,6 +2,7 @@ import importlib.util
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import textwrap
 from tempfile import TemporaryDirectory
@@ -1965,6 +1966,146 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("Evidence artifact: launchplane-break-glass-rollback", workflow_text)
         self.assertIn("manual break-glass only", workflow_text)
 
+    def test_deploy_launchplane_routes_dispatch_values_out_of_shell_source(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+        shell_blocks = re.findall(
+            r"(?ms)^        run: \|\n(.*?)(?=^        [a-zA-Z][a-zA-Z_-]*:|^      - |^  [a-zA-Z0-9_-]+:|\Z)",
+            workflow_text,
+        )
+        emergency_job = workflow_text.split("  emergency-dokploy-rollback:\n", 1)[1]
+
+        self.assertGreater(len(shell_blocks), 0)
+        self.assertNotIn("${{", "\n".join(shell_blocks))
+        self.assertNotIn("git_ref:", workflow_text)
+        self.assertGreaterEqual(
+            workflow_text.count(
+                "github.ref == format('refs/heads/{0}', github.event.repository.default_branch)"
+            ),
+            3,
+        )
+        self.assertGreaterEqual(workflow_text.count("github.ref_type == 'branch'"), 3)
+        self.assertIn(
+            "BREAK_GLASS_IMAGE_REFERENCE: ${{ inputs.break_glass_image_reference }}",
+            emergency_job,
+        )
+        self.assertIn("BREAK_GLASS_REASON: ${{ inputs.break_glass_reason }}", emergency_job)
+        self.assertIn(
+            "LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE: ${{ inputs.break_glass_image_reference }}",
+            emergency_job,
+        )
+        self.assertIn(
+            "LAUNCHPLANE_ROLLBACK_REASON: ${{ inputs.break_glass_reason }}",
+            emergency_job,
+        )
+        self.assertIn(
+            'printf -- "- Reason: %s\\n" "$LAUNCHPLANE_ROLLBACK_REASON"',
+            emergency_job,
+        )
+        self.assertIn(
+            'printf -- "- Rollback image: %s\\n" "$LAUNCHPLANE_ROLLBACK_IMAGE_REFERENCE"',
+            emergency_job,
+        )
+
+        validation_step = emergency_job.split("- name: Validate manual break-glass request", 1)[
+            1
+        ].split("- name: Run manual direct Dokploy rollback", 1)[0]
+        validation_script = textwrap.dedent(validation_step.split("        run: |\n", 1)[1])
+        image_reference = "ghcr.io/cbusillo/launchplane@sha256:" + ("a" * 64)
+
+        with TemporaryDirectory() as temporary_directory:
+            command_marker = Path(temporary_directory) / "command-substitution-ran"
+            rollback_reason = f'Restore after "review" $(touch {command_marker})'
+            subprocess.run(
+                ["bash", "-ceu", validation_script],
+                check=True,
+                env={
+                    **os.environ,
+                    "AUTHZ_GRANTS_MODE": "none",
+                    "BREAK_GLASS_IMAGE_REFERENCE": image_reference,
+                    "BREAK_GLASS_REASON": rollback_reason,
+                    "GITHUB_REPOSITORY": "cbusillo/launchplane",
+                    "LAUNCHPLANE_DOKPLOY_TARGET_ID": "launchplane-target",
+                    "LAUNCHPLANE_DOKPLOY_TARGET_TYPE": "compose",
+                    "LAUNCHPLANE_IMAGE_REPOSITORY": "ghcr.io/cbusillo/launchplane",
+                },
+                text=True,
+            )
+
+            self.assertFalse(command_marker.exists())
+
+    def test_deploy_launchplane_rejects_multiline_previous_image_output(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+        render_step = workflow_text.split("- name: Render Launchplane self deploy request", 1)[
+            1
+        ].split("- name: Request Launchplane self deploy", 1)[0]
+        render_script = textwrap.dedent(render_step.split("        run: |\n", 1)[1]).split(
+            "service_env_json=", 1
+        )[0]
+
+        with TemporaryDirectory() as temporary_directory:
+            response_file = Path(temporary_directory) / "runtime.json"
+            output_file = Path(temporary_directory) / "github-output"
+            response_file.write_text(
+                json.dumps(
+                    {
+                        "runtime": {
+                            "docker_image_reference": (
+                                "ghcr.io/cbusillo/launchplane@sha256:"
+                                + ("a" * 64)
+                                + "\nprevious_image_reference=attacker-controlled"
+                            )
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                ["bash", "-ceu", render_script],
+                check=False,
+                capture_output=True,
+                env={
+                    **os.environ,
+                    "DEPLOY_IMAGE_REFERENCE": "ghcr.io/cbusillo/launchplane@sha256:"
+                    + ("b" * 64),
+                    "GITHUB_OUTPUT": str(output_file),
+                    "IMAGE_REPOSITORY": "ghcr.io/cbusillo/launchplane",
+                    "PREVIOUS_RUNTIME_RESPONSE_FILE": str(response_file),
+                },
+                text=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("must not contain control characters", result.stderr)
+            self.assertFalse(output_file.exists())
+
+    def test_deploy_launchplane_break_glass_limits_credentials_and_permissions(self) -> None:
+        workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")
+        deploy_job = workflow_text.split("  deploy:\n", 1)[1].split(
+            "  operator-authz-grants:\n", 1
+        )[0]
+        emergency_job = workflow_text.split("  emergency-dokploy-rollback:\n", 1)[1]
+        validation_step = emergency_job.split("- name: Validate manual break-glass request", 1)[
+            1
+        ].split("- name: Run manual direct Dokploy rollback", 1)[0]
+        rollback_step = emergency_job.split("- name: Run manual direct Dokploy rollback", 1)[
+            1
+        ].split("- name: Upload break-glass rollback evidence", 1)[0]
+
+        self.assertIn("environment: launchplane-break-glass", emergency_job)
+        self.assertIn("permissions:\n      contents: read", emergency_job)
+        self.assertNotIn("id-token:", emergency_job)
+        self.assertNotIn("packages:", emergency_job)
+        self.assertIn("uses: actions/checkout@v7", emergency_job)
+        self.assertIn("uses: actions/upload-artifact@v7", emergency_job)
+        self.assertNotIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST", deploy_job)
+        self.assertNotIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN", deploy_job)
+        self.assertNotIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST", validation_step)
+        self.assertNotIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN", validation_step)
+        self.assertIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST", rollback_step)
+        self.assertIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN", rollback_step)
+        self.assertIn("must use the configured Launchplane image repository", validation_step)
+        self.assertIn("between 8 and 500 printable characters", validation_step)
+
     def test_deploy_authz_grants_seed_local_admin_self_deploy_authority(self) -> None:
         script_text = Path("scripts/deploy/ensure-authz-grants.sh").read_text(encoding="utf-8")
 
@@ -2197,10 +2338,11 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self_deploy_block = workflow_text.split("- name: Read previous Launchplane runtime", 1)[
             1
-        ].split("- name: Capture failed Launchplane deploy diagnostics", 1)[0]
+        ].split("- name: Render Launchplane rollback request", 1)[0]
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_URL", self_deploy_block)
         self.assertNotIn("ACTIONS_ID_TOKEN_REQUEST_TOKEN", self_deploy_block)
         self.assertNotIn("Authorization: Bearer", self_deploy_block)
+        self.assertNotIn("Capture failed Launchplane deploy diagnostics", workflow_text)
 
     def test_deploy_workflow_requests_rollback_through_shared_request(self) -> None:
         workflow_text = Path(".github/workflows/deploy-launchplane.yml").read_text(encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -93,15 +93,15 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.7.0"
+version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
     { name = "joserfc" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/82/4d0603f30c1b4629b1f091bb266b0d7986434891d6940a8c87f8098db24e/authlib-1.7.0.tar.gz", hash = "sha256:b3e326c9aa9cc3ea95fe7d89fd880722d3608da4d00e8a27e061e64b48d801d5", size = 175890, upload-time = "2026-04-18T11:00:28.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ca/48/c954218b2a250e23f178f10167c4173fecb5a75d2c206f0a67ba58006c26/authlib-1.7.0-py2.py3-none-any.whl", hash = "sha256:e36817afb02f6f0b6bf55f150782499ddd6ddf44b402bb055d3263cc65ac9ae0", size = 258779, upload-time = "2026-04-18T11:00:26.64Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
 ]
 
 [[package]]
@@ -389,7 +389,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.18.5" },
-    { name = "authlib", specifier = ">=1.7.0" },
+    { name = "authlib", specifier = ">=1.7.2" },
     { name = "click", specifier = ">=8.4.2" },
     { name = "fastapi", specifier = ">=0.139.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=2.2.0" },


### PR DESCRIPTION
## Summary
- route all dispatch values through environment variables and validate immutable image/output values
- restrict privileged manual jobs to the repository default branch, excluding colliding tags and arbitrary refs
- gate direct provider rollback behind the configured protected `launchplane-break-glass` environment with least-privilege credentials
- upgrade Authlib to 1.7.2 and extend workflow/config-authority regression coverage

## Validation
- `uv run python -m unittest tests.test_product_onboarding tests.test_config_authority_audit` (204 tests)
- `uv run --extra dev ruff check control_plane/config_authority_audit.py tests/test_config_authority_audit.py tests/test_product_onboarding.py`
- `actionlint .github/workflows/deploy-launchplane.yml`
- `uv lock --check`
- `uv run --with pip-audit pip-audit --ignore-vuln PYSEC-2025-183`

Closes #1681