### PR TITLE
security: pin workflow supply-chain inputs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ version: 2
 
 updates:
   - package-ecosystem: github-actions
+    # Inline release-tag provenance comments keep full-SHA action pin updates reviewable.
     directory: "/"
     open-pull-requests-limit: 5
     schedule:

--- a/.github/github.json
+++ b/.github/github.json
@@ -25,6 +25,7 @@
     "operations": "docs/operations.md",
     "records": "docs/records.md",
     "secrets": "docs/secrets.md",
+    "githubActionsSecurity": "docs/github-actions-security.md",
     "publicReadiness": "docs/public-readiness.md",
     "style": ["docs/style/python.md", "docs/style/testing.md"],
     "policies": ["docs/policies/coding-standards.md"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ name: CI
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   static_checks:
     if: >-
@@ -17,10 +20,10 @@ jobs:
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -48,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -87,23 +90,23 @@ jobs:
         launchplane-ci:${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           name: launchplane-ci-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Log in to GHCR for build cache
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
       - name: Build runtime image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -115,7 +118,7 @@ jobs:
             type=gha,scope=launchplane-ci,mode=max
 
       - name: Restore Trivy cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/trivy-cache
           key: ${{ runner.os }}-trivy-${{ github.run_id }}
@@ -130,7 +133,7 @@ jobs:
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "${LAUNCHPLANE_TRIVY_CACHE_DIR}:/root/.cache" \
-            ghcr.io/aquasecurity/trivy:0.70.0 \
+            ghcr.io/aquasecurity/trivy:0.70.0@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e \
             image \
             --scanners vulnerability \
             --ignore-unfixed \
@@ -154,16 +157,16 @@ jobs:
         launchplane-ci:${{ github.run_id }}-${{ github.run_attempt }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
         with:
           name: launchplane-ci-${{ github.run_id }}-${{ github.run_attempt }}
 
       - name: Build runtime image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -173,7 +176,7 @@ jobs:
             type=gha,scope=launchplane-ci
 
       - name: Restore Trivy cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ runner.temp }}/trivy-cache
           key: ${{ runner.os }}-trivy-${{ github.run_id }}
@@ -188,7 +191,7 @@ jobs:
           docker run --rm \
             -v /var/run/docker.sock:/var/run/docker.sock \
             -v "${LAUNCHPLANE_TRIVY_CACHE_DIR}:/root/.cache" \
-            ghcr.io/aquasecurity/trivy:0.70.0 \
+            ghcr.io/aquasecurity/trivy:0.70.0@sha256:be1190afcb28352bfddc4ddeb71470835d16462af68d310f9f4bca710961a41e \
             image \
             --scanners vulnerability \
             --ignore-unfixed \
@@ -209,15 +212,15 @@ jobs:
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -235,7 +238,7 @@ jobs:
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: >-
@@ -256,15 +259,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -282,7 +285,7 @@ jobs:
         run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
       - name: Restore pnpm store
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ steps.pnpm-store.outputs.path }}
           key: >-
@@ -307,7 +310,7 @@ jobs:
       UNITTEST_TIMINGS_CACHE: .ci-cache/unittest-timings/history.json
     steps:
       - name: Restore unittest timings
-        uses: actions/cache/restore@v6
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.UNITTEST_TIMINGS_CACHE }}
           key: >-
@@ -329,7 +332,7 @@ jobs:
             > "${snapshot_directory}/snapshot-id"
 
       - name: Upload unittest timing snapshot
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unittest-timing-snapshot
           path: ${{ runner.temp }}/unittest-timing-snapshot
@@ -356,10 +359,10 @@ jobs:
         shard_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -368,7 +371,8 @@ jobs:
         run: uv python install 3.13
 
       - name: Download unittest timing snapshot
-        uses: actions/download-artifact@v7
+        # v7 downloads one named artifact; the following v8 step needs merge-multiple.
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: unittest-timing-snapshot
           path: ${{ runner.temp }}/unittest-timing-snapshot
@@ -393,7 +397,7 @@ jobs:
 
       - name: Upload unittest timings
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: unittest-timings-${{ matrix.shard_index }}
           path: ${{ runner.temp }}/unittest-timings/shard-${{ matrix.shard_index }}.json
@@ -417,10 +421,10 @@ jobs:
       UNITTEST_MAX_SECONDS_PER_TARGET: "30"
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -440,13 +444,13 @@ jobs:
           fi
 
       - name: Download unittest timing snapshot
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: unittest-timing-snapshot
           path: ${{ runner.temp }}/unittest-timing-snapshot
 
       - name: Download unittest timings
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: unittest-timings-*
           path: ${{ runner.temp }}/unittest-timings
@@ -464,7 +468,7 @@ jobs:
 
       - name: Save unittest timings
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v6
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ${{ env.UNITTEST_TIMINGS_CACHE }}
           key: >-
@@ -477,10 +481,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -500,7 +504,7 @@ jobs:
       - ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}
     services:
       postgres:
-        image: postgres:17
+        image: postgres:17@sha256:0af65001d05296a2ead57ac4a6412433d8913d1bb5d0c88435a7d1e1ee5cb04b
         env:
           POSTGRES_USER: launchplane_test
           POSTGRES_DB: launchplane_root
@@ -514,10 +518,10 @@ jobs:
           --health-retries 20
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,15 +34,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/deploy-launchplane.yml
+++ b/.github/workflows/deploy-launchplane.yml
@@ -252,19 +252,19 @@ jobs:
           PY
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ steps.prep.outputs.checkout_ref }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install Python
         run: uv python install 3.13
 
       - name: Set up Docker Buildx
         if: steps.prep.outputs.should_build == 'true'
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GHCR
         if: steps.prep.outputs.should_build == 'true'
@@ -289,7 +289,7 @@ jobs:
       - name: Build and push Launchplane image
         if: steps.prep.outputs.should_build == 'true'
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./Dockerfile
@@ -321,7 +321,7 @@ jobs:
       - name: Read previous Launchplane runtime
         id: previous_runtime
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -537,7 +537,7 @@ jobs:
       - name: Request Launchplane self deploy
         id: self_deploy_request
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -586,7 +586,7 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Wait for deployed Launchplane runtime image
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -660,7 +660,7 @@ jobs:
           exit 1
 
       - name: Verify deployed Launchplane runtime image after health
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -711,7 +711,7 @@ jobs:
           && steps.rollback_request.outputs.previous_image_reference != ''
         id: rollback_request_action
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -789,7 +789,7 @@ jobs:
           && steps.rollback_request_action.outcome == 'success'
         id: rollback_runtime
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -928,7 +928,7 @@ jobs:
           && steps.rollback_request_action.outcome == 'success'
           && steps.rollback_runtime.outcome == 'success'
           && steps.rollback_health.outcome == 'success'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -961,7 +961,7 @@ jobs:
 
       - name: Ensure GitHub Actions authz grants
         if: steps.authz_grants.outputs.has_github_actions_grants == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -973,7 +973,7 @@ jobs:
 
       - name: Ensure terminal-agent authz grants
         if: steps.authz_grants.outputs.has_terminal_agents_grants == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -985,7 +985,7 @@ jobs:
 
       - name: Ensure local-operator authz grants
         if: steps.authz_grants.outputs.has_local_operators_grants == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -997,7 +997,7 @@ jobs:
 
       - name: Ensure local-admin authz grants
         if: steps.authz_grants.outputs.has_local_admins_grants == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -1009,7 +1009,7 @@ jobs:
 
       - name: Ensure GitHub human authz grants
         if: steps.authz_grants.outputs.has_github_humans_grants == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -1021,7 +1021,7 @@ jobs:
 
       - name: Ensure runtime key-safety policy
         if: steps.authz_grants.outputs.has_runtime_key_safety_policy == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -1034,7 +1034,7 @@ jobs:
       - name: Read deployed Launchplane runtime
         id: deployed_runtime
         continue-on-error: true
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ steps.service.outputs.service_url }}
           audience: ${{ steps.service.outputs.service_audience }}
