### PR TITLE
Bound webhook ingress and harden outbound HTTP

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -657,7 +657,9 @@ _PREVIEW_GENERATION_EVIDENCE_ROUTE = "/v1/evidence/previews/generations"
 _PREVIEW_DESTROYED_EVIDENCE_ROUTE = "/v1/evidence/previews/destroyed"
 _RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-host-hygiene/audits"
 _RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-lane-registration/audits"
+_EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _EVIDENCE_INGRESS_MAX_BODY_BYTES = 2 * 1024 * 1024
+_GITHUB_WEBHOOK_MAX_BODY_BYTES = 2 * 1024 * 1024
 _EVIDENCE_INGRESS_ROUTES = frozenset(
     {
         _DEPLOYMENT_EVIDENCE_ROUTE,
@@ -669,6 +671,18 @@ _EVIDENCE_INGRESS_ROUTES = frozenset(
         _RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE,
     }
 )
+_BOUNDED_REQUEST_BODY_CONTRACTS: dict[str, tuple[str, int, bool, bool]] = {
+    **{
+        route: ("Evidence ingress", _EVIDENCE_INGRESS_MAX_BODY_BYTES, True, False)
+        for route in _EVIDENCE_INGRESS_ROUTES
+    },
+    _EVERY_CODE_GITHUB_WEBHOOK_ROUTE: (
+        "GitHub webhook",
+        _GITHUB_WEBHOOK_MAX_BODY_BYTES,
+        False,
+        True,
+    ),
+}
 _DOKPLOY_TARGET_SETUP_ROUTE = "/v1/dokploy-targets/setup"
 _PUBLIC_INGRESS_MONITOR_RUN_ONCE_ROUTE = "/v1/products/public-ingress-monitor/run-once"
 _PUBLIC_INGRESS_NOTIFICATION_POLICY_APPLY_ROUTE = "/v1/public-ingress/notification-policies/apply"
@@ -715,7 +729,6 @@ _AUTH_LOGOUT_ROUTE = "/auth/logout"
 _LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 _AGENT_WRITE_INTENT_EVALUATE_ROUTE = "/v1/agent/write-intents/evaluate"
 _EVERY_CODE_WORK_REQUEST_RERUN_ROUTE = "/v1/every-code/work-requests/rerun"
-_EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
 _AGENT_WRITE_INTENT_MAX_AGE = timedelta(hours=24)
 
 AuthzPolicyRouteEnvelope = (
@@ -894,32 +907,34 @@ class AuthLogoutResponse(BaseModel):
     trace_id: str
 
 
-class EvidenceIngressRequestContractMiddleware:
+class BoundedRequestBodyMiddleware:
     def __init__(self, app: ASGIApp) -> None:
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if (
-            scope.get("type") != "http"
-            or str(scope.get("method", "")).upper() != "POST"
-            or str(scope.get("path", "")) not in _EVIDENCE_INGRESS_ROUTES
-        ):
+        if scope.get("type") != "http" or str(scope.get("method", "")).upper() != "POST":
             await self.app(scope, receive, send)
             return
-
-        content_type_values = _asgi_header_values(scope=scope, name="content-type")
-        content_type = content_type_values[0] if len(content_type_values) == 1 else ""
-        media_type = content_type.split(";", 1)[0].strip().lower()
-        if media_type != "application/json":
-            await _send_launchplane_error_response(
-                scope=scope,
-                receive=receive,
-                send=send,
-                status_code=400,
-                code="invalid_request",
-                message="Evidence ingress requests require Content-Type: application/json.",
-            )
+        contract = _BOUNDED_REQUEST_BODY_CONTRACTS.get(str(scope.get("path", "")))
+        if contract is None:
+            await self.app(scope, receive, send)
             return
+        request_label, max_body_bytes, require_json, require_exact_length = contract
+
+        if require_json:
+            content_type_values = _asgi_header_values(scope=scope, name="content-type")
+            content_type = content_type_values[0] if len(content_type_values) == 1 else ""
+            media_type = content_type.split(";", 1)[0].strip().lower()
+            if media_type != "application/json":
+                await _send_launchplane_error_response(
+                    scope=scope,
+                    receive=receive,
+                    send=send,
+                    status_code=400,
+                    code="invalid_request",
+                    message=f"{request_label} requests require Content-Type: application/json.",
+                )
+                return
 
         transfer_encoding_tokens = {
             token.split(";", 1)[0].strip().lower()
@@ -927,14 +942,16 @@ class EvidenceIngressRequestContractMiddleware:
             for token in value.split(",")
             if token.strip()
         }
-        if "chunked" in transfer_encoding_tokens:
+        if "chunked" in transfer_encoding_tokens or (
+            require_exact_length and transfer_encoding_tokens
+        ):
             await _send_launchplane_error_response(
                 scope=scope,
                 receive=receive,
                 send=send,
                 status_code=413,
                 code="request_entity_too_large",
-                message="Evidence ingress requests require a bounded Content-Length.",
+                message=f"{request_label} requests require a bounded Content-Length.",
             )
             return
 
@@ -946,7 +963,7 @@ class EvidenceIngressRequestContractMiddleware:
                 send=send,
                 status_code=413,
                 code="request_entity_too_large",
-                message="Evidence ingress requests require a bounded Content-Length.",
+                message=f"{request_label} requests require a bounded Content-Length.",
             )
             return
         if len(content_length_values) != 1:
@@ -956,7 +973,7 @@ class EvidenceIngressRequestContractMiddleware:
                 send=send,
                 status_code=400,
                 code="invalid_request",
-                message="Evidence ingress requests require exactly one Content-Length header.",
+                message=f"{request_label} requests require exactly one Content-Length header.",
             )
             return
         content_length = content_length_values[0].strip()
@@ -967,44 +984,78 @@ class EvidenceIngressRequestContractMiddleware:
                 send=send,
                 status_code=400,
                 code="invalid_request",
-                message="Evidence ingress Content-Length must be an unsigned decimal integer.",
+                message=(f"{request_label} Content-Length must be an unsigned decimal integer."),
             )
             return
-        declared_body_size = int(content_length)
-        if declared_body_size > _EVIDENCE_INGRESS_MAX_BODY_BYTES:
+        normalized_content_length = content_length.lstrip("0") or "0"
+        max_body_size_text = str(max_body_bytes)
+        if len(normalized_content_length) > len(max_body_size_text) or (
+            len(normalized_content_length) == len(max_body_size_text)
+            and normalized_content_length > max_body_size_text
+        ):
             await _send_launchplane_error_response(
                 scope=scope,
                 receive=receive,
                 send=send,
                 status_code=413,
                 code="request_entity_too_large",
-                message="Evidence ingress request body is too large.",
+                message=f"{request_label} request body is too large.",
             )
             return
+        declared_body_size = int(normalized_content_length)
 
         buffered_messages: list[Message] = []
         observed_body_size = 0
         while True:
             message = await receive()
+            if message.get("type") == "http.disconnect":
+                return
             if message.get("type") != "http.request":
-                buffered_messages.append(message)
-                break
+                await _send_launchplane_error_response(
+                    scope=scope,
+                    receive=receive,
+                    send=send,
+                    status_code=400,
+                    code="invalid_request",
+                    message=f"{request_label} request body ended before completion.",
+                )
+                return
             body = message.get("body", b"")
-            if isinstance(body, bytes):
-                observed_body_size += len(body)
-            if observed_body_size > _EVIDENCE_INGRESS_MAX_BODY_BYTES:
+            if not isinstance(body, bytes):
+                await _send_launchplane_error_response(
+                    scope=scope,
+                    receive=receive,
+                    send=send,
+                    status_code=400,
+                    code="invalid_request",
+                    message=f"{request_label} request body is invalid.",
+                )
+                return
+            observed_body_size += len(body)
+            if observed_body_size > max_body_bytes:
                 await _send_launchplane_error_response(
                     scope=scope,
                     receive=receive,
                     send=send,
                     status_code=413,
                     code="request_entity_too_large",
-                    message="Evidence ingress request body is too large.",
+                    message=f"{request_label} request body is too large.",
                 )
                 return
             buffered_messages.append(message)
             if not message.get("more_body", False):
                 break
