### PR TITLE
security: make managed-secret roots explicit and rotatable

### DIFF
--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -221,3 +221,39 @@ def secrets_show(database_url: str, secret_id: str) -> None:
     finally:
         postgres_store.close()
     click.echo(json.dumps(payload, indent=2, sort_keys=True))
+
+
+@secrets.command("reencrypt")
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane managed secrets.",
+)
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Apply the re-encryption rather than just dry-running.",
+)
+@click.option(
+    "--allow-direct-db-mutation",
+    is_flag=True,
+    default=False,
+    help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
+)
+def secrets_reencrypt(database_url: str, apply: bool, allow_direct_db_mutation: bool) -> None:
+    _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
+    postgres_store = PostgresRecordStore(database_url=database_url)
+    postgres_store.ensure_schema()
+    try:
+        result = control_plane_secrets.reencrypt_secrets(
+            record_store=postgres_store,
+            apply=apply,
+        )
+    finally:
+        postgres_store.close()
+    
+    click.echo(json.dumps(result, indent=2, sort_keys=True))
+    if result["status"] == "error":
+        raise click.exceptions.Exit(1)

--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -271,7 +271,7 @@ def secrets_reencrypt(
         )
     finally:
         postgres_store.close()
-    
+
     click.echo(json.dumps(result, indent=2, sort_keys=True))
     if result["status"] == "error":
         raise click.exceptions.Exit(1)

--- a/control_plane/cli_storage_secrets.py
+++ b/control_plane/cli_storage_secrets.py
@@ -237,12 +237,28 @@ def secrets_show(database_url: str, secret_id: str) -> None:
     help="Apply the re-encryption rather than just dry-running.",
 )
 @click.option(
+    "--expected-plan-digest",
+    default="",
+    help="Matching digest emitted by a successful dry-run.",
+)
+@click.option(
+    "--reason",
+    default="",
+    help="Operator reason recorded with an applied re-encryption.",
+)
+@click.option(
     "--allow-direct-db-mutation",
     is_flag=True,
     default=False,
     help="Acknowledge direct local DB mutation for explicit local/bootstrap repair.",
 )
-def secrets_reencrypt(database_url: str, apply: bool, allow_direct_db_mutation: bool) -> None:
+def secrets_reencrypt(
+    database_url: str,
+    apply: bool,
+    expected_plan_digest: str,
+    reason: str,
+    allow_direct_db_mutation: bool,
+) -> None:
     _require_direct_db_mutation_acknowledgement(allow_direct_db_mutation)
     postgres_store = PostgresRecordStore(database_url=database_url)
     postgres_store.ensure_schema()