@@ -1191,7 +1191,7 @@ jobs:
 
       - name: Upload v2 deployed smoke evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: launchplane-v2-deployed-smoke
           path: |
@@ -1298,7 +1298,7 @@ jobs:
           }
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Render operator-configured authz grants
         id: authz_grants
@@ -1385,9 +1385,9 @@ jobs:
       LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS: ${{ vars.LAUNCHPLANE_DOKPLOY_DEPLOY_TIMEOUT_SECONDS }}
       LAUNCHPLANE_IMAGE_REPOSITORY: ${{ vars.LAUNCHPLANE_IMAGE_REPOSITORY }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Validate manual break-glass request
         shell: bash
@@ -1470,7 +1470,7 @@ jobs:
 
       - name: Upload break-glass rollback evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: launchplane-break-glass-rollback
           path: ${{ runner.temp }}/launchplane-break-glass-rollback.json

--- a/.github/workflows/dokploy-target-inspect.yml
+++ b/.github/workflows/dokploy-target-inspect.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Inspect target
         id: inspect_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Upload inspect evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dokploy-target-inspect
           path: dokploy-target-inspect-response.json

--- a/.github/workflows/dokploy-target-setup.yml
+++ b/.github/workflows/dokploy-target-setup.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: Request Launchplane target setup
         id: target_setup_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -339,7 +339,7 @@ jobs:
 
       - name: Upload setup evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dokploy-target-setup-result
           path: dokploy-target-setup.json

--- a/.github/workflows/edge-endpoint-apply.yml
+++ b/.github/workflows/edge-endpoint-apply.yml
@@ -78,7 +78,7 @@ jobs:
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build edge endpoint payload
         id: payload
@@ -193,7 +193,7 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload response
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: edge-endpoint-apply
           path: edge-endpoint-apply.json

--- a/.github/workflows/ingress-route-apply.yml
+++ b/.github/workflows/ingress-route-apply.yml
@@ -49,7 +49,7 @@ jobs:
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Validate ingress route apply confirmation
         shell: bash
@@ -166,7 +166,7 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload apply response
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ingress-route-apply
           path: ingress-route-apply.json

--- a/.github/workflows/ingress-route-audit-read.yml
+++ b/.github/workflows/ingress-route-audit-read.yml
@@ -112,7 +112,7 @@ jobs:
 
       - name: Request redacted audit records
         id: audit_read_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -200,7 +200,7 @@ jobs:
 
       - name: Upload audit read response
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ingress-route-audit-read
           path: ingress-route-audit-read.json

--- a/.github/workflows/ingress-route-canary-apply.yml
+++ b/.github/workflows/ingress-route-canary-apply.yml
@@ -92,7 +92,7 @@ jobs:
 
       - name: Request ingress route canary apply
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           method: POST
@@ -127,7 +127,7 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload canary apply response
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ingress-route-canary-apply
           path: ingress-route-canary-apply.json

--- a/.github/workflows/ingress-route-dry-run.yml
+++ b/.github/workflows/ingress-route-dry-run.yml
@@ -74,7 +74,7 @@ jobs:
     env:
       LAUNCHPLANE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Build ingress route dry run payload
         id: payload
@@ -266,7 +266,7 @@ jobs:
           } >>"$GITHUB_STEP_SUMMARY"
 
       - name: Upload dry run response
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ingress-route-dry-run
           path: ingress-route-dry-run.json

--- a/.github/workflows/live-target-runtime.yml
+++ b/.github/workflows/live-target-runtime.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Apply live target runtime sync
         id: live_target_runtime_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Upload response artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: live-target-runtime-response
           path: |

--- a/.github/workflows/merge-train-policy-import.yml
+++ b/.github/workflows/merge-train-policy-import.yml
@@ -100,10 +100,10 @@ jobs:
           PY
 
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Install Python
         run: uv python install 3.13
@@ -196,7 +196,7 @@ jobs:
 
       - name: Request policy import dry-run
         id: dry_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.service.outputs.audience }}
@@ -242,7 +242,7 @@ jobs:
 
       - name: Apply policy import
         if: env.APPLY_POLICY == 'true'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.service.outputs.audience }}

--- a/.github/workflows/merge-train-runner.yml
+++ b/.github/workflows/merge-train-runner.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Read scheduled merge-train targets
         if: github.event_name == 'schedule'
         id: scheduled_target_read
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.scheduled_target_request.outputs.service_audience }}
@@ -324,7 +324,7 @@ jobs:
       - name: Read merge-train admission
         if: steps.admission_request.outputs.should_request == 'true'
         id: admission_read
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission_request.outputs.service_audience }}
@@ -402,7 +402,7 @@ jobs:
           env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none' ||
           env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none' ||
           env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none')
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Prepare merge-train run-once request
         id: level1_request
@@ -446,7 +446,7 @@ jobs:
       - name: Send merge-train run-once request
         if: steps.level1_request.outputs.should_request == 'true'
         id: level1_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -558,7 +558,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'controller'
         id: controller_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -638,7 +638,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'controller' &&
           steps.controller_summary.outputs.feedback_count != '0'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -705,7 +705,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_BATCH_CANDIDATE_MODE != 'none'
         id: batch_candidate_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -814,7 +814,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_STACK_COLLAPSE_MODE != 'none'
         id: stack_collapse_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -936,7 +936,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_BATCH_LANDING_MODE != 'none'
         id: batch_landing_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}
@@ -1052,7 +1052,7 @@ jobs:
           steps.admission.outputs.admission_status == 'admitted' &&
           env.MERGE_TRAIN_RUNNER_MODE == 'level1' &&
           steps.manual_phase_feedback.outputs.feedback_count != '0'
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ steps.admission.outputs.service_audience }}

--- a/.github/workflows/odoo-config-parameter-override.yml
+++ b/.github/workflows/odoo-config-parameter-override.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Write config parameter override
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload override result
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: odoo-config-parameter-override-${{ inputs.product }}-${{ inputs.context }}-${{ inputs.instance }}
           path: odoo-config-parameter-override.json