+
+        if require_exact_length and observed_body_size != declared_body_size:
+            await _send_launchplane_error_response(
+                scope=scope,
+                receive=receive,
+                send=send,
+                status_code=400,
+                code="invalid_request",
+                message=f"{request_label} Content-Length does not match the request body.",
+            )
+            return
 
         next_message_index = 0
 
@@ -3994,7 +4045,7 @@ def create_launchplane_fastapi_app(
                 shared_record_store.close()
 
     app = _LaunchplaneFastAPI(title="Launchplane API", version="0.1.0", lifespan=lifespan)
-    app.add_middleware(EvidenceIngressRequestContractMiddleware)
+    app.add_middleware(BoundedRequestBodyMiddleware)
     odoo_preview_apply_lock = asyncio.Lock()
     resolved_oauth_login_state_store = (
         oauth_login_state_store if oauth_login_state_store is not None else OAuthLoginStateStore()
@@ -19815,6 +19866,7 @@ def create_launchplane_fastapi_app(
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},
             404: {"model": LaunchplaneErrorResponse},
+            413: {"model": LaunchplaneErrorResponse},
             503: {"model": LaunchplaneErrorResponse},
         },
     )

--- a/control_plane/notifications.py
+++ b/control_plane/notifications.py
@@ -1,41 +1,13 @@
 from __future__ import annotations
 
-import ipaddress
 import json
 from urllib.parse import urlsplit
-from urllib.request import Request, urlopen
+
+from control_plane.outbound_http import public_url_error as public_url_error
+from control_plane.outbound_http import request_public_http
 
 
 USER_AGENT = "Launchplane notifications/1.0"
-
-
-def public_url_error(url: str) -> str:
-    parsed = urlsplit(url.strip())
-    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-        return "invalid_url"
-    hostname = (parsed.hostname or "").lower()
-    if hostname in {"localhost", "127.0.0.1", "::1"}:
-        return "private_url"
-    try:
-        ip_address = ipaddress.ip_address(hostname)
-        if (
-            ip_address.is_private
-            or ip_address.is_loopback
-            or ip_address.is_link_local
-            or ip_address.is_multicast
-            or ip_address.is_reserved
-            or ip_address.is_unspecified
-        ):
-            return "private_url"
-    except ValueError:
-        pass
-    if (
-        hostname.endswith(".local")
-        or hostname.endswith(".internal")
-        or hostname.endswith(".invalid")
-    ):
-        return "private_url"
-    return ""
 
 
 def public_discord_url_error(url: str) -> str:
@@ -44,12 +16,6 @@ def public_discord_url_error(url: str) -> str:
         return public_error
     parsed = urlsplit(url.strip())
     hostname = (parsed.hostname or "").lower()
-    try:
-        ipaddress.ip_address(hostname)
-    except ValueError:
-        pass
-    else:
-        return "invalid_url"
     if hostname not in {"discord.com", "discordapp.com"} and not (
         hostname.endswith(".discord.com") or hostname.endswith(".discordapp.com")
     ):
@@ -58,12 +24,15 @@ def public_discord_url_error(url: str) -> str:
 
 
 def post_discord_webhook(webhook_url: str, payload: dict[str, object]) -> None:
-    request = Request(
+    url_error = public_discord_url_error(webhook_url)
+    if url_error:
+        raise ValueError(f"Discord webhook URL is not allowed: {url_error}.")
+    response = request_public_http(
         webhook_url,
         method="POST",
         headers={"Content-Type": "application/json", "User-Agent": USER_AGENT},
-        data=json.dumps(payload).encode("utf-8"),
+        body=json.dumps(payload).encode("utf-8"),
+        timeout_seconds=15,
     )
-    with urlopen(request, timeout=15) as response:  # noqa: S310 - operator-configured webhook URL with SSRF guard.
-        if not 200 <= response.status < 300:
-            raise RuntimeError(f"Discord webhook returned HTTP {response.status}")
+    if not 200 <= response.status_code < 300:
+        raise RuntimeError(f"Discord webhook returned HTTP {response.status_code}")

--- a/control_plane/outbound_http.py
+++ b/control_plane/outbound_http.py
@@ -1,0 +1,578 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from http.client import HTTPConnection, HTTPSConnection
+from ipaddress import IPv4Address, IPv6Address, ip_address
+from time import monotonic
+from typing import Literal, Protocol, cast
+from urllib.parse import SplitResult, urljoin, urlsplit, urlunsplit
+import socket
+
+
+PublicUrlError = Literal["invalid_url", "private_url"]
+PublicHttpDestinationErrorCode = Literal["dns_failure", "invalid_url", "private_url"]
+SocketAddress = tuple[str, int] | tuple[str, int, int, int]
+ResolvedAddressInfo = tuple[int, int, int, str, SocketAddress]
+AddressResolver = Callable[[str, int], tuple[ResolvedAddressInfo, ...]]
+
+
+@dataclass(frozen=True)
+class ResolvedHttpAddress:
+    family: int
+    socket_type: int
+    protocol: int
+    socket_address: SocketAddress
+    ip: IPv4Address | IPv6Address
+
+
+@dataclass(frozen=True)
+class PublicHttpDestination:
+    url: str
+    scheme: Literal["http", "https"]
+    hostname: str
+    port: int
+    request_target: str
+    addresses: tuple[ResolvedHttpAddress, ...]
+
+    @property
+    def origin(self) -> tuple[str, str, int]:
+        return self.scheme, self.hostname, self.port
+
+
+@dataclass(frozen=True)
+class PublicHttpResponse:
+    status_code: int
+    final_url: str
+    redirect_count: int
+    headers: tuple[tuple[str, str], ...]
+    body: bytes
+
+    def header(self, name: str) -> str:
+        normalized_name = name.lower()
+        return next(
+            (value for key, value in self.headers if key.lower() == normalized_name),
+            "",
+        )
+
+
+class PublicHttpDestinationError(ValueError):
+    def __init__(self, code: PublicHttpDestinationErrorCode, message: str) -> None:
+        super().__init__(message)
+        self.code: PublicHttpDestinationErrorCode = code
+
+
+class _HttpResponse(Protocol):
+    status: int
+
+    def getheader(self, name: str, default: str | None = None) -> str | None: ...
+
+    def getheaders(self) -> list[tuple[str, str]]: ...
+
+    def read(self, amount: int | None = None) -> bytes: ...
+
+    def read1(self, amount: int = -1) -> bytes: ...
+
+    def close(self) -> None: ...
+
+
+class _HttpConnection(Protocol):
+    sock: socket.socket | None
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        body: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None: ...
+
+    def getresponse(self) -> _HttpResponse: ...
+
+    def close(self) -> None: ...
+
+
+PublicHttpConnectionFactory = Callable[[PublicHttpDestination, float], _HttpConnection]
+
+
+def public_url_error(url: str) -> PublicUrlError | Literal[""]:
+    try:
+        parsed, hostname, _port = _parse_http_url(url)
+    except ValueError:
+        return "invalid_url"
+    if parsed.username is not None or parsed.password is not None:
+        return "invalid_url"
+    if _private_hostname(hostname):
+        return "private_url"
+    try:
+        address = ip_address(hostname)
+    except ValueError:
+        return ""
+    if not _is_public_address(address):
+        return "private_url"
+    return ""
+
+
+def resolve_public_http_destination(
+    url: str,
+    *,
+    resolver: AddressResolver | None = None,
+) -> PublicHttpDestination:
+    structural_error = public_url_error(url)
+    if structural_error:
+        raise PublicHttpDestinationError(
+            structural_error,
+            f"Public HTTP destination is not allowed: {structural_error}.",
+        )
+    parsed, hostname, port = _parse_http_url(url)
+    resolve = resolver or _system_address_resolver
+    try:
+        address_info = resolve(hostname, port)
+    except socket.gaierror as error:
+        raise PublicHttpDestinationError(
+            "dns_failure",
+            f"Public HTTP destination DNS resolution failed for {hostname}.",
+        ) from error
+    if not address_info:
+        raise PublicHttpDestinationError(
+            "dns_failure",
+            f"Public HTTP destination DNS resolution returned no addresses for {hostname}.",
+        )
+
+    resolved_addresses: list[ResolvedHttpAddress] = []
+    seen_addresses: set[tuple[int, int, int, SocketAddress]] = set()
+    for family, socket_type, protocol, _canonical_name, socket_address in address_info:
+        if family not in {socket.AF_INET, socket.AF_INET6}:
+            raise PublicHttpDestinationError(
+                "dns_failure",
+                f"Public HTTP destination resolved to unsupported address family {family}.",
+            )
+        if socket_type != socket.SOCK_STREAM:
+            raise PublicHttpDestinationError(
+                "dns_failure",
+                "Public HTTP destination resolved to an unsupported socket type.",
+            )
+        try:
+            resolved_ip = ip_address(socket_address[0].split("%", 1)[0])
+        except ValueError as error:
+            raise PublicHttpDestinationError(
+                "dns_failure",
+                "Public HTTP destination resolved to an invalid IP address.",
+            ) from error
+        if not _is_public_address(resolved_ip):
+            raise PublicHttpDestinationError(
+                "private_url",
+                (
+                    "Public HTTP destination DNS answers include a non-public address; "
+                    "mixed public/private answer sets are rejected."
+                ),
+            )
+        address_key = (family, socket_type, protocol, socket_address)
+        if address_key in seen_addresses:
+            continue
+        seen_addresses.add(address_key)
+        resolved_addresses.append(
+            ResolvedHttpAddress(
+                family=family,
+                socket_type=socket_type,
+                protocol=protocol,
+                socket_address=socket_address,
+                ip=resolved_ip,
+            )
+        )
+    if not resolved_addresses:
+        raise PublicHttpDestinationError(
+            "dns_failure",
+            f"Public HTTP destination DNS resolution returned no usable addresses for {hostname}.",
+        )
+
+    scheme = cast(Literal["http", "https"], parsed.scheme.lower())
+    path = parsed.path or "/"
+    return PublicHttpDestination(
+        url=urlunsplit((scheme, parsed.netloc, path, parsed.query, "")),
+        scheme=scheme,
+        hostname=hostname,
+        port=port,
+        request_target=urlunsplit(("", "", path, parsed.query, "")),
+        addresses=tuple(resolved_addresses),
+    )
+
+
+def request_public_http(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: Mapping[str, str] | None = None,
+    body: bytes | None = None,
+    timeout_seconds: float,
+    max_redirects: int = 10,
+    max_response_body_bytes: int = 256 * 1024,
+    resolver: AddressResolver | None = None,
+    connection_factory: PublicHttpConnectionFactory | None = None,
+) -> PublicHttpResponse:
+    if timeout_seconds <= 0:
+        raise ValueError("Public HTTP timeout must be positive.")
+    if max_redirects < 0:
+        raise ValueError("Public HTTP redirect limit must not be negative.")
+    if max_response_body_bytes < 0:
+        raise ValueError("Public HTTP response body limit must not be negative.")
+
+    deadline = monotonic() + timeout_seconds
+    current_url = url
+    current_method = method.strip().upper() or "GET"
+    current_body = body
+    current_headers = _safe_request_headers(headers or {})
+    redirect_count = 0
+    open_connection = connection_factory or _public_http_connection
+
+    while True:
+        destination = resolve_public_http_destination(current_url, resolver=resolver)
+        connection = open_connection(destination, _remaining_seconds(deadline))
+        response: _HttpResponse | None = None
+        try:
+            connection.request(
+                current_method,
+                destination.request_target,
+                body=current_body,
+                headers=current_headers,
+            )
+            response = connection.getresponse()
+            response_headers = tuple(response.getheaders())
+            location = response.getheader("Location", "") or ""
+            if response.status in {301, 302, 303, 307, 308} and location:
+                response_body = b""
+            else:
+                response_body = _read_response_body(
+                    response=response,
+                    connection=connection,
+                    deadline=deadline,
+                    max_response_body_bytes=max_response_body_bytes,
+                )
+                if len(response_body) > max_response_body_bytes:
+                    response_body = response_body[:max_response_body_bytes]
+            status_code = response.status
+        finally:
+            if response is not None:
+                response.close()
+            connection.close()
+
+        if status_code not in {301, 302, 303, 307, 308} or not location:
+            return PublicHttpResponse(
+                status_code=status_code,
+                final_url=destination.url,
+                redirect_count=redirect_count,
+                headers=response_headers,
+                body=response_body,
+            )
+        if redirect_count >= max_redirects:
+            raise RuntimeError(f"redirect loop after {max_redirects} redirects")
+
+        next_url = urljoin(destination.url, location)
+        try:
+            next_structural_destination = _parse_http_url(next_url)
+        except ValueError as error:
+            raise PublicHttpDestinationError(
+                "invalid_url",
+                "Public HTTP redirect destination is not a valid HTTP URL.",
+            ) from error
+        if _normalized_url(destination.url) == _normalized_url(next_url):
+            raise RuntimeError(f"self redirect from {destination.url}")
+        next_origin = (
+            next_structural_destination[0].scheme.lower(),
+            next_structural_destination[1],
+            next_structural_destination[2],
+        )
+        if destination.origin != next_origin:
+            current_headers = _without_sensitive_headers(current_headers)
+        if status_code == 303 or (
+            status_code in {301, 302} and current_method not in {"GET", "HEAD"}
+        ):
+            current_method = "GET"
+            current_body = None
+            current_headers = _without_entity_headers(current_headers)
+        current_url = next_url
+        redirect_count += 1
+
+
+def request_private_http(
+    url: str,
+    *,
+    method: str = "GET",
+    headers: Mapping[str, str] | None = None,
+    body: bytes | None = None,
+    timeout_seconds: float,
+    max_redirects: int = 10,
+    max_response_body_bytes: int = 256 * 1024,
+    connection_factory: PublicHttpConnectionFactory | None = None,
+) -> PublicHttpResponse:
+    if timeout_seconds <= 0:
+        raise ValueError("Private HTTP timeout must be positive.")
+    if max_redirects < 0:
+        raise ValueError("Private HTTP redirect limit must not be negative.")
+    if max_response_body_bytes < 0:
+        raise ValueError("Private HTTP response body limit must not be negative.")
+    deadline = monotonic() + timeout_seconds
+    open_connection = connection_factory or _private_http_connection
+    current_url = url
+    current_method = method.strip().upper() or "GET"
+    current_body = body
+    current_headers = _safe_request_headers(headers or {})
+    redirect_count = 0
+
+    while True:
+        parsed, hostname, port = _parse_http_url(current_url)
+        scheme = cast(Literal["http", "https"], parsed.scheme.lower())
+        path = parsed.path or "/"
+        destination = PublicHttpDestination(
+            url=urlunsplit((scheme, parsed.netloc, path, parsed.query, "")),
+            scheme=scheme,
+            hostname=hostname,
+            port=port,
+            request_target=urlunsplit(("", "", path, parsed.query, "")),
+            addresses=(),
+        )
+        connection = open_connection(destination, _remaining_seconds(deadline))
+        response: _HttpResponse | None = None
+        try:
+            connection.request(
+                current_method,
+                destination.request_target,
+                body=current_body,
+                headers=current_headers,
+            )
+            response = connection.getresponse()
+            response_headers = tuple(response.getheaders())
+            location = response.getheader("Location", "") or ""
+            if response.status in {301, 302, 303, 307, 308} and location:
+                response_body = b""
+            else:
+                response_body = _read_response_body(
+                    response=response,
+                    connection=connection,
+                    deadline=deadline,
+                    max_response_body_bytes=max_response_body_bytes,
+                )
+                if len(response_body) > max_response_body_bytes:
+                    response_body = response_body[:max_response_body_bytes]
+            status_code = response.status
+        finally:
+            if response is not None:
+                response.close()
+            connection.close()
+
+        if status_code not in {301, 302, 303, 307, 308} or not location:
+            return PublicHttpResponse(
+                status_code=status_code,
+                final_url=destination.url,
+                redirect_count=redirect_count,
+                headers=response_headers,
+                body=response_body,
+            )
+        if redirect_count >= max_redirects:
+            raise RuntimeError(f"redirect loop after {max_redirects} redirects")
+        next_url = urljoin(destination.url, location)
+        next_parsed, next_hostname, next_port = _parse_http_url(next_url)
+        if _normalized_url(destination.url) == _normalized_url(next_url):
+            raise RuntimeError(f"self redirect from {destination.url}")
+        next_origin = (next_parsed.scheme.lower(), next_hostname, next_port)
+        if destination.origin != next_origin:
+            current_headers = _without_sensitive_headers(current_headers)
+        if status_code == 303 or (
+            status_code in {301, 302} and current_method not in {"GET", "HEAD"}
+        ):
+            current_method = "GET"
+            current_body = None
+            current_headers = _without_entity_headers(current_headers)
+        current_url = next_url
+        redirect_count += 1
+
+
+def _read_response_body(
+    *,
+    response: _HttpResponse,
+    connection: _HttpConnection,
+    deadline: float,
+    max_response_body_bytes: int,
+) -> bytes:
+    body_parts: list[bytes] = []
+    remaining_bytes = max_response_body_bytes + 1
+    while remaining_bytes > 0:
+        _set_socket_timeout(connection, _remaining_seconds(deadline))
+        body_part = response.read1(min(64 * 1024, remaining_bytes))
+        if not body_part:
+            break
+        body_parts.append(body_part)
+        remaining_bytes -= len(body_part)
+    return b"".join(body_parts)
+
+
+def _parse_http_url(url: str) -> tuple[SplitResult, str, int]:
+    normalized_url = url.strip()
+    try:
+        parsed = urlsplit(normalized_url)
+        port = parsed.port
+    except ValueError as error:
+        raise ValueError("Invalid HTTP URL.") from error
+    scheme = parsed.scheme.lower()
+    hostname = (parsed.hostname or "").strip().rstrip(".").lower()
+    if scheme not in {"http", "https"} or not parsed.netloc or not hostname:
+        raise ValueError("Invalid HTTP URL.")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError("HTTP URLs with user information are not allowed.")
+    if "%" in hostname:
+        raise ValueError("Scoped hostnames are not allowed.")
+    return parsed, hostname, port if port is not None else (443 if scheme == "https" else 80)
+
+
+def _private_hostname(hostname: str) -> bool:
+    return hostname == "localhost" or hostname.endswith(
+        (".localhost", ".local", ".internal", ".invalid")
+    )
+
+
+def _is_public_address(address: IPv4Address | IPv6Address) -> bool:
+    if (
+        address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_reserved
+        or address.is_unspecified
+        or not address.is_global
+    ):
+        return False
+    if isinstance(address, IPv6Address):
+        if address.ipv4_mapped is not None and not _is_public_address(address.ipv4_mapped):
+            return False
+        if address.sixtofour is not None and not _is_public_address(address.sixtofour):
+            return False
+        if address.teredo is not None and any(
+            not _is_public_address(embedded_address) for embedded_address in address.teredo
+        ):
+            return False
+    return True
+
+
+def _system_address_resolver(hostname: str, port: int) -> tuple[ResolvedAddressInfo, ...]:
+    address_info = socket.getaddrinfo(
+        hostname,
+        port,
+        family=socket.AF_UNSPEC,
+        type=socket.SOCK_STREAM,
+    )
+    return tuple(cast(ResolvedAddressInfo, item) for item in address_info)
+
+
+class _ValidatedAddressConnector:
+    def __init__(self, addresses: tuple[ResolvedHttpAddress, ...]) -> None:
+        self.addresses = addresses
+
+    def __call__(
+        self,
+        _address: tuple[str, int],
+        timeout: object,
+        source_address: tuple[str, int] | None,
+    ) -> socket.socket:
+        timeout_seconds = float(timeout) if isinstance(timeout, int | float) else None
+        deadline = monotonic() + timeout_seconds if timeout_seconds is not None else None
+        last_error: OSError | None = None
+        for address in self.addresses:
+            connection_socket = socket.socket(
+                address.family,
+                address.socket_type,
+                address.protocol,
+            )
+            try:
+                if source_address is not None:
+                    connection_socket.bind(source_address)
+                if deadline is not None:
+                    connection_socket.settimeout(_remaining_seconds(deadline))
+                connection_socket.connect(address.socket_address)
+                return connection_socket
+            except OSError as error:
+                last_error = error
+                connection_socket.close()
+        if last_error is not None:
+            raise last_error
+        raise OSError("Public HTTP destination has no validated addresses.")
+
+
+def _public_http_connection(
+    destination: PublicHttpDestination,
+    timeout_seconds: float,
+) -> _HttpConnection:
+    if destination.scheme == "https":
+        connection: HTTPConnection = HTTPSConnection(
+            destination.hostname,
+            destination.port,
+            timeout=timeout_seconds,
+        )
+    else:
+        connection = HTTPConnection(
+            destination.hostname,
+            destination.port,
+            timeout=timeout_seconds,
+        )
+    setattr(connection, "_create_connection", _ValidatedAddressConnector(destination.addresses))
+    return cast(_HttpConnection, connection)
+
+
+def _private_http_connection(
+    destination: PublicHttpDestination,
+    timeout_seconds: float,
+) -> _HttpConnection:
+    connection_type = HTTPSConnection if destination.scheme == "https" else HTTPConnection
+    return cast(
+        _HttpConnection,
+        connection_type(destination.hostname, destination.port, timeout=timeout_seconds),
+    )
+
+
+def _remaining_seconds(deadline: float) -> float:
+    remaining = deadline - monotonic()
+    if remaining <= 0:
+        raise TimeoutError("HTTP request timed out.")
+    return remaining
+
+
+def _set_socket_timeout(connection: _HttpConnection, timeout_seconds: float) -> None:
+    if connection.sock is not None:
+        connection.sock.settimeout(timeout_seconds)
+
+
+def _safe_request_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in {"host", "content-length", "transfer-encoding"}
+    }
+
+
+def _without_sensitive_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in {"authorization", "cookie", "proxy-authorization"}
+    }
+
+
+def _without_entity_headers(headers: Mapping[str, str]) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in headers.items()
+        if key.lower() not in {"content-encoding", "content-language", "content-type"}
+    }
+
+
+def _normalized_url(url: str) -> str:
+    parsed, hostname, port = _parse_http_url(url)
+    path = parsed.path or "/"
+    return urlunsplit(
+        (
+            parsed.scheme.lower(),
+            f"{hostname}:{port}",
+            path.rstrip("/") or "/",
+            parsed.query,
+            "",
+        )
+    )

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -3,11 +3,10 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from email.message import EmailMessage
-from http.client import HTTPMessage
-from typing import IO, Protocol, cast
+from typing import Protocol, cast
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlsplit, urlunsplit
-from urllib.request import HTTPRedirectHandler, OpenerDirector, Request, build_opener, urlopen
+from urllib.request import Request, urlopen
 import json
 import os
 import smtplib