@@ -250,6 +266,8 @@ def secrets_reencrypt(database_url: str, apply: bool, allow_direct_db_mutation: 
         result = control_plane_secrets.reencrypt_secrets(
             record_store=postgres_store,
             apply=apply,
+            expected_plan_digest=expected_plan_digest,
+            reason=reason,
         )
     finally:
         postgres_store.close()

--- a/control_plane/contracts/secret_record.py
+++ b/control_plane/contracts/secret_record.py
@@ -141,7 +141,9 @@ class SecretRotationWrite(BaseModel):
         if self.record.secret_id != self.version.secret_id:
             raise ValueError("secret rotation record and version must reference the same secret")
         if self.record.secret_id != self.audit_event.secret_id:
-            raise ValueError("secret rotation record and audit event must reference the same secret")
+            raise ValueError(
+                "secret rotation record and audit event must reference the same secret"
+            )
         if self.record.current_version_id != self.version.version_id:
             raise ValueError("secret rotation record must point to the new version")
         if self.expected_current_version_id == self.version.version_id:

--- a/control_plane/contracts/secret_record.py
+++ b/control_plane/contracts/secret_record.py
@@ -124,3 +124,26 @@ class SecretAuditEvent(BaseModel):
         if not self.recorded_at.strip():
             raise ValueError("secret audit event requires recorded_at")
         return self
+
+
+class SecretRotationWrite(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_current_version_id: str
+    record: SecretRecord
+    version: SecretVersion
+    audit_event: SecretAuditEvent
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "SecretRotationWrite":
+        if not self.expected_current_version_id.strip():
+            raise ValueError("secret rotation write requires expected_current_version_id")
+        if self.record.secret_id != self.version.secret_id:
+            raise ValueError("secret rotation record and version must reference the same secret")
+        if self.record.secret_id != self.audit_event.secret_id:
+            raise ValueError("secret rotation record and audit event must reference the same secret")
+        if self.record.current_version_id != self.version.version_id:
+            raise ValueError("secret rotation record must point to the new version")
+        if self.expected_current_version_id == self.version.version_id:
+            raise ValueError("secret rotation must create a new version")
+        return self

--- a/control_plane/contracts/secret_reencryption_request.py
+++ b/control_plane/contracts/secret_reencryption_request.py
@@ -1,0 +1,32 @@
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class SecretReencryptionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1, le=1)
+    mode: Literal["dry-run", "apply"] = "dry-run"
+    expected_plan_digest: str = ""
+    reason: str = Field(min_length=1, max_length=240)
+    source_label: str = Field(default="service-secret-rotation", min_length=1, max_length=96)
+
+    @model_validator(mode="after")
+    def _validate_request(self) -> "SecretReencryptionRequest":
+        self.reason = self.reason.strip()
+        self.source_label = self.source_label.strip()
+        if not self.reason:
+            raise ValueError("secret re-encryption request requires reason")
+        if not self.source_label:
+            raise ValueError("secret re-encryption request requires source_label")
+        if self.mode == "apply":
+            digest = self.expected_plan_digest.strip().lower()
+            if len(digest) != 64 or any(
+                character not in "0123456789abcdef" for character in digest
+            ):
+                raise ValueError("secret re-encryption apply requires a SHA-256 plan digest")
+            self.expected_plan_digest = digest
+        elif self.expected_plan_digest.strip():
+            raise ValueError("secret re-encryption dry-run must not set expected_plan_digest")
+        return self

--- a/control_plane/every_code_notifications_delivery.py
+++ b/control_plane/every_code_notifications_delivery.py
@@ -231,7 +231,7 @@ def _launchplane_managed_secret_resolver(
             return ""
         try:
             version = record_store.read_secret_version(record.current_version_id)
-            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
+            return control_plane_secrets._decrypt_secret_value(version.ciphertext, version.key_id)
         except Exception:  # noqa: BLE001 - notification attempts capture unreadable secrets.
             return ""
 

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -662,8 +662,12 @@ _PREVIEW_DESTROYED_EVIDENCE_ROUTE = "/v1/evidence/previews/destroyed"
 _RUNNER_HOST_HYGIENE_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-host-hygiene/audits"
 _RUNNER_LANE_REGISTRATION_AUDIT_EVIDENCE_ROUTE = "/v1/evidence/runner-lane-registration/audits"
 _EVERY_CODE_GITHUB_WEBHOOK_ROUTE = "/v1/every-code/github-webhook"
+_PRODUCT_CONFIG_APPLY_ROUTE = "/v1/product-config/apply"
+_SECRET_REENCRYPT_ROUTE = "/v1/secrets/reencrypt"
 _EVIDENCE_INGRESS_MAX_BODY_BYTES = 2 * 1024 * 1024
 _GITHUB_WEBHOOK_MAX_BODY_BYTES = 2 * 1024 * 1024
+_PRODUCT_CONFIG_MAX_BODY_BYTES = 2 * 1024 * 1024
+_SECRET_REENCRYPT_MAX_BODY_BYTES = 64 * 1024
 _EVIDENCE_INGRESS_ROUTES = frozenset(
     {
         _DEPLOYMENT_EVIDENCE_ROUTE,
@@ -684,6 +688,18 @@ _BOUNDED_REQUEST_BODY_CONTRACTS: dict[str, tuple[str, int, bool, bool]] = {
         "GitHub webhook",
         _GITHUB_WEBHOOK_MAX_BODY_BYTES,
         False,
+        True,
+    ),
+    _PRODUCT_CONFIG_APPLY_ROUTE: (
+        "Product config",
+        _PRODUCT_CONFIG_MAX_BODY_BYTES,
+        True,
+        True,
+    ),
+    _SECRET_REENCRYPT_ROUTE: (
+        "Managed-secret re-encryption",
+        _SECRET_REENCRYPT_MAX_BODY_BYTES,
+        True,
         True,
     ),
 }
@@ -717,8 +733,6 @@ _PRODUCT_EXPECTED_CONFIG_APPLY_ROUTE = "/v1/product-profiles/expected-config/app
 _PRODUCT_PREVIEW_TLS_APPLY_ROUTE = "/v1/product-profiles/preview-tls/apply"
 _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/apply"
 _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
-_PRODUCT_CONFIG_APPLY_ROUTE = "/v1/product-config/apply"
-_SECRET_REENCRYPT_ROUTE = "/v1/secrets/reencrypt"
 _PRODUCT_ONBOARDING_APPLY_ROUTE = "/v1/product-onboarding/apply"
 _MERGE_TRAIN_POLICY_IMPORT_ROUTE = "/v1/merge-train/policies/import"
 _AUTHZ_POLICY_GITHUB_ACTIONS_GRANTS_ROUTE = "/v1/authz-policies/github-actions/grants"
@@ -12721,12 +12735,21 @@ def create_launchplane_fastapi_app(
             record_store=record_store,
             trace_id=trace_id,
         )
+        actor = product_config_identity_actor(identity)
+        operation_token = ""
+        if reencryption_request.mode == "apply":
+            operation_token = hashlib.sha256(
+                "\x1f".join((actor, normalized_idempotency_key, payload_fingerprint)).encode(
+                    "utf-8"
+                )
+            ).hexdigest()
         try:
             result = control_plane_secrets.reencrypt_secrets(
                 record_store=database_store,
                 apply=reencryption_request.mode == "apply",
                 expected_plan_digest=reencryption_request.expected_plan_digest,
-                actor=product_config_identity_actor(identity),
+                operation_token=operation_token,
+                actor=actor,
                 source_label=reencryption_request.source_label,
                 reason=reencryption_request.reason,
             )

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -499,6 +499,7 @@ from control_plane.contracts.runner_lane_registration_evidence import (
     RunnerLaneRegistrationAuditEvidenceEnvelope,
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyTarget
+from control_plane.contracts.secret_reencryption_request import SecretReencryptionRequest
 from control_plane.contracts.secret_record import SecretScope
 from control_plane.contracts.public_ingress_monitoring import PublicIngressNotificationPolicyRecord
 from control_plane.drivers.registry import build_driver_context_view, list_driver_descriptors
@@ -717,6 +718,7 @@ _PRODUCT_PREVIEW_TLS_APPLY_ROUTE = "/v1/product-profiles/preview-tls/apply"
 _PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE = "/v1/product-profiles/context-cutover/apply"
 _PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE = "/v1/product-profiles/legacy-context-cleanup/apply"
 _PRODUCT_CONFIG_APPLY_ROUTE = "/v1/product-config/apply"
+_SECRET_REENCRYPT_ROUTE = "/v1/secrets/reencrypt"
 _PRODUCT_ONBOARDING_APPLY_ROUTE = "/v1/product-onboarding/apply"
 _MERGE_TRAIN_POLICY_IMPORT_ROUTE = "/v1/merge-train/policies/import"
 _AUTHZ_POLICY_GITHUB_ACTIONS_GRANTS_ROUTE = "/v1/authz-policies/github-actions/grants"
@@ -12225,6 +12227,18 @@ def create_launchplane_fastapi_app(
             )
         return record_store
 
+    def require_secret_reencryption_database_store(
+        *, record_store: object, trace_id: str
+    ) -> PostgresRecordStore:
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_required",
+                message="Managed-secret re-encryption requires DB-backed Launchplane storage.",
+            )
+        return record_store
+
     def require_product_onboarding_database_store(
         *, record_store: object, trace_id: str
     ) -> PostgresRecordStore:
@@ -12627,6 +12641,121 @@ def create_launchplane_fastapi_app(
             response=product_config_response,
         )
         return product_config_response
+
+    async def reencrypt_managed_secrets(
+        request: Request,
+        identity: Annotated[LaunchplaneIdentity, Depends(read_identity)],
+        record_store: Annotated[object, Depends(get_record_store)],
+        idempotency_key: Annotated[str, Header(alias="Idempotency-Key")] = "",
+    ) -> AcceptedEvidenceResponse:
+        trace_id = next_trace_id()
+        if isinstance(identity, TerminalAgentIdentity):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Terminal agent credentials cannot rotate managed-secret roots.",
+            )
+        try:
+            raw_payload = await request.json()
+        except ValueError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Managed-secret re-encryption request failed validation.",
+            ) from error
+        if not isinstance(raw_payload, dict):
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Managed-secret re-encryption request failed validation.",
+            )
+        request_payload = cast(dict[str, object], raw_payload)
+        try:
+            reencryption_request = SecretReencryptionRequest.model_validate(request_payload)
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Managed-secret re-encryption request failed validation.",
+            ) from error
+        action = f"secret.reencrypt.{reencryption_request.mode}"
+        if not resolved_authz_policy_runtime.policy.allows(
+            identity=identity,
+            action=action,
+            product="launchplane",
+            context="launchplane",
+        ):
+            raise _launchplane_http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot re-encrypt Launchplane managed secrets.",
+            )
+        if reencryption_request.mode == "apply" and not idempotency_key.strip():
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Managed-secret re-encryption apply requires Idempotency-Key.",
+            )
+        (
+            normalized_idempotency_key,
+            payload_fingerprint,
+            replay_response,
+        ) = await replay_apply_idempotency(
+            request=request,
+            record_store=record_store,
+            identity=identity,
+            route_path=_SECRET_REENCRYPT_ROUTE,
+            idempotency_key=idempotency_key,
+            trace_id=trace_id,
+            check_replay=reencryption_request.mode == "apply",
+        )
+        if replay_response is not None:
+            return replay_response
+        database_store = require_secret_reencryption_database_store(
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+        try:
+            result = control_plane_secrets.reencrypt_secrets(
+                record_store=database_store,
+                apply=reencryption_request.mode == "apply",
+                expected_plan_digest=reencryption_request.expected_plan_digest,
+                actor=product_config_identity_actor(identity),
+                source_label=reencryption_request.source_label,
+                reason=reencryption_request.reason,
+            )
+        except click.ClickException as error:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="secret_key_configuration_invalid",
+                message="Managed-secret key configuration is unavailable or invalid.",
+            ) from error
+        if reencryption_request.mode == "apply" and result["status"] != "ok":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="secret_reencryption_conflict",
+                message="Managed-secret state no longer matches the approved dry-run.",
+            )
+        response = accepted_evidence_response(trace_id=trace_id, records={}, result=result)
+        if reencryption_request.mode == "apply":
+            store_apply_idempotency(
+                record_store=database_store,
+                identity=identity,
+                route_path=_SECRET_REENCRYPT_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=response,
+            )
+        return response
 
     async def apply_product_onboarding(
         request: Request,
@@ -20637,6 +20766,32 @@ def create_launchplane_fastapi_app(
         },
         operation_id="apply_product_config",
         summary="Plan or apply product config",
+        responses={
+            400: {"model": LaunchplaneErrorResponse},
+            401: {"model": LaunchplaneErrorResponse},
+            403: {"model": LaunchplaneErrorResponse},
+            409: {"model": LaunchplaneErrorResponse},
+            503: {"model": LaunchplaneErrorResponse},
+        },
+    )
+
+    app.add_api_route(
+        _SECRET_REENCRYPT_ROUTE,
+        reencrypt_managed_secrets,
+        methods=["POST"],
+        status_code=202,
+        response_model=AcceptedEvidenceResponse,
+        response_model_exclude_none=True,
+        openapi_extra={
+            "requestBody": {
+                "required": True,
+                "content": {
+                    "application/json": {"schema": _openapi_model_schema(SecretReencryptionRequest)}
+                },
+            }
+        },
+        operation_id="reencrypt_managed_secrets",
+        summary="Dry-run or apply managed-secret root re-encryption",
         responses={
             400: {"model": LaunchplaneErrorResponse},
             401: {"model": LaunchplaneErrorResponse},

--- a/control_plane/preview_pr_feedback_notifications.py
+++ b/control_plane/preview_pr_feedback_notifications.py
@@ -338,7 +338,7 @@ def launchplane_managed_secret_resolver(
             return ""
         try:
             version = record_store.read_secret_version(record.current_version_id)
-            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
+            return control_plane_secrets._decrypt_secret_value(version.ciphertext, version.key_id)
         except Exception:  # noqa: BLE001 - notification attempts capture unreadable secrets.
             return ""
 

--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -473,7 +473,7 @@ def _product_config_secret_current_action(
     if existing_record is None:
         return "created", ""
     current_version = record_store.read_secret_version(existing_record.current_version_id)
-    if control_plane_secrets._decrypt_secret_value(current_version.ciphertext) == str(
+    if control_plane_secrets._decrypt_secret_value(current_version.ciphertext, current_version.key_id) == str(
         secret["value"]
     ):
         return "unchanged", existing_record.secret_id

--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -475,9 +475,9 @@ def _product_config_secret_current_action(
     if existing_record is None:
         return "created", ""
     current_version = record_store.read_secret_version(existing_record.current_version_id)
-    if control_plane_secrets._decrypt_secret_value(current_version.ciphertext, current_version.key_id) == str(
-        secret["value"]
-    ):
+    if control_plane_secrets._decrypt_secret_value(
+        current_version.ciphertext, current_version.key_id
+    ) == str(secret["value"]):
         return "unchanged", existing_record.secret_id
     return "rotated", existing_record.secret_id
 

--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import json
-import os
 from json import JSONDecodeError
 from pathlib import Path
 from typing import Literal, Protocol, TypedDict, cast
+
+import click
 
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
@@ -24,7 +25,6 @@ from control_plane.runtime_key_safety import (
 from control_plane.workflows.ship import utc_now_timestamp
 
 
-MASTER_ENCRYPTION_KEY_ENV_KEYS = ("LAUNCHPLANE_MASTER_ENCRYPTION_KEY",)
 SECRET_SHAPED_RUNTIME_ENV_KEY_PARTS = {"PASSWORD", "TOKEN", "SECRET", "KEY"}
 ProductConfigMode = Literal["dry-run", "apply"]
 _VALID_SECRET_SCOPES: tuple[SecretScope, ...] = ("global", "context", "context_instance")
@@ -452,12 +452,14 @@ def _validate_product_config_target_alignment(
 def _require_product_config_master_key_if_needed(secrets: tuple[dict[str, object], ...]) -> None:
     if not secrets:
         return
-    if not any(os.environ.get(key, "").strip() for key in MASTER_ENCRYPTION_KEY_ENV_KEYS):
-        expected_keys = " or ".join(MASTER_ENCRYPTION_KEY_ENV_KEYS)
+    try:
+        control_plane_secrets.validate_secret_key_configuration()
+    except click.ClickException as error:
         raise ProductConfigError(
-            f"Product config secrets require {expected_keys} in the trusted Launchplane context.",
+            "Product config secrets require valid Launchplane secret-key configuration in the "
+            "trusted Launchplane context.",
             code="secret_configuration_required",
-        )
+        ) from error
 
 
 def _product_config_secret_current_action(

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import json
 import os
+import re
 import uuid
 from dataclasses import dataclass
-from typing import Literal, Protocol
+from typing import Literal, Mapping, Protocol
 
 import click
 from cryptography.fernet import Fernet, InvalidToken
@@ -15,6 +17,7 @@ from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
     SecretRecord,
+    SecretRotationWrite,
     SecretScope,
     SecretVersion,
 )
@@ -28,6 +31,9 @@ LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS = (LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR,
 DOKPLOY_SECRET_INTEGRATION = "dokploy"
 RUNTIME_ENVIRONMENT_SECRET_INTEGRATION = "runtime_environment"
 SECRET_STATUS_CONFIGURED = "configured"
+LEGACY_SECRET_KEY_ID = "launchplane-master-key"
+_KEY_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_MIN_UNIQUE_KEY_BYTES = 16
 
 SecretWriteAction = Literal["created", "rotated", "unchanged"]
 SecretBindingRelabelAction = Literal["relabelled", "unchanged"]
@@ -80,6 +86,8 @@ class SecretWriteStore(SecretReadStore, Protocol):
 
     def write_secret_audit_event(self, event: SecretAuditEvent) -> None: ...
 
+    def write_secret_rotations(self, rotations: tuple[SecretRotationWrite, ...]) -> None: ...
+
 
 def _secret_slug(value: str) -> str:
     compact = "".join(
@@ -118,46 +126,111 @@ def _scope_rank(scope: str) -> int:
     return 2
 
 
-@dataclass
+@dataclass(frozen=True)
 class KeyRing:
     active_key_id: str
-    keys: dict[str, Fernet]
+    keys: Mapping[str, Fernet]
+    legacy_compatibility_key_loaded: bool = False
+
+
+def _validated_key_id(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not _KEY_ID_PATTERN.fullmatch(value):
+        raise click.ClickException(
+            f"Invalid {LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR} configuration: "
+            f"{label} must match {_KEY_ID_PATTERN.pattern!r}."
+        )
+    return value
+
+
+def _canonical_fernet_key(raw_key: object, *, key_id: str) -> bytes:
+    if not isinstance(raw_key, str) or raw_key != raw_key.strip():
+        raise click.ClickException(
+            f"Invalid canonical key material for key {key_id!r}: expected an exact string."
+        )
+    try:
+        encoded = raw_key.encode("ascii")
+        decoded = base64.b64decode(encoded, altchars=b"-_", validate=True)
+    except (UnicodeEncodeError, binascii.Error, ValueError) as error:
+        raise click.ClickException(
+            f"Invalid canonical key material for key {key_id!r}: expected URL-safe base64."
+        ) from error
+    if len(decoded) != 32 or base64.urlsafe_b64encode(decoded) != encoded:
+        raise click.ClickException(
+            f"Invalid canonical key material for key {key_id!r}: expected 32 canonical bytes."
+        )
+    if len(set(decoded)) < _MIN_UNIQUE_KEY_BYTES:
+        raise click.ClickException(
+            f"Invalid canonical key material for key {key_id!r}: key material lacks entropy."
+        )
+    return encoded
 
 def _get_key_ring() -> KeyRing:
     keys_json = os.environ.get(LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR, "").strip()
     if keys_json:
         try:
             parsed = json.loads(keys_json)
-            active_key_id = parsed["active_key_id"]
+            if not isinstance(parsed, dict):
+                raise ValueError("configuration must be a JSON object")
+            unexpected_fields = sorted(set(parsed) - {"active_key_id", "keys"})
+            if unexpected_fields:
+                raise ValueError(f"unexpected fields: {', '.join(unexpected_fields)}")
+            active_key_id = _validated_key_id(
+                parsed["active_key_id"], label="active_key_id"
+            )
             keys_dict = parsed["keys"]
-            if not isinstance(active_key_id, str) or not isinstance(keys_dict, dict):
-                raise ValueError("JSON must contain string active_key_id and dict keys")
-        except (KeyError, ValueError, TypeError) as e:
-            raise click.ClickException(f"Invalid {LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR} configuration: {e}")
+            if not isinstance(keys_dict, dict) or not keys_dict:
+                raise ValueError("keys must be a non-empty object")
+        except (KeyError, ValueError, TypeError) as error:
+            raise click.ClickException(
+                f"Invalid {LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR} configuration: {error}"
+            ) from error
 
-        fernet_keys = {}
+        encoded_keys: dict[str, bytes] = {}
         for key_id, raw_key in keys_dict.items():
-            encoded = str(raw_key).encode("utf-8")
-            try:
-                fernet_keys[key_id] = Fernet(encoded)
-            except (ValueError, TypeError) as e:
-                raise click.ClickException(f"Invalid canonical key material for key '{key_id}': {e}")
+            validated_key_id = _validated_key_id(key_id, label="key id")
+            encoded_keys[validated_key_id] = _canonical_fernet_key(
+                raw_key, key_id=validated_key_id
+            )
 
-        if active_key_id not in fernet_keys:
+        if active_key_id not in encoded_keys:
             raise click.ClickException(f"Active key id '{active_key_id}' not found in keys.")
 
-        return KeyRing(active_key_id, fernet_keys)
-    
+        legacy_compatibility_key_loaded = False
+        legacy_value = os.environ.get(LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR, "").strip()
+        if legacy_value:
+            legacy_key = _master_fernet_key(legacy_value)
+            configured_legacy_key = encoded_keys.get(LEGACY_SECRET_KEY_ID)
+            if configured_legacy_key is not None and configured_legacy_key != legacy_key:
+                raise click.ClickException(
+                    f"{LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR} key {LEGACY_SECRET_KEY_ID!r} "
+                    f"does not match {LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR}."
+                )
+            if configured_legacy_key is None:
+                encoded_keys[LEGACY_SECRET_KEY_ID] = legacy_key
+                legacy_compatibility_key_loaded = True
+
+        return KeyRing(
+            active_key_id=active_key_id,
+            keys={key_id: Fernet(encoded) for key_id, encoded in encoded_keys.items()},
+            legacy_compatibility_key_loaded=legacy_compatibility_key_loaded,
+        )
+
     for environment_key in LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS:
         configured_value = os.environ.get(environment_key, "")
         if configured_value.strip():
-            key_id = "launchplane-master-key"
             fernet = Fernet(_master_fernet_key(configured_value))
-            return KeyRing(key_id, {key_id: fernet})
-    
-    key_id = "launchplane-master-key"
-    fernet = Fernet(_master_fernet_key(""))
-    return KeyRing(key_id, {key_id: fernet})
+            return KeyRing(
+                active_key_id=LEGACY_SECRET_KEY_ID,
+                keys={LEGACY_SECRET_KEY_ID: fernet},
+                legacy_compatibility_key_loaded=True,
+            )
+
+    expected_keys = " or ".join(
+        (LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR, *LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS)
+    )
+    raise click.ClickException(
+        f"Launchplane managed secrets require {expected_keys} to read or write encrypted values."
+    )
 
 def _master_fernet_key(raw_key: str) -> bytes:
     normalized = raw_key.strip()
@@ -173,6 +246,10 @@ def _master_fernet_key(raw_key: str) -> bytes:
     except (ValueError, TypeError):
         digest = hashlib.sha256(encoded).digest()
         return base64.urlsafe_b64encode(digest)
+
+
+def validate_secret_key_configuration() -> None:
+    _get_key_ring()
 
 def _encrypt_secret_value(plaintext_value: str) -> tuple[str, str]:
     key_ring = _get_key_ring()
@@ -636,80 +713,146 @@ def reencrypt_secrets(
     *,
     record_store: SecretWriteStore,
     apply: bool = False,
+    expected_plan_digest: str = "",
     actor: str = "cli",
     source_label: str = "manual",
+    reason: str = "",
 ) -> dict[str, object]:
     key_ring = _get_key_ring()
     active_key_id = key_ring.active_key_id
-    
-    rotated_count = 0
-    unchanged_count = 0
-    error_count = 0
+
+    records = tuple(
+        sorted(
+            (
+                record
+                for record in record_store.list_secret_records(limit=None)
+                if record.status == SECRET_STATUS_CONFIGURED
+            ),
+            key=lambda item: item.secret_id,
+        )
+    )
+    versions = tuple(record_store.read_secret_version(record.current_version_id) for record in records)
+    plan_entries = tuple(
+        {
+            "secret_id": record.secret_id,
+            "current_version_id": version.version_id,
+            "key_id": version.key_id,
+        }
+        for record, version in zip(records, versions, strict=True)
+    )
+    plan_digest = hashlib.sha256(
+        json.dumps(
+            {"active_key_id": active_key_id, "entries": plan_entries},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()
+    key_usage: dict[str, int] = {}
+    for version in versions:
+        key_usage[version.key_id] = key_usage.get(version.key_id, 0) + 1
+
     errors: list[str] = []
-    
-    records = record_store.list_secret_records(limit=None)
-    for record in records:
-        if record.status != SECRET_STATUS_CONFIGURED:
-            continue
-        current_version = record_store.read_secret_version(record.current_version_id)
-        if current_version.key_id == active_key_id:
-            unchanged_count += 1
-            continue
-        
+    for record, version in zip(records, versions, strict=True):
         try:
-            plaintext = _decrypt_secret_value(current_version.ciphertext, current_version.key_id)
-        except click.ClickException as e:
-            error_count += 1
-            errors.append(f"Failed to decrypt secret {record.secret_id}: {e}")
-            continue
+            _decrypt_secret_value(version.ciphertext, version.key_id)
+        except click.ClickException as error:
+            errors.append(f"Managed secret {record.secret_id} is not decryptable: {error}")
 
-        if apply:
-            now = utc_now_timestamp()
-            ciphertext, new_key_id = _encrypt_secret_value(plaintext)
-            version_id = _version_id(secret_id=record.secret_id)
-            
-            record_store.write_secret_version(
-                SecretVersion(
-                    version_id=version_id,
-                    secret_id=record.secret_id,
-                    created_at=now,
-                    created_by=actor,
-                    key_id=new_key_id,
-                    ciphertext=ciphertext,
-                )
-            )
-            
-            record_store.write_secret_record(
-                record.model_copy(update={"current_version_id": version_id, "updated_at": now, "updated_by": actor})
-            )
-            
-            record_store.write_secret_audit_event(
-                SecretAuditEvent(
-                    event_id=_audit_event_id(secret_id=record.secret_id, event_type="rotated"),
-                    secret_id=record.secret_id,
-                    event_type="rotated",
-                    recorded_at=now,
-                    actor=actor,
-                    detail=f"Launchplane re-encrypted managed secret from {source_label}.",
-                    metadata={
-                        "source": source_label, 
-                        "old_key_id": current_version.key_id,
-                        "new_key_id": new_key_id,
-                        "old_version_id": current_version.version_id,
-                        "new_version_id": version_id,
-                    },
-                )
-            )
-        rotated_count += 1
+    candidate_count = sum(version.key_id != active_key_id for version in versions)
+    unchanged_count = len(versions) - candidate_count
+    retirement_blocked_key_ids = sorted(
+        key_id
+        for key_id in key_ring.keys
+        if key_id != active_key_id and key_usage.get(key_id, 0) > 0
+    )
+    retirement_ready_key_ids = sorted(
+        key_id
+        for key_id in key_ring.keys
+        if key_id != active_key_id and key_usage.get(key_id, 0) == 0
+    )
 
-    return {
-        "status": "ok" if error_count == 0 else "error",
+    result: dict[str, object] = {
+        "status": "ok" if not errors else "error",
         "dry_run": not apply,
-        "rotated_count": rotated_count,
+        "plan_digest": plan_digest,
+        "rotated_count": candidate_count,
         "unchanged_count": unchanged_count,
-        "error_count": error_count,
+        "error_count": len(errors),
         "errors": errors,
         "active_key_id": active_key_id,
-        "allowed_key_ids": list(key_ring.keys.keys()),
+        "retirement_blocked_key_ids": retirement_blocked_key_ids,
+        "retirement_ready_key_ids": retirement_ready_key_ids,
+        "legacy_compatibility_key_loaded": key_ring.legacy_compatibility_key_loaded,
     }
+    if errors or not apply:
+        return result
+    if not reason.strip():
+        return {
+            **result,
+            "status": "error",
+            "error_count": 1,
+            "errors": ["Managed-secret re-encryption apply requires a reason."],
+        }
+    if expected_plan_digest != plan_digest:
+        return {
+            **result,
+            "status": "error",
+            "error_count": 1,
+            "errors": ["Managed-secret re-encryption apply requires the matching dry-run digest."],
+        }
 
+    rotations: list[SecretRotationWrite] = []
+    for record, current_version in zip(records, versions, strict=True):
+        if current_version.key_id == active_key_id:
+            continue
+        plaintext = _decrypt_secret_value(current_version.ciphertext, current_version.key_id)
+        ciphertext, new_key_id = _encrypt_secret_value(plaintext)
+        now = utc_now_timestamp()
+        version_id = _version_id(secret_id=record.secret_id)
+        new_version = SecretVersion(
+            version_id=version_id,
+            secret_id=record.secret_id,
+            created_at=now,
+            created_by=actor,
+            key_id=new_key_id,
+            ciphertext=ciphertext,
+        )
+        updated_record = record.model_copy(
+            update={"current_version_id": version_id, "updated_at": now, "updated_by": actor}
+        )
+        audit_event = SecretAuditEvent(
+            event_id=_audit_event_id(secret_id=record.secret_id, event_type="rotated"),
+            secret_id=record.secret_id,
+            event_type="rotated",
+            recorded_at=now,
+            actor=actor,
+            detail="Launchplane re-encrypted a managed secret under the active key.",
+            metadata={
+                "source": source_label,
+                "reason": reason.strip(),
+                "rotation_plan_digest": plan_digest,
+                "old_key_id": current_version.key_id,
+                "new_key_id": new_key_id,
+                "old_version_id": current_version.version_id,
+                "new_version_id": version_id,
+            },
+        )
+        rotations.append(
+            SecretRotationWrite(
+                expected_current_version_id=current_version.version_id,
+                record=updated_record,
+                version=new_version,
+                audit_event=audit_event,
+            )
+        )
+
+    try:
+        record_store.write_secret_rotations(tuple(rotations))
+    except (FileNotFoundError, ValueError):
+        return {
+            **result,
+            "status": "error",
+            "error_count": 1,
+            "errors": ["Managed-secret state changed after the matching dry-run."],
+        }
+    return result

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -13,6 +13,7 @@ from typing import Literal, Mapping, Protocol
 import click
 from cryptography.fernet import Fernet, InvalidToken
 
+from control_plane.child_process_errors import redact_untrusted_text
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -86,6 +87,8 @@ class SecretWriteStore(SecretReadStore, Protocol):
 
     def write_secret_audit_event(self, event: SecretAuditEvent) -> None: ...
 
+
+class SecretRotationStore(SecretWriteStore, Protocol):
     def write_secret_rotations(self, rotations: tuple[SecretRotationWrite, ...]) -> None: ...
 
 
@@ -164,6 +167,7 @@ def _canonical_fernet_key(raw_key: object, *, key_id: str) -> bytes:
         )
     return encoded
 
+
 def _get_key_ring() -> KeyRing:
     keys_json = os.environ.get(LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR, "").strip()
     if keys_json:
@@ -174,9 +178,7 @@ def _get_key_ring() -> KeyRing:
             unexpected_fields = sorted(set(parsed) - {"active_key_id", "keys"})
             if unexpected_fields:
                 raise ValueError(f"unexpected fields: {', '.join(unexpected_fields)}")
-            active_key_id = _validated_key_id(
-                parsed["active_key_id"], label="active_key_id"
-            )
+            active_key_id = _validated_key_id(parsed["active_key_id"], label="active_key_id")
             keys_dict = parsed["keys"]
             if not isinstance(keys_dict, dict) or not keys_dict:
                 raise ValueError("keys must be a non-empty object")
@@ -188,9 +190,7 @@ def _get_key_ring() -> KeyRing:
         encoded_keys: dict[str, bytes] = {}
         for key_id, raw_key in keys_dict.items():
             validated_key_id = _validated_key_id(key_id, label="key id")
-            encoded_keys[validated_key_id] = _canonical_fernet_key(
-                raw_key, key_id=validated_key_id
-            )
+            encoded_keys[validated_key_id] = _canonical_fernet_key(raw_key, key_id=validated_key_id)
 
         if active_key_id not in encoded_keys:
             raise click.ClickException(f"Active key id '{active_key_id}' not found in keys.")
@@ -232,10 +232,13 @@ def _get_key_ring() -> KeyRing:
         f"Launchplane managed secrets require {expected_keys} to read or write encrypted values."
     )
 
+
 def _master_fernet_key(raw_key: str) -> bytes:
     normalized = raw_key.strip()
     if not normalized:
-        expected_keys = f"{LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR} or " + " or ".join(LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS)
+        expected_keys = f"{LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR} or " + " or ".join(
+            LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS
+        )
         raise click.ClickException(
             f"Launchplane managed secrets require {expected_keys} to read or write encrypted values."
         )
@@ -250,6 +253,7 @@ def _master_fernet_key(raw_key: str) -> bytes:
 
 def validate_secret_key_configuration() -> None:
     _get_key_ring()
+
 
 def _encrypt_secret_value(plaintext_value: str) -> tuple[str, str]:
     key_ring = _get_key_ring()
@@ -350,9 +354,7 @@ def resolve_secret_values_for_integration_from_store(
         record
         for record in record_store.list_secret_records(integration=integration)
         if record.status == SECRET_STATUS_CONFIGURED
-        and _scope_matches_record(
-            record, context_name=context_name, instance_name=instance_name
-        )
+        and _scope_matches_record(record, context_name=context_name, instance_name=instance_name)
     ]
     candidate_records.sort(
         key=lambda record: (_scope_rank(record.scope), record.updated_at, record.secret_id)
@@ -369,7 +371,9 @@ def resolve_secret_values_for_integration_from_store(
         if binding is None:
             continue
         version = record_store.read_secret_version(record.current_version_id)
-        resolved_values[binding.binding_key] = _decrypt_secret_value(version.ciphertext, version.key_id)
+        resolved_values[binding.binding_key] = _decrypt_secret_value(
+            version.ciphertext, version.key_id
+        )
     return resolved_values
 
 
@@ -467,7 +471,10 @@ def write_secret_value(
     )
     if existing_record is not None:
         current_version = record_store.read_secret_version(existing_record.current_version_id)
-        if _decrypt_secret_value(current_version.ciphertext, current_version.key_id) == plaintext_value:
+        if (
+            _decrypt_secret_value(current_version.ciphertext, current_version.key_id)
+            == plaintext_value
+        ):
             binding = SecretBinding(
                 binding_id=_binding_id(secret_id=secret_id, binding_key=binding_key),
                 secret_id=secret_id,
@@ -709,9 +716,10 @@ def list_secret_statuses(
     statuses.sort(key=lambda item: (str(item["updated_at"]), str(item["secret_id"])), reverse=True)
     return statuses
 
+
 def reencrypt_secrets(
     *,
-    record_store: SecretWriteStore,
+    record_store: SecretRotationStore,
     apply: bool = False,
     expected_plan_digest: str = "",
     actor: str = "cli",
@@ -731,7 +739,9 @@ def reencrypt_secrets(
             key=lambda item: item.secret_id,
         )
     )
-    versions = tuple(record_store.read_secret_version(record.current_version_id) for record in records)
+    versions = tuple(
+        record_store.read_secret_version(record.current_version_id) for record in records
+    )
     plan_entries = tuple(
         {
             "secret_id": record.secret_id,
@@ -801,6 +811,16 @@ def reencrypt_secrets(
             "errors": ["Managed-secret re-encryption apply requires the matching dry-run digest."],
         }
 
+    safe_reason = redact_untrusted_text(
+        reason,
+        fallback="Operator-requested managed-secret rotation.",
+        maximum_length=160,
+    )
+    safe_source_label = redact_untrusted_text(
+        source_label,
+        fallback="managed-secret-rotation",
+        maximum_length=96,
+    )
     rotations: list[SecretRotationWrite] = []
     for record, current_version in zip(records, versions, strict=True):
         if current_version.key_id == active_key_id:
@@ -828,8 +848,8 @@ def reencrypt_secrets(
             actor=actor,
             detail="Launchplane re-encrypted a managed secret under the active key.",
             metadata={
-                "source": source_label,
-                "reason": reason.strip(),
+                "source": safe_source_label,
+                "reason": safe_reason,
                 "rotation_plan_digest": plan_digest,
                 "old_key_id": current_version.key_id,
                 "new_key_id": new_key_id,

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -717,11 +717,73 @@ def list_secret_statuses(
     return statuses
 
 
+def _recover_completed_reencryption(
+    *,
+    record_store: SecretRotationStore,
+    records: tuple[SecretRecord, ...],
+    expected_plan_digest: str,
+    operation_token: str,
+    active_key_id: str,
+) -> dict[str, object] | None:
+    if not expected_plan_digest or not operation_token:
+        return None
+    matching_events: list[SecretAuditEvent] = []
+    for record in records:
+        matching_events.extend(
+            event
+            for event in record_store.list_secret_audit_events(secret_id=record.secret_id)
+            if event.event_type == "rotated"
+            and event.metadata.get("rotation_plan_digest") == expected_plan_digest
+            and event.metadata.get("operation_token") == operation_token
+        )
+    if not matching_events:
+        return None
+    first_metadata = matching_events[0].metadata
+    try:
+        rotated_count = int(first_metadata["rotation_candidate_count"])
+        unchanged_count = int(first_metadata["rotation_unchanged_count"])
+        retirement_blocked_key_ids = json.loads(first_metadata["retirement_blocked_key_ids"])
+        retirement_ready_key_ids = json.loads(first_metadata["retirement_ready_key_ids"])
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if (
+        rotated_count != len(matching_events)
+        or not isinstance(retirement_blocked_key_ids, list)
+        or not all(isinstance(key_id, str) for key_id in retirement_blocked_key_ids)
+        or not isinstance(retirement_ready_key_ids, list)
+        or not all(isinstance(key_id, str) for key_id in retirement_ready_key_ids)
+        or any(
+            event.metadata.get("new_key_id") != active_key_id
+            or event.metadata.get("rotation_candidate_count") != str(rotated_count)
+            or event.metadata.get("rotation_unchanged_count") != str(unchanged_count)
+            for event in matching_events
+        )
+    ):
+        return None
+    return {
+        "status": "ok",
+        "dry_run": False,
+        "plan_digest": expected_plan_digest,
+        "rotated_count": rotated_count,
+        "unchanged_count": unchanged_count,
+        "error_count": 0,
+        "errors": [],
+        "active_key_id": active_key_id,
+        "retirement_blocked_key_ids": retirement_blocked_key_ids,
+        "retirement_ready_key_ids": retirement_ready_key_ids,
+        "legacy_compatibility_key_loaded": (
+            first_metadata.get("legacy_compatibility_key_loaded") == "true"
+        ),
+        "recovered": True,
+    }
+
+
 def reencrypt_secrets(
     *,
     record_store: SecretRotationStore,
     apply: bool = False,
     expected_plan_digest: str = "",
+    operation_token: str = "",
     actor: str = "cli",
     source_label: str = "manual",
     reason: str = "",
@@ -729,13 +791,10 @@ def reencrypt_secrets(
     key_ring = _get_key_ring()
     active_key_id = key_ring.active_key_id
 
+    all_records = tuple(record_store.list_secret_records(limit=None))
     records = tuple(
         sorted(
-            (
-                record
-                for record in record_store.list_secret_records(limit=None)
-                if record.status == SECRET_STATUS_CONFIGURED
-            ),
+            (record for record in all_records if record.status == SECRET_STATUS_CONFIGURED),
             key=lambda item: item.secret_id,
         )
     )
@@ -793,6 +852,7 @@ def reencrypt_secrets(
         "retirement_blocked_key_ids": retirement_blocked_key_ids,
         "retirement_ready_key_ids": retirement_ready_key_ids,
         "legacy_compatibility_key_loaded": key_ring.legacy_compatibility_key_loaded,
+        "recovered": False,
     }
     if errors or not apply:
         return result
@@ -804,6 +864,15 @@ def reencrypt_secrets(
             "errors": ["Managed-secret re-encryption apply requires a reason."],
         }
     if expected_plan_digest != plan_digest:
+        recovered_result = _recover_completed_reencryption(
+            record_store=record_store,
+            records=all_records,
+            expected_plan_digest=expected_plan_digest,
+            operation_token=operation_token,
+            active_key_id=active_key_id,
+        )
+        if recovered_result is not None:
+            return recovered_result
         return {
             **result,
             "status": "error",
@@ -851,6 +920,18 @@ def reencrypt_secrets(
                 "source": safe_source_label,
                 "reason": safe_reason,
                 "rotation_plan_digest": plan_digest,
+                "operation_token": operation_token,
+                "rotation_candidate_count": str(candidate_count),
+                "rotation_unchanged_count": str(unchanged_count),
+                "retirement_blocked_key_ids": json.dumps(
+                    retirement_blocked_key_ids, separators=(",", ":")
+                ),
+                "retirement_ready_key_ids": json.dumps(
+                    retirement_ready_key_ids, separators=(",", ":")
+                ),
+                "legacy_compatibility_key_loaded": str(
+                    key_ring.legacy_compatibility_key_loaded
+                ).lower(),
                 "old_key_id": current_version.key_id,
                 "new_key_id": new_key_id,
                 "old_version_id": current_version.version_id,

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 import os
 import uuid
+from dataclasses import dataclass
 from typing import Literal, Protocol
 
 import click
@@ -20,6 +22,7 @@ from control_plane.storage.factory import resolve_database_url
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.ship import utc_now_timestamp
 
+LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR = "LAUNCHPLANE_SECRET_KEYS_JSON"
 LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR = "LAUNCHPLANE_MASTER_ENCRYPTION_KEY"
 LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS = (LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR,)
 DOKPLOY_SECRET_INTEGRATION = "dokploy"
@@ -115,10 +118,51 @@ def _scope_rank(scope: str) -> int:
     return 2
 
 
+@dataclass
+class KeyRing:
+    active_key_id: str
+    keys: dict[str, Fernet]
+
+def _get_key_ring() -> KeyRing:
+    keys_json = os.environ.get(LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR, "").strip()
+    if keys_json:
+        try:
+            parsed = json.loads(keys_json)
+            active_key_id = parsed["active_key_id"]
+            keys_dict = parsed["keys"]
+            if not isinstance(active_key_id, str) or not isinstance(keys_dict, dict):
+                raise ValueError("JSON must contain string active_key_id and dict keys")
+        except (KeyError, ValueError, TypeError) as e:
+            raise click.ClickException(f"Invalid {LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR} configuration: {e}")
+
+        fernet_keys = {}
+        for key_id, raw_key in keys_dict.items():
+            encoded = str(raw_key).encode("utf-8")
+            try:
+                fernet_keys[key_id] = Fernet(encoded)
+            except (ValueError, TypeError) as e:
+                raise click.ClickException(f"Invalid canonical key material for key '{key_id}': {e}")
+
+        if active_key_id not in fernet_keys:
+            raise click.ClickException(f"Active key id '{active_key_id}' not found in keys.")
+
+        return KeyRing(active_key_id, fernet_keys)
+    
+    for environment_key in LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS:
+        configured_value = os.environ.get(environment_key, "")
+        if configured_value.strip():
+            key_id = "launchplane-master-key"
+            fernet = Fernet(_master_fernet_key(configured_value))
+            return KeyRing(key_id, {key_id: fernet})
+    
+    key_id = "launchplane-master-key"
+    fernet = Fernet(_master_fernet_key(""))
+    return KeyRing(key_id, {key_id: fernet})
+
 def _master_fernet_key(raw_key: str) -> bytes:
     normalized = raw_key.strip()
     if not normalized:
-        expected_keys = " or ".join(LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS)
+        expected_keys = f"{LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR} or " + " or ".join(LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS)
         raise click.ClickException(
             f"Launchplane managed secrets require {expected_keys} to read or write encrypted values."
         )
@@ -130,25 +174,24 @@ def _master_fernet_key(raw_key: str) -> bytes:
         digest = hashlib.sha256(encoded).digest()
         return base64.urlsafe_b64encode(digest)
 
-
-def _secret_cipher() -> Fernet:
-    for environment_key in LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VARS:
-        configured_value = os.environ.get(environment_key, "")
-        if configured_value.strip():
-            return Fernet(_master_fernet_key(configured_value))
-    return Fernet(_master_fernet_key(""))
+def _encrypt_secret_value(plaintext_value: str) -> tuple[str, str]:
+    key_ring = _get_key_ring()
+    cipher = key_ring.keys[key_ring.active_key_id]
+    return cipher.encrypt(plaintext_value.encode("utf-8")).decode("utf-8"), key_ring.active_key_id
 
 
-def _encrypt_secret_value(plaintext_value: str) -> str:
-    return _secret_cipher().encrypt(plaintext_value.encode("utf-8")).decode("utf-8")
-
-
-def _decrypt_secret_value(ciphertext: str) -> str:
+def _decrypt_secret_value(ciphertext: str, key_id: str) -> str:
+    key_ring = _get_key_ring()
+    cipher = key_ring.keys.get(key_id)
+    if not cipher:
+        raise click.ClickException(
+            f"Launchplane could not decrypt a managed secret: key_id '{key_id}' is unknown or retired."
+        )
     try:
-        return _secret_cipher().decrypt(ciphertext.encode("utf-8")).decode("utf-8")
+        return cipher.decrypt(ciphertext.encode("utf-8")).decode("utf-8")
     except InvalidToken as error:
         raise click.ClickException(
-            "Launchplane could not decrypt a managed secret with the configured master key."
+            f"Launchplane could not decrypt a managed secret with key_id '{key_id}'."
         ) from error
 
 
@@ -249,7 +292,7 @@ def resolve_secret_values_for_integration_from_store(
         if binding is None:
             continue
         version = record_store.read_secret_version(record.current_version_id)
-        resolved_values[binding.binding_key] = _decrypt_secret_value(version.ciphertext)
+        resolved_values[binding.binding_key] = _decrypt_secret_value(version.ciphertext, version.key_id)
     return resolved_values
 
 
@@ -347,7 +390,7 @@ def write_secret_value(
     )
     if existing_record is not None:
         current_version = record_store.read_secret_version(existing_record.current_version_id)
-        if _decrypt_secret_value(current_version.ciphertext) == plaintext_value:
+        if _decrypt_secret_value(current_version.ciphertext, current_version.key_id) == plaintext_value:
             binding = SecretBinding(
                 binding_id=_binding_id(secret_id=secret_id, binding_key=binding_key),
                 secret_id=secret_id,
@@ -362,13 +405,15 @@ def write_secret_value(
             return {"status": "ok", "secret_id": secret_id, "action": "unchanged"}
     action: SecretWriteAction = "created" if existing_record is None else "rotated"
     version_id = _version_id(secret_id=secret_id)
+    ciphertext, key_id = _encrypt_secret_value(plaintext_value)
     record_store.write_secret_version(
         SecretVersion(
             version_id=version_id,
             secret_id=secret_id,
             created_at=now,
             created_by=actor,
-            ciphertext=_encrypt_secret_value(plaintext_value),
+            key_id=key_id,
+            ciphertext=ciphertext,
         )
     )
     created_at = existing_record.created_at if existing_record is not None else now
@@ -586,3 +631,85 @@ def list_secret_statuses(
         statuses.append(build_secret_status(record_store, secret_id=record.secret_id))
     statuses.sort(key=lambda item: (str(item["updated_at"]), str(item["secret_id"])), reverse=True)
     return statuses
+
+def reencrypt_secrets(
+    *,
+    record_store: SecretWriteStore,
+    apply: bool = False,
+    actor: str = "cli",
+    source_label: str = "manual",
+) -> dict[str, object]:
+    key_ring = _get_key_ring()
+    active_key_id = key_ring.active_key_id
+    
+    rotated_count = 0
+    unchanged_count = 0
+    error_count = 0
+    errors: list[str] = []
+    
+    records = record_store.list_secret_records(limit=None)
+    for record in records:
+        if record.status != SECRET_STATUS_CONFIGURED:
+            continue
+        current_version = record_store.read_secret_version(record.current_version_id)
+        if current_version.key_id == active_key_id:
+            unchanged_count += 1
+            continue
+        
+        try:
+            plaintext = _decrypt_secret_value(current_version.ciphertext, current_version.key_id)
+        except click.ClickException as e:
+            error_count += 1
+            errors.append(f"Failed to decrypt secret {record.secret_id}: {e}")
+            continue
+
+        if apply:
+            now = utc_now_timestamp()
+            ciphertext, new_key_id = _encrypt_secret_value(plaintext)
+            version_id = _version_id(secret_id=record.secret_id)
+            
+            record_store.write_secret_version(
+                SecretVersion(
+                    version_id=version_id,
+                    secret_id=record.secret_id,
+                    created_at=now,
+                    created_by=actor,
+                    key_id=new_key_id,
+                    ciphertext=ciphertext,
+                )
+            )
+            
+            record_store.write_secret_record(
+                record.model_copy(update={"current_version_id": version_id, "updated_at": now, "updated_by": actor})
+            )
+            
+            record_store.write_secret_audit_event(
+                SecretAuditEvent(
+                    event_id=_audit_event_id(secret_id=record.secret_id, event_type="rotated"),
+                    secret_id=record.secret_id,
+                    event_type="rotated",
+                    recorded_at=now,
+                    actor=actor,
+                    detail=f"Launchplane re-encrypted managed secret from {source_label}.",
+                    metadata={
+                        "source": source_label, 
+                        "old_key_id": current_version.key_id,
+                        "new_key_id": new_key_id,
+                        "old_version_id": current_version.version_id,
+                        "new_version_id": version_id,
+                    },
+                )
+            )
+        rotated_count += 1
+
+    return {
+        "status": "ok" if error_count == 0 else "error",
+        "dry_run": not apply,
+        "rotated_count": rotated_count,
+        "unchanged_count": unchanged_count,
+        "error_count": error_count,
+        "errors": errors,
+        "active_key_id": active_key_id,
+        "allowed_key_ids": list(key_ring.keys.keys()),
+    }
+

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -107,6 +107,7 @@ from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
     SecretRecord,
+    SecretRotationWrite,
     SecretVersion,
 )
 from control_plane.contracts.verireel_prod_backup_gate_operation import (
@@ -5507,6 +5508,59 @@ class PostgresRecordStore(HumanSessionStore):
                 payload=self._payload_dict(event),
             )
         )
+
+    def write_secret_rotations(self, rotations: tuple[SecretRotationWrite, ...]) -> None:
+        ordered_rotations = tuple(sorted(rotations, key=lambda item: item.record.secret_id))
+        with self._session_factory() as session:
+            for rotation in ordered_rotations:
+                statement = (
+                    select(LaunchplaneSecretRow)
+                    .where(LaunchplaneSecretRow.secret_id == rotation.record.secret_id)
+                    .with_for_update()
+                )
+                current_row = session.scalar(statement)
+                if current_row is None:
+                    raise FileNotFoundError(
+                        f"No Launchplane secret record found for {rotation.record.secret_id!r}"
+                    )
+                if current_row.current_version_id != rotation.expected_current_version_id:
+                    raise ValueError("Managed secret changed after rotation preflight.")
+            for rotation in ordered_rotations:
+                version = rotation.version
+                record = rotation.record
+                event = rotation.audit_event
+                session.merge(
+                    LaunchplaneSecretVersionRow(
+                        version_id=version.version_id,
+                        secret_id=version.secret_id,
+                        created_at=version.created_at,
+                        payload=self._payload_dict(version),
+                    )
+                )
+                session.merge(
+                    LaunchplaneSecretRow(
+                        secret_id=record.secret_id,
+                        scope=record.scope,
+                        integration=record.integration,
+                        name=record.name,
+                        context=record.context,
+                        instance=record.instance,
+                        status=record.status,
+                        current_version_id=record.current_version_id,
+                        updated_at=record.updated_at,
+                        payload=self._payload_dict(record),
+                    )
+                )
+                session.merge(
+                    LaunchplaneSecretAuditEventRow(
+                        event_id=event.event_id,
+                        secret_id=event.secret_id,
+                        event_type=event.event_type,
+                        recorded_at=event.recorded_at,
+                        payload=self._payload_dict(event),
+                    )
+                )
+            session.commit()
 
     def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:
         return self._list_models(

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -1134,7 +1134,7 @@ def public_ingress_managed_secret_resolver(
             return ""
         try:
             version = record_store.read_secret_version(record.current_version_id)
-            return control_plane_secrets._decrypt_secret_value(version.ciphertext)
+            return control_plane_secrets._decrypt_secret_value(version.ciphertext, version.key_id)
         except Exception:  # noqa: BLE001 - delivery records capture unreadable secrets per destination.
             return ""
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -551,7 +551,8 @@ uv run launchplane service inspect-dokploy-target \
 
 That command reports only non-secret metadata and fails closed when the live
 Launchplane target is missing critical runtime pieces such as
-`LAUNCHPLANE_DATABASE_URL`, `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`,
+`LAUNCHPLANE_DATABASE_URL`, `LAUNCHPLANE_SECRET_KEYS_JSON` (or the
+migration-only legacy `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`),
 Launchplane-managed Dokploy secret bindings, or a Dokploy SSH key for a private
 `git@github.com:...` compose source.
 
@@ -559,8 +560,8 @@ The intended live service contract is now bootstrap-only target env plus
 DB-backed Launchplane records:
 
 - keep bootstrap/process inputs such as `LAUNCHPLANE_DATABASE_URL`,
-  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, and policy selectors on the service
-  target
+  `LAUNCHPLANE_SECRET_KEYS_JSON`, migration-only
+  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, and policy selectors on the service target
 - move Dokploy credentials into Launchplane-managed secret records
 - move per-context runtime values, ship-mode overrides, preview base URLs, and
   product-specific worker config into Launchplane runtime-environment records
@@ -772,7 +773,8 @@ Current derived-state behavior:
   writes non-secret values to runtime-environment records and secret-shaped
   values to managed secret records while returning only key names, actions,
   counts, actor, and source metadata. Bundles with secrets require
-  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`. Runtime and secret scopes default from
+  valid `LAUNCHPLANE_SECRET_KEYS_JSON` or the migration-only legacy key. Runtime
+  and secret scopes default from
   the top-level `context`/`instance`; nested `runtime_env` and secret routes must
   match that top-level target. Dry-run validates secret scope/route
   compatibility and runtime key-safety policy before reporting a plan, so apply
@@ -792,14 +794,23 @@ Current derived-state behavior:
   credentials stay read-only and cannot apply product config. The service
   response is redacted and the route rejects nested runtime or secret targets
   that differ from the authorized top-level context/instance. It fails closed
-  when secret writes are requested without the Launchplane master encryption key
-  in the service runtime or when no active runtime key-safety policy allows the
+  when secret writes are requested without valid Launchplane secret-key
+  configuration in the service runtime or when no active runtime key-safety policy allows the
   requested binding. When apply changes runtime-environment keys for a tracked
   Dokploy target, the response includes a required `live_target_runtime_apply`
   `next_actions` item. Treat product-config apply as a record mutation only
   until that next action has been dry-run and applied through
   `/v1/live-target-runtime/apply`; redeploying the same app image does not sync
   the live Dokploy target environment.
+- `POST /v1/secrets/reencrypt` is the normal shared/production root-rotation
+  path. Run `mode: "dry-run"` with `secret.reencrypt.dry-run`, then submit
+  `mode: "apply"` with the returned plan digest, a reason, an
+  `Idempotency-Key`, and `secret.reencrypt.apply`. Launchplane atomically writes
+  the new versions, current-version pointers, and audit events. If the mutation
+  commits before idempotency evidence is persisted, a retry with the same
+  request recovers from the rotation audit token instead of rotating again.
+  Direct `launchplane secrets reencrypt --apply` remains bootstrap/recovery-only
+  and requires explicit direct-DB acknowledgement.
 - The operator UI uses the same service route. It requires a successful dry-run
   result before enabling apply, clears rendered secret input values after each
   submit, and shows only key/action/count metadata from Launchplane responses.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -12,8 +12,11 @@ title: Secrets
 - Dokploy credentials belong to `launchplane`.
 - Launchplane can now persist managed secret values in the Postgres
   shared-service backend when `LAUNCHPLANE_DATABASE_URL` is configured.
-- Managed secret values are encrypted before Launchplane stores them; the master
-  key stays outside the database in `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`.
+  Secret versions are encrypted before Launchplane stores them.
+- New deployments must use `LAUNCHPLANE_SECRET_KEYS_JSON` with explicit, canonical
+  high-entropy Fernet roots to manage encryption keys. Existing deployments can
+  continue to use `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` as a legacy fallback, but
+  should migrate to the JSON format to support explicit rotation and key retirement.
 - Keep bootstrap values only in process env long enough to write the real
   Launchplane-managed secret records.
 - Runtime environment truth should live in Launchplane DB records in steady
@@ -80,14 +83,15 @@ ids may decrypt old versions only during an explicit rotation or recovery window
 The target rotation model is:
 
 1. Introduce a new bootstrap decryption root or platform-secret reference and an
-   active `encryption_key_id`.
+   active `encryption_key_id` in `LAUNCHPLANE_SECRET_KEYS_JSON`.
 2. Keep the previous decryption root available only as an allowed historical key
-   for versions that still carry its key id.
+   in the JSON keys map for versions that still carry its key id.
 3. Re-encrypt managed-secret versions under the new key id through a
-   Launchplane-owned rotation path that writes audit evidence.
+   Launchplane-owned rotation path that writes audit evidence:
+   `uv run launchplane secrets reencrypt --apply`.
 4. Verify that all active versions are readable under the new key id.
-5. Retire the old key id so later reads fail closed if any active secret still
-   depends on it.
+5. Retire the old key id by removing it from `LAUNCHPLANE_SECRET_KEYS_JSON` so
+   later reads fail closed if any active secret still depends on it.
 
 Rotation is a service/storage operation, not a product workflow shortcut. It
 must not copy plaintext into GitHub issues, workflow logs, checked-in files,
@@ -222,7 +226,8 @@ decryption key state denies the reveal or resolution.
 
 - Treat these as bootstrap/process concerns, not product runtime truth:
   - `LAUNCHPLANE_DATABASE_URL`
-  - `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`
+  - `LAUNCHPLANE_SECRET_KEYS_JSON`
+  - `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` (legacy fallback)
   - policy/bootstrap selectors such as `LAUNCHPLANE_POLICY_*`
   - service-ingress bearer secrets such as
     `LAUNCHPLANE_TERMINAL_AGENT_READ_TOKEN` and
@@ -243,10 +248,10 @@ decryption key state denies the reveal or resolution.
 - Never commit alternate secret files or rendered env artifacts.
 - Do not rely on a repo-local `.env` for control-plane-owned secrets.
 - Missing Dokploy credentials are a hard error, not a silent fallback.
-- Missing `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` is a hard error when Launchplane
-  needs to read or write DB-backed managed secrets.
+- Missing `LAUNCHPLANE_SECRET_KEYS_JSON` (and its legacy fallback `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`)
+  is a hard error when Launchplane needs to read or write DB-backed managed secrets.
 - The live Launchplane Dokploy target should expose bootstrap env such as
-  `LAUNCHPLANE_DATABASE_URL` and `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, while
+  `LAUNCHPLANE_DATABASE_URL` and `LAUNCHPLANE_SECRET_KEYS_JSON`, while
   Dokploy credentials and runtime/product values should resolve from
   Launchplane-managed records instead of target env.
 - Use `uv run launchplane service inspect-dokploy-target ...` to verify that
@@ -277,7 +282,8 @@ decryption key state denies the reveal or resolution.
   values or writing records. `--apply` writes non-secret runtime keys and
   managed secret values through the same DB-backed stores. Run this command only
   from a trusted Launchplane context with current `LAUNCHPLANE_DATABASE_URL` and,
-  when secrets are present, `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`. Dry-run and
+  when secrets are present, `LAUNCHPLANE_SECRET_KEYS_JSON` (or the legacy
+  `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`). Dry-run and
   apply both reject invalid secret scopes or scope/context/instance mismatches
   before any managed secret write starts. Runtime-environment secret bundles
   also require an active runtime key-safety policy that allows each requested
@@ -318,6 +324,6 @@ decryption key state denies the reveal or resolution.
 ## Bootstrap
 
 Bring up the service with bootstrap env such as `LAUNCHPLANE_DATABASE_URL` and
-`LAUNCHPLANE_MASTER_ENCRYPTION_KEY`, then write the durable DB-backed secret
+`LAUNCHPLANE_SECRET_KEYS_JSON`, then write the durable DB-backed secret
 and runtime records through the normal Launchplane commands. Dokploy
 credentials belong in Launchplane-managed secrets before Dokploy operations run.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -14,9 +14,11 @@ title: Secrets
   shared-service backend when `LAUNCHPLANE_DATABASE_URL` is configured.
   Secret versions are encrypted before Launchplane stores them.
 - New deployments must use `LAUNCHPLANE_SECRET_KEYS_JSON` with explicit, canonical
-  high-entropy Fernet roots to manage encryption keys. Existing deployments can
-  continue to use `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` as a legacy fallback, but
-  should migrate to the JSON format to support explicit rotation and key retirement.
+  high-entropy Fernet roots to manage encryption keys. Generate roots with a
+  cryptographically secure secret manager or `Fernet.generate_key()` and store
+  the JSON value in the Launchplane service bootstrap secret, never in the repo.
+  Existing deployments can temporarily keep `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`
+  as a migration-only historical root.
 - Keep bootstrap values only in process env long enough to write the real
   Launchplane-managed secret records.
 - Runtime environment truth should live in Launchplane DB records in steady
@@ -86,12 +88,58 @@ The target rotation model is:
    active `encryption_key_id` in `LAUNCHPLANE_SECRET_KEYS_JSON`.
 2. Keep the previous decryption root available only as an allowed historical key
    in the JSON keys map for versions that still carry its key id.
-3. Re-encrypt managed-secret versions under the new key id through a
-   Launchplane-owned rotation path that writes audit evidence:
-   `uv run launchplane secrets reencrypt --apply`.
-4. Verify that all active versions are readable under the new key id.
-5. Retire the old key id by removing it from `LAUNCHPLANE_SECRET_KEYS_JSON` so
-   later reads fail closed if any active secret still depends on it.
+3. Run the deployed Launchplane service re-encryption endpoint in dry-run mode.
+   The response reports unreadable versions, the active-key usage summary, keys
+   blocked from retirement, and a digest bound to the current secret versions.
+4. Apply through the same service endpoint with the dry-run digest, an operator
+   reason, and an idempotency key. Launchplane atomically writes every new
+   ciphertext version, current-version pointer, and audit event.
+5. Run dry-run again and verify the previous key id is reported as ready for
+   retirement.
+6. Retire the previous root by removing it from the service bootstrap key ring.
+   Later reads fail closed if any active secret still depends on that id.
+
+`LAUNCHPLANE_SECRET_KEYS_JSON` has this bootstrap-only shape:
+
+```json
+{
+  "active_key_id": "root-2026-07",
+  "keys": {
+    "root-2026-07": "<canonical-url-safe-base64-fernet-key>",
+    "root-2026-04": "<historical-canonical-url-safe-base64-fernet-key>"
+  }
+}
+```
+
+Key ids use 1-64 ASCII letters, digits, dots, underscores, or hyphens. Each key
+must be the exact URL-safe base64 encoding of 32 high-entropy bytes. Launchplane
+rejects passphrases, whitespace-normalized values, low-diversity test material,
+unknown JSON fields, missing active keys, and mismatches between the JSON legacy
+entry and the legacy bootstrap variable.
+
+### Migrating The Legacy Root
+
+Existing secret-version payloads without an explicit historical label resolve
+to the compatibility id `launchplane-master-key`. To migrate without deriving or
+printing the old root:
+
+1. Keep the existing `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` set on the deployed
+   Launchplane service.
+2. Add `LAUNCHPLANE_SECRET_KEYS_JSON` with a new canonical active key. Do not
+   copy a legacy passphrase into the JSON map. Launchplane loads the legacy env
+   value as the historical `launchplane-master-key` only for this migration
+   window.
+3. Run dry-run and stop if any version is unreadable or the reported plan does
+   not include the expected legacy-key usage.
+4. Apply with the matching digest and verify the next dry-run reports
+   `launchplane-master-key` as ready for retirement.
+5. Remove `LAUNCHPLANE_MASTER_ENCRYPTION_KEY` and restart the service. A final
+   dry-run must remain clean before the old bootstrap secret is destroyed.
+
+Old ciphertext versions and audit metadata retain the old/new key ids and
+version ids as rollback evidence. To roll back before destroying an old root,
+restore that root as an allowed active key and run the same audited dry-run/apply
+flow in reverse; Launchplane creates new versions instead of mutating history.
 
 Rotation is a service/storage operation, not a product workflow shortcut. It
 must not copy plaintext into GitHub issues, workflow logs, checked-in files,
@@ -277,6 +325,11 @@ decryption key state denies the reveal or resolution.
   writes. Routine shared and production secret changes should use product-config
   dry-run/apply through the deployed service route or operator UI instead of
   arbitrary local secret writes.
+- `uv run launchplane secrets reencrypt --allow-direct-db-mutation` is a
+  bootstrap/recovery-only dry-run. A direct apply additionally requires
+  `--expected-plan-digest`, `--reason`, and `--apply`. Routine shared and
+  production root rotation must use the deployed service endpoint rather than
+  an arbitrary checkout.
 - `uv run launchplane product-config apply --input-file bundle.json --dry-run`
   previews an approved product runtime/secret bundle without printing plaintext
   values or writing records. `--apply` writes non-secret runtime keys and

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1330,11 +1330,22 @@ target. It reuses the same planner/writer as `launchplane product-config apply`,
 returns only actions, keys, counts, actor/source metadata, and secret IDs, uses
 generic validation messages for rejected requests, and fails closed when the
 record store is not DB-backed, when a secret bundle is submitted without
-`LAUNCHPLANE_MASTER_ENCRYPTION_KEY` in the trusted Launchplane runtime, or when
+valid `LAUNCHPLANE_SECRET_KEYS_JSON` (or the migration-only legacy
+`LAUNCHPLANE_MASTER_ENCRYPTION_KEY`) in the trusted Launchplane runtime, or when
 there is no active runtime key-safety policy that allows the requested managed
 secret binding for the target runtime class. Request bodies for this route must
 not be copied into logs, issues, docs, or workflow artifacts because they can
 contain plaintext secret values.
+
+`POST /v1/secrets/reencrypt` owns shared and production managed-secret root
+rotation. The route requires JSON with a bounded body, exact
+`secret.reencrypt.dry-run` or `secret.reencrypt.apply` authority, a reason, and
+DB-backed storage. Apply additionally requires the matching dry-run digest and
+an `Idempotency-Key`. Version, current-pointer, and audit writes commit in one
+transaction; the audit operation token provides retry recovery if idempotency
+evidence cannot be persisted after that transaction. Terminal-agent read
+credentials cannot call the route, and responses expose key IDs and counts but
+never plaintext or ciphertext.
 
 #### Product-config secret source contract
 

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -38224,6 +38224,167 @@
         "summary": "Apply runtime key-safety policy records"
       }
     },
+    "/v1/secrets/reencrypt": {
+      "post": {
+        "operationId": "reencrypt_managed_secrets",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Idempotency-Key",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Idempotency-Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": false,
+                "properties": {
+                  "expected_plan_digest": {
+                    "default": "",
+                    "title": "Expected Plan Digest",
+                    "type": "string"
+                  },
+                  "mode": {
+                    "default": "dry-run",
+                    "enum": [
+                      "dry-run",
+                      "apply"
+                    ],
+                    "title": "Mode",
+                    "type": "string"
+                  },
+                  "reason": {
+                    "maxLength": 240,
+                    "minLength": 1,
+                    "title": "Reason",
+                    "type": "string"
+                  },
+                  "schema_version": {
+                    "default": 1,
+                    "maximum": 1,
+                    "minimum": 1,
+                    "title": "Schema Version",
+                    "type": "integer"
+                  },
+                  "source_label": {
+                    "default": "service-secret-rotation",
+                    "maxLength": 96,
+                    "minLength": 1,
+                    "title": "Source Label",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "reason"
+                ],
+                "title": "SecretReencryptionRequest",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AcceptedEvidenceResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Dry-run or apply managed-secret root re-encryption"
+      }
+    },
     "/v1/secrets/{secret_id}": {
       "get": {
         "operationId": "read_secret_status",

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -286,11 +286,13 @@ def _runtime_secret_record(
 def _runtime_secret_version(
     *, secret_id: str, version_id: str, plaintext_value: str
 ) -> SecretVersion:
+    ciphertext, key_id = control_plane_secrets._encrypt_secret_value(plaintext_value)
     return SecretVersion(
         version_id=version_id,
         secret_id=secret_id,
         created_at="2026-04-30T22:00:00Z",
-        ciphertext=control_plane_secrets._encrypt_secret_value(plaintext_value),
+        ciphertext=ciphertext,
+        key_id=key_id,
     )
 
 

--- a/tests/test_http_app_policy_apply.py
+++ b/tests/test_http_app_policy_apply.py
@@ -2066,6 +2066,7 @@ class FastApiProductConfigApplyTests(unittest.IsolatedAsyncioTestCase):
             app,
             {},
             authorization="Bearer terminal-agent-token",
+            headers={"Content-Type": "application/json"},
             raw_body=b"not-json",
         )
 

--- a/tests/test_http_app_secret_rotation.py
+++ b/tests/test_http_app_secret_rotation.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from control_plane import secrets as control_plane_secrets
+from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.service_auth import LaunchplaneAuthzPolicy
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.http_app_test_support import _asgi_request
+from tests.test_service import _identity, _sqlite_database_url, _StubVerifier
+
+
+def _fernet_key(offset: int) -> str:
+    return base64.urlsafe_b64encode(bytes((offset + index) % 256 for index in range(32))).decode()
+
+
+def _secret_rotation_policy(*actions: str) -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "every/verireel",
+                    "workflow_refs": [
+                        "every/verireel/.github/workflows/preview-control-plane.yml@refs/heads/main"
+                    ],
+                    "event_names": ["pull_request"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": list(actions),
+                }
+            ]
+        }
+    )
+
+
+class FastApiSecretRotationTests(unittest.IsolatedAsyncioTestCase):
+    async def test_secret_reencryption_requires_dry_run_and_replays_apply(self) -> None:
+        key1 = _fernet_key(0)
+        key2 = _fernet_key(32)
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                with patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                            {"active_key_id": "key-1", "keys": {"key-1": key1}}
+                        )
+                    },
+                    clear=True,
+                ):
+                    write_result = control_plane_secrets.write_secret_value(
+                        record_store=store,
+                        scope="global",
+                        integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                        name="host",
+                        plaintext_value="https://provider.example",
+                        binding_key="DOKPLOY_HOST",
+                        actor="test",
+                    )
+
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_secret_rotation_policy(
+                        "secret.reencrypt.dry-run", "secret.reencrypt.apply"
+                    ),
+                    record_store_factory=lambda: store,
+                )
+                rotation_environment = {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                        {
+                            "active_key_id": "key-2",
+                            "keys": {"key-1": key1, "key-2": key2},
+                        }
+                    )
+                }
+                with patch.dict(os.environ, rotation_environment, clear=True):
+                    dry_run_response = await _asgi_request(
+                        app,
+                        "POST",
+                        "/v1/secrets/reencrypt",
+                        headers={"Authorization": "Bearer valid-token"},
+                        payload={
+                            "schema_version": 1,
+                            "mode": "dry-run",
+                            "reason": "Rotate the managed-secret root.",
+                            "source_label": "service-test",
+                        },
+                    )
+                    dry_run_payload = dry_run_response.json()
+                    plan_digest = dry_run_payload["result"]["plan_digest"]
+                    apply_payload = {
+                        "schema_version": 1,
+                        "mode": "apply",
+                        "expected_plan_digest": plan_digest,
+                        "reason": "Rotate the managed-secret root.",
+                        "source_label": "service-test",
+                    }
+                    apply_headers = {
+                        "Authorization": "Bearer valid-token",
+                        "Idempotency-Key": "secret-rotation-test",
+                    }
+                    apply_response = await _asgi_request(
+                        app,
+                        "POST",
+                        "/v1/secrets/reencrypt",
+                        headers=apply_headers,
+                        payload=apply_payload,
+                    )
+                    replay_response = await _asgi_request(
+                        app,
+                        "POST",
+                        "/v1/secrets/reencrypt",
+                        headers=apply_headers,
+                        payload=apply_payload,
+                    )
+
+                secret_id = str(write_result["secret_id"])
+                current_record = store.read_secret_record(secret_id)
+                current_version = store.read_secret_version(current_record.current_version_id)
+                versions = store.list_secret_versions(secret_id=secret_id)
+            finally:
+                store.close()
+
+        self.assertEqual(dry_run_response.status_code, 202)
+        self.assertEqual(dry_run_payload["result"]["status"], "ok")
+        self.assertEqual(dry_run_payload["result"]["rotated_count"], 1)
+        self.assertEqual(dry_run_payload["result"]["retirement_blocked_key_ids"], ["key-1"])
+        self.assertEqual(apply_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        self.assertEqual(replay_response.json()["result"], apply_response.json()["result"])
+        self.assertNotIn("https://provider.example", json.dumps(apply_response.json()))
+        self.assertEqual(current_version.key_id, "key-2")
+        self.assertEqual(len(versions), 2)
+
+    async def test_secret_reencryption_apply_requires_idempotency_and_matching_digest(self) -> None:
+        key = _fernet_key(0)
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            try:
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_secret_rotation_policy("secret.reencrypt.apply"),
+                    record_store_factory=lambda: store,
+                )
+                payload = {
+                    "schema_version": 1,
+                    "mode": "apply",
+                    "expected_plan_digest": "0" * 64,
+                    "reason": "Exercise apply guards.",
+                }
+                with patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                            {"active_key_id": "key-1", "keys": {"key-1": key}}
+                        )
+                    },
+                    clear=True,
+                ):
+                    missing_idempotency = await _asgi_request(
+                        app,
+                        "POST",
+                        "/v1/secrets/reencrypt",
+                        headers={"Authorization": "Bearer valid-token"},
+                        payload=payload,
+                    )
+                    stale_plan = await _asgi_request(
+                        app,
+                        "POST",
+                        "/v1/secrets/reencrypt",
+                        headers={
+                            "Authorization": "Bearer valid-token",
+                            "Idempotency-Key": "stale-secret-rotation",
+                        },
+                        payload=payload,
+                    )
+            finally:
+                store.close()
+
+        self.assertEqual(missing_idempotency.status_code, 400)
+        self.assertEqual(missing_idempotency.json()["error"]["code"], "idempotency_key_required")
+        self.assertEqual(stale_plan.status_code, 409)
+        self.assertEqual(stale_plan.json()["error"]["code"], "secret_reencryption_conflict")

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -10,6 +10,7 @@ from typing import cast
 from unittest.mock import patch
 
 from click.testing import CliRunner
+from cryptography.fernet import Fernet
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.cli import main
@@ -2056,7 +2057,12 @@ ODOO_DB_PASSWORD = "file-secret"
                 os.environ,
                 {
                     "LAUNCHPLANE_DATABASE_URL": database_url,
-                    "LAUNCHPLANE_MASTER_ENCRYPTION_KEY": "test-master-key",
+                    "LAUNCHPLANE_SECRET_KEYS_JSON": json.dumps(
+                        {
+                            "active_key_id": "test-key",
+                            "keys": {"test-key": Fernet.generate_key().decode()},
+                        }
+                    ),
                 },
                 clear=True,
             ):
@@ -2445,7 +2451,8 @@ ODOO_DB_PASSWORD = "file-secret"
 
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn(
-            "Product config secrets require LAUNCHPLANE_MASTER_ENCRYPTION_KEY", result.output
+            "Product config secrets require valid Launchplane secret-key configuration",
+            result.output,
         )
         self.assertNotIn("smtp-secret-value", result.output)
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import base64
+import json
 import os
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
+
+import click
+from cryptography.fernet import Fernet
+from sqlalchemy.orm import Session
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments
@@ -19,6 +25,10 @@ from control_plane.storage.postgres import PostgresRecordStore
 
 def _sqlite_database_url(database_path: Path) -> str:
     return f"sqlite+pysqlite:///{database_path}"
+
+
+def _test_fernet_key(offset: int) -> str:
+    return base64.urlsafe_b64encode(bytes((offset + index) % 256 for index in range(32))).decode()
 
 
 def _seed_runtime_environment_records(
@@ -302,133 +312,221 @@ class LaunchplaneSecretsTests(unittest.TestCase):
             store.close()
 
 
-    def test_json_encryption_keys(self) -> None:
-        import base64
-        import json
-        from cryptography.fernet import Fernet
-        import click
-        key1 = base64.urlsafe_b64encode(b"0" * 32).decode()
-        key2 = base64.urlsafe_b64encode(b"1" * 32).decode()
+    def test_json_encryption_keys_are_exact_and_fail_closed(self) -> None:
+        key1 = _test_fernet_key(0)
+        key2 = _test_fernet_key(32)
         with patch.dict(
             os.environ,
             {
-                control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps({
-                    "active_key_id": "key-2",
-                    "keys": {
-                        "key-1": key1,
-                        "key-2": key2,
+                control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                    {
+                        "active_key_id": "key-2",
+                        "keys": {"key-1": key1, "key-2": key2},
                     }
-                }),
+                ),
             },
             clear=True,
         ):
             ciphertext, key_id = control_plane_secrets._encrypt_secret_value("plaintext-data")
             self.assertEqual(key_id, "key-2")
-            
-            decrypted = control_plane_secrets._decrypt_secret_value(ciphertext, "key-2")
-            self.assertEqual(decrypted, "plaintext-data")
-            
-            with self.assertRaises(click.ClickException) as ctx:
-                control_plane_secrets._decrypt_secret_value(ciphertext, "key-3")
-            self.assertIn("key_id 'key-3' is unknown", str(ctx.exception))
-            
-            # Encrypt with key-1 manually and verify it decrypts
-            f1 = Fernet(key1.encode())
-            c1 = f1.encrypt(b"old-data").decode()
-            decrypted_1 = control_plane_secrets._decrypt_secret_value(c1, "key-1")
-            self.assertEqual(decrypted_1, "old-data")
+            self.assertEqual(
+                control_plane_secrets._decrypt_secret_value(ciphertext, "key-2"),
+                "plaintext-data",
+            )
 
-    def test_reencrypt_secrets(self) -> None:
-        import base64
-        import json
-        key1 = base64.urlsafe_b64encode(b"0" * 32).decode()
-        key2 = base64.urlsafe_b64encode(b"1" * 32).decode()
-        
+            with self.assertRaisesRegex(click.ClickException, "key_id 'key-3' is unknown"):
+                control_plane_secrets._decrypt_secret_value(ciphertext, "key-3")
+
+            wrong_key_ciphertext = Fernet(key1.encode()).encrypt(b"old-data").decode()
+            with self.assertRaisesRegex(click.ClickException, "could not decrypt"):
+                control_plane_secrets._decrypt_secret_value(wrong_key_ciphertext, "key-2")
+
+            tampered = ciphertext[:-2] + ("A" if ciphertext[-2] != "A" else "B") + ciphertext[-1]
+            with self.assertRaisesRegex(click.ClickException, "could not decrypt"):
+                control_plane_secrets._decrypt_secret_value(tampered, "key-2")
+
+    def test_json_encryption_keys_reject_malformed_or_weak_configuration(self) -> None:
+        invalid_configurations = (
+            {"active_key_id": "bad key", "keys": {"bad key": _test_fernet_key(0)}},
+            {"active_key_id": "key-1", "keys": {"key-1": "not-a-fernet-key"}},
+            {
+                "active_key_id": "key-1",
+                "keys": {
+                    "key-1": base64.urlsafe_b64encode(b"0" * 32).decode(),
+                },
+            },
+            {
+                "active_key_id": "key-1",
+                "keys": {"key-1": _test_fernet_key(0)},
+                "unexpected": True,
+            },
+        )
+        for configuration in invalid_configurations:
+            with self.subTest(configuration=configuration):
+                with patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                            configuration
+                        )
+                    },
+                    clear=True,
+                ):
+                    with self.assertRaises(click.ClickException):
+                        control_plane_secrets.validate_secret_key_configuration()
+
+    def test_reencrypt_secrets_migrates_legacy_key_and_proves_retirement(self) -> None:
+        key2 = _test_fernet_key(32)
         with TemporaryDirectory() as temporary_directory_name:
             control_plane_root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
             store = PostgresRecordStore(database_url=database_url)
             store.ensure_schema()
-            
-            # Step 1: Write secret using key-1
-            with patch.dict(
-                os.environ,
-                {
-                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps({
-                        "active_key_id": "key-1",
-                        "keys": {"key-1": key1}
-                    }),
-                    "LAUNCHPLANE_DATABASE_URL": database_url,
-                },
-                clear=True,
-            ):
-                result1 = control_plane_secrets.write_secret_value(
-                    record_store=store,
-                    scope="global",
-                    integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
-                    name="host",
-                    plaintext_value="https://dokploy.db.example",
-                    binding_key="DOKPLOY_HOST",
-                    actor="test",
-                )
-                self.assertEqual(result1["status"], "ok")
-            
-            # Step 2: Rotate key (active is now key-2, key-1 still present), do dry run
-            with patch.dict(
-                os.environ,
-                {
-                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps({
-                        "active_key_id": "key-2",
-                        "keys": {"key-1": key1, "key-2": key2}
-                    }),
-                    "LAUNCHPLANE_DATABASE_URL": database_url,
-                },
-                clear=True,
-            ):
-                reencrypt_result_dry = control_plane_secrets.reencrypt_secrets(
-                    record_store=store,
-                    apply=False,
-                )
-                self.assertTrue(reencrypt_result_dry["dry_run"])
-                self.assertEqual(reencrypt_result_dry["rotated_count"], 1)
-                self.assertEqual(reencrypt_result_dry["unchanged_count"], 0)
-                
-                reencrypt_result = control_plane_secrets.reencrypt_secrets(
-                    record_store=store,
-                    apply=True,
-                )
-                self.assertFalse(reencrypt_result["dry_run"])
-                self.assertEqual(reencrypt_result["rotated_count"], 1)
-                self.assertEqual(reencrypt_result["unchanged_count"], 0)
-                
-                # Doing it again should yield 0 rotated, 1 unchanged
-                reencrypt_result_noop = control_plane_secrets.reencrypt_secrets(
-                    record_store=store,
-                    apply=True,
-                )
-                self.assertEqual(reencrypt_result_noop["rotated_count"], 0)
-                self.assertEqual(reencrypt_result_noop["unchanged_count"], 1)
+            try:
+                with patch.dict(
+                    os.environ,
+                    {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "legacy-passphrase"},
+                    clear=True,
+                ):
+                    control_plane_secrets.write_secret_value(
+                        record_store=store,
+                        scope="global",
+                        integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                        name="host",
+                        plaintext_value="https://dokploy.db.example",
+                        binding_key="DOKPLOY_HOST",
+                        actor="test",
+                    )
 
-            # Step 3: Retire key-1 (no longer present), decryption works because it's re-encrypted
-            with patch.dict(
-                os.environ,
-                {
-                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps({
-                        "active_key_id": "key-2",
-                        "keys": {"key-2": key2}
-                    }),
-                    "LAUNCHPLANE_DATABASE_URL": database_url,
-                },
-                clear=True,
-            ):
-                # We can still read the secret
-                values = control_plane_secrets.resolve_secret_values_for_integration_from_store(
-                    record_store=store,
-                    integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                migration_environment = {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                        {"active_key_id": "key-2", "keys": {"key-2": key2}}
+                    ),
+                    control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "legacy-passphrase",
+                }
+                with patch.dict(os.environ, migration_environment, clear=True):
+                    dry_run = control_plane_secrets.reencrypt_secrets(record_store=store)
+                    self.assertEqual(dry_run["status"], "ok")
+                    self.assertEqual(dry_run["rotated_count"], 1)
+                    self.assertEqual(
+                        dry_run["retirement_blocked_key_ids"],
+                        [control_plane_secrets.LEGACY_SECRET_KEY_ID],
+                    )
+                    self.assertTrue(dry_run["legacy_compatibility_key_loaded"])
+
+                    applied = control_plane_secrets.reencrypt_secrets(
+                        record_store=store,
+                        apply=True,
+                        expected_plan_digest=cast(str, dry_run["plan_digest"]),
+                        reason="Rotate the managed-secret root.",
+                        actor="operator:test",
+                        source_label="test-migration",
+                    )
+                    self.assertEqual(applied["status"], "ok")
+                    self.assertEqual(applied["rotated_count"], 1)
+
+                    follow_up = control_plane_secrets.reencrypt_secrets(record_store=store)
+                    self.assertEqual(follow_up["rotated_count"], 0)
+                    self.assertEqual(
+                        follow_up["retirement_ready_key_ids"],
+                        [control_plane_secrets.LEGACY_SECRET_KEY_ID],
+                    )
+
+                with patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                            {"active_key_id": "key-2", "keys": {"key-2": key2}}
+                        )
+                    },
+                    clear=True,
+                ):
+                    values = control_plane_secrets.resolve_secret_values_for_integration_from_store(
+                        record_store=store,
+                        integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                    )
+                    self.assertEqual(values["DOKPLOY_HOST"], "https://dokploy.db.example")
+                    audit_events = store.list_secret_audit_events(
+                        secret_id="secret-dokploy-host"
+                    )
+                    rotation_event = next(
+                        event for event in audit_events if event.event_type == "rotated"
+                    )
+                    self.assertEqual(
+                        rotation_event.metadata["old_key_id"],
+                        control_plane_secrets.LEGACY_SECRET_KEY_ID,
+                    )
+                    self.assertEqual(rotation_event.metadata["new_key_id"], "key-2")
+                    self.assertIn("old_version_id", rotation_event.metadata)
+                    self.assertIn("new_version_id", rotation_event.metadata)
+            finally:
+                store.close()
+
+    def test_reencrypt_secrets_is_atomic_when_storage_commit_fails(self) -> None:
+        key1 = _test_fernet_key(0)
+        key2 = _test_fernet_key(32)
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            try:
+                with patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                            {"active_key_id": "key-1", "keys": {"key-1": key1}}
+                        )
+                    },
+                    clear=True,
+                ):
+                    write_result = control_plane_secrets.write_secret_value(
+                        record_store=store,
+                        scope="global",
+                        integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                        name="host",
+                        plaintext_value="https://dokploy.db.example",
+                        binding_key="DOKPLOY_HOST",
+                        actor="test",
+                    )
+                secret_id = cast(str, write_result["secret_id"])
+                original_record = store.read_secret_record(secret_id)
+                original_version_count = len(store.list_secret_versions(secret_id=secret_id))
+                original_event_count = len(store.list_secret_audit_events(secret_id=secret_id))
+
+                with patch.dict(
+                    os.environ,
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps(
+                            {
+                                "active_key_id": "key-2",
+                                "keys": {"key-1": key1, "key-2": key2},
+                            }
+                        )
+                    },
+                    clear=True,
+                ):
+                    dry_run = control_plane_secrets.reencrypt_secrets(record_store=store)
+                    with patch.object(Session, "commit", side_effect=RuntimeError("commit failed")):
+                        with self.assertRaisesRegex(RuntimeError, "commit failed"):
+                            control_plane_secrets.reencrypt_secrets(
+                                record_store=store,
+                                apply=True,
+                                expected_plan_digest=cast(str, dry_run["plan_digest"]),
+                                reason="Exercise atomic rollback.",
+                            )
+
+                self.assertEqual(
+                    store.read_secret_record(secret_id).current_version_id,
+                    original_record.current_version_id,
                 )
-                self.assertEqual(values.get("DOKPLOY_HOST"), "https://dokploy.db.example")
-            
-            store.close()
+                self.assertEqual(
+                    len(store.list_secret_versions(secret_id=secret_id)), original_version_count
+                )
+                self.assertEqual(
+                    len(store.list_secret_audit_events(secret_id=secret_id)), original_event_count
+                )
+            finally:
+                store.close()
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -311,7 +311,6 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                 )
             store.close()
 
-
     def test_json_encryption_keys_are_exact_and_fail_closed(self) -> None:
         key1 = _test_fernet_key(0)
         key2 = _test_fernet_key(32)
@@ -385,7 +384,9 @@ class LaunchplaneSecretsTests(unittest.TestCase):
             try:
                 with patch.dict(
                     os.environ,
-                    {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "legacy-passphrase"},
+                    {
+                        control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "legacy-passphrase"
+                    },
                     clear=True,
                 ):
                     control_plane_secrets.write_secret_value(
@@ -446,9 +447,7 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                         integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
                     )
                     self.assertEqual(values["DOKPLOY_HOST"], "https://dokploy.db.example")
-                    audit_events = store.list_secret_audit_events(
-                        secret_id="secret-dokploy-host"
-                    )
+                    audit_events = store.list_secret_audit_events(secret_id="secret-dokploy-host")
                     rotation_event = next(
                         event for event in audit_events if event.event_type == "rotated"
                     )
@@ -466,7 +465,9 @@ class LaunchplaneSecretsTests(unittest.TestCase):
         key1 = _test_fernet_key(0)
         key2 = _test_fernet_key(32)
         with TemporaryDirectory() as temporary_directory_name:
-            database_url = _sqlite_database_url(Path(temporary_directory_name) / "launchplane.sqlite3")
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
             store = PostgresRecordStore(database_url=database_url)
             store.ensure_schema()
             try:
@@ -488,7 +489,7 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                         binding_key="DOKPLOY_HOST",
                         actor="test",
                     )
-                secret_id = cast(str, write_result["secret_id"])
+                secret_id = write_result["secret_id"]
                 original_record = store.read_secret_record(secret_id)
                 original_version_count = len(store.list_secret_versions(secret_id=secret_id))
                 original_event_count = len(store.list_secret_audit_events(secret_id=secret_id))
@@ -527,6 +528,7 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                 )
             finally:
                 store.close()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -419,12 +419,28 @@ class LaunchplaneSecretsTests(unittest.TestCase):
                         record_store=store,
                         apply=True,
                         expected_plan_digest=cast(str, dry_run["plan_digest"]),
+                        operation_token="test-operation-token",
                         reason="Rotate the managed-secret root.",
                         actor="operator:test",
                         source_label="test-migration",
                     )
                     self.assertEqual(applied["status"], "ok")
                     self.assertEqual(applied["rotated_count"], 1)
+
+                    recovered = control_plane_secrets.reencrypt_secrets(
+                        record_store=store,
+                        apply=True,
+                        expected_plan_digest=cast(str, dry_run["plan_digest"]),
+                        operation_token="test-operation-token",
+                        reason="Rotate the managed-secret root.",
+                        actor="operator:test",
+                        source_label="test-migration",
+                    )
+                    self.assertEqual(recovered["status"], "ok")
+                    self.assertTrue(recovered["recovered"])
+                    self.assertEqual(
+                        len(store.list_secret_versions(secret_id="secret-dokploy-host")), 2
+                    )
 
                     follow_up = control_plane_secrets.reencrypt_secrets(record_store=store)
                     self.assertEqual(follow_up["rotated_count"], 0)

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -302,5 +302,133 @@ class LaunchplaneSecretsTests(unittest.TestCase):
             store.close()
 
 
+    def test_json_encryption_keys(self) -> None:
+        import base64
+        import json
+        from cryptography.fernet import Fernet
+        import click
+        key1 = base64.urlsafe_b64encode(b"0" * 32).decode()
+        key2 = base64.urlsafe_b64encode(b"1" * 32).decode()
+        with patch.dict(
+            os.environ,
+            {
+                control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps({
+                    "active_key_id": "key-2",
+                    "keys": {
+                        "key-1": key1,
+                        "key-2": key2,
+                    }
+                }),
+            },
+            clear=True,
+        ):
+            ciphertext, key_id = control_plane_secrets._encrypt_secret_value("plaintext-data")
+            self.assertEqual(key_id, "key-2")
+            
+            decrypted = control_plane_secrets._decrypt_secret_value(ciphertext, "key-2")
+            self.assertEqual(decrypted, "plaintext-data")
+            
+            with self.assertRaises(click.ClickException) as ctx:
+                control_plane_secrets._decrypt_secret_value(ciphertext, "key-3")
+            self.assertIn("key_id 'key-3' is unknown", str(ctx.exception))
+            
+            # Encrypt with key-1 manually and verify it decrypts
+            f1 = Fernet(key1.encode())
+            c1 = f1.encrypt(b"old-data").decode()
+            decrypted_1 = control_plane_secrets._decrypt_secret_value(c1, "key-1")
+            self.assertEqual(decrypted_1, "old-data")
+
+    def test_reencrypt_secrets(self) -> None:
+        import base64
+        import json
+        key1 = base64.urlsafe_b64encode(b"0" * 32).decode()
+        key2 = base64.urlsafe_b64encode(b"1" * 32).decode()
+        
+        with TemporaryDirectory() as temporary_directory_name:
+            control_plane_root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(control_plane_root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            
+            # Step 1: Write secret using key-1
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps({
+                        "active_key_id": "key-1",
+                        "keys": {"key-1": key1}
+                    }),
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                },
+                clear=True,
+            ):
+                result1 = control_plane_secrets.write_secret_value(
+                    record_store=store,
+                    scope="global",
+                    integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                    name="host",
+                    plaintext_value="https://dokploy.db.example",
+                    binding_key="DOKPLOY_HOST",
+                    actor="test",
+                )
+                self.assertEqual(result1["status"], "ok")
+            
+            # Step 2: Rotate key (active is now key-2, key-1 still present), do dry run
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps({
+                        "active_key_id": "key-2",
+                        "keys": {"key-1": key1, "key-2": key2}
+                    }),
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                },
+                clear=True,
+            ):
+                reencrypt_result_dry = control_plane_secrets.reencrypt_secrets(
+                    record_store=store,
+                    apply=False,
+                )
+                self.assertTrue(reencrypt_result_dry["dry_run"])
+                self.assertEqual(reencrypt_result_dry["rotated_count"], 1)
+                self.assertEqual(reencrypt_result_dry["unchanged_count"], 0)
+                
+                reencrypt_result = control_plane_secrets.reencrypt_secrets(
+                    record_store=store,
+                    apply=True,
+                )
+                self.assertFalse(reencrypt_result["dry_run"])
+                self.assertEqual(reencrypt_result["rotated_count"], 1)
+                self.assertEqual(reencrypt_result["unchanged_count"], 0)
+                
+                # Doing it again should yield 0 rotated, 1 unchanged
+                reencrypt_result_noop = control_plane_secrets.reencrypt_secrets(
+                    record_store=store,
+                    apply=True,
+                )
+                self.assertEqual(reencrypt_result_noop["rotated_count"], 0)
+                self.assertEqual(reencrypt_result_noop["unchanged_count"], 1)
+
+            # Step 3: Retire key-1 (no longer present), decryption works because it's re-encrypted
+            with patch.dict(
+                os.environ,
+                {
+                    control_plane_secrets.LAUNCHPLANE_SECRET_KEYS_JSON_ENV_VAR: json.dumps({
+                        "active_key_id": "key-2",
+                        "keys": {"key-2": key2}
+                    }),
+                    "LAUNCHPLANE_DATABASE_URL": database_url,
+                },
+                clear=True,
+            ):
+                # We can still read the secret
+                values = control_plane_secrets.resolve_secret_values_for_integration_from_store(
+                    record_store=store,
+                    integration=control_plane_secrets.DOKPLOY_SECRET_INTEGRATION,
+                )
+                self.assertEqual(values.get("DOKPLOY_HOST"), "https://dokploy.db.example")
+            
+            store.close()
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_webhook_body_guard.py
+++ b/tests/test_webhook_body_guard.py
@@ -12,9 +12,46 @@ from control_plane.http_app import BoundedRequestBodyMiddleware
 
 _WEBHOOK_PATH = "/v1/every-code/github-webhook"
 _WEBHOOK_BODY_LIMIT = 2 * 1024 * 1024
+_JSON_MUTATION_ROUTES = (
+    ("/v1/product-config/apply", 2 * 1024 * 1024),
+    ("/v1/secrets/reencrypt", 64 * 1024),
+)
 
 
 class WebhookBodyGuardTests(unittest.IsolatedAsyncioTestCase):
+    async def test_json_mutation_routes_require_json_content_type(self) -> None:
+        for path, _limit in _JSON_MUTATION_ROUTES:
+            with self.subTest(path=path):
+                guarded_bodies: list[bytes] = []
+                response = await _invoke_guarded_webhook(
+                    path=path,
+                    headers=[("Content-Length", "2")],
+                    chunks=(b"{}",),
+                    guarded_bodies=guarded_bodies,
+                )
+
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(response.json()["error"]["code"], "invalid_request")
+                self.assertEqual(guarded_bodies, [])
+
+    async def test_json_mutation_routes_reject_oversized_declared_bodies(self) -> None:
+        for path, limit in _JSON_MUTATION_ROUTES:
+            with self.subTest(path=path):
+                guarded_bodies: list[bytes] = []
+                response = await _invoke_guarded_webhook(
+                    path=path,
+                    headers=[
+                        ("Content-Type", "application/json"),
+                        ("Content-Length", str(limit + 1)),
+                    ],
+                    chunks=(b"",),
+                    guarded_bodies=guarded_bodies,
+                )
+
+                self.assertEqual(response.status_code, 413)
+                self.assertEqual(response.receive_count, 0)
+                self.assertEqual(guarded_bodies, [])
+
     async def test_exact_declared_chunked_asgi_body_reaches_downstream(self) -> None:
         guarded_bodies: list[bytes] = []
         response = await _invoke_guarded_webhook(
@@ -123,13 +160,14 @@ class _GuardResponse:
 
 async def _invoke_guarded_webhook(
     *,
+    path: str = _WEBHOOK_PATH,
     headers: list[tuple[str, str]],
     chunks: tuple[bytes, ...],
     guarded_bodies: list[bytes],
 ) -> _GuardResponse:
     downstream = _body_capturing_app(guarded_bodies)
     app = BoundedRequestBodyMiddleware(downstream)
-    scope = _webhook_scope(headers=headers)
+    scope = _webhook_scope(path=path, headers=headers)
     messages: list[Message] = [
         {
             "type": "http.request",
@@ -159,15 +197,15 @@ async def _invoke_guarded_webhook(
     return _GuardResponse(start["status"], body, receive_count)
 
 
-def _webhook_scope(*, headers: list[tuple[str, str]]) -> Scope:
+def _webhook_scope(*, path: str = _WEBHOOK_PATH, headers: list[tuple[str, str]]) -> Scope:
     return {
         "type": "http",
         "asgi": {"version": "3.0", "spec_version": "2.3"},
         "http_version": "1.1",
         "method": "POST",
         "scheme": "https",
-        "path": _WEBHOOK_PATH,
-        "raw_path": _WEBHOOK_PATH.encode("ascii"),
+        "path": path,
+        "raw_path": path.encode("ascii"),
         "query_string": b"",
         "headers": [
             (name.lower().encode("ascii"), value.encode("latin-1")) for name, value in headers


### PR DESCRIPTION
## Summary
- require strict canonical high-entropy key rings for new deployments while preserving a safe legacy migration window
- record and enforce exact encryption key IDs for every secret version
- add atomic dry-run/apply re-encryption with retirement and rollback evidence
- expose an authz-, reason-, digest-, idempotency-, and bounded-body-protected service endpoint
- recover retries from audit evidence if rotation commits before idempotency persistence
- keep direct CLI rotation bootstrap/recovery-only and update product-config, docs, tests, and OpenAPI

## Validation
- all 12 local unittest shards passed (1,880 targets)
- targeted secret, HTTP rotation, and request-body tests passed
- Ruff, mypy, frontend OpenAPI drift/type/build validation passed
- two independent final security reviews: SHIP

Closes #1683