### PR TITLE
Make product authority bundles transactional

### DIFF
--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -34,6 +34,7 @@ from control_plane.dokploy_target_setup_http import (
     DokployTargetSetupEnvelope,
     execute_dokploy_target_setup,
 )
+from control_plane import product_config as control_plane_product_config
 from control_plane import product_config_service as control_plane_product_config_service
 from control_plane import product_context_audit as control_plane_product_context_audit
 from control_plane import product_context_cutover as control_plane_product_context_cutover
@@ -593,6 +594,7 @@ from control_plane.launchplane_mutations import (
 )
 from control_plane.storage.factory import build_shared_record_store
 from control_plane.storage.factory import storage_backend_name
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
 from control_plane.storage.postgres import (
     DbOnlyMutationRequest,
     MutationReservationResult,
@@ -606,7 +608,7 @@ from control_plane.workflows.evidence_ingestion import (
     apply_deployment_evidence,
     apply_promotion_evidence,
 )
-from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
+from control_plane.workflows.product_onboarding import plan_product_onboarding_authority_bundle
 from control_plane.workflows.public_ingress_monitor import (
     PublicIngressMonitorStore,
     public_ingress_notification_drivers,
@@ -13360,6 +13362,31 @@ def create_launchplane_fastapi_app(
             )
         )
 
+    def authority_bundle_with_apply_idempotency(
+        *,
+        bundle: ProductAuthorityBundle,
+        identity: LaunchplaneIdentity,
+        route_path: str,
+        idempotency_key: str,
+        request_fingerprint_value: str,
+        trace_id: str,
+        response: BaseModel,
+    ) -> ProductAuthorityBundle:
+        if not idempotency_key.strip():
+            return bundle
+        return bundle.model_copy(
+            update={
+                "idempotency_record": build_apply_idempotency_record(
+                    identity=identity,
+                    route_path=route_path,
+                    idempotency_key=idempotency_key,
+                    request_fingerprint_value=request_fingerprint_value,
+                    trace_id=trace_id,
+                    response=response,
+                )
+            }
+        )
+
     async def apply_product_config(
         request: Request,
         identity: Annotated[LaunchplaneIdentity, Depends(read_browser_mutation_identity)],
@@ -13466,16 +13493,20 @@ def create_launchplane_fastapi_app(
             record_store=record_store,
             trace_id=trace_id,
         )
-        driver_result, product_config_error = (
-            control_plane_product_config_service.apply_product_config_service_request(
-                record_store=database_store,
-                payload=product_config_request.product_config_payload(),
-                mode=product_config_request.mode,
-                actor=product_config_identity_actor(identity),
-                source_label=product_config_request.source_label,
+        try:
+            driver_result, authority_bundle = (
+                control_plane_product_config.plan_product_config_authority_bundle(
+                    record_store=database_store,
+                    payload=product_config_request.product_config_payload(),
+                    mode=product_config_request.mode,
+                    actor=product_config_identity_actor(identity),
+                    source_label=product_config_request.source_label,
+                )
             )
-        )
-        if product_config_error is not None:
+        except control_plane_product_config.ProductConfigError as error:
+            product_config_error = (
+                control_plane_product_config_service.product_config_service_error(error)
+            )
             raise _launchplane_http_error(
                 status_code=product_config_error.status_code,
                 trace_id=trace_id,
@@ -13509,15 +13540,18 @@ def create_launchplane_fastapi_app(
                 trace_id=trace_id,
                 response=product_config_response,
             )
-        store_apply_idempotency(
-            record_store=database_store,
-            identity=identity,
-            route_path=_PRODUCT_CONFIG_APPLY_ROUTE,
-            idempotency_key=normalized_idempotency_key,
-            request_fingerprint_value=payload_fingerprint,
-            trace_id=trace_id,
-            response=product_config_response,
-        )
+        if product_config_request.mode == "apply":
+            database_store.write_product_authority_bundle(
+                authority_bundle_with_apply_idempotency(
+                    bundle=authority_bundle,
+                    identity=identity,
+                    route_path=_PRODUCT_CONFIG_APPLY_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint_value=payload_fingerprint,
+                    trace_id=trace_id,
+                    response=product_config_response,
+                )
+            )
         return product_config_response
 
     async def reencrypt_managed_secrets(
@@ -13607,12 +13641,34 @@ def create_launchplane_fastapi_app(
                     "utf-8"
                 )
             ).hexdigest()
+
+        def reencryption_idempotency_record(
+            result_payload: dict[str, object],
+        ) -> LaunchplaneIdempotencyRecord:
+            return build_apply_idempotency_record(
+                identity=identity,
+                route_path=_SECRET_REENCRYPT_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=accepted_evidence_response(
+                    trace_id=trace_id,
+                    records={},
+                    result=result_payload,
+                ),
+            )
+
         try:
             result = control_plane_secrets.reencrypt_secrets(
                 record_store=database_store,
                 apply=reencryption_request.mode == "apply",
                 expected_plan_digest=reencryption_request.expected_plan_digest,
                 operation_token=operation_token,
+                idempotency_record_factory=(
+                    reencryption_idempotency_record
+                    if reencryption_request.mode == "apply"
+                    else None
+                ),
                 actor=actor,
                 source_label=reencryption_request.source_label,
                 reason=reencryption_request.reason,
@@ -13632,16 +13688,6 @@ def create_launchplane_fastapi_app(
                 message="Managed-secret state no longer matches the approved dry-run.",
             )
         response = accepted_evidence_response(trace_id=trace_id, records={}, result=result)
-        if reencryption_request.mode == "apply":
-            store_apply_idempotency(
-                record_store=database_store,
-                identity=identity,
-                route_path=_SECRET_REENCRYPT_ROUTE,
-                idempotency_key=normalized_idempotency_key,
-                request_fingerprint_value=payload_fingerprint,
-                trace_id=trace_id,
-                response=response,
-            )
         return response
 
     async def apply_product_onboarding(
@@ -13708,7 +13754,7 @@ def create_launchplane_fastapi_app(
         if replay_response is not None:
             return replay_response
         try:
-            onboarding_result = apply_product_onboarding_manifest(
+            onboarding_result, authority_bundle = plan_product_onboarding_authority_bundle(
                 record_store=database_store,
                 manifest=onboarding_request.manifest,
             )
@@ -13735,14 +13781,16 @@ def create_launchplane_fastapi_app(
             },
             result=driver_result,
         )
-        store_apply_idempotency(
-            record_store=database_store,
-            identity=identity,
-            route_path=_PRODUCT_ONBOARDING_APPLY_ROUTE,
-            idempotency_key=normalized_idempotency_key,
-            request_fingerprint_value=payload_fingerprint,
-            trace_id=trace_id,
-            response=onboarding_response,
+        database_store.write_product_authority_bundle(
+            authority_bundle_with_apply_idempotency(
+                bundle=authority_bundle,
+                identity=identity,
+                route_path=_PRODUCT_ONBOARDING_APPLY_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=onboarding_response,
+            )
         )
         return onboarding_response
 
@@ -14414,9 +14462,11 @@ def create_launchplane_fastapi_app(
                 message="Requested cutover contexts are not owned by the product profile.",
             )
         try:
-            result = control_plane_product_context_cutover.apply_product_context_cutover(
-                record_store=database_store,
-                request=context_cutover_request,
+            result, authority_bundle = (
+                control_plane_product_context_cutover.plan_product_context_cutover_authority_bundle(
+                    record_store=database_store,
+                    request=context_cutover_request,
+                )
             )
         except ValueError as error:
             raise _launchplane_http_error(
@@ -14430,15 +14480,18 @@ def create_launchplane_fastapi_app(
             records={"product_profile": context_cutover_request.product},
             result=result,
         )
-        store_apply_idempotency(
-            record_store=database_store,
-            identity=identity,
-            route_path=_PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE,
-            idempotency_key=normalized_idempotency_key,
-            request_fingerprint_value=payload_fingerprint,
-            trace_id=trace_id,
-            response=response,
-        )
+        if context_cutover_request.mode == "apply":
+            database_store.write_product_authority_bundle(
+                authority_bundle_with_apply_idempotency(
+                    bundle=authority_bundle,
+                    identity=identity,
+                    route_path=_PRODUCT_CONTEXT_CUTOVER_APPLY_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint_value=payload_fingerprint,
+                    trace_id=trace_id,
+                    response=response,
+                )
+            )
         return response
 
     async def apply_product_legacy_context_cleanup(
@@ -14510,9 +14563,11 @@ def create_launchplane_fastapi_app(
         if replay_response is not None:
             return replay_response
         try:
-            result = control_plane_product_context_cutover.apply_legacy_context_cleanup(
-                record_store=database_store,
-                request=legacy_cleanup_request,
+            result, authority_bundle = (
+                control_plane_product_context_cutover.plan_legacy_context_cleanup_authority_bundle(
+                    record_store=database_store,
+                    request=legacy_cleanup_request,
+                )
             )
         except control_plane_product_context_cutover.LegacyContextCleanupBoundaryError as error:
             raise _launchplane_http_error(
@@ -14540,15 +14595,18 @@ def create_launchplane_fastapi_app(
             records={"product_profile": legacy_cleanup_request.product},
             result=result,
         )
-        store_apply_idempotency(
-            record_store=database_store,
-            identity=identity,
-            route_path=_PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE,
-            idempotency_key=normalized_idempotency_key,
-            request_fingerprint_value=payload_fingerprint,
-            trace_id=trace_id,
-            response=response,
-        )
+        if legacy_cleanup_request.mode == "apply":
+            database_store.write_product_authority_bundle(
+                authority_bundle_with_apply_idempotency(
+                    bundle=authority_bundle,
+                    identity=identity,
+                    route_path=_PRODUCT_LEGACY_CONTEXT_CLEANUP_APPLY_ROUTE,
+                    idempotency_key=normalized_idempotency_key,
+                    request_fingerprint_value=payload_fingerprint,
+                    trace_id=trace_id,
+                    response=response,
+                )
+            )
         return response
 
     def resolve_ingress_edge_endpoint(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -13540,7 +13540,17 @@ def create_launchplane_fastapi_app(
                 trace_id=trace_id,
                 response=product_config_response,
             )
-        if product_config_request.mode == "apply":
+        if product_config_request.mode == "dry-run":
+            store_apply_idempotency(
+                record_store=database_store,
+                identity=identity,
+                route_path=_PRODUCT_CONFIG_APPLY_ROUTE,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint_value=payload_fingerprint,
+                trace_id=trace_id,
+                response=product_config_response,
+            )
+        else:
             database_store.write_product_authority_bundle(
                 authority_bundle_with_apply_idempotency(
                     bundle=authority_bundle,

--- a/control_plane/product_config.py
+++ b/control_plane/product_config.py
@@ -16,12 +16,15 @@ from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeKeySafetyTarget,
 )
+from control_plane.contracts.secret_record import SecretAuditEvent, SecretRecord, SecretVersion
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.secret_record import SecretScope
 from control_plane.runtime_key_safety import (
     evaluate_runtime_key_safety,
     latest_active_runtime_key_safety_policy,
 )
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundleStore
 from control_plane.workflows.ship import utc_now_timestamp
 
 
@@ -30,7 +33,11 @@ ProductConfigMode = Literal["dry-run", "apply"]
 _VALID_SECRET_SCOPES: tuple[SecretScope, ...] = ("global", "context", "context_instance")
 
 
-class ProductConfigStore(control_plane_secrets.SecretWriteStore, Protocol):
+class ProductConfigStore(
+    control_plane_secrets.SecretWriteStore,
+    ProductAuthorityBundleStore,
+    Protocol,
+):
     def list_runtime_environment_records(
         self, *, context_name: str = "", instance_name: str = ""
     ) -> tuple[RuntimeEnvironmentRecord, ...]: ...
@@ -50,6 +57,17 @@ class _SecretBindingLookupKwargs(TypedDict, total=False):
     context_name: str
     instance_name: str
     limit: int | None
+
+
+class _ProductConfigSecretWritePlan(TypedDict):
+    secret_id: str
+    action: str
+    updated_at: str
+    configured_binding: SecretBinding
+    secret_versions: list[SecretVersion]
+    secret_records: list[SecretRecord]
+    secret_bindings: list[SecretBinding]
+    secret_audit_events: list[SecretAuditEvent]
 
 
 class ProductConfigError(ValueError):
@@ -123,6 +141,26 @@ def apply_product_config_bundle(
     actor: str,
     source_label: str,
 ) -> dict[str, object]:
+    result, bundle = plan_product_config_authority_bundle(
+        record_store=record_store,
+        payload=payload,
+        mode=mode,
+        actor=actor,
+        source_label=source_label,
+    )
+    if mode == "apply":
+        record_store.write_product_authority_bundle(bundle)
+    return result
+
+
+def plan_product_config_authority_bundle(
+    *,
+    record_store: ProductConfigStore,
+    payload: dict[str, object],
+    mode: ProductConfigMode,
+    actor: str,
+    source_label: str,
+) -> tuple[dict[str, object], ProductAuthorityBundle]:
     if mode not in {"dry-run", "apply"}:
         raise ProductConfigError("Product config mode must be 'dry-run' or 'apply'.")
     product, context_name, instance_name = product_context(payload)
@@ -155,13 +193,17 @@ def apply_product_config_bundle(
         secrets=secrets,
     )
     apply_changes = mode == "apply"
+    secret_versions: list[SecretVersion] = []
+    secret_records: list[SecretRecord] = []
+    secret_bindings: list[SecretBinding] = []
+    secret_audit_events: list[SecretAuditEvent] = []
     for secret in secrets:
         planned_action, existing_secret_id = _product_config_secret_current_action(
             record_store=record_store,
             secret=secret,
         )
         if apply_changes:
-            result = control_plane_secrets.write_secret_value(
+            secret_plan = _plan_product_config_secret_write(
                 record_store=record_store,
                 scope=cast(SecretScope, str(secret["scope"])),
                 integration=str(secret["integration"]),
@@ -174,30 +216,21 @@ def apply_product_config_bundle(
                 actor=actor,
                 source_label=source_label,
             )
-            secret_id = str(result["secret_id"])
-            binding_key = str(secret["binding_key"])
-            now = utc_now_timestamp()
-            _retire_disabled_runtime_secret_placeholders(
-                record_store=record_store,
-                configured_binding=SecretBinding(
-                    binding_id=control_plane_secrets.expected_secret_binding_id(
-                        secret_id=secret_id,
-                        binding_key=binding_key,
-                    ),
-                    secret_id=secret_id,
-                    integration=str(secret["integration"]),
-                    binding_key=binding_key,
-                    context=str(secret["context"]),
-                    instance=str(secret["instance"]),
-                    status="configured",
-                    created_at=now,
-                    updated_at=now,
+            secret_id = secret_plan["secret_id"]
+            secret_versions.extend(secret_plan["secret_versions"])
+            secret_records.extend(secret_plan["secret_records"])
+            secret_bindings.extend(secret_plan["secret_bindings"])
+            secret_audit_events.extend(secret_plan["secret_audit_events"])
+            secret_bindings.extend(
+                _planned_disabled_runtime_secret_placeholder_retirements(
+                    record_store=record_store,
+                    configured_binding=secret_plan["configured_binding"],
+                    updated_at=secret_plan["updated_at"],
                 ),
-                updated_at=now,
             )
             secret_summaries.append(
                 _summarize_product_config_secret_input(
-                    action=str(result["action"]),
+                    action=secret_plan["action"],
                     secret=secret,
                     secret_id=secret_id,
                 )
@@ -210,8 +243,9 @@ def apply_product_config_bundle(
                 secret_id=existing_secret_id,
             )
         )
+    runtime_records: tuple[RuntimeEnvironmentRecord, ...] = ()
     if apply_changes and runtime_record is not None and runtime_summary["action"] != "unchanged":
-        record_store.write_runtime_environment_record(runtime_record)
+        runtime_records = (runtime_record,)
         runtime_summary = {
             **runtime_summary,
             "record": summarize_runtime_environment_record(runtime_record),
@@ -220,7 +254,7 @@ def apply_product_config_bundle(
     changed_secret_count = sum(
         1 for item in secret_summaries if item["action"] in {"created", "rotated"}
     )
-    return {
+    result: dict[str, object] = {
         "status": "ok",
         "mode": mode,
         "product": product,
@@ -238,6 +272,14 @@ def apply_product_config_bundle(
             "secret_change_count": changed_secret_count,
         },
     }
+    bundle = ProductAuthorityBundle(
+        runtime_environments=runtime_records,
+        secret_versions=tuple(secret_versions),
+        secret_records=tuple(secret_records),
+        secret_bindings=tuple(secret_bindings),
+        secret_audit_events=tuple(secret_audit_events),
+    )
+    return result, bundle
 
 
 def _default_runtime_scope(*, context_name: str, instance_name: str) -> str:
@@ -482,6 +524,122 @@ def _product_config_secret_current_action(
     return "rotated", existing_record.secret_id
 
 
+def _plan_product_config_secret_write(
+    *,
+    record_store: control_plane_secrets.SecretWriteStore,
+    scope: SecretScope,
+    integration: str,
+    name: str,
+    plaintext_value: str,
+    binding_key: str,
+    context_name: str = "",
+    instance_name: str = "",
+    description: str = "",
+    actor: str = "",
+    source_label: str = "manual",
+) -> _ProductConfigSecretWritePlan:
+    if not plaintext_value.strip():
+        raise ProductConfigError("Product config secret values must be non-empty.")
+    now = utc_now_timestamp()
+    existing_record = record_store.find_secret_record(
+        scope=scope,
+        integration=integration,
+        name=name,
+        context=context_name,
+        instance=instance_name,
+    )
+    secret_id = (
+        existing_record.secret_id
+        if existing_record is not None
+        else control_plane_secrets.expected_secret_id(
+            integration=integration,
+            name=name,
+            context=context_name,
+            instance=instance_name,
+        )
+    )
+    created_at = existing_record.created_at if existing_record is not None else now
+    binding = SecretBinding(
+        binding_id=control_plane_secrets.expected_secret_binding_id(
+            secret_id=secret_id,
+            binding_key=binding_key,
+        ),
+        secret_id=secret_id,
+        integration=integration,
+        binding_key=binding_key,
+        context=context_name,
+        instance=instance_name,
+        created_at=created_at,
+        updated_at=now,
+    )
+    if existing_record is not None:
+        current_version = record_store.read_secret_version(existing_record.current_version_id)
+        if (
+            control_plane_secrets._decrypt_secret_value(
+                current_version.ciphertext,
+                current_version.key_id,
+            )
+            == plaintext_value
+        ):
+            return {
+                "secret_id": secret_id,
+                "action": "unchanged",
+                "updated_at": now,
+                "configured_binding": binding,
+                "secret_versions": [],
+                "secret_records": [],
+                "secret_bindings": [binding],
+                "secret_audit_events": [],
+            }
+    action = "created" if existing_record is None else "rotated"
+    version_id = control_plane_secrets._version_id(secret_id=secret_id)
+    ciphertext, key_id = control_plane_secrets._encrypt_secret_value(plaintext_value)
+    version = SecretVersion(
+        version_id=version_id,
+        secret_id=secret_id,
+        created_at=now,
+        created_by=actor,
+        key_id=key_id,
+        ciphertext=ciphertext,
+    )
+    record = SecretRecord(
+        secret_id=secret_id,
+        scope=scope,
+        integration=integration,
+        name=name,
+        context=context_name,
+        instance=instance_name,
+        description=description,
+        current_version_id=version_id,
+        created_at=created_at,
+        updated_at=now,
+        updated_by=actor,
+        last_validated_at=existing_record.last_validated_at if existing_record is not None else "",
+    )
+    event = SecretAuditEvent(
+        event_id=control_plane_secrets._audit_event_id(
+            secret_id=secret_id,
+            event_type=action,
+        ),
+        secret_id=secret_id,
+        event_type="created" if action == "created" else "rotated",
+        recorded_at=now,
+        actor=actor,
+        detail=f"Launchplane {action} managed secret from {source_label}.",
+        metadata={"source": source_label, "binding_key": binding_key},
+    )
+    return {
+        "secret_id": secret_id,
+        "action": action,
+        "updated_at": now,
+        "configured_binding": binding,
+        "secret_versions": [version],
+        "secret_records": [record],
+        "secret_bindings": [binding],
+        "secret_audit_events": [event],
+    }
+
+
 def _evaluate_product_config_runtime_key_safety(
     *,
     record_store: ProductConfigStore,
@@ -638,6 +796,48 @@ def _retire_disabled_runtime_secret_placeholders(
                 }
             )
         )
+
+
+def _planned_disabled_runtime_secret_placeholder_retirements(
+    *,
+    record_store: ProductConfigStore,
+    configured_binding: SecretBinding,
+    updated_at: str,
+) -> tuple[SecretBinding, ...]:
+    if (
+        configured_binding.integration
+        != control_plane_secrets.RUNTIME_ENVIRONMENT_SECRET_INTEGRATION
+    ):
+        return ()
+    context_name = configured_binding.context.strip()
+    instance_name = configured_binding.instance.strip()
+    lookup_kwargs: _SecretBindingLookupKwargs = {
+        "integration": configured_binding.integration,
+        "limit": None,
+    }
+    if context_name:
+        lookup_kwargs["context_name"] = context_name
+    if instance_name:
+        lookup_kwargs["instance_name"] = instance_name
+    retirements: list[SecretBinding] = []
+    for binding in record_store.list_secret_bindings(**lookup_kwargs):
+        if binding.binding_id == configured_binding.binding_id:
+            continue
+        if binding.context != context_name or binding.instance != instance_name:
+            continue
+        if binding.binding_key != configured_binding.binding_key:
+            continue
+        if binding.status != "disabled":
+            continue
+        retirements.append(
+            binding.model_copy(
+                update={
+                    "integration": f"retired:{binding.integration}",
+                    "updated_at": updated_at,
+                }
+            )
+        )
+    return tuple(retirements)
 
 
 def _product_config_runtime_environment_class(

--- a/control_plane/product_context_cutover.py
+++ b/control_plane/product_context_cutover.py
@@ -22,6 +22,9 @@ from control_plane.contracts.secret_record import (
     SecretRecord,
     SecretVersion,
 )
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundleStore
+from control_plane.storage.product_authority_bundle import RuntimeEnvironmentDelete
 from control_plane.workflows.provider_target_dual_write import (
     prepare_provider_target_from_dokploy_records,
 )
@@ -82,7 +85,11 @@ class ProductContextCutoverReadStore(Protocol):
     def list_release_tuple_records(self) -> tuple[ReleaseTupleRecord, ...]: ...
 
 
-class ProductContextCutoverStore(ProductContextCutoverReadStore, Protocol):
+class ProductContextCutoverStore(
+    ProductContextCutoverReadStore,
+    ProductAuthorityBundleStore,
+    Protocol,
+):
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> None: ...
 
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None: ...
@@ -328,6 +335,16 @@ def _target_instance_exists(
         getattr(record, "context", "") == target_context
         and getattr(record, "instance", "") == instance
         for record in records
+    )
+
+
+def _source_provider_targets(
+    *, record_store: ProductContextCutoverStore, source_context: str
+) -> tuple[ProviderTargetRecord, ...]:
+    return tuple(
+        record
+        for record in record_store.list_physical_provider_target_records()
+        if record.context == source_context
     )
 
 
@@ -584,9 +601,23 @@ def apply_product_context_cutover(
     record_store: ProductContextCutoverStore,
     request: ProductContextCutoverRequest,
 ) -> dict[str, object]:
+    result, bundle = plan_product_context_cutover_authority_bundle(
+        record_store=record_store,
+        request=request,
+    )
+    if request.mode == "apply":
+        record_store.write_product_authority_bundle(bundle)
+    return result
+
+
+def plan_product_context_cutover_authority_bundle(
+    *,
+    record_store: ProductContextCutoverStore,
+    request: ProductContextCutoverRequest,
+) -> tuple[dict[str, object], ProductAuthorityBundle]:
     plan = plan_product_context_cutover(record_store=record_store, request=request)
     if request.mode == "dry-run":
-        return plan
+        return plan, ProductAuthorityBundle()
 
     now = utc_now_timestamp()
     source_target_records = tuple(
@@ -650,6 +681,7 @@ def apply_product_context_cutover(
             target_id_record=target_id_record,
         )
 
+    runtime_records: list[RuntimeEnvironmentRecord] = []
     for runtime_record in record_store.list_runtime_environment_records(
         context_name=request.source_context
     ):
@@ -660,7 +692,7 @@ def apply_product_context_cutover(
             )
         )
         if not exists:
-            record_store.write_runtime_environment_record(
+            runtime_records.append(
                 runtime_record.model_copy(
                     update={
                         "context": request.target_context,
@@ -670,15 +702,10 @@ def apply_product_context_cutover(
                 )
             )
 
-    for copied_target_record in planned_target_records.values():
-        record_store.write_dokploy_target_record(copied_target_record)
-
-    for copied_target_id_record in planned_target_id_records.values():
-        record_store.write_dokploy_target_id_record(copied_target_id_record)
-
-    for provider_target_record in planned_provider_target_records.values():
-        record_store.write_provider_target_record(provider_target_record)
-
+    secret_versions: list[SecretVersion] = []
+    secret_records: list[SecretRecord] = []
+    secret_bindings: list[SecretBinding] = []
+    secret_audit_events: list[SecretAuditEvent] = []
     for secret_record in record_store.list_secret_records(
         context_name=request.source_context,
         limit=None,
@@ -701,7 +728,7 @@ def apply_product_context_cutover(
             secret_id=target_secret_id,
             source_version_id=source_version.version_id,
         )
-        record_store.write_secret_version(
+        secret_versions.append(
             SecretVersion(
                 version_id=target_version_id,
                 secret_id=target_secret_id,
@@ -712,7 +739,7 @@ def apply_product_context_cutover(
                 ciphertext=source_version.ciphertext,
             )
         )
-        record_store.write_secret_record(
+        secret_records.append(
             SecretRecord(
                 secret_id=target_secret_id,
                 scope=secret_record.scope,
@@ -740,7 +767,7 @@ def apply_product_context_cutover(
             )
             if item.secret_id == secret_record.secret_id
         ):
-            record_store.write_secret_binding(
+            secret_bindings.append(
                 SecretBinding(
                     binding_id=_target_secret_binding_id(
                         secret_id=target_secret_id,
@@ -757,7 +784,7 @@ def apply_product_context_cutover(
                     updated_at=now,
                 )
             )
-        record_store.write_secret_audit_event(
+        secret_audit_events.append(
             SecretAuditEvent(
                 event_id=_target_secret_event_id(
                     secret_id=target_secret_id,
@@ -777,6 +804,7 @@ def apply_product_context_cutover(
             )
         )
 
+    inventory_records: list[EnvironmentInventory] = []
     for inventory_record in tuple(
         item
         for item in record_store.list_environment_inventory()
@@ -788,12 +816,13 @@ def apply_product_context_cutover(
             for target in record_store.list_environment_inventory()
         )
         if not exists:
-            record_store.write_environment_inventory(
+            inventory_records.append(
                 inventory_record.model_copy(
                     update={"context": request.target_context, "updated_at": now}
                 )
             )
 
+    release_tuple_records: list[ReleaseTupleRecord] = []
     for release_tuple_record in tuple(
         item
         for item in record_store.list_release_tuple_records()
@@ -805,7 +834,7 @@ def apply_product_context_cutover(
             for target in record_store.list_release_tuple_records()
         )
         if not exists:
-            record_store.write_release_tuple_record(
+            release_tuple_records.append(
                 release_tuple_record.model_copy(
                     update={
                         "context": request.target_context,
@@ -823,9 +852,23 @@ def apply_product_context_cutover(
         now=now,
         source_label=request.source_label,
     )
+    profile_records: tuple[LaunchplaneProductProfileRecord, ...] = ()
     if _profile_semantic_payload(profile) != _profile_semantic_payload(next_profile):
-        record_store.write_product_profile_record(next_profile)
-    return {**plan, "applied": True}
+        profile_records = (next_profile,)
+    bundle = ProductAuthorityBundle(
+        product_profiles=profile_records,
+        dokploy_targets=tuple(planned_target_records.values()),
+        dokploy_target_ids=tuple(planned_target_id_records.values()),
+        provider_targets=tuple(planned_provider_target_records.values()),
+        runtime_environments=tuple(runtime_records),
+        secret_versions=tuple(secret_versions),
+        secret_records=tuple(secret_records),
+        secret_bindings=tuple(secret_bindings),
+        secret_audit_events=tuple(secret_audit_events),
+        environment_inventory=tuple(inventory_records),
+        release_tuples=tuple(release_tuple_records),
+    )
+    return {**plan, "applied": True}, bundle
 
 
 def plan_legacy_context_cleanup(
@@ -973,35 +1016,53 @@ def apply_legacy_context_cleanup(
     record_store: ProductContextCutoverStore,
     request: LegacyContextCleanupRequest,
 ) -> dict[str, object]:
+    result, bundle = plan_legacy_context_cleanup_authority_bundle(
+        record_store=record_store,
+        request=request,
+    )
+    if request.mode == "apply":
+        record_store.write_product_authority_bundle(bundle)
+    return result
+
+
+def plan_legacy_context_cleanup_authority_bundle(
+    *,
+    record_store: ProductContextCutoverStore,
+    request: LegacyContextCleanupRequest,
+) -> tuple[dict[str, object], ProductAuthorityBundle]:
     plan = plan_legacy_context_cleanup(record_store=record_store, request=request)
     if request.mode == "dry-run":
-        return plan
+        return plan, ProductAuthorityBundle()
     if plan["blocked"]:
         raise ValueError("Legacy context cleanup plan has blocked records.")
 
     now = utc_now_timestamp()
     actor = request.actor or request.source_label
+    runtime_deletes: list[RuntimeEnvironmentDelete] = []
     for runtime_record in record_store.list_runtime_environment_records(
         context_name=request.source_context
     ):
-        status = record_store.delete_runtime_environment_record_with_event(
-            event=_runtime_delete_event(
-                record=runtime_record,
-                actor=actor,
-                source_label=request.source_label,
-                now=now,
-            ),
-            expected_record=runtime_record,
+        runtime_deletes.append(
+            RuntimeEnvironmentDelete(
+                expected_record=runtime_record,
+                event=_runtime_delete_event(
+                    record=runtime_record,
+                    actor=actor,
+                    source_label=request.source_label,
+                    now=now,
+                ),
+            )
         )
-        if status == "changed":
-            raise ValueError("Runtime environment record changed during cleanup.")
 
+    secret_records: list[SecretRecord] = []
+    secret_bindings: list[SecretBinding] = []
+    secret_audit_events: list[SecretAuditEvent] = []
     for secret_record in record_store.list_secret_records(
         context_name=request.source_context,
         limit=None,
     ):
         if secret_record.status != "disabled":
-            record_store.write_secret_record(
+            secret_records.append(
                 secret_record.model_copy(
                     update={
                         "status": "disabled",
@@ -1010,7 +1071,7 @@ def apply_legacy_context_cleanup(
                     }
                 )
             )
-            record_store.write_secret_audit_event(
+            secret_audit_events.append(
                 SecretAuditEvent(
                     event_id=_secret_cleanup_event_id(secret_record.secret_id),
                     secret_id=secret_record.secret_id,
@@ -1027,26 +1088,32 @@ def apply_legacy_context_cleanup(
             )
         for binding in _source_secret_bindings(record_store=record_store, record=secret_record):
             if binding.status != "disabled":
-                record_store.write_secret_binding(
+                secret_bindings.append(
                     binding.model_copy(update={"status": "disabled", "updated_at": now})
                 )
 
-    for target_id_record in tuple(
+    target_id_deletes = tuple(
         item
         for item in record_store.list_dokploy_target_id_records()
         if item.context == request.source_context
-    ):
-        status = record_store.delete_dokploy_target_id_record(expected_record=target_id_record)
-        if status == "changed":
-            raise ValueError("Dokploy target ID record changed during cleanup.")
+    )
 
-    for dokploy_target_record in tuple(
+    target_deletes = tuple(
         item
         for item in record_store.list_dokploy_target_records()
         if item.context == request.source_context
-    ):
-        status = record_store.delete_dokploy_target_record(expected_record=dokploy_target_record)
-        if status == "changed":
-            raise ValueError("Dokploy target record changed during cleanup.")
-
-    return {**plan, "applied": True}
+    )
+    provider_target_deletes = _source_provider_targets(
+        record_store=record_store,
+        source_context=request.source_context,
+    )
+    bundle = ProductAuthorityBundle(
+        delete_runtime_environments=tuple(runtime_deletes),
+        secret_records=tuple(secret_records),
+        secret_bindings=tuple(secret_bindings),
+        secret_audit_events=tuple(secret_audit_events),
+        delete_provider_targets=provider_target_deletes,
+        delete_dokploy_target_ids=target_id_deletes,
+        delete_dokploy_targets=target_deletes,
+    )
+    return {**plan, "applied": True}, bundle

--- a/control_plane/product_context_cutover.py
+++ b/control_plane/product_context_cutover.py
@@ -24,6 +24,7 @@ from control_plane.contracts.secret_record import (
 )
 from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
 from control_plane.storage.product_authority_bundle import ProductAuthorityBundleStore
+from control_plane.storage.product_authority_bundle import ProviderTargetWrite
 from control_plane.storage.product_authority_bundle import RuntimeEnvironmentDelete
 from control_plane.workflows.provider_target_dual_write import (
     prepare_provider_target_from_dokploy_records,
@@ -665,6 +666,10 @@ def plan_product_context_cutover_authority_bundle(
     final_target_records = {**target_target_records, **planned_target_records}
     final_target_id_records = {**target_id_records, **planned_target_id_records}
     affected_target_instances = sorted(set(planned_target_records) | set(planned_target_id_records))
+    current_provider_targets = {
+        (record.context, record.instance): record
+        for record in record_store.list_physical_provider_target_records()
+    }
     planned_provider_target_records: dict[str, ProviderTargetRecord] = {}
     for instance in affected_target_instances:
         target_record = final_target_records.get(instance)
@@ -859,7 +864,14 @@ def plan_product_context_cutover_authority_bundle(
         product_profiles=profile_records,
         dokploy_targets=tuple(planned_target_records.values()),
         dokploy_target_ids=tuple(planned_target_id_records.values()),
-        provider_targets=tuple(planned_provider_target_records.values()),
+        provider_target_writes=tuple(
+            ProviderTargetWrite(
+                record=record,
+                expected_record=current_provider_targets.get((record.context, record.instance)),
+                expected_absent=(record.context, record.instance) not in current_provider_targets,
+            )
+            for record in planned_provider_target_records.values()
+        ),
         runtime_environments=tuple(runtime_records),
         secret_versions=tuple(secret_versions),
         secret_records=tuple(secret_records),

--- a/control_plane/secrets.py
+++ b/control_plane/secrets.py
@@ -8,12 +8,13 @@ import os
 import re
 import uuid
 from dataclasses import dataclass
-from typing import Literal, Mapping, Protocol
+from typing import Callable, Literal, Mapping, Protocol
 
 import click
 from cryptography.fernet import Fernet, InvalidToken
 
 from control_plane.child_process_errors import redact_untrusted_text
+from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
     SecretBinding,
@@ -89,7 +90,12 @@ class SecretWriteStore(SecretReadStore, Protocol):
 
 
 class SecretRotationStore(SecretWriteStore, Protocol):
-    def write_secret_rotations(self, rotations: tuple[SecretRotationWrite, ...]) -> None: ...
+    def write_secret_rotations(
+        self,
+        rotations: tuple[SecretRotationWrite, ...],
+        *,
+        idempotency_record: LaunchplaneIdempotencyRecord | None = None,
+    ) -> None: ...
 
 
 def _secret_slug(value: str) -> str:
@@ -784,6 +790,9 @@ def reencrypt_secrets(
     apply: bool = False,
     expected_plan_digest: str = "",
     operation_token: str = "",
+    idempotency_record: LaunchplaneIdempotencyRecord | None = None,
+    idempotency_record_factory: Callable[[dict[str, object]], LaunchplaneIdempotencyRecord]
+    | None = None,
     actor: str = "cli",
     source_label: str = "manual",
     reason: str = "",
@@ -948,7 +957,13 @@ def reencrypt_secrets(
         )
 
     try:
-        record_store.write_secret_rotations(tuple(rotations))
+        completion_idempotency_record = idempotency_record
+        if completion_idempotency_record is None and idempotency_record_factory is not None:
+            completion_idempotency_record = idempotency_record_factory(result)
+        record_store.write_secret_rotations(
+            tuple(rotations),
+            idempotency_record=completion_idempotency_record,
+        )
     except (FileNotFoundError, ValueError):
         return {
             **result,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -154,7 +154,10 @@ class FilesystemRecordStore:
         return self.state_dir / record_type / f"{record_id}.json"
 
     def _write_model(self, record_type: str, record_id: str, model: BaseModel) -> Path:
-        self._recover_product_authority_bundle_stages()
+        with self._product_authority_bundle_lock():
+            return self._write_model_locked(record_type, record_id, model)
+
+    def _write_model_locked(self, record_type: str, record_id: str, model: BaseModel) -> Path:
         record_path = self._record_path(record_type, record_id)
         record_path.parent.mkdir(parents=True, exist_ok=True)
         descriptor, temporary_path = tempfile.mkstemp(
@@ -191,7 +194,12 @@ class FilesystemRecordStore:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     def _create_model_if_absent(self, record_type: str, record_id: str, model: BaseModel) -> bool:
-        self._recover_product_authority_bundle_stages()
+        with self._product_authority_bundle_lock():
+            return self._create_model_if_absent_locked(record_type, record_id, model)
+
+    def _create_model_if_absent_locked(
+        self, record_type: str, record_id: str, model: BaseModel
+    ) -> bool:
         record_path = self._record_path(record_type, record_id)
         record_path.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -210,7 +218,12 @@ class FilesystemRecordStore:
     def _read_model(
         self, model_type: type[RecordModel], record_type: str, record_id: str
     ) -> RecordModel:
-        self._recover_product_authority_bundle_stages()
+        with self._product_authority_bundle_lock():
+            return self._read_model_locked(model_type, record_type, record_id)
+
+    def _read_model_locked(
+        self, model_type: type[RecordModel], record_type: str, record_id: str
+    ) -> RecordModel:
         record_path = self._record_path(record_type, record_id)
         payload = json.loads(record_path.read_text(encoding="utf-8"))
         return model_type.model_validate(payload)
@@ -221,7 +234,12 @@ class FilesystemRecordStore:
     def _list_models(
         self, model_type: type[RecordModel], record_type: str
     ) -> tuple[RecordModel, ...]:
-        self._recover_product_authority_bundle_stages()
+        with self._product_authority_bundle_lock():
+            return self._list_models_locked(model_type, record_type)
+
+    def _list_models_locked(
+        self, model_type: type[RecordModel], record_type: str
+    ) -> tuple[RecordModel, ...]:
         record_dir = self._record_dir(record_type)
         if not record_dir.exists():
             return ()
@@ -238,11 +256,11 @@ class FilesystemRecordStore:
     def _after_product_authority_bundle_step(self, step_name: str) -> None:
         _ = step_name
 
-    def _recover_product_authority_bundle_stages(self) -> None:
-        if self._recovering_product_authority_bundle:
-            return
+    @contextmanager
+    def _product_authority_bundle_lock(self) -> Iterator[None]:
         with self._exclusive_record_lock("product_authority_bundles", "global"):
             self._recover_product_authority_bundle_stages_locked()
+            yield
 
     def _recover_product_authority_bundle_stages_locked(self) -> None:
         if self._recovering_product_authority_bundle:
@@ -276,8 +294,7 @@ class FilesystemRecordStore:
     def write_product_authority_bundle(self, bundle: ProductAuthorityBundle) -> None:
         if not bundle.requires_write():
             return
-        with self._exclusive_record_lock("product_authority_bundles", "global"):
-            self._recover_product_authority_bundle_stages_locked()
+        with self._product_authority_bundle_lock():
             stage_id = f"{_utc_now_timestamp().replace(':', '').replace('-', '')}-{time.time_ns()}"
             stage_dir = self._product_authority_bundle_stage_root() / stage_id
             records_dir = stage_dir / "records"
@@ -1619,7 +1636,20 @@ class FilesystemRecordStore:
         record_id: str,
         expected_record: BaseModel,
     ) -> CurrentAuthorityDeleteStatus:
-        self._recover_product_authority_bundle_stages()
+        with self._product_authority_bundle_lock():
+            return self._delete_expected_authority_record_locked(
+                record_type=record_type,
+                record_id=record_id,
+                expected_record=expected_record,
+            )
+
+    def _delete_expected_authority_record_locked(
+        self,
+        *,
+        record_type: str,
+        record_id: str,
+        expected_record: BaseModel,
+    ) -> CurrentAuthorityDeleteStatus:
         record_path = self._record_path(record_type, record_id)
         current_payload = self._read_json_file(record_path)
         if current_payload is None:
@@ -1960,26 +1990,26 @@ class FilesystemRecordStore:
         return tuple(records)
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
-        self._recover_product_authority_bundle_stages()
-        return self._read_product_profile_record_path(
-            self._record_path("launchplane_product_profiles", product)
-        )
+        with self._product_authority_bundle_lock():
+            return self._read_product_profile_record_path(
+                self._record_path("launchplane_product_profiles", product)
+            )
 
     def list_product_profile_records(
         self,
         *,
         driver_id: str = "",
     ) -> tuple[LaunchplaneProductProfileRecord, ...]:
-        self._recover_product_authority_bundle_stages()
-        record_dir = self._record_dir("launchplane_product_profiles")
-        records: list[LaunchplaneProductProfileRecord] = []
-        if record_dir.exists():
-            for record_path in sorted(record_dir.glob("*.json")):
-                record = self._read_product_profile_record_path(record_path)
-                if not driver_id or record.driver_id == driver_id:
-                    records.append(record)
-        records.sort(key=lambda record: record.product)
-        return tuple(records)
+        with self._product_authority_bundle_lock():
+            record_dir = self._record_dir("launchplane_product_profiles")
+            records: list[LaunchplaneProductProfileRecord] = []
+            if record_dir.exists():
+                for record_path in sorted(record_dir.glob("*.json")):
+                    record = self._read_product_profile_record_path(record_path)
+                    if not driver_id or record.driver_id == driver_id:
+                        records.append(record)
+            records.sort(key=lambda record: record.product)
+            return tuple(records)
 
     def _read_product_profile_record_path(
         self, record_path: Path

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -110,8 +110,11 @@ from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrat
 from control_plane.contracts.verireel_prod_backup_gate_operation import (
     VeriReelProdBackupGateOperationRecord,
 )
-from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
-from control_plane.storage.product_authority_bundle import RuntimeEnvironmentDelete
+from control_plane.storage.product_authority_bundle import (
+    ProductAuthorityBundle,
+    ProviderTargetWrite,
+    RuntimeEnvironmentDelete,
+)
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
 RuntimeEnvironmentDeleteStatus = Literal["deleted", "missing", "changed"]
@@ -420,16 +423,17 @@ class FilesystemRecordStore:
                 model=target_id_record,
                 step_name="write_dokploy_target_id",
             )
-        for provider_target_record in bundle.provider_targets:
+        for provider_target_write in bundle.provider_target_writes:
+            self._validate_provider_target_write(provider_target_write)
             self._stage_product_authority_bundle_write(
                 stage_dir=stage_dir,
                 entries=entries,
                 record_type="launchplane_provider_targets",
                 record_id=_context_instance_record_id(
-                    provider_target_record.context,
-                    provider_target_record.instance,
+                    provider_target_write.record.context,
+                    provider_target_write.record.instance,
                 ),
-                model=provider_target_record,
+                model=provider_target_write.record,
                 step_name="write_provider_target",
             )
         for runtime_record in bundle.runtime_environments:
@@ -531,6 +535,25 @@ class FilesystemRecordStore:
         )
         entries.append(entry)
         self._after_product_authority_bundle_step(f"stage_{step_name}")
+
+    def _validate_provider_target_write(self, write: ProviderTargetWrite) -> None:
+        record_path = self._record_path(
+            "launchplane_provider_targets",
+            _context_instance_record_id(write.record.context, write.record.instance),
+        )
+        current_payload = self._read_json_file(record_path)
+        if write.expected_absent:
+            if current_payload is not None:
+                raise ValueError(
+                    "Provider target record was created after authority bundle planning."
+                )
+            return
+        expected_record = write.expected_record
+        if expected_record is None:
+            raise ValueError("Provider target write expectation is missing.")
+        expected_payload = expected_record.model_dump(mode="json", exclude_none=True)
+        if current_payload != expected_payload:
+            raise ValueError("Provider target record changed after authority bundle planning.")
 
     def _stage_product_authority_bundle_delete(
         self,
@@ -2830,19 +2853,30 @@ class FilesystemRecordStore:
         promotion_record: PromotionRecord,
         inventory: EnvironmentInventory,
     ) -> Path:
-        promotion_path = self._record_path("promotions", promotion_record.record_id)
-        inventory_path = self._record_path("inventory", f"{inventory.context}-{inventory.instance}")
-        previous_promotion = promotion_path.read_bytes() if promotion_path.exists() else None
-        previous_inventory = inventory_path.read_bytes() if inventory_path.exists() else None
-        try:
-            self.write_environment_inventory(inventory)
-            return self.write_promotion_record(promotion_record)
-        except Exception:
-            with suppress(Exception):
-                self._restore_record_path(promotion_path, previous_promotion)
-            with suppress(Exception):
-                self._restore_record_path(inventory_path, previous_inventory)
-            raise
+        with self._product_authority_bundle_lock():
+            promotion_path = self._record_path("promotions", promotion_record.record_id)
+            inventory_path = self._record_path(
+                "inventory", f"{inventory.context}-{inventory.instance}"
+            )
+            previous_promotion = promotion_path.read_bytes() if promotion_path.exists() else None
+            previous_inventory = inventory_path.read_bytes() if inventory_path.exists() else None
+            try:
+                self._write_model_locked(
+                    "inventory",
+                    f"{inventory.context}-{inventory.instance}",
+                    inventory,
+                )
+                return self._write_model_locked(
+                    "promotions",
+                    promotion_record.record_id,
+                    promotion_record,
+                )
+            except Exception:
+                with suppress(Exception):
+                    self._restore_record_path(promotion_path, previous_promotion)
+                with suppress(Exception):
+                    self._restore_record_path(inventory_path, previous_inventory)
+                raise
 
     @staticmethod
     def _restore_record_path(record_path: Path, payload: bytes | None) -> None:

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -1,7 +1,8 @@
+import fcntl
 import hashlib
 import json
 import os
-import fcntl
+import shutil
 import tempfile
 import time
 from collections.abc import Callable, Iterator
@@ -89,14 +90,50 @@ from control_plane.contracts.public_ingress_monitoring import PublicIngressIncid
 from control_plane.contracts.public_ingress_monitoring import PublicIngressObservationRecord
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.runtime_environment_record import (
+    RuntimeEnvironmentDeleteEvent,
+    RuntimeEnvironmentRecord,
+)
+from control_plane.contracts.secret_record import (
+    SecretAuditEvent,
+    SecretBinding,
+    SecretRecord,
+    SecretRotationWrite,
+    SecretVersion,
+)
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
 from control_plane.contracts.verireel_prod_backup_gate_operation import (
     VeriReelProdBackupGateOperationRecord,
 )
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
+from control_plane.storage.product_authority_bundle import RuntimeEnvironmentDelete
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
+RuntimeEnvironmentDeleteStatus = Literal["deleted", "missing", "changed"]
+CurrentAuthorityDeleteStatus = Literal["deleted", "missing", "changed"]
+ProviderTargetCreateStatus = Literal["created", "exists"]
+
+
+class _AuthorityBundleStageEntry(BaseModel):
+    action: Literal["write", "delete"]
+    record_type: str
+    record_id: str
+    final_path: str
+    step_name: str
+    staged_path: str = ""
+    expected_payload: dict[str, object] | None = None
+
+
+class _AuthorityBundleStageManifest(BaseModel):
+    schema_version: int = 1
+    stage_id: str
+    state: Literal["ready", "publishing"]
+    entries: tuple[_AuthorityBundleStageEntry, ...]
 
 
 def _utc_now_timestamp() -> str:
@@ -111,11 +148,13 @@ class FilesystemRecordStore:
 
     def __init__(self, state_dir: Path) -> None:
         self.state_dir = state_dir
+        self._recovering_product_authority_bundle = False
 
     def _record_path(self, record_type: str, record_id: str) -> Path:
         return self.state_dir / record_type / f"{record_id}.json"
 
     def _write_model(self, record_type: str, record_id: str, model: BaseModel) -> Path:
+        self._recover_product_authority_bundle_stages()
         record_path = self._record_path(record_type, record_id)
         record_path.parent.mkdir(parents=True, exist_ok=True)
         descriptor, temporary_path = tempfile.mkstemp(
@@ -152,6 +191,7 @@ class FilesystemRecordStore:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
 
     def _create_model_if_absent(self, record_type: str, record_id: str, model: BaseModel) -> bool:
+        self._recover_product_authority_bundle_stages()
         record_path = self._record_path(record_type, record_id)
         record_path.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -170,6 +210,7 @@ class FilesystemRecordStore:
     def _read_model(
         self, model_type: type[RecordModel], record_type: str, record_id: str
     ) -> RecordModel:
+        self._recover_product_authority_bundle_stages()
         record_path = self._record_path(record_type, record_id)
         payload = json.loads(record_path.read_text(encoding="utf-8"))
         return model_type.model_validate(payload)
@@ -180,6 +221,7 @@ class FilesystemRecordStore:
     def _list_models(
         self, model_type: type[RecordModel], record_type: str
     ) -> tuple[RecordModel, ...]:
+        self._recover_product_authority_bundle_stages()
         record_dir = self._record_dir(record_type)
         if not record_dir.exists():
             return ()
@@ -189,6 +231,397 @@ class FilesystemRecordStore:
             payload = json.loads(record_path.read_text(encoding="utf-8"))
             records.append(model_type.model_validate(payload))
         return tuple(records)
+
+    def _product_authority_bundle_stage_root(self) -> Path:
+        return self.state_dir / ".product_authority_bundle_stages"
+
+    def _after_product_authority_bundle_step(self, step_name: str) -> None:
+        _ = step_name
+
+    def _recover_product_authority_bundle_stages(self) -> None:
+        if self._recovering_product_authority_bundle:
+            return
+        stage_root = self._product_authority_bundle_stage_root()
+        if not stage_root.exists():
+            return
+        self._recovering_product_authority_bundle = True
+        try:
+            for stage_dir in sorted(path for path in stage_root.iterdir() if path.is_dir()):
+                manifest_path = stage_dir / "manifest.json"
+                if not manifest_path.exists():
+                    shutil.rmtree(stage_dir, ignore_errors=True)
+                    continue
+                manifest = _AuthorityBundleStageManifest.model_validate_json(
+                    manifest_path.read_text(encoding="utf-8")
+                )
+                if manifest.state == "ready":
+                    shutil.rmtree(stage_dir, ignore_errors=True)
+                    continue
+                self._publish_product_authority_bundle_stage(
+                    manifest=manifest,
+                    stage_dir=stage_dir,
+                    recovering=True,
+                )
+            with suppress(OSError):
+                stage_root.rmdir()
+        finally:
+            self._recovering_product_authority_bundle = False
+
+    def write_product_authority_bundle(self, bundle: ProductAuthorityBundle) -> None:
+        if not bundle.requires_write():
+            return
+        self._recover_product_authority_bundle_stages()
+        stage_id = f"{_utc_now_timestamp().replace(':', '').replace('-', '')}-{time.time_ns()}"
+        stage_dir = self._product_authority_bundle_stage_root() / stage_id
+        records_dir = stage_dir / "records"
+        records_dir.mkdir(parents=True, exist_ok=False)
+        entries: list[_AuthorityBundleStageEntry] = []
+        try:
+            self._stage_product_authority_bundle_entries(
+                bundle=bundle,
+                stage_dir=stage_dir,
+                entries=entries,
+            )
+            manifest = _AuthorityBundleStageManifest(
+                stage_id=stage_id,
+                state="ready",
+                entries=tuple(entries),
+            )
+            self._write_product_authority_bundle_stage_manifest(
+                stage_dir=stage_dir,
+                manifest=manifest,
+            )
+            self._after_product_authority_bundle_step("stage_product_authority_bundle")
+            publishing_manifest = manifest.model_copy(update={"state": "publishing"})
+            self._write_product_authority_bundle_stage_manifest(
+                stage_dir=stage_dir,
+                manifest=publishing_manifest,
+            )
+            self._after_product_authority_bundle_step("publish_product_authority_bundle")
+            self._publish_product_authority_bundle_stage(
+                manifest=publishing_manifest,
+                stage_dir=stage_dir,
+                recovering=False,
+            )
+        except Exception:
+            if not (stage_dir / "manifest.json").exists():
+                shutil.rmtree(stage_dir, ignore_errors=True)
+            raise
+
+    def _stage_product_authority_bundle_entries(
+        self,
+        *,
+        bundle: ProductAuthorityBundle,
+        stage_dir: Path,
+        entries: list[_AuthorityBundleStageEntry],
+    ) -> None:
+        for delete_item in bundle.delete_runtime_environments:
+            self._stage_product_authority_bundle_delete(
+                entries=entries,
+                record_type="launchplane_runtime_environments",
+                record_id=_runtime_environment_record_id(delete_item.expected_record),
+                expected_model=delete_item.expected_record,
+                step_name="delete_runtime_environment",
+            )
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="launchplane_runtime_environment_delete_events",
+                record_id=delete_item.event.event_id,
+                model=delete_item.event,
+                step_name="write_runtime_environment_delete_event",
+            )
+        for provider_target_delete in bundle.delete_provider_targets:
+            self._stage_product_authority_bundle_delete(
+                entries=entries,
+                record_type="launchplane_provider_targets",
+                record_id=_context_instance_record_id(
+                    provider_target_delete.context,
+                    provider_target_delete.instance,
+                ),
+                expected_model=provider_target_delete,
+                step_name="delete_provider_target",
+            )
+        for target_id_delete in bundle.delete_dokploy_target_ids:
+            self._stage_product_authority_bundle_delete(
+                entries=entries,
+                record_type="dokploy_target_ids",
+                record_id=_context_instance_record_id(
+                    target_id_delete.context,
+                    target_id_delete.instance,
+                ),
+                expected_model=target_id_delete,
+                step_name="delete_dokploy_target_id",
+            )
+        for target_delete in bundle.delete_dokploy_targets:
+            self._stage_product_authority_bundle_delete(
+                entries=entries,
+                record_type="dokploy_targets",
+                record_id=_context_instance_record_id(
+                    target_delete.context, target_delete.instance
+                ),
+                expected_model=target_delete,
+                step_name="delete_dokploy_target",
+            )
+
+        for profile_record in bundle.product_profiles:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="launchplane_product_profiles",
+                record_id=profile_record.product,
+                model=profile_record,
+                step_name="write_product_profile",
+            )
+        for target_record in bundle.dokploy_targets:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="dokploy_targets",
+                record_id=_context_instance_record_id(
+                    target_record.context, target_record.instance
+                ),
+                model=target_record,
+                step_name="write_dokploy_target",
+            )
+        for target_id_record in bundle.dokploy_target_ids:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="dokploy_target_ids",
+                record_id=_context_instance_record_id(
+                    target_id_record.context,
+                    target_id_record.instance,
+                ),
+                model=target_id_record,
+                step_name="write_dokploy_target_id",
+            )
+        for provider_target_record in bundle.provider_targets:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="launchplane_provider_targets",
+                record_id=_context_instance_record_id(
+                    provider_target_record.context,
+                    provider_target_record.instance,
+                ),
+                model=provider_target_record,
+                step_name="write_provider_target",
+            )
+        for runtime_record in bundle.runtime_environments:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="launchplane_runtime_environments",
+                record_id=_runtime_environment_record_id(runtime_record),
+                model=runtime_record,
+                step_name="write_runtime_environment",
+            )
+        for version in bundle.secret_versions:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="launchplane_secret_versions",
+                record_id=version.version_id,
+                model=version,
+                step_name="write_secret_version",
+            )
+        for secret_record in bundle.secret_records:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="launchplane_secrets",
+                record_id=secret_record.secret_id,
+                model=secret_record,
+                step_name="write_secret_record",
+            )
+        for binding in bundle.secret_bindings:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="launchplane_secret_bindings",
+                record_id=binding.binding_id,
+                model=binding,
+                step_name="write_secret_binding",
+            )
+        for event in bundle.secret_audit_events:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="launchplane_secret_audit_events",
+                record_id=event.event_id,
+                model=event,
+                step_name="write_secret_audit_event",
+            )
+        for inventory_record in bundle.environment_inventory:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="inventory",
+                record_id=f"{inventory_record.context}-{inventory_record.instance}",
+                model=inventory_record,
+                step_name="write_environment_inventory",
+            )
+        for release_record in bundle.release_tuples:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="release_tuples",
+                record_id=f"{release_record.context}-{release_record.channel}",
+                model=release_record,
+                step_name="write_release_tuple",
+            )
+        if bundle.idempotency_record is not None:
+            self._stage_product_authority_bundle_write(
+                stage_dir=stage_dir,
+                entries=entries,
+                record_type="idempotency",
+                record_id=bundle.idempotency_record.record_id,
+                model=bundle.idempotency_record,
+                step_name="write_idempotency",
+            )
+
+    def _stage_product_authority_bundle_write(
+        self,
+        *,
+        stage_dir: Path,
+        entries: list[_AuthorityBundleStageEntry],
+        record_type: str,
+        record_id: str,
+        model: BaseModel,
+        step_name: str,
+    ) -> None:
+        payload = model.model_dump(mode="json", exclude_none=True)
+        staged_path = stage_dir / "records" / f"{len(entries):04d}.json"
+        self._write_json_file(staged_path, payload)
+        entry = _AuthorityBundleStageEntry(
+            action="write",
+            record_type=record_type,
+            record_id=record_id,
+            final_path=self._record_path(record_type, record_id)
+            .relative_to(self.state_dir)
+            .as_posix(),
+            staged_path=staged_path.relative_to(stage_dir).as_posix(),
+            expected_payload=payload,
+            step_name=step_name,
+        )
+        entries.append(entry)
+        self._after_product_authority_bundle_step(f"stage_{step_name}")
+
+    def _stage_product_authority_bundle_delete(
+        self,
+        *,
+        entries: list[_AuthorityBundleStageEntry],
+        record_type: str,
+        record_id: str,
+        expected_model: BaseModel,
+        step_name: str,
+    ) -> None:
+        expected_payload = expected_model.model_dump(mode="json", exclude_none=True)
+        final_path = self._record_path(record_type, record_id)
+        current_payload = self._read_json_file(final_path)
+        if current_payload is None:
+            raise FileNotFoundError(f"{record_type} record {record_id} was already deleted.")
+        if current_payload != expected_payload:
+            raise ValueError(f"{record_type} record {record_id} changed during bundle write.")
+        entries.append(
+            _AuthorityBundleStageEntry(
+                action="delete",
+                record_type=record_type,
+                record_id=record_id,
+                final_path=final_path.relative_to(self.state_dir).as_posix(),
+                expected_payload=expected_payload,
+                step_name=step_name,
+            )
+        )
+        self._after_product_authority_bundle_step(f"stage_{step_name}")
+
+    def _write_product_authority_bundle_stage_manifest(
+        self, *, stage_dir: Path, manifest: _AuthorityBundleStageManifest
+    ) -> None:
+        self._write_json_file(
+            stage_dir / "manifest.json",
+            manifest.model_dump(mode="json", exclude_none=True),
+        )
+
+    def _publish_product_authority_bundle_stage(
+        self,
+        *,
+        manifest: _AuthorityBundleStageManifest,
+        stage_dir: Path,
+        recovering: bool,
+    ) -> None:
+        for entry in manifest.entries:
+            final_path = self.state_dir / entry.final_path
+            if entry.action == "write":
+                self._publish_product_authority_bundle_write_entry(
+                    entry=entry,
+                    stage_dir=stage_dir,
+                    final_path=final_path,
+                )
+            else:
+                self._publish_product_authority_bundle_delete_entry(
+                    entry=entry,
+                    final_path=final_path,
+                    recovering=recovering,
+                )
+            self._after_product_authority_bundle_step(entry.step_name)
+        shutil.rmtree(stage_dir, ignore_errors=False)
+
+    def _publish_product_authority_bundle_write_entry(
+        self,
+        *,
+        entry: _AuthorityBundleStageEntry,
+        stage_dir: Path,
+        final_path: Path,
+    ) -> None:
+        staged_path = stage_dir / entry.staged_path
+        final_path.parent.mkdir(parents=True, exist_ok=True)
+        if staged_path.exists():
+            os.replace(staged_path, final_path)
+            return
+        current_payload = self._read_json_file(final_path)
+        if current_payload != entry.expected_payload:
+            raise RuntimeError(
+                f"Cannot recover authority bundle write for {entry.record_type}/{entry.record_id}."
+            )
+
+    def _publish_product_authority_bundle_delete_entry(
+        self,
+        *,
+        entry: _AuthorityBundleStageEntry,
+        final_path: Path,
+        recovering: bool,
+    ) -> None:
+        current_payload = self._read_json_file(final_path)
+        if current_payload is None:
+            return
+        if current_payload != entry.expected_payload:
+            action = "recover" if recovering else "publish"
+            raise RuntimeError(
+                f"Cannot {action} authority bundle delete for "
+                f"{entry.record_type}/{entry.record_id}; live record changed."
+            )
+        final_path.unlink()
+
+    @staticmethod
+    def _write_json_file(path: Path, payload: dict[str, object]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = path.with_suffix(path.suffix + f".{os.getpid()}.tmp")
+        with temporary_path.open("w", encoding="utf-8") as record_file:
+            record_file.write(json.dumps(payload, indent=2, sort_keys=True))
+            record_file.flush()
+            os.fsync(record_file.fileno())
+        os.replace(temporary_path, path)
+
+    @staticmethod
+    def _read_json_file(path: Path) -> dict[str, object] | None:
+        if not path.exists():
+            return None
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            raise ValueError(f"Record file {path} does not contain a JSON object.")
+        return payload
 
     @staticmethod
     def _record_sort_timestamp(finished_at: str, started_at: str) -> tuple[str, str]:
@@ -850,6 +1283,345 @@ class FilesystemRecordStore:
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> Path:
         return self._write_model("launchplane_product_profiles", record.product, record)
 
+    def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> Path:
+        return self._write_model(
+            "dokploy_target_ids",
+            _context_instance_record_id(record.context, record.instance),
+            record,
+        )
+
+    def read_dokploy_target_id_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetIdRecord:
+        return self._read_model(
+            DokployTargetIdRecord,
+            "dokploy_target_ids",
+            _context_instance_record_id(context_name, instance_name),
+        )
+
+    def list_dokploy_target_id_records(self) -> tuple[DokployTargetIdRecord, ...]:
+        records = list(self._list_models(DokployTargetIdRecord, "dokploy_target_ids"))
+        records.sort(key=lambda record: (record.context, record.instance))
+        return tuple(records)
+
+    def delete_dokploy_target_id_record(
+        self,
+        *,
+        expected_record: DokployTargetIdRecord,
+    ) -> CurrentAuthorityDeleteStatus:
+        return self._delete_expected_authority_record(
+            record_type="dokploy_target_ids",
+            record_id=_context_instance_record_id(
+                expected_record.context,
+                expected_record.instance,
+            ),
+            expected_record=expected_record,
+        )
+
+    def write_dokploy_target_record(self, record: DokployTargetRecord) -> Path:
+        return self._write_model(
+            "dokploy_targets",
+            _context_instance_record_id(record.context, record.instance),
+            record,
+        )
+
+    def read_dokploy_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> DokployTargetRecord:
+        return self._read_model(
+            DokployTargetRecord,
+            "dokploy_targets",
+            _context_instance_record_id(context_name, instance_name),
+        )
+
+    def list_dokploy_target_records(self) -> tuple[DokployTargetRecord, ...]:
+        records = list(self._list_models(DokployTargetRecord, "dokploy_targets"))
+        records.sort(key=lambda record: (record.context, record.instance))
+        return tuple(records)
+
+    def delete_dokploy_target_record(
+        self,
+        *,
+        expected_record: DokployTargetRecord,
+    ) -> CurrentAuthorityDeleteStatus:
+        return self._delete_expected_authority_record(
+            record_type="dokploy_targets",
+            record_id=_context_instance_record_id(
+                expected_record.context,
+                expected_record.instance,
+            ),
+            expected_record=expected_record,
+        )
+
+    def write_provider_target_record(self, record: ProviderTargetRecord) -> Path:
+        return self._write_model(
+            "launchplane_provider_targets",
+            _context_instance_record_id(record.context, record.instance),
+            record,
+        )
+
+    def read_provider_target_record(
+        self, *, context_name: str, instance_name: str
+    ) -> ProviderTargetRecord:
+        return self._read_model(
+            ProviderTargetRecord,
+            "launchplane_provider_targets",
+            _context_instance_record_id(context_name, instance_name),
+        )
+
+    def list_provider_target_records(
+        self, *, provider_id: str = ""
+    ) -> tuple[ProviderTargetRecord, ...]:
+        normalized_provider_id = provider_id.strip().lower()
+        records = [
+            record
+            for record in self._list_models(
+                ProviderTargetRecord,
+                "launchplane_provider_targets",
+            )
+            if not normalized_provider_id or record.provider_id == normalized_provider_id
+        ]
+        records.sort(key=lambda record: (record.context, record.instance))
+        return tuple(records)
+
+    def list_physical_provider_target_records(self) -> tuple[ProviderTargetRecord, ...]:
+        return self.list_provider_target_records()
+
+    def create_provider_target_record_if_absent(
+        self, record: ProviderTargetRecord
+    ) -> ProviderTargetCreateStatus:
+        created = self._create_model_if_absent(
+            "launchplane_provider_targets",
+            _context_instance_record_id(record.context, record.instance),
+            record,
+        )
+        return "created" if created else "exists"
+
+    def delete_provider_target_record(
+        self,
+        *,
+        expected_record: ProviderTargetRecord,
+    ) -> CurrentAuthorityDeleteStatus:
+        return self._delete_expected_authority_record(
+            record_type="launchplane_provider_targets",
+            record_id=_context_instance_record_id(
+                expected_record.context,
+                expected_record.instance,
+            ),
+            expected_record=expected_record,
+        )
+
+    def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> Path:
+        return self._write_model(
+            "launchplane_runtime_environments",
+            _runtime_environment_record_id(record),
+            record,
+        )
+
+    def delete_runtime_environment_record_with_event(
+        self,
+        *,
+        event: RuntimeEnvironmentDeleteEvent,
+        expected_record: RuntimeEnvironmentRecord,
+    ) -> RuntimeEnvironmentDeleteStatus:
+        bundle = ProductAuthorityBundle(
+            delete_runtime_environments=(
+                RuntimeEnvironmentDelete(expected_record=expected_record, event=event),
+            )
+        )
+        try:
+            self.write_product_authority_bundle(bundle)
+        except FileNotFoundError:
+            return "missing"
+        except ValueError:
+            return "changed"
+        return "deleted"
+
+    def write_runtime_environment_delete_event(self, event: RuntimeEnvironmentDeleteEvent) -> Path:
+        return self._write_model(
+            "launchplane_runtime_environment_delete_events",
+            event.event_id,
+            event,
+        )
+
+    def list_runtime_environment_delete_events(
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+    ) -> tuple[RuntimeEnvironmentDeleteEvent, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                RuntimeEnvironmentDeleteEvent,
+                "launchplane_runtime_environment_delete_events",
+            )
+            if (not scope or record.scope == scope)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        ]
+        records.sort(key=lambda record: (record.recorded_at, record.event_id), reverse=True)
+        return tuple(records)
+
+    def list_runtime_environment_records(
+        self,
+        *,
+        scope: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+    ) -> tuple[RuntimeEnvironmentRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                RuntimeEnvironmentRecord,
+                "launchplane_runtime_environments",
+            )
+            if (not scope or record.scope == scope)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        ]
+        records.sort(key=lambda record: (record.scope, record.context, record.instance))
+        return tuple(records)
+
+    def write_secret_record(self, record: SecretRecord) -> Path:
+        return self._write_model("launchplane_secrets", record.secret_id, record)
+
+    def read_secret_record(self, secret_id: str) -> SecretRecord:
+        return self._read_model(SecretRecord, "launchplane_secrets", secret_id)
+
+    def find_secret_record(
+        self,
+        *,
+        scope: str,
+        integration: str,
+        name: str,
+        context: str = "",
+        instance: str = "",
+    ) -> SecretRecord | None:
+        records = [
+            record
+            for record in self._list_models(SecretRecord, "launchplane_secrets")
+            if record.scope == scope
+            and record.integration == integration
+            and record.name == name
+            and record.context == context
+            and record.instance == instance
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.secret_id), reverse=True)
+        return records[0] if records else None
+
+    def list_secret_records(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(SecretRecord, "launchplane_secrets")
+            if (not integration or record.integration == integration)
+            and (not context_name or record.context == context_name)
+            and (not instance_name or record.instance == instance_name)
+        ]
+        records.sort(key=lambda record: (record.updated_at, record.secret_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_secret_version(self, version: SecretVersion) -> Path:
+        return self._write_model("launchplane_secret_versions", version.version_id, version)
+
+    def read_secret_version(self, version_id: str) -> SecretVersion:
+        return self._read_model(SecretVersion, "launchplane_secret_versions", version_id)
+
+    def list_secret_versions(self, *, secret_id: str) -> tuple[SecretVersion, ...]:
+        records = [
+            version
+            for version in self._list_models(SecretVersion, "launchplane_secret_versions")
+            if version.secret_id == secret_id
+        ]
+        records.sort(key=lambda version: (version.created_at, version.version_id), reverse=True)
+        return tuple(records)
+
+    def write_secret_binding(self, binding: SecretBinding) -> Path:
+        return self._write_model("launchplane_secret_bindings", binding.binding_id, binding)
+
+    def list_secret_bindings(
+        self,
+        *,
+        integration: str = "",
+        context_name: str = "",
+        instance_name: str = "",
+        limit: int | None = None,
+    ) -> tuple[SecretBinding, ...]:
+        records = [
+            binding
+            for binding in self._list_models(SecretBinding, "launchplane_secret_bindings")
+            if (not integration or binding.integration == integration)
+            and (not context_name or binding.context == context_name)
+            and (not instance_name or binding.instance == instance_name)
+        ]
+        records.sort(key=lambda binding: (binding.updated_at, binding.binding_id), reverse=True)
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_secret_audit_event(self, event: SecretAuditEvent) -> Path:
+        return self._write_model("launchplane_secret_audit_events", event.event_id, event)
+
+    def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:
+        records = [
+            event
+            for event in self._list_models(
+                SecretAuditEvent,
+                "launchplane_secret_audit_events",
+            )
+            if event.secret_id == secret_id
+        ]
+        records.sort(key=lambda event: (event.recorded_at, event.event_id), reverse=True)
+        return tuple(records)
+
+    def write_secret_rotations(
+        self,
+        rotations: tuple[SecretRotationWrite, ...],
+        *,
+        idempotency_record: LaunchplaneIdempotencyRecord | None = None,
+    ) -> None:
+        ordered_rotations = tuple(sorted(rotations, key=lambda item: item.record.secret_id))
+        for rotation in ordered_rotations:
+            current_record = self.read_secret_record(rotation.record.secret_id)
+            if current_record.current_version_id != rotation.expected_current_version_id:
+                raise ValueError("Managed secret changed after rotation preflight.")
+        self.write_product_authority_bundle(
+            ProductAuthorityBundle(
+                secret_versions=tuple(rotation.version for rotation in ordered_rotations),
+                secret_records=tuple(rotation.record for rotation in ordered_rotations),
+                secret_audit_events=tuple(rotation.audit_event for rotation in ordered_rotations),
+                idempotency_record=idempotency_record,
+            )
+        )
+
+    def _delete_expected_authority_record(
+        self,
+        *,
+        record_type: str,
+        record_id: str,
+        expected_record: BaseModel,
+    ) -> CurrentAuthorityDeleteStatus:
+        self._recover_product_authority_bundle_stages()
+        record_path = self._record_path(record_type, record_id)
+        current_payload = self._read_json_file(record_path)
+        if current_payload is None:
+            return "missing"
+        expected_payload = expected_record.model_dump(mode="json", exclude_none=True)
+        if current_payload != expected_payload:
+            return "changed"
+        record_path.unlink()
+        return "deleted"
+
     def write_public_ingress_observation_record(
         self, record: PublicIngressObservationRecord
     ) -> Path:
@@ -1180,6 +1952,7 @@ class FilesystemRecordStore:
         return tuple(records)
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
+        self._recover_product_authority_bundle_stages()
         return self._read_product_profile_record_path(
             self._record_path("launchplane_product_profiles", product)
         )
@@ -1189,6 +1962,7 @@ class FilesystemRecordStore:
         *,
         driver_id: str = "",
     ) -> tuple[LaunchplaneProductProfileRecord, ...]:
+        self._recover_product_authority_bundle_stages()
         record_dir = self._record_dir("launchplane_product_profiles")
         records: list[LaunchplaneProductProfileRecord] = []
         if record_dir.exists():
@@ -2478,6 +3252,25 @@ def _runner_host_hygiene_audit_record_id(audit_record_key: str) -> str:
 def _runner_lane_registration_audit_record_id(audit_record_key: str) -> str:
     digest = hashlib.sha256(audit_record_key.encode()).hexdigest()[:16]
     return audit_record_key.strip().replace("/", "-") + f"-{digest}"
+
+
+def _context_instance_record_id(context: str, instance: str) -> str:
+    return _record_id_from_parts(context, instance)
+
+
+def _runtime_environment_record_id(record: RuntimeEnvironmentRecord) -> str:
+    if record.scope == "global":
+        return "global"
+    if record.scope == "context":
+        return _record_id_from_parts(record.scope, record.context)
+    return _record_id_from_parts(record.scope, record.context, record.instance)
+
+
+def _record_id_from_parts(*parts: str) -> str:
+    normalized_parts = tuple(part.strip() for part in parts)
+    raw_id = "-".join(normalized_parts)
+    digest = hashlib.sha256("\x1f".join(normalized_parts).encode("utf-8")).hexdigest()[:12]
+    return raw_id.replace("/", "-").replace("\\", "-") + f"-{digest}"
 
 
 def _edge_endpoint_record_id(endpoint_key: str) -> str:

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -241,6 +241,12 @@ class FilesystemRecordStore:
     def _recover_product_authority_bundle_stages(self) -> None:
         if self._recovering_product_authority_bundle:
             return
+        with self._exclusive_record_lock("product_authority_bundles", "global"):
+            self._recover_product_authority_bundle_stages_locked()
+
+    def _recover_product_authority_bundle_stages_locked(self) -> None:
+        if self._recovering_product_authority_bundle:
+            return
         stage_root = self._product_authority_bundle_stage_root()
         if not stage_root.exists():
             return
@@ -270,43 +276,44 @@ class FilesystemRecordStore:
     def write_product_authority_bundle(self, bundle: ProductAuthorityBundle) -> None:
         if not bundle.requires_write():
             return
-        self._recover_product_authority_bundle_stages()
-        stage_id = f"{_utc_now_timestamp().replace(':', '').replace('-', '')}-{time.time_ns()}"
-        stage_dir = self._product_authority_bundle_stage_root() / stage_id
-        records_dir = stage_dir / "records"
-        records_dir.mkdir(parents=True, exist_ok=False)
-        entries: list[_AuthorityBundleStageEntry] = []
-        try:
-            self._stage_product_authority_bundle_entries(
-                bundle=bundle,
-                stage_dir=stage_dir,
-                entries=entries,
-            )
-            manifest = _AuthorityBundleStageManifest(
-                stage_id=stage_id,
-                state="ready",
-                entries=tuple(entries),
-            )
-            self._write_product_authority_bundle_stage_manifest(
-                stage_dir=stage_dir,
-                manifest=manifest,
-            )
-            self._after_product_authority_bundle_step("stage_product_authority_bundle")
-            publishing_manifest = manifest.model_copy(update={"state": "publishing"})
-            self._write_product_authority_bundle_stage_manifest(
-                stage_dir=stage_dir,
-                manifest=publishing_manifest,
-            )
-            self._after_product_authority_bundle_step("publish_product_authority_bundle")
-            self._publish_product_authority_bundle_stage(
-                manifest=publishing_manifest,
-                stage_dir=stage_dir,
-                recovering=False,
-            )
-        except Exception:
-            if not (stage_dir / "manifest.json").exists():
-                shutil.rmtree(stage_dir, ignore_errors=True)
-            raise
+        with self._exclusive_record_lock("product_authority_bundles", "global"):
+            self._recover_product_authority_bundle_stages_locked()
+            stage_id = f"{_utc_now_timestamp().replace(':', '').replace('-', '')}-{time.time_ns()}"
+            stage_dir = self._product_authority_bundle_stage_root() / stage_id
+            records_dir = stage_dir / "records"
+            records_dir.mkdir(parents=True, exist_ok=False)
+            entries: list[_AuthorityBundleStageEntry] = []
+            try:
+                self._stage_product_authority_bundle_entries(
+                    bundle=bundle,
+                    stage_dir=stage_dir,
+                    entries=entries,
+                )
+                manifest = _AuthorityBundleStageManifest(
+                    stage_id=stage_id,
+                    state="ready",
+                    entries=tuple(entries),
+                )
+                self._write_product_authority_bundle_stage_manifest(
+                    stage_dir=stage_dir,
+                    manifest=manifest,
+                )
+                self._after_product_authority_bundle_step("stage_product_authority_bundle")
+                publishing_manifest = manifest.model_copy(update={"state": "publishing"})
+                self._write_product_authority_bundle_stage_manifest(
+                    stage_dir=stage_dir,
+                    manifest=publishing_manifest,
+                )
+                self._after_product_authority_bundle_step("publish_product_authority_bundle")
+                self._publish_product_authority_bundle_stage(
+                    manifest=publishing_manifest,
+                    stage_dir=stage_dir,
+                    recovering=False,
+                )
+            except Exception:
+                if not (stage_dir / "manifest.json").exists():
+                    shutil.rmtree(stage_dir, ignore_errors=True)
+                raise
 
     def _stage_product_authority_bundle_entries(
         self,
@@ -566,7 +573,7 @@ class FilesystemRecordStore:
                     recovering=recovering,
                 )
             self._after_product_authority_bundle_step(entry.step_name)
-        shutil.rmtree(stage_dir, ignore_errors=False)
+        shutil.rmtree(stage_dir, ignore_errors=True)
 
     def _publish_product_authority_bundle_write_entry(
         self,
@@ -602,7 +609,8 @@ class FilesystemRecordStore:
                 f"Cannot {action} authority bundle delete for "
                 f"{entry.record_type}/{entry.record_id}; live record changed."
             )
-        final_path.unlink()
+        with suppress(FileNotFoundError):
+            final_path.unlink()
 
     @staticmethod
     def _write_json_file(path: Path, payload: dict[str, object]) -> None:

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -129,6 +129,7 @@ from control_plane.contracts.verireel_prod_backup_gate_operation import (
 from control_plane.service_auth import GitHubHumanIdentity
 from control_plane.service_human_auth import HumanSessionStore, LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
 from control_plane.storage.schema_invariants import verify_postgres_schema_invariants
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
@@ -1749,6 +1750,339 @@ class PostgresRecordStore(HumanSessionStore):
         with self._session_factory() as session:
             session.merge(row)
             session.commit()
+
+    def _after_product_authority_bundle_step(self, step_name: str) -> None:
+        return None
+
+    def _merge_authority_row(self, session: Any, row: Base, *, step_name: str) -> None:
+        session.merge(row)
+        self._after_product_authority_bundle_step(step_name)
+
+    def _product_profile_row(
+        self, record: LaunchplaneProductProfileRecord
+    ) -> LaunchplaneProductProfileRow:
+        return LaunchplaneProductProfileRow(
+            product=record.product,
+            display_name=record.display_name,
+            repository=record.repository,
+            driver_id=record.driver_id,
+            updated_at=record.updated_at,
+            payload=self._payload_dict(record),
+        )
+
+    def _dokploy_target_id_row(
+        self, record: DokployTargetIdRecord
+    ) -> LaunchplaneDokployTargetIdRow:
+        return LaunchplaneDokployTargetIdRow(
+            context=record.context,
+            instance=record.instance,
+            target_id=record.target_id,
+            updated_at=record.updated_at,
+            payload=self._payload_dict(record),
+        )
+
+    def _dokploy_target_row(self, record: DokployTargetRecord) -> LaunchplaneDokployTargetRow:
+        return LaunchplaneDokployTargetRow(
+            context=record.context,
+            instance=record.instance,
+            updated_at=record.updated_at,
+            payload=self._payload_dict(record),
+        )
+
+    def _provider_target_row(self, record: ProviderTargetRecord) -> LaunchplaneProviderTargetRow:
+        return LaunchplaneProviderTargetRow(
+            context=record.context,
+            instance=record.instance,
+            provider_id=record.provider_id,
+            target_category=record.target_category,
+            target_id=record.target_id,
+            display_name=record.display_name,
+            provider_target_type=record.provider_target_type,
+            updated_at=record.updated_at,
+            payload=self._payload_dict(record),
+        )
+
+    def _runtime_environment_row(
+        self, record: RuntimeEnvironmentRecord
+    ) -> LaunchplaneRuntimeEnvironmentRow:
+        return LaunchplaneRuntimeEnvironmentRow(
+            scope=record.scope,
+            context=record.context,
+            instance=record.instance,
+            updated_at=record.updated_at,
+            payload=self._payload_dict(record),
+        )
+
+    def _runtime_environment_delete_event_row(
+        self, event: RuntimeEnvironmentDeleteEvent
+    ) -> LaunchplaneRuntimeEnvironmentDeleteEventRow:
+        return LaunchplaneRuntimeEnvironmentDeleteEventRow(
+            event_id=event.event_id,
+            scope=event.scope,
+            context=event.context,
+            instance=event.instance,
+            recorded_at=event.recorded_at,
+            payload=self._payload_dict(event),
+        )
+
+    def _secret_row(self, record: SecretRecord) -> LaunchplaneSecretRow:
+        return LaunchplaneSecretRow(
+            secret_id=record.secret_id,
+            scope=record.scope,
+            integration=record.integration,
+            name=record.name,
+            context=record.context,
+            instance=record.instance,
+            status=record.status,
+            current_version_id=record.current_version_id,
+            updated_at=record.updated_at,
+            payload=self._payload_dict(record),
+        )
+
+    def _secret_version_row(self, version: SecretVersion) -> LaunchplaneSecretVersionRow:
+        return LaunchplaneSecretVersionRow(
+            version_id=version.version_id,
+            secret_id=version.secret_id,
+            created_at=version.created_at,
+            payload=self._payload_dict(version),
+        )
+
+    def _secret_binding_row(self, binding: SecretBinding) -> LaunchplaneSecretBindingRow:
+        return LaunchplaneSecretBindingRow(
+            binding_id=binding.binding_id,
+            secret_id=binding.secret_id,
+            integration=binding.integration,
+            binding_key=binding.binding_key,
+            context=binding.context,
+            instance=binding.instance,
+            status=binding.status,
+            updated_at=binding.updated_at,
+            payload=self._payload_dict(binding),
+        )
+
+    def _secret_audit_event_row(self, event: SecretAuditEvent) -> LaunchplaneSecretAuditEventRow:
+        return LaunchplaneSecretAuditEventRow(
+            event_id=event.event_id,
+            secret_id=event.secret_id,
+            event_type=event.event_type,
+            recorded_at=event.recorded_at,
+            payload=self._payload_dict(event),
+        )
+
+    def _environment_inventory_row(self, record: EnvironmentInventory) -> LaunchplaneInventoryRow:
+        return LaunchplaneInventoryRow(
+            context=record.context,
+            instance=record.instance,
+            artifact_id=_artifact_id_from_model(record),
+            source_git_ref=record.source_git_ref,
+            updated_at=record.updated_at,
+            deployment_record_id=record.deployment_record_id,
+            promotion_record_id=record.promotion_record_id,
+            promoted_from_instance=record.promoted_from_instance,
+            payload=self._payload_dict(record),
+        )
+
+    def _release_tuple_row(self, record: ReleaseTupleRecord) -> LaunchplaneReleaseTupleRow:
+        return LaunchplaneReleaseTupleRow(
+            context=record.context,
+            channel=record.channel,
+            tuple_id=record.tuple_id,
+            artifact_id=record.artifact_id,
+            minted_at=record.minted_at,
+            provenance=record.provenance,
+            payload=self._payload_dict(record),
+        )
+
+    def write_product_authority_bundle(self, bundle: ProductAuthorityBundle) -> None:
+        if not bundle.requires_write():
+            return
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            for delete_item in bundle.delete_runtime_environments:
+                row = session.scalar(
+                    self._runtime_environment_statement(
+                        scope=delete_item.expected_record.scope,
+                        context=delete_item.expected_record.context,
+                        instance=delete_item.expected_record.instance,
+                        for_update=True,
+                    )
+                )
+                if row is None:
+                    raise FileNotFoundError("Runtime environment record was already deleted.")
+                current_record = self._read_payload(
+                    model_type=RuntimeEnvironmentRecord,
+                    payload=row.payload,
+                )
+                if self._payload_dict(current_record) != self._payload_dict(
+                    delete_item.expected_record
+                ):
+                    raise ValueError("Runtime environment record changed during bundle write.")
+                session.delete(row)
+                self._after_product_authority_bundle_step("delete_runtime_environment")
+                self._merge_authority_row(
+                    session,
+                    self._runtime_environment_delete_event_row(delete_item.event),
+                    step_name="write_runtime_environment_delete_event",
+                )
+
+            for provider_target_delete in bundle.delete_provider_targets:
+                self._delete_current_authority_row(
+                    session=session,
+                    orm_model=LaunchplaneProviderTargetRow,
+                    model_type=ProviderTargetRecord,
+                    filters=(
+                        LaunchplaneProviderTargetRow.context == provider_target_delete.context,
+                        LaunchplaneProviderTargetRow.instance == provider_target_delete.instance,
+                    ),
+                    expected_record=provider_target_delete,
+                    label="Provider target record",
+                    step_name="delete_provider_target",
+                )
+            for target_id_delete in bundle.delete_dokploy_target_ids:
+                self._delete_current_authority_row(
+                    session=session,
+                    orm_model=LaunchplaneDokployTargetIdRow,
+                    model_type=DokployTargetIdRecord,
+                    filters=(
+                        LaunchplaneDokployTargetIdRow.context == target_id_delete.context,
+                        LaunchplaneDokployTargetIdRow.instance == target_id_delete.instance,
+                    ),
+                    expected_record=target_id_delete,
+                    label="Dokploy target ID record",
+                    step_name="delete_dokploy_target_id",
+                )
+            for target_delete in bundle.delete_dokploy_targets:
+                self._delete_current_authority_row(
+                    session=session,
+                    orm_model=LaunchplaneDokployTargetRow,
+                    model_type=DokployTargetRecord,
+                    filters=(
+                        LaunchplaneDokployTargetRow.context == target_delete.context,
+                        LaunchplaneDokployTargetRow.instance == target_delete.instance,
+                    ),
+                    expected_record=target_delete,
+                    label="Dokploy target record",
+                    step_name="delete_dokploy_target",
+                )
+
+            for profile_record in bundle.product_profiles:
+                self._merge_authority_row(
+                    session,
+                    self._product_profile_row(profile_record),
+                    step_name="write_product_profile",
+                )
+            for target_record in bundle.dokploy_targets:
+                self._merge_authority_row(
+                    session,
+                    self._dokploy_target_row(target_record),
+                    step_name="write_dokploy_target",
+                )
+            for target_id_record in bundle.dokploy_target_ids:
+                self._merge_authority_row(
+                    session,
+                    self._dokploy_target_id_row(target_id_record),
+                    step_name="write_dokploy_target_id",
+                )
+            for provider_target_record in bundle.provider_targets:
+                self._merge_authority_row(
+                    session,
+                    self._provider_target_row(provider_target_record),
+                    step_name="write_provider_target",
+                )
+            for runtime_record in bundle.runtime_environments:
+                self._merge_authority_row(
+                    session,
+                    self._runtime_environment_row(runtime_record),
+                    step_name="write_runtime_environment",
+                )
+            for version in bundle.secret_versions:
+                self._merge_authority_row(
+                    session,
+                    self._secret_version_row(version),
+                    step_name="write_secret_version",
+                )
+            for secret_record in bundle.secret_records:
+                self._merge_authority_row(
+                    session, self._secret_row(secret_record), step_name="write_secret_record"
+                )
+            for binding in bundle.secret_bindings:
+                self._merge_authority_row(
+                    session,
+                    self._secret_binding_row(binding),
+                    step_name="write_secret_binding",
+                )
+            for event in bundle.secret_audit_events:
+                self._merge_authority_row(
+                    session,
+                    self._secret_audit_event_row(event),
+                    step_name="write_secret_audit_event",
+                )
+            for inventory_record in bundle.environment_inventory:
+                self._merge_authority_row(
+                    session,
+                    self._environment_inventory_row(inventory_record),
+                    step_name="write_environment_inventory",
+                )
+            for release_record in bundle.release_tuples:
+                self._merge_authority_row(
+                    session,
+                    self._release_tuple_row(release_record),
+                    step_name="write_release_tuple",
+                )
+            if bundle.idempotency_record is not None:
+                self._merge_authority_row(
+                    session,
+                    self._idempotency_row(bundle.idempotency_record),
+                    step_name="write_idempotency",
+                )
+            session.commit()
+
+    def _delete_current_authority_row(
+        self,
+        *,
+        session: Any,
+        orm_model: type[Base],
+        model_type: type[RecordModel],
+        filters: Sequence[object],
+        expected_record: RecordModel,
+        label: str,
+        step_name: str,
+    ) -> None:
+        statement = select(orm_model).where(*cast(Any, filters)).limit(1)
+        if not self.database_url.startswith("sqlite"):
+            statement = statement.with_for_update()
+        row = session.scalar(statement)
+        if row is None:
+            raise FileNotFoundError(f"{label} was already deleted.")
+        current_record = self._read_payload(
+            model_type=model_type,
+            payload=cast(_PayloadRow, row).payload,
+        )
+        if self._payload_dict(current_record) != self._payload_dict(expected_record):
+            raise ValueError(f"{label} changed during bundle write.")
+        session.delete(row)
+        self._after_product_authority_bundle_step(step_name)
+
+    def _runtime_environment_statement(
+        self,
+        *,
+        scope: str,
+        context: str,
+        instance: str,
+        for_update: bool = False,
+    ) -> Any:
+        statement = (
+            select(LaunchplaneRuntimeEnvironmentRow)
+            .where(
+                LaunchplaneRuntimeEnvironmentRow.scope == scope,
+                LaunchplaneRuntimeEnvironmentRow.context == context,
+                LaunchplaneRuntimeEnvironmentRow.instance == instance,
+            )
+            .limit(1)
+        )
+        if for_update and not self.database_url.startswith("sqlite"):
+            statement = statement.with_for_update()
+        return statement
 
     def _read_model(
         self,
@@ -3845,19 +4179,7 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def write_environment_inventory(self, record: EnvironmentInventory) -> None:
-        self._write_row(
-            LaunchplaneInventoryRow(
-                context=record.context,
-                instance=record.instance,
-                artifact_id=_artifact_id_from_model(record),
-                source_git_ref=record.source_git_ref,
-                updated_at=record.updated_at,
-                deployment_record_id=record.deployment_record_id,
-                promotion_record_id=record.promotion_record_id,
-                promoted_from_instance=record.promoted_from_instance,
-                payload=self._payload_dict(record),
-            )
-        )
+        self._write_row(self._environment_inventory_row(record))
 
     def read_environment_inventory(
         self, *, context_name: str, instance_name: str
@@ -5215,17 +5537,7 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def write_release_tuple_record(self, record: ReleaseTupleRecord) -> None:
-        self._write_row(
-            LaunchplaneReleaseTupleRow(
-                context=record.context,
-                channel=record.channel,
-                tuple_id=record.tuple_id,
-                artifact_id=record.artifact_id,
-                minted_at=record.minted_at,
-                provenance=record.provenance,
-                payload=self._payload_dict(record),
-            )
-        )
+        self._write_row(self._release_tuple_row(record))
 
     def read_release_tuple_record(
         self, *, context_name: str, channel_name: str
@@ -5284,16 +5596,7 @@ class PostgresRecordStore(HumanSessionStore):
         return records
 
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> None:
-        self._write_row(
-            LaunchplaneProductProfileRow(
-                product=record.product,
-                display_name=record.display_name,
-                repository=record.repository,
-                driver_id=record.driver_id,
-                updated_at=record.updated_at,
-                payload=self._payload_dict(record),
-            )
-        )
+        self._write_row(self._product_profile_row(record))
 
     def compare_and_write_product_profile_record(
         self,
@@ -6161,15 +6464,7 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def write_dokploy_target_id_record(self, record: DokployTargetIdRecord) -> None:
-        self._write_row(
-            LaunchplaneDokployTargetIdRow(
-                context=record.context,
-                instance=record.instance,
-                target_id=record.target_id,
-                updated_at=record.updated_at,
-                payload=self._payload_dict(record),
-            )
-        )
+        self._write_row(self._dokploy_target_id_row(record))
 
     def read_dokploy_target_id_record(
         self, *, context_name: str, instance_name: str
@@ -6222,14 +6517,7 @@ class PostgresRecordStore(HumanSessionStore):
             return "deleted"
 
     def write_dokploy_target_record(self, record: DokployTargetRecord) -> None:
-        self._write_row(
-            LaunchplaneDokployTargetRow(
-                context=record.context,
-                instance=record.instance,
-                updated_at=record.updated_at,
-                payload=self._payload_dict(record),
-            )
-        )
+        self._write_row(self._dokploy_target_row(record))
 
     def read_dokploy_target_record(
         self, *, context_name: str, instance_name: str
@@ -6293,19 +6581,7 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def write_provider_target_record(self, record: ProviderTargetRecord) -> None:
-        self._write_row(
-            LaunchplaneProviderTargetRow(
-                context=record.context,
-                instance=record.instance,
-                provider_id=record.provider_id,
-                target_category=record.target_category,
-                target_id=record.target_id,
-                display_name=record.display_name,
-                provider_target_type=record.provider_target_type,
-                updated_at=record.updated_at,
-                payload=self._payload_dict(record),
-            )
-        )
+        self._write_row(self._provider_target_row(record))
 
     def create_provider_target_record_if_absent(
         self, record: ProviderTargetRecord
@@ -6387,15 +6663,7 @@ class PostgresRecordStore(HumanSessionStore):
             return "deleted"
 
     def write_runtime_environment_record(self, record: RuntimeEnvironmentRecord) -> None:
-        self._write_row(
-            LaunchplaneRuntimeEnvironmentRow(
-                scope=record.scope,
-                context=record.context,
-                instance=record.instance,
-                updated_at=record.updated_at,
-                payload=self._payload_dict(record),
-            )
-        )
+        self._write_row(self._runtime_environment_row(record))
 
     def delete_runtime_environment_record_with_event(
         self,
@@ -6438,16 +6706,7 @@ class PostgresRecordStore(HumanSessionStore):
             return "deleted"
 
     def write_runtime_environment_delete_event(self, event: RuntimeEnvironmentDeleteEvent) -> None:
-        self._write_row(
-            LaunchplaneRuntimeEnvironmentDeleteEventRow(
-                event_id=event.event_id,
-                scope=event.scope,
-                context=event.context,
-                instance=event.instance,
-                recorded_at=event.recorded_at,
-                payload=self._payload_dict(event),
-            )
-        )
+        self._write_row(self._runtime_environment_delete_event_row(event))
 
     def list_runtime_environment_delete_events(
         self,
@@ -6692,20 +6951,7 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def write_secret_record(self, record: SecretRecord) -> None:
-        self._write_row(
-            LaunchplaneSecretRow(
-                secret_id=record.secret_id,
-                scope=record.scope,
-                integration=record.integration,
-                name=record.name,
-                context=record.context,
-                instance=record.instance,
-                status=record.status,
-                current_version_id=record.current_version_id,
-                updated_at=record.updated_at,
-                payload=self._payload_dict(record),
-            )
-        )
+        self._write_row(self._secret_row(record))
 
     def read_secret_record(self, secret_id: str) -> SecretRecord:
         return self._read_model(
@@ -6768,14 +7014,7 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def write_secret_version(self, version: SecretVersion) -> None:
-        self._write_row(
-            LaunchplaneSecretVersionRow(
-                version_id=version.version_id,
-                secret_id=version.secret_id,
-                created_at=version.created_at,
-                payload=self._payload_dict(version),
-            )
-        )
+        self._write_row(self._secret_version_row(version))
 
     def read_secret_version(self, version_id: str) -> SecretVersion:
         return self._read_model(
@@ -6796,19 +7035,7 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def write_secret_binding(self, binding: SecretBinding) -> None:
-        self._write_row(
-            LaunchplaneSecretBindingRow(
-                binding_id=binding.binding_id,
-                secret_id=binding.secret_id,
-                integration=binding.integration,
-                binding_key=binding.binding_key,
-                context=binding.context,
-                instance=binding.instance,
-                status=binding.status,
-                updated_at=binding.updated_at,
-                payload=self._payload_dict(binding),
-            )
-        )
+        self._write_row(self._secret_binding_row(binding))
 
     def list_secret_bindings(
         self,
@@ -6837,19 +7064,17 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def write_secret_audit_event(self, event: SecretAuditEvent) -> None:
-        self._write_row(
-            LaunchplaneSecretAuditEventRow(
-                event_id=event.event_id,
-                secret_id=event.secret_id,
-                event_type=event.event_type,
-                recorded_at=event.recorded_at,
-                payload=self._payload_dict(event),
-            )
-        )
+        self._write_row(self._secret_audit_event_row(event))
 
-    def write_secret_rotations(self, rotations: tuple[SecretRotationWrite, ...]) -> None:
+    def write_secret_rotations(
+        self,
+        rotations: tuple[SecretRotationWrite, ...],
+        *,
+        idempotency_record: LaunchplaneIdempotencyRecord | None = None,
+    ) -> None:
         ordered_rotations = tuple(sorted(rotations, key=lambda item: item.record.secret_id))
         with self._session_factory() as session:
+            self._begin_serialized_write(session)
             for rotation in ordered_rotations:
                 statement = (
                     select(LaunchplaneSecretRow)
@@ -6867,37 +7092,15 @@ class PostgresRecordStore(HumanSessionStore):
                 version = rotation.version
                 record = rotation.record
                 event = rotation.audit_event
-                session.merge(
-                    LaunchplaneSecretVersionRow(
-                        version_id=version.version_id,
-                        secret_id=version.secret_id,
-                        created_at=version.created_at,
-                        payload=self._payload_dict(version),
-                    )
-                )
-                session.merge(
-                    LaunchplaneSecretRow(
-                        secret_id=record.secret_id,
-                        scope=record.scope,
-                        integration=record.integration,
-                        name=record.name,
-                        context=record.context,
-                        instance=record.instance,
-                        status=record.status,
-                        current_version_id=record.current_version_id,
-                        updated_at=record.updated_at,
-                        payload=self._payload_dict(record),
-                    )
-                )
-                session.merge(
-                    LaunchplaneSecretAuditEventRow(
-                        event_id=event.event_id,
-                        secret_id=event.secret_id,
-                        event_type=event.event_type,
-                        recorded_at=event.recorded_at,
-                        payload=self._payload_dict(event),
-                    )
-                )
+                session.merge(self._secret_version_row(version))
+                self._after_product_authority_bundle_step("write_secret_rotation_version")
+                session.merge(self._secret_row(record))
+                self._after_product_authority_bundle_step("write_secret_rotation_record")
+                session.merge(self._secret_audit_event_row(event))
+                self._after_product_authority_bundle_step("write_secret_rotation_audit")
+            if idempotency_record is not None:
+                session.merge(self._idempotency_row(idempotency_record))
+                self._after_product_authority_bundle_step("write_idempotency")
             session.commit()
 
     def list_secret_audit_events(self, *, secret_id: str) -> tuple[SecretAuditEvent, ...]:

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Literal, NamedTuple, Protocol, TypeVar, cast
@@ -129,7 +130,10 @@ from control_plane.contracts.verireel_prod_backup_gate_operation import (
 from control_plane.service_auth import GitHubHumanIdentity
 from control_plane.service_human_auth import HumanSessionStore, LaunchplaneHumanSession
 from control_plane.storage.filesystem import FilesystemRecordStore
-from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
+from control_plane.storage.product_authority_bundle import (
+    ProductAuthorityBundle,
+    ProviderTargetWrite,
+)
 from control_plane.storage.schema_invariants import verify_postgres_schema_invariants
 
 RecordModel = TypeVar("RecordModel", bound=BaseModel)
@@ -1898,6 +1902,7 @@ class PostgresRecordStore(HumanSessionStore):
             return
         with self._session_factory() as session:
             self._begin_serialized_write(session)
+            self._lock_product_authority_bundle_write(session)
             for delete_item in bundle.delete_runtime_environments:
                 row = session.scalar(
                     self._runtime_environment_statement(
@@ -1983,11 +1988,10 @@ class PostgresRecordStore(HumanSessionStore):
                     self._dokploy_target_id_row(target_id_record),
                     step_name="write_dokploy_target_id",
                 )
-            for provider_target_record in bundle.provider_targets:
-                self._merge_authority_row(
-                    session,
-                    self._provider_target_row(provider_target_record),
-                    step_name="write_provider_target",
+            for provider_target_write in bundle.provider_target_writes:
+                self._write_provider_target_with_expectation(
+                    session=session,
+                    write=provider_target_write,
                 )
             for runtime_record in bundle.runtime_environments:
                 self._merge_authority_row(
@@ -2036,6 +2040,54 @@ class PostgresRecordStore(HumanSessionStore):
                     step_name="write_idempotency",
                 )
             session.commit()
+
+    def _write_provider_target_with_expectation(
+        self,
+        *,
+        session: Any,
+        write: ProviderTargetWrite,
+    ) -> None:
+        statement = (
+            select(LaunchplaneProviderTargetRow)
+            .where(
+                LaunchplaneProviderTargetRow.context == write.record.context,
+                LaunchplaneProviderTargetRow.instance == write.record.instance,
+            )
+            .limit(1)
+        )
+        if not self.database_url.startswith("sqlite"):
+            statement = statement.with_for_update()
+        row = session.scalar(statement)
+        if write.expected_absent:
+            if row is not None:
+                raise ValueError(
+                    "Provider target record was created after authority bundle planning."
+                )
+            session.add(self._provider_target_row(write.record))
+            try:
+                session.flush()
+            except IntegrityError as error:
+                raise ValueError(
+                    "Provider target record was created after authority bundle planning."
+                ) from error
+            self._after_product_authority_bundle_step("write_provider_target")
+            return
+        expected_record = write.expected_record
+        if expected_record is None:
+            raise ValueError("Provider target write expectation is missing.")
+        if row is None:
+            raise ValueError("Provider target record changed after authority bundle planning.")
+        current_record = self._read_payload(
+            model_type=ProviderTargetRecord,
+            payload=row.payload,
+        )
+        if self._payload_dict(current_record) != self._payload_dict(expected_record):
+            raise ValueError("Provider target record changed after authority bundle planning.")
+        self._merge_authority_row(
+            session,
+            self._provider_target_row(write.record),
+            step_name="write_provider_target",
+        )
 
     def _delete_current_authority_row(
         self,
@@ -2273,6 +2325,29 @@ class PostgresRecordStore(HumanSessionStore):
     def _begin_serialized_write(self, session: Any) -> None:
         if self.database_url.startswith("sqlite"):
             session.execute(text("BEGIN IMMEDIATE"))
+
+    def _lock_product_authority_bundle_write(self, session: Any) -> None:
+        if self.database_url.startswith("sqlite"):
+            return
+        session.execute(
+            text("select pg_advisory_xact_lock(hashtextextended(:lock_name, 0))"),
+            {"lock_name": "launchplane:product-authority-bundle"},
+        )
+
+    @contextmanager
+    def _product_authority_bundle_read_guard(self) -> Iterator[None]:
+        with self._session_factory() as session:
+            if self.database_url.startswith("sqlite"):
+                session.execute(text("BEGIN IMMEDIATE"))
+            else:
+                session.execute(
+                    text("select pg_advisory_xact_lock_shared(hashtextextended(:lock_name, 0))"),
+                    {"lock_name": "launchplane:product-authority-bundle"},
+                )
+            try:
+                yield
+            finally:
+                session.rollback()
 
     def _database_mutation_timestamp(self, session: Any) -> str:
         if self.database_url.startswith("sqlite"):
@@ -6789,6 +6864,15 @@ class PostgresRecordStore(HumanSessionStore):
         )
 
     def read_lane_summary(self, *, context_name: str, instance_name: str) -> LaunchplaneLaneSummary:
+        with self._product_authority_bundle_read_guard():
+            return self._read_lane_summary_unlocked(
+                context_name=context_name,
+                instance_name=instance_name,
+            )
+
+    def _read_lane_summary_unlocked(
+        self, *, context_name: str, instance_name: str
+    ) -> LaunchplaneLaneSummary:
         runtime_environment_records = (
             *self.list_runtime_environment_records(scope="global"),
             *self.list_runtime_environment_records(scope="context", context_name=context_name),

--- a/control_plane/storage/product_authority_bundle.py
+++ b/control_plane/storage/product_authority_bundle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
@@ -30,13 +30,34 @@ class RuntimeEnvironmentDelete(BaseModel):
     event: RuntimeEnvironmentDeleteEvent
 
 
+class ProviderTargetWrite(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    record: ProviderTargetRecord
+    expected_record: ProviderTargetRecord | None = None
+    expected_absent: bool = False
+
+    @model_validator(mode="after")
+    def validate_expectation(self) -> ProviderTargetWrite:
+        if (self.expected_record is None) == (not self.expected_absent):
+            raise ValueError(
+                "Provider target writes require exactly one current-record expectation."
+            )
+        if self.expected_record is not None and (
+            self.expected_record.context != self.record.context
+            or self.expected_record.instance != self.record.instance
+        ):
+            raise ValueError("Provider target write expectation must identify the same route.")
+        return self
+
+
 class ProductAuthorityBundle(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     product_profiles: tuple[LaunchplaneProductProfileRecord, ...] = ()
     dokploy_targets: tuple[DokployTargetRecord, ...] = ()
     dokploy_target_ids: tuple[DokployTargetIdRecord, ...] = ()
-    provider_targets: tuple[ProviderTargetRecord, ...] = ()
+    provider_target_writes: tuple[ProviderTargetWrite, ...] = ()
     runtime_environments: tuple[RuntimeEnvironmentRecord, ...] = ()
     secret_records: tuple[SecretRecord, ...] = ()
     secret_versions: tuple[SecretVersion, ...] = ()
@@ -56,7 +77,7 @@ class ProductAuthorityBundle(BaseModel):
                 self.product_profiles,
                 self.dokploy_targets,
                 self.dokploy_target_ids,
-                self.provider_targets,
+                self.provider_target_writes,
                 self.runtime_environments,
                 self.secret_records,
                 self.secret_versions,

--- a/control_plane/storage/product_authority_bundle.py
+++ b/control_plane/storage/product_authority_bundle.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from pydantic import BaseModel, ConfigDict
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_environment_record import (
+    RuntimeEnvironmentDeleteEvent,
+    RuntimeEnvironmentRecord,
+)
+from control_plane.contracts.secret_record import (
+    SecretAuditEvent,
+    SecretBinding,
+    SecretRecord,
+    SecretVersion,
+)
+
+
+class RuntimeEnvironmentDelete(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    expected_record: RuntimeEnvironmentRecord
+    event: RuntimeEnvironmentDeleteEvent
+
+
+class ProductAuthorityBundle(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    product_profiles: tuple[LaunchplaneProductProfileRecord, ...] = ()
+    dokploy_targets: tuple[DokployTargetRecord, ...] = ()
+    dokploy_target_ids: tuple[DokployTargetIdRecord, ...] = ()
+    provider_targets: tuple[ProviderTargetRecord, ...] = ()
+    runtime_environments: tuple[RuntimeEnvironmentRecord, ...] = ()
+    secret_records: tuple[SecretRecord, ...] = ()
+    secret_versions: tuple[SecretVersion, ...] = ()
+    secret_bindings: tuple[SecretBinding, ...] = ()
+    secret_audit_events: tuple[SecretAuditEvent, ...] = ()
+    environment_inventory: tuple[EnvironmentInventory, ...] = ()
+    release_tuples: tuple[ReleaseTupleRecord, ...] = ()
+    delete_runtime_environments: tuple[RuntimeEnvironmentDelete, ...] = ()
+    delete_dokploy_targets: tuple[DokployTargetRecord, ...] = ()
+    delete_dokploy_target_ids: tuple[DokployTargetIdRecord, ...] = ()
+    delete_provider_targets: tuple[ProviderTargetRecord, ...] = ()
+    idempotency_record: LaunchplaneIdempotencyRecord | None = None
+
+    def requires_write(self) -> bool:
+        return any(
+            (
+                self.product_profiles,
+                self.dokploy_targets,
+                self.dokploy_target_ids,
+                self.provider_targets,
+                self.runtime_environments,
+                self.secret_records,
+                self.secret_versions,
+                self.secret_bindings,
+                self.secret_audit_events,
+                self.environment_inventory,
+                self.release_tuples,
+                self.delete_runtime_environments,
+                self.delete_dokploy_targets,
+                self.delete_dokploy_target_ids,
+                self.delete_provider_targets,
+                self.idempotency_record is not None,
+            )
+        )
+
+
+class ProductAuthorityBundleStore(Protocol):
+    def write_product_authority_bundle(self, bundle: ProductAuthorityBundle) -> None: ...

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -20,8 +20,11 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretBinding
-from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
-from control_plane.storage.product_authority_bundle import ProductAuthorityBundleStore
+from control_plane.storage.product_authority_bundle import (
+    ProductAuthorityBundle,
+    ProductAuthorityBundleStore,
+    ProviderTargetWrite,
+)
 from control_plane.workflows.provider_target_dual_write import (
     prepare_provider_target_from_dokploy_records,
 )
@@ -351,6 +354,10 @@ def plan_product_onboarding_authority_bundle(
         provider_targets=provider_targets,
         provider_target_ids=provider_target_ids,
     )
+    current_provider_targets = {
+        (record.context, record.instance): record
+        for record in record_store.list_physical_provider_target_records()
+    }
     runtime_environments = build_runtime_environment_records(
         manifest=manifest, updated_at=recorded_at
     )
@@ -392,7 +399,14 @@ def plan_product_onboarding_authority_bundle(
         product_profiles=(product_profile,),
         dokploy_targets=provider_targets,
         dokploy_target_ids=provider_target_ids,
-        provider_targets=physical_provider_targets,
+        provider_target_writes=tuple(
+            ProviderTargetWrite(
+                record=record,
+                expected_record=current_provider_targets.get((record.context, record.instance)),
+                expected_absent=(record.context, record.instance) not in current_provider_targets,
+            )
+            for record in physical_provider_targets
+        ),
         runtime_environments=runtime_environments,
         secret_bindings=(*secret_bindings, *secret_binding_plan.retired_bindings),
     )

--- a/control_plane/workflows/product_onboarding.py
+++ b/control_plane/workflows/product_onboarding.py
@@ -20,14 +20,15 @@ from control_plane.contracts.product_profile_record import (
 )
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretBinding
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundleStore
 from control_plane.workflows.provider_target_dual_write import (
     prepare_provider_target_from_dokploy_records,
-    write_provider_target_from_dokploy_records,
 )
 from control_plane.workflows.ship import utc_now_timestamp
 
 
-class ProductOnboardingRecordStore(Protocol):
+class ProductOnboardingRecordStore(ProductAuthorityBundleStore, Protocol):
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
 
     def write_product_profile_record(self, record: LaunchplaneProductProfileRecord) -> None: ...
@@ -317,6 +318,21 @@ def apply_product_onboarding_manifest(
     manifest: ProductOnboardingManifest,
     updated_at: str = "",
 ) -> ProductOnboardingApplyResult:
+    result, bundle = plan_product_onboarding_authority_bundle(
+        record_store=record_store,
+        manifest=manifest,
+        updated_at=updated_at,
+    )
+    record_store.write_product_authority_bundle(bundle)
+    return result
+
+
+def plan_product_onboarding_authority_bundle(
+    *,
+    record_store: ProductOnboardingRecordStore,
+    manifest: ProductOnboardingManifest,
+    updated_at: str = "",
+) -> tuple[ProductOnboardingApplyResult, ProductAuthorityBundle]:
     recorded_at = updated_at.strip() or manifest.updated_at.strip() or utc_now_timestamp()
     existing_product_profile = _read_existing_product_profile(
         record_store=record_store,
@@ -364,25 +380,7 @@ def apply_product_onboarding_manifest(
             target_id_record=target_id_record,
         )
 
-    record_store.write_product_profile_record(product_profile)
-    for target_record in provider_targets:
-        record_store.write_dokploy_target_record(target_record)
-    for target_id_record in provider_target_ids:
-        record_store.write_dokploy_target_id_record(target_id_record)
-    for target_record, target_id_record in provider_target_pairs:
-        write_provider_target_from_dokploy_records(
-            record_store=record_store,
-            target_record=target_record,
-            target_id_record=target_id_record,
-        )
-    for runtime_record in runtime_environments:
-        record_store.write_runtime_environment_record(runtime_record)
-    for binding in secret_bindings:
-        record_store.write_secret_binding(binding)
-    for binding in secret_binding_plan.retired_bindings:
-        record_store.write_secret_binding(binding)
-
-    return ProductOnboardingApplyResult(
+    result = ProductOnboardingApplyResult(
         product=manifest.product,
         product_profile=product_profile,
         provider_targets=provider_targets,
@@ -390,6 +388,15 @@ def apply_product_onboarding_manifest(
         runtime_environments=runtime_environments,
         secret_bindings=secret_bindings,
     )
+    bundle = ProductAuthorityBundle(
+        product_profiles=(product_profile,),
+        dokploy_targets=provider_targets,
+        dokploy_target_ids=provider_target_ids,
+        provider_targets=physical_provider_targets,
+        runtime_environments=runtime_environments,
+        secret_bindings=(*secret_bindings, *secret_binding_plan.retired_bindings),
+    )
+    return result, bundle
 
 
 def _health_url(base_url: str, health_path: str) -> str:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -835,22 +835,26 @@ Current derived-state behavior:
   response is redacted and the route rejects nested runtime or secret targets
   that differ from the authorized top-level context/instance. It fails closed
   when secret writes are requested without valid Launchplane secret-key
-  configuration in the service runtime or when no active runtime key-safety policy allows the
-  requested binding. When apply changes runtime-environment keys for a tracked
-  Dokploy target, the response includes a required `live_target_runtime_apply`
-  `next_actions` item. Treat product-config apply as a record mutation only
-  until that next action has been dry-run and applied through
-  `/v1/live-target-runtime/apply`; redeploying the same app image does not sync
-  the live Dokploy target environment.
+  configuration in the service runtime or when no active runtime key-safety
+  policy allows the requested binding. Apply commits through a product
+  authority bundle, so runtime-environment records, managed-secret versions,
+  current secret pointers, bindings, audit events, and idempotency completion
+  publish together or roll back together. When apply changes
+  runtime-environment keys for a tracked Dokploy target, the response includes a
+  required `live_target_runtime_apply` `next_actions` item. Treat
+  product-config apply as a record mutation only until that next action has
+  been dry-run and applied through `/v1/live-target-runtime/apply`; redeploying
+  the same app image does not sync the live Dokploy target environment.
 - `POST /v1/secrets/reencrypt` is the normal shared/production root-rotation
   path. Run `mode: "dry-run"` with `secret.reencrypt.dry-run`, then submit
   `mode: "apply"` with the returned plan digest, a reason, an
   `Idempotency-Key`, and `secret.reencrypt.apply`. Launchplane atomically writes
-  the new versions, current-version pointers, and audit events. If the mutation
-  commits before idempotency evidence is persisted, a retry with the same
-  request recovers from the rotation audit token instead of rotating again.
-  Direct `launchplane secrets reencrypt --apply` remains bootstrap/recovery-only
-  and requires explicit direct-DB acknowledgement.
+  the new versions, current-version pointers, audit events, and idempotency
+  completion evidence in one storage transaction. A failure before commit leaves
+  current pointers and replay evidence unchanged; a committed apply is replayable
+  by the same idempotency key. Direct `launchplane secrets reencrypt --apply`
+  remains bootstrap/recovery-only and requires explicit direct-DB
+  acknowledgement.
 - The operator UI uses the same service route. It requires a successful dry-run
   result before enabling apply, clears rendered secret input values after each
   submit, and shows only key/action/count metadata from Launchplane responses.

--- a/docs/records.md
+++ b/docs/records.md
@@ -155,7 +155,11 @@ version, binding, audit evidence, required runtime-environment changes, and
 applicable idempotency completion are in the same transaction. Cleanup deletes
 compare the current row payload with the planned expected record under the
 storage boundary and fail closed on missing or drifted authority instead of
-publishing a partial graph.
+publishing a partial graph. Provider-target writes likewise carry an
+expected-current or expected-absent precondition so a concurrent route owner
+cannot be overwritten after planning. Lane-summary reads hold a shared bundle
+guard while assembling their multi-record view, so a bundle commit cannot split
+one response across the old and new authority graphs.
 
 Filesystem storage remains local rehearsal state, not shared runtime authority.
 Its product authority bundle path stages every replacement under
@@ -166,6 +170,8 @@ resumable: the next store access completes remaining `os.replace` writes and
 expected-payload deletes from the manifest, then removes the stage. If live data
 changed from the manifest while recovery was pending, recovery fails closed and
 leaves the stage for operator inspection rather than guessing at authority.
+Ordinary filesystem reads, writes, creates, deletes, and composite promotion
+evidence rollback hold the same bundle lock through their live-file access.
 
 Provider-backed routes must durably reserve first, bind their stable provider
 operation or reconciliation key before invoking the provider, and complete only

--- a/docs/records.md
+++ b/docs/records.md
@@ -142,6 +142,31 @@ boundary. Filesystem storage retains typed route-binding read/write parity for
 local rehearsal, but the service does not emulate the PostgreSQL transaction by
 performing a split filesystem apply.
 
+Product authority bundle writes are the same atomicity boundary for product
+runtime/config ownership. PostgreSQL storage exposes a single
+`write_product_authority_bundle` repository method for the authority graph that
+can include product profiles, provider targets, legacy Dokploy target records,
+runtime-environment rows and delete events, managed-secret versions/current
+pointers/bindings/audit events, environment inventory, release tuples, and the
+completed idempotency response. Product config, onboarding, context cutover,
+and legacy cleanup plan their whole graph first and then commit through this
+method once. A current managed-secret pointer must not advance unless the new
+version, binding, audit evidence, required runtime-environment changes, and
+applicable idempotency completion are in the same transaction. Cleanup deletes
+compare the current row payload with the planned expected record under the
+storage boundary and fail closed on missing or drifted authority instead of
+publishing a partial graph.
+
+Filesystem storage remains local rehearsal state, not shared runtime authority.
+Its product authority bundle path stages every replacement under
+`.product_authority_bundle_stages/` before touching live record files. A stage
+left in `ready` state is discarded on the next store access because no live file
+has been published yet. A stage left in `publishing` state is explicitly
+resumable: the next store access completes remaining `os.replace` writes and
+expected-payload deletes from the manifest, then removes the stage. If live data
+changed from the manifest while recovery was pending, recovery fails closed and
+leaves the stage for operator inspection rather than guessing at authority.
+
 Provider-backed routes must durably reserve first, bind their stable provider
 operation or reconciliation key before invoking the provider, and complete only
 after durable local evidence is ready. A crash or timeout after key binding is

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -93,7 +93,8 @@ The target rotation model is:
    blocked from retirement, and a digest bound to the current secret versions.
 4. Apply through the same service endpoint with the dry-run digest, an operator
    reason, and an idempotency key. Launchplane atomically writes every new
-   ciphertext version, current-version pointer, and audit event.
+   ciphertext version, current-version pointer, audit event, and apply
+   idempotency completion record.
 5. Run dry-run again and verify the previous key id is reported as ready for
    retirement.
 6. Retire the previous root by removing it from the service bootstrap key ring.
@@ -333,7 +334,10 @@ decryption key state denies the reveal or resolution.
 - `uv run launchplane product-config apply --input-file bundle.json --dry-run`
   previews an approved product runtime/secret bundle without printing plaintext
   values or writing records. `--apply` writes non-secret runtime keys and
-  managed secret values through the same DB-backed stores. Run this command only
+  managed secret values through the same DB-backed authority bundle. Runtime
+  records, encrypted secret versions, current secret pointers, bindings, audit
+  events, and applicable idempotency evidence commit together or roll back
+  together. Run this command only
   from a trusted Launchplane context with current `LAUNCHPLANE_DATABASE_URL` and,
   when secrets are present, `LAUNCHPLANE_SECRET_KEYS_JSON` (or the legacy
   `LAUNCHPLANE_MASTER_ENCRYPTION_KEY`). Dry-run and

--- a/tests/test_http_app_policy_apply.py
+++ b/tests/test_http_app_policy_apply.py
@@ -2453,6 +2453,54 @@ class FastApiProductConfigApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(conflict_response.status_code, 409)
         self.assertEqual(conflict_response.json()["error"]["code"], "idempotency_key_reused")
 
+    async def test_product_config_dry_run_idempotency_replay_and_conflict(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _write_runtime_key_safety_policy(database_url=database_url)
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_product_config_policy(action="product_config.plan"),
+                record_store_factory=lambda: app_store,
+            )
+            payload = {**_product_config_payload(), "mode": "dry-run"}
+            changed_payload = {
+                **payload,
+                "runtime_env": {"scope": "instance", "env": {"CONTACT_EMAIL_MODE": "api"}},
+            }
+
+            with patch.dict(
+                os.environ,
+                {control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"},
+                clear=True,
+            ):
+                first_response = await _post_product_config_apply(
+                    app,
+                    payload,
+                    idempotency_key="product-config-dry-run-idempotent",
+                )
+                replay_response = await _post_product_config_apply(
+                    app,
+                    payload,
+                    idempotency_key="product-config-dry-run-idempotent",
+                )
+                conflict_response = await _post_product_config_apply(
+                    app,
+                    changed_payload,
+                    idempotency_key="product-config-dry-run-idempotent",
+                )
+            app_store.close()
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        self.assertTrue(replay_response.json()["replayed"])
+        self.assertEqual(
+            replay_response.json()["original_trace_id"], first_response.json()["trace_id"]
+        )
+        self.assertEqual(conflict_response.status_code, 409)
+        self.assertEqual(conflict_response.json()["error"]["code"], "idempotency_key_reused")
+
     async def test_product_config_accepts_legacy_flat_runtime_env(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -52,6 +52,7 @@ from control_plane.storage.postgres import (
     MutationReservationResult,
     PostgresRecordStore,
 )
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
 from control_plane.storage.schema_invariants import EXPECTED_ALEMBIC_HEAD_REVISION
 
 POSTGRES_TEST_URL_ENV = "LAUNCHPLANE_TEST_POSTGRES_URL"
@@ -559,6 +560,64 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
 
 
 class RealPostgresStorageConcurrencyTests(unittest.TestCase):
+    def test_lane_summary_waits_for_authority_bundle_commit(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            bundle_step_reached = threading.Event()
+            release_bundle = threading.Event()
+            read_started = threading.Event()
+            read_finished = threading.Event()
+            errors: list[BaseException] = []
+
+            class _BlockingStore(PostgresRecordStore):
+                def _after_product_authority_bundle_step(self, step_name: str) -> None:
+                    if step_name == "write_product_profile":
+                        bundle_step_reached.set()
+                        if not release_bundle.wait(timeout=5):
+                            raise TimeoutError("timed out waiting to release authority bundle")
+
+            blocking_store = _BlockingStore(database_url=store.database_url)
+            reader_store = PostgresRecordStore(database_url=store.database_url)
+
+            def write_bundle() -> None:
+                try:
+                    blocking_store.write_product_authority_bundle(
+                        ProductAuthorityBundle(product_profiles=(_product_profile(),))
+                    )
+                except BaseException as exc:
+                    errors.append(exc)
+
+            def read_lane_summary() -> None:
+                read_started.set()
+                try:
+                    reader_store.read_lane_summary(
+                        context_name="example-product",
+                        instance_name="prod",
+                    )
+                except BaseException as exc:
+                    errors.append(exc)
+                finally:
+                    read_finished.set()
+
+            writer_thread = threading.Thread(target=write_bundle)
+            reader_thread = threading.Thread(target=read_lane_summary)
+            writer_thread.start()
+            try:
+                self.assertTrue(bundle_step_reached.wait(timeout=5))
+                reader_thread.start()
+                self.assertTrue(read_started.wait(timeout=5))
+                self.assertFalse(read_finished.wait(timeout=0.1))
+            finally:
+                release_bundle.set()
+                writer_thread.join(timeout=5)
+                if reader_thread.ident is not None:
+                    reader_thread.join(timeout=5)
+                blocking_store.close()
+                reader_store.close()
+
+        self.assertFalse(writer_thread.is_alive())
+        self.assertFalse(reader_thread.is_alive())
+        self.assertEqual(errors, [])
+
     def test_every_code_two_workers_claim_exactly_once(self) -> None:
         with _store_for_fresh_head_database() as store:
             record = _every_code_work_request()

--- a/tests/test_product_authority_bundle_transactions.py
+++ b/tests/test_product_authority_bundle_transactions.py
@@ -352,6 +352,7 @@ def _assert_write_bundle_published(
 ) -> None:
     test_case.assertEqual(len(store.list_product_profile_records()), 1)
     test_case.assertEqual(len(store.list_dokploy_target_records()), 1)
+    test_case.assertEqual(len(store.list_dokploy_target_id_records()), 1)
     test_case.assertEqual(len(store.list_provider_target_records()), 1)
     test_case.assertEqual(len(store.list_runtime_environment_records()), 1)
     test_case.assertEqual(len(store.list_secret_records()), 1)

--- a/tests/test_product_authority_bundle_transactions.py
+++ b/tests/test_product_authority_bundle_transactions.py
@@ -1,6 +1,9 @@
+import threading
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+from pydantic import BaseModel
 
 from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
@@ -57,6 +60,22 @@ class _FailingFilesystemRecordStore(FilesystemRecordStore):
         self.steps.append(step_name)
         if step_name == self.fail_step:
             raise RuntimeError(f"injected failure after {step_name}")
+
+
+class _BlockingFilesystemRecordStore(FilesystemRecordStore):
+    def __init__(self, state_dir: Path) -> None:
+        super().__init__(state_dir)
+        self.block_next_provider_target_write = False
+        self.write_started = threading.Event()
+        self.release_write = threading.Event()
+
+    def _write_model_locked(self, record_type: str, record_id: str, model: BaseModel) -> Path:
+        if self.block_next_provider_target_write and record_type == "launchplane_provider_targets":
+            self.block_next_provider_target_write = False
+            self.write_started.set()
+            if not self.release_write.wait(timeout=5):
+                raise TimeoutError("timed out waiting to release provider-target write")
+        return super()._write_model_locked(record_type, record_id, model)
 
 
 def _product_profile() -> LaunchplaneProductProfileRecord:
@@ -607,6 +626,86 @@ class ProductAuthorityBundleTransactionTests(unittest.TestCase):
                 recovered_store = FilesystemRecordStore(state_dir)
                 _assert_cleanup_records_removed(self, recovered_store)
                 self.assertFalse((state_dir / ".product_authority_bundle_stages").exists())
+
+    def test_filesystem_bundle_serializes_with_ordinary_record_write(self) -> None:
+        with TemporaryDirectory() as temporary_dir:
+            state_dir = Path(temporary_dir)
+            store = _BlockingFilesystemRecordStore(state_dir)
+            runtime_record = _seed_cleanup_records(store)
+            replacement_target = _provider_target(
+                context="example-legacy",
+                instance="old-prod",
+                target_id="replacement-app",
+            )
+            write_errors: list[BaseException] = []
+            bundle_errors: list[BaseException] = []
+            bundle_started = threading.Event()
+            bundle_finished = threading.Event()
+
+            def write_target() -> None:
+                try:
+                    store.write_provider_target_record(replacement_target)
+                except BaseException as exc:
+                    write_errors.append(exc)
+
+            def delete_bundle() -> None:
+                bundle_started.set()
+                try:
+                    store.write_product_authority_bundle(_delete_bundle())
+                except BaseException as exc:
+                    bundle_errors.append(exc)
+                finally:
+                    bundle_finished.set()
+
+            store.block_next_provider_target_write = True
+            write_thread = threading.Thread(target=write_target)
+            bundle_thread = threading.Thread(target=delete_bundle)
+            write_thread.start()
+            try:
+                self.assertTrue(store.write_started.wait(timeout=5))
+                bundle_thread.start()
+                self.assertTrue(bundle_started.wait(timeout=5))
+                self.assertFalse(bundle_finished.wait(timeout=0.1))
+            finally:
+                store.release_write.set()
+                write_thread.join(timeout=5)
+                if bundle_thread.ident is not None:
+                    bundle_thread.join(timeout=5)
+
+            self.assertFalse(write_thread.is_alive())
+            self.assertFalse(bundle_thread.is_alive())
+            self.assertEqual(write_errors, [])
+            self.assertEqual(len(bundle_errors), 1)
+            self.assertIsInstance(bundle_errors[0], ValueError)
+            self.assertEqual(
+                store.read_provider_target_record(
+                    context_name="example-legacy",
+                    instance_name="old-prod",
+                ),
+                replacement_target,
+            )
+            self.assertEqual(
+                store.list_runtime_environment_records(
+                    context_name="example-legacy",
+                    instance_name="old-prod",
+                ),
+                (runtime_record,),
+            )
+            self.assertEqual(store.list_runtime_environment_delete_events(), ())
+            self.assertEqual(
+                store.read_dokploy_target_id_record(
+                    context_name="example-legacy",
+                    instance_name="old-prod",
+                ).target_id,
+                "old-app",
+            )
+            self.assertIsNone(
+                store.read_idempotency_record(
+                    scope="test-suite",
+                    route_path="/v1/test/authority-bundle/apply",
+                    idempotency_key="authority-bundle-key",
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_product_authority_bundle_transactions.py
+++ b/tests/test_product_authority_bundle_transactions.py
@@ -1,0 +1,612 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
+from control_plane.contracts.dokploy_target_record import DokployTargetRecord
+from control_plane.contracts.environment_inventory import EnvironmentInventory
+from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductImageProfile,
+)
+from control_plane.contracts.promotion_record import DeploymentEvidence
+from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
+from control_plane.contracts.runtime_environment_record import (
+    RuntimeEnvironmentDeleteEvent,
+    RuntimeEnvironmentRecord,
+)
+from control_plane.contracts.secret_record import (
+    SecretAuditEvent,
+    SecretBinding,
+    SecretRecord,
+    SecretVersion,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.storage.product_authority_bundle import (
+    ProductAuthorityBundle,
+    RuntimeEnvironmentDelete,
+)
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+class _FailingPostgresRecordStore(PostgresRecordStore):
+    def __init__(self, *, database_url: str, fail_step: str | None = None) -> None:
+        super().__init__(database_url=database_url)
+        self.fail_step = fail_step
+        self.steps: list[str] = []
+
+    def _after_product_authority_bundle_step(self, step_name: str) -> None:
+        self.steps.append(step_name)
+        if step_name == self.fail_step:
+            raise RuntimeError(f"injected failure after {step_name}")
+
+
+class _FailingFilesystemRecordStore(FilesystemRecordStore):
+    def __init__(self, state_dir: Path, *, fail_step: str | None = None) -> None:
+        super().__init__(state_dir)
+        self.fail_step = fail_step
+        self.steps: list[str] = []
+
+    def _after_product_authority_bundle_step(self, step_name: str) -> None:
+        self.steps.append(step_name)
+        if step_name == self.fail_step:
+            raise RuntimeError(f"injected failure after {step_name}")
+
+
+def _product_profile() -> LaunchplaneProductProfileRecord:
+    return LaunchplaneProductProfileRecord(
+        product="example-product",
+        display_name="Example Product",
+        repository="example/example-product",
+        driver_id="generic-web",
+        image=ProductImageProfile(repository="ghcr.io/example/example-product"),
+        runtime_port=8080,
+        health_path="/health",
+        updated_at="2026-07-01T00:00:00Z",
+        source="test:authority-bundle",
+    )
+
+
+def _dokploy_target(
+    *, context: str = "example-product", instance: str = "prod"
+) -> DokployTargetRecord:
+    return DokployTargetRecord(
+        context=context,
+        instance=instance,
+        target_type="application",
+        target_name=f"{context}-{instance}",
+        updated_at="2026-07-01T00:00:00Z",
+        source_label="test:authority-bundle",
+    )
+
+
+def _dokploy_target_id(
+    *, context: str = "example-product", instance: str = "prod", target_id: str = "app-prod"
+) -> DokployTargetIdRecord:
+    return DokployTargetIdRecord(
+        context=context,
+        instance=instance,
+        target_id=target_id,
+        updated_at="2026-07-01T00:00:01Z",
+        source_label="test:authority-bundle",
+    )
+
+
+def _provider_target(
+    *, context: str = "example-product", instance: str = "prod", target_id: str = "app-prod"
+) -> ProviderTargetRecord:
+    return ProviderTargetRecord(
+        context=context,
+        instance=instance,
+        provider_id="dokploy",
+        target_category="application",
+        target_id=target_id,
+        display_name=f"{context}-{instance}",
+        provider_target_type="application",
+        updated_at="2026-07-01T00:00:02Z",
+        source_label="test:authority-bundle",
+    )
+
+
+def _runtime_environment(
+    *, context: str = "example-product", instance: str = "prod"
+) -> RuntimeEnvironmentRecord:
+    return RuntimeEnvironmentRecord(
+        scope="instance",
+        context=context,
+        instance=instance,
+        env={"EXAMPLE_MODE": "enabled"},
+        updated_at="2026-07-01T00:00:03Z",
+        source_label="test:authority-bundle",
+    )
+
+
+def _runtime_delete_event(record: RuntimeEnvironmentRecord) -> RuntimeEnvironmentDeleteEvent:
+    return RuntimeEnvironmentDeleteEvent(
+        event_id=f"runtime-delete-{record.context}-{record.instance}",
+        recorded_at="2026-07-01T00:00:04Z",
+        actor="test-suite",
+        scope=record.scope,
+        context=record.context,
+        instance=record.instance,
+        source_label="test:authority-bundle",
+        env_keys=tuple(sorted(record.env)),
+        env_value_count=len(record.env),
+        detail="Injected cleanup delete event.",
+    )
+
+
+def _secret_version() -> SecretVersion:
+    return SecretVersion(
+        version_id="secret-example-v1",
+        secret_id="secret-example",
+        created_at="2026-07-01T00:00:05Z",
+        created_by="test-suite",
+        ciphertext="gAAAAABexampleciphertext",
+    )
+
+
+def _secret_record() -> SecretRecord:
+    return SecretRecord(
+        secret_id="secret-example",
+        scope="context_instance",
+        integration="runtime_environment",
+        name="EXAMPLE_SECRET",
+        context="example-product",
+        instance="prod",
+        current_version_id="secret-example-v1",
+        created_at="2026-07-01T00:00:05Z",
+        updated_at="2026-07-01T00:00:05Z",
+        updated_by="test-suite",
+    )
+
+
+def _secret_binding() -> SecretBinding:
+    return SecretBinding(
+        binding_id="secret-binding-example",
+        secret_id="secret-example",
+        integration="runtime_environment",
+        binding_key="EXAMPLE_SECRET",
+        context="example-product",
+        instance="prod",
+        created_at="2026-07-01T00:00:06Z",
+        updated_at="2026-07-01T00:00:06Z",
+    )
+
+
+def _secret_audit_event() -> SecretAuditEvent:
+    return SecretAuditEvent(
+        event_id="secret-audit-example-created",
+        secret_id="secret-example",
+        event_type="created",
+        recorded_at="2026-07-01T00:00:07Z",
+        actor="test-suite",
+        detail="Created by authority bundle test.",
+    )
+
+
+def _environment_inventory() -> EnvironmentInventory:
+    return EnvironmentInventory(
+        context="example-product",
+        instance="prod",
+        source_git_ref="refs/heads/main",
+        deploy=DeploymentEvidence(
+            target_name="example-product-prod",
+            target_type="application",
+            deploy_mode="deploy",
+            status="pass",
+        ),
+        updated_at="2026-07-01T00:00:08Z",
+        deployment_record_id="deployment-example-prod",
+    )
+
+
+def _release_tuple() -> ReleaseTupleRecord:
+    return ReleaseTupleRecord(
+        tuple_id="tuple-example-prod",
+        context="example-product",
+        channel="prod",
+        artifact_id="artifact-example-prod",
+        repo_shas={"example-product": "abcdef1"},
+        deployment_record_id="deployment-example-prod",
+        provenance="ship",
+        minted_at="2026-07-01T00:00:09Z",
+    )
+
+
+def _idempotency_record() -> LaunchplaneIdempotencyRecord:
+    return LaunchplaneIdempotencyRecord(
+        record_id="idempotency-trace-authority-bundle",
+        scope="test-suite",
+        route_path="/v1/test/authority-bundle/apply",
+        idempotency_key="authority-bundle-key",
+        request_fingerprint="authority-bundle-fingerprint",
+        response_status_code=202,
+        response_trace_id="trace-authority-bundle",
+        recorded_at="2026-07-01T00:00:10Z",
+        response_payload={"trace_id": "trace-authority-bundle", "result": {"status": "ok"}},
+    )
+
+
+def _write_bundle() -> ProductAuthorityBundle:
+    return ProductAuthorityBundle(
+        product_profiles=(_product_profile(),),
+        dokploy_targets=(_dokploy_target(),),
+        dokploy_target_ids=(_dokploy_target_id(),),
+        provider_targets=(_provider_target(),),
+        runtime_environments=(_runtime_environment(),),
+        secret_versions=(_secret_version(),),
+        secret_records=(_secret_record(),),
+        secret_bindings=(_secret_binding(),),
+        secret_audit_events=(_secret_audit_event(),),
+        environment_inventory=(_environment_inventory(),),
+        release_tuples=(_release_tuple(),),
+        idempotency_record=_idempotency_record(),
+    )
+
+
+def _delete_bundle() -> ProductAuthorityBundle:
+    runtime_record = _runtime_environment(context="example-legacy", instance="old-prod")
+    return ProductAuthorityBundle(
+        delete_runtime_environments=(
+            RuntimeEnvironmentDelete(
+                expected_record=runtime_record,
+                event=_runtime_delete_event(runtime_record),
+            ),
+        ),
+        delete_provider_targets=(
+            _provider_target(context="example-legacy", instance="old-prod", target_id="old-app"),
+        ),
+        delete_dokploy_target_ids=(
+            _dokploy_target_id(context="example-legacy", instance="old-prod", target_id="old-app"),
+        ),
+        delete_dokploy_targets=(_dokploy_target(context="example-legacy", instance="old-prod"),),
+        idempotency_record=_idempotency_record().model_copy(
+            update={"record_id": "idempotency-trace-authority-cleanup"}
+        ),
+    )
+
+
+def _seed_cleanup_records(
+    store: PostgresRecordStore | FilesystemRecordStore,
+) -> RuntimeEnvironmentRecord:
+    runtime_record = _runtime_environment(context="example-legacy", instance="old-prod")
+    store.write_runtime_environment_record(runtime_record)
+    store.write_provider_target_record(
+        _provider_target(context="example-legacy", instance="old-prod", target_id="old-app")
+    )
+    store.write_dokploy_target_id_record(
+        _dokploy_target_id(context="example-legacy", instance="old-prod", target_id="old-app")
+    )
+    store.write_dokploy_target_record(
+        _dokploy_target(context="example-legacy", instance="old-prod")
+    )
+    return runtime_record
+
+
+def _assert_cleanup_records_present(
+    test_case: unittest.TestCase,
+    store: PostgresRecordStore | FilesystemRecordStore,
+    runtime_record: RuntimeEnvironmentRecord,
+) -> None:
+    test_case.assertEqual(
+        store.list_runtime_environment_records(
+            context_name="example-legacy", instance_name="old-prod"
+        ),
+        (runtime_record,),
+    )
+    test_case.assertEqual(store.list_runtime_environment_delete_events(), ())
+    test_case.assertEqual(
+        store.read_provider_target_record(
+            context_name="example-legacy", instance_name="old-prod"
+        ).target_id,
+        "old-app",
+    )
+    test_case.assertEqual(
+        store.read_dokploy_target_id_record(
+            context_name="example-legacy", instance_name="old-prod"
+        ).target_id,
+        "old-app",
+    )
+    test_case.assertIsNone(
+        store.read_idempotency_record(
+            scope="test-suite",
+            route_path="/v1/test/authority-bundle/apply",
+            idempotency_key="authority-bundle-key",
+        )
+    )
+
+
+def _assert_cleanup_records_removed(
+    test_case: unittest.TestCase,
+    store: PostgresRecordStore | FilesystemRecordStore,
+) -> None:
+    test_case.assertEqual(
+        store.list_runtime_environment_records(
+            context_name="example-legacy", instance_name="old-prod"
+        ),
+        (),
+    )
+    test_case.assertEqual(len(store.list_runtime_environment_delete_events()), 1)
+    test_case.assertEqual(store.list_provider_target_records(), ())
+    test_case.assertEqual(store.list_dokploy_target_id_records(), ())
+    test_case.assertEqual(store.list_dokploy_target_records(), ())
+    test_case.assertIsNotNone(
+        store.read_idempotency_record(
+            scope="test-suite",
+            route_path="/v1/test/authority-bundle/apply",
+            idempotency_key="authority-bundle-key",
+        )
+    )
+
+
+def _assert_write_bundle_published(
+    test_case: unittest.TestCase,
+    store: PostgresRecordStore | FilesystemRecordStore,
+) -> None:
+    test_case.assertEqual(len(store.list_product_profile_records()), 1)
+    test_case.assertEqual(len(store.list_dokploy_target_records()), 1)
+    test_case.assertEqual(len(store.list_provider_target_records()), 1)
+    test_case.assertEqual(len(store.list_runtime_environment_records()), 1)
+    test_case.assertEqual(len(store.list_secret_records()), 1)
+    test_case.assertEqual(len(store.list_secret_versions(secret_id="secret-example")), 1)
+    test_case.assertEqual(len(store.list_secret_bindings()), 1)
+    test_case.assertEqual(len(store.list_secret_audit_events(secret_id="secret-example")), 1)
+    test_case.assertEqual(len(store.list_environment_inventory()), 1)
+    test_case.assertEqual(len(store.list_release_tuple_records()), 1)
+    test_case.assertIsNotNone(
+        store.read_idempotency_record(
+            scope="test-suite",
+            route_path="/v1/test/authority-bundle/apply",
+            idempotency_key="authority-bundle-key",
+        )
+    )
+
+
+def _assert_write_bundle_absent(
+    test_case: unittest.TestCase,
+    store: PostgresRecordStore | FilesystemRecordStore,
+) -> None:
+    test_case.assertEqual(store.list_product_profile_records(), ())
+    test_case.assertEqual(store.list_dokploy_target_records(), ())
+    test_case.assertEqual(store.list_dokploy_target_id_records(), ())
+    test_case.assertEqual(store.list_provider_target_records(), ())
+    test_case.assertEqual(store.list_runtime_environment_records(), ())
+    test_case.assertEqual(store.list_secret_versions(secret_id="secret-example"), ())
+    test_case.assertEqual(store.list_secret_records(), ())
+    test_case.assertEqual(store.list_secret_bindings(), ())
+    test_case.assertEqual(store.list_secret_audit_events(secret_id="secret-example"), ())
+    test_case.assertEqual(store.list_environment_inventory(), ())
+    test_case.assertEqual(store.list_release_tuple_records(), ())
+    test_case.assertIsNone(
+        store.read_idempotency_record(
+            scope="test-suite",
+            route_path="/v1/test/authority-bundle/apply",
+            idempotency_key="authority-bundle-key",
+        )
+    )
+
+
+class ProductAuthorityBundleTransactionTests(unittest.TestCase):
+    def test_postgres_authority_bundle_rolls_back_after_each_write_step(self) -> None:
+        write_steps = (
+            "write_product_profile",
+            "write_dokploy_target",
+            "write_dokploy_target_id",
+            "write_provider_target",
+            "write_runtime_environment",
+            "write_secret_version",
+            "write_secret_record",
+            "write_secret_binding",
+            "write_secret_audit_event",
+            "write_environment_inventory",
+            "write_release_tuple",
+            "write_idempotency",
+        )
+        for fail_step in write_steps:
+            with self.subTest(fail_step=fail_step), TemporaryDirectory() as temporary_dir:
+                store = _FailingPostgresRecordStore(
+                    database_url=_sqlite_database_url(Path(temporary_dir) / "launchplane.sqlite3"),
+                    fail_step=fail_step,
+                )
+                store.ensure_schema()
+
+                with self.assertRaisesRegex(RuntimeError, fail_step):
+                    store.write_product_authority_bundle(_write_bundle())
+
+                self.assertIn(fail_step, store.steps)
+                self.assertEqual(store.list_product_profile_records(), ())
+                self.assertEqual(store.list_dokploy_target_records(), ())
+                self.assertEqual(store.list_dokploy_target_id_records(), ())
+                self.assertEqual(store.list_provider_target_records(), ())
+                self.assertEqual(store.list_runtime_environment_records(), ())
+                self.assertEqual(store.list_secret_versions(secret_id="secret-example"), ())
+                self.assertEqual(store.list_secret_records(), ())
+                self.assertEqual(store.list_secret_bindings(), ())
+                self.assertEqual(store.list_secret_audit_events(secret_id="secret-example"), ())
+                self.assertEqual(store.list_environment_inventory(), ())
+                self.assertEqual(store.list_release_tuple_records(), ())
+                self.assertIsNone(
+                    store.read_idempotency_record(
+                        scope="test-suite",
+                        route_path="/v1/test/authority-bundle/apply",
+                        idempotency_key="authority-bundle-key",
+                    )
+                )
+
+    def test_postgres_authority_bundle_commits_full_graph_and_idempotency(self) -> None:
+        with TemporaryDirectory() as temporary_dir:
+            store = _FailingPostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_dir) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+
+            store.write_product_authority_bundle(_write_bundle())
+
+            self.assertEqual(len(store.list_product_profile_records()), 1)
+            self.assertEqual(len(store.list_dokploy_target_records()), 1)
+            self.assertEqual(len(store.list_provider_target_records()), 1)
+            self.assertEqual(len(store.list_runtime_environment_records()), 1)
+            self.assertEqual(len(store.list_secret_versions(secret_id="secret-example")), 1)
+            self.assertEqual(len(store.list_secret_records()), 1)
+            self.assertEqual(len(store.list_secret_bindings()), 1)
+            self.assertEqual(len(store.list_secret_audit_events(secret_id="secret-example")), 1)
+            self.assertEqual(len(store.list_environment_inventory()), 1)
+            self.assertEqual(len(store.list_release_tuple_records()), 1)
+            self.assertIsNotNone(
+                store.read_idempotency_record(
+                    scope="test-suite",
+                    route_path="/v1/test/authority-bundle/apply",
+                    idempotency_key="authority-bundle-key",
+                )
+            )
+
+    def test_postgres_authority_bundle_rolls_back_cleanup_deletes_and_audit(self) -> None:
+        delete_steps = (
+            "delete_runtime_environment",
+            "write_runtime_environment_delete_event",
+            "delete_provider_target",
+            "delete_dokploy_target_id",
+            "delete_dokploy_target",
+            "write_idempotency",
+        )
+        for fail_step in delete_steps:
+            with self.subTest(fail_step=fail_step), TemporaryDirectory() as temporary_dir:
+                store = _FailingPostgresRecordStore(
+                    database_url=_sqlite_database_url(Path(temporary_dir) / "launchplane.sqlite3"),
+                    fail_step=fail_step,
+                )
+                store.ensure_schema()
+                runtime_record = _seed_cleanup_records(store)
+
+                with self.assertRaisesRegex(RuntimeError, fail_step):
+                    store.write_product_authority_bundle(_delete_bundle())
+
+                self.assertIn(fail_step, store.steps)
+                _assert_cleanup_records_present(self, store, runtime_record)
+
+    def test_filesystem_staging_failures_discard_unpublished_bundle(self) -> None:
+        stage_steps = (
+            "stage_write_product_profile",
+            "stage_write_dokploy_target",
+            "stage_write_dokploy_target_id",
+            "stage_write_provider_target",
+            "stage_write_runtime_environment",
+            "stage_write_secret_version",
+            "stage_write_secret_record",
+            "stage_write_secret_binding",
+            "stage_write_secret_audit_event",
+            "stage_write_environment_inventory",
+            "stage_write_release_tuple",
+            "stage_write_idempotency",
+            "stage_product_authority_bundle",
+        )
+        for fail_step in stage_steps:
+            with self.subTest(fail_step=fail_step), TemporaryDirectory() as temporary_dir:
+                state_dir = Path(temporary_dir)
+                store = _FailingFilesystemRecordStore(state_dir, fail_step=fail_step)
+
+                with self.assertRaisesRegex(RuntimeError, fail_step):
+                    store.write_product_authority_bundle(_write_bundle())
+
+                _assert_write_bundle_absent(self, FilesystemRecordStore(state_dir))
+                self.assertFalse((state_dir / ".product_authority_bundle_stages").exists())
+
+    def test_filesystem_ready_stage_recovers_by_discarding_unpublished_bundle(self) -> None:
+        with TemporaryDirectory() as temporary_dir:
+            state_dir = Path(temporary_dir)
+            store = _FailingFilesystemRecordStore(
+                state_dir,
+                fail_step="stage_product_authority_bundle",
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "stage_product_authority_bundle"):
+                store.write_product_authority_bundle(_write_bundle())
+
+            self.assertEqual(FilesystemRecordStore(state_dir).list_product_profile_records(), ())
+            self.assertFalse((state_dir / ".product_authority_bundle_stages").exists())
+
+    def test_filesystem_publishing_stage_recovers_after_each_write_step(self) -> None:
+        publish_steps = (
+            "publish_product_authority_bundle",
+            "write_product_profile",
+            "write_dokploy_target",
+            "write_dokploy_target_id",
+            "write_provider_target",
+            "write_runtime_environment",
+            "write_secret_version",
+            "write_secret_record",
+            "write_secret_binding",
+            "write_secret_audit_event",
+            "write_environment_inventory",
+            "write_release_tuple",
+            "write_idempotency",
+        )
+        for fail_step in publish_steps:
+            with self.subTest(fail_step=fail_step), TemporaryDirectory() as temporary_dir:
+                state_dir = Path(temporary_dir)
+                store = _FailingFilesystemRecordStore(state_dir, fail_step=fail_step)
+
+                with self.assertRaisesRegex(RuntimeError, fail_step):
+                    store.write_product_authority_bundle(_write_bundle())
+
+                recovered_store = FilesystemRecordStore(state_dir)
+                _assert_write_bundle_published(self, recovered_store)
+                self.assertFalse((state_dir / ".product_authority_bundle_stages").exists())
+
+    def test_filesystem_cleanup_staging_failures_discard_without_live_deletes(self) -> None:
+        stage_steps = (
+            "stage_delete_runtime_environment",
+            "stage_write_runtime_environment_delete_event",
+            "stage_delete_provider_target",
+            "stage_delete_dokploy_target_id",
+            "stage_delete_dokploy_target",
+            "stage_write_idempotency",
+            "stage_product_authority_bundle",
+        )
+        for fail_step in stage_steps:
+            with self.subTest(fail_step=fail_step), TemporaryDirectory() as temporary_dir:
+                state_dir = Path(temporary_dir)
+                seed_store = FilesystemRecordStore(state_dir)
+                runtime_record = _seed_cleanup_records(seed_store)
+                store = _FailingFilesystemRecordStore(state_dir, fail_step=fail_step)
+
+                with self.assertRaisesRegex(RuntimeError, fail_step):
+                    store.write_product_authority_bundle(_delete_bundle())
+
+                recovered_store = FilesystemRecordStore(state_dir)
+                _assert_cleanup_records_present(self, recovered_store, runtime_record)
+                self.assertFalse((state_dir / ".product_authority_bundle_stages").exists())
+
+    def test_filesystem_cleanup_publishing_stage_recovers_after_each_step(self) -> None:
+        publish_steps = (
+            "publish_product_authority_bundle",
+            "delete_runtime_environment",
+            "write_runtime_environment_delete_event",
+            "delete_provider_target",
+            "delete_dokploy_target_id",
+            "delete_dokploy_target",
+            "write_idempotency",
+        )
+        for fail_step in publish_steps:
+            with self.subTest(fail_step=fail_step), TemporaryDirectory() as temporary_dir:
+                state_dir = Path(temporary_dir)
+                _seed_cleanup_records(FilesystemRecordStore(state_dir))
+                store = _FailingFilesystemRecordStore(state_dir, fail_step=fail_step)
+
+                with self.assertRaisesRegex(RuntimeError, fail_step):
+                    store.write_product_authority_bundle(_delete_bundle())
+
+                recovered_store = FilesystemRecordStore(state_dir)
+                _assert_cleanup_records_removed(self, recovered_store)
+                self.assertFalse((state_dir / ".product_authority_bundle_stages").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_product_authority_bundle_transactions.py
+++ b/tests/test_product_authority_bundle_transactions.py
@@ -30,6 +30,7 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.storage.product_authority_bundle import (
     ProductAuthorityBundle,
+    ProviderTargetWrite,
     RuntimeEnvironmentDelete,
 )
 
@@ -258,7 +259,9 @@ def _write_bundle() -> ProductAuthorityBundle:
         product_profiles=(_product_profile(),),
         dokploy_targets=(_dokploy_target(),),
         dokploy_target_ids=(_dokploy_target_id(),),
-        provider_targets=(_provider_target(),),
+        provider_target_writes=(
+            ProviderTargetWrite(record=_provider_target(), expected_absent=True),
+        ),
         runtime_environments=(_runtime_environment(),),
         secret_versions=(_secret_version(),),
         secret_records=(_secret_record(),),
@@ -414,6 +417,57 @@ def _assert_write_bundle_absent(
 
 
 class ProductAuthorityBundleTransactionTests(unittest.TestCase):
+    def test_postgres_authority_bundle_rejects_stale_provider_target_absence(self) -> None:
+        with TemporaryDirectory() as temporary_dir:
+            store = _FailingPostgresRecordStore(
+                database_url=_sqlite_database_url(Path(temporary_dir) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            concurrent_target = _provider_target(target_id="concurrent-app")
+            store.write_provider_target_record(concurrent_target)
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "created after authority bundle planning",
+            ):
+                store.write_product_authority_bundle(_write_bundle())
+
+            self.assertEqual(store.list_provider_target_records(), (concurrent_target,))
+            self.assertEqual(store.list_product_profile_records(), ())
+            self.assertEqual(store.list_runtime_environment_records(), ())
+            self.assertIsNone(
+                store.read_idempotency_record(
+                    scope="test-suite",
+                    route_path="/v1/test/authority-bundle/apply",
+                    idempotency_key="authority-bundle-key",
+                )
+            )
+
+    def test_filesystem_authority_bundle_rejects_stale_provider_target_absence(self) -> None:
+        with TemporaryDirectory() as temporary_dir:
+            state_dir = Path(temporary_dir)
+            store = FilesystemRecordStore(state_dir)
+            concurrent_target = _provider_target(target_id="concurrent-app")
+            store.write_provider_target_record(concurrent_target)
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "created after authority bundle planning",
+            ):
+                store.write_product_authority_bundle(_write_bundle())
+
+            self.assertEqual(store.list_provider_target_records(), (concurrent_target,))
+            self.assertEqual(store.list_product_profile_records(), ())
+            self.assertEqual(store.list_runtime_environment_records(), ())
+            self.assertIsNone(
+                store.read_idempotency_record(
+                    scope="test-suite",
+                    route_path="/v1/test/authority-bundle/apply",
+                    idempotency_key="authority-bundle-key",
+                )
+            )
+            self.assertFalse((state_dir / ".product_authority_bundle_stages").exists())
+
     def test_postgres_authority_bundle_rolls_back_after_each_write_step(self) -> None:
         write_steps = (
             "write_product_profile",

--- a/tests/test_product_config_service.py
+++ b/tests/test_product_config_service.py
@@ -15,6 +15,7 @@ from control_plane.product_config_service import (
     apply_product_config_service_request,
     product_config_service_error,
 )
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
 
 
 class _FailingProductConfigStore:
@@ -88,6 +89,9 @@ class _FailingProductConfigStore:
 
     def write_secret_audit_event(self, event: SecretAuditEvent) -> None:
         raise AssertionError("dry-run test should not write secret audit events")
+
+    def write_product_authority_bundle(self, bundle: ProductAuthorityBundle) -> None:
+        raise AssertionError("dry-run test should not write product authority bundles")
 
 
 class ProductConfigServiceTests(unittest.TestCase):

--- a/tests/test_product_context_cutover.py
+++ b/tests/test_product_context_cutover.py
@@ -799,6 +799,11 @@ class ProductContextCutoverTests(unittest.TestCase):
                     for record in store.list_dokploy_target_id_records()
                     if record.context == "sellyouroutboard-testing"
                 )
+                source_provider_targets = tuple(
+                    record
+                    for record in store.list_provider_target_records()
+                    if record.context == "sellyouroutboard-testing"
+                )
                 target = store.read_dokploy_target_record(
                     context_name="sellyouroutboard",
                     instance_name="prod",
@@ -841,6 +846,7 @@ class ProductContextCutoverTests(unittest.TestCase):
         self.assertEqual(target_secret.status, "configured")
         self.assertEqual(source_target_records, ())
         self.assertEqual(source_target_ids, ())
+        self.assertEqual(source_provider_targets, ())
         self.assertEqual(target.target_name, "syo-prod-app")
         self.assertEqual(len(delete_events), 2)
         self.assertEqual([event.event_type for event in audit_events], ["disabled"])

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -10,6 +10,7 @@ from control_plane.contracts.product_profile_record import LaunchplaneProductPro
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.contracts.secret_record import SecretBinding
 from control_plane.product_onboarding_service import build_product_onboarding_service_result
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
 from control_plane.workflows.product_onboarding import apply_product_onboarding_manifest
 
 
@@ -65,6 +66,20 @@ class _ProductOnboardingStore:
 
     def write_secret_binding(self, binding: SecretBinding) -> None:
         self.secret_bindings.append(binding)
+
+    def write_product_authority_bundle(self, bundle: ProductAuthorityBundle) -> None:
+        for profile_record in bundle.product_profiles:
+            self.write_product_profile_record(profile_record)
+        for target_record in bundle.dokploy_targets:
+            self.write_dokploy_target_record(target_record)
+        for target_id_record in bundle.dokploy_target_ids:
+            self.write_dokploy_target_id_record(target_id_record)
+        for provider_target_record in bundle.provider_targets:
+            self.write_provider_target_record(provider_target_record)
+        for runtime_record in bundle.runtime_environments:
+            self.write_runtime_environment_record(runtime_record)
+        for binding in bundle.secret_bindings:
+            self.write_secret_binding(binding)
 
 
 class ProductOnboardingServiceTests(unittest.TestCase):

--- a/tests/test_product_onboarding_service.py
+++ b/tests/test_product_onboarding_service.py
@@ -74,8 +74,8 @@ class _ProductOnboardingStore:
             self.write_dokploy_target_record(target_record)
         for target_id_record in bundle.dokploy_target_ids:
             self.write_dokploy_target_id_record(target_id_record)
-        for provider_target_record in bundle.provider_targets:
-            self.write_provider_target_record(provider_target_record)
+        for provider_target_write in bundle.provider_target_writes:
+            self.write_provider_target_record(provider_target_write.record)
         for runtime_record in bundle.runtime_environments:
             self.write_runtime_environment_record(runtime_record)
         for binding in bundle.secret_bindings:

--- a/tests/test_runtime_environments.py
+++ b/tests/test_runtime_environments.py
@@ -31,6 +31,7 @@ from control_plane.contracts.secret_record import SecretBinding
 from control_plane.contracts.secret_record import SecretRecord
 from control_plane.contracts.secret_record import SecretVersion
 from control_plane.storage.postgres import PostgresRecordStore
+from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
 
 
 def _sqlite_database_url(database_path: Path) -> str:
@@ -256,6 +257,18 @@ class _FakeProductConfigStore:
             if not status or record.status == status
         )
         return records[:limit] if limit is not None else records
+
+    def write_product_authority_bundle(self, bundle: ProductAuthorityBundle) -> None:
+        for runtime_record in bundle.runtime_environments:
+            self.write_runtime_environment_record(runtime_record)
+        for version in bundle.secret_versions:
+            self.write_secret_version(version)
+        for secret_record in bundle.secret_records:
+            self.write_secret_record(secret_record)
+        for binding in bundle.secret_bindings:
+            self.write_secret_binding(binding)
+        for event in bundle.secret_audit_events:
+            self.write_secret_audit_event(event)
 
 
 class _FakeRuntimeEnvironmentStore:


### PR DESCRIPTION
## Summary
- commit product config, onboarding, context cutover, cleanup, secret, audit, inventory, and idempotency authority records through one PostgreSQL transaction
- add crash-recoverable staged filesystem publication serialized with ordinary record access
- enforce provider-target expected-current/expected-absent preconditions and guard lane-summary reads from straddling bundle commits
- preserve product-config dry-run replay semantics while keeping apply idempotency atomic

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (1928 tests)
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff check and format check
- real PostgreSQL integration gate (25 tests)
- independent final review: SHIP

Closes #1689