--- a/.github/workflows/odoo-driver-route-smoke.yml
+++ b/.github/workflows/odoo-driver-route-smoke.yml
@@ -87,7 +87,7 @@ jobs:
       INSTANCE: ${{ inputs.instance }}
       SOURCE_GIT_REF: ${{ inputs.source_git_ref }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Check public route registration
         env:
@@ -456,7 +456,7 @@ jobs:
 
       - name: Upload route smoke evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: >-
             odoo-driver-route-smoke-${{ inputs.product }}-${{

--- a/.github/workflows/odoo-stable-bootstrap.yml
+++ b/.github/workflows/odoo-stable-bootstrap.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Create bootstrap operation
         id: create_bootstrap
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -205,7 +205,7 @@ jobs:
 
       - name: Poll bootstrap operation
         id: poll_bootstrap
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upload bootstrap result
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: odoo-stable-bootstrap-result
           path: |

--- a/.github/workflows/odoo-target-replacement-apply.yml
+++ b/.github/workflows/odoo-target-replacement-apply.yml
@@ -223,7 +223,7 @@ jobs:
 
       - name: Create replacement operation
         id: create_replacement
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -274,7 +274,7 @@ jobs:
 
       - name: Poll replacement operation
         id: poll_replacement
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -339,7 +339,7 @@ jobs:
 
       - name: Upload replacement apply result
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: odoo-target-replacement-apply
           path: |

--- a/.github/workflows/odoo-target-replacement-plan.yml
+++ b/.github/workflows/odoo-target-replacement-plan.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Build replacement plan
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Upload replacement plan
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: odoo-target-replacement-plan
           path: odoo-target-replacement-plan.json

--- a/.github/workflows/odoo-website-bootstrap-override.yml
+++ b/.github/workflows/odoo-website-bootstrap-override.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Write website bootstrap override
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload override result
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: odoo-website-bootstrap-override-${{ inputs.product }}-${{ inputs.context }}-${{ inputs.instance }}
           path: odoo-website-bootstrap-override.json

--- a/.github/workflows/preview-lifecycle.yml
+++ b/.github/workflows/preview-lifecycle.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Run Launchplane-owned preview lifecycle
         id: preview_lifecycle_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ env.LAUNCHPLANE_AUDIENCE }}

--- a/.github/workflows/product-context-cutover-audit.yml
+++ b/.github/workflows/product-context-cutover-audit.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Request redacted cutover audit
         id: audit_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -108,7 +108,7 @@ jobs:
           echo "warnings_count=${warnings_count}" >> "$GITHUB_OUTPUT"
 
       - name: Upload redacted audit artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: launchplane-context-cutover-audit-${{ inputs.product }}
           path: launchplane-context-cutover-audit.json

--- a/.github/workflows/product-context-cutover.yml
+++ b/.github/workflows/product-context-cutover.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Request Launchplane product context cutover
         id: cutover_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           route-path: /v1/product-profiles/context-cutover/apply
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload cutover artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: launchplane-product-context-cutover-${{ inputs.product }}
           path: launchplane-product-context-cutover.json

--- a/.github/workflows/product-environment-evidence.yml
+++ b/.github/workflows/product-environment-evidence.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Upload route evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: >-
             product-environment-evidence-${{ inputs.target_set }}-routes
@@ -134,7 +134,7 @@ jobs:
 
       - name: Read product environment evidence
         id: environment_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -204,7 +204,7 @@ jobs:
 
       - name: Read product environment config status
         id: config_status_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -277,7 +277,7 @@ jobs:
 
       - name: Upload product environment evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: >-
             product-environment-evidence-${{ inputs.target_set }}-${{

--- a/.github/workflows/product-expected-config.yml
+++ b/.github/workflows/product-expected-config.yml
@@ -79,7 +79,7 @@ jobs:
       CONFIRMATION: ${{ inputs.confirmation }}
       REASON: ${{ inputs.reason }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Validate apply guard
         shell: bash
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload expected config evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: product-expected-config-result
           path: product-expected-config.json

--- a/.github/workflows/product-legacy-context-cleanup.yml
+++ b/.github/workflows/product-legacy-context-cleanup.yml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Request Launchplane legacy context cleanup
         id: cleanup_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           route-path: /v1/product-profiles/legacy-context-cleanup/apply
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload cleanup artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: launchplane-product-legacy-context-cleanup-${{ inputs.product }}
           path: launchplane-product-legacy-context-cleanup.json

--- a/.github/workflows/product-onboarding.yml
+++ b/.github/workflows/product-onboarding.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Request product onboarding apply
         id: onboarding_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload onboarding evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: product-onboarding-result
           path: product-onboarding.json

--- a/.github/workflows/product-preview-tls.yml
+++ b/.github/workflows/product-preview-tls.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Request product preview TLS operation
         id: preview_tls_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: Upload product preview TLS evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: product-preview-tls-result
           path: product-preview-tls.json

--- a/.github/workflows/provider-target-operations.yml
+++ b/.github/workflows/provider-target-operations.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload route evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: >-
             provider-target-ops-${{ inputs.mode }}-${{ inputs.target_set }}-routes
@@ -200,7 +200,7 @@ jobs:
 
       - name: Request provider-target operation
         id: provider_target_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ env.LAUNCHPLANE_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -234,7 +234,7 @@ jobs:
 
       - name: Upload operation evidence
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: >-
             provider-target-ops-${{ inputs.mode }}-${{ inputs.target_set }}-${{

--- a/.github/workflows/public-ingress-monitor.yml
+++ b/.github/workflows/public-ingress-monitor.yml
@@ -38,7 +38,7 @@ jobs:
         inputs.notify && 'true' || 'false' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run public ingress monitor
         uses: ./.github/actions/launchplane-request

--- a/.github/workflows/reusable-generic-web-preview-lifecycle.yml
+++ b/.github/workflows/reusable-generic-web-preview-lifecycle.yml
@@ -216,7 +216,7 @@ jobs:
     steps:
       - name: Request Launchplane generic-web preview refresh
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -266,7 +266,7 @@ jobs:
     steps:
       - name: Request Launchplane generic-web preview destroy
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -310,7 +310,7 @@ jobs:
     steps:
       - name: Request Launchplane unsupported preview feedback
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-preview-verification.yml
+++ b/.github/workflows/reusable-generic-web-preview-verification.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Request Launchplane generic-web preview verification
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-prod-promotion.yml
+++ b/.github/workflows/reusable-generic-web-prod-promotion.yml
@@ -278,7 +278,7 @@ jobs:
 
       - name: Request Launchplane generic-web prod promotion
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-prod-rollback.yml
+++ b/.github/workflows/reusable-generic-web-prod-rollback.yml
@@ -189,7 +189,7 @@ jobs:
 
       - name: Request Launchplane generic-web prod rollback
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-stable-deploy.yml
+++ b/.github/workflows/reusable-generic-web-stable-deploy.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Request Launchplane generic-web stable deploy
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-generic-web-stable-verification.yml
+++ b/.github/workflows/reusable-generic-web-stable-verification.yml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Request Launchplane generic-web stable verification
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-artifact-publish.yml
+++ b/.github/workflows/reusable-odoo-artifact-publish.yml
@@ -201,7 +201,7 @@ jobs:
           } >>"$GITHUB_OUTPUT"
 
       - name: Checkout tenant repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ steps.source.outputs.repository }}
           ref: ${{ steps.source.outputs.source_git_ref }}
@@ -210,18 +210,18 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
         run: uv python install 3.13
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -229,7 +229,7 @@ jobs:
 
       - name: Resolve Launchplane publish inputs
         id: publish_inputs
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -285,7 +285,7 @@ jobs:
           fi
 
       - name: Checkout devkit repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ steps.publish_inputs.outputs.devkit_repository }}
           path: odoo-devkit
@@ -293,7 +293,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout shared addons repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ steps.publish_inputs.outputs.shared_addons_repository }}
           path: odoo-shared-addons