@@ -55,6 +54,9 @@ from control_plane.notifications import (
     public_discord_url_error,
     public_url_error,
 )
+from control_plane.outbound_http import PublicHttpDestinationError
+from control_plane.outbound_http import request_private_http
+from control_plane.outbound_http import request_public_http
 from control_plane.workflows.odoo_verification import (
     default_odoo_health_url,
     is_legacy_derived_odoo_health_url,
@@ -199,28 +201,6 @@ class PublicIngressMonitorResult(BaseModel):
 HttpGet = Callable[[str, int], HttpObservation]
 
 
-class _RedirectTrackingHandler(HTTPRedirectHandler):
-    def redirect_request(
-        self,
-        req: Request,
-        fp: IO[bytes],
-        code: int,
-        msg: str,
-        headers: HTTPMessage,
-        newurl: str,
-    ) -> Request | None:
-        old_url = req.full_url
-        if _normalized_url(old_url) == _normalized_url(newurl):
-            raise RuntimeError(f"self redirect from {old_url}")
-        request = super().redirect_request(req, fp, code, msg, headers, newurl)
-        if request is not None:
-            redirects = int(getattr(req, "redirect_count", 0)) + 1
-            setattr(request, "redirect_count", redirects)
-            if redirects > MAX_REDIRECTS:
-                raise RuntimeError(f"redirect loop after {MAX_REDIRECTS} redirects")
-        return request
-
-
 def discover_public_ingress_monitor_targets(
     record_store: PublicIngressMonitorStore,
 ) -> tuple[PublicIngressMonitorTarget, ...]:
@@ -355,10 +335,12 @@ def run_public_ingress_monitor_once(
     timeout_seconds: int = 10,
     notify: bool = True,
     http_get: HttpGet | None = None,
+    private_http_get: HttpGet | None = None,
     notification_drivers: PublicIngressNotificationDrivers | None = None,
 ) -> PublicIngressMonitorResult:
     observed_at = checked_at.strip() or utc_now_timestamp()
-    get = http_get or fetch_public_ingress_url
+    public_get = http_get or fetch_public_ingress_url
+    private_get = private_http_get or fetch_private_health_url
     records: list[PublicIngressObservationRecord] = []
     incidents: list[PublicIngressIncidentRecord] = []
     delivery_attempts: list[PublicIngressNotificationAttemptRecord] = []
@@ -370,7 +352,7 @@ def run_public_ingress_monitor_once(
             target=target,
             checked_at=observed_at,
             timeout_seconds=timeout_seconds,
-            http_get=get,
+            http_get=(private_get if target.check_kind == "private_http" else public_get),
         )
         record_store.write_public_ingress_observation_record(record)
         records.append(record)
@@ -628,23 +610,45 @@ def check_public_ingress_target(
 
 
 def fetch_public_ingress_url(url: str, timeout_seconds: int) -> HttpObservation:
-    opener: OpenerDirector = build_opener(_RedirectTrackingHandler)
-    request = Request(url, headers={"User-Agent": USER_AGENT}, method="GET")
-    with opener.open(request, timeout=timeout_seconds) as response:  # noqa: S310 - operator-configured product URLs.
-        body = response.read(1024 * 256)
-        payload: object = None
-        content_type = response.headers.get("content-type", "")
-        if body and "json" in content_type.lower():
-            try:
-                payload = json.loads(body.decode("utf-8"))
-            except (UnicodeDecodeError, json.JSONDecodeError):
-                payload = None
-        return HttpObservation(
-            status_code=response.status,
-            final_url=response.geturl(),
-            redirect_count=int(getattr(response, "redirect_count", 0)),
-            payload=payload,
-        )
+    response = request_public_http(
+        url,
+        headers={"User-Agent": USER_AGENT},
+        timeout_seconds=timeout_seconds,
+        max_redirects=MAX_REDIRECTS,
+    )
+    payload: object = None
+    if response.body and "json" in response.header("content-type").lower():
+        try:
+            payload = json.loads(response.body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+    return HttpObservation(
+        status_code=response.status_code,
+        final_url=response.final_url,
+        redirect_count=response.redirect_count,
+        payload=payload,
+    )
+
+
+def fetch_private_health_url(url: str, timeout_seconds: int) -> HttpObservation:
+    response = request_private_http(
+        url,
+        headers={"User-Agent": USER_AGENT},
+        timeout_seconds=timeout_seconds,
+        max_redirects=MAX_REDIRECTS,
+    )
+    payload: object = None
+    if response.body and "json" in response.header("content-type").lower():
+        try:
+            payload = json.loads(response.body.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            payload = None
+    return HttpObservation(
+        status_code=response.status_code,
+        final_url=response.final_url,
+        redirect_count=response.redirect_count,
+        payload=payload,
+    )
 
 
 def _check_url(
@@ -670,13 +674,10 @@ def _check_url(
     if target.check_kind != "private_http":
         public_url_error = _public_url_error(url)
     if public_url_error is not None:
-        status: PublicIngressObservationStatus = (
-            "skipped" if public_url_error == "private_url" else "fail"
-        )
         return PublicIngressTargetObservation(
             target=target_kind,
             url=url,
-            status=status,
+            status="fail",
             failure_code=public_url_error,
             summary=_failure_summary(public_url_error),
         )
@@ -698,6 +699,13 @@ def _check_url(
         )
     except TimeoutError:
         return _failed_target(target_kind=target_kind, url=url, code="connection_timeout")
+    except PublicHttpDestinationError as error:
+        return _failed_target(
+            target_kind=target_kind,
+            url=url,
+            code=error.code,
+            summary=str(error),
+        )
     except URLError as error:
         return _url_error_observation(target_kind=target_kind, url=url, error=error)
     except ssl.SSLError:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -334,6 +334,20 @@ names are compatibility names for the existing health-monitor observation
 family. Observations are sensor evidence; incident records are keyed by product,
 lane, and health-check name so public, private, and provider failures do not
 overwrite each other.
+
+`public_http` uses the centralized public outbound HTTP policy. Every initial
+destination and redirect hop is resolved independently; all IPv4 and IPv6
+answers must be globally routable, and any private, loopback, link-local,
+multicast, reserved, unspecified, unsupported-family, or mixed public/private
+answer set fails closed before a connection is opened. Launchplane connects to
+the validated socket address directly while retaining the original hostname for
+the HTTP `Host` header and TLS SNI/certificate validation, so the connect step
+does not perform a second DNS lookup. The monitor timeout is shared across
+connect, request, response read, and redirect hops; the operating-system
+resolver still owns its own DNS lookup timeout. `private_http` is intentionally
+separate: only a scoped active private-health endpoint record can select the
+explicit private client, and public checks never fall back to that path.
+
 Notification routing is a separate service-backed policy and delivery concern,
 not lane-owned text config. The initial notification destinations are GitHub
 issues, email, and Discord; each is selected by DB-backed policy and evidenced

--- a/docs/records.md
+++ b/docs/records.md
@@ -483,8 +483,10 @@ a configured transition notification.
 
 These records are the source for the product environment read model's
 `public_ingress` summary. A passing observation is verified evidence, a failing
-observation marks the lane stale/unhealthy, and a skipped private URL is treated
-as unsupported rather than silently healthy.
+observation marks the lane stale/unhealthy, and a public check whose literal or
+resolved destination is non-public records a failing `private_url` observation.
+The `skipped` status remains readable for historical records, but current public
+checks do not treat a private destination as unsupported or silently healthy.
 
 ## Public Ingress Incident Records
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -395,15 +395,20 @@ behavior can differ between request methods.
 
 `POST /v1/every-code/github-webhook` is the only unauthenticated write route.
 It trusts the request body through GitHub webhook HMAC verification instead of
-OIDC. The route requires `X-Hub-Signature-256`, `X-GitHub-Delivery`, and
-`X-GitHub-Event`, supports `issues.labeled` events for the `every-code` label,
-and accepts pull-request `closed` events to terminalize linked Every Code work
-requests. Other signed events, actions, or labels return `202` with
-`skipped: true`. Matching issue-label deliveries create or return the durable
-Every Code work request and include `deduped` plus the delivery id in the
-response. Matching pull-request close deliveries can close every linked request
-referenced by the PR, including still-queued requests that never stored a result
-PR URL. The route is native FastAPI.
+OIDC. Before buffering or HMAC processing, the ASGI boundary requires exactly
+one unsigned-decimal `Content-Length`, rejects transfer-encoded or missing-length
+requests, caps both declared and observed body bytes at 2 MiB, and rejects a
+declared/observed length mismatch. Contract failures return `400` or `413`
+without invoking the webhook handler. The route requires
+`X-Hub-Signature-256`, `X-GitHub-Delivery`, and `X-GitHub-Event`, supports
+`issues.labeled` events for the `every-code` label, and accepts pull-request
+`closed` events to terminalize linked Every Code work requests. Other signed
+events, actions, or labels return `202` with `skipped: true`. Matching
+issue-label deliveries create or return the durable Every Code work request and
+include `deduped` plus the delivery id in the response. Matching pull-request
+close deliveries can close every linked request referenced by the PR, including
+still-queued requests that never stored a result PR URL. The route is native
+FastAPI.
 
 The Every Code worker read, native claim, and status routes also accept a
 dedicated local-worker bearer token. Configure

--- a/tests/test_outbound_http.py
+++ b/tests/test_outbound_http.py
@@ -1,0 +1,379 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+import socket
+import unittest
+from unittest.mock import MagicMock, patch
+
+from control_plane import outbound_http
+from control_plane.outbound_http import (
+    AddressResolver,
+    PublicHttpDestination,
+    PublicHttpDestinationError,
+    PublicHttpResponse,
+    ResolvedAddressInfo,
+    request_private_http,
+    request_public_http,
+    resolve_public_http_destination,
+)
+from control_plane.notifications import post_discord_webhook
+
+
+_PUBLIC_IPV4 = "93.184.216.34"
+_PUBLIC_IPV6 = "2606:4700:4700::1111"
+
+
+def _address_info(ip: str, port: int) -> ResolvedAddressInfo:
+    if ":" in ip:
+        return socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port, 0, 0)
+    return socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", (ip, port)
+
+
+def _resolver_for(*ips: str) -> AddressResolver:
+    def resolve(_hostname: str, port: int) -> tuple[ResolvedAddressInfo, ...]:
+        return tuple(_address_info(ip, port) for ip in ips)
+
+    return resolve
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        *,
+        status: int,
+        headers: tuple[tuple[str, str], ...] = (),
+        body: bytes = b"",
+    ) -> None:
+        self.status = status
+        self.headers = headers
+        self.body = body
+        self.body_offset = 0
+        self.closed = False
+
+    def getheader(self, name: str, default: str | None = None) -> str | None:
+        normalized_name = name.lower()
+        return next(
+            (value for key, value in self.headers if key.lower() == normalized_name),
+            default,
+        )
+
+    def getheaders(self) -> list[tuple[str, str]]:
+        return list(self.headers)
+
+    def read(self, amount: int | None = None) -> bytes:
+        return self.body if amount is None else self.body[:amount]
+
+    def read1(self, amount: int = -1) -> bytes:
+        if self.body_offset >= len(self.body):
+            return b""
+        if amount < 0:
+            amount = len(self.body) - self.body_offset
+        body_part = self.body[self.body_offset : self.body_offset + amount]
+        self.body_offset += len(body_part)
+        return body_part
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeConnection:
+    sock: socket.socket | None = None
+
+    def __init__(
+        self,
+        response: _FakeResponse,
+        *,
+        request_error: BaseException | None = None,
+    ) -> None:
+        self.response = response
+        self.request_error = request_error
+        self.requests: list[tuple[str, str, bytes | None, dict[str, str]]] = []
+        self.closed = False
+
+    def request(
+        self,
+        method: str,
+        url: str,
+        body: bytes | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if self.request_error is not None:
+            raise self.request_error
+        self.requests.append((method, url, body, dict(headers or {})))
+
+    def getresponse(self) -> _FakeResponse:
+        return self.response
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class PublicOutboundHttpTests(unittest.TestCase):
+    def test_normal_public_request_uses_validated_destination(self) -> None:
+        connection = _FakeConnection(
+            _FakeResponse(
+                status=200,
+                headers=(("Content-Type", "application/json"),),
+                body=b'{"status":"ok"}',
+            )
+        )
+        destinations: list[PublicHttpDestination] = []
+
+        def connection_factory(
+            destination: PublicHttpDestination, _timeout: float
+        ) -> _FakeConnection:
+            destinations.append(destination)
+            return connection
+
+        response = request_public_http(
+            "https://public.example/health?full=1",
+            headers={"User-Agent": "test"},
+            timeout_seconds=5,
+            resolver=_resolver_for(_PUBLIC_IPV4),
+            connection_factory=connection_factory,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.body, b'{"status":"ok"}')
+        self.assertEqual(destinations[0].hostname, "public.example")
+        self.assertEqual(str(destinations[0].addresses[0].ip), _PUBLIC_IPV4)
+        self.assertEqual(
+            connection.requests,
+            [("GET", "/health?full=1", None, {"User-Agent": "test"})],
+        )
+
+    def test_mixed_public_private_dns_answers_fail_closed(self) -> None:
+        with self.assertRaises(PublicHttpDestinationError) as raised:
+            resolve_public_http_destination(
+                "https://mixed.example/health",
+                resolver=_resolver_for(_PUBLIC_IPV4, "10.0.0.5"),
+            )
+
+        self.assertEqual(raised.exception.code, "private_url")
+
+    def test_ipv6_public_answer_is_allowed_and_non_public_ranges_are_rejected(self) -> None:
+        destination = resolve_public_http_destination(
+            "https://ipv6.example/health",
+            resolver=_resolver_for(_PUBLIC_IPV6),
+        )
+        self.assertEqual(str(destination.addresses[0].ip), _PUBLIC_IPV6)
+
+        for address in ("::1", "fe80::1", "ff02::1", "2001:db8::1", "::"):
+            with self.subTest(address=address):
+                with self.assertRaises(PublicHttpDestinationError) as raised:
+                    resolve_public_http_destination(
+                        "https://ipv6.example/health",
+                        resolver=_resolver_for(address),
+                    )
+                self.assertEqual(raised.exception.code, "private_url")
+
+    def test_redirect_to_private_literal_is_rejected_before_second_connection(self) -> None:
+        connections: list[_FakeConnection] = []
+
+        def connection_factory(
+            _destination: PublicHttpDestination, _timeout: float
+        ) -> _FakeConnection:
+            connection = _FakeConnection(
+                _FakeResponse(
+                    status=302,
+                    headers=(("Location", "http://127.0.0.1/admin"),),
+                )
+            )
+            connections.append(connection)
+            return connection
+
+        with self.assertRaises(PublicHttpDestinationError) as raised:
+            request_public_http(
+                "https://public.example/health",
+                timeout_seconds=5,
+                resolver=_resolver_for(_PUBLIC_IPV4),
+                connection_factory=connection_factory,
+            )
+
+        self.assertEqual(raised.exception.code, "private_url")
+        self.assertEqual(len(connections), 1)
+
+    def test_public_redirect_revalidates_next_hop_and_reports_final_url(self) -> None:
+        resolved_hostnames: list[str] = []
+
+        def resolver(hostname: str, port: int) -> tuple[ResolvedAddressInfo, ...]:
+            resolved_hostnames.append(hostname)
+            return (_address_info(_PUBLIC_IPV4, port),)
+
+        def connection_factory(
+            destination: PublicHttpDestination, _timeout: float
+        ) -> _FakeConnection:
+            if destination.hostname == "public.example":
+                return _FakeConnection(
+                    _FakeResponse(
+                        status=302,
+                        headers=(("Location", "https://next.example/ready"),),
+                    )
+                )
+            return _FakeConnection(_FakeResponse(status=200, body=b"ready"))
+
+        response = request_public_http(
+            "https://public.example/health",
+            timeout_seconds=5,
+            resolver=resolver,
+            connection_factory=connection_factory,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.final_url, "https://next.example/ready")
+        self.assertEqual(response.redirect_count, 1)
+        self.assertEqual(resolved_hostnames, ["public.example", "next.example"])
+
+    def test_each_redirect_hostname_is_resolved_and_revalidated(self) -> None:
+        resolved_hostnames: list[str] = []
+
+        def resolver(hostname: str, port: int) -> tuple[ResolvedAddressInfo, ...]:
+            resolved_hostnames.append(hostname)
+            address = _PUBLIC_IPV4 if hostname == "public.example" else "10.0.0.5"
+            return (_address_info(address, port),)
+
+        def connection_factory(
+            _destination: PublicHttpDestination, _timeout: float
+        ) -> _FakeConnection:
+            return _FakeConnection(
+                _FakeResponse(
+                    status=302,
+                    headers=(("Location", "https://rebound.example/secret"),),
+                )
+            )
+
+        with self.assertRaises(PublicHttpDestinationError) as raised:
+            request_public_http(
+                "https://public.example/health",
+                timeout_seconds=5,
+                resolver=resolver,
+                connection_factory=connection_factory,
+            )
+
+        self.assertEqual(raised.exception.code, "private_url")
+        self.assertEqual(resolved_hostnames, ["public.example", "rebound.example"])
+
+    def test_dns_rebinding_cannot_replace_validated_address_at_connect(self) -> None:
+        destination = resolve_public_http_destination(
+            "http://public.example/health",
+            resolver=_resolver_for(_PUBLIC_IPV4),
+        )
+        connector = outbound_http._ValidatedAddressConnector(destination.addresses)
+        connection_socket = MagicMock(spec=socket.socket)
+
+        with (
+            patch("control_plane.outbound_http.socket.socket", return_value=connection_socket),
+            patch(
+                "control_plane.outbound_http.socket.getaddrinfo",
+                side_effect=AssertionError("connector must not re-resolve DNS"),
+            ),
+        ):
+            connected_socket = connector((destination.hostname, destination.port), 5.0, None)
+
+        self.assertIs(connected_socket, connection_socket)
+        connection_socket.connect.assert_called_once_with((_PUBLIC_IPV4, 80))
+
+    def test_request_timeout_is_propagated_and_connection_is_closed(self) -> None:
+        connection = _FakeConnection(
+            _FakeResponse(status=200),
+            request_error=TimeoutError("timed out"),
+        )
+
+        with self.assertRaises(TimeoutError):
+            request_public_http(
+                "https://public.example/health",
+                timeout_seconds=0.1,
+                resolver=_resolver_for(_PUBLIC_IPV4),
+                connection_factory=lambda _destination, _timeout: connection,
+            )
+
+        self.assertTrue(connection.closed)
+
+    def test_response_body_read_enforces_absolute_deadline(self) -> None:
+        connection = _FakeConnection(_FakeResponse(status=200, body=b"slow"))
+
+        with (
+            patch("control_plane.outbound_http.monotonic", side_effect=(0.0, 0.0, 0.9, 1.1)),
+            self.assertRaises(TimeoutError),
+        ):
+            request_public_http(
+                "https://public.example/health",
+                timeout_seconds=1,
+                resolver=_resolver_for(_PUBLIC_IPV4),
+                connection_factory=lambda _destination, _timeout: connection,
+            )
+
+        self.assertTrue(connection.closed)
+
+    def test_private_response_body_uses_same_absolute_deadline(self) -> None:
+        connection = _FakeConnection(_FakeResponse(status=200, body=b"slow"))
+
+        with (
+            patch("control_plane.outbound_http.monotonic", side_effect=(0.0, 0.0, 0.9, 1.1)),
+            self.assertRaises(TimeoutError),
+        ):
+            request_private_http(
+                "http://10.0.0.5/health",
+                timeout_seconds=1,
+                connection_factory=lambda _destination, _timeout: connection,
+            )
+
+        self.assertTrue(connection.closed)
+
+    def test_private_redirect_uses_bounded_client_for_each_hop(self) -> None:
+        requested_hosts: list[str] = []
+
+        def connection_factory(
+            destination: PublicHttpDestination, _timeout: float
+        ) -> _FakeConnection:
+            requested_hosts.append(destination.hostname)
+            if destination.hostname == "10.0.0.5":
+                return _FakeConnection(
+                    _FakeResponse(
+                        status=302,
+                        headers=(("Location", "http://10.0.0.6/ready"),),
+                    )
+                )
+            return _FakeConnection(_FakeResponse(status=200, body=b"ready"))
+
+        response = request_private_http(
+            "http://10.0.0.5/health",
+            timeout_seconds=5,
+            connection_factory=connection_factory,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.redirect_count, 1)
+        self.assertEqual(response.final_url, "http://10.0.0.6/ready")
+        self.assertEqual(requested_hosts, ["10.0.0.5", "10.0.0.6"])
+
+    def test_discord_webhook_uses_public_http_policy_client(self) -> None:
+        with patch(
+            "control_plane.notifications.request_public_http",
+            return_value=PublicHttpResponse(
+                status_code=204,
+                final_url="https://discord.com/api/webhooks/test/webhook",
+                redirect_count=0,
+                headers=(),
+                body=b"",
+            ),
+        ) as request:
+            post_discord_webhook(
+                "https://discord.com/api/webhooks/test/webhook",
+                {"content": "hello"},
+            )
+
+        request.assert_called_once()
+        self.assertEqual(request.call_args.kwargs["method"], "POST")
+        self.assertIn(b'"content": "hello"', request.call_args.kwargs["body"])
+
+    def test_discord_webhook_rejects_non_discord_destination_before_request(self) -> None:
+        with patch("control_plane.notifications.request_public_http") as request:
+            with self.assertRaises(ValueError):
+                post_discord_webhook("https://example.com/hook", {"content": "hello"})
+
+        request.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -38,6 +38,7 @@ from control_plane.workflows.public_ingress_monitor import (
     discover_public_ingress_monitor_targets,
     run_public_ingress_monitor_once,
 )
+from control_plane.outbound_http import PublicHttpDestinationError
 
 
 def _public_health_monitoring(
@@ -391,7 +392,7 @@ class PublicIngressMonitorTests(unittest.TestCase):
 
         self.assertEqual(discover_public_ingress_monitor_targets(store), ())
 
-    def test_private_url_records_skipped_observation_without_request(self) -> None:
+    def test_private_url_records_failed_observation_without_request(self) -> None:
         lane = ProductLaneProfile(
             instance="prod",
             context="example-site",
@@ -407,9 +408,41 @@ class PublicIngressMonitorTests(unittest.TestCase):
             http_get=lambda url, _timeout: _capture_request(requested_urls, url),
         )
 
-        self.assertEqual(result.skipped_count, 1)
+        self.assertEqual(result.fail_count, 1)
         self.assertEqual(requested_urls, [])
+        self.assertEqual(store.records[0].status, "fail")
         self.assertEqual(store.records[0].failure_code, "private_url")
+
+    def test_public_http_timeout_records_connection_timeout(self) -> None:
+        store = _Store((_profile(),))
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:05:30Z",
+            http_get=lambda _url, _timeout: (_ for _ in ()).throw(TimeoutError("timed out")),
+        )
+
+        self.assertEqual(result.fail_count, 1)
+        self.assertEqual(store.records[0].failure_code, "connection_timeout")
+
+    def test_public_http_destination_policy_failure_records_private_url(self) -> None:
+        store = _Store((_profile(),))
+
+        with patch(
+            "control_plane.workflows.public_ingress_monitor.request_public_http",
+            side_effect=PublicHttpDestinationError(
+                "private_url",
+                "redirect resolved to a private address",
+            ),
+        ):
+            result = run_public_ingress_monitor_once(
+                record_store=store,
+                checked_at="2026-05-29T12:05:45Z",
+            )
+
+        self.assertEqual(result.fail_count, 1)
+        self.assertEqual(store.records[0].failure_code, "private_url")
+        self.assertIn("private address", store.records[0].targets[0].summary)
 
     def test_private_http_check_requests_private_health_endpoint_url(self) -> None:
         lane = ProductLaneProfile(
@@ -429,10 +462,14 @@ class PublicIngressMonitorTests(unittest.TestCase):
         _add_private_endpoint(store)
         requested_urls: list[str] = []
 
+        def reject_public_client(_url: str, _timeout: int) -> HttpObservation:
+            raise AssertionError("private health checks must not use the public HTTP client")
+
         result = run_public_ingress_monitor_once(
             record_store=store,
             checked_at="2026-05-29T12:06:00Z",
-            http_get=lambda url, _timeout: _capture_request(requested_urls, url),
+            http_get=reject_public_client,
+            private_http_get=lambda url, _timeout: _capture_request(requested_urls, url),
         )
 
         self.assertEqual(result.pass_count, 1)
@@ -462,7 +499,7 @@ class PublicIngressMonitorTests(unittest.TestCase):
         result = run_public_ingress_monitor_once(
             record_store=store,
             checked_at="2026-05-29T12:06:30Z",
-            http_get=lambda url, _timeout: _capture_request(requested_urls, url),
+            private_http_get=lambda url, _timeout: _capture_request(requested_urls, url),
         )
 
         self.assertEqual(result.pass_count, 1)
@@ -654,14 +691,18 @@ class PublicIngressMonitorTests(unittest.TestCase):
         store = _Store((_profile(lane=lane),))
         _add_private_endpoint(store)
 
-        result = run_public_ingress_monitor_once(
-            record_store=store,
-            checked_at="2026-05-29T12:08:00Z",
-            http_get=lambda url, _timeout: HttpObservation(
+        def failing_get(url: str, _timeout: int) -> HttpObservation:
+            return HttpObservation(
                 status_code=503,
                 final_url=url,
                 redirect_count=0,
-            ),
+            )
+
+        result = run_public_ingress_monitor_once(
+            record_store=store,
+            checked_at="2026-05-29T12:08:00Z",
+            http_get=failing_get,
+            private_http_get=failing_get,
         )
 
         self.assertEqual(result.fail_count, 2)
@@ -1153,6 +1194,11 @@ class PublicIngressMonitorTests(unittest.TestCase):
             http_get=lambda _url, _timeout: HttpObservation(
                 status_code=503,
                 final_url="https://example.test",
+                redirect_count=0,
+            ),
+            private_http_get=lambda _url, _timeout: HttpObservation(
+                status_code=503,
+                final_url="http://10.0.0.5:8080/health",
                 redirect_count=0,
             ),
             notification_drivers=drivers,

--- a/tests/test_webhook_body_guard.py
+++ b/tests/test_webhook_body_guard.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+import json
+import unittest
+
+from starlette.types import Message, Receive, Scope, Send
+
+from control_plane.http_app import BoundedRequestBodyMiddleware
+
+
+_WEBHOOK_PATH = "/v1/every-code/github-webhook"
+_WEBHOOK_BODY_LIMIT = 2 * 1024 * 1024
+
+
+class WebhookBodyGuardTests(unittest.IsolatedAsyncioTestCase):
+    async def test_exact_declared_chunked_asgi_body_reaches_downstream(self) -> None:
+        guarded_bodies: list[bytes] = []
+        response = await _invoke_guarded_webhook(
+            headers=[("Content-Length", "4")],
+            chunks=(b"ab", b"cd"),
+            guarded_bodies=guarded_bodies,
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(guarded_bodies, [b"abcd"])
+
+    async def test_transfer_encoding_chunked_is_rejected_before_downstream(self) -> None:
+        guarded_bodies: list[bytes] = []
+        response = await _invoke_guarded_webhook(
+            headers=[("Transfer-Encoding", "chunked")],
+            chunks=(b"{}",),
+            guarded_bodies=guarded_bodies,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        self.assertEqual(response.json()["error"]["code"], "request_entity_too_large")
+        self.assertEqual(guarded_bodies, [])
+
+    async def test_forged_content_length_is_rejected_before_downstream(self) -> None:
+        guarded_bodies: list[bytes] = []
+        response = await _invoke_guarded_webhook(
+            headers=[("Content-Length", "1")],
+            chunks=(b"{}",),
+            guarded_bodies=guarded_bodies,
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        self.assertIn("Content-Length does not match", response.json()["error"]["message"])
+        self.assertEqual(guarded_bodies, [])
+
+    async def test_declared_body_over_limit_is_rejected_without_reading_body(self) -> None:
+        guarded_bodies: list[bytes] = []
+        response = await _invoke_guarded_webhook(
+            headers=[("Content-Length", str(_WEBHOOK_BODY_LIMIT + 1))],
+            chunks=(b"",),
+            guarded_bodies=guarded_bodies,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        self.assertEqual(response.receive_count, 0)
+        self.assertEqual(guarded_bodies, [])
+
+    async def test_extremely_large_declared_length_fails_without_integer_conversion(self) -> None:
+        guarded_bodies: list[bytes] = []
+        response = await _invoke_guarded_webhook(
+            headers=[("Content-Length", "9" * 5000)],
+            chunks=(b"",),
+            guarded_bodies=guarded_bodies,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        self.assertEqual(response.receive_count, 0)
+        self.assertEqual(guarded_bodies, [])
+
+    async def test_observed_body_over_limit_is_rejected_while_streaming(self) -> None:
+        guarded_bodies: list[bytes] = []
+        response = await _invoke_guarded_webhook(
+            headers=[("Content-Length", str(_WEBHOOK_BODY_LIMIT))],
+            chunks=(b"a" * _WEBHOOK_BODY_LIMIT, b"b"),
+            guarded_bodies=guarded_bodies,
+        )
+
+        self.assertEqual(response.status_code, 413)
+        self.assertEqual(response.receive_count, 2)
+        self.assertEqual(guarded_bodies, [])
+
+    async def test_client_disconnect_returns_without_sending_response(self) -> None:
+        guarded_bodies: list[bytes] = []
+        sent: list[Message] = []
+        messages: list[Message] = [
+            {"type": "http.request", "body": b"{}", "more_body": True},
+            {"type": "http.disconnect"},
+        ]
+        app = BoundedRequestBodyMiddleware(_body_capturing_app(guarded_bodies))
+        scope = _webhook_scope(headers=[("Content-Length", "4")])
+
+        async def receive() -> Message:
+            return messages.pop(0)
+
+        async def send(message: Message) -> None:
+            sent.append(message)
+
+        await app(scope, receive, send)
+
+        self.assertEqual(sent, [])
+        self.assertEqual(guarded_bodies, [])
+
+
+class _GuardResponse:
+    def __init__(self, status_code: int, body: bytes, receive_count: int) -> None:
+        self.status_code = status_code
+        self.body = body
+        self.receive_count = receive_count
+
+    def json(self) -> dict[str, Any]:
+        payload = json.loads(self.body.decode("utf-8"))
+        assert isinstance(payload, dict)
+        return payload
+
+
+async def _invoke_guarded_webhook(
+    *,
+    headers: list[tuple[str, str]],
+    chunks: tuple[bytes, ...],
+    guarded_bodies: list[bytes],
+) -> _GuardResponse:
+    downstream = _body_capturing_app(guarded_bodies)
+    app = BoundedRequestBodyMiddleware(downstream)
+    scope = _webhook_scope(headers=headers)
+    messages: list[Message] = [
+        {
+            "type": "http.request",
+            "body": chunk,
+            "more_body": index < len(chunks) - 1,
+        }
+        for index, chunk in enumerate(chunks)
+    ]
+    sent: list[Message] = []
+    receive_count = 0
+
+    async def receive() -> Message:
+        nonlocal receive_count
+        receive_count += 1
+        if messages:
+            return messages.pop(0)
+        return {"type": "http.disconnect"}
+
+    async def send(message: Message) -> None:
+        sent.append(message)
+
+    await app(scope, receive, send)
+    start = next(message for message in sent if message["type"] == "http.response.start")
+    body = b"".join(
+        message.get("body", b"") for message in sent if message["type"] == "http.response.body"
+    )
+    return _GuardResponse(start["status"], body, receive_count)
+
+
+def _webhook_scope(*, headers: list[tuple[str, str]]) -> Scope:
+    return {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.3"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "https",
+        "path": _WEBHOOK_PATH,
+        "raw_path": _WEBHOOK_PATH.encode("ascii"),
+        "query_string": b"",
+        "headers": [
+            (name.lower().encode("ascii"), value.encode("latin-1")) for name, value in headers
+        ],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 443),
+    }
+
+
+def _body_capturing_app(
+    guarded_bodies: list[bytes],
+) -> Callable[[Scope, Receive, Send], Awaitable[None]]:
+    async def app(_scope: Scope, receive: Receive, send: Send) -> None:
+        body_parts: list[bytes] = []
+        while True:
+            message = await receive()
+            if message["type"] != "http.request":
+                break
+            body_parts.append(message.get("body", b""))
+            if not message.get("more_body", False):
+                break
+        guarded_bodies.append(b"".join(body_parts))
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    return app
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- enforce a 2 MiB pre-HMAC body limit with exact Content-Length checks on GitHub webhook ingress
- centralize public HTTP egress with per-hop DNS validation, literal-IP connection pinning, IPv4/IPv6 private-range rejection, TLS hostname preservation, redirect revalidation, bounded bodies, and absolute deadlines
- keep intentional private health checks on an explicit separate client while applying the same bounded absolute-deadline reads
- route Discord/public-ingress traffic through the hardened client and document the trust boundary

## Validation
- `uv run python -m unittest tests.test_outbound_http tests.test_webhook_body_guard tests.test_public_ingress_monitor` (51 tests)
- changed-file Ruff and mypy
- independent security reviews covering ASGI disconnects, DNS rebinding, TLS/SNI, redirect semantics, and trickle-response deadlines
- full 1,870-target local gate passed before final focused review; final blocker fixes revalidated by targeted tests

Closes #1682