### PR TITLE
Redact child-process failures at shared boundaries

### DIFF
--- a/control_plane/child_process_errors.py
+++ b/control_plane/child_process_errors.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import logging
+import re
+import subprocess
+from typing import Literal
+
+
+_MAX_SAFE_DETAIL_LENGTH = 240
+_MAX_SAFE_DIAGNOSTIC_LENGTH = 160
+_MAX_SAFE_OPERATION_LENGTH = 96
+_LOGGER = logging.getLogger(__name__)
+_URL_PATTERN = re.compile(r"(?i)\b(?:https?|ssh)://[^\s<>\"'`]+")
+_SECRET_ASSIGNMENT_PATTERN = re.compile(
+    r"""(?ix)
+    \b
+    (?P<name>
+        [a-z0-9_.-]*
+        (?:token|secret|password|passwd|api[_-]?key|credential|private[_-]?key|database[_-]?url)
+        [a-z0-9_.-]*
+    )
+    \s*[:=]\s*
+    (?P<value>\"[^\"\n]*\"|'[^'\n]*'|[^\s,;]+)
+    """
+)
+_SECRET_OPTION_PATTERN = re.compile(
+    r"""(?ix)
+    (?P<option>--(?:token|secret|password|passwd|api[-_]key|credential|private[-_]key))
+    \s+
+    (?P<value>\"[^\"\n]*\"|'[^'\n]*'|\S+)
+    """
+)
+_AUTHORIZATION_HEADER_PATTERN = re.compile(
+    r"(?i)\b(?P<name>(?:proxy-)?authorization)\s*:\s*"
+    r"(?:(?P<scheme>bearer|basic)\s+)?[^\r\n]*"
+)
+_COOKIE_HEADER_PATTERN = re.compile(r"(?i)\b(?P<name>set-cookie|cookie)\s*:[^\r\n]*")
+_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{4,}")
+_GITHUB_TOKEN_PATTERN = re.compile(r"(?i)\b(?:gh[pousr]_[a-z0-9_]+|github_pat_[a-z0-9_]+)\b")
+_LONG_SECRET_PATTERN = re.compile(r"(?<![a-zA-Z0-9])[a-zA-Z0-9.~+/-]{32,}(?![a-zA-Z0-9])")
+_PATH_PATTERN = re.compile(r"(?<![\w.-])(?:~|/)(?:[^\s,;:=<>\"']+/)+[^\s,;:=<>\"']+")
+_INTERNAL_HOST_PATTERN = re.compile(
+    r"""(?ix)
+    (?<![a-z0-9_.-])
+    (?:
+        localhost|
+        host\.docker\.internal|
+        0\.0\.0\.0|
+        127(?:\.\d{1,3}){3}|
+        10(?:\.\d{1,3}){3}|
+        192\.168(?:\.\d{1,3}){2}|
+        172\.(?:1[6-9]|2[0-9]|3[0-1])(?:\.\d{1,3}){2}|
+        [a-z0-9][a-z0-9.-]*\.(?:internal|local|lan|home|corp)
+    )
+    (?::\d{1,5})?
+    (?![a-z0-9_.-])
+    """
+)
+
+
+ProcessTool = Literal["child_process", "github_cli"]
+
+
+@dataclass(frozen=True)
+class ChildProcessFailure:
+    code: str
+    detail: str
+    correlation_id: str
+    exit_code: int | None
+
+    def operator_message(self) -> str:
+        return f"{self.detail} [error_code={self.code} correlation_id={self.correlation_id}]"
+
+
+def redact_untrusted_text(
+    value: str,
+    *,
+    fallback: str,
+    maximum_length: int = _MAX_SAFE_DETAIL_LENGTH,
+) -> str:
+    """Return bounded text safe for records, API responses, and operator output."""
+
+    if maximum_length < 4:
+        raise ValueError("maximum_length must be at least 4")
+    text = _redact_text(value)
+    if not text:
+        text = _redact_text(fallback)
+    return _bound_text(text, maximum_length)
+
+
+def normalize_child_process_failure(
+    *,
+    operation: str,
+    tool: ProcessTool,
+    returncode: int | None = None,
+    stdout: str = "",
+    stderr: str = "",
+    exception: OSError | subprocess.CalledProcessError | None = None,
+) -> ChildProcessFailure:
+    """Normalize subprocess failure output without retaining raw child-process text."""
+
+    resolved_returncode = returncode
+    resolved_stdout = stdout
+    resolved_stderr = stderr
+    if isinstance(exception, subprocess.CalledProcessError):
+        if resolved_returncode is None:
+            resolved_returncode = exception.returncode
+        if not resolved_stdout:
+            resolved_stdout = _string_value(exception.stdout)
+        if not resolved_stderr:
+            resolved_stderr = _string_value(exception.stderr)
+
+    if isinstance(exception, FileNotFoundError):
+        code = f"{tool}_unavailable"
+        outcome = "is unavailable"
+    elif isinstance(exception, OSError):
+        code = f"{tool}_start_failed"
+        outcome = "could not start"
+    else:
+        code = f"{tool}_failed"
+        outcome = "failed"
+        if resolved_returncode is not None:
+            outcome = f"{outcome} with exit status {resolved_returncode}"
+
+    safe_operation = redact_untrusted_text(
+        operation,
+        fallback="Child-process operation",
+        maximum_length=_MAX_SAFE_OPERATION_LENGTH,
+    )
+    raw_diagnostic = resolved_stderr or resolved_stdout
+    if not raw_diagnostic and exception is not None:
+        raw_diagnostic = str(exception)
+    safe_diagnostic = redact_untrusted_text(
+        raw_diagnostic,
+        fallback="",
+        maximum_length=_MAX_SAFE_DIAGNOSTIC_LENGTH,
+    )
+    detail = f"{safe_operation} {outcome}"
+    if safe_diagnostic:
+        detail = f"{detail}: {safe_diagnostic}"
+    else:
+        detail = f"{detail}."
+    detail = redact_untrusted_text(
+        detail,
+        fallback="Child-process operation failed.",
+        maximum_length=_MAX_SAFE_DETAIL_LENGTH,
+    )
+    correlation_source = "\x1f".join((code, detail, str(resolved_returncode)))
+    correlation_id = f"cpf-{hashlib.sha256(correlation_source.encode()).hexdigest()[:16]}"
+    failure = ChildProcessFailure(
+        code=code,
+        detail=detail,
+        correlation_id=correlation_id,
+        exit_code=resolved_returncode,
+    )
+    _LOGGER.info(
+        "Normalized child-process failure: error_code=%s correlation_id=%s exit_code=%s",
+        failure.code,
+        failure.correlation_id,
+        failure.exit_code,
+    )
+    return failure
+
+
+def _redact_text(value: str) -> str:
+    text = _AUTHORIZATION_HEADER_PATTERN.sub(
+        lambda match: (
+            f"{match.group('name')}: {match.group('scheme').title()} [redacted]"
+            if match.group("scheme")
+            else f"{match.group('name')}: [redacted]"
+        ),
+        value.strip(),
+    )
+    text = _COOKIE_HEADER_PATTERN.sub(
+        lambda match: f"{match.group('name')}: [redacted]",
+        text,
+    )
+    text = " ".join(text.split())
+    if not text:
+        return ""
+    text = _URL_PATTERN.sub("[redacted-url]", text)
+    text = _SECRET_ASSIGNMENT_PATTERN.sub(
+        lambda match: f"{match.group('name')}=[redacted]",
+        text,
+    )
+    text = _SECRET_OPTION_PATTERN.sub(lambda match: f"{match.group('option')} [redacted]", text)
+    text = _BEARER_PATTERN.sub("Bearer [redacted]", text)
+    text = _GITHUB_TOKEN_PATTERN.sub("[redacted-token]", text)
+    text = _PATH_PATTERN.sub("[redacted-path]", text)
+    text = _INTERNAL_HOST_PATTERN.sub("[redacted-host]", text)
+    return _LONG_SECRET_PATTERN.sub("[redacted-secret]", text)
+
+
+def _bound_text(value: str, maximum_length: int) -> str:
+    if len(value) <= maximum_length:
+        return value
+    return value[: maximum_length - 3].rstrip() + "..."
+
+
+def _string_value(value: object | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/control_plane/cli_every_code.py
+++ b/control_plane/cli_every_code.py
@@ -9,6 +9,7 @@ import click
 
 from control_plane import every_code_reconciliation as control_plane_every_code_reconciliation
 from control_plane import every_code_webhooks as control_plane_every_code_webhooks
+from control_plane.child_process_errors import normalize_child_process_failure
 from control_plane.every_code_reconciliation import (
     EveryCodeReconciliationStore,
     EveryCodeRerunStore,
@@ -108,9 +109,13 @@ def _gh_current_user_login() -> str:
             capture_output=True,
             check=True,
         )
-    except subprocess.CalledProcessError as error:
-        detail = (error.stderr or error.stdout or str(error)).strip()
-        raise click.ClickException(detail) from error
+    except (OSError, subprocess.CalledProcessError) as error:
+        failure = normalize_child_process_failure(
+            operation="Determine current GitHub user",
+            tool="github_cli",
+            exception=error,
+        )
+        raise click.ClickException(failure.operator_message()) from error
     login = result.stdout.strip()
     if not login:
         raise click.ClickException("Could not determine GitHub user login from gh.")
@@ -869,7 +874,7 @@ def every_code_sync_webhooks(
             webhook_url=resolved_webhook_url,
             topic=topic,
         )
-    except (ValueError, subprocess.CalledProcessError) as error:
+    except (ValueError, control_plane_every_code_webhooks.EveryCodeWebhookSyncError) as error:
         raise click.ClickException(str(error)) from error
     failed = [result for result in results if result.status == "error"]
     click.echo(

--- a/control_plane/contracts/data_provenance.py
+++ b/control_plane/contracts/data_provenance.py
@@ -1,24 +1,16 @@
 from __future__ import annotations
 
-import re
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict
+
+from control_plane.child_process_errors import redact_untrusted_text
 
 
 FreshnessStatus = Literal["verified", "recorded", "stale", "missing", "unsupported"]
 SourceKind = Literal["record", "provider", "descriptor", "unsupported"]
 AgentContextSensitivity = Literal["public", "internal", "restricted"]
 AgentContextEvidenceState = FreshnessStatus
-
-_MAX_AGENT_CONTEXT_TEXT_LENGTH = 240
-_PATH_PATTERN = re.compile(r"(?<!\w)(?:/[^\s,;:=]+){2,}")
-_TOKEN_ASSIGNMENT_PATTERN = re.compile(
-    r"(?i)\b([a-z0-9_.-]*(?:token|secret|password|passwd|api[_-]?key|bearer)[a-z0-9_.-]*)"
-    r"\s*[:=]\s*([^\s,;]+)"
-)
-_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{8,}")
-_LONG_SECRET_PATTERN = re.compile(r"(?<![a-zA-Z0-9])[a-zA-Z0-9._~+/=-]{32,}(?![a-zA-Z0-9])")
 
 
 class DataProvenance(BaseModel):
@@ -61,16 +53,7 @@ class AgentContextProvenance(BaseModel):
 def safe_agent_context_text(value: str, *, fallback: str) -> str:
     """Return bounded text suitable for agent-facing context payloads."""
 
-    text = " ".join(value.strip().split())
-    if not text:
-        return fallback
-    text = _PATH_PATTERN.sub("[redacted-path]", text)
-    text = _TOKEN_ASSIGNMENT_PATTERN.sub(lambda match: f"{match.group(1)}=[redacted]", text)
-    text = _BEARER_PATTERN.sub("Bearer [redacted]", text)
-    text = _LONG_SECRET_PATTERN.sub("[redacted-secret]", text)
-    if len(text) > _MAX_AGENT_CONTEXT_TEXT_LENGTH:
-        text = text[: _MAX_AGENT_CONTEXT_TEXT_LENGTH - 1].rstrip() + "..."
-    return text or fallback
+    return redact_untrusted_text(value, fallback=fallback)
 
 
 def agent_safe_host_label(value: str) -> str:

--- a/control_plane/every_code_webhooks.py
+++ b/control_plane/every_code_webhooks.py
@@ -5,6 +5,8 @@ import json
 import subprocess
 from typing import Callable, Sequence
 
+from control_plane.child_process_errors import ChildProcessFailure, normalize_child_process_failure
+
 
 EVERY_CODE_WEBHOOK_EVENTS = (
     "issues",
@@ -65,6 +67,8 @@ class EveryCodeWebhookSyncResult:
     hook_id: int = 0
     events: tuple[str, ...] = EVERY_CODE_WEBHOOK_EVENTS
     error: str = ""
+    error_code: str = ""
+    error_correlation_id: str = ""
     labels_synced: int = 0
 
     def as_payload(self) -> dict[str, object]:
@@ -78,7 +82,17 @@ class EveryCodeWebhookSyncResult:
             payload["hook_id"] = self.hook_id
         if self.error:
             payload["error"] = self.error
+        if self.error_code:
+            payload["error_code"] = self.error_code
+        if self.error_correlation_id:
+            payload["error_correlation_id"] = self.error_correlation_id
         return payload
+
+
+class EveryCodeWebhookSyncError(RuntimeError):
+    def __init__(self, failure: ChildProcessFailure) -> None:
+        super().__init__(failure.operator_message())
+        self.failure = failure
 
 
 def sync_every_code_webhooks(
@@ -99,7 +113,16 @@ def sync_every_code_webhooks(
     if not webhook_url.strip():
         raise ValueError("Every Code webhook sync requires webhook_url")
     run = runner or _run_gh
-    repos = _topic_repositories(owner=normalized_owner, topic=topic, runner=run)
+    try:
+        repos = _topic_repositories(owner=normalized_owner, topic=topic, runner=run)
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise EveryCodeWebhookSyncError(
+            normalize_child_process_failure(
+                operation="List Every Code webhook repositories",
+                tool="github_cli",
+                exception=error,
+            )
+        ) from error
     results: list[EveryCodeWebhookSyncResult] = []
     for repo in repos:
         try:
@@ -112,9 +135,21 @@ def sync_every_code_webhooks(
                     runner=run,
                 )
             )
-        except subprocess.CalledProcessError as error:
-            detail = (error.stderr or error.stdout or str(error)).strip()
-            results.append(EveryCodeWebhookSyncResult(repo=repo, status="error", error=detail))
+        except (OSError, subprocess.CalledProcessError) as error:
+            failure = normalize_child_process_failure(
+                operation="Sync Every Code webhook",
+                tool="github_cli",
+                exception=error,
+            )
+            results.append(
+                EveryCodeWebhookSyncResult(
+                    repo=repo,
+                    status="error",
+                    error=failure.detail,
+                    error_code=failure.code,
+                    error_correlation_id=failure.correlation_id,
+                )
+            )
     return tuple(results)
 
 

--- a/control_plane/every_code_worker.py
+++ b/control_plane/every_code_worker.py
@@ -16,6 +16,11 @@ from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
+from control_plane.child_process_errors import (
+    ChildProcessFailure,
+    normalize_child_process_failure,
+    redact_untrusted_text,
+)
 from control_plane.contracts.every_code_pr_feedback_record import (
     EveryCodePrFeedbackRecord,
     EveryCodePrFeedbackStatus,
@@ -105,9 +110,7 @@ class EveryCodeWorkerStore(Protocol):
     ) -> tuple[LaunchplaneProductProfileRecord, ...]: ...
 
 
-Runner = Callable[
-    [Sequence[str], Mapping[str, str] | None], subprocess.CompletedProcess[str]
-]
+Runner = Callable[[Sequence[str], Mapping[str, str] | None], subprocess.CompletedProcess[str]]
 EVERY_CODE_GITHUB_TOKEN_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN"
 EVERY_CODE_GITHUB_ACTOR_ENV_KEY = "LAUNCHPLANE_EVERY_CODE_GITHUB_ACTOR"
 
@@ -121,6 +124,12 @@ ProcessLauncher = Callable[[Sequence[str], Path, Path], DaemonProcess]
 
 class EveryCodeWorkerApiError(RuntimeError):
     pass
+
+
+class EveryCodeWorkerChildProcessError(RuntimeError):
+    def __init__(self, failure: ChildProcessFailure) -> None:
+        super().__init__(failure.operator_message())
+        self.failure = failure
 
 
 def _try_every_code_worker_maintenance(
@@ -379,6 +388,8 @@ class EveryCodeWorkerHandoffResult:
     checkout_root: str = ""
     worktree_root: str = ""
     worktree_branch: str = ""
+    error_code: str = ""
+    error_correlation_id: str = ""
 
     def with_detail_suffix(self, suffix: str) -> EveryCodeWorkerHandoffResult:
         normalized_suffix = suffix.strip()
@@ -394,10 +405,12 @@ class EveryCodeWorkerHandoffResult:
             checkout_root=self.checkout_root,
             worktree_root=self.worktree_root,
             worktree_branch=self.worktree_branch,
+            error_code=self.error_code,
+            error_correlation_id=self.error_correlation_id,
         )
 
     def as_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "status": self.status,
             "detail": self.detail,
             "request_id": self.request_id,
@@ -408,6 +421,11 @@ class EveryCodeWorkerHandoffResult:
             "worktree_root": self.worktree_root,
             "worktree_branch": self.worktree_branch,
         }
+        if self.error_code:
+            payload["error_code"] = self.error_code
+        if self.error_correlation_id:
+            payload["error_correlation_id"] = self.error_correlation_id
+        return payload
 
 
 @dataclass(frozen=True)
@@ -511,15 +529,22 @@ class EveryCodePrFeedbackApplyResult:
     feedback_id: str = ""
     request_id: str = ""
     session_name: str = ""
+    error_code: str = ""
+    error_correlation_id: str = ""
 
     def as_payload(self) -> dict[str, object]:
-        return {
+        payload: dict[str, object] = {
             "status": self.status,
             "detail": self.detail,
             "feedback_id": self.feedback_id,
             "request_id": self.request_id,
             "session_name": self.session_name,
         }
+        if self.error_code:
+            payload["error_code"] = self.error_code
+        if self.error_correlation_id:
+            payload["error_correlation_id"] = self.error_correlation_id
+        return payload
 
 
 @dataclass(frozen=True)
@@ -725,16 +750,18 @@ def _post_every_code_claim_comment(
     runner: Runner,
     github_token_env: str = EVERY_CODE_GITHUB_TOKEN_ENV_KEY,
     github_actor_env: str = EVERY_CODE_GITHUB_ACTOR_ENV_KEY,
-) -> str:
+) -> ChildProcessFailure | None:
     repository = record.repository.strip()
     if not repository or record.issue_number <= 0:
-        return ""
+        return None
     try:
         github_env = _every_code_github_env(
             github_token_env=github_token_env,
             github_actor_env=github_actor_env,
             runner=runner,
         )
+    except EveryCodeWorkerChildProcessError as error:
+        return error.failure
     except RuntimeError as exc:
         raise RuntimeError(f"Could not verify GitHub claim-comment actor: {exc}") from exc
     body = every_code_claim_comment_body(
@@ -757,11 +784,20 @@ def _post_every_code_claim_comment(
             github_env,
         )
     except OSError as exc:
-        return f"Could not post GitHub working comment: {exc}"
+        return normalize_child_process_failure(
+            operation="Could not post GitHub working comment",
+            tool="github_cli",
+            exception=exc,
+        )
     if result.returncode != 0:
-        detail = result.stderr.strip() or result.stdout.strip() or "gh issue comment failed"
-        return f"Could not post GitHub working comment: {detail}"
-    return ""
+        return normalize_child_process_failure(
+            operation="Could not post GitHub working comment",
+            tool="github_cli",
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    return None
 
 
 def _every_code_github_env(
@@ -779,24 +815,34 @@ def _every_code_github_env(
     github_env = {"GH_TOKEN": github_token, "GITHUB_TOKEN": github_token}
     expected_actor_env_key = github_actor_env.strip()
     expected_actor = (
-        os.environ.get(expected_actor_env_key, "").strip()
-        if expected_actor_env_key
-        else ""
+        os.environ.get(expected_actor_env_key, "").strip() if expected_actor_env_key else ""
     )
     try:
         actor_result = runner(("gh", "api", "user", "--jq", ".login"), github_env)
     except OSError as exc:
-        raise RuntimeError(f"Could not verify GitHub actor: {exc}") from exc
+        raise EveryCodeWorkerChildProcessError(
+            normalize_child_process_failure(
+                operation="Verify Every Code GitHub actor",
+                tool="github_cli",
+                exception=exc,
+            )
+        ) from exc
     if actor_result.returncode != 0:
-        detail = actor_result.stderr.strip() or actor_result.stdout.strip() or "gh api user failed"
-        raise RuntimeError(f"Could not verify GitHub actor: {detail}")
+        raise EveryCodeWorkerChildProcessError(
+            normalize_child_process_failure(
+                operation="Verify Every Code GitHub actor",
+                tool="github_cli",
+                returncode=actor_result.returncode,
+                stdout=actor_result.stdout,
+                stderr=actor_result.stderr,
+            )
+        )
     actual_actor = actor_result.stdout.strip()
     if not actual_actor:
         raise RuntimeError("Could not verify GitHub actor: empty login")
     if expected_actor and actual_actor.casefold() != expected_actor.casefold():
         raise RuntimeError(
-            "Every Code GitHub actor mismatch: "
-            f"expected {expected_actor!r}, got {actual_actor!r}"
+            f"Every Code GitHub actor mismatch: expected {expected_actor!r}, got {actual_actor!r}"
         )
     return github_env
 
@@ -817,8 +863,13 @@ def _remove_every_code_source_issue_labels(
             github_actor_env=github_actor_env,
             runner=runner,
         )
+    except EveryCodeWorkerChildProcessError as error:
+        return error.failure.operator_message()
     except RuntimeError as exc:
-        return str(exc)
+        return redact_untrusted_text(
+            str(exc),
+            fallback="Could not verify Every Code GitHub label-cleanup actor.",
+        )
     errors: list[str] = []
     for label in (record.trigger_label.strip(), "preview-ready"):
         if not label:
@@ -838,11 +889,22 @@ def _remove_every_code_source_issue_labels(
                 github_env,
             )
         except OSError as exc:
-            errors.append(f"{label}: {exc}")
+            failure = normalize_child_process_failure(
+                operation="Remove Every Code source issue label",
+                tool="github_cli",
+                exception=exc,
+            )
+            errors.append(f"{label}: {failure.operator_message()}")
             continue
         if result.returncode != 0:
-            detail = result.stderr.strip() or result.stdout.strip() or "gh issue edit failed"
-            errors.append(f"{label}: {detail}")
+            failure = normalize_child_process_failure(
+                operation="Remove Every Code source issue label",
+                tool="github_cli",
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+            errors.append(f"{label}: {failure.operator_message()}")
     if errors:
         return "Could not remove Every Code source issue labels: " + "; ".join(errors)
     return ""
@@ -1129,9 +1191,9 @@ def run_every_code_worker_once(
 
     session_name = every_code_tmux_session_name(claimed_record.request_id)
     run = runner or _run_subprocess
-    claim_comment_warning = ""
+    claim_comment_failure: ChildProcessFailure | None = None
     try:
-        claim_comment_warning = _post_every_code_claim_comment(
+        claim_comment_failure = _post_every_code_claim_comment(
             record=claimed_record,
             host=normalized_host,
             session_name=session_name,
@@ -1152,12 +1214,13 @@ def run_every_code_worker_once(
                 checkout_root=checkout_root,
             ),
         )
-    if claim_comment_warning:
+    if claim_comment_failure is not None:
         return _block_every_code_request(
             record_store=record_store,
             record=claimed_record,
             host=normalized_host,
-            detail=claim_comment_warning,
+            detail=claim_comment_failure.detail,
+            failure=claim_comment_failure,
             session_name=session_name,
             checkout_root=resolve_every_code_checkout_root(
                 claimed_record,
@@ -1175,6 +1238,21 @@ def run_every_code_worker_once(
             checkout_root=checkout_root,
             state_dir=resolved_worktree_state_dir,
             runner=run,
+        )
+    except EveryCodeWorkerChildProcessError as error:
+        fallback_checkout_root = resolve_every_code_checkout_root(
+            claimed_record,
+            workspace_root=workspace_root,
+            checkout_root=checkout_root,
+        )
+        return _block_every_code_request(
+            record_store=record_store,
+            record=claimed_record,
+            host=normalized_host,
+            detail=error.failure.detail,
+            failure=error.failure,
+            session_name=session_name,
+            checkout_root=fallback_checkout_root,
         )
     except RuntimeError as exc:
         fallback_checkout_root = resolve_every_code_checkout_root(
@@ -1251,20 +1329,34 @@ def run_every_code_worker_once(
                 None,
             )
         except OSError as exc:
+            failure = normalize_child_process_failure(
+                operation="Launch Every Code tmux session",
+                tool="child_process",
+                exception=exc,
+            )
             return _block_every_code_request(
                 record_store=record_store,
                 record=claimed_record,
                 host=normalized_host,
-                detail=f"Could not launch tmux session: {exc}",
+                detail=failure.detail,
+                failure=failure,
                 session_name=session_name,
                 checkout_root=prepared_checkout.source_checkout_root,
             )
         if launch_result.returncode != 0:
+            failure = normalize_child_process_failure(
+                operation="Launch Every Code tmux session",
+                tool="child_process",
+                returncode=launch_result.returncode,
+                stdout=launch_result.stdout,
+                stderr=launch_result.stderr,
+            )
             return _block_every_code_request(
                 record_store=record_store,
                 record=claimed_record,
                 host=normalized_host,
-                detail=f"tmux launch failed: {launch_result.stderr.strip()}",
+                detail=failure.detail,
+                failure=failure,
                 session_name=session_name,
                 checkout_root=prepared_checkout.source_checkout_root,
             )
@@ -1289,7 +1381,6 @@ def run_every_code_worker_once(
                 for part in (
                     f"Visible tmux session: {session_name}",
                     f"Worktree: {resolved_checkout_root}",
-                    claim_comment_warning,
                 )
                 if part
             ),
@@ -2334,23 +2425,51 @@ def _apply_every_code_pr_feedback_record(
             ),
             None,
         )
-    except OSError:
+    except OSError as exc:
         _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="confused", runner=runner)
+        failure = normalize_child_process_failure(
+            operation="Relaunch Every Code tmux session for PR feedback",
+            tool="child_process",
+            exception=exc,
+        )
+        _persist_every_code_pr_feedback_failure(
+            record_store=record_store,
+            request_id=feedback.request_id,
+            host=host,
+            failure=failure,
+        )
         return EveryCodePrFeedbackApplyResult(
             status="blocked",
-            detail=f"Could not relaunch tmux session {session_name!r} for PR feedback.",
+            detail=failure.detail,
             feedback_id=feedback.feedback_id,
             request_id=feedback.request_id,
             session_name=session_name,
+            error_code=failure.code,
+            error_correlation_id=failure.correlation_id,
         )
     if launch_result.returncode != 0:
         _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="confused", runner=runner)
+        failure = normalize_child_process_failure(
+            operation="Relaunch Every Code tmux session for PR feedback",
+            tool="child_process",
+            returncode=launch_result.returncode,
+            stdout=launch_result.stdout,
+            stderr=launch_result.stderr,
+        )
+        _persist_every_code_pr_feedback_failure(
+            record_store=record_store,
+            request_id=feedback.request_id,
+            host=host,
+            failure=failure,
+        )
         return EveryCodePrFeedbackApplyResult(
             status="blocked",
-            detail=f"tmux relaunch failed: {launch_result.stderr.strip()}",
+            detail=failure.detail,
             feedback_id=feedback.feedback_id,
             request_id=feedback.request_id,
             session_name=session_name,
+            error_code=failure.code,
+            error_correlation_id=failure.correlation_id,
         )
     _mark_every_code_pr_feedback(record_store, feedback=feedback, status="applied")
     _acknowledge_every_code_pr_feedback(feedback=feedback, reaction="rocket", runner=runner)
@@ -2361,6 +2480,28 @@ def _apply_every_code_pr_feedback_record(
         request_id=feedback.request_id,
         session_name=session_name,
     )
+
+
+def _persist_every_code_pr_feedback_failure(
+    *,
+    record_store: EveryCodeWorkerStore,
+    request_id: str,
+    host: str,
+    failure: ChildProcessFailure,
+) -> None:
+    record = record_store.read_every_code_work_request_record(request_id)
+    if record.state in TERMINAL_EVERY_CODE_STATES:
+        return
+    blocked_record = apply_every_code_work_request_status(
+        record,
+        EveryCodeWorkRequestStatusUpdate(
+            state="blocked",
+            host=host,
+            updated_at=utc_now_timestamp(),
+            error_message=failure.operator_message(),
+        ),
+    )
+    record_store.write_every_code_work_request_record(blocked_record)
 
 
 def _acknowledge_every_code_pr_feedback(
@@ -3732,10 +3873,19 @@ def request_every_code_pr_preview_label(
             None,
         )
     except OSError as exc:
-        return f"Could not request Launchplane preview: {exc}"
+        return normalize_child_process_failure(
+            operation="Request Launchplane preview label",
+            tool="github_cli",
+            exception=exc,
+        ).operator_message()
     if result.returncode != 0:
-        detail = result.stderr.strip() or result.stdout.strip() or "gh pr edit failed"
-        return f"Could not request Launchplane preview: {detail}"
+        return normalize_child_process_failure(
+            operation="Request Launchplane preview label",
+            tool="github_cli",
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        ).operator_message()
     return f"Requested Launchplane preview with `{preview_label}`."
 
 
@@ -3891,13 +4041,26 @@ def _git_branch_exists(source_checkout_root: Path, *, branch: str, runner: Runne
             None,
         )
     except OSError as exc:
-        raise RuntimeError(f"Could not inspect Every Code worktree branch: {exc}") from exc
+        raise EveryCodeWorkerChildProcessError(
+            normalize_child_process_failure(
+                operation="Inspect Every Code worktree branch",
+                tool="child_process",
+                exception=exc,
+            )
+        ) from exc
     if result.returncode == 0:
         return True
     if result.returncode == 1:
         return False
-    message = result.stderr.strip() or result.stdout.strip() or "git show-ref failed"
-    raise RuntimeError(f"Could not inspect Every Code worktree branch: {message}")
+    raise EveryCodeWorkerChildProcessError(
+        normalize_child_process_failure(
+            operation="Inspect Every Code worktree branch",
+            tool="child_process",
+            returncode=result.returncode,
+            stdout=result.stdout,
+            stderr=result.stderr,
+        )
+    )
 
 
 def _git_output(args: Sequence[str], *, runner: Runner, detail: str) -> str:
@@ -3911,10 +4074,23 @@ def _git_checked(
     try:
         result = runner(args, None)
     except OSError as exc:
-        raise RuntimeError(f"Could not {detail}: {exc}") from exc
+        raise EveryCodeWorkerChildProcessError(
+            normalize_child_process_failure(
+                operation=f"Git operation: {detail}",
+                tool="child_process",
+                exception=exc,
+            )
+        ) from exc
     if result.returncode != 0:
-        message = result.stderr.strip() or result.stdout.strip() or f"{args[0]} failed"
-        raise RuntimeError(f"Could not {detail}: {message}")
+        raise EveryCodeWorkerChildProcessError(
+            normalize_child_process_failure(
+                operation=f"Git operation: {detail}",
+                tool="child_process",
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+        )
     return result
 
 
@@ -4071,25 +4247,39 @@ def _block_every_code_request(
     record: EveryCodeWorkRequestRecord,
     host: str,
     detail: str,
+    failure: ChildProcessFailure | None = None,
     session_name: str,
     checkout_root: Path,
 ) -> EveryCodeWorkerHandoffResult:
+    safe_detail = (
+        failure.detail
+        if failure is not None
+        else redact_untrusted_text(
+            detail,
+            fallback="Every Code work request was blocked.",
+        )
+    )
+    error_code = failure.code if failure is not None else ""
+    error_correlation_id = failure.correlation_id if failure is not None else ""
+    persisted_error = failure.operator_message() if failure is not None else safe_detail
     blocked_record = apply_every_code_work_request_status(
         record_store.read_every_code_work_request_record(record.request_id),
         EveryCodeWorkRequestStatusUpdate(
             state="blocked",
             host=host,
             updated_at=utc_now_timestamp(),
-            error_message=detail,
+            error_message=persisted_error,
         ),
     )
     record_store.write_every_code_work_request_record(blocked_record)
     return EveryCodeWorkerHandoffResult(
         status="blocked",
-        detail=detail,
+        detail=safe_detail,
         request_id=blocked_record.request_id,
         repository=blocked_record.repository,
         issue_number=blocked_record.issue_number,
         session_name=session_name,
         checkout_root=str(checkout_root),
+        error_code=error_code,
+        error_correlation_id=error_correlation_id,
     )

--- a/control_plane/work_graph_github_projects.py
+++ b/control_plane/work_graph_github_projects.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 import click
 
+from control_plane.child_process_errors import normalize_child_process_failure
 from control_plane.contracts.work_graph_read_model import (
     WorkGraphPlanningIssueFacts,
     WorkItemFocus,
@@ -156,14 +157,19 @@ def _run_gh_json(command: Sequence[str]) -> dict[str, Any]:
             text=True,
         )
     except FileNotFoundError as error:
-        raise click.ClickException(
-            "GitHub CLI is required for work graph Project facts."
-        ) from error
+        failure = normalize_child_process_failure(
+            operation="Load GitHub Project planning facts",
+            tool="github_cli",
+            exception=error,
+        )
+        raise click.ClickException(failure.operator_message()) from error
     except subprocess.CalledProcessError as error:
-        detail = (error.stderr or error.stdout or str(error)).strip()
-        raise click.ClickException(
-            f"GitHub Project planning facts could not be loaded: {detail}"
-        ) from error
+        failure = normalize_child_process_failure(
+            operation="Load GitHub Project planning facts",
+            tool="github_cli",
+            exception=error,
+        )
+        raise click.ClickException(failure.operator_message()) from error
     try:
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as error:
@@ -298,18 +304,23 @@ def _run_optional_gh_json(command: Sequence[str]) -> object | None:
             text=True,
         )
     except FileNotFoundError as error:
-        raise click.ClickException(
-            "GitHub CLI is required for work graph Project facts."
-        ) from error
+        failure = normalize_child_process_failure(
+            operation="Load GitHub Project planning signals",
+            tool="github_cli",
+            exception=error,
+        )
+        raise click.ClickException(failure.operator_message()) from error
     except subprocess.CalledProcessError as error:
         if error.returncode == 8 and tuple(command[1:3]) == ("pr", "checks"):
             return [{"bucket": "pending"}]
-        detail = (error.stderr or error.stdout or str(error)).strip()
-        if "not found" in detail.lower() or "does not exist" in detail.lower():
+        failure = normalize_child_process_failure(
+            operation="Load GitHub Project planning signals",
+            tool="github_cli",
+            exception=error,
+        )
+        if "not found" in failure.detail.lower() or "does not exist" in failure.detail.lower():
             return None
-        raise click.ClickException(
-            f"GitHub Project planning signals could not be loaded: {detail}"
-        ) from error
+        raise click.ClickException(failure.operator_message()) from error
     try:
         payload: object = json.loads(result.stdout)
         return payload

--- a/control_plane/work_graph_issue_inbox.py
+++ b/control_plane/work_graph_issue_inbox.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 import click
 from pydantic import BaseModel, ConfigDict, Field
 
+from control_plane.child_process_errors import normalize_child_process_failure
 from control_plane.contracts.work_graph_read_model import WorkGraphPlanningIssueFacts
 from control_plane.work_graph_github_projects import (
     GitHubProjectPlanningFactsConfig,
@@ -82,6 +83,8 @@ class GitHubIssueInboxReconcileItem(BaseModel):
     url: str = ""
     action: Literal["would_add", "added", "already_present", "failed", "skipped"]
     detail: str = ""
+    error_code: str = ""
+    error_correlation_id: str = ""
 
 
 class GitHubIssueInboxReconcileResult(BaseModel):
@@ -170,7 +173,10 @@ def build_github_issue_inbox_read_model(
         repository_count=len(groups),
         issue_count=sum(group.issue_count for group in groups),
         stale_project_item_count=sum(
-            1 for group in groups for issue in group.issues if issue.project_status in {"stale", "closed"}
+            1
+            for group in groups
+            for issue in group.issues
+            if issue.project_status in {"stale", "closed"}
         ),
         repositories=groups,
     )
@@ -424,14 +430,24 @@ def _apply_issue_reconcile_item(
     try:
         _project_item_add(config=config, issue=issue)
     except FileNotFoundError as error:
-        raise click.ClickException(
-            "GitHub CLI is required for work graph issue inbox reconciliation."
-        ) from error
+        failure = normalize_child_process_failure(
+            operation="Add GitHub issue inbox item to Project",
+            tool="github_cli",
+            exception=error,
+        )
+        raise click.ClickException(failure.operator_message()) from error
     except subprocess.CalledProcessError as error:
+        failure = normalize_child_process_failure(
+            operation="Add GitHub issue inbox item to Project",
+            tool="github_cli",
+            exception=error,
+        )
         return _reconcile_item(
             issue=issue,
             action="failed",
-            detail=_redacted_gh_error(error),
+            detail=failure.detail,
+            error_code=failure.code,
+            error_correlation_id=failure.correlation_id,
         )
     return _reconcile_item(issue=issue, action="added")
 
@@ -462,6 +478,8 @@ def _reconcile_item(
     issue: GitHubIssueInboxIssue,
     action: Literal["would_add", "added", "already_present", "failed", "skipped"],
     detail: str = "",
+    error_code: str = "",
+    error_correlation_id: str = "",
 ) -> GitHubIssueInboxReconcileItem:
     return GitHubIssueInboxReconcileItem(
         key=issue.key,
@@ -471,18 +489,8 @@ def _reconcile_item(
         url=issue.url,
         action=action,
         detail=detail,
-    )
-
-
-def _redacted_gh_error(error: subprocess.CalledProcessError) -> str:
-    detail = (error.stderr or error.stdout or str(error)).strip()
-    return (
-        re.sub(
-            r"(?i)(gh[pousr]_[A-Za-z0-9_]+|github_pat_[A-Za-z0-9_]+|bearer\s+[A-Za-z0-9._-]+)",
-            "[redacted]",
-            detail,
-        )
-        or "GitHub Project item-add failed."
+        error_code=error_code,
+        error_correlation_id=error_correlation_id,
     )
 
 
@@ -495,10 +503,19 @@ def _run_gh_json_array(command: Sequence[str]) -> list[object]:
             text=True,
         )
     except FileNotFoundError as error:
-        raise click.ClickException("GitHub CLI is required for work graph issue inbox.") from error
+        failure = normalize_child_process_failure(
+            operation="Load GitHub issue inbox",
+            tool="github_cli",
+            exception=error,
+        )
+        raise click.ClickException(failure.operator_message()) from error
     except subprocess.CalledProcessError as error:
-        detail = (error.stderr or error.stdout or str(error)).strip()
-        raise click.ClickException(f"GitHub issue inbox could not be loaded: {detail}") from error
+        failure = normalize_child_process_failure(
+            operation="Load GitHub issue inbox",
+            tool="github_cli",
+            exception=error,
+        )
+        raise click.ClickException(failure.operator_message()) from error
     try:
         payload: object = json.loads(result.stdout)
     except json.JSONDecodeError as error:

--- a/docs/agent-context-boundary.md
+++ b/docs/agent-context-boundary.md
@@ -114,6 +114,11 @@ webhook delivery ids, issue bodies, or prompt text. Managed secret evidence is
 metadata-only: binding keys, runtime destinations, policy ids/digests, and safe
 finding codes.
 
+Child-process failures that reach durable records, API responses, or operator
+output must use a stable error code, a correlation id, and a bounded redacted
+detail. Do not persist or log raw child-process stdout or stderr; logs may retain
+only the safe error code, correlation id, and exit status needed for diagnosis.
+
 Every agent-facing authorization response should include an `agent_audit`
 envelope with decision, safe reason code, subject, action, product, context,
 policy source, policy digest, and authz-policy source kind. Read models should

--- a/tests/test_child_process_errors.py
+++ b/tests/test_child_process_errors.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import unittest
+
+from control_plane.child_process_errors import (
+    normalize_child_process_failure,
+    redact_untrusted_text,
+)
+
+
+class ChildProcessErrorTests(unittest.TestCase):
+    def test_normalize_redacts_subprocess_sentinels_with_deterministic_correlation(self) -> None:
+        stderr = "\n".join(
+            (
+                "read /Users/operator/.config/launchplane/credentials",
+                "connect ECONNREFUSED 10.42.0.19:4444",
+                "Authorization: Bearer example-bearer-value",
+                "Authorization: Basic dXNlcjpzaG91bGQtbm90LXN1cnZpdmU=",
+                "Cookie: launchplane_session=short-cookie-secret",
+                "Set-Cookie: launchplane_session=short-response-secret; Secure",
+                "LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN=example-token-value",
+                "request https://octocat:password@build.internal/api/private failed",
+                "retry this safe diagnostic",
+            )
+        )
+
+        with self.assertLogs("control_plane.child_process_errors", level="INFO") as logs:
+            first = normalize_child_process_failure(
+                operation="Sync Every Code webhook",
+                tool="github_cli",
+                returncode=1,
+                stderr=stderr,
+            )
+            second = normalize_child_process_failure(
+                operation="Sync Every Code webhook",
+                tool="github_cli",
+                returncode=1,
+                stderr=stderr,
+            )
+
+        self.assertEqual(first.code, "github_cli_failed")
+        self.assertEqual(first.correlation_id, second.correlation_id)
+        self.assertTrue(first.correlation_id.startswith("cpf-"))
+        self.assertLessEqual(len(first.detail), 240)
+        self.assertNotIn("\n", first.detail)
+        for value in (
+            "example-bearer-value",
+            "dXNlcjpzaG91bGQtbm90LXN1cnZpdmU=",
+            "short-cookie-secret",
+            "short-response-secret",
+            "example-token-value",
+            "octocat:password",
+            "build.internal",
+            "10.42.0.19",
+            "/Users/operator/.config/launchplane/credentials",
+        ):
+            self.assertNotIn(value, first.detail)
+            self.assertNotIn(value, first.operator_message())
+        log_output = "\n".join(logs.output)
+        self.assertIn(first.code, log_output)
+        self.assertIn(first.correlation_id, log_output)
+        self.assertNotIn("example-token-value", log_output)
+
+    def test_redact_untrusted_text_covers_process_output_sentinels(self) -> None:
+        detail = redact_untrusted_text(
+            "\n".join(
+                (
+                    "read /Users/operator/.config/launchplane/credentials",
+                    "connect ECONNREFUSED 10.42.0.19:4444",
+                    "Authorization: Bearer example-bearer-value",
+                    "Authorization: Basic dXNlcjpzaG91bGQtbm90LXN1cnZpdmU=",
+                    "Cookie: launchplane_session=short-cookie-secret",
+                    "Set-Cookie: launchplane_session=short-response-secret; Secure",
+                    "LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN=example-token-value",
+                    "request https://octocat:password@build.internal/api/private failed",
+                    "retry this safe diagnostic",
+                )
+            ),
+            fallback="Unavailable.",
+            maximum_length=500,
+        )
+
+        self.assertNotIn("\n", detail)
+        self.assertIn("[redacted-path]", detail)
+        self.assertIn("[redacted-host]", detail)
+        self.assertIn("Authorization: Bearer [redacted]", detail)
+        self.assertIn("Authorization: Basic [redacted]", detail)
+        self.assertIn("Cookie: [redacted]", detail)
+        self.assertIn("Set-Cookie: [redacted]", detail)
+        self.assertIn("LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN=[redacted]", detail)
+        self.assertIn("[redacted-url]", detail)
+        self.assertIn("retry this safe diagnostic", detail)
+
+    def test_redact_untrusted_text_preserves_ordinary_safe_messages(self) -> None:
+        detail = "GitHub API returned 403: Resource not accessible by integration."
+
+        self.assertEqual(redact_untrusted_text(detail, fallback="Unavailable."), detail)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_every_code_webhooks.py
+++ b/tests/test_every_code_webhooks.py
@@ -59,6 +59,21 @@ class _WebhookRunner:
         raise AssertionError(f"unexpected command: {command}")
 
 
+class _FailingWebhookRunner(_WebhookRunner):
+    def __init__(self, *, error_detail: str) -> None:
+        super().__init__(hooks={"cbusillo/code": [], "cbusillo/launchplane": []})
+        self.error_detail = error_detail
+
+    def __call__(
+        self, args: Sequence[str], input_text: str | None
+    ) -> subprocess.CompletedProcess[str]:
+        command = tuple(args)
+        if command[:3] == ("gh", "api", "repos/cbusillo/code/hooks"):
+            self.calls.append((command, input_text))
+            raise subprocess.CalledProcessError(1, command, stderr=self.error_detail)
+        return super().__call__(args, input_text)
+
+
 class EveryCodeWebhookSyncTests(unittest.TestCase):
     def test_sync_updates_existing_hook_and_creates_missing_hook(self) -> None:
         webhook_url = "https://launchplane.example/v1/every-code/github-webhook"
@@ -150,6 +165,38 @@ class EveryCodeWebhookSyncTests(unittest.TestCase):
                 webhook_url="",
                 runner=_WebhookRunner(hooks={}),
             )
+
+    def test_sync_redacts_github_cli_failure_in_operator_payload(self) -> None:
+        runner = _FailingWebhookRunner(
+            error_detail=(
+                "github_pat_example_token_value\n"
+                "Authorization: Bearer example-bearer-value\n"
+                "https://operator:password@hooks.internal/private\n"
+                "LAUNCHPLANE_EVERY_CODE_GITHUB_TOKEN=example-token-value"
+            )
+        )
+
+        results = sync_every_code_webhooks(
+            owner="cbusillo",
+            webhook_secret="secret",
+            webhook_url="https://launchplane.example/v1/every-code/github-webhook",
+            runner=runner,
+        )
+
+        failed = results[0]
+        payload = json.dumps(failed.as_payload())
+        self.assertEqual(failed.status, "error")
+        self.assertEqual(failed.error_code, "github_cli_failed")
+        self.assertTrue(failed.error_correlation_id.startswith("cpf-"))
+        self.assertNotIn("\n", failed.error)
+        for value in (
+            "github_pat_example_token_value",
+            "example-bearer-value",
+            "operator:password",
+            "hooks.internal",
+            "example-token-value",
+        ):
+            self.assertNotIn(value, payload)
 
     def test_cli_sync_webhooks_requires_webhook_url_config(self) -> None:
         result = CliRunner().invoke(

--- a/tests/test_every_code_worker.py
+++ b/tests/test_every_code_worker.py
@@ -224,6 +224,7 @@ class _Runner:
         self,
         *,
         fail_issue_comment: bool = False,
+        issue_comment_error_detail: str = "rate limited",
         existing_branch: bool = False,
         pr_view_payload: dict[str, object] | None = None,
         pr_list_payload: list[dict[str, object]] | None = None,
@@ -231,6 +232,7 @@ class _Runner:
     ) -> None:
         self.calls: list[tuple[str, ...]] = []
         self.fail_issue_comment = fail_issue_comment
+        self.issue_comment_error_detail = issue_comment_error_detail
         self.existing_branch = existing_branch
         self.pr_view_payload = pr_view_payload
         self.pr_list_payload = pr_list_payload
@@ -268,7 +270,7 @@ class _Runner:
             if env is None or env.get("GH_TOKEN") != "bot-token":
                 return subprocess.CompletedProcess(args, 1, "", "missing bot token")
             if self.fail_issue_comment:
-                return subprocess.CompletedProcess(args, 1, "", "rate limited")
+                return subprocess.CompletedProcess(args, 1, "", self.issue_comment_error_detail)
             return subprocess.CompletedProcess(args, 0, "", "")
         if args[:3] == ("gh", "issue", "edit"):
             if env is None or env.get("GH_TOKEN") != "bot-token":
@@ -336,6 +338,25 @@ class _GoneSessionRunner(_Runner):
             return subprocess.CompletedProcess(args, 1, "", "no session")
         if args[0] == "tmux" and args[1] == "new-session":
             return subprocess.CompletedProcess(args, 0, "", "")
+        return super().__call__(args, env)
+
+
+class _FailingFeedbackRelaunchRunner(_GoneSessionRunner):
+    def __call__(
+        self, args: Sequence[str], env: Mapping[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        if args[0] == "tmux" and args[1] == "new-session":
+            self.calls.append(tuple(args))
+            return subprocess.CompletedProcess(
+                args,
+                1,
+                "",
+                (
+                    "Authorization: Basic dXNlcjpzaG91bGQtbm90LXN1cnZpdmU=\n"
+                    "Cookie: launchplane_session=short-cookie-secret\n"
+                    "connect worker.internal failed"
+                ),
+            )
         return super().__call__(args, env)
 
 
@@ -1961,6 +1982,63 @@ class EveryCodeWorkerTests(unittest.TestCase):
         )
         self.assertIn("Every Code received new PR feedback", launch_call[-1])
 
+    def test_apply_feedback_persists_redacted_relaunch_failure(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=_Runner(),
+            )
+            finished_record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            ).model_copy(
+                update={
+                    "state": "done",
+                    "finished_at": "2026-05-06T19:05:00Z",
+                    "updated_at": "2026-05-06T19:05:00Z",
+                    "result_pr_url": "https://github.com/cbusillo/code/pull/26",
+                    "result_summary": "Opened PR.",
+                }
+            )
+            store.write_every_code_work_request_record(finished_record)
+            store.write_every_code_pr_feedback_record(_feedback_record())
+
+            result = apply_every_code_pr_feedback_for_host(
+                record_store=store,
+                host="Chris-Studio",
+                state_dir=temporary_root / "state",
+                runner=_FailingFeedbackRelaunchRunner(),
+            )
+            feedback = store.list_every_code_pr_feedback_records(limit=1)[0]
+            blocked_record = store.read_every_code_work_request_record(
+                "every-code-cbusillo-code-123-test"
+            )
+
+        payload = json.dumps({"result": result.as_payload(), "record": blocked_record.model_dump()})
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.error_code, "child_process_failed")
+        self.assertTrue(result.error_correlation_id.startswith("cpf-"))
+        self.assertEqual(feedback.status, "pending")
+        self.assertEqual(blocked_record.state, "blocked")
+        self.assertIn(f"error_code={result.error_code}", blocked_record.error_message)
+        self.assertIn(
+            f"correlation_id={result.error_correlation_id}", blocked_record.error_message
+        )
+        for value in (
+            "dXNlcjpzaG91bGQtbm90LXN1cnZpdmU=",
+            "short-cookie-secret",
+            "worker.internal",
+        ):
+            self.assertNotIn(value, payload)
+
     def test_apply_feedback_ignores_request_closed_by_linked_pr(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
@@ -2786,6 +2864,55 @@ class EveryCodeWorkerTests(unittest.TestCase):
         self.assertFalse(any(call[1] == "new-session" for call in runner.calls))
         self.assertTrue(any(call[:3] == ("gh", "issue", "comment") for call in runner.calls))
 
+    def test_run_once_redacts_claim_comment_failure_before_persistence(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            temporary_root = Path(temporary_directory_name)
+            checkout_root = temporary_root / "Developer" / "code"
+            checkout_root.mkdir(parents=True)
+            (checkout_root / ".git").mkdir()
+            store = FilesystemRecordStore(state_dir=temporary_root / "state")
+            store.write_every_code_work_request_record(_queued_record())
+            runner = _Runner(
+                fail_issue_comment=True,
+                issue_comment_error_detail=(
+                    "Bearer example-bearer-value\n"
+                    "Authorization: Basic dXNlcjpzaG91bGQtbm90LXN1cnZpdmU=\n"
+                    "Cookie: launchplane_session=short-cookie-secret\n"
+                    "GH_TOKEN=example-token-value\n"
+                    "https://operator:password@worker.internal/private/log\n"
+                    "/Users/operator/.config/launchplane/token"
+                ),
+            )
+
+            result = run_every_code_worker_once(
+                record_store=store,
+                host="Chris-Studio",
+                workspace_root=temporary_root / "Developer",
+                state_dir=temporary_root / "state",
+                runner=runner,
+            )
+            record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
+
+        payload = json.dumps({"result": result.as_payload(), "record": record.model_dump()})
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual(result.error_code, "github_cli_failed")
+        self.assertTrue(result.error_correlation_id.startswith("cpf-"))
+        self.assertIn(f"error_code={result.error_code}", record.error_message)
+        self.assertIn(f"correlation_id={result.error_correlation_id}", record.error_message)
+        self.assertNotIn("error_code", record.model_dump())
+        self.assertNotIn("error_correlation_id", record.model_dump())
+        self.assertNotIn("\n", record.error_message)
+        for value in (
+            "example-bearer-value",
+            "dXNlcjpzaG91bGQtbm90LXN1cnZpdmU=",
+            "short-cookie-secret",
+            "example-token-value",
+            "operator:password",
+            "worker.internal",
+            "/Users/operator/.config/launchplane/token",
+        ):
+            self.assertNotIn(value, payload)
+
     def test_run_once_blocks_before_launch_without_claim_comment_token(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             temporary_root = Path(temporary_directory_name)
@@ -2806,7 +2933,9 @@ class EveryCodeWorkerTests(unittest.TestCase):
                     runner=runner,
                 )
             record = store.read_every_code_work_request_record("every-code-cbusillo-code-123-test")
-            worktree_exists = every_code_worktree_root(_queued_record(), state_dir=state_dir).exists()
+            worktree_exists = every_code_worktree_root(
+                _queued_record(), state_dir=state_dir
+            ).exists()
 
         self.assertEqual(result.status, "blocked")
         self.assertEqual(record.state, "blocked")

--- a/tests/test_work_graph_issue_inbox.py
+++ b/tests/test_work_graph_issue_inbox.py
@@ -415,8 +415,10 @@ class GitHubIssueInboxTests(unittest.TestCase):
 
         self.assertEqual(result.failed_count, 1)
         self.assertEqual(result.items[0].action, "failed")
-        self.assertIn("[redacted]", result.items[0].detail)
+        self.assertIn("[redacted-token]", result.items[0].detail)
         self.assertNotIn("ghp_supersecret", result.items[0].detail)
+        self.assertEqual(result.items[0].error_code, "github_cli_failed")
+        self.assertTrue(result.items[0].error_correlation_id.startswith("cpf-"))
 
     def test_reconcile_issue_inbox_apply_reports_empty_and_already_present(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- centralize child-process and GitHub CLI failure normalization with bounded safe details, stable error codes, and deterministic correlation ids
- redact credential URLs, paths, internal hosts, bearer/basic authorization, cookies, token assignments, and multiline output before records, APIs, logs, or operator messages
- preserve rollback compatibility by storing code/correlation inside the existing bounded `error_message` wire field while exposing structured fields only on ephemeral result envelopes
- persist PR-feedback relaunch failures by blocking the durable work request instead of silently dropping the result

## Validation
- `uv run python -m unittest tests.test_child_process_errors tests.test_every_code_worker tests.test_every_code_webhooks tests.test_work_graph_issue_inbox` (110 tests)
- changed-file Ruff and mypy
- independent security review verified redaction coverage, API-backed durability, rollback compatibility, and feedback failure persistence

Closes #1684