@@ -350,7 +350,7 @@ jobs:
 
       - name: Record artifact in Launchplane
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-odoo-preview.yml
+++ b/.github/workflows/reusable-odoo-preview.yml
@@ -278,7 +278,7 @@ jobs:
           fi
 
       - name: Checkout tenant repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ steps.facts.outputs.tenant_repository }}
           ref: ${{ steps.facts.outputs.source_git_ref }}
@@ -287,13 +287,13 @@ jobs:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Set up Python
         run: uv python install 3.13
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 22
 
@@ -320,7 +320,7 @@ jobs:
           git ls-remote --refs "https://github.com/${SOURCE_ACCESS_PROBE_REPOSITORY}.git" main >/dev/null
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -328,7 +328,7 @@ jobs:
 
       - name: Render Launchplane publish inputs request
         id: publish_inputs_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           request-kind: artifact-publish-inputs
           product: ${{ inputs.product }}
@@ -338,7 +338,7 @@ jobs:
 
       - name: Resolve Launchplane publish inputs
         id: publish_inputs
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -386,7 +386,7 @@ jobs:
           fi
 
       - name: Checkout devkit repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ steps.publish_inputs.outputs.devkit_repository }}
           path: odoo-devkit
@@ -394,7 +394,7 @@ jobs:
           persist-credentials: false
 
       - name: Checkout shared addons repo
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ steps.publish_inputs.outputs.shared_addons_repository }}
           path: odoo-shared-addons
@@ -451,7 +451,7 @@ jobs:
 
       - name: Render Launchplane isolated preview apply inputs request
         id: dry_run_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           request-kind: preview-apply-inputs
           product: ${{ inputs.product }}
@@ -463,7 +463,7 @@ jobs:
 
       - name: Request Launchplane isolated preview apply inputs
         id: dry_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -485,7 +485,7 @@ jobs:
 
       - name: Render Launchplane isolated preview apply request
         id: launchplane_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           request-kind: preview-apply
           product: ${{ inputs.product }}
@@ -499,7 +499,7 @@ jobs:
 
       - name: Request Launchplane isolated preview apply
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -575,7 +575,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: cbusillo/launchplane/.github/workflows/reusable-preview-feedback-status.yml@main
+    uses: ./.github/workflows/reusable-preview-feedback-status.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}
@@ -653,7 +653,7 @@ jobs:
 
       - name: Render Launchplane isolated preview destroy inputs request
         id: dry_run_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           request-kind: preview-apply-inputs
           product: ${{ inputs.product }}
@@ -665,7 +665,7 @@ jobs:
 
       - name: Request Launchplane isolated preview destroy inputs
         id: dry_run
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -686,7 +686,7 @@ jobs:
 
       - name: Render Launchplane isolated preview destroy request
         id: launchplane_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           request-kind: preview-apply
           product: ${{ inputs.product }}
@@ -700,7 +700,7 @@ jobs:
 
       - name: Request Launchplane isolated preview destroy
         id: launchplane
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -764,7 +764,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: cbusillo/launchplane/.github/workflows/reusable-preview-feedback-status.yml@main
+    uses: ./.github/workflows/reusable-preview-feedback-status.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}

--- a/.github/workflows/reusable-preview-feedback-status.yml
+++ b/.github/workflows/reusable-preview-feedback-status.yml
@@ -241,7 +241,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main
+    uses: ./.github/workflows/reusable-preview-pr-feedback.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}

--- a/.github/workflows/reusable-preview-pr-feedback.yml
+++ b/.github/workflows/reusable-preview-pr-feedback.yml
@@ -154,7 +154,7 @@ jobs:
 
       - name: Request Launchplane preview PR feedback
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-preview-request-notice.yml
+++ b/.github/workflows/reusable-preview-request-notice.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: Resolve preview request notice
         id: notice
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           PREVIEW_LABEL: ${{ inputs.preview_label }}
           RUN_URL: >-
@@ -153,7 +153,7 @@ jobs:
   feedback:
     if: ${{ needs.resolve.outputs.should_record == 'true' }}
     needs: resolve
-    uses: cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main
+    uses: ./.github/workflows/reusable-preview-pr-feedback.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}

--- a/.github/workflows/reusable-product-driver-app-maintenance.yml
+++ b/.github/workflows/reusable-product-driver-app-maintenance.yml
@@ -186,7 +186,7 @@ jobs:
 
       - name: Request Launchplane app maintenance
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-post-deploy.yml
+++ b/.github/workflows/reusable-product-driver-post-deploy.yml
@@ -120,7 +120,7 @@ jobs:
 
       - name: Request Launchplane post-deploy driver
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-prod-backup-gate.yml
+++ b/.github/workflows/reusable-product-driver-prod-backup-gate.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Request Launchplane prod backup gate
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-prod-launch-readiness.yml
+++ b/.github/workflows/reusable-product-driver-prod-launch-readiness.yml
@@ -81,7 +81,7 @@ permissions:
 
 jobs:
   resolve-prod-environment:
-    uses: cbusillo/launchplane/.github/workflows/reusable-product-driver-stable-environment.yml@main
+    uses: ./.github/workflows/reusable-product-driver-stable-environment.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}
@@ -94,7 +94,7 @@ jobs:
 
   verify-prod-runtime:
     needs: resolve-prod-environment
-    uses: cbusillo/launchplane/.github/workflows/reusable-product-driver-runtime-verification.yml@main
+    uses: ./.github/workflows/reusable-product-driver-runtime-verification.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}

--- a/.github/workflows/reusable-product-driver-prod-promotion.yml
+++ b/.github/workflows/reusable-product-driver-prod-promotion.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Request Launchplane VeriReel prod promotion
         id: lp_verireel
         if: ${{ steps.request.outputs.driver == 'verireel' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -280,7 +280,7 @@ jobs:
       - name: Request Launchplane Odoo prod promotion
         id: lp_odoo
         if: ${{ steps.request.outputs.driver == 'odoo' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-prod-rollback.yml
+++ b/.github/workflows/reusable-product-driver-prod-rollback.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Request Launchplane VeriReel prod rollback
         id: lp_verireel
         if: ${{ steps.request.outputs.driver == 'verireel' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -247,7 +247,7 @@ jobs:
       - name: Request Launchplane Odoo prod rollback
         id: lp_odoo
         if: ${{ steps.request.outputs.driver == 'odoo' }}
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-runtime-verification.yml
+++ b/.github/workflows/reusable-product-driver-runtime-verification.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Request Launchplane runtime verification
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-stable-deploy.yml
+++ b/.github/workflows/reusable-product-driver-stable-deploy.yml
@@ -141,7 +141,7 @@ jobs:
 
       - name: Request Launchplane stable deploy
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-stable-environment.yml
+++ b/.github/workflows/reusable-product-driver-stable-environment.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Request Launchplane stable environment
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-testing-deploy.yml
+++ b/.github/workflows/reusable-product-driver-testing-deploy.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Request Launchplane Odoo target replacement apply
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}
@@ -252,7 +252,7 @@ jobs:
 
       - name: Poll target replacement operation result
         id: poll_result
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-driver-testing-reset.yml
+++ b/.github/workflows/reusable-product-driver-testing-reset.yml
@@ -59,7 +59,7 @@ permissions:
 
 jobs:
   verify-before-reset:
-    uses: cbusillo/launchplane/.github/workflows/reusable-product-driver-runtime-verification.yml@main
+    uses: ./.github/workflows/reusable-product-driver-runtime-verification.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}
@@ -74,7 +74,7 @@ jobs:
 
   reset-testing:
     needs: verify-before-reset
-    uses: cbusillo/launchplane/.github/workflows/reusable-product-driver-app-maintenance.yml@main
+    uses: ./.github/workflows/reusable-product-driver-app-maintenance.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}
@@ -90,7 +90,7 @@ jobs:
 
   verify-after-reset:
     needs: reset-testing
-    uses: cbusillo/launchplane/.github/workflows/reusable-product-driver-runtime-verification.yml@main
+    uses: ./.github/workflows/reusable-product-driver-runtime-verification.yml
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}

--- a/.github/workflows/reusable-product-driver-testing-verification.yml
+++ b/.github/workflows/reusable-product-driver-testing-verification.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Request Launchplane testing verification
         id: lp
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: >-
             ${{ inputs.launchplane_url || vars.LAUNCHPLANE_PUBLIC_URL }}

--- a/.github/workflows/reusable-product-repo-config-authority.yml
+++ b/.github/workflows/reusable-product-repo-config-authority.yml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out product repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           path: product-repo
           fetch-depth: 0
 
       - name: Check out Launchplane audit tool
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: cbusillo/launchplane
           ref: main
@@ -37,12 +37,12 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ inputs.python-version }}
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
 

