### PR TITLE
Add real PostgreSQL schema and concurrency gate

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -33,6 +33,7 @@
     "test": {
       "default": "uv run launchplane ci unittest-shard local",
       "targeted": "uv run python -m unittest {modules}",
+      "postgresIntegration": "LAUNCHPLANE_TEST_POSTGRES_URL=postgresql+psycopg://... uv run launchplane ci postgres-integration",
       "shardPlan": "uv run launchplane ci unittest-shard plan --shard-count {shard_count} --timings-file {timings_file} --max-tests-per-target {max_tests_per_target} --max-seconds-per-target {max_seconds_per_target}",
       "shardRun": "uv run launchplane ci unittest-shard run --shard-count {shard_count} --shard-index {shard_index} --timings-file {timings_file} --max-tests-per-target {max_tests_per_target} --max-seconds-per-target {max_seconds_per_target} --timings-output {timings_output}",
       "shardGranularity": "whole modules by default; large or timing-known-slow modules may split into unittest target IDs"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,6 +473,46 @@ jobs:
       - name: Run unit tests
         run: uv run python -m unittest
 
+  postgres_integration:
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on:
+      - self-hosted
+      - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: launchplane_test
+          POSTGRES_DB: launchplane_root
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd "pg_isready -U launchplane_test -d launchplane_root"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Run PostgreSQL integration tests
+        env:
+          LAUNCHPLANE_TEST_POSTGRES_URL: >-
+            postgresql+psycopg://launchplane_test@127.0.0.1:${{ job.services.postgres.ports['5432'] }}/launchplane_root
+        run: uv run launchplane ci postgres-integration
+
   ci_gate:
     name: ci-gate
     runs-on: ubuntu-latest
@@ -486,6 +526,7 @@ jobs:
       - frontend_validate_fork
       - test
       - test_fork
+      - postgres_integration
     if: always() && github.event_name == 'pull_request'
     permissions:
       contents: read
@@ -502,6 +543,7 @@ jobs:
           FRONTEND_VALIDATE_FORK_RESULT: ${{ needs.frontend_validate_fork.result }}
           TEST_RESULT: ${{ needs.test.result }}
           TEST_FORK_RESULT: ${{ needs.test_fork.result }}
+          POSTGRES_INTEGRATION_RESULT: ${{ needs.postgres_integration.result }}
         run: |
           set -euo pipefail
           require_success() {
@@ -518,6 +560,7 @@ jobs:
             require_success container_scan "${CONTAINER_SCAN_RESULT}"
             require_success frontend_validate "${FRONTEND_VALIDATE_RESULT}"
             require_success test "${TEST_RESULT}"
+            require_success postgres_integration "${POSTGRES_INTEGRATION_RESULT}"
           else
             require_success static_checks_fork "${STATIC_CHECKS_FORK_RESULT}"
             require_success container_scan_fork "${CONTAINER_SCAN_FORK_RESULT}"

--- a/control_plane/cli_ci.py
+++ b/control_plane/cli_ci.py
@@ -37,6 +37,7 @@ DEFAULT_LOCAL_TIMINGS_FILE = Path(".ci-cache/unittest-timings/history.json")
 LOCAL_RUN_RECORD_TYPE = "unittest_local_shard_run"
 LOCAL_PROCESS_POLL_SECONDS = 0.05
 LOCAL_PROCESS_TERMINATE_SECONDS = 5.0
+POSTGRES_INTEGRATION_MODULE = "tests.test_postgres_integration"
 
 
 @dataclass(frozen=True)
@@ -53,6 +54,40 @@ def register_ci_commands(main: click.Group) -> None:
 @click.group()
 def ci() -> None:
     """CI support commands."""
+
+
+@ci.command("postgres-integration")
+@click.option(
+    "--database-url",
+    envvar="LAUNCHPLANE_TEST_POSTGRES_URL",
+    default="",
+    help=(
+        "Root PostgreSQL service URL used to create an isolated test database. "
+        "Defaults to LAUNCHPLANE_TEST_POSTGRES_URL."
+    ),
+)
+@click.option("--verbosity", type=int, default=2, show_default=True)
+def run_postgres_integration_tests(database_url: str, verbosity: int) -> None:
+    """Run real-PostgreSQL schema and concurrency integration tests."""
+    normalized_database_url = database_url.strip()
+    if not normalized_database_url:
+        raise click.ClickException(
+            "Set LAUNCHPLANE_TEST_POSTGRES_URL or pass --database-url with a "
+            "PostgreSQL service URL. The test harness creates an isolated database."
+        )
+    environment = os.environ.copy()
+    environment["LAUNCHPLANE_TEST_POSTGRES_URL"] = normalized_database_url
+    command = [
+        sys.executable,
+        "-m",
+        "unittest",
+        "-v" if verbosity > 1 else "",
+        POSTGRES_INTEGRATION_MODULE,
+    ]
+    command = [argument for argument in command if argument]
+    result = subprocess.run(command, cwd=Path.cwd(), env=environment, check=False)
+    if result.returncode != 0:
+        raise click.ClickException("PostgreSQL integration tests failed")
 
 
 @ci.group("unittest-shard")

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -115,6 +115,7 @@ from control_plane.contracts.verireel_prod_backup_gate_operation import (
 from control_plane.service_auth import GitHubHumanIdentity
 from control_plane.service_human_auth import HumanSessionStore, LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.schema_invariants import verify_postgres_schema_invariants
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
 ConnectionFactory = Callable[[], Any]
@@ -1537,6 +1538,7 @@ class PostgresRecordStore(HumanSessionStore):
         Base.metadata.create_all(self._engine)
 
     def verify_schema(self) -> None:
+        backend_name = self._engine.url.get_backend_name()
         inspector = inspect(self._engine)
         existing_tables = set(inspector.get_table_names())
         missing_tables = tuple(
@@ -1564,6 +1566,8 @@ class PostgresRecordStore(HumanSessionStore):
                 "Launchplane shared storage schema is missing required column(s): "
                 f"{missing}. Run Alembic migrations before starting the hosted service."
             )
+        if backend_name == "postgresql":
+            verify_postgres_schema_invariants(self._engine)
 
     def close(self) -> None:
         self._engine.dispose()

--- a/control_plane/storage/schema_adoption.py
+++ b/control_plane/storage/schema_adoption.py
@@ -9,6 +9,11 @@ from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 
 from control_plane.storage.postgres import Base, _build_engine
+from control_plane.storage.schema_invariants import (
+    critical_column_type_errors,
+    critical_index_errors,
+    postgres_index_definitions,
+)
 
 LEGACY_BASELINE_REVISION = "fe94a0486977"
 LEGACY_CURRENT_SCHEMA_REVISION = "b1c3d5e7f9a1"
@@ -140,11 +145,16 @@ class SchemaInspectorProtocol(Protocol):
     def get_columns(self, table_name: str) -> Sequence[Mapping[str, object]]:
         raise NotImplementedError
 
+    def get_indexes(self, table_name: str) -> Sequence[Mapping[str, object]]:
+        raise NotImplementedError
+
 
 def verify_existing_schema_for_stamp(
     *,
     inspector: SchemaInspectorProtocol,
     expected_schema: Mapping[str, frozenset[str]],
+    index_definitions: Mapping[tuple[str, str], str] | None = None,
+    verify_column_types: bool = False,
 ) -> None:
     existing_tables = set(inspector.get_table_names())
     expected_tables = set(expected_schema)
@@ -177,6 +187,16 @@ def verify_existing_schema_for_stamp(
                 f"{table_name} has unexpected columns: {', '.join(unexpected_columns)}"
             )
 
+    errors.extend(
+        critical_index_errors(
+            inspector=inspector,
+            table_names=existing_tables,
+            index_definitions=index_definitions,
+        )
+    )
+    if verify_column_types:
+        errors.extend(critical_column_type_errors(inspector, table_names=existing_tables))
+
     if errors:
         joined_errors = "; ".join(errors)
         raise SchemaAdoptionError(
@@ -202,14 +222,24 @@ def schema_stamp_revision_for_engine(engine: Engine) -> str:
             version_rows = connection.execute(text("select version_num from alembic_version")).fetchall()
         version_numbers = {str(row[0]).strip() for row in version_rows if str(row[0]).strip()}
         if version_numbers == {LEGACY_BASELINE_REVISION} and has_current_marker_table:
-            verify_existing_schema_for_stamp(inspector=inspector, expected_schema=expected_schema)
+            verify_existing_schema_for_stamp(
+                inspector=inspector,
+                expected_schema=expected_schema,
+                index_definitions=_index_definitions_for_engine(engine),
+                verify_column_types=_uses_postgresql(engine),
+            )
             return LEGACY_CURRENT_SCHEMA_REVISION
         return ""
 
     if not existing_tables.intersection(expected_schema):
         return ""
 
-    verify_existing_schema_for_stamp(inspector=inspector, expected_schema=expected_schema)
+    verify_existing_schema_for_stamp(
+        inspector=inspector,
+        expected_schema=expected_schema,
+        index_definitions=_index_definitions_for_engine(engine),
+        verify_column_types=_uses_postgresql(engine),
+    )
     if has_current_marker_table:
         return LEGACY_CURRENT_SCHEMA_REVISION
     return LEGACY_BASELINE_REVISION
@@ -221,6 +251,16 @@ def schema_stamp_revision(database_url: str) -> str:
         return schema_stamp_revision_for_engine(engine)
     finally:
         engine.dispose()
+
+
+def _index_definitions_for_engine(engine: Engine) -> Mapping[tuple[str, str], str] | None:
+    if _uses_postgresql(engine):
+        return postgres_index_definitions(engine)
+    return None
+
+
+def _uses_postgresql(engine: Engine) -> bool:
+    return engine.url.get_backend_name() == "postgresql"
 
 
 def main() -> int:

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+from sqlalchemy import inspect, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import SQLAlchemyError
+
+EXPECTED_ALEMBIC_HEAD_REVISION = "c9d1e3f5a7b9"
+
+
+class SchemaInspectorProtocol(Protocol):
+    def get_indexes(self, table_name: str) -> Sequence[Mapping[str, object]]:
+        raise NotImplementedError
+
+    def get_columns(self, table_name: str) -> Sequence[Mapping[str, object]]:
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class CriticalColumnType:
+    table_name: str
+    column_name: str
+    accepted_type_tokens: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CriticalIndex:
+    table_name: str
+    index_name: str
+    column_names: tuple[str, ...]
+    unique: bool = False
+    predicate_tokens: tuple[str, ...] = ()
+
+
+CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
+    CriticalColumnType(
+        "launchplane_idempotency_records",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_idempotency_records",
+        "response_status_code",
+        ("integer", "int4"),
+    ),
+    CriticalColumnType(
+        "launchplane_odoo_stable_bootstrap_operations",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_odoo_stable_bootstrap_operations",
+        "attempt",
+        ("integer", "int4"),
+    ),
+    CriticalColumnType(
+        "launchplane_odoo_stable_target_replacement_operations",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_odoo_stable_target_replacement_operations",
+        "attempt",
+        ("integer", "int4"),
+    ),
+    CriticalColumnType(
+        "launchplane_verireel_prod_backup_gate_operations",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_verireel_prod_backup_gate_operations",
+        "attempt",
+        ("integer", "int4"),
+    ),
+)
+
+_ACTIVE_OPERATION_PREDICATE_TOKENS = ("status", "pending", "running")
+
+CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
+    CriticalIndex(
+        "launchplane_idempotency_records",
+        "launchplane_idempotency_scope_route_key_idx",
+        ("scope", "route_path", "idempotency_key"),
+        unique=True,
+    ),
+    CriticalIndex(
+        "launchplane_odoo_stable_bootstrap_operations",
+        "launchplane_odoo_bootstrap_operation_idempotency_idx",
+        ("idempotency_key", "updated_at"),
+    ),
+    CriticalIndex(
+        "launchplane_odoo_stable_bootstrap_operations",
+        "launchplane_odoo_bootstrap_active_lane_uidx",
+        ("product", "context", "instance"),
+        unique=True,
+        predicate_tokens=_ACTIVE_OPERATION_PREDICATE_TOKENS,
+    ),
+    CriticalIndex(
+        "launchplane_odoo_stable_bootstrap_operations",
+        "launchplane_odoo_bootstrap_worker_claim_idx",
+        ("status", "lease_expires_at", "updated_at"),
+    ),
+    CriticalIndex(
+        "launchplane_odoo_stable_target_replacement_operations",
+        "launchplane_odoo_replacement_operation_idempotency_idx",
+        ("idempotency_scope", "idempotency_key", "updated_at"),
+    ),
+    CriticalIndex(
+        "launchplane_odoo_stable_target_replacement_operations",
+        "launchplane_odoo_replacement_active_lane_uidx",
+        ("product", "context", "instance"),
+        unique=True,
+        predicate_tokens=_ACTIVE_OPERATION_PREDICATE_TOKENS,
+    ),
+    CriticalIndex(
+        "launchplane_odoo_stable_target_replacement_operations",
+        "launchplane_odoo_replacement_worker_claim_idx",
+        ("status", "lease_expires_at", "updated_at"),
+    ),
+    CriticalIndex(
+        "launchplane_verireel_prod_backup_gate_operations",
+        "launchplane_verireel_backup_gate_active_record_uidx",
+        ("backup_record_id",),
+        unique=True,
+        predicate_tokens=_ACTIVE_OPERATION_PREDICATE_TOKENS,
+    ),
+    CriticalIndex(
+        "launchplane_verireel_prod_backup_gate_operations",
+        "launchplane_verireel_backup_gate_worker_claim_idx",
+        ("status", "lease_expires_at", "updated_at"),
+    ),
+)
+
+
+def verify_postgres_schema_invariants(engine: Engine) -> None:
+    backend_name = engine.url.get_backend_name()
+    if backend_name != "postgresql":
+        raise RuntimeError(
+            "Launchplane shared storage requires PostgreSQL for hosted service startup; "
+            f"got {backend_name!r}."
+        )
+    _verify_alembic_head(engine)
+    inspector = inspect(engine)
+    errors = [
+        *critical_column_type_errors(inspector),
+        *critical_index_errors(
+            inspector=inspector,
+            table_names=set(inspector.get_table_names()),
+            index_definitions=postgres_index_definitions(engine),
+        ),
+    ]
+    if errors:
+        joined_errors = "; ".join(errors)
+        raise RuntimeError(
+            "Launchplane shared storage schema is missing required PostgreSQL "
+            f"invariant(s): {joined_errors}. Run Alembic migrations before "
+            "starting the hosted service."
+        )
+
+
+def critical_column_type_errors(
+    inspector: SchemaInspectorProtocol,
+    *,
+    table_names: set[str] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    for expected_type in CRITICAL_POSTGRES_COLUMN_TYPES:
+        if table_names is not None and expected_type.table_name not in table_names:
+            continue
+        columns = {
+            str(column.get("name", "")): column
+            for column in inspector.get_columns(expected_type.table_name)
+        }
+        column = columns.get(expected_type.column_name)
+        if column is None:
+            errors.append(
+                f"{expected_type.table_name}.{expected_type.column_name} missing type metadata"
+            )
+            continue
+        observed_type = _normalized_type_name(column.get("type"))
+        if not any(token in observed_type for token in expected_type.accepted_type_tokens):
+            errors.append(
+                f"{expected_type.table_name}.{expected_type.column_name} has type "
+                f"{observed_type or '<unknown>'}; expected one of "
+                f"{', '.join(expected_type.accepted_type_tokens)}"
+            )
+    return errors
+
+
+def critical_index_errors(
+    *,
+    inspector: SchemaInspectorProtocol,
+    table_names: set[str],
+    expected_indexes: tuple[CriticalIndex, ...] = CRITICAL_SCHEMA_INDEXES,
+    index_definitions: Mapping[tuple[str, str], str] | None = None,
+) -> list[str]:
+    errors: list[str] = []
+    resolved_index_definitions = index_definitions or {}
+    for expected_index in expected_indexes:
+        if expected_index.table_name not in table_names:
+            continue
+        indexes_by_name = {
+            str(index.get("name", "")): index
+            for index in inspector.get_indexes(expected_index.table_name)
+        }
+        observed_index = indexes_by_name.get(expected_index.index_name)
+        if observed_index is None:
+            errors.append(
+                f"{expected_index.table_name} missing required index "
+                f"{expected_index.index_name}"
+            )
+            continue
+        observed_unique = bool(observed_index.get("unique", False))
+        if observed_unique != expected_index.unique:
+            expected_unique = "unique" if expected_index.unique else "non-unique"
+            observed_unique_label = "unique" if observed_unique else "non-unique"
+            errors.append(
+                f"{expected_index.index_name} is {observed_unique_label}; "
+                f"expected {expected_unique}"
+            )
+        observed_columns = _observed_index_columns(observed_index)
+        if observed_columns != expected_index.column_names:
+            errors.append(
+                f"{expected_index.index_name} covers {', '.join(observed_columns) or '<none>'}; "
+                f"expected {', '.join(expected_index.column_names)}"
+            )
+        if expected_index.predicate_tokens:
+            predicate_text = _normalized_predicate_text(
+                observed_index,
+                resolved_index_definitions.get(
+                    (expected_index.table_name, expected_index.index_name), ""
+                ),
+            )
+            missing_tokens = [
+                token
+                for token in expected_index.predicate_tokens
+                if token not in predicate_text
+            ]
+            if missing_tokens:
+                errors.append(
+                    f"{expected_index.index_name} has predicate "
+                    f"{predicate_text or '<none>'}; expected tokens "
+                    f"{', '.join(expected_index.predicate_tokens)}"
+                )
+    return errors
+
+
+def _verify_alembic_head(engine: Engine) -> None:
+    try:
+        with engine.connect() as connection:
+            version_rows = connection.execute(
+                text("select version_num from alembic_version")
+            ).fetchall()
+    except SQLAlchemyError as error:
+        raise RuntimeError(
+            "Launchplane shared storage schema is missing Alembic version metadata. "
+            "Run Alembic migrations before starting the hosted service."
+        ) from error
+    version_numbers = tuple(str(row[0]).strip() for row in version_rows if str(row[0]).strip())
+    if version_numbers != (EXPECTED_ALEMBIC_HEAD_REVISION,):
+        observed = ", ".join(version_numbers) if version_numbers else "<none>"
+        raise RuntimeError(
+            "Launchplane shared storage schema is not at the checked-in Alembic head: "
+            f"observed {observed}; expected {EXPECTED_ALEMBIC_HEAD_REVISION}. Run "
+            "Alembic migrations before starting the hosted service."
+        )
+
+
+def postgres_index_definitions(engine: Engine) -> dict[tuple[str, str], str]:
+    with engine.connect() as connection:
+        rows = connection.execute(
+            text(
+                "select tablename, indexname, indexdef "
+                "from pg_indexes where schemaname = current_schema()"
+            )
+        ).mappings()
+        return {
+            (str(row["tablename"]), str(row["indexname"])): str(row["indexdef"])
+            for row in rows
+        }
+
+
+def _normalized_type_name(type_value: object) -> str:
+    tokens = {
+        type(type_value).__name__.lower(),
+        str(type_value).lower(),
+    }
+    return " ".join(sorted(tokens))
+
+
+def _observed_index_columns(index: Mapping[str, object]) -> tuple[str, ...]:
+    column_names = _object_sequence(index.get("column_names"))
+    expressions = _object_sequence(index.get("expressions"))
+    observed_columns: list[str] = []
+    for position, column_name in enumerate(column_names):
+        normalized_column = _normalize_index_column(column_name)
+        if not normalized_column and position < len(expressions):
+            normalized_column = _normalize_index_column(expressions[position])
+        if normalized_column:
+            observed_columns.append(normalized_column)
+    if not observed_columns:
+        for expression in expressions:
+            normalized_expression = _normalize_index_column(expression)
+            if normalized_expression:
+                observed_columns.append(normalized_expression)
+    return tuple(observed_columns)
+
+
+def _object_sequence(value: object) -> tuple[object, ...]:
+    if isinstance(value, (list, tuple)):
+        return tuple(value)
+    return ()
+
+
+def _normalize_index_column(value: object) -> str:
+    if value is None:
+        return ""
+    normalized = str(value).strip().strip('"').lower()
+    if not normalized:
+        return ""
+    normalized = normalized.split()[0].strip('"')
+    return normalized.split("::", maxsplit=1)[0].strip('"')
+
+
+def _normalized_predicate_text(index: Mapping[str, object], index_definition: str) -> str:
+    predicate_parts = [index_definition]
+    dialect_options = index.get("dialect_options")
+    if isinstance(dialect_options, Mapping):
+        for key, value in dialect_options.items():
+            if str(key).endswith("_where") and value is not None:
+                predicate_parts.append(str(value))
+    return " ".join(predicate_parts).lower().replace('"', "")

--- a/docs/records.md
+++ b/docs/records.md
@@ -34,7 +34,12 @@ HTTP service; schema or payload changes must therefore land as explicit Alembic
 revisions. Runtime code can still call `ensure_schema()` for compatibility, but
 it only creates tables for local SQLite/test databases. For shared-service
 database URLs, `ensure_schema()` verifies that Alembic has already created the
-required tables and columns and fails closed when migrations are missing.
+required tables and columns and fails closed when migrations are missing. Hosted
+Postgres verification also requires the database to be at the checked-in
+Alembic head and verifies the critical JSONB/integer types, unique indexes,
+worker-claim indexes, and partial active-operation predicates used by
+idempotency, claims, leases, CAS-style owner checks, and active operation
+reservations.
 
 For a fresh database, apply the current schema with:
 
@@ -46,9 +51,11 @@ For an existing Launchplane database that already has the tables created by the
 pre-migration `create_all` path, adopt the baseline by stamping the database at
 the current revision only after the automated schema adoption verifier passes.
 The verifier inspects existing Launchplane-owned tables and fails closed when a
-live table is missing an ORM-managed column or has an unexpected column. A
-failure means the operator must stop and reconcile the schema before stamping;
-do not hand-edit the Alembic version table or skip the check.
+live table is missing an ORM-managed column, has an unexpected column, or has a
+critical idempotency/active-operation index with missing uniqueness, columns, or
+partial predicate. A failure means the operator must stop and reconcile the
+schema before stamping; do not hand-edit the Alembic version table or skip the
+check.
 
 The hosted startup wrapper runs the verifier before stamping and then applies
 migrations:
@@ -77,6 +84,17 @@ payload snapshots. Fields that the GUI or drivers need to filter, order, join,
 authorize, constrain, display regularly, or act on should be promoted into ORM
 columns/tables and migrated explicitly while keeping the payload copy as
 historical evidence.
+
+The production schema proof runs against real PostgreSQL, not SQLite:
+
+```bash
+LAUNCHPLANE_TEST_POSTGRES_URL=postgresql+psycopg://... uv run launchplane ci postgres-integration
+```
+
+The test URL points at a disposable PostgreSQL service/database root. The harness
+creates isolated databases, applies Alembic from empty schema to `head`, verifies
+the exact schema head and critical invariants, and then drops the databases. It
+must not use Launchplane runtime credentials or shared production databases.
 
 ## ORM Query Boundary
 

--- a/docs/style/testing.md
+++ b/docs/style/testing.md
@@ -34,6 +34,29 @@ the ignored `.ci-cache/` directory and remains a balancing hint rather than test
 authority. A failed run leaves the previous timing history unchanged instead of
 learning from a partial suite.
 
+Storage tests that instantiate `PostgresRecordStore` with `sqlite+pysqlite://`
+are portability and local rehearsal tests. They prove ORM mapping, payload round
+trips, and SQLite-compatible migration mechanics, but they do not prove
+PostgreSQL row locks, `SKIP LOCKED`, JSONB column types, Alembic head adoption,
+or partial unique index predicates.
+
+The real PostgreSQL storage proof is an explicit integration gate:
+
+```bash
+LAUNCHPLANE_TEST_POSTGRES_URL=postgresql+psycopg://... uv run launchplane ci postgres-integration
+```
+
+The URL is a temporary/root test service URL, not a Launchplane runtime
+credential. The harness creates and drops isolated databases, upgrades each from
+empty schema through Alembic `head`, verifies the exact checked-in schema head
+and critical indexes/types, and runs focused two-connection concurrency tests
+for idempotency conflicts, operation claims, stale lease owners, lease recovery,
+and active-operation partial uniqueness. Same-repo CI provides the URL via a
+PostgreSQL service container; fork PRs keep the SQLite/unittest path only. Keep
+the integration module focused: target runtime is under 2 minutes in CI, and any
+flake should be treated as a storage or harness bug rather than hidden with a
+retry loop.
+
 The lower-level CI shard commands remain available for diagnosis:
 
 ```bash
@@ -65,5 +88,7 @@ shard plan includes per-target timing-source diagnostics:
   default estimate until a shard timing artifact teaches it better.
 
 GitHub Actions remains the source of truth for required pull-request gates. The
-local command is the official pre-review full-suite proof; it does not replace
-CI's runner isolation, artifact retention, or required status checks.
+local command is the official pre-review full-suite proof; the PostgreSQL
+integration command is the official production storage-semantics proof when a
+local or CI PostgreSQL service is available. Neither local command replaces CI's
+runner isolation, artifact retention, or required status checks.

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -16,6 +16,7 @@ class DocsContractsTests(TestCase):
         self.assertIn("CONTAINER_SCAN_FORK_RESULT", ci_workflow)
         self.assertIn("FRONTEND_VALIDATE_FORK_RESULT", ci_workflow)
         self.assertIn("TEST_FORK_RESULT", ci_workflow)
+        self.assertIn("POSTGRES_INTEGRATION_RESULT", ci_workflow)
         self.assertIn("  workflow_lint_fork:", security_workflow)
         self.assertIn("  secret_scan_fork:", security_workflow)
         self.assertIn("  security_gate:\n    name: security-gate", security_workflow)
@@ -35,9 +36,15 @@ class DocsContractsTests(TestCase):
             "uv run python -m unittest {modules}",
             metadata["qualityGate"]["test"]["targeted"],
         )
+        self.assertIn(
+            "uv run launchplane ci postgres-integration",
+            metadata["qualityGate"]["test"]["postgresIntegration"],
+        )
         self.assertIn("uv run launchplane ci unittest-shard local", testing_docs)
+        self.assertIn("uv run launchplane ci postgres-integration", testing_docs)
         self.assertIn("12 shards with a 20-test/30-second split threshold", testing_docs)
         self.assertIn("GitHub Actions remains the source of truth", testing_docs)
+        self.assertIn("  postgres_integration:", ci_workflow)
         self.assertIn("  test_timing_snapshot:", ci_workflow)
         self.assertIn('UNITTEST_SHARD_COUNT: "12"', ci_workflow)
         self.assertIn('UNITTEST_MAX_TESTS_PER_TARGET: "20"', ci_workflow)

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+import os
+import threading
+import unittest
+from uuid import uuid4
+
+from alembic import command as alembic_command
+from alembic.config import Config as AlembicConfig
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import IntegrityError, OperationalError
+
+from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.contracts.idempotency_record import build_launchplane_idempotency_record_id
+from control_plane.contracts.odoo_stable_bootstrap import OdooStableBootstrapRequest
+from control_plane.contracts.odoo_stable_bootstrap_operation import (
+    OdooStableBootstrapOperationRecord,
+    OdooStableBootstrapOperationPhase,
+    OdooStableBootstrapOperationStatus,
+)
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.storage.schema_invariants import EXPECTED_ALEMBIC_HEAD_REVISION
+
+POSTGRES_TEST_URL_ENV = "LAUNCHPLANE_TEST_POSTGRES_URL"
+LOCK_WAIT_TIMEOUT = "1000ms"
+def _postgres_root_database_url() -> str:
+    database_url = os.environ.get(POSTGRES_TEST_URL_ENV, "").strip()
+    if not database_url:
+        raise unittest.SkipTest(f"{POSTGRES_TEST_URL_ENV} is not set")
+    url = make_url(database_url)
+    if url.get_backend_name() != "postgresql":
+        raise unittest.SkipTest(f"{POSTGRES_TEST_URL_ENV} must use postgresql+psycopg")
+    return database_url
+
+
+def _alembic_config(database_url: str) -> AlembicConfig:
+    config = AlembicConfig("alembic.ini")
+    config.set_main_option("sqlalchemy.url", database_url)
+    return config
+
+
+@contextmanager
+def _isolated_postgres_database() -> Iterator[str]:
+    root_database_url = _postgres_root_database_url()
+    root_url = make_url(root_database_url)
+    database_name = f"launchplane_test_{uuid4().hex}"
+    database_url = root_url.set(database=database_name).render_as_string(
+        hide_password=False
+    )
+    root_engine = create_engine(root_database_url, isolation_level="AUTOCOMMIT")
+    try:
+        with root_engine.connect() as connection:
+            connection.execute(
+                text(f'CREATE DATABASE "{database_name}"')
+            )
+        try:
+            yield database_url
+        finally:
+            with root_engine.connect() as connection:
+                connection.execute(
+                    text(
+                        "select pg_terminate_backend(pid) "
+                        "from pg_stat_activity where datname = :database_name"
+                    ),
+                    {"database_name": database_name},
+                )
+                connection.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+    finally:
+        root_engine.dispose()
+
+
+def _upgrade_empty_database_to_head(database_url: str) -> None:
+    alembic_command.upgrade(_alembic_config(database_url), "head")
+
+
+@contextmanager
+def _store_for_fresh_head_database() -> Iterator[PostgresRecordStore]:
+    with _isolated_postgres_database() as database_url:
+        _upgrade_empty_database_to_head(database_url)
+        store = PostgresRecordStore(database_url=database_url)
+        try:
+            store.verify_schema()
+            yield store
+        finally:
+            store.close()
+
+
+def _bootstrap_operation(
+    *,
+    operation_id: str = "odoo-stable-bootstrap-cm-testing-20260517t000000z-base",
+    idempotency_key: str = "bootstrap-cm-testing",
+    status: OdooStableBootstrapOperationStatus = "pending",
+    phase: OdooStableBootstrapOperationPhase = "created",
+    created_at: str = "2026-05-17T00:00:00Z",
+    updated_at: str = "2026-05-17T00:00:00Z",
+    lease_owner: str = "",
+    lease_expires_at: str = "",
+    heartbeat_at: str = "",
+    attempt: int = 0,
+    started_at: str = "",
+    finished_at: str = "",
+    error_message: str = "",
+) -> OdooStableBootstrapOperationRecord:
+    return OdooStableBootstrapOperationRecord(
+        operation_id=operation_id,
+        product="odoo-tenant-cm",
+        context="cm",
+        instance="testing",
+        idempotency_key=idempotency_key,
+        request_fingerprint=f"fingerprint-{idempotency_key}",
+        request=OdooStableBootstrapRequest(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            confirmation="bootstrap cm testing",
+        ),
+        status=status,
+        phase=phase,
+        created_at=created_at,
+        updated_at=updated_at,
+        lease_owner=lease_owner,
+        lease_expires_at=lease_expires_at,
+        heartbeat_at=heartbeat_at,
+        attempt=attempt,
+        started_at=started_at or (updated_at if status == "running" else ""),
+        finished_at=finished_at,
+        error_message=error_message,
+    )
+
+
+def _idempotency_record(
+    *, response_trace_id: str, request_fingerprint: str
+) -> LaunchplaneIdempotencyRecord:
+    return LaunchplaneIdempotencyRecord(
+        record_id=build_launchplane_idempotency_record_id(response_trace_id=response_trace_id),
+        scope="github-actions|cbusillo/launchplane|workflow:test",
+        route_path="/v1/evidence/previews/generations",
+        idempotency_key="preview-generation:launchplane:test:1",
+        request_fingerprint=request_fingerprint,
+        response_status_code=202,
+        response_trace_id=response_trace_id,
+        recorded_at="2026-07-01T00:00:00Z",
+        response_payload={"status": "accepted", "trace_id": response_trace_id},
+    )
+
+
+class RealPostgresSchemaIntegrationTests(unittest.TestCase):
+    def test_alembic_from_empty_database_reaches_exact_head_and_required_invariants(
+        self,
+    ) -> None:
+        with _isolated_postgres_database() as database_url:
+            _upgrade_empty_database_to_head(database_url)
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.verify_schema()
+                engine = store._engine
+                inspector = inspect(engine)
+                indexes = {
+                    index["name"]: index
+                    for index in inspector.get_indexes(
+                        "launchplane_odoo_stable_bootstrap_operations"
+                    )
+                }
+                idempotency_indexes = {
+                    index["name"]: index
+                    for index in inspector.get_indexes("launchplane_idempotency_records")
+                }
+                payload_type = _column_type(
+                    engine,
+                    table_name="launchplane_idempotency_records",
+                    column_name="payload",
+                )
+                alembic_version = _current_alembic_version(engine)
+            finally:
+                store.close()
+
+        self.assertEqual(alembic_version, EXPECTED_ALEMBIC_HEAD_REVISION)
+        self.assertEqual(payload_type, "jsonb")
+        self.assertTrue(
+            idempotency_indexes["launchplane_idempotency_scope_route_key_idx"]["unique"]
+        )
+        self.assertTrue(indexes["launchplane_odoo_bootstrap_active_lane_uidx"]["unique"])
+
+    def test_startup_verification_fails_closed_when_critical_index_is_missing(
+        self,
+    ) -> None:
+        with _isolated_postgres_database() as database_url:
+            _upgrade_empty_database_to_head(database_url)
+            engine = create_engine(database_url)
+            with engine.begin() as connection:
+                connection.execute(
+                    text("drop index launchplane_idempotency_scope_route_key_idx")
+                )
+            engine.dispose()
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "launchplane_idempotency_records missing required index",
+                ):
+                    store.verify_schema()
+            finally:
+                store.close()
+
+    def test_startup_verification_fails_closed_when_partial_predicate_is_missing(
+        self,
+    ) -> None:
+        with _isolated_postgres_database() as database_url:
+            _upgrade_empty_database_to_head(database_url)
+            engine = create_engine(database_url)
+            with engine.begin() as connection:
+                connection.execute(text("drop index launchplane_odoo_bootstrap_active_lane_uidx"))
+                connection.execute(
+                    text(
+                        "create unique index launchplane_odoo_bootstrap_active_lane_uidx "
+                        "on launchplane_odoo_stable_bootstrap_operations "
+                        "(product, context, instance)"
+                    )
+                )
+            engine.dispose()
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "launchplane_odoo_bootstrap_active_lane_uidx has predicate",
+                ):
+                    store.verify_schema()
+            finally:
+                store.close()
+
+
+class RealPostgresStorageConcurrencyTests(unittest.TestCase):
+    def test_two_connections_claim_exactly_one_pending_operation_and_recover_lease(
+        self,
+    ) -> None:
+        with _store_for_fresh_head_database() as store:
+            store.write_odoo_stable_bootstrap_operation_record(_bootstrap_operation())
+
+            first_claim = store.claim_next_odoo_stable_bootstrap_operation_record(
+                lease_owner="worker-a",
+                lease_expires_at="2026-05-17T00:10:00Z",
+                claimed_at="2026-05-17T00:01:00Z",
+            )
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            try:
+                second_claim = second_store.claim_next_odoo_stable_bootstrap_operation_record(
+                    lease_owner="worker-b",
+                    lease_expires_at="2026-05-17T00:11:00Z",
+                    claimed_at="2026-05-17T00:02:00Z",
+                )
+                stale_owner_heartbeat = second_store.heartbeat_odoo_stable_bootstrap_operation_record(
+                    operation_id=first_claim.operation_id if first_claim else "missing",
+                    lease_owner="worker-b",
+                    heartbeat_at="2026-05-17T00:03:00Z",
+                    lease_expires_at="2026-05-17T00:13:00Z",
+                )
+                recovered_ids = store.recover_expired_odoo_stable_bootstrap_operation_records(
+                    now="2026-05-17T00:12:00Z",
+                    safe_phases=("running",),
+                    max_attempts=3,
+                )
+                recovered_claim = second_store.claim_next_odoo_stable_bootstrap_operation_record(
+                    lease_owner="worker-b",
+                    lease_expires_at="2026-05-17T00:22:00Z",
+                    claimed_at="2026-05-17T00:13:00Z",
+                )
+            finally:
+                second_store.close()
+
+        self.assertIsNotNone(first_claim)
+        assert first_claim is not None
+        self.assertEqual(first_claim.lease_owner, "worker-a")
+        self.assertIsNone(second_claim)
+        self.assertFalse(stale_owner_heartbeat)
+        self.assertEqual(recovered_ids, (first_claim.operation_id,))
+        self.assertIsNotNone(recovered_claim)
+        assert recovered_claim is not None
+        self.assertEqual(recovered_claim.lease_owner, "worker-b")
+        self.assertEqual(recovered_claim.attempt, 2)
+
+    def test_row_lock_blocks_stale_owner_completion_until_claim_commits(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            store.write_odoo_stable_bootstrap_operation_record(_bootstrap_operation())
+            blocker = create_engine(store.database_url)
+            stale_owner_result: list[bool | BaseException] = []
+            worker_started = threading.Event()
+            worker: threading.Thread | None = None
+            try:
+                with blocker.connect() as connection:
+                    transaction = connection.begin()
+                    try:
+                        locked_row = connection.execute(
+                            text(
+                                "select operation_id "
+                                "from launchplane_odoo_stable_bootstrap_operations "
+                                "where status = 'pending' "
+                                "for update"
+                            )
+                        ).fetchone()
+                        self.assertIsNotNone(locked_row)
+                        worker = threading.Thread(
+                            target=_attempt_stale_owner_completion,
+                            args=(store.database_url, stale_owner_result, worker_started),
+                        )
+                        worker.start()
+                        self.assertTrue(worker_started.wait(timeout=5))
+                        worker.join(timeout=5)
+                        self.assertFalse(worker.is_alive())
+                        self.assertEqual(len(stale_owner_result), 1)
+                        lock_error = stale_owner_result[0]
+                        self.assertIsInstance(lock_error, OperationalError)
+                        assert isinstance(lock_error, OperationalError)
+                        self.assertEqual(getattr(lock_error.orig, "sqlstate", ""), "55P03")
+                    finally:
+                        transaction.rollback()
+                post_lock_result = store.complete_odoo_stable_bootstrap_operation_record(
+                    record=_bootstrap_operation(
+                        status="pass",
+                        phase="completed",
+                        updated_at="2026-05-17T00:04:00Z",
+                        finished_at="2026-05-17T00:04:00Z",
+                    ),
+                    lease_owner="stale-worker",
+                )
+            finally:
+                blocker.dispose()
+
+        self.assertFalse(post_lock_result)
+
+    def test_idempotency_unique_index_rejects_conflicting_two_connection_insert(
+        self,
+    ) -> None:
+        with _store_for_fresh_head_database() as store:
+            first_record = _idempotency_record(
+                response_trace_id="launchplane_req_first",
+                request_fingerprint="fingerprint-first",
+            )
+            conflicting_record = _idempotency_record(
+                response_trace_id="launchplane_req_second",
+                request_fingerprint="fingerprint-second",
+            )
+            store.write_idempotency_record(first_record)
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            try:
+                with self.assertRaises(IntegrityError):
+                    second_store.write_idempotency_record(conflicting_record)
+                loaded = second_store.read_idempotency_record(
+                    scope=first_record.scope,
+                    route_path=first_record.route_path,
+                    idempotency_key=first_record.idempotency_key,
+                )
+            finally:
+                second_store.close()
+
+        self.assertIsNotNone(loaded)
+        assert loaded is not None
+        self.assertEqual(loaded.request_fingerprint, "fingerprint-first")
+
+    def test_partial_unique_active_operation_index_rejects_second_active_lane(
+        self,
+    ) -> None:
+        with _store_for_fresh_head_database() as store:
+            first_record = _bootstrap_operation(
+                operation_id="odoo-stable-bootstrap-cm-testing-first",
+                idempotency_key="bootstrap-first",
+            )
+            second_active_record = _bootstrap_operation(
+                operation_id="odoo-stable-bootstrap-cm-testing-second",
+                idempotency_key="bootstrap-second",
+            )
+            terminal_record = _bootstrap_operation(
+                operation_id="odoo-stable-bootstrap-cm-testing-terminal",
+                idempotency_key="bootstrap-terminal",
+                status="fail",
+                phase="failed",
+                created_at="2026-05-17T00:02:00Z",
+                updated_at="2026-05-17T00:02:00Z",
+                finished_at="2026-05-17T00:02:00Z",
+                error_message="terminal record does not reserve active lane",
+            )
+            store.write_odoo_stable_bootstrap_operation_record(first_record)
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            try:
+                existing_record, created = (
+                    second_store.create_odoo_stable_bootstrap_operation_record_if_no_active_lane(
+                        second_active_record
+                    )
+                )
+                second_store.write_odoo_stable_bootstrap_operation_record(terminal_record)
+                terminal_records = second_store.list_odoo_stable_bootstrap_operation_records(
+                    statuses=("fail",),
+                )
+            finally:
+                second_store.close()
+
+        self.assertFalse(created)
+        self.assertEqual(existing_record.operation_id, first_record.operation_id)
+        self.assertEqual([record.operation_id for record in terminal_records], [terminal_record.operation_id])
+
+
+def _attempt_stale_owner_completion(
+    database_url: str,
+    results: list[bool | BaseException],
+    started: threading.Event,
+) -> None:
+    worker_url = make_url(database_url).update_query_dict(
+        {"options": f"-c lock_timeout={LOCK_WAIT_TIMEOUT}"}
+    )
+    store = PostgresRecordStore(database_url=worker_url.render_as_string(hide_password=False))
+    try:
+        started.set()
+        result = store.complete_odoo_stable_bootstrap_operation_record(
+            record=_bootstrap_operation(
+                status="pass",
+                phase="completed",
+                updated_at="2026-05-17T00:04:00Z",
+                finished_at="2026-05-17T00:04:00Z",
+            ),
+            lease_owner="stale-worker",
+        )
+        results.append(result)
+    except BaseException as error:
+        results.append(error)
+    finally:
+        store.close()
+
+
+def _current_alembic_version(engine: Engine) -> str:
+    with engine.connect() as connection:
+        return str(connection.execute(text("select version_num from alembic_version")).scalar_one())
+
+
+def _column_type(engine: Engine, *, table_name: str, column_name: str) -> str:
+    with engine.connect() as connection:
+        return str(
+            connection.execute(
+                text(
+                    "select data_type from information_schema.columns "
+                    "where table_schema = current_schema() "
+                    "and table_name = :table_name and column_name = :column_name"
+                ),
+                {"table_name": table_name, "column_name": column_name},
+            ).scalar_one()
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_schema_adoption.py
+++ b/tests/test_schema_adoption.py
@@ -11,14 +11,22 @@ from control_plane.storage.schema_adoption import (
 
 
 class FakeInspector:
-    def __init__(self, columns_by_table: dict[str, set[str]]) -> None:
+    def __init__(
+        self,
+        columns_by_table: dict[str, set[str]],
+        indexes_by_table: dict[str, list[dict[str, object]]] | None = None,
+    ) -> None:
         self.columns_by_table = columns_by_table
+        self.indexes_by_table = indexes_by_table or {}
 
     def get_table_names(self) -> list[str]:
         return list(self.columns_by_table)
 
     def get_columns(self, table_name: str) -> list[dict[str, object]]:
         return [{"name": column_name} for column_name in self.columns_by_table[table_name]]
+
+    def get_indexes(self, table_name: str) -> list[dict[str, object]]:
+        return self.indexes_by_table.get(table_name, [])
 
 
 class SchemaAdoptionTests(unittest.TestCase):
@@ -123,6 +131,101 @@ class SchemaAdoptionTests(unittest.TestCase):
             inspector=inspector,
             expected_schema=LEGACY_BASELINE_SCHEMA,
         )
+
+    def test_rejects_existing_critical_table_missing_required_index(self) -> None:
+        columns_by_table = {
+            table_name: set(columns) for table_name, columns in LEGACY_CURRENT_SCHEMA.items()
+        }
+        table_name = "launchplane_odoo_stable_target_replacement_operations"
+        columns_by_table[table_name] = {
+            "operation_id",
+            "product",
+            "context",
+            "instance",
+            "idempotency_key",
+            "idempotency_scope",
+            "status",
+            "phase",
+            "created_at",
+            "updated_at",
+            "lease_owner",
+            "lease_expires_at",
+            "heartbeat_at",
+            "attempt",
+            "payload",
+        }
+        inspector = FakeInspector(columns_by_table)
+
+        with self.assertRaisesRegex(
+            SchemaAdoptionError,
+            "launchplane_odoo_stable_target_replacement_operations missing "
+            "required index launchplane_odoo_replacement_operation_idempotency_idx",
+        ):
+            verify_existing_schema_for_stamp(
+                inspector=inspector,
+                expected_schema={
+                    **LEGACY_CURRENT_SCHEMA,
+                    table_name: frozenset(columns_by_table[table_name]),
+                },
+            )
+
+    def test_rejects_existing_active_operation_index_without_partial_predicate(
+        self,
+    ) -> None:
+        columns_by_table = {
+            table_name: set(columns) for table_name, columns in LEGACY_CURRENT_SCHEMA.items()
+        }
+        table_name = "launchplane_odoo_stable_bootstrap_operations"
+        columns_by_table[table_name] = {
+            "operation_id",
+            "product",
+            "context",
+            "instance",
+            "idempotency_key",
+            "status",
+            "phase",
+            "created_at",
+            "updated_at",
+            "lease_owner",
+            "lease_expires_at",
+            "heartbeat_at",
+            "attempt",
+            "payload",
+        }
+        inspector = FakeInspector(
+            columns_by_table,
+            indexes_by_table={
+                table_name: [
+                    {
+                        "name": "launchplane_odoo_bootstrap_operation_idempotency_idx",
+                        "unique": False,
+                        "column_names": ["idempotency_key", "updated_at"],
+                    },
+                    {
+                        "name": "launchplane_odoo_bootstrap_active_lane_uidx",
+                        "unique": True,
+                        "column_names": ["product", "context", "instance"],
+                    },
+                    {
+                        "name": "launchplane_odoo_bootstrap_worker_claim_idx",
+                        "unique": False,
+                        "column_names": ["status", "lease_expires_at", "updated_at"],
+                    },
+                ]
+            },
+        )
+
+        with self.assertRaisesRegex(
+            SchemaAdoptionError,
+            "launchplane_odoo_bootstrap_active_lane_uidx has predicate <none>",
+        ):
+            verify_existing_schema_for_stamp(
+                inspector=inspector,
+                expected_schema={
+                    **LEGACY_CURRENT_SCHEMA,
+                    table_name: frozenset(columns_by_table[table_name]),
+                },
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a real PostgreSQL integration harness that creates isolated databases and migrates from empty to the exact Alembic head
- fail hosted startup and schema adoption closed on critical PostgreSQL type, index, predicate, and migration-head drift
- exercise two-connection lease, stale-owner, idempotency, and partial unique-index behavior
- add a fork-safe PostgreSQL service job to the required CI gate and document SQLite versus PostgreSQL test authority

## Validation
- `uv run launchplane ci postgres-integration` against `postgres:17` (7 tests)
- `uv run python -m unittest tests.test_schema_adoption tests.test_docs_contracts`
- changed-file Ruff and mypy
- `actionlint .github/workflows/ci.yml`
- independent infrastructure review; row-lock proof revised to assert PostgreSQL lock-timeout SQLSTATE instead of timing

Closes #1687