--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -73,10 +73,10 @@ jobs:
         }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Validate workflow configuration
         shell: bash
@@ -191,7 +191,7 @@ jobs:
             | tee runner-host-hygiene-result.json
 
       - name: Upload executor result
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: runner-host-hygiene-result
           path: runner-host-hygiene-result.json

--- a/.github/workflows/runner-lane-registration.yml
+++ b/.github/workflows/runner-lane-registration.yml
@@ -66,10 +66,10 @@ jobs:
       LAUNCHPLANE_SERVICE_URL: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
 
       - name: Validate workflow configuration
         shell: bash
@@ -199,7 +199,7 @@ jobs:
 
       - name: Upload registration result
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: runner-lane-registration-result
           path: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -26,14 +26,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Enforce immutable GitHub Action references
+        run: >-
+          uv run --no-project --python 3.13 python -m unittest
+          tests.test_github_actions_security
 
       - name: Lint GitHub Actions workflows
         run: |
           docker run --rm \
             -v "${PWD}:/repo" \
             -w /repo \
-            rhysd/actionlint:1.7.12 \
+            rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
             -config-file .github/actionlint.yaml
 
   workflow_lint_fork:
@@ -46,14 +57,25 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
+
+      - name: Install Python
+        run: uv python install 3.13
+
+      - name: Enforce immutable GitHub Action references
+        run: >-
+          uv run --no-project --python 3.13 python -m unittest
+          tests.test_github_actions_security
 
       - name: Lint GitHub Actions workflows
         run: |
           docker run --rm \
             -v "${PWD}:/repo" \
             -w /repo \
-            rhysd/actionlint:1.7.12 \
+            rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667 \
             -config-file .github/actionlint.yaml
 
   secret_scan:
@@ -68,7 +90,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Scan current tree for committed secrets
         run: |
@@ -80,7 +102,7 @@ jobs:
           docker run --rm \
             -v "${scan_path}:/repo:ro" \
             -w /repo \
-            ghcr.io/gitleaks/gitleaks:v8.30.1 detect \
+            ghcr.io/gitleaks/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f detect \
             --source . \
             --no-git \
             --redact \
@@ -96,7 +118,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Scan current tree for committed secrets
         run: |
@@ -108,7 +130,7 @@ jobs:
           docker run --rm \
             -v "${scan_path}:/repo:ro" \
             -w /repo \
-            ghcr.io/gitleaks/gitleaks:v8.30.1 detect \
+            ghcr.io/gitleaks/gitleaks:v8.30.1@sha256:c00b6bd0aeb3071cbcb79009cb16a60dd9e0a7c60e2be9ab65d25e6bc8abbb7f detect \
             --source . \
             --no-git \
             --redact \

--- a/.github/workflows/tracked-target-logs.yml
+++ b/.github/workflows/tracked-target-logs.yml
@@ -55,7 +55,7 @@ jobs:
       SINCE: ${{ inputs.since }}
       SEARCH: ${{ inputs.search }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Validate inputs
         shell: bash
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload tracked target logs
         if: ${{ always() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: >-
             tracked-target-logs-${{ inputs.context }}-${{

--- a/.github/workflows/work-graph-snapshot-validate.yml
+++ b/.github/workflows/work-graph-snapshot-validate.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Request work graph snapshot
         id: snapshot_request
-        uses: cbusillo/launchplane/.github/actions/launchplane-request@main
+        uses: cbusillo/launchplane/.github/actions/launchplane-request@adcf937c6aef14e02478724040852d1d2a82a850 # main
         with:
           launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
           audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload snapshot artifact
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: launchplane-work-graph-snapshot
           path: launchplane-work-graph-snapshot.json

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,8 @@ Use these docs as the source of truth for `launchplane`.
   before making Launchplane public.
 - [secrets.md](secrets.md) — Managed secrets, key rotation, plaintext exposure,
   and local contract.
+- [github-actions-security.md](github-actions-security.md) — GitHub Actions
+  supply-chain pinning, source classification, provenance, and update policy.
 - [style/python.md](style/python.md) — Python conventions.
 - [style/testing.md](style/testing.md) — testing conventions.
 - [policies/coding-standards.md](policies/coding-standards.md) — naming and

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -1,0 +1,77 @@
+---
+title: GitHub Actions Supply-Chain Security
+---
+
+## Purpose
+
+Launchplane workflows treat every remote `uses:` reference and static container
+image as executable supply-chain input. Remote actions and cross-repository
+composite actions must resolve to a reviewed, immutable 40-character Git commit
+SHA. Static container images must retain a reviewable release tag and resolve to
+an immutable `sha256` manifest digest.
+
+## Reference Classes
+
+| Reference class | Trust | Typical privilege | Required form |
+| --- | --- | --- | --- |
+| Same-repository local action or reusable workflow | Same reviewed workflow commit | Depends on the caller workflow | `./.github/actions/...` or `./.github/workflows/...` |
+| GitHub-maintained action | GitHub-maintained | Checkout, artifacts, cache, runtime setup, GitHub API, CodeQL | Full SHA plus a release-tag provenance comment |
+| Third-party publisher | Third-party publisher | Python bootstrap, registry authentication, image build and publication | Full SHA plus a release-tag provenance comment |
+| First-party cross-repository Launchplane action | First-party cross-repository | OIDC-authenticated Launchplane requests and preview-client setup | Full SHA plus `# main` provenance |
+| Static workflow container image | Official or third-party publisher | Workflow linting, secret/vulnerability scanning, integration services | Release tag plus `@sha256:<manifest-digest>` |
+
+Relative reusable-workflow references are preferred for same-repository workflow
+composition. Reusable workflows retain a SHA-pinned Launchplane composite-action
+reference when they must source the action independently of a caller checkout.
+
+## Privilege Priority
+
+High-privilege references receive the strictest review first: the
+`launchplane-request` composite action can make OIDC-authenticated control-plane
+requests, while Docker login, Buildx, and build-push actions can access registry
+credentials and publish images. Checkout and runtime-bootstrap actions execute
+before those operations and are pinned to the same immutable standard. Artifact,
+cache, GitHub API, and CodeQL actions remain fully pinned because they execute
+remote code or move workflow data across trust boundaries.
+
+## Policy
+
+- A remote action source must be listed in
+  `tests/test_github_actions_security.py` with its trust and privilege class.
+- A remote action must use a full 40-character lowercase commit SHA; tags,
+  branches, short SHAs, and expressions are rejected.
+- Every remote pin must retain its provenance comment: an exact release tag for
+  public actions or `main` for the first-party cross-repository composite
+  actions.
+- The mutable remote-reference allowlist is explicitly represented by
+  `MUTABLE_REFERENCE_ALLOWLIST` and is currently empty. Any temporary exception
+  must be scoped to one workflow path and one literal reference, with a
+  corresponding test and security review.
+- Same-repository reusable workflows must use relative paths rather than a
+  repository-qualified reference.
+- Every static container image source must be classified in the policy test and
+  use a release tag plus a 64-character `sha256` manifest digest. Mutable tags
+  without a digest are rejected.
+
+The security workflow runs this policy for both same-repository and fork pull
+requests before actionlint. The unit-test suite runs it as well, so a mutable
+reference cannot pass the required CI path.
+
+## Provenance And Updates
+
+Each public action pin carries the exact release tag in an inline comment, for
+example `actions/checkout@<full-sha> # v7.0.0`. The comment makes a pin directly
+reviewable and lets Dependabot update the SHA and tag together in a normal pull
+request. First-party cross-repository pins use `# main`; Dependabot tracks the
+GitHub Actions ecosystem weekly through `.github/dependabot.yml`.
+
+Dependabot does not update container references embedded in workflow scripts.
+For those images, resolve the reviewed release manifest with
+`docker buildx imagetools inspect <image>:<tag> --format '{{.Manifest.Digest}}'`,
+update the tag and digest together, and let the policy test reject omissions or
+unclassified sources.
+
+Review each update PR as a supply-chain change: verify the repository, release
+or reviewed source commit, action provenance, and the workflow permissions that
+will execute it. This repository treats Dependabot updates as normal pull
+requests subject to code review, required checks, and branch protection.

--- a/tests/test_config_authority_audit.py
+++ b/tests/test_config_authority_audit.py
@@ -66,7 +66,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("Build policy apply payload", workflow_text)
         self.assertIn("Apply policy import", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("route-path: /v1/merge-train/policies/import", workflow_text)
@@ -119,7 +119,7 @@ class ConfigAuthorityAuditTest(unittest.TestCase):
         self.assertIn("Post manual phase PR feedback", workflow_text)
         self.assertIn("Send manual phase PR feedback", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main", workflow_text
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@", workflow_text
         )
         self.assertIn(
             "audience: ${{ steps.scheduled_target_request.outputs.service_audience }}",

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -152,7 +152,7 @@ class DocsContractsTests(TestCase):
 
         self.assertIn("Capture v2 deployed smoke evidence", deploy_workflow)
         self.assertIn("launchplane-v2-deployed-smoke.json", deploy_workflow)
-        self.assertIn("actions/upload-artifact@v7", deploy_workflow)
+        self.assertIn("actions/upload-artifact@", deploy_workflow)
         self.assertIn("/v1/health", deploy_workflow)
         self.assertIn("/v1/service/runtime", deploy_workflow)
         self.assertIn("/openapi.json", deploy_workflow)
@@ -436,7 +436,7 @@ class DocsContractsTests(TestCase):
         self.assertIn("workflow_call:", preview_feedback_status_workflow)
         self.assertIn("mode:", preview_feedback_status_workflow)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main",
+            "uses: ./.github/workflows/reusable-preview-pr-feedback.yml",
             preview_feedback_status_workflow,
         )
         self.assertIn(

--- a/tests/test_github_actions_security.py
+++ b/tests/test_github_actions_security.py
@@ -1,0 +1,249 @@
+import re
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from unittest import TestCase
+
+
+USES_LINE_PATTERN = re.compile(
+    r"^\s*(?:-\s+)?uses:\s*(?P<reference>[^#\s]+)(?:\s+#\s*(?P<provenance>.+?))?\s*$"
+)
+FULL_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+VERSION_PROVENANCE_PATTERN = re.compile(r"^v\d+(?:\.\d+){0,2}(?:[-+][A-Za-z0-9.-]+)?$")
+CONTAINER_TAG_PATTERN = re.compile(r"^v?\d+(?:\.\d+){0,2}(?:[-+][A-Za-z0-9.-]+)?$")
+STATIC_CONTAINER_REFERENCE_PATTERN = re.compile(
+    r"(?P<source>(?:[a-z0-9.-]+/)+[a-z0-9._/-]+|postgres):"
+    r"(?P<tag>v?[0-9][A-Za-z0-9._-]*)"
+    r"(?:@sha256:(?P<digest>[0-9a-f]{64}))?"
+)
+LOCAL_REFERENCE_PREFIXES = ("./.github/actions/", "./.github/workflows/")
+SELF_REUSABLE_WORKFLOW_PREFIX = "cbusillo/launchplane/.github/workflows/"
+FIRST_PARTY_CROSS_REPOSITORY_ACTION_PREFIX = "cbusillo/launchplane/.github/actions/"
+MUTABLE_REFERENCE_ALLOWLIST: Mapping[Path, frozenset[str]] = {}
+
+
+@dataclass(frozen=True)
+class ActionClassification:
+    trust: str
+    privilege: str
+
+
+@dataclass(frozen=True)
+class ActionReference:
+    path: Path
+    line_number: int
+    reference: str
+    provenance: str | None
+
+    @property
+    def location(self) -> str:
+        return f"{self.path}:{self.line_number}"
+
+
+@dataclass(frozen=True)
+class ContainerReference:
+    path: Path
+    line_number: int
+    source: str
+    tag: str
+    digest: str | None
+
+    @property
+    def location(self) -> str:
+        return f"{self.path}:{self.line_number}"
+
+
+APPROVED_REMOTE_ACTIONS: Mapping[str, ActionClassification] = {
+    "actions/cache": ActionClassification("GitHub-maintained", "cache transport"),
+    "actions/cache/restore": ActionClassification("GitHub-maintained", "cache restore"),
+    "actions/cache/save": ActionClassification("GitHub-maintained", "cache persistence"),
+    "actions/checkout": ActionClassification("GitHub-maintained", "repository checkout"),
+    "actions/download-artifact": ActionClassification("GitHub-maintained", "artifact download"),
+    "actions/github-script": ActionClassification("GitHub-maintained", "GitHub API interaction"),
+    "actions/setup-node": ActionClassification("GitHub-maintained", "Node runtime bootstrap"),
+    "actions/setup-python": ActionClassification("GitHub-maintained", "Python runtime bootstrap"),
+    "actions/upload-artifact": ActionClassification("GitHub-maintained", "artifact upload"),
+    "astral-sh/setup-uv": ActionClassification("Third-party publisher", "Python tool bootstrap"),
+    "cbusillo/launchplane/.github/actions/launchplane-request": ActionClassification(
+        "First-party cross-repository", "OIDC-authenticated Launchplane API requests"
+    ),
+    "cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client": (
+        ActionClassification("First-party cross-repository", "preview request client setup")
+    ),
+    "docker/build-push-action": ActionClassification(
+        "Third-party publisher", "container build and publication"
+    ),
+    "docker/login-action": ActionClassification(
+        "Third-party publisher", "container registry authentication"
+    ),
+    "docker/setup-buildx-action": ActionClassification(
+        "Third-party publisher", "container build bootstrap"
+    ),
+    "github/codeql-action/analyze": ActionClassification(
+        "GitHub-maintained", "code scanning analysis"
+    ),
+    "github/codeql-action/init": ActionClassification(
+        "GitHub-maintained", "code scanning initialization"
+    ),
+}
+APPROVED_CONTAINER_IMAGES: Mapping[str, ActionClassification] = {
+    "ghcr.io/aquasecurity/trivy": ActionClassification(
+        "Third-party publisher", "runtime image vulnerability scanning"
+    ),
+    "ghcr.io/gitleaks/gitleaks": ActionClassification(
+        "Third-party publisher", "repository secret scanning"
+    ),
+    "postgres": ActionClassification("Official image", "integration-test database"),
+    "rhysd/actionlint": ActionClassification("Third-party publisher", "workflow linting"),
+}
+
+
+def _action_reference_files() -> tuple[Path, ...]:
+    workflow_files = sorted(Path(".github/workflows").glob("*.yml"))
+    composite_action_files = sorted(Path(".github/actions").rglob("action.y*ml"))
+    return tuple(workflow_files + composite_action_files)
+
+
+def _action_references() -> Iterator[ActionReference]:
+    for path in _action_reference_files():
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            match = USES_LINE_PATTERN.match(line)
+            if match is None:
+                continue
+            yield ActionReference(
+                path=path,
+                line_number=line_number,
+                reference=match.group("reference"),
+                provenance=match.group("provenance"),
+            )
+
+
+def _container_references() -> Iterator[ContainerReference]:
+    for path in sorted(Path(".github/workflows").glob("*.yml")):
+        for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+            for match in STATIC_CONTAINER_REFERENCE_PATTERN.finditer(line):
+                yield ContainerReference(
+                    path=path,
+                    line_number=line_number,
+                    source=match.group("source"),
+                    tag=match.group("tag"),
+                    digest=match.group("digest"),
+                )
+
+
+class GitHubActionsSecurityTests(TestCase):
+    def test_action_reference_parser_covers_inline_step_syntax(self) -> None:
+        match = USES_LINE_PATTERN.match(
+            "      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0"
+        )
+
+        self.assertIsNotNone(match)
+        assert match is not None
+        self.assertEqual(
+            match.group("reference"),
+            "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+        )
+        self.assertEqual(match.group("provenance"), "v7.0.0")
+
+    def test_remote_action_references_are_classified_and_immutably_pinned(self) -> None:
+        observed_sources: set[str] = set()
+        violations: list[str] = []
+
+        for action in _action_references():
+            if action.reference.startswith("./"):
+                if not action.reference.startswith(LOCAL_REFERENCE_PREFIXES):
+                    violations.append(
+                        f"{action.location}: unsupported local action reference {action.reference!r}."
+                    )
+                if "@" in action.reference:
+                    violations.append(
+                        f"{action.location}: local action reference must not include a ref."
+                    )
+                continue
+
+            if action.reference in MUTABLE_REFERENCE_ALLOWLIST.get(action.path, frozenset()):
+                continue
+
+            source, separator, revision = action.reference.rpartition("@")
+            if not separator:
+                violations.append(
+                    f"{action.location}: remote action reference must include a full commit SHA."
+                )
+                continue
+            if source.startswith(SELF_REUSABLE_WORKFLOW_PREFIX):
+                violations.append(
+                    f"{action.location}: same-repository reusable workflows must use a relative path."
+                )
+            classification = APPROVED_REMOTE_ACTIONS.get(source)
+            if classification is None:
+                violations.append(
+                    f"{action.location}: unclassified remote action source {source!r}."
+                )
+            else:
+                observed_sources.add(source)
+            if FULL_SHA_PATTERN.fullmatch(revision) is None:
+                violations.append(
+                    f"{action.location}: remote action {source!r} must use a 40-character SHA."
+                )
+            if action.provenance is None:
+                violations.append(
+                    f"{action.location}: remote action {source!r} must document its provenance."
+                )
+            elif source.startswith(FIRST_PARTY_CROSS_REPOSITORY_ACTION_PREFIX):
+                if action.provenance != "main":
+                    violations.append(
+                        f"{action.location}: first-party cross-repository action provenance must be 'main'."
+                    )
+            elif VERSION_PROVENANCE_PATTERN.fullmatch(action.provenance) is None:
+                violations.append(
+                    f"{action.location}: release provenance must use a version tag, not {action.provenance!r}."
+                )
+
+        self.assertFalse(violations, "\n".join(violations))
+        self.assertSetEqual(set(APPROVED_REMOTE_ACTIONS), observed_sources)
+
+    def test_static_container_references_are_classified_and_digest_pinned(self) -> None:
+        observed_sources: set[str] = set()
+        violations: list[str] = []
+
+        for image in _container_references():
+            classification = APPROVED_CONTAINER_IMAGES.get(image.source)
+            if classification is None:
+                violations.append(
+                    f"{image.location}: unclassified container image source {image.source!r}."
+                )
+            else:
+                observed_sources.add(image.source)
+            if image.digest is None:
+                violations.append(
+                    f"{image.location}: container image {image.source!r} must use a sha256 digest."
+                )
+            if CONTAINER_TAG_PATTERN.fullmatch(image.tag) is None:
+                violations.append(
+                    f"{image.location}: container image tag {image.tag!r} is not reviewable."
+                )
+
+        self.assertFalse(violations, "\n".join(violations))
+        self.assertSetEqual(set(APPROVED_CONTAINER_IMAGES), observed_sources)
+
+    def test_security_gate_runs_action_pinning_policy_for_all_pull_requests(self) -> None:
+        security_workflow = Path(".github/workflows/security.yml").read_text(encoding="utf-8")
+
+        self.assertEqual(2, security_workflow.count("tests.test_github_actions_security"))
+        self.assertEqual(2, security_workflow.count("Enforce immutable GitHub Action references"))
+
+    def test_documentation_and_dependabot_preserve_reviewable_pin_updates(self) -> None:
+        docs_index = Path("docs/README.md").read_text(encoding="utf-8")
+        policy = Path("docs/github-actions-security.md").read_text(encoding="utf-8")
+        dependabot = Path(".github/dependabot.yml").read_text(encoding="utf-8")
+
+        self.assertIn("github-actions-security.md", docs_index)
+        self.assertIn("GitHub-maintained", policy)
+        self.assertIn("Third-party publisher", policy)
+        self.assertIn("First-party cross-repository", policy)
+        self.assertIn("High-privilege", policy)
+        self.assertIn("container image", policy)
+        self.assertIn("MUTABLE_REFERENCE_ALLOWLIST", policy)
+        self.assertIn("Dependabot", policy)
+        self.assertIn("package-ecosystem: github-actions", dependabot)
+        self.assertIn("interval: weekly", dependabot)

--- a/tests/test_preview_workflow_contract.py
+++ b/tests/test_preview_workflow_contract.py
@@ -223,7 +223,7 @@ class PreviewWorkflowContractTests(unittest.TestCase):
         self.assertIn("value=\"${value//$'\\n'/ }\"", workflow)
         self.assertNotIn("LAUNCHPLANE_FAILURE_SUMMARY", workflow)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main",
+            "uses: ./.github/workflows/reusable-preview-pr-feedback.yml",
             workflow,
         )
         self.assertIn("status: ${{ needs.resolve.outputs.status }}", workflow)
@@ -250,7 +250,7 @@ class PreviewWorkflowContractTests(unittest.TestCase):
             r"uses: actions/github-script@(?:v\d+(?:\.\d+){0,2}|[0-9a-f]{40})(?:\s|$)",
         )
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/workflows/reusable-preview-pr-feedback.yml@main",
+            "uses: ./.github/workflows/reusable-preview-pr-feedback.yml",
             workflow,
         )
         self.assertIn("status: ${{ needs.resolve.outputs.status }}", workflow)

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -752,7 +752,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
                 self.assertIn("runs-on: ubuntu-latest", workflow_text)
                 self.assertIn(
-                    "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+                    "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
                     workflow_text,
                 )
                 self.assertIn(f"route-path: {route_path}", workflow_text)
@@ -785,7 +785,7 @@ class ProductOnboardingTests(unittest.TestCase):
         )
         self.assertIn("runs-on: ubuntu-latest", stable_bootstrap_workflow)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             stable_bootstrap_workflow,
         )
         self.assertIn(
@@ -857,7 +857,7 @@ class ProductOnboardingTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         self.assertIn("runs-on: ubuntu-latest", target_apply_workflow)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             target_apply_workflow,
         )
         self.assertIn(
@@ -1013,7 +1013,7 @@ class ProductOnboardingTests(unittest.TestCase):
         )
         self.assertIn("fail-fast: false", provider_target_workflow)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             provider_target_workflow,
         )
         self.assertIn(
@@ -1066,13 +1066,11 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("environment:.value.environment", workflow_text)
         self.assertIn("fail-fast: false", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertEqual(
-            workflow_text.count(
-                "uses: cbusillo/launchplane/.github/actions/launchplane-request@main"
-            ),
+            workflow_text.count("uses: cbusillo/launchplane/.github/actions/launchplane-request@"),
             2,
         )
         self.assertIn("launchplane-url: ${{ env.LAUNCHPLANE_URL }}", workflow_text)
@@ -1127,7 +1125,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn("runs-on: ubuntu-latest", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
@@ -1182,7 +1180,7 @@ class ProductOnboardingTests(unittest.TestCase):
             workflow_text,
         )
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}", workflow_text)
@@ -1253,7 +1251,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("needs.validate.outputs.pr_url", workflow_text)
         self.assertIn("needs.validate.outputs.source_git_ref", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main",
+            "uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@",
             workflow_text,
         )
         self.assertEqual(workflow_text.count("          request-kind: artifact-publish-inputs"), 1)
@@ -1269,7 +1267,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("preview-refresh-feedback:", workflow_text)
         self.assertIn("preview-destroy-feedback:", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/workflows/reusable-preview-feedback-status.yml@main",
+            "uses: ./.github/workflows/reusable-preview-feedback-status.yml",
             workflow_text,
         )
         self.assertIn("source_access_probe_repository", workflow_text)
@@ -1518,7 +1516,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn("runs-on: ubuntu-latest", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
@@ -1627,7 +1625,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn("runs-on: ubuntu-latest", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn(
@@ -1677,7 +1675,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn("runs-on: ubuntu-latest", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("launchplane-url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}", workflow_text)
@@ -1709,7 +1707,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("- self-hosted", workflow_text)
         self.assertIn("- ${{ vars.LAUNCHPLANE_RUNNER_LABEL }}", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("launchplane-url: ${{ env.LAUNCHPLANE_URL }}", workflow_text)
@@ -1741,7 +1739,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn("runs-on: ubuntu-latest", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn(
@@ -1962,7 +1960,7 @@ class ProductOnboardingTests(unittest.TestCase):
         )
         self.assertIn("launchplane-break-glass-rollback.json", workflow_text)
         self.assertIn("name: launchplane-break-glass-rollback", workflow_text)
-        self.assertIn("uses: actions/upload-artifact@v7", workflow_text)
+        self.assertIn("uses: actions/upload-artifact@", workflow_text)
         self.assertIn("Evidence artifact: launchplane-break-glass-rollback", workflow_text)
         self.assertIn("manual break-glass only", workflow_text)
 
@@ -2065,8 +2063,7 @@ class ProductOnboardingTests(unittest.TestCase):
                 capture_output=True,
                 env={
                     **os.environ,
-                    "DEPLOY_IMAGE_REFERENCE": "ghcr.io/cbusillo/launchplane@sha256:"
-                    + ("b" * 64),
+                    "DEPLOY_IMAGE_REFERENCE": "ghcr.io/cbusillo/launchplane@sha256:" + ("b" * 64),
                     "GITHUB_OUTPUT": str(output_file),
                     "IMAGE_REPOSITORY": "ghcr.io/cbusillo/launchplane",
                     "PREVIOUS_RUNTIME_RESPONSE_FILE": str(response_file),
@@ -2095,8 +2092,8 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("permissions:\n      contents: read", emergency_job)
         self.assertNotIn("id-token:", emergency_job)
         self.assertNotIn("packages:", emergency_job)
-        self.assertIn("uses: actions/checkout@v7", emergency_job)
-        self.assertIn("uses: actions/upload-artifact@v7", emergency_job)
+        self.assertIn("uses: actions/checkout@", emergency_job)
+        self.assertIn("uses: actions/upload-artifact@", emergency_job)
         self.assertNotIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST", deploy_job)
         self.assertNotIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_TOKEN", deploy_job)
         self.assertNotIn("LAUNCHPLANE_EMERGENCY_DOKPLOY_HOST", validation_step)
@@ -2227,7 +2224,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("id: deployed_runtime", workflow_text)
         self.assertIn("continue-on-error: true", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("route-path: /v1/service/runtime", workflow_text)
@@ -2353,7 +2350,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("id: rollback_request_action", workflow_text)
         self.assertIn("continue-on-error: true", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("route-path: /v1/drivers/launchplane/self-deploy", workflow_text)
@@ -2437,7 +2434,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn("runs-on: ubuntu-latest", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
@@ -2475,7 +2472,7 @@ class ProductOnboardingTests(unittest.TestCase):
 
         self.assertIn("runs-on: ubuntu-latest", workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)
@@ -2513,7 +2510,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("context/instance or target_type/target_id is required.", workflow_text)
         self.assertIn('echo "route_path=/v1/dokploy-targets/inspect?${query}"', workflow_text)
         self.assertIn(
-            "uses: cbusillo/launchplane/.github/actions/launchplane-request@main",
+            "uses: cbusillo/launchplane/.github/actions/launchplane-request@",
             workflow_text,
         )
         self.assertIn("audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}", workflow_text)


### PR DESCRIPTION
## Summary
- pin every remote GitHub Action and cross-repository action to a reviewed full commit SHA with provenance
- convert same-repository reusable workflow calls to local paths
- digest-pin static workflow container images and scope CI token permissions
- add fail-closed policy tests for action and container references on same-repo and fork PR paths
- document source classification and Dependabot/manual update procedures

## Validation
- `actionlint`
- 16 focused policy/docs tests
- Ruff check and format check
- config-authority audit: `status: ok`
- public action tag and container manifest digests independently verified
- independent final review: SHIP

Closes #1686