### PR TITLE
Add a transactional outbox for external deliveries

### DIFF
--- a/control_plane/cli_service.py
+++ b/control_plane/cli_service.py
@@ -11,6 +11,15 @@ import uuid
 import click
 
 from control_plane import dokploy as control_plane_dokploy
+from control_plane.outbox_worker import (
+    DEFAULT_OUTBOX_WORKER_ERROR_BACKOFF_SECONDS,
+    DEFAULT_OUTBOX_WORKER_LEASE_SECONDS,
+    DEFAULT_OUTBOX_WORKER_MAX_CONSECUTIVE_ERRORS,
+    DEFAULT_OUTBOX_WORKER_POLL_SECONDS,
+    OutboxWorkerStore,
+    run_outbox_worker_loop,
+    run_outbox_worker_once,
+)
 from control_plane.openapi_export import write_canonical_openapi
 from control_plane.contracts.driver_descriptor import DriverContextView
 from control_plane.drivers.registry import build_driver_context_view
@@ -41,6 +50,7 @@ from control_plane.workflows.verireel_prod_backup_gate_operation_worker import (
     run_verireel_prod_backup_gate_operation_worker_loop,
     run_verireel_prod_backup_gate_operation_worker_once,
 )
+from control_plane.workflows.public_ingress_monitor import public_ingress_notification_drivers
 
 
 _DATABASE_URL_ENV_KEYS = ("LAUNCHPLANE_DATABASE_URL",)
@@ -265,6 +275,151 @@ def service_serve(
         audience=audience,
         database_url=database_url,
     )
+
+
+@service.group("outbox-workers")
+def service_outbox_workers() -> None:
+    """Run Launchplane-owned transactional outbox delivery workers."""
+
+
+@service_outbox_workers.command("run-once")
+@click.option(
+    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
+)
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane shared-service core records.",
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Launchplane repo root used by outbox delivery workflows.",
+)
+@click.option(
+    "--lease-owner",
+    default="",
+    help="Worker lease owner id. Defaults to a generated process-local id.",
+)
+@click.option(
+    "--lease-seconds",
+    type=int,
+    default=DEFAULT_OUTBOX_WORKER_LEASE_SECONDS,
+    show_default=True,
+)
+def service_outbox_workers_run_once(
+    state_dir: Path,
+    database_url: str,
+    control_plane_root: Path | None,
+    lease_owner: str,
+    lease_seconds: int,
+) -> None:
+    if not database_url.strip():
+        raise click.ClickException(
+            "Outbox workers require --database-url or LAUNCHPLANE_DATABASE_URL."
+        )
+    generated_lease_owner = (
+        f"{socket.gethostname()}:{uuid.uuid4()}" if not lease_owner.strip() else lease_owner
+    )
+    record_store = _store(state_dir=state_dir, database_url=database_url)
+    result = run_outbox_worker_once(
+        record_store=cast(OutboxWorkerStore, record_store),
+        control_plane_root=control_plane_root or _control_plane_root(),
+        lease_owner=generated_lease_owner,
+        lease_seconds=lease_seconds,
+        notification_drivers=public_ingress_notification_drivers(record_store=record_store),
+    )
+    click.echo(json.dumps(asdict(result), indent=2, sort_keys=True))
+
+
+@service_outbox_workers.command("run")
+@click.option(
+    "--state-dir", type=click.Path(path_type=Path), default=Path("state"), show_default=True
+)
+@click.option(
+    "--database-url",
+    envvar=_DATABASE_URL_ENV_KEYS,
+    required=True,
+    help="Postgres connection string for Launchplane shared-service core records.",
+)
+@click.option(
+    "--control-plane-root",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional Launchplane repo root used by outbox delivery workflows.",
+)
+@click.option(
+    "--lease-owner",
+    default="",
+    help="Worker lease owner id. Defaults to a generated process-local id.",
+)
+@click.option(
+    "--lease-seconds",
+    type=int,
+    default=DEFAULT_OUTBOX_WORKER_LEASE_SECONDS,
+    show_default=True,
+)
+@click.option(
+    "--poll-seconds",
+    type=int,
+    default=DEFAULT_OUTBOX_WORKER_POLL_SECONDS,
+    show_default=True,
+)
+@click.option(
+    "--error-backoff-seconds",
+    type=int,
+    default=DEFAULT_OUTBOX_WORKER_ERROR_BACKOFF_SECONDS,
+    show_default=True,
+)
+@click.option(
+    "--max-consecutive-errors",
+    type=int,
+    default=DEFAULT_OUTBOX_WORKER_MAX_CONSECUTIVE_ERRORS,
+    show_default=True,
+)
+def service_outbox_workers_run(
+    state_dir: Path,
+    database_url: str,
+    control_plane_root: Path | None,
+    lease_owner: str,
+    lease_seconds: int,
+    poll_seconds: int,
+    error_backoff_seconds: int,
+    max_consecutive_errors: int,
+) -> None:
+    if not database_url.strip():
+        raise click.ClickException(
+            "Outbox workers require --database-url or LAUNCHPLANE_DATABASE_URL."
+        )
+    generated_lease_owner = (
+        f"{socket.gethostname()}:{uuid.uuid4()}" if not lease_owner.strip() else lease_owner
+    )
+    record_store = _store(state_dir=state_dir, database_url=database_url)
+    stop_event = Event()
+
+    def _request_stop(_signum: int, _frame: object) -> None:
+        stop_event.set()
+
+    previous_sigterm = signal.signal(signal.SIGTERM, _request_stop)
+    previous_sigint = signal.signal(signal.SIGINT, _request_stop)
+    try:
+        run_outbox_worker_loop(
+            record_store=cast(OutboxWorkerStore, record_store),
+            control_plane_root=control_plane_root or _control_plane_root(),
+            lease_owner=generated_lease_owner,
+            should_stop=stop_event.is_set,
+            lease_seconds=lease_seconds,
+            poll_seconds=poll_seconds,
+            error_backoff_seconds=error_backoff_seconds,
+            max_consecutive_errors=max_consecutive_errors,
+            notification_drivers=public_ingress_notification_drivers(record_store=record_store),
+        )
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
+        signal.signal(signal.SIGINT, previous_sigint)
+    click.echo(json.dumps({"status": "stopped"}, indent=2, sort_keys=True))
 
 
 @service.group("odoo-workers")

--- a/control_plane/contracts/outbox_delivery.py
+++ b/control_plane/contracts/outbox_delivery.py
@@ -108,6 +108,24 @@ def build_outbox_dedupe_key(*, kind: str, parts: tuple[str, ...]) -> str:
     return ":".join([kind.strip(), *(part.strip() for part in parts if part.strip())])
 
 
+def retry_outbox_delivery(
+    record: OutboxDeliveryRecord,
+    *,
+    error_code: str,
+) -> OutboxDeliveryRecord:
+    return record.model_copy(
+        update={
+            "state": "pending",
+            "error_code": error_code.strip() or "provider_error",
+            "action": "",
+            "external_id": "",
+            "external_url": "",
+            "lease_owner": "",
+            "lease_expires_at": "",
+        }
+    )
+
+
 def _required_text(value: str, message: str) -> str:
     normalized = value.strip()
     if not normalized:

--- a/control_plane/contracts/outbox_delivery.py
+++ b/control_plane/contracts/outbox_delivery.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+OutboxDeliveryKind = Literal[
+    "github_workflow_dispatch",
+    "public_ingress_notification",
+]
+OutboxDeliveryState = Literal[
+    "pending",
+    "running",
+    "delivered",
+    "failed",
+    "reconcile_required",
+]
+
+
+class OutboxDeliveryRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    delivery_id: str
+    kind: OutboxDeliveryKind
+    state: OutboxDeliveryState = "pending"
+    aggregate_type: str
+    aggregate_id: str
+    dedupe_key: str
+    created_at: str
+    updated_at: str
+    next_attempt_at: str
+    lease_owner: str = ""
+    lease_expires_at: str = ""
+    attempt: int = Field(default=0, ge=0)
+    max_attempts: int = Field(default=6, ge=1, le=100)
+    provider_operation_key: str = ""
+    provider_id: str = ""
+    external_id: str = ""
+    external_url: str = ""
+    action: str = ""
+    error_code: str = ""
+    payload: dict[str, object] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def _validate_record(self) -> "OutboxDeliveryRecord":
+        self.delivery_id = _required_text(self.delivery_id, "outbox delivery requires delivery_id")
+        self.aggregate_type = _required_text(
+            self.aggregate_type, "outbox delivery requires aggregate_type"
+        )
+        self.aggregate_id = _required_text(
+            self.aggregate_id, "outbox delivery requires aggregate_id"
+        )
+        self.dedupe_key = _required_text(self.dedupe_key, "outbox delivery requires dedupe_key")
+        self.created_at = _required_text(self.created_at, "outbox delivery requires created_at")
+        self.updated_at = _required_text(self.updated_at, "outbox delivery requires updated_at")
+        self.next_attempt_at = _required_text(
+            self.next_attempt_at, "outbox delivery requires next_attempt_at"
+        )
+        self.lease_owner = self.lease_owner.strip()
+        self.lease_expires_at = self.lease_expires_at.strip()
+        self.provider_operation_key = self.provider_operation_key.strip()
+        self.provider_id = self.provider_id.strip()
+        self.external_id = self.external_id.strip()
+        self.external_url = self.external_url.strip()
+        self.action = self.action.strip()
+        self.error_code = self.error_code.strip()
+        if self.state == "running":
+            if not self.lease_owner:
+                raise ValueError("running outbox deliveries require lease_owner")
+            if not self.lease_expires_at:
+                raise ValueError("running outbox deliveries require lease_expires_at")
+        elif self.lease_owner or self.lease_expires_at:
+            raise ValueError("non-running outbox deliveries cannot retain lease fields")
+        if self.state == "delivered" and not self.action:
+            raise ValueError("delivered outbox deliveries require action")
+        if self.state == "failed" and not self.error_code:
+            raise ValueError("failed outbox deliveries require error_code")
+        if self.state == "reconcile_required" and not self.provider_operation_key:
+            raise ValueError("reconcile-required outbox deliveries require provider_operation_key")
+        _reject_sensitive_payload(self.payload)
+        return self
+
+
+def build_outbox_delivery_id(*, kind: str, dedupe_key: str) -> str:
+    digest = hashlib.sha256(
+        json.dumps(
+            {"kind": kind.strip(), "dedupe_key": dedupe_key.strip()},
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:20]
+    return "-".join(
+        token
+        for token in (
+            "outbox",
+            _record_token(kind),
+            digest,
+        )
+        if token
+    )
+
+
+def build_outbox_dedupe_key(*, kind: str, parts: tuple[str, ...]) -> str:
+    return ":".join([kind.strip(), *(part.strip() for part in parts if part.strip())])
+
+
+def _required_text(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    return normalized
+
+
+def _record_token(value: str) -> str:
+    return "".join(
+        character if character.isalnum() else "-" for character in value.strip().lower()
+    ).strip("-")
+
+
+def _reject_sensitive_payload(value: object, *, path: str = "payload") -> None:
+    if isinstance(value, dict):
+        for raw_key, nested in value.items():
+            key = str(raw_key).strip().lower()
+            if _looks_sensitive_key(key):
+                raise ValueError(
+                    f"outbox delivery payload cannot include sensitive field {path}.{key}"
+                )
+            _reject_sensitive_payload(nested, path=f"{path}.{key}")
+    elif isinstance(value, (list, tuple)):
+        for index, nested in enumerate(value):
+            _reject_sensitive_payload(nested, path=f"{path}[{index}]")
+
+
+def _looks_sensitive_key(key: str) -> bool:
+    sensitive_tokens = (
+        "authorization",
+        "bearer",
+        "ciphertext",
+        "cookie",
+        "password",
+        "secret",
+        "token",
+        "webhook_url",
+    )
+    return any(token in key for token in sensitive_tokens)

--- a/control_plane/generic_web_promotion_http.py
+++ b/control_plane/generic_web_promotion_http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from datetime import datetime
 from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -8,6 +9,11 @@ from pydantic import BaseModel, ConfigDict, Field
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
+)
+from control_plane.contracts.outbox_delivery import (
+    OutboxDeliveryRecord,
+    build_outbox_dedupe_key,
+    build_outbox_delivery_id,
 )
 from control_plane.drivers.generic_web_dispatch import (
     GenericWebProdPromotionEnvelope,
@@ -24,8 +30,12 @@ from control_plane.workflows.generic_web_promotion import (
 )
 from control_plane.workflows.generic_web_promotion_workflow import (
     GenericWebPromotionWorkflowResult,
-    dispatch_generic_web_promotion_workflow,
+    _github_timestamp_precision,
+    _normalize_bump,
+    _workflow_dispatch_run_ids,
 )
+from control_plane.workflows.launchplane import resolve_launchplane_github_token
+from control_plane.workflows.ship import utc_now_timestamp
 
 
 GENERIC_WEB_PROD_PROMOTION_ROUTE = _GENERIC_WEB_PROD_PROMOTION_ROUTE.route_path
@@ -47,6 +57,7 @@ __all__ = [
     "GenericWebPromotionWorkflowResponse",
     "GenericWebPromotionWorkflowResponseResult",
     "dispatch_generic_web_promotion_workflow_result",
+    "build_generic_web_promotion_workflow_outbox_delivery",
     "execute_generic_web_prod_promotion_result",
     "resolve_generic_web_promotion_destination_lane",
     "resolve_generic_web_promotion_workflow_lane",
@@ -140,7 +151,7 @@ class GenericWebPromotionWorkflowResponseResult(BaseModel):
     ref: str = ""
     dry_run: bool = False
     bump: Literal["patch", "minor", "major"] = "patch"
-    dispatch_status: Literal["dispatched"] = "dispatched"
+    dispatch_status: Literal["pending", "dispatched"] = "pending"
     run_id: int = 0
     run_url: str = ""
     run_status: str = "pending"
@@ -229,13 +240,112 @@ def dispatch_generic_web_promotion_workflow_result(
     control_plane_root: Path,
     request: GenericWebPromotionWorkflowEnvelope,
     profile: LaunchplaneProductProfileRecord,
-) -> tuple[dict[str, str], GenericWebPromotionWorkflowResult]:
-    driver_result = dispatch_generic_web_promotion_workflow(
+) -> tuple[dict[str, str], GenericWebPromotionWorkflowResult, OutboxDeliveryRecord]:
+    delivery = build_generic_web_promotion_workflow_outbox_delivery(
         control_plane_root=control_plane_root,
+        request=request,
         profile=profile,
-        request=request.workflow,
     )
-    return {}, driver_result
+    workflow = profile.promotion_workflow
+    bump = _normalize_bump(
+        request.workflow.bump if request.workflow.bump is not None else workflow.default_bump
+    )
+    result = GenericWebPromotionWorkflowResult(
+        product=profile.product,
+        context=request.workflow.context,
+        repository=profile.repository,
+        workflow_id=workflow.workflow_id.strip(),
+        ref=workflow.ref.strip(),
+        dry_run=request.workflow.dry_run,
+        bump=bump,
+        dispatch_status="pending",
+    )
+    return {"outbox_delivery_id": delivery.delivery_id}, result, delivery
+
+
+def build_generic_web_promotion_workflow_outbox_delivery(
+    *,
+    control_plane_root: Path,
+    request: GenericWebPromotionWorkflowEnvelope,
+    profile: LaunchplaneProductProfileRecord,
+) -> OutboxDeliveryRecord:
+    owner, repo = _repository_parts(profile.repository)
+    workflow = profile.promotion_workflow
+    workflow_id = workflow.workflow_id.strip()
+    ref = workflow.ref.strip()
+    bump = _normalize_bump(
+        request.workflow.bump if request.workflow.bump is not None else workflow.default_bump
+    )
+    token = resolve_launchplane_github_token(
+        control_plane_root=control_plane_root,
+        context_name=request.workflow.context,
+    )
+    if not token:
+        raise GenericWebPromotionRouteDependencyError(
+            "Launchplane runtime records do not expose GITHUB_TOKEN for this context."
+        )
+    previous_run_ids = _workflow_dispatch_run_ids(
+        owner=owner,
+        repo=repo,
+        workflow_id=workflow_id,
+        ref=ref,
+        token=token,
+    )
+    created_at = utc_now_timestamp()
+    dispatch_started_at = (
+        _github_timestamp_precision(datetime.fromisoformat(created_at.replace("Z", "+00:00")))
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+    inputs = {
+        workflow.dry_run_input.strip(): str(request.workflow.dry_run).lower(),
+        workflow.bump_input.strip(): bump,
+    }
+    dedupe_key = build_outbox_dedupe_key(
+        kind="github_workflow_dispatch",
+        parts=(
+            profile.product,
+            request.workflow.context,
+            workflow_id,
+            ref,
+            str(request.workflow.dry_run),
+            bump,
+        ),
+    )
+    return OutboxDeliveryRecord(
+        delivery_id=build_outbox_delivery_id(
+            kind="github_workflow_dispatch",
+            dedupe_key=dedupe_key,
+        ),
+        kind="github_workflow_dispatch",
+        aggregate_type="generic_web_promotion_workflow",
+        aggregate_id=f"{profile.product}:{request.workflow.context}",
+        dedupe_key=dedupe_key,
+        created_at=created_at,
+        updated_at=created_at,
+        next_attempt_at=created_at,
+        payload={
+            "repository": profile.repository,
+            "workflow_id": workflow_id,
+            "ref": ref,
+            "inputs": inputs,
+            "previous_run_ids": sorted(previous_run_ids),
+            "dispatch_started_at": dispatch_started_at,
+            "credential_context": request.workflow.context,
+            "observe_timeout_seconds": request.workflow.observe_timeout_seconds,
+        },
+    )
+
+
+def _repository_parts(repository: str) -> tuple[str, str]:
+    owner, separator, repo = repository.strip().partition("/")
+    owner = owner.strip()
+    repo = repo.strip()
+    if not separator or not owner or not repo or "/" in repo:
+        raise GenericWebPromotionRouteDependencyError(
+            "GitHub repository must use owner/repo format."
+        )
+    return owner, repo
 
 
 def should_store_generic_web_promotion_idempotency(

--- a/control_plane/generic_web_promotion_http.py
+++ b/control_plane/generic_web_promotion_http.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from datetime import datetime
 from typing import Literal, cast
@@ -240,11 +241,13 @@ def dispatch_generic_web_promotion_workflow_result(
     control_plane_root: Path,
     request: GenericWebPromotionWorkflowEnvelope,
     profile: LaunchplaneProductProfileRecord,
+    delivery_key: str,
 ) -> tuple[dict[str, str], GenericWebPromotionWorkflowResult, OutboxDeliveryRecord]:
     delivery = build_generic_web_promotion_workflow_outbox_delivery(
         control_plane_root=control_plane_root,
         request=request,
         profile=profile,
+        delivery_key=delivery_key,
     )
     workflow = profile.promotion_workflow
     bump = _normalize_bump(
@@ -268,6 +271,7 @@ def build_generic_web_promotion_workflow_outbox_delivery(
     control_plane_root: Path,
     request: GenericWebPromotionWorkflowEnvelope,
     profile: LaunchplaneProductProfileRecord,
+    delivery_key: str,
 ) -> OutboxDeliveryRecord:
     owner, repo = _repository_parts(profile.repository)
     workflow = profile.promotion_workflow
@@ -310,6 +314,7 @@ def build_generic_web_promotion_workflow_outbox_delivery(
             ref,
             str(request.workflow.dry_run),
             bump,
+            hashlib.sha256(delivery_key.strip().encode("utf-8")).hexdigest()[:20],
         ),
     )
     return OutboxDeliveryRecord(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -599,6 +599,7 @@ from control_plane.storage.postgres import (
     DbOnlyMutationRequest,
     MutationReservationResult,
     MutationReservationUpdateResult,
+    OutboxWithIdempotencyRequest,
     PostgresRecordStore,
     RouteBindingMutationResult,
 )
@@ -16657,7 +16658,7 @@ def create_launchplane_fastapi_app(
                 replayed_response.model_dump(mode="json")
             )
         try:
-            records, result = dispatch_generic_web_promotion_workflow_result(
+            records, result, outbox_delivery = dispatch_generic_web_promotion_workflow_result(
                 control_plane_root=resolved_control_plane_root,
                 request=workflow_request,
                 profile=profile,
@@ -16683,9 +16684,16 @@ def create_launchplane_fastapi_app(
                 result.model_dump(mode="json")
             ),
         )
-        if should_store_generic_web_promotion_idempotency(result):
-            store_apply_idempotency(
-                record_store=record_store,
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="outbox_requires_postgres",
+                message="Workflow dispatch requires PostgreSQL transactional outbox storage.",
+            )
+        idempotency_record = None
+        if normalized_key and should_store_generic_web_promotion_idempotency(result):
+            idempotency_record = build_apply_idempotency_record(
                 identity=identity,
                 route_path=_GENERIC_WEB_PROD_PROMOTION_WORKFLOW_ROUTE,
                 idempotency_key=normalized_key,
@@ -16693,6 +16701,12 @@ def create_launchplane_fastapi_app(
                 trace_id=trace_id,
                 response=response,
             )
+        record_store.enqueue_outbox_delivery_with_idempotency(
+            OutboxWithIdempotencyRequest(
+                delivery=outbox_delivery,
+                idempotency_record=idempotency_record,
+            )
+        )
         return response
 
     def resolve_verireel_route_authorization(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -16662,6 +16662,11 @@ def create_launchplane_fastapi_app(
                 control_plane_root=resolved_control_plane_root,
                 request=workflow_request,
                 profile=profile,
+                delivery_key=(
+                    f"{idempotency_scope(identity)}:{normalized_key}"
+                    if normalized_key
+                    else trace_id
+                ),
             )
         except FileNotFoundError as error:
             raise _launchplane_http_error(

--- a/control_plane/outbox_worker.py
+++ b/control_plane/outbox_worker.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+import time
+from typing import Protocol
+
+from control_plane.contracts.outbox_delivery import OutboxDeliveryRecord
+from control_plane.workflows.generic_web_promotion_workflow import (
+    dispatch_generic_web_promotion_workflow_delivery,
+)
+from control_plane.workflows.public_ingress_monitor import (
+    PublicIngressNotificationDriverSet,
+    deliver_public_ingress_notification_outbox_delivery,
+)
+
+
+DEFAULT_OUTBOX_WORKER_LEASE_SECONDS = 300
+DEFAULT_OUTBOX_WORKER_POLL_SECONDS = 5
+DEFAULT_OUTBOX_WORKER_ERROR_BACKOFF_SECONDS = 10
+DEFAULT_OUTBOX_WORKER_MAX_CONSECUTIVE_ERRORS = 5
+
+
+class OutboxWorkerStore(Protocol):
+    def claim_next_outbox_delivery_record(
+        self,
+        *,
+        lease_owner: str,
+        lease_seconds: int = 300,
+        now: str = "",
+    ) -> object: ...
+
+    def mark_outbox_delivery_provider_started(
+        self,
+        *,
+        record: OutboxDeliveryRecord,
+        lease_owner: str,
+        provider_operation_key: str,
+        provider_id: str = "",
+        updated_at: str = "",
+    ) -> object: ...
+
+    def complete_outbox_delivery_record(
+        self,
+        *,
+        record: OutboxDeliveryRecord,
+        lease_owner: str,
+    ) -> object: ...
+
+
+@dataclass(frozen=True)
+class OutboxWorkerStepResult:
+    status: str
+    delivery_id: str = ""
+    kind: str = ""
+    error_code: str = ""
+
+
+def run_outbox_worker_once(
+    *,
+    record_store: OutboxWorkerStore,
+    control_plane_root: Path,
+    lease_owner: str,
+    lease_seconds: int = DEFAULT_OUTBOX_WORKER_LEASE_SECONDS,
+    notification_drivers: PublicIngressNotificationDriverSet | None = None,
+) -> OutboxWorkerStepResult:
+    claim = record_store.claim_next_outbox_delivery_record(
+        lease_owner=lease_owner,
+        lease_seconds=lease_seconds,
+    )
+    if getattr(claim, "status", "") == "empty":
+        return OutboxWorkerStepResult(status="idle")
+    record = getattr(claim, "record", None)
+    if not isinstance(record, OutboxDeliveryRecord):
+        return OutboxWorkerStepResult(status="idle")
+    if record.kind == "github_workflow_dispatch":
+        result = dispatch_generic_web_promotion_workflow_delivery(
+            record=record,
+            control_plane_root=control_plane_root,
+            mark_provider_started=lambda provider_operation_key, provider_id: (
+                _mark_provider_started(
+                    record_store=record_store,
+                    record=record,
+                    lease_owner=lease_owner,
+                    provider_operation_key=provider_operation_key,
+                    provider_id=provider_id,
+                )
+            ),
+        )
+    elif record.kind == "public_ingress_notification":
+        result = deliver_public_ingress_notification_outbox_delivery(
+            record=record,
+            drivers=notification_drivers or PublicIngressNotificationDriverSet(),
+            mark_provider_started=lambda provider_operation_key, provider_id: (
+                _mark_provider_started(
+                    record_store=record_store,
+                    record=record,
+                    lease_owner=lease_owner,
+                    provider_operation_key=provider_operation_key,
+                    provider_id=provider_id,
+                )
+            ),
+        )
+    else:
+        result = record.model_copy(
+            update={"state": "failed", "error_code": "unsupported_outbox_kind"}
+        )
+    completion = record_store.complete_outbox_delivery_record(
+        record=result,
+        lease_owner=lease_owner,
+    )
+    completed = getattr(completion, "record", result)
+    if not isinstance(completed, OutboxDeliveryRecord):
+        completed = result
+    if getattr(completion, "status", "") != "updated":
+        return OutboxWorkerStepResult(
+            status="completion_failed",
+            delivery_id=record.delivery_id,
+            kind=record.kind,
+            error_code=str(getattr(completion, "status", "unknown")),
+        )
+    return OutboxWorkerStepResult(
+        status=completed.state,
+        delivery_id=completed.delivery_id,
+        kind=completed.kind,
+        error_code=completed.error_code,
+    )
+
+
+def run_outbox_worker_loop(
+    *,
+    record_store: OutboxWorkerStore,
+    control_plane_root: Path,
+    lease_owner: str,
+    should_stop: Callable[[], bool],
+    lease_seconds: int = DEFAULT_OUTBOX_WORKER_LEASE_SECONDS,
+    poll_seconds: int = DEFAULT_OUTBOX_WORKER_POLL_SECONDS,
+    error_backoff_seconds: int = DEFAULT_OUTBOX_WORKER_ERROR_BACKOFF_SECONDS,
+    max_consecutive_errors: int = DEFAULT_OUTBOX_WORKER_MAX_CONSECUTIVE_ERRORS,
+    notification_drivers: PublicIngressNotificationDriverSet | None = None,
+) -> None:
+    consecutive_errors = 0
+    while not should_stop():
+        try:
+            result = run_outbox_worker_once(
+                record_store=record_store,
+                control_plane_root=control_plane_root,
+                lease_owner=lease_owner,
+                lease_seconds=lease_seconds,
+                notification_drivers=notification_drivers,
+            )
+            consecutive_errors = 0
+        except Exception:  # noqa: BLE001 - worker loop backoff keeps process bounded.
+            consecutive_errors += 1
+            if consecutive_errors >= max_consecutive_errors:
+                raise
+            time.sleep(max(1, error_backoff_seconds))
+            continue
+        if result.status == "idle":
+            time.sleep(max(1, poll_seconds))
+
+
+def _mark_provider_started(
+    *,
+    record_store: OutboxWorkerStore,
+    record: OutboxDeliveryRecord,
+    lease_owner: str,
+    provider_operation_key: str,
+    provider_id: str,
+) -> None:
+    update = record_store.mark_outbox_delivery_provider_started(
+        record=record,
+        lease_owner=lease_owner,
+        provider_operation_key=provider_operation_key,
+        provider_id=provider_id,
+    )
+    if getattr(update, "status", "") != "updated":
+        raise RuntimeError("outbox_provider_marker_not_recorded")

--- a/control_plane/storage/migrations/versions/a2b4c6d8e0f2_add_outbox_deliveries.py
+++ b/control_plane/storage/migrations/versions/a2b4c6d8e0f2_add_outbox_deliveries.py
@@ -1,0 +1,102 @@
+"""add outbox deliveries
+
+Revision ID: a2b4c6d8e0f2
+Revises: f2a4c6e8b0d2
+Create Date: 2026-07-13 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "a2b4c6d8e0f2"
+down_revision: str | None = "f2a4c6e8b0d2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_outbox_deliveries"
+_DEDUPE_INDEX = "launchplane_outbox_deliveries_dedupe_uidx"
+_CLAIM_INDEX = "launchplane_outbox_deliveries_claim_idx"
+_AGGREGATE_INDEX = "launchplane_outbox_deliveries_aggregate_idx"
+_PROVIDER_KEY_INDEX = "launchplane_outbox_deliveries_provider_key_idx"
+
+
+def _table_exists(table_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return table_name in set(inspector.get_table_names())
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    connection = op.get_bind()
+    inspector = sa.inspect(connection)
+    return index_name in {str(index["name"]) for index in inspector.get_indexes(table_name)}
+
+
+def _payload_column() -> sa.Column[object]:
+    return sa.Column(
+        "payload",
+        sa.JSON().with_variant(postgresql.JSONB(astext_type=sa.Text()), "postgresql"),
+        nullable=False,
+    )
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE):
+        op.create_table(
+            _TABLE,
+            sa.Column("delivery_id", sa.String(), nullable=False),
+            sa.Column("kind", sa.String(), nullable=False),
+            sa.Column("state", sa.String(), nullable=False),
+            sa.Column("aggregate_type", sa.String(), nullable=False),
+            sa.Column("aggregate_id", sa.String(), nullable=False),
+            sa.Column("dedupe_key", sa.String(), nullable=False),
+            sa.Column("created_at", sa.String(), nullable=False),
+            sa.Column("updated_at", sa.String(), nullable=False),
+            sa.Column("next_attempt_at", sa.String(), nullable=False),
+            sa.Column("lease_owner", sa.String(), nullable=False, server_default=""),
+            sa.Column("lease_expires_at", sa.String(), nullable=False, server_default=""),
+            sa.Column("attempt", sa.Integer(), nullable=False, server_default="0"),
+            sa.Column("max_attempts", sa.Integer(), nullable=False, server_default="6"),
+            sa.Column("provider_operation_key", sa.String(), nullable=False, server_default=""),
+            sa.Column("provider_id", sa.String(), nullable=False, server_default=""),
+            sa.Column("external_id", sa.String(), nullable=False, server_default=""),
+            sa.Column("external_url", sa.String(), nullable=False, server_default=""),
+            sa.Column("action", sa.String(), nullable=False, server_default=""),
+            sa.Column("error_code", sa.String(), nullable=False, server_default=""),
+            _payload_column(),
+            sa.PrimaryKeyConstraint("delivery_id"),
+        )
+    if not _index_exists(_TABLE, _DEDUPE_INDEX):
+        op.create_index(_DEDUPE_INDEX, _TABLE, ["dedupe_key"], unique=True)
+    if not _index_exists(_TABLE, _CLAIM_INDEX):
+        op.create_index(
+            _CLAIM_INDEX,
+            _TABLE,
+            ["state", "next_attempt_at", "lease_expires_at", "created_at"],
+        )
+    if not _index_exists(_TABLE, _AGGREGATE_INDEX):
+        op.create_index(
+            _AGGREGATE_INDEX,
+            _TABLE,
+            ["aggregate_type", "aggregate_id", sa.text("created_at DESC")],
+        )
+    if not _index_exists(_TABLE, _PROVIDER_KEY_INDEX):
+        op.create_index(_PROVIDER_KEY_INDEX, _TABLE, ["provider_operation_key"])
+
+
+def downgrade() -> None:
+    if _table_exists(_TABLE):
+        for index_name in (
+            _PROVIDER_KEY_INDEX,
+            _AGGREGATE_INDEX,
+            _CLAIM_INDEX,
+            _DEDUPE_INDEX,
+        ):
+            if _index_exists(_TABLE, index_name):
+                op.drop_index(index_name, table_name=_TABLE)
+        op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     desc,
     func,
     inspect,
+    or_,
     text,
     select,
 )
@@ -80,6 +81,7 @@ from control_plane.contracts.odoo_stable_bootstrap_operation import (
 from control_plane.contracts.odoo_stable_target_replacement_operation import (
     OdooStableTargetReplacementOperationRecord,
 )
+from control_plane.contracts.outbox_delivery import OutboxDeliveryRecord
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
@@ -232,6 +234,26 @@ class RouteBindingMutationResult(NamedTuple):
     idempotency_record: LaunchplaneIdempotencyRecord | None = None
 
 
+OutboxDeliveryClaimStatus = Literal["claimed", "empty"]
+OutboxDeliveryCompletionStatus = Literal[
+    "updated",
+    "missing",
+    "not_running",
+    "owner_mismatch",
+    "lease_expired",
+]
+
+
+class OutboxDeliveryClaimResult(NamedTuple):
+    status: OutboxDeliveryClaimStatus
+    record: OutboxDeliveryRecord | None = None
+
+
+class OutboxDeliveryCompletionResult(NamedTuple):
+    status: OutboxDeliveryCompletionStatus
+    record: OutboxDeliveryRecord | None = None
+
+
 @dataclass(frozen=True)
 class DbOnlyMutationRequest:
     scope: str
@@ -243,6 +265,12 @@ class DbOnlyMutationRequest:
     response_trace_id: str
     response_payload: dict[str, Any]
     lease_seconds: int = 300
+
+
+@dataclass(frozen=True)
+class OutboxWithIdempotencyRequest:
+    delivery: OutboxDeliveryRecord
+    idempotency_record: LaunchplaneIdempotencyRecord | None = None
 
 
 def _utc_now_timestamp() -> str:
@@ -1358,6 +1386,51 @@ class LaunchplaneIdempotencyRow(Base):
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
+class LaunchplaneOutboxDeliveryRow(Base):
+    __tablename__ = "launchplane_outbox_deliveries"
+    __table_args__ = (
+        Index("launchplane_outbox_deliveries_dedupe_uidx", "dedupe_key", unique=True),
+        Index(
+            "launchplane_outbox_deliveries_claim_idx",
+            "state",
+            "next_attempt_at",
+            "lease_expires_at",
+            "created_at",
+        ),
+        Index(
+            "launchplane_outbox_deliveries_aggregate_idx",
+            "aggregate_type",
+            "aggregate_id",
+            desc("created_at"),
+        ),
+        Index(
+            "launchplane_outbox_deliveries_provider_key_idx",
+            "provider_operation_key",
+        ),
+    )
+
+    delivery_id: Mapped[str] = mapped_column(String, primary_key=True)
+    kind: Mapped[str] = mapped_column(String, nullable=False)
+    state: Mapped[str] = mapped_column(String, nullable=False)
+    aggregate_type: Mapped[str] = mapped_column(String, nullable=False)
+    aggregate_id: Mapped[str] = mapped_column(String, nullable=False)
+    dedupe_key: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[str] = mapped_column(String, nullable=False)
+    updated_at: Mapped[str] = mapped_column(String, nullable=False)
+    next_attempt_at: Mapped[str] = mapped_column(String, nullable=False)
+    lease_owner: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    lease_expires_at: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    attempt: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    max_attempts: Mapped[int] = mapped_column(Integer, nullable=False, server_default="6")
+    provider_operation_key: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    provider_id: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    external_id: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    external_url: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    action: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    error_code: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
 class LaunchplaneOdooStableBootstrapOperationRow(Base):
     __tablename__ = "launchplane_odoo_stable_bootstrap_operations"
     __table_args__ = (
@@ -2301,6 +2374,55 @@ class PostgresRecordStore(HumanSessionStore):
         row.recorded_at = record.recorded_at
         row.payload = self._payload_dict(record)
 
+    def _outbox_delivery_row(self, record: OutboxDeliveryRecord) -> LaunchplaneOutboxDeliveryRow:
+        return LaunchplaneOutboxDeliveryRow(
+            delivery_id=record.delivery_id,
+            kind=record.kind,
+            state=record.state,
+            aggregate_type=record.aggregate_type,
+            aggregate_id=record.aggregate_id,
+            dedupe_key=record.dedupe_key,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+            next_attempt_at=record.next_attempt_at,
+            lease_owner=record.lease_owner,
+            lease_expires_at=record.lease_expires_at,
+            attempt=record.attempt,
+            max_attempts=record.max_attempts,
+            provider_operation_key=record.provider_operation_key,
+            provider_id=record.provider_id,
+            external_id=record.external_id,
+            external_url=record.external_url,
+            action=record.action,
+            error_code=record.error_code,
+            payload=self._payload_dict(record),
+        )
+
+    def _sync_outbox_delivery_row(
+        self,
+        row: LaunchplaneOutboxDeliveryRow,
+        record: OutboxDeliveryRecord,
+    ) -> None:
+        row.kind = record.kind
+        row.state = record.state
+        row.aggregate_type = record.aggregate_type
+        row.aggregate_id = record.aggregate_id
+        row.dedupe_key = record.dedupe_key
+        row.created_at = record.created_at
+        row.updated_at = record.updated_at
+        row.next_attempt_at = record.next_attempt_at
+        row.lease_owner = record.lease_owner
+        row.lease_expires_at = record.lease_expires_at
+        row.attempt = record.attempt
+        row.max_attempts = record.max_attempts
+        row.provider_operation_key = record.provider_operation_key
+        row.provider_id = record.provider_id
+        row.external_id = record.external_id
+        row.external_url = record.external_url
+        row.action = record.action
+        row.error_code = record.error_code
+        row.payload = self._payload_dict(record)
+
     def _idempotency_statement(
         self,
         *,
@@ -2382,6 +2504,15 @@ class PostgresRecordStore(HumanSessionStore):
         payload.update(updates)
         return LaunchplaneIdempotencyRecord.model_validate(payload)
 
+    def _updated_outbox_delivery_record(
+        self,
+        record: OutboxDeliveryRecord,
+        **updates: object,
+    ) -> OutboxDeliveryRecord:
+        payload = record.model_dump(mode="json")
+        payload.update(updates)
+        return OutboxDeliveryRecord.model_validate(payload)
+
     def _mutation_transition_identity(
         self,
         record: LaunchplaneIdempotencyRecord,
@@ -2414,6 +2545,256 @@ class PostgresRecordStore(HumanSessionStore):
                 "Running or reconcile-required reservations must use mutation reservation methods."
             )
         self._write_row(self._idempotency_row(record))
+
+    def write_outbox_delivery_record(self, record: OutboxDeliveryRecord) -> None:
+        self._write_row(self._outbox_delivery_row(record))
+
+    def enqueue_outbox_delivery_with_idempotency(
+        self, request: OutboxWithIdempotencyRequest
+    ) -> OutboxDeliveryRecord:
+        if (
+            request.idempotency_record is not None
+            and request.idempotency_record.state != "completed"
+        ):
+            raise ValueError("Outbox idempotency evidence must be completed replay evidence.")
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            existing_row = session.scalar(
+                select(LaunchplaneOutboxDeliveryRow)
+                .where(LaunchplaneOutboxDeliveryRow.dedupe_key == request.delivery.dedupe_key)
+                .limit(1)
+            )
+            if existing_row is None:
+                delivery = request.delivery
+                session.add(self._outbox_delivery_row(delivery))
+            else:
+                delivery = self._read_payload(
+                    model_type=OutboxDeliveryRecord,
+                    payload=existing_row.payload,
+                )
+            if request.idempotency_record is not None:
+                session.merge(self._idempotency_row(request.idempotency_record))
+            session.commit()
+            return delivery
+
+    def read_outbox_delivery_record(self, delivery_id: str) -> OutboxDeliveryRecord:
+        return self._read_model(
+            model_type=OutboxDeliveryRecord,
+            orm_model=LaunchplaneOutboxDeliveryRow,
+            filters=(LaunchplaneOutboxDeliveryRow.delivery_id == delivery_id,),
+        )
+
+    def list_outbox_delivery_records(
+        self,
+        *,
+        states: tuple[str, ...] = (),
+        kind: str = "",
+        aggregate_type: str = "",
+        aggregate_id: str = "",
+        limit: int | None = None,
+    ) -> tuple[OutboxDeliveryRecord, ...]:
+        filters: list[object] = []
+        if states:
+            filters.append(LaunchplaneOutboxDeliveryRow.state.in_(states))
+        if kind:
+            filters.append(LaunchplaneOutboxDeliveryRow.kind == kind)
+        if aggregate_type:
+            filters.append(LaunchplaneOutboxDeliveryRow.aggregate_type == aggregate_type)
+        if aggregate_id:
+            filters.append(LaunchplaneOutboxDeliveryRow.aggregate_id == aggregate_id)
+        return self._list_models(
+            model_type=OutboxDeliveryRecord,
+            orm_model=LaunchplaneOutboxDeliveryRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneOutboxDeliveryRow.created_at.asc(),
+                LaunchplaneOutboxDeliveryRow.delivery_id.asc(),
+            ),
+            limit=limit,
+        )
+
+    def claim_next_outbox_delivery_record(
+        self,
+        *,
+        lease_owner: str,
+        lease_seconds: int = 300,
+        now: str = "",
+    ) -> OutboxDeliveryClaimResult:
+        normalized_lease_owner = lease_owner.strip()
+        if not normalized_lease_owner:
+            raise ValueError("Outbox delivery claim requires lease_owner.")
+        observed_at = now.strip()
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            if not observed_at:
+                observed_at = self._database_mutation_timestamp(session)
+            lease_expires_at = self._mutation_lease_expiry(
+                observed_at=observed_at,
+                lease_seconds=lease_seconds,
+            )
+            statement = (
+                select(LaunchplaneOutboxDeliveryRow)
+                .where(
+                    LaunchplaneOutboxDeliveryRow.state.in_(
+                        ("pending", "running", "reconcile_required")
+                    ),
+                    LaunchplaneOutboxDeliveryRow.next_attempt_at <= observed_at,
+                    or_(
+                        LaunchplaneOutboxDeliveryRow.state == "pending",
+                        LaunchplaneOutboxDeliveryRow.state == "reconcile_required",
+                        LaunchplaneOutboxDeliveryRow.lease_expires_at == "",
+                        LaunchplaneOutboxDeliveryRow.lease_expires_at < observed_at,
+                    ),
+                )
+                .order_by(
+                    LaunchplaneOutboxDeliveryRow.next_attempt_at.asc(),
+                    LaunchplaneOutboxDeliveryRow.created_at.asc(),
+                    LaunchplaneOutboxDeliveryRow.delivery_id.asc(),
+                )
+                .limit(1)
+            )
+            if not self.database_url.startswith("sqlite"):
+                statement = statement.with_for_update(skip_locked=True)
+            row = session.scalar(statement)
+            if row is None:
+                return OutboxDeliveryClaimResult(status="empty")
+            record = self._read_payload(model_type=OutboxDeliveryRecord, payload=row.payload)
+            if record.state == "running" and record.provider_operation_key:
+                record = self._updated_outbox_delivery_record(
+                    record,
+                    state="reconcile_required",
+                    lease_owner="",
+                    lease_expires_at="",
+                    updated_at=observed_at,
+                    next_attempt_at=observed_at,
+                    error_code="lease_expired_after_provider_marker",
+                )
+            if record.attempt >= record.max_attempts:
+                failed_record = self._updated_outbox_delivery_record(
+                    record,
+                    state="failed",
+                    lease_owner="",
+                    lease_expires_at="",
+                    updated_at=observed_at,
+                    next_attempt_at=observed_at,
+                    error_code="max_attempts_exhausted",
+                )
+                self._sync_outbox_delivery_row(row, failed_record)
+                session.commit()
+                return OutboxDeliveryClaimResult(status="empty")
+            claimed_record = self._updated_outbox_delivery_record(
+                record,
+                state="running",
+                updated_at=observed_at,
+                lease_owner=normalized_lease_owner,
+                lease_expires_at=lease_expires_at,
+                attempt=record.attempt + 1,
+                error_code="",
+            )
+            self._sync_outbox_delivery_row(row, claimed_record)
+            session.commit()
+            return OutboxDeliveryClaimResult(status="claimed", record=claimed_record)
+
+    def mark_outbox_delivery_provider_started(
+        self,
+        *,
+        record: OutboxDeliveryRecord,
+        lease_owner: str,
+        provider_operation_key: str,
+        provider_id: str = "",
+        updated_at: str = "",
+    ) -> OutboxDeliveryCompletionResult:
+        normalized_provider_operation_key = provider_operation_key.strip()
+        if not normalized_provider_operation_key:
+            raise ValueError("Outbox provider start requires provider_operation_key.")
+        return self._update_running_outbox_delivery(
+            record=record,
+            lease_owner=lease_owner,
+            updates={
+                "provider_operation_key": normalized_provider_operation_key,
+                "provider_id": provider_id.strip(),
+                "updated_at": updated_at.strip(),
+            },
+        )
+
+    def complete_outbox_delivery_record(
+        self,
+        *,
+        record: OutboxDeliveryRecord,
+        lease_owner: str,
+    ) -> OutboxDeliveryCompletionResult:
+        return self._update_running_outbox_delivery(
+            record=record,
+            lease_owner=lease_owner,
+            updates=record.model_dump(mode="json"),
+            require_terminal=True,
+        )
+
+    def _update_running_outbox_delivery(
+        self,
+        *,
+        record: OutboxDeliveryRecord,
+        lease_owner: str,
+        updates: dict[str, object],
+        require_terminal: bool = False,
+    ) -> OutboxDeliveryCompletionResult:
+        normalized_lease_owner = lease_owner.strip()
+        if not normalized_lease_owner:
+            raise ValueError("Outbox delivery update requires lease_owner.")
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            observed_at = self._database_mutation_timestamp(session)
+            statement = (
+                select(LaunchplaneOutboxDeliveryRow)
+                .where(LaunchplaneOutboxDeliveryRow.delivery_id == record.delivery_id)
+                .limit(1)
+            )
+            if not self.database_url.startswith("sqlite"):
+                statement = statement.with_for_update()
+            row = session.scalar(statement)
+            if row is None:
+                return OutboxDeliveryCompletionResult(status="missing")
+            current_record = self._read_payload(
+                model_type=OutboxDeliveryRecord,
+                payload=row.payload,
+            )
+            if current_record.state != "running":
+                return OutboxDeliveryCompletionResult(status="not_running", record=current_record)
+            if current_record.lease_owner != normalized_lease_owner:
+                return OutboxDeliveryCompletionResult(
+                    status="owner_mismatch", record=current_record
+                )
+            if current_record.lease_expires_at <= observed_at:
+                return OutboxDeliveryCompletionResult(status="lease_expired", record=current_record)
+            next_updates = dict(updates)
+            if not str(next_updates.get("updated_at") or "").strip():
+                next_updates["updated_at"] = observed_at
+            if require_terminal:
+                next_updates["lease_owner"] = ""
+                next_updates["lease_expires_at"] = ""
+            else:
+                next_updates["state"] = "running"
+                next_updates["lease_owner"] = normalized_lease_owner
+                next_updates["lease_expires_at"] = current_record.lease_expires_at
+            updated_record = self._updated_outbox_delivery_record(current_record, **next_updates)
+            if require_terminal and updated_record.kind == "public_ingress_notification":
+                attempt_payload = updated_record.payload.get("attempt_result")
+                if isinstance(attempt_payload, dict):
+                    attempt = PublicIngressNotificationAttemptRecord.model_validate(attempt_payload)
+                    session.merge(
+                        LaunchplanePublicIngressNotificationAttemptRow(
+                            attempt_id=attempt.attempt_id,
+                            incident_id=attempt.incident_id,
+                            event=attempt.event,
+                            destination_kind=attempt.destination_kind,
+                            delivery_status=attempt.delivery_status,
+                            attempted_at=attempt.attempted_at,
+                            payload=self._payload_dict(attempt),
+                        )
+                    )
+            self._sync_outbox_delivery_row(row, updated_record)
+            session.commit()
+            return OutboxDeliveryCompletionResult(status="updated", record=updated_record)
 
     def read_idempotency_record(
         self,
@@ -6395,6 +6776,43 @@ class PostgresRecordStore(HumanSessionStore):
                 payload=self._payload_dict(record),
             )
         )
+
+    def write_public_ingress_transition_with_outbox(
+        self,
+        *,
+        observation: PublicIngressObservationRecord,
+        incidents: tuple[PublicIngressIncidentRecord, ...],
+        outbox_deliveries: tuple[OutboxDeliveryRecord, ...] = (),
+    ) -> None:
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            session.merge(
+                LaunchplanePublicIngressObservationRow(
+                    record_id=observation.record_id,
+                    product=observation.product,
+                    context=observation.context,
+                    instance=observation.instance,
+                    status=observation.status,
+                    observed_at=observation.observed_at,
+                    payload=self._payload_dict(observation),
+                )
+            )
+            for incident in incidents:
+                session.merge(
+                    LaunchplanePublicIngressIncidentRow(
+                        incident_id=incident.incident_id,
+                        product=incident.product,
+                        context=incident.context,
+                        instance=incident.instance,
+                        status=incident.status,
+                        opened_at=incident.opened_at,
+                        latest_observed_at=incident.latest_observed_at,
+                        payload=self._payload_dict(incident),
+                    )
+                )
+            for delivery in outbox_deliveries:
+                session.merge(self._outbox_delivery_row(delivery))
+            session.commit()
 
     def list_public_ingress_incident_records(
         self,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -2559,6 +2559,10 @@ class PostgresRecordStore(HumanSessionStore):
             raise ValueError("Outbox idempotency evidence must be completed replay evidence.")
         with self._session_factory() as session:
             self._begin_serialized_write(session)
+            self._lock_outbox_dedupe_keys(
+                session,
+                dedupe_keys=(request.delivery.dedupe_key,),
+            )
             existing_row = session.scalar(
                 select(LaunchplaneOutboxDeliveryRow)
                 .where(LaunchplaneOutboxDeliveryRow.dedupe_key == request.delivery.dedupe_key)
@@ -2576,6 +2580,20 @@ class PostgresRecordStore(HumanSessionStore):
                 session.merge(self._idempotency_row(request.idempotency_record))
             session.commit()
             return delivery
+
+    def _lock_outbox_dedupe_keys(
+        self,
+        session: Any,
+        *,
+        dedupe_keys: tuple[str, ...],
+    ) -> None:
+        if self.database_url.startswith("sqlite"):
+            return
+        for dedupe_key in sorted(set(dedupe_keys)):
+            session.execute(
+                text("select pg_advisory_xact_lock(hashtextextended(:lock_name, 0))"),
+                {"lock_name": f"launchplane:outbox:{dedupe_key}"},
+            )
 
     def read_outbox_delivery_record(self, delivery_id: str) -> OutboxDeliveryRecord:
         return self._read_model(
@@ -2772,6 +2790,15 @@ class PostgresRecordStore(HumanSessionStore):
             if require_terminal:
                 next_updates["lease_owner"] = ""
                 next_updates["lease_expires_at"] = ""
+                if next_updates.get("state") in {"pending", "reconcile_required"}:
+                    retry_seconds = min(
+                        300,
+                        5 * (2 ** min(max(current_record.attempt - 1, 0), 6)),
+                    )
+                    next_updates["next_attempt_at"] = self._mutation_lease_expiry(
+                        observed_at=observed_at,
+                        lease_seconds=retry_seconds,
+                    )
             else:
                 next_updates["state"] = "running"
                 next_updates["lease_owner"] = normalized_lease_owner
@@ -6786,6 +6813,10 @@ class PostgresRecordStore(HumanSessionStore):
     ) -> None:
         with self._session_factory() as session:
             self._begin_serialized_write(session)
+            self._lock_outbox_dedupe_keys(
+                session,
+                dedupe_keys=tuple(delivery.dedupe_key for delivery in outbox_deliveries),
+            )
             session.merge(
                 LaunchplanePublicIngressObservationRow(
                     record_id=observation.record_id,
@@ -6811,7 +6842,13 @@ class PostgresRecordStore(HumanSessionStore):
                     )
                 )
             for delivery in outbox_deliveries:
-                session.merge(self._outbox_delivery_row(delivery))
+                existing_delivery = session.scalar(
+                    select(LaunchplaneOutboxDeliveryRow)
+                    .where(LaunchplaneOutboxDeliveryRow.dedupe_key == delivery.dedupe_key)
+                    .limit(1)
+                )
+                if existing_delivery is None:
+                    session.add(self._outbox_delivery_row(delivery))
             session.commit()
 
     def list_public_ingress_incident_records(

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -8,7 +8,7 @@ from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
-EXPECTED_ALEMBIC_HEAD_REVISION = "f2a4c6e8b0d2"
+EXPECTED_ALEMBIC_HEAD_REVISION = "a2b4c6d8e0f2"
 
 
 class SchemaInspectorProtocol(Protocol):
@@ -110,6 +110,21 @@ CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
         "payload",
         ("jsonb",),
     ),
+    CriticalColumnType(
+        "launchplane_outbox_deliveries",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_outbox_deliveries",
+        "attempt",
+        ("integer", "int4"),
+    ),
+    CriticalColumnType(
+        "launchplane_outbox_deliveries",
+        "max_attempts",
+        ("integer", "int4"),
+    ),
 )
 
 _ACTIVE_OPERATION_PREDICATE_TOKENS = ("status", "pending", "running")
@@ -186,6 +201,17 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
         "launchplane_route_bindings",
         "launchplane_route_bindings_updated_idx",
         ("updated_at",),
+    ),
+    CriticalIndex(
+        "launchplane_outbox_deliveries",
+        "launchplane_outbox_deliveries_dedupe_uidx",
+        ("dedupe_key",),
+        unique=True,
+    ),
+    CriticalIndex(
+        "launchplane_outbox_deliveries",
+        "launchplane_outbox_deliveries_claim_idx",
+        ("state", "next_attempt_at", "lease_expires_at", "created_at"),
     ),
 )
 

--- a/control_plane/workflows/generic_web_promotion_workflow.py
+++ b/control_plane/workflows/generic_web_promotion_workflow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from pathlib import Path
 import time
+from collections.abc import Callable
 from typing import Literal
 from urllib.parse import quote, urlencode
 
@@ -10,6 +11,7 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.outbox_delivery import OutboxDeliveryRecord
 from control_plane.workflows.generic_web_deploy import product_profile_uses_generic_web_base
 from control_plane.workflows.launchplane import github_api_request, resolve_launchplane_github_token
 
@@ -47,7 +49,7 @@ class GenericWebPromotionWorkflowResult(BaseModel):
     ref: str
     dry_run: bool
     bump: BumpLevel
-    dispatch_status: Literal["dispatched"] = "dispatched"
+    dispatch_status: Literal["pending", "dispatched"] = "dispatched"
     run_id: int = 0
     run_url: str = ""
     run_status: str = "pending"
@@ -128,6 +130,93 @@ def dispatch_generic_web_promotion_workflow(
         run_status=_string_value(run.get("status")) if run else "pending",
         run_conclusion=_string_value(run.get("conclusion")) if run else "",
     )
+
+
+def dispatch_generic_web_promotion_workflow_delivery(
+    *,
+    record: OutboxDeliveryRecord,
+    control_plane_root: Path,
+    mark_provider_started: Callable[[str, str], None],
+) -> OutboxDeliveryRecord:
+    delivery_record = record
+    payload = record.payload
+    try:
+        owner, repo = _repository_parts(_required_payload_text(payload, "repository"))
+        workflow_id = _required_payload_text(payload, "workflow_id")
+        ref = _required_payload_text(payload, "ref")
+        credential_context = _required_payload_text(payload, "credential_context")
+        inputs = _string_dict(payload.get("inputs"))
+        previous_run_ids = _int_set(payload.get("previous_run_ids"))
+        min_created_at = _datetime_value(payload.get("dispatch_started_at"))
+        if min_created_at is None:
+            min_created_at = datetime.now(UTC)
+        token = resolve_launchplane_github_token(
+            control_plane_root=control_plane_root,
+            context_name=credential_context,
+        )
+        if not token:
+            return _failed_outbox_delivery(record, "missing_managed_github_token")
+        provider_operation_key = _workflow_provider_operation_key(
+            repository=f"{owner}/{repo}",
+            workflow_id=workflow_id,
+            ref=ref,
+            dispatch_started_at=_github_timestamp_precision(min_created_at)
+            .isoformat()
+            .replace("+00:00", "Z"),
+            inputs=inputs,
+        )
+        if (
+            record.provider_operation_key
+            and record.provider_operation_key != provider_operation_key
+        ):
+            return _failed_outbox_delivery(record, "provider_marker_mismatch")
+        delivery_record = record.model_copy(
+            update={
+                "provider_operation_key": provider_operation_key,
+                "provider_id": "github",
+            }
+        )
+        if not record.provider_operation_key:
+            mark_provider_started(provider_operation_key, "github")
+        existing_run = _latest_workflow_dispatch_run(
+            owner=owner,
+            repo=repo,
+            workflow_id=workflow_id,
+            ref=ref,
+            token=token,
+            previous_run_ids=previous_run_ids,
+            min_created_at=min_created_at,
+        )
+        if existing_run:
+            return _delivered_workflow_outbox_delivery(delivery_record, existing_run)
+        github_api_request(
+            path=f"/repos/{owner}/{repo}/actions/workflows/{quote(workflow_id, safe='')}/dispatches",
+            token=token,
+            method="POST",
+            body={"ref": ref, "inputs": inputs},
+        )
+        run = _wait_for_workflow_run(
+            owner=owner,
+            repo=repo,
+            workflow_id=workflow_id,
+            ref=ref,
+            token=token,
+            previous_run_ids=previous_run_ids,
+            min_created_at=min_created_at,
+            timeout_seconds=_bounded_observe_timeout(payload.get("observe_timeout_seconds")),
+        )
+        if run:
+            return _delivered_workflow_outbox_delivery(delivery_record, run)
+        return delivery_record.model_copy(
+            update={
+                "state": "reconcile_required",
+                "provider_operation_key": provider_operation_key,
+                "provider_id": "github",
+                "action": "workflow_dispatch_sent",
+            }
+        )
+    except Exception as error:  # noqa: BLE001 - worker stores bounded provider-safe errors.
+        return _failed_outbox_delivery(delivery_record, _provider_safe_error_code(error))
 
 
 def _normalize_bump(value: str) -> BumpLevel:
@@ -273,3 +362,90 @@ def _datetime_value(value: object) -> datetime | None:
 
 def _github_timestamp_precision(value: datetime) -> datetime:
     return value.astimezone(UTC).replace(microsecond=0)
+
+
+def _workflow_provider_operation_key(
+    *,
+    repository: str,
+    workflow_id: str,
+    ref: str,
+    dispatch_started_at: str,
+    inputs: dict[str, str],
+) -> str:
+    input_fingerprint = "|".join(f"{key}={inputs[key]}" for key in sorted(inputs))
+    return ":".join(
+        (
+            "github_workflow_dispatch",
+            repository.strip(),
+            workflow_id.strip(),
+            ref.strip(),
+            dispatch_started_at.strip(),
+            input_fingerprint,
+        )
+    )
+
+
+def _delivered_workflow_outbox_delivery(
+    record: OutboxDeliveryRecord,
+    run: dict[str, object],
+) -> OutboxDeliveryRecord:
+    return record.model_copy(
+        update={
+            "state": "delivered",
+            "provider_id": "github",
+            "external_id": str(_int_value(run.get("id")) or ""),
+            "external_url": _string_value(run.get("html_url")),
+            "action": "dispatched_workflow",
+            "error_code": "",
+            "lease_owner": "",
+            "lease_expires_at": "",
+        }
+    )
+
+
+def _failed_outbox_delivery(record: OutboxDeliveryRecord, error_code: str) -> OutboxDeliveryRecord:
+    return record.model_copy(
+        update={
+            "state": "failed",
+            "error_code": error_code.strip() or "provider_error",
+            "action": "",
+            "external_id": "",
+            "external_url": "",
+            "lease_owner": "",
+            "lease_expires_at": "",
+        }
+    )
+
+
+def _provider_safe_error_code(error: Exception) -> str:
+    if isinstance(error, click.ClickException):
+        return "github_dispatch_invalid_request"
+    return "github_provider_error"
+
+
+def _required_payload_text(payload: dict[str, object], key: str) -> str:
+    value = _optional_payload_text(payload, key)
+    if not value:
+        raise click.ClickException(f"outbox workflow dispatch payload missing {key}")
+    return value
+
+
+def _optional_payload_text(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _string_dict(value: object) -> dict[str, str]:
+    if not isinstance(value, dict):
+        return {}
+    return {str(key): str(item) for key, item in value.items()}
+
+
+def _int_set(value: object) -> set[int]:
+    if not isinstance(value, list):
+        return set()
+    return {item for item in value if isinstance(item, int)}
+
+
+def _bounded_observe_timeout(value: object) -> int:
+    return value if isinstance(value, int) and 0 <= value <= 60 else 0

--- a/control_plane/workflows/generic_web_promotion_workflow.py
+++ b/control_plane/workflows/generic_web_promotion_workflow.py
@@ -11,7 +11,10 @@ import click
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
-from control_plane.contracts.outbox_delivery import OutboxDeliveryRecord
+from control_plane.contracts.outbox_delivery import (
+    OutboxDeliveryRecord,
+    retry_outbox_delivery,
+)
 from control_plane.workflows.generic_web_deploy import product_profile_uses_generic_web_base
 from control_plane.workflows.launchplane import github_api_request, resolve_launchplane_github_token
 
@@ -176,19 +179,21 @@ def dispatch_generic_web_promotion_workflow_delivery(
                 "provider_id": "github",
             }
         )
-        if not record.provider_operation_key:
+        reconciling_existing_marker = bool(record.provider_operation_key)
+        if not reconciling_existing_marker:
             mark_provider_started(provider_operation_key, "github")
-        existing_run = _latest_workflow_dispatch_run(
-            owner=owner,
-            repo=repo,
-            workflow_id=workflow_id,
-            ref=ref,
-            token=token,
-            previous_run_ids=previous_run_ids,
-            min_created_at=min_created_at,
-        )
-        if existing_run:
-            return _delivered_workflow_outbox_delivery(delivery_record, existing_run)
+        else:
+            existing_run = _latest_workflow_dispatch_run(
+                owner=owner,
+                repo=repo,
+                workflow_id=workflow_id,
+                ref=ref,
+                token=token,
+                previous_run_ids=previous_run_ids,
+                min_created_at=min_created_at,
+            )
+            if existing_run:
+                return _delivered_workflow_outbox_delivery(delivery_record, existing_run)
         github_api_request(
             path=f"/repos/{owner}/{repo}/actions/workflows/{quote(workflow_id, safe='')}/dispatches",
             token=token,
@@ -215,8 +220,18 @@ def dispatch_generic_web_promotion_workflow_delivery(
                 "action": "workflow_dispatch_sent",
             }
         )
-    except Exception as error:  # noqa: BLE001 - worker stores bounded provider-safe errors.
-        return _failed_outbox_delivery(delivery_record, _provider_safe_error_code(error))
+    except click.ClickException as error:
+        if error.__cause__ is None:
+            return _failed_outbox_delivery(delivery_record, _provider_safe_error_code(error))
+        return retry_outbox_delivery(
+            delivery_record,
+            error_code=_provider_safe_error_code(error),
+        )
+    except Exception as error:  # noqa: BLE001 - provider failures remain bounded retries.
+        return retry_outbox_delivery(
+            delivery_record,
+            error_code=_provider_safe_error_code(error),
+        )
 
 
 def _normalize_bump(value: str) -> BumpLevel:
@@ -418,7 +433,7 @@ def _failed_outbox_delivery(record: OutboxDeliveryRecord, error_code: str) -> Ou
 
 
 def _provider_safe_error_code(error: Exception) -> str:
-    if isinstance(error, click.ClickException):
+    if isinstance(error, click.ClickException) and error.__cause__ is None:
         return "github_dispatch_invalid_request"
     return "github_provider_error"
 

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -21,6 +21,7 @@ from control_plane.contracts.outbox_delivery import (
     OutboxDeliveryRecord,
     build_outbox_dedupe_key,
     build_outbox_delivery_id,
+    retry_outbox_delivery,
 )
 from control_plane.contracts.product_health_monitoring_migration import (
     canonical_health_check_record_token,
@@ -39,6 +40,7 @@ from control_plane.contracts.public_ingress_monitoring import (
     PublicIngressNotificationAttemptRecord,
     PublicIngressNotificationDeliveryStatus,
     PublicIngressNotificationDestination,
+    PublicIngressNotificationDestinationKind,
     PublicIngressNotificationPolicyRecord,
     PublicIngressObservationRecord,
     PublicIngressObservationStatus,
@@ -395,11 +397,14 @@ def run_public_ingress_monitor_once(
             1 for incident in incident_records if incident.status == "resolved"
         )
         for incident in incident_records:
-            if (
-                notify
-                and notification_drivers is not None
-                and not (callable(transition_writer) and outbox_deliveries)
-            ):
+            if notify and notification_drivers is not None:
+                direct_destination_kinds: (
+                    tuple[PublicIngressNotificationDestinationKind, ...] | None
+                ) = None
+                if callable(transition_writer) and any(
+                    delivery.aggregate_id == incident.incident_id for delivery in outbox_deliveries
+                ):
+                    direct_destination_kinds = ("email", "discord")
                 delivery_attempts.extend(
                     deliver_public_ingress_incident_notifications(
                         record_store=record_store,
@@ -407,6 +412,7 @@ def run_public_ingress_monitor_once(
                         incident=incident,
                         observation=record,
                         drivers=notification_drivers,
+                        destination_kinds=direct_destination_kinds,
                     )
                 )
     return PublicIngressMonitorResult(
@@ -431,10 +437,13 @@ def deliver_public_ingress_incident_notifications(
     incident: PublicIngressIncidentRecord,
     observation: PublicIngressObservationRecord,
     drivers: PublicIngressNotificationDrivers,
+    destination_kinds: tuple[PublicIngressNotificationDestinationKind, ...] | None = None,
 ) -> tuple[PublicIngressNotificationAttemptRecord, ...]:
     attempts: list[PublicIngressNotificationAttemptRecord] = []
     for policy in _matching_notification_policies(record_store=record_store, incident=incident):
         for destination in policy.destinations:
+            if destination_kinds is not None and destination.kind not in destination_kinds:
+                continue
             attempt_id = build_public_ingress_notification_attempt_id(
                 incident_id=incident.incident_id,
                 event=event,
@@ -1309,6 +1318,15 @@ def deliver_public_ingress_notification_outbox_delivery(
                 },
             )
             if reconciled_response:
+                if action == "close":
+                    reconciled_response = drivers.github_client(
+                        "ensure_closed",
+                        {
+                            "repository": destination.github_repository,
+                            "issue_number": destination.github_issue_number,
+                            "issue_url": existing_issue_url,
+                        },
+                    )
                 return _delivered_public_ingress_outbox_delivery(
                     record=delivery_record,
                     payload=payload,
@@ -1338,7 +1356,7 @@ def deliver_public_ingress_notification_outbox_delivery(
             marker=marker,
             response=response,
         )
-    except Exception as error:  # noqa: BLE001 - worker stores bounded provider-safe errors.
+    except (ValueError, KeyError) as error:
         return delivery_record.model_copy(
             update={
                 "state": "failed",
@@ -1346,6 +1364,11 @@ def deliver_public_ingress_notification_outbox_delivery(
                 "lease_owner": "",
                 "lease_expires_at": "",
             }
+        )
+    except Exception as error:  # noqa: BLE001 - provider failures remain bounded retries.
+        return retry_outbox_delivery(
+            delivery_record,
+            error_code=_public_ingress_provider_safe_error_code(error),
         )
 
 
@@ -1622,6 +1645,28 @@ def _gh_issue_client(
             payload=payload,
             token=resolved_token,
         )
+    if action == "ensure_closed":
+        repository, issue_number = _github_issue_reference(payload)
+        issue = _github_api_request(
+            method="GET",
+            path=f"/repos/{repository}/issues/{issue_number}",
+            token=resolved_token,
+        )
+        if not isinstance(issue, dict):
+            raise RuntimeError("GitHub issue lookup response must be a JSON object.")
+        if str(issue.get("state") or "").strip().lower() != "closed":
+            issue = _github_api_request(
+                method="PATCH",
+                path=f"/repos/{repository}/issues/{issue_number}",
+                token=resolved_token,
+                body={"state": "closed", "state_reason": "completed"},
+            )
+            if not isinstance(issue, dict):
+                raise RuntimeError("GitHub issue close response must be a JSON object.")
+        return {
+            "url": str(issue.get("html_url") or issue.get("url") or "").strip(),
+            "id": str(issue.get("node_id") or issue.get("id") or "").strip(),
+        }
     if action == "create":
         repository = _github_repository_path(str(payload["repository"]))
         body: dict[str, object] = {

--- a/control_plane/workflows/public_ingress_monitor.py
+++ b/control_plane/workflows/public_ingress_monitor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from email.message import EmailMessage
 from typing import Protocol, cast
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import quote, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
 import json
 import os
@@ -17,6 +17,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.outbox_delivery import (
+    OutboxDeliveryRecord,
+    build_outbox_dedupe_key,
+    build_outbox_delivery_id,
+)
 from control_plane.contracts.product_health_monitoring_migration import (
     canonical_health_check_record_token,
 )
@@ -354,20 +359,47 @@ def run_public_ingress_monitor_once(
             timeout_seconds=timeout_seconds,
             http_get=(private_get if target.check_kind == "private_http" else public_get),
         )
-        record_store.write_public_ingress_observation_record(record)
         records.append(record)
         incident_records = reconcile_public_ingress_incident(
             record_store=record_store,
             record=record,
             previous_record=previous_record,
+            write_records=False,
         )
+        outbox_deliveries = (
+            _public_ingress_notification_outbox_deliveries(
+                record_store=record_store,
+                incident_records=incident_records,
+                observation=record,
+                previous_record=previous_record,
+            )
+            if notify
+            else ()
+        )
+        transition_writer = getattr(
+            record_store, "write_public_ingress_transition_with_outbox", None
+        )
+        if callable(transition_writer) and outbox_deliveries:
+            transition_writer(
+                observation=record,
+                incidents=incident_records,
+                outbox_deliveries=outbox_deliveries,
+            )
+        else:
+            record_store.write_public_ingress_observation_record(record)
+            for incident in incident_records:
+                record_store.write_public_ingress_incident_record(incident)
         incidents.extend(incident_records)
         open_incident_count += sum(1 for incident in incident_records if incident.status == "open")
         resolved_incident_count += sum(
             1 for incident in incident_records if incident.status == "resolved"
         )
         for incident in incident_records:
-            if notify and notification_drivers is not None:
+            if (
+                notify
+                and notification_drivers is not None
+                and not (callable(transition_writer) and outbox_deliveries)
+            ):
                 delivery_attempts.extend(
                     deliver_public_ingress_incident_notifications(
                         record_store=record_store,
@@ -456,11 +488,90 @@ def deliver_public_ingress_incident_notifications(
     return tuple(attempts)
 
 
+def _public_ingress_notification_outbox_deliveries(
+    *,
+    record_store: PublicIngressMonitorStore,
+    incident_records: tuple[PublicIngressIncidentRecord, ...],
+    observation: PublicIngressObservationRecord,
+    previous_record: PublicIngressObservationRecord | None,
+) -> tuple[OutboxDeliveryRecord, ...]:
+    deliveries: list[OutboxDeliveryRecord] = []
+    for incident in incident_records:
+        event = _incident_event(incident=incident, previous_record=previous_record)
+        for policy in _matching_notification_policies(record_store=record_store, incident=incident):
+            for destination in policy.destinations:
+                if destination.kind != "github_issue" or destination.status != "enabled":
+                    continue
+                attempt_id = build_public_ingress_notification_attempt_id(
+                    incident_id=incident.incident_id,
+                    event=event,
+                    policy_id=policy.policy_id,
+                    destination_id=destination.destination_id,
+                    observation_id=observation.record_id,
+                )
+                existing_attempt = _notification_attempt(
+                    record_store=record_store,
+                    attempt_id=attempt_id,
+                    incident_id=incident.incident_id,
+                    event=event,
+                )
+                if existing_attempt is not None:
+                    continue
+                previous_attempts = record_store.list_public_ingress_notification_attempt_records(
+                    incident_id=incident.incident_id,
+                    destination_kind="github_issue",
+                )
+                body = public_ingress_incident_notification_body(
+                    event=event,
+                    incident=incident,
+                    observation=observation,
+                    marker=attempt_id,
+                )
+                dedupe_key = build_outbox_dedupe_key(
+                    kind="public_ingress_notification",
+                    parts=(attempt_id,),
+                )
+                created_at = observation.observed_at
+                deliveries.append(
+                    OutboxDeliveryRecord(
+                        delivery_id=build_outbox_delivery_id(
+                            kind="public_ingress_notification",
+                            dedupe_key=dedupe_key,
+                        ),
+                        kind="public_ingress_notification",
+                        aggregate_type="public_ingress_incident",
+                        aggregate_id=incident.incident_id,
+                        dedupe_key=dedupe_key,
+                        created_at=created_at,
+                        updated_at=created_at,
+                        next_attempt_at=created_at,
+                        payload={
+                            "attempt": {
+                                "attempt_id": attempt_id,
+                                "incident_id": incident.incident_id,
+                                "event": event,
+                                "policy_id": policy.policy_id,
+                                "destination_id": destination.destination_id,
+                                "destination_kind": destination.kind,
+                                "attempted_at": observation.observed_at,
+                                "observation_id": observation.record_id,
+                            },
+                            "destination": _github_notification_destination_payload(destination),
+                            "body": body,
+                            "existing_issue_url": _latest_external_url(previous_attempts),
+                            "marker": attempt_id,
+                        },
+                    )
+                )
+    return tuple(deliveries)
+
+
 def reconcile_public_ingress_incident(
     *,
     record_store: PublicIngressMonitorStore,
     record: PublicIngressObservationRecord,
     previous_record: PublicIngressObservationRecord | None,
+    write_records: bool = True,
 ) -> tuple[PublicIngressIncidentRecord, ...]:
     open_incidents = _open_incidents(record_store=record_store, record=record)
     if record.status == "fail":
@@ -500,7 +611,8 @@ def reconcile_public_ingress_incident(
                 failure_code=record.failure_code or "unknown_error",
                 summary=record.summary,
             )
-        record_store.write_public_ingress_incident_record(incident)
+        if write_records:
+            record_store.write_public_ingress_incident_record(incident)
         return (incident,)
     if record.status == "pass" and open_incidents:
         resolved_incidents: list[PublicIngressIncidentRecord] = []
@@ -515,7 +627,8 @@ def reconcile_public_ingress_incident(
                     "summary": record.summary,
                 }
             )
-            record_store.write_public_ingress_incident_record(incident)
+            if write_records:
+                record_store.write_public_ingress_incident_record(incident)
             resolved_incidents.append(incident)
         return tuple(resolved_incidents)
     return ()
@@ -1153,6 +1266,89 @@ def public_ingress_notification_drivers(
     )
 
 
+def deliver_public_ingress_notification_outbox_delivery(
+    *,
+    record: OutboxDeliveryRecord,
+    drivers: PublicIngressNotificationDriverSet,
+    mark_provider_started: Callable[[str, str], None],
+) -> OutboxDeliveryRecord:
+    delivery_record = record
+    try:
+        payload = record.payload
+        attempt_payload = _dict_payload(payload.get("attempt"))
+        destination = PublicIngressNotificationDestination.model_validate(
+            _dict_payload(payload.get("destination"))
+        )
+        body = _required_payload_text(payload, "body")
+        marker = _required_payload_text(payload, "marker")
+        existing_issue_url = _optional_payload_text(payload, "existing_issue_url")
+        action = "create" if not existing_issue_url else "comment"
+        if attempt_payload.get("event") == "resolved" and existing_issue_url:
+            action = "close"
+        provider_operation_key = ":".join(
+            (
+                "public_ingress_notification",
+                str(attempt_payload.get("attempt_id") or "").strip(),
+                action,
+            )
+        )
+        delivery_record = record.model_copy(
+            update={
+                "provider_operation_key": provider_operation_key,
+                "provider_id": "github",
+            }
+        )
+        if record.provider_operation_key:
+            reconciled_response = drivers.github_client(
+                "find_marker",
+                {
+                    "repository": destination.github_repository,
+                    "issue_number": destination.github_issue_number,
+                    "issue_url": existing_issue_url,
+                    "marker": marker,
+                },
+            )
+            if reconciled_response:
+                return _delivered_public_ingress_outbox_delivery(
+                    record=delivery_record,
+                    payload=payload,
+                    attempt_payload=attempt_payload,
+                    action=action,
+                    marker=marker,
+                    response=reconciled_response,
+                )
+        else:
+            mark_provider_started(provider_operation_key, "github")
+        response = drivers.github_client(
+            action,
+            {
+                "repository": destination.github_repository,
+                "title": f"Public ingress incident: {attempt_payload.get('incident_id', '')}",
+                "body": body,
+                "labels": [destination.github_label] if destination.github_label else [],
+                "issue_number": destination.github_issue_number,
+                "issue_url": existing_issue_url,
+            },
+        )
+        return _delivered_public_ingress_outbox_delivery(
+            record=delivery_record,
+            payload=payload,
+            attempt_payload=attempt_payload,
+            action=action,
+            marker=marker,
+            response=response,
+        )
+    except Exception as error:  # noqa: BLE001 - worker stores bounded provider-safe errors.
+        return delivery_record.model_copy(
+            update={
+                "state": "failed",
+                "error_code": _public_ingress_provider_safe_error_code(error),
+                "lease_owner": "",
+                "lease_expires_at": "",
+            }
+        )
+
+
 def _deliver_github_issue_notification(
     *,
     destination: PublicIngressNotificationDestination,
@@ -1210,6 +1406,99 @@ def _deliver_github_issue_notification(
         external_url=str(response.get("url", issue_url)).strip(),
         external_id=str(response.get("id", "")).strip(),
     )
+
+
+def _github_notification_action_name(action: str) -> str:
+    if action == "create":
+        return "created_issue"
+    if action == "close":
+        return "closed_issue"
+    return "commented_issue"
+
+
+def _delivered_public_ingress_outbox_delivery(
+    *,
+    record: OutboxDeliveryRecord,
+    payload: dict[str, object],
+    attempt_payload: dict[str, object],
+    action: str,
+    marker: str,
+    response: dict[str, object],
+) -> OutboxDeliveryRecord:
+    attempt = PublicIngressNotificationAttemptRecord(
+        attempt_id=str(attempt_payload["attempt_id"]),
+        incident_id=str(attempt_payload["incident_id"]),
+        event=_public_ingress_event_value(attempt_payload.get("event")),
+        policy_id=str(attempt_payload["policy_id"]),
+        destination_id=str(attempt_payload["destination_id"]),
+        destination_kind="github_issue",
+        delivery_status="delivered",
+        attempted_at=str(attempt_payload["attempted_at"]),
+        observation_id=str(attempt_payload["observation_id"]),
+        external_url=str(response.get("url", "")).strip(),
+        external_id=str(response.get("id", "")).strip() or marker,
+        action=_github_notification_action_name(action),
+    )
+    return record.model_copy(
+        update={
+            "state": "delivered",
+            "provider_id": "github",
+            "external_id": attempt.external_id,
+            "external_url": attempt.external_url,
+            "action": attempt.action,
+            "error_code": "",
+            "lease_owner": "",
+            "lease_expires_at": "",
+            "payload": {**payload, "attempt_result": attempt.model_dump(mode="json")},
+        }
+    )
+
+
+def _github_notification_destination_payload(
+    destination: PublicIngressNotificationDestination,
+) -> dict[str, object]:
+    return {
+        "destination_id": destination.destination_id,
+        "kind": destination.kind,
+        "status": destination.status,
+        "github_repository": destination.github_repository,
+        "github_issue_number": destination.github_issue_number,
+        "github_label": destination.github_label,
+    }
+
+
+def _dict_payload(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError("outbox public ingress payload is malformed")
+    return {str(key): item for key, item in value.items()}
+
+
+def _required_payload_text(payload: dict[str, object], key: str) -> str:
+    value = _optional_payload_text(payload, key)
+    if not value:
+        raise ValueError(f"outbox public ingress payload missing {key}")
+    return value
+
+
+def _optional_payload_text(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _public_ingress_provider_safe_error_code(error: Exception) -> str:
+    if isinstance(error, (ValueError, KeyError)):
+        return "invalid_outbox_payload"
+    return "github_provider_error"
+
+
+def _public_ingress_event_value(value: object) -> PublicIngressIncidentEvent:
+    if value == "opened":
+        return "opened"
+    if value == "updated":
+        return "updated"
+    if value == "resolved":
+        return "resolved"
+    raise ValueError("outbox public ingress payload has invalid event")
 
 
 def _deliver_email_notification(
@@ -1292,6 +1581,7 @@ def public_ingress_incident_notification_body(
     event: PublicIngressIncidentEvent,
     incident: PublicIngressIncidentRecord,
     observation: PublicIngressObservationRecord,
+    marker: str = "",
 ) -> str:
     lines = [
         f"Launchplane public ingress incident {event}: {incident.product}/{incident.instance}",
@@ -1306,6 +1596,9 @@ def public_ingress_incident_notification_body(
     ]
     for target in observation.targets:
         lines.append(f"- {target.target}: {target.status} {target.summary}")
+    if marker.strip():
+        lines.append("")
+        lines.append(f"<!-- launchplane-public-ingress-notification:{marker.strip()} -->")
     return "\n".join(lines)
 
 
@@ -1324,6 +1617,11 @@ def _gh_issue_client(
     action: str, payload: dict[str, object], *, token: str | None = None
 ) -> dict[str, object]:
     resolved_token = _public_ingress_github_token(token)
+    if action == "find_marker":
+        return _find_github_issue_notification_marker(
+            payload=payload,
+            token=resolved_token,
+        )
     if action == "create":
         repository = _github_repository_path(str(payload["repository"]))
         body: dict[str, object] = {
@@ -1368,6 +1666,63 @@ def _gh_issue_client(
     return {
         "url": str(response.get("html_url") or response.get("url") or "").strip(),
         "id": str(response.get("node_id") or response.get("id") or "").strip(),
+    }
+
+
+def _find_github_issue_notification_marker(
+    *, payload: dict[str, object], token: str
+) -> dict[str, object]:
+    repository = _github_repository_path(str(payload["repository"]))
+    marker = str(payload.get("marker", "")).strip()
+    if not marker:
+        raise ValueError("GitHub issue marker lookup requires marker.")
+    issue_number = payload.get("issue_number")
+    issue_url = str(payload.get("issue_url", "")).strip()
+    if issue_number is not None or issue_url:
+        issue_repository, resolved_issue_number = _github_issue_reference(payload)
+        if issue_repository != repository:
+            raise ValueError("GitHub issue marker repository must match notification repository.")
+        issue = _github_api_request(
+            method="GET",
+            path=f"/repos/{repository}/issues/{resolved_issue_number}",
+            token=token,
+        )
+        if isinstance(issue, dict) and _github_payload_contains_marker(issue, marker):
+            return _github_issue_marker_response(issue)
+        comments = _github_api_request(
+            method="GET",
+            path=f"/repos/{repository}/issues/{resolved_issue_number}/comments?per_page=100",
+            token=token,
+        )
+        if isinstance(comments, list):
+            for comment in comments:
+                if isinstance(comment, dict) and _github_payload_contains_marker(comment, marker):
+                    return _github_issue_marker_response(comment)
+        return {}
+    query = quote(f'repo:{repository} type:issue in:body "{marker}"', safe="")
+    search = _github_api_request(
+        method="GET",
+        path=f"/search/issues?q={query}&per_page=10",
+        token=token,
+    )
+    if isinstance(search, dict):
+        items = search.get("items")
+        if isinstance(items, list):
+            for issue in items:
+                if isinstance(issue, dict) and _github_payload_contains_marker(issue, marker):
+                    return _github_issue_marker_response(issue)
+    return {}
+
+
+def _github_payload_contains_marker(payload: dict[str, object], marker: str) -> bool:
+    body = payload.get("body")
+    return isinstance(body, str) and marker in body
+
+
+def _github_issue_marker_response(payload: dict[str, object]) -> dict[str, object]:
+    return {
+        "url": str(payload.get("html_url") or payload.get("url") or "").strip(),
+        "id": str(payload.get("node_id") or payload.get("id") or "").strip(),
     }
 
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -178,19 +178,29 @@ workers may run concurrently; the claim query uses `FOR UPDATE SKIP LOCKED` so
 one locked row does not block unrelated pending deliveries. A worker records a
 provider operation marker before the external call. If it crashes after the
 marker is recorded, the next worker reconciles provider state before resending.
-Do not update outbox rows manually or clear provider markers to force a retry.
+Transient provider failures return the row to `pending` with database-clock
+exponential backoff and retain any provider marker so the next attempt
+reconciles before resending. Attempts are bounded by the row's `max_attempts`;
+invalid payloads and exhausted retries become terminal failures. Do not update
+outbox rows manually or clear provider markers to force a retry.
 
 Generic-web promotion workflow dispatches are queued by
 `POST /v1/drivers/generic-web/prod-promotion-workflow`; the HTTP response shows
 `dispatch_status=pending` and includes `records.outbox_delivery_id`. The worker
 resolves the managed GitHub token from Launchplane runtime records, sends the
 dispatch, then marks the outbox delivery delivered when the corresponding run is
-observed.
+observed. The delivery dedupe key includes a hashed transition identity: replay
+of one request reuses its row, while a later dispatch with the same workflow
+inputs creates a new row instead of being suppressed forever.
 
 Public-ingress monitor GitHub issue notifications are also queued when the
 record store supports the transactional outbox. Observation, incident, and
-pending notification rows commit atomically. Email and Discord notification
-paths remain direct-delivery until they are explicitly migrated.
+pending notification rows commit atomically. Mixed policies queue only the
+GitHub destinations while continuing to deliver and record email and Discord
+attempts directly. Resolved-incident reconciliation verifies the issue is
+actually closed after finding the marker, covering a crash between the marker
+comment and the close request. Email and Discord notification paths remain
+direct-delivery until they are explicitly migrated.
 
 ## Target Launchplane Ingress
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -31,6 +31,9 @@ checkout.
 - `release-tuples`: inspect state-backed tuple records and explicitly export a
   TOML catalog from minted state.
 - `service`: run the first local Launchplane HTTP ingress slice.
+  `service outbox-workers run-once` and `service outbox-workers run` operate
+  PostgreSQL transactional outbox deliveries for external workflow dispatch and
+  notification effects.
 - `ship`: plan, resolve, and execute artifact-backed deploy requests.
 - `storage provider-target-audit`: run the read-only provider-target parity
   preflight before backfill or provider-target authority cutover.
@@ -151,6 +154,43 @@ still produces replay evidence. Before planning, the route uses the database
 clock to reject active claims, replay completed claims, transition bound expired
 claims to reconciliation, and release only expired unbound orphan claims that
 cannot have committed the atomic profile write.
+
+## Transactional Outbox Workers
+
+External deliveries now use PostgreSQL outbox rows instead of request-thread
+provider calls when the business transition must commit before the effect. Run
+outbox workers only against Launchplane shared storage:
+
+```bash
+uv run launchplane service outbox-workers run \
+  --database-url "$LAUNCHPLANE_DATABASE_URL"
+```
+
+For a bounded operational probe or smoke check, run one claim/delivery step:
+
+```bash
+uv run launchplane service outbox-workers run-once \
+  --database-url "$LAUNCHPLANE_DATABASE_URL"
+```
+
+Outbox workers claim due rows with leases and PostgreSQL row locks. Multiple
+workers may run concurrently; the claim query uses `FOR UPDATE SKIP LOCKED` so
+one locked row does not block unrelated pending deliveries. A worker records a
+provider operation marker before the external call. If it crashes after the
+marker is recorded, the next worker reconciles provider state before resending.
+Do not update outbox rows manually or clear provider markers to force a retry.
+
+Generic-web promotion workflow dispatches are queued by
+`POST /v1/drivers/generic-web/prod-promotion-workflow`; the HTTP response shows
+`dispatch_status=pending` and includes `records.outbox_delivery_id`. The worker
+resolves the managed GitHub token from Launchplane runtime records, sends the
+dispatch, then marks the outbox delivery delivered when the corresponding run is
+observed.
+
+Public-ingress monitor GitHub issue notifications are also queued when the
+record store supports the transactional outbox. Observation, incident, and
+pending notification rows commit atomically. Email and Discord notification
+paths remain direct-delivery until they are explicitly migrated.
 
 ## Target Launchplane Ingress
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -178,6 +178,38 @@ operation or reconciliation key before invoking the provider, and complete only
 after durable local evidence is ready. A crash or timeout after key binding is
 an unknown outcome, not permission to retry the provider mutation.
 
+## Transactional Outbox
+
+External deliveries that are not safe to perform inside the request transaction
+use `launchplane_outbox_deliveries`. Business state and the pending outbox row
+must commit in the same PostgreSQL transaction, so a crash before a worker runs
+leaves durable intent instead of a lost notification or workflow dispatch. The
+first migrated paths are generic-web promotion workflow dispatches and GitHub
+public-ingress incident notifications.
+
+Outbox rows are intentionally provider-neutral and secret-free. Payloads may
+carry stable routing facts, bounded provider inputs, prior observation IDs,
+hidden reconciliation markers, and safe credential context names, but they must
+not carry bearer tokens, webhook URLs, encrypted secret blobs, cookies,
+passwords, raw provider error bodies, or other secret-bearing fields. Validation
+rejects sensitive payload key names so delivery records remain durable evidence,
+not a secret store.
+
+Workers claim due rows with bounded leases. PostgreSQL claims use `FOR UPDATE
+SKIP LOCKED` over pending or expired work so multiple service instances can
+claim independently without blocking on the same row. Completion remains
+lease-owner fenced; stale owners cannot record terminal state after another
+worker reclaims the delivery. Attempts are bounded by `max_attempts`.
+
+Provider calls record a stable `provider_operation_key` and `provider_id` before
+the external send. If a worker crashes after recording that marker, a later
+worker reclaims the row and reconciles before resending. GitHub workflow
+dispatch reconciliation checks for a new workflow run not present before the
+original dispatch; public-ingress GitHub notifications include a hidden marker
+in issue/comment bodies and search for that marker before posting again. Unknown
+provider failures are stored only as bounded `error_code` values such as
+`github_provider_error` or `invalid_outbox_payload`.
+
 ## ORM Query Boundary
 
 Launchplane's Postgres storage layer should expose GUI and driver reads through

--- a/docs/records.md
+++ b/docs/records.md
@@ -209,6 +209,15 @@ original dispatch; public-ingress GitHub notifications include a hidden marker
 in issue/comment bodies and search for that marker before posting again. Unknown
 provider failures are stored only as bounded `error_code` values such as
 `github_provider_error` or `invalid_outbox_payload`.
+Retryable provider errors return to `pending` with bounded database-clock
+backoff; provider markers remain attached so post-send uncertainty reconciles
+before another effect. Dedupe keys identify one business transition rather than
+the workflow parameters forever, allowing a later legitimate dispatch with the
+same inputs to enqueue a distinct delivery.
+Workflow dispatches only adopt an observed run when reclaiming an existing
+provider marker; a first attempt records its marker and sends rather than
+claiming an unrelated concurrent run. Resolved public-ingress notifications
+also ensure the GitHub issue is closed after marker reconciliation.
 
 ## ORM Query Boundary
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -1687,10 +1687,14 @@ provider-target authority when an explicit row is missing.
 Generic web prod promotion uses native FastAPI. It can be exercised directly
 with `POST /v1/drivers/generic-web/prod-promotion`; browser sessions may only
 use this route with `dry_run=true`. The operator UI then uses the native
-`POST /v1/drivers/generic-web/prod-promotion-workflow` route to dispatch the
-product-owned GitHub workflow configured by the DB-backed product profile. That
+`POST /v1/drivers/generic-web/prod-promotion-workflow` route to queue a
+transactional outbox dispatch for the product-owned GitHub workflow configured
+by the DB-backed product profile. The HTTP response reports
+`dispatch_status=pending` and `records.outbox_delivery_id`; Launchplane outbox
+workers later resolve the managed `GITHUB_TOKEN`, reconcile any prior dispatch
+marker, send the workflow dispatch, and record the observed workflow run. That
 workflow remains responsible for product release/tag behavior while Launchplane
-supplies authz, managed `GITHUB_TOKEN` lookup, dispatch inputs, and workflow-run
+supplies authz, managed token lookup, dispatch inputs, and workflow-run
 observation. Native FastAPI owns both paths while descriptor discovery remains
 available.
 

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -4857,8 +4857,11 @@
             "type": "string"
           },
           "dispatch_status": {
-            "const": "dispatched",
-            "default": "dispatched",
+            "default": "pending",
+            "enum": [
+              "pending",
+              "dispatched"
+            ],
             "title": "Dispatch Status",
             "type": "string"
           },

--- a/frontend/generated/openapi-ui.json
+++ b/frontend/generated/openapi-ui.json
@@ -5178,8 +5178,11 @@
             "type": "string"
           },
           "dispatch_status": {
-            "const": "dispatched",
-            "default": "dispatched",
+            "default": "pending",
+            "enum": [
+              "pending",
+              "dispatched"
+            ],
             "title": "Dispatch Status",
             "type": "string"
           },

--- a/frontend/src/generated/openapi.ts/types.gen.ts
+++ b/frontend/src/generated/openapi.ts/types.gen.ts
@@ -518,7 +518,7 @@ export type GenericWebPromotionWorkflowResponse = {
 export type GenericWebPromotionWorkflowResponseResult = {
     bump: 'patch' | 'minor' | 'major';
     context: string;
-    dispatch_status: 'dispatched';
+    dispatch_status: 'pending' | 'dispatched';
     dry_run: boolean;
     product: string;
     ref: string;

--- a/tests/test_generic_web_promotion.py
+++ b/tests/test_generic_web_promotion.py
@@ -24,6 +24,10 @@ from control_plane.contracts.promotion_record import (
 )
 from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
+from control_plane.drivers.generic_web_dispatch import GenericWebPromotionWorkflowEnvelope
+from control_plane.generic_web_promotion_http import (
+    build_generic_web_promotion_workflow_outbox_delivery,
+)
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployRequest,
     GenericWebDeployResult,
@@ -862,6 +866,55 @@ class GenericWebProdPromotionTests(unittest.TestCase):
 
 
 class GenericWebPromotionWorkflowTests(unittest.TestCase):
+    def test_outbox_delivery_deduplicates_one_transition_not_all_future_dispatches(
+        self,
+    ) -> None:
+        profile = _profile()
+        request = GenericWebPromotionWorkflowEnvelope(
+            product=profile.product,
+            workflow=GenericWebPromotionWorkflowRequest(
+                product=profile.product,
+                context="sellyouroutboard-testing",
+                dry_run=False,
+                bump="patch",
+                observe_timeout_seconds=0,
+            ),
+        )
+        with (
+            patch(
+                "control_plane.generic_web_promotion_http.resolve_launchplane_github_token",
+                return_value="github-token",
+            ),
+            patch(
+                "control_plane.generic_web_promotion_http._workflow_dispatch_run_ids",
+                return_value={25237186635},
+            ),
+        ):
+            first = build_generic_web_promotion_workflow_outbox_delivery(
+                control_plane_root=Path("."),
+                request=request,
+                profile=profile,
+                delivery_key="dispatch-request-one",
+            )
+            replay = build_generic_web_promotion_workflow_outbox_delivery(
+                control_plane_root=Path("."),
+                request=request,
+                profile=profile,
+                delivery_key="dispatch-request-one",
+            )
+            later_dispatch = build_generic_web_promotion_workflow_outbox_delivery(
+                control_plane_root=Path("."),
+                request=request,
+                profile=profile,
+                delivery_key="dispatch-request-two",
+            )
+
+        self.assertEqual(first.delivery_id, replay.delivery_id)
+        self.assertEqual(first.dedupe_key, replay.dedupe_key)
+        self.assertNotEqual(first.delivery_id, later_dispatch.delivery_id)
+        self.assertNotEqual(first.dedupe_key, later_dispatch.dedupe_key)
+        self.assertNotIn("dispatch-request-one", first.dedupe_key)
+
     def test_dispatch_accepts_based_driver_product_profile(self) -> None:
         with (
             patch(

--- a/tests/test_outbox_worker.py
+++ b/tests/test_outbox_worker.py
@@ -1,0 +1,195 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any
+from unittest.mock import patch
+
+from control_plane.contracts.outbox_delivery import (
+    OutboxDeliveryRecord,
+    build_outbox_delivery_id,
+    build_outbox_dedupe_key,
+)
+from control_plane.outbox_worker import run_outbox_worker_once
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+def _workflow_delivery() -> OutboxDeliveryRecord:
+    dedupe_key = build_outbox_dedupe_key(
+        kind="github_workflow_dispatch",
+        parts=("example-product", "example-context", "deploy.yml", "main", "false", "patch"),
+    )
+    return OutboxDeliveryRecord(
+        delivery_id=build_outbox_delivery_id(
+            kind="github_workflow_dispatch",
+            dedupe_key=dedupe_key,
+        ),
+        kind="github_workflow_dispatch",
+        aggregate_type="generic_web_promotion_workflow",
+        aggregate_id="example-product:example-context",
+        dedupe_key=dedupe_key,
+        created_at="2026-07-13T00:00:00Z",
+        updated_at="2026-07-13T00:00:00Z",
+        next_attempt_at="2026-07-13T00:00:00Z",
+        payload={
+            "repository": "example/repo",
+            "workflow_id": "deploy.yml",
+            "ref": "main",
+            "inputs": {"dry_run": "false", "bump": "patch"},
+            "previous_run_ids": [100],
+            "dispatch_started_at": "2026-07-13T00:00:00Z",
+            "credential_context": "example-context",
+            "observe_timeout_seconds": 0,
+        },
+    )
+
+
+class OutboxWorkerTests(unittest.TestCase):
+    def test_crash_before_send_leaves_pending_delivery_for_later_worker(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            delivery = _workflow_delivery()
+            store.write_outbox_delivery_record(delivery)
+
+            loaded = store.read_outbox_delivery_record(delivery.delivery_id)
+            requests: list[tuple[str, str]] = []
+            posted = False
+
+            def github_request(
+                *,
+                path: str,
+                token: str,
+                method: str = "GET",
+                body: dict[str, object] | None = None,
+            ) -> dict[str, Any] | None:
+                nonlocal posted
+                del token, body
+                requests.append((method, path))
+                if method == "POST":
+                    posted = True
+                    return None
+                if not posted:
+                    return {"workflow_runs": []}
+                return {
+                    "workflow_runs": [
+                        {
+                            "id": 101,
+                            "html_url": "https://github.example/actions/runs/101",
+                            "status": "queued",
+                            "created_at": "2026-07-13T00:00:00Z",
+                        }
+                    ]
+                }
+
+            with (
+                patch(
+                    "control_plane.workflows.generic_web_promotion_workflow.resolve_launchplane_github_token",
+                    return_value="github-token",
+                ),
+                patch(
+                    "control_plane.workflows.generic_web_promotion_workflow.github_api_request",
+                    side_effect=github_request,
+                ),
+            ):
+                worker_result = run_outbox_worker_once(
+                    record_store=store,
+                    control_plane_root=Path("."),
+                    lease_owner="worker-a",
+                )
+            store.close()
+
+        self.assertEqual(loaded.state, "pending")
+        self.assertEqual(worker_result.status, "delivered")
+        self.assertEqual([method for method, _path in requests], ["GET", "POST", "GET"])
+
+    def test_crash_after_send_reconciles_existing_workflow_run_before_resend(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            delivery = _workflow_delivery()
+            store.write_outbox_delivery_record(delivery)
+            claimed = store.claim_next_outbox_delivery_record(
+                lease_owner="worker-a",
+                now="2026-07-13T00:00:01Z",
+            )
+            assert claimed.record is not None
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                return_value="2026-07-13T00:00:02Z",
+            ):
+                store.mark_outbox_delivery_provider_started(
+                    record=claimed.record,
+                    lease_owner="worker-a",
+                    provider_operation_key="github_workflow_dispatch:example/repo:deploy.yml:main:2026-07-13T00:00:00Z:bump=patch|dry_run=false",
+                    provider_id="github",
+                    updated_at="2026-07-13T00:00:01Z",
+                )
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: "2026-07-13T00:10:00Z",
+            ):
+                requests: list[tuple[str, str]] = []
+
+                def github_request(
+                    *,
+                    path: str,
+                    token: str,
+                    method: str = "GET",
+                    body: dict[str, object] | None = None,
+                ) -> dict[str, Any] | None:
+                    del token, body
+                    requests.append((method, path))
+                    if method == "POST":
+                        self.fail("reconciliation must not resend workflow_dispatch")
+                    return {
+                        "workflow_runs": [
+                            {
+                                "id": 101,
+                                "html_url": "https://github.example/actions/runs/101",
+                                "status": "queued",
+                                "created_at": "2026-07-13T00:00:00Z",
+                            }
+                        ]
+                    }
+
+                with (
+                    patch(
+                        "control_plane.workflows.generic_web_promotion_workflow.resolve_launchplane_github_token",
+                        return_value="github-token",
+                    ),
+                    patch(
+                        "control_plane.workflows.generic_web_promotion_workflow.github_api_request",
+                        side_effect=github_request,
+                    ),
+                ):
+                    worker_result = run_outbox_worker_once(
+                        record_store=store,
+                        control_plane_root=Path("."),
+                        lease_owner="worker-b",
+                    )
+            loaded = store.read_outbox_delivery_record(delivery.delivery_id)
+            store.close()
+
+        self.assertEqual(worker_result.status, "delivered")
+        self.assertEqual(loaded.state, "delivered")
+        self.assertEqual(loaded.provider_id, "github")
+        self.assertEqual(loaded.external_id, "101")
+        self.assertEqual([method for method, _path in requests], ["GET"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_outbox_worker.py
+++ b/tests/test_outbox_worker.py
@@ -4,6 +4,8 @@ from tempfile import TemporaryDirectory
 from typing import Any
 from unittest.mock import patch
 
+import click
+
 from control_plane.contracts.outbox_delivery import (
     OutboxDeliveryRecord,
     build_outbox_delivery_id,
@@ -48,6 +50,71 @@ def _workflow_delivery() -> OutboxDeliveryRecord:
 
 
 class OutboxWorkerTests(unittest.TestCase):
+    def test_transient_github_failure_schedules_bounded_retry(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            delivery = _workflow_delivery()
+            store.write_outbox_delivery_record(delivery)
+
+            def github_request(
+                *,
+                path: str,
+                token: str,
+                method: str = "GET",
+                body: dict[str, object] | None = None,
+            ) -> dict[str, Any] | None:
+                del path, token, method, body
+                try:
+                    raise OSError("temporary network failure")
+                except OSError as cause:
+                    raise click.ClickException("GitHub request failed") from cause
+
+            with (
+                patch.object(
+                    store,
+                    "_database_mutation_timestamp",
+                    side_effect=lambda _session: "2026-07-13T00:00:01Z",
+                ),
+                patch(
+                    "control_plane.workflows.generic_web_promotion_workflow.resolve_launchplane_github_token",
+                    return_value="github-token",
+                ),
+                patch(
+                    "control_plane.workflows.generic_web_promotion_workflow.github_api_request",
+                    side_effect=github_request,
+                ),
+            ):
+                worker_result = run_outbox_worker_once(
+                    record_store=store,
+                    control_plane_root=Path("."),
+                    lease_owner="worker-a",
+                )
+            loaded = store.read_outbox_delivery_record(delivery.delivery_id)
+            early_claim = store.claim_next_outbox_delivery_record(
+                lease_owner="worker-b",
+                now="2026-07-13T00:00:05Z",
+            )
+            retry_claim = store.claim_next_outbox_delivery_record(
+                lease_owner="worker-b",
+                now="2026-07-13T00:00:06Z",
+            )
+            store.close()
+
+        self.assertEqual(worker_result.status, "pending")
+        self.assertEqual(loaded.state, "pending")
+        self.assertEqual(loaded.attempt, 1)
+        self.assertEqual(loaded.error_code, "github_provider_error")
+        self.assertEqual(loaded.next_attempt_at, "2026-07-13T00:00:06Z")
+        self.assertEqual(early_claim.status, "empty")
+        self.assertEqual(retry_claim.status, "claimed")
+        assert retry_claim.record is not None
+        self.assertEqual(retry_claim.record.attempt, 2)
+
     def test_crash_before_send_leaves_pending_delivery_for_later_worker(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(
@@ -108,7 +175,7 @@ class OutboxWorkerTests(unittest.TestCase):
 
         self.assertEqual(loaded.state, "pending")
         self.assertEqual(worker_result.status, "delivered")
-        self.assertEqual([method for method, _path in requests], ["GET", "POST", "GET"])
+        self.assertEqual([method for method, _path in requests], ["POST", "GET"])
 
     def test_crash_after_send_reconciles_existing_workflow_run_before_resend(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -34,6 +34,11 @@ from control_plane.contracts.odoo_stable_bootstrap_operation import (
     OdooStableBootstrapOperationPhase,
     OdooStableBootstrapOperationStatus,
 )
+from control_plane.contracts.outbox_delivery import (
+    OutboxDeliveryRecord,
+    build_outbox_delivery_id,
+    build_outbox_dedupe_key,
+)
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductImageProfile,
@@ -50,6 +55,7 @@ from control_plane.contracts.route_binding_record import (
 from control_plane.storage.postgres import (
     DbOnlyMutationRequest,
     MutationReservationResult,
+    OutboxWithIdempotencyRequest,
     PostgresRecordStore,
 )
 from control_plane.storage.product_authority_bundle import ProductAuthorityBundle
@@ -305,6 +311,27 @@ def _route_binding() -> EnvironmentRouteBindingRecord:
     )
 
 
+def _outbox_delivery(*, suffix: str = "one") -> OutboxDeliveryRecord:
+    dedupe_key = build_outbox_dedupe_key(
+        kind="github_workflow_dispatch",
+        parts=("postgres", suffix),
+    )
+    return OutboxDeliveryRecord(
+        delivery_id=build_outbox_delivery_id(
+            kind="github_workflow_dispatch",
+            dedupe_key=dedupe_key,
+        ),
+        kind="github_workflow_dispatch",
+        aggregate_type="postgres_test",
+        aggregate_id=suffix,
+        dedupe_key=dedupe_key,
+        created_at="2026-07-13T00:00:00Z",
+        updated_at="2026-07-13T00:00:00Z",
+        next_attempt_at="2026-07-13T00:00:00Z",
+        payload={"repository": "example/repo", "workflow_id": "deploy.yml"},
+    )
+
+
 class RealPostgresSchemaIntegrationTests(unittest.TestCase):
     def test_alembic_from_empty_database_reaches_exact_head_and_required_invariants(
         self,
@@ -330,6 +357,14 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
                     column["name"]: column
                     for column in inspector.get_columns("launchplane_idempotency_records")
                 }
+                outbox_indexes = {
+                    index["name"]: index
+                    for index in inspector.get_indexes("launchplane_outbox_deliveries")
+                }
+                outbox_columns = {
+                    column["name"]: column
+                    for column in inspector.get_columns("launchplane_outbox_deliveries")
+                }
                 payload_type = _column_type(
                     engine,
                     table_name="launchplane_idempotency_records",
@@ -340,6 +375,21 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
                     table_name="launchplane_idempotency_records",
                     column_name="attempt",
                 )
+                outbox_payload_type = _column_type(
+                    engine,
+                    table_name="launchplane_outbox_deliveries",
+                    column_name="payload",
+                )
+                outbox_attempt_type = _column_type(
+                    engine,
+                    table_name="launchplane_outbox_deliveries",
+                    column_name="attempt",
+                )
+                outbox_max_attempts_type = _column_type(
+                    engine,
+                    table_name="launchplane_outbox_deliveries",
+                    column_name="max_attempts",
+                )
                 alembic_version = _current_alembic_version(engine)
             finally:
                 store.close()
@@ -347,7 +397,13 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
         self.assertEqual(alembic_version, EXPECTED_ALEMBIC_HEAD_REVISION)
         self.assertEqual(payload_type, "jsonb")
         self.assertEqual(attempt_type, "integer")
+        self.assertEqual(outbox_payload_type, "jsonb")
+        self.assertEqual(outbox_attempt_type, "integer")
+        self.assertEqual(outbox_max_attempts_type, "integer")
         self.assertTrue(idempotency_columns["response_status_code"]["nullable"])
+        self.assertFalse(outbox_columns["payload"]["nullable"])
+        self.assertTrue(outbox_indexes["launchplane_outbox_deliveries_dedupe_uidx"]["unique"])
+        self.assertFalse(outbox_indexes["launchplane_outbox_deliveries_claim_idx"]["unique"])
         self.assertTrue(
             idempotency_indexes["launchplane_idempotency_scope_route_key_idx"]["unique"]
         )
@@ -553,6 +609,49 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
                 with self.assertRaisesRegex(
                     RuntimeError,
                     "launchplane_odoo_bootstrap_active_lane_uidx has predicate",
+                ):
+                    store.verify_schema()
+            finally:
+                store.close()
+
+    def test_startup_verification_fails_closed_when_outbox_claim_index_is_missing(
+        self,
+    ) -> None:
+        with _isolated_postgres_database() as database_url:
+            _upgrade_empty_database_to_head(database_url)
+            engine = create_engine(database_url)
+            with engine.begin() as connection:
+                connection.execute(text("drop index launchplane_outbox_deliveries_claim_idx"))
+            engine.dispose()
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "launchplane_outbox_deliveries_claim_idx",
+                ):
+                    store.verify_schema()
+            finally:
+                store.close()
+
+    def test_startup_verification_fails_closed_when_outbox_payload_is_not_jsonb(
+        self,
+    ) -> None:
+        with _isolated_postgres_database() as database_url:
+            _upgrade_empty_database_to_head(database_url)
+            engine = create_engine(database_url)
+            with engine.begin() as connection:
+                connection.execute(
+                    text(
+                        "alter table launchplane_outbox_deliveries "
+                        "alter column payload type json using payload::json"
+                    )
+                )
+            engine.dispose()
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "launchplane_outbox_deliveries.payload has type",
                 ):
                     store.verify_schema()
             finally:
@@ -786,6 +885,84 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
         self.assertEqual(loaded.state, "claimed")
         assert replay_evidence is not None
         self.assertEqual(replay_evidence.state, "completed")
+    def test_outbox_claim_skips_locked_pending_row_and_claims_next_delivery(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            first = _outbox_delivery(suffix="first").model_copy(
+                update={
+                    "created_at": "2026-07-13T00:00:00Z",
+                    "updated_at": "2026-07-13T00:00:00Z",
+                    "next_attempt_at": "2026-07-13T00:00:00Z",
+                }
+            )
+            second = _outbox_delivery(suffix="second").model_copy(
+                update={
+                    "created_at": "2026-07-13T00:00:01Z",
+                    "updated_at": "2026-07-13T00:00:01Z",
+                    "next_attempt_at": "2026-07-13T00:00:00Z",
+                }
+            )
+            store.write_outbox_delivery_record(first)
+            store.write_outbox_delivery_record(second)
+            blocker = create_engine(store.database_url)
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            try:
+                with blocker.connect() as connection:
+                    transaction = connection.begin()
+                    try:
+                        locked_delivery_id = connection.execute(
+                            text(
+                                "select delivery_id from launchplane_outbox_deliveries "
+                                "where delivery_id = :delivery_id for update"
+                            ),
+                            {"delivery_id": first.delivery_id},
+                        ).scalar_one()
+                        claimed = second_store.claim_next_outbox_delivery_record(
+                            lease_owner="worker-b",
+                            now="2026-07-13T00:00:02Z",
+                        )
+                    finally:
+                        transaction.rollback()
+                first_claim = store.claim_next_outbox_delivery_record(
+                    lease_owner="worker-a",
+                    now="2026-07-13T00:00:03Z",
+                )
+            finally:
+                second_store.close()
+                blocker.dispose()
+
+        self.assertEqual(locked_delivery_id, first.delivery_id)
+        self.assertEqual(claimed.status, "claimed")
+        assert claimed.record is not None
+        self.assertEqual(claimed.record.delivery_id, second.delivery_id)
+        self.assertEqual(claimed.record.lease_owner, "worker-b")
+        self.assertEqual(first_claim.status, "claimed")
+        assert first_claim.record is not None
+        self.assertEqual(first_claim.record.delivery_id, first.delivery_id)
+        self.assertEqual(first_claim.record.lease_owner, "worker-a")
+
+    def test_outbox_enqueue_with_idempotency_is_atomic_on_validation_failure(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            delivery = _outbox_delivery(suffix="atomic-validation")
+            invalid_reservation = _mutation_reservation(
+                lease_owner="worker-a",
+                idempotency_key="product-preview-tls:postgres:outbox-invalid",
+            )
+            with self.assertRaisesRegex(ValueError, "completed replay evidence"):
+                store.enqueue_outbox_delivery_with_idempotency(
+                    OutboxWithIdempotencyRequest(
+                        delivery=delivery,
+                        idempotency_record=invalid_reservation,
+                    )
+                )
+            rows = store.list_outbox_delivery_records()
+            stored_reservation = store.read_idempotency_record(
+                scope=invalid_reservation.scope,
+                route_path=invalid_reservation.route_path,
+                idempotency_key=invalid_reservation.idempotency_key,
+            )
+
+        self.assertEqual(rows, ())
+        self.assertIsNone(stored_reservation)
 
     def test_two_connections_claim_exactly_one_pending_operation_and_recover_lease(
         self,

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -659,6 +659,32 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
 
 
 class RealPostgresStorageConcurrencyTests(unittest.TestCase):
+    def test_concurrent_outbox_enqueue_reuses_one_delivery(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            delivery = _outbox_delivery(suffix="concurrent-enqueue")
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            barrier = threading.Barrier(2)
+
+            def enqueue(active_store: PostgresRecordStore) -> OutboxDeliveryRecord:
+                barrier.wait(timeout=5)
+                return active_store.enqueue_outbox_delivery_with_idempotency(
+                    OutboxWithIdempotencyRequest(delivery=delivery)
+                )
+
+            try:
+                with ThreadPoolExecutor(max_workers=2) as executor:
+                    first_future = executor.submit(enqueue, store)
+                    second_future = executor.submit(enqueue, second_store)
+                    first = first_future.result(timeout=10)
+                    second = second_future.result(timeout=10)
+                rows = store.list_outbox_delivery_records()
+            finally:
+                second_store.close()
+
+        self.assertEqual(first.delivery_id, delivery.delivery_id)
+        self.assertEqual(second.delivery_id, delivery.delivery_id)
+        self.assertEqual([row.delivery_id for row in rows], [delivery.delivery_id])
+
     def test_lane_summary_waits_for_authority_bundle_commit(self) -> None:
         with _store_for_fresh_head_database() as store:
             bundle_step_reached = threading.Event()
@@ -885,6 +911,7 @@ class RealPostgresStorageConcurrencyTests(unittest.TestCase):
         self.assertEqual(loaded.state, "claimed")
         assert replay_evidence is not None
         self.assertEqual(replay_evidence.state, "completed")
+
     def test_outbox_claim_skips_locked_pending_row_and_claims_next_delivery(self) -> None:
         with _store_for_fresh_head_database() as store:
             first = _outbox_delivery(suffix="first").model_copy(

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -102,6 +102,12 @@ from control_plane.contracts.odoo_stable_bootstrap_operation import (
 from control_plane.contracts.odoo_stable_target_replacement_operation import (
     OdooStableTargetReplacementOperationRecord,
 )
+from control_plane.contracts.outbox_delivery import (
+    OutboxDeliveryKind,
+    OutboxDeliveryRecord,
+    OutboxDeliveryState,
+    build_outbox_delivery_id,
+)
 from control_plane.contracts.preview_desired_state_record import PreviewDesiredStateRecord
 from control_plane.contracts.preview_enablement_record import PreviewEnablementRecord
 from control_plane.contracts.preview_generation_record import (
@@ -176,6 +182,7 @@ from control_plane.storage.postgres import (
     LaunchplaneIdempotencyRow,
     LaunchplaneProductProfileRow,
     MutationReservationResult,
+    OutboxWithIdempotencyRequest,
     PostgresRecordStore,
 )
 from tests.merge_train_policy_fixtures import build_test_merge_train_policy
@@ -248,6 +255,41 @@ def _mutation_reservation(
         lease_owner=lease_owner,
         lease_expires_at=lease_expires_at,
         reserved_at=reserved_at,
+    )
+
+
+def _outbox_delivery(
+    *,
+    kind: OutboxDeliveryKind = "github_workflow_dispatch",
+    dedupe_key: str = "github-workflow-dispatch:example/repo:deploy.yml:main:abc123",
+    state: OutboxDeliveryState = "pending",
+    created_at: str = "2026-07-13T00:00:00Z",
+    next_attempt_at: str = "2026-07-13T00:00:00Z",
+    provider_operation_key: str = "",
+    attempt: int = 0,
+    lease_owner: str = "",
+    lease_expires_at: str = "",
+) -> OutboxDeliveryRecord:
+    return OutboxDeliveryRecord(
+        delivery_id=build_outbox_delivery_id(kind=kind, dedupe_key=dedupe_key),
+        kind=kind,
+        state=state,
+        aggregate_type="generic_web_promotion_workflow",
+        aggregate_id="example-product:example-context",
+        dedupe_key=dedupe_key,
+        created_at=created_at,
+        updated_at=created_at,
+        next_attempt_at=next_attempt_at,
+        lease_owner=lease_owner,
+        lease_expires_at=lease_expires_at,
+        attempt=attempt,
+        provider_operation_key=provider_operation_key,
+        payload={
+            "repository": "example/repo",
+            "workflow_id": "deploy.yml",
+            "ref": "main",
+            "inputs": {"dry_run": "false"},
+        },
     )
 
 
@@ -2014,6 +2056,140 @@ class PostgresRecordStoreTests(unittest.TestCase):
             assert loaded is not None
             self.assertEqual(loaded.request_fingerprint, "fingerprint-123")
             self.assertEqual(loaded.response_payload["records"]["preview_id"], "preview-35")
+
+    def test_outbox_delivery_round_trip_claim_and_complete(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+            delivery = _outbox_delivery()
+
+            store.write_outbox_delivery_record(delivery)
+            claimed = store.claim_next_outbox_delivery_record(
+                lease_owner="worker-a",
+                lease_seconds=300,
+                now="2026-07-13T00:00:10Z",
+            )
+            assert claimed.record is not None
+            delivered_record = claimed.record.model_copy(
+                update={
+                    "state": "delivered",
+                    "action": "dispatched_workflow",
+                    "external_id": "12345",
+                    "external_url": "https://github.example/actions/runs/12345",
+                }
+            )
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                return_value="2026-07-13T00:00:20Z",
+            ):
+                stale_completion = store.complete_outbox_delivery_record(
+                    record=delivered_record,
+                    lease_owner="worker-b",
+                )
+                completion = store.complete_outbox_delivery_record(
+                    record=delivered_record,
+                    lease_owner="worker-a",
+                )
+            loaded = store.read_outbox_delivery_record(delivery.delivery_id)
+            store.close()
+
+        self.assertEqual(claimed.status, "claimed")
+        self.assertEqual(claimed.record.state, "running")
+        self.assertEqual(claimed.record.lease_owner, "worker-a")
+        self.assertEqual(claimed.record.attempt, 1)
+        self.assertEqual(stale_completion.status, "owner_mismatch")
+        self.assertEqual(completion.status, "updated")
+        self.assertEqual(loaded.state, "delivered")
+        self.assertEqual(loaded.lease_owner, "")
+        self.assertEqual(loaded.external_id, "12345")
+
+    def test_outbox_enqueue_with_idempotency_commits_both_records(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+            delivery = _outbox_delivery()
+            idempotency = LaunchplaneIdempotencyRecord(
+                record_id=build_launchplane_idempotency_record_id(
+                    response_trace_id="launchplane_req_outbox",
+                ),
+                scope="github-actions:outbox-test",
+                route_path="/v1/drivers/generic-web/prod-promotion-workflow",
+                idempotency_key="outbox-idempotency-key",
+                request_fingerprint="fingerprint-outbox",
+                response_status_code=202,
+                response_trace_id="launchplane_req_outbox",
+                recorded_at="2026-07-13T00:00:00Z",
+                response_payload={
+                    "status": "accepted",
+                    "records": {"outbox_delivery_id": delivery.delivery_id},
+                },
+            )
+
+            first = store.enqueue_outbox_delivery_with_idempotency(
+                OutboxWithIdempotencyRequest(
+                    delivery=delivery,
+                    idempotency_record=idempotency,
+                )
+            )
+            duplicate = store.enqueue_outbox_delivery_with_idempotency(
+                OutboxWithIdempotencyRequest(
+                    delivery=delivery.model_copy(update={"delivery_id": "ignored-duplicate"}),
+                    idempotency_record=None,
+                )
+            )
+            loaded_idempotency = store.read_idempotency_record(
+                scope=idempotency.scope,
+                route_path=idempotency.route_path,
+                idempotency_key=idempotency.idempotency_key,
+            )
+            outbox_rows = store.list_outbox_delivery_records(states=("pending",))
+            store.close()
+
+        self.assertEqual(first.delivery_id, delivery.delivery_id)
+        self.assertEqual(duplicate.delivery_id, delivery.delivery_id)
+        self.assertIsNotNone(loaded_idempotency)
+        assert loaded_idempotency is not None
+        self.assertEqual(
+            loaded_idempotency.response_payload["records"]["outbox_delivery_id"],
+            delivery.delivery_id,
+        )
+        self.assertEqual([row.delivery_id for row in outbox_rows], [delivery.delivery_id])
+
+    def test_outbox_claim_marks_expired_provider_marker_for_reconciliation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=_sqlite_database_url(database_path))
+            store.ensure_schema()
+            delivery = _outbox_delivery(
+                state="running",
+                provider_operation_key="github-workflow-dispatch:example/repo:deploy.yml:main:abc123",
+                attempt=1,
+                lease_owner="worker-a",
+                lease_expires_at="2026-07-13T00:01:00Z",
+            )
+            store.write_outbox_delivery_record(delivery)
+
+            claimed = store.claim_next_outbox_delivery_record(
+                lease_owner="worker-b",
+                now="2026-07-13T00:02:00Z",
+            )
+            loaded = store.read_outbox_delivery_record(delivery.delivery_id)
+            store.close()
+
+        self.assertEqual(claimed.status, "claimed")
+        assert claimed.record is not None
+        self.assertEqual(claimed.record.state, "running")
+        self.assertEqual(claimed.record.lease_owner, "worker-b")
+        self.assertEqual(claimed.record.attempt, 2)
+        self.assertEqual(
+            claimed.record.provider_operation_key,
+            "github-workflow-dispatch:example/repo:deploy.yml:main:abc123",
+        )
+        self.assertEqual(loaded.state, "running")
+        self.assertEqual(loaded.lease_owner, "worker-b")
 
     def test_mutation_reservation_replays_conflicts_and_reclaims_expired_lease(
         self,

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
 import unittest
 from typing import Literal
 from unittest.mock import patch
@@ -39,6 +41,8 @@ from control_plane.workflows.public_ingress_monitor import (
     run_public_ingress_monitor_once,
 )
 from control_plane.outbound_http import PublicHttpDestinationError
+from control_plane.storage.postgres import PostgresRecordStore
+from tests.support.stores import _sqlite_database_url
 
 
 def _public_health_monitoring(
@@ -1120,6 +1124,64 @@ class PublicIngressMonitorTests(unittest.TestCase):
         self.assertEqual(github_calls[0][0], "create")
         self.assertEqual(email_subjects, ["[Launchplane] Public ingress opened: example-site/prod"])
         self.assertEqual(discord_posts[0][0], "https://discord.com/api/webhooks/test/webhook")
+
+    def test_postgres_monitor_writes_github_notifications_to_outbox(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_product_profile_record(_profile())
+            store.write_public_ingress_notification_policy_record(
+                _notification_policy(
+                    PublicIngressNotificationDestination(
+                        destination_id="github-main",
+                        kind="github_issue",
+                        github_repository="cbusillo/launchplane",
+                        github_label="public-ingress",
+                    )
+                )
+            )
+
+            result = run_public_ingress_monitor_once(
+                record_store=store,
+                checked_at="2026-05-29T12:25:00Z",
+                http_get=lambda _url, _timeout: HttpObservation(
+                    status_code=503,
+                    final_url="https://example.test",
+                    redirect_count=0,
+                ),
+            )
+            outbox_rows = store.list_outbox_delivery_records(
+                states=("pending",), kind="public_ingress_notification"
+            )
+            attempts = store.list_public_ingress_notification_attempt_records()
+            observations = store.list_public_ingress_observation_records()
+            incidents = store.list_public_ingress_incident_records()
+            store.close()
+
+        self.assertEqual(result.open_incident_count, 1)
+        self.assertEqual(result.delivery_attempt_count, 0)
+        self.assertEqual(len(observations), 1)
+        self.assertEqual(len(incidents), 1)
+        self.assertEqual(attempts, ())
+        self.assertEqual(len(outbox_rows), 1)
+        self.assertEqual(outbox_rows[0].aggregate_id, incidents[0].incident_id)
+        self.assertIn(
+            "launchplane-public-ingress-notification", str(outbox_rows[0].payload["body"])
+        )
+        self.assertEqual(
+            outbox_rows[0].payload["destination"],
+            {
+                "destination_id": "github-main",
+                "kind": "github_issue",
+                "status": "enabled",
+                "github_repository": "cbusillo/launchplane",
+                "github_issue_number": None,
+                "github_label": "public-ingress",
+            },
+        )
 
     def test_notification_policies_can_scope_to_health_check_kind(self) -> None:
         lane = ProductLaneProfile(

--- a/tests/test_public_ingress_monitor.py
+++ b/tests/test_public_ingress_monitor.py
@@ -13,6 +13,7 @@ from click.testing import CliRunner
 from control_plane.cli import main as launchplane_cli
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.outbox_delivery import OutboxDeliveryRecord
 from control_plane.contracts.product_health_monitoring_migration import (
     canonical_health_check_record_token,
 )
@@ -37,10 +38,13 @@ from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.workflows.public_ingress_monitor import (
     HttpObservation,
     PublicIngressNotificationDriverSet,
+    _gh_issue_client,
+    deliver_public_ingress_notification_outbox_delivery,
     discover_public_ingress_monitor_targets,
     run_public_ingress_monitor_once,
 )
 from control_plane.outbound_http import PublicHttpDestinationError
+from control_plane.outbox_worker import run_outbox_worker_once
 from control_plane.storage.postgres import PostgresRecordStore
 from tests.support.stores import _sqlite_database_url
 
@@ -1182,6 +1186,249 @@ class PublicIngressMonitorTests(unittest.TestCase):
                 "github_label": "public-ingress",
             },
         )
+
+    def test_postgres_mixed_notification_policy_keeps_direct_email_and_discord(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_product_profile_record(_profile())
+            store.write_public_ingress_notification_policy_record(
+                _notification_policy(
+                    PublicIngressNotificationDestination(
+                        destination_id="github-main",
+                        kind="github_issue",
+                        github_repository="cbusillo/launchplane",
+                        github_label="public-ingress",
+                    ),
+                    PublicIngressNotificationDestination(
+                        destination_id="email-ops",
+                        kind="email",
+                        email_to=("ops@example.test",),
+                        email_from="launchplane@example.test",
+                        smtp_host="smtp.example.test",
+                        smtp_username_secret="smtp-username",
+                        smtp_password_secret="smtp-password",
+                    ),
+                    PublicIngressNotificationDestination(
+                        destination_id="discord-ops",
+                        kind="discord",
+                        discord_webhook_secret="discord-webhook",
+                    ),
+                )
+            )
+            email_subjects: list[str] = []
+            discord_posts: list[tuple[str, dict[str, object]]] = []
+            drivers = PublicIngressNotificationDriverSet(
+                github_client=lambda _action, _payload: self.fail(
+                    "GitHub notifications must remain queued"
+                ),
+                email_sender=lambda _destination, message: email_subjects.append(
+                    str(message["Subject"])
+                ),
+                discord_sender=lambda webhook_url, payload: discord_posts.append(
+                    (webhook_url, payload)
+                ),
+                secret_resolver=lambda secret_name: {
+                    "discord-webhook": "https://discord.com/api/webhooks/test/webhook",
+                    "smtp-username": "launchplane",
+                    "smtp-password": "secret",
+                }.get(secret_name, ""),
+            )
+
+            result = run_public_ingress_monitor_once(
+                record_store=store,
+                checked_at="2026-05-29T12:25:00Z",
+                http_get=lambda _url, _timeout: HttpObservation(
+                    status_code=503,
+                    final_url="https://example.test",
+                    redirect_count=0,
+                ),
+                notification_drivers=drivers,
+            )
+            outbox_rows = store.list_outbox_delivery_records(
+                states=("pending",),
+                kind="public_ingress_notification",
+            )
+            attempts = store.list_public_ingress_notification_attempt_records()
+            store.close()
+
+        self.assertEqual(result.delivery_attempt_count, 2)
+        self.assertEqual(len(outbox_rows), 1)
+        self.assertEqual(
+            {attempt.destination_kind for attempt in attempts},
+            {"email", "discord"},
+        )
+        self.assertEqual(email_subjects, ["[Launchplane] Public ingress opened: example-site/prod"])
+        self.assertEqual(len(discord_posts), 1)
+
+    def test_close_reconciliation_ensures_issue_is_closed_after_marker_comment(self) -> None:
+        marker = "attempt-public-ingress-resolved"
+        record = OutboxDeliveryRecord(
+            delivery_id="outbox-public-ingress-close",
+            kind="public_ingress_notification",
+            state="running",
+            aggregate_type="public_ingress_incident",
+            aggregate_id="incident-example-site-prod",
+            dedupe_key=f"public_ingress_notification:{marker}",
+            created_at="2026-05-29T12:25:00Z",
+            updated_at="2026-05-29T12:25:01Z",
+            next_attempt_at="2026-05-29T12:25:00Z",
+            lease_owner="worker-b",
+            lease_expires_at="2026-05-29T12:30:00Z",
+            attempt=2,
+            provider_operation_key=f"public_ingress_notification:{marker}:close",
+            provider_id="github",
+            payload={
+                "attempt": {
+                    "attempt_id": marker,
+                    "incident_id": "incident-example-site-prod",
+                    "event": "resolved",
+                    "policy_id": "public-ingress-notifications-example-site",
+                    "destination_id": "github-main",
+                    "destination_kind": "github_issue",
+                    "attempted_at": "2026-05-29T12:25:00Z",
+                    "observation_id": "observation-example-site-prod",
+                },
+                "destination": {
+                    "destination_id": "github-main",
+                    "kind": "github_issue",
+                    "status": "enabled",
+                    "github_repository": "cbusillo/launchplane",
+                    "github_issue_number": None,
+                    "github_label": "public-ingress",
+                },
+                "body": f"Resolved\n<!-- launchplane-public-ingress-notification:{marker} -->",
+                "existing_issue_url": "https://github.com/cbusillo/launchplane/issues/123",
+                "marker": marker,
+            },
+        )
+        actions: list[str] = []
+
+        def github_client(action: str, _payload: dict[str, object]) -> dict[str, object]:
+            actions.append(action)
+            if action == "find_marker":
+                return {
+                    "url": "https://github.com/cbusillo/launchplane/issues/123#issuecomment-1",
+                    "id": "comment-1",
+                }
+            if action == "ensure_closed":
+                return {
+                    "url": "https://github.com/cbusillo/launchplane/issues/123",
+                    "id": "issue-123",
+                }
+            self.fail(f"unexpected GitHub action {action}")
+
+        result = deliver_public_ingress_notification_outbox_delivery(
+            record=record,
+            drivers=PublicIngressNotificationDriverSet(github_client=github_client),
+            mark_provider_started=lambda _provider_operation_key, _provider_id: self.fail(
+                "existing provider marker must not be replaced"
+            ),
+        )
+
+        self.assertEqual(actions, ["find_marker", "ensure_closed"])
+        self.assertEqual(result.state, "delivered")
+        self.assertEqual(result.action, "closed_issue")
+        self.assertEqual(result.external_id, "issue-123")
+
+    def test_github_ensure_closed_patches_open_issue_without_duplicate_comment(self) -> None:
+        with patch(
+            "control_plane.workflows.public_ingress_monitor._github_api_request",
+            side_effect=(
+                {
+                    "state": "open",
+                    "html_url": "https://github.com/cbusillo/launchplane/issues/123",
+                    "node_id": "issue-123",
+                },
+                {
+                    "state": "closed",
+                    "html_url": "https://github.com/cbusillo/launchplane/issues/123",
+                    "node_id": "issue-123",
+                },
+            ),
+        ) as request_mock:
+            response = _gh_issue_client(
+                "ensure_closed",
+                {
+                    "repository": "cbusillo/launchplane",
+                    "issue_url": "https://github.com/cbusillo/launchplane/issues/123",
+                },
+                token="github-token",
+            )
+
+        self.assertEqual(response["id"], "issue-123")
+        self.assertEqual(
+            [call.kwargs["method"] for call in request_mock.call_args_list],
+            ["GET", "PATCH"],
+        )
+        self.assertEqual(
+            request_mock.call_args_list[1].kwargs["body"],
+            {"state": "closed", "state_reason": "completed"},
+        )
+
+    def test_transient_github_notification_failure_schedules_retry(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
+            store.write_product_profile_record(_profile())
+            store.write_public_ingress_notification_policy_record(
+                _notification_policy(
+                    PublicIngressNotificationDestination(
+                        destination_id="github-main",
+                        kind="github_issue",
+                        github_repository="cbusillo/launchplane",
+                        github_label="public-ingress",
+                    )
+                )
+            )
+            run_public_ingress_monitor_once(
+                record_store=store,
+                checked_at="2026-05-29T12:25:00Z",
+                http_get=lambda _url, _timeout: HttpObservation(
+                    status_code=503,
+                    final_url="https://example.test",
+                    redirect_count=0,
+                ),
+            )
+            delivery = store.list_outbox_delivery_records(
+                states=("pending",),
+                kind="public_ingress_notification",
+            )[0]
+
+            def github_client(
+                _action: str,
+                _payload: dict[str, object],
+            ) -> dict[str, object]:
+                raise RuntimeError("temporary GitHub failure")
+
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: "2026-05-29T12:25:01Z",
+            ):
+                worker_result = run_outbox_worker_once(
+                    record_store=store,
+                    control_plane_root=Path("."),
+                    lease_owner="worker-a",
+                    notification_drivers=PublicIngressNotificationDriverSet(
+                        github_client=github_client
+                    ),
+                )
+            loaded = store.read_outbox_delivery_record(delivery.delivery_id)
+            attempts = store.list_public_ingress_notification_attempt_records()
+            store.close()
+
+        self.assertEqual(worker_result.status, "pending")
+        self.assertEqual(loaded.state, "pending")
+        self.assertEqual(loaded.error_code, "github_provider_error")
+        self.assertEqual(loaded.next_attempt_at, "2026-05-29T12:25:06Z")
+        self.assertEqual(attempts, ())
 
     def test_notification_policies_can_scope_to_health_check_kind(self) -> None:
         lane = ProductLaneProfile(

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -156,7 +156,6 @@ from tests.support.stores import (
 from control_plane.workflows.generic_web_promotion import GenericWebProdPromotionResult
 from control_plane.workflows.generic_web_deploy import GenericWebDeployResult
 from control_plane.workflows.generic_web_rollback import GenericWebRollbackApplyResult
-from control_plane.workflows.generic_web_promotion_workflow import GenericWebPromotionWorkflowResult
 from control_plane.workflows.generic_web_preview import (
     GenericWebPreviewDestroyResult,
     GenericWebPreviewInventoryItem,
@@ -9257,7 +9256,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
             session_manager = _fastapi_human_session_manager()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
@@ -9277,6 +9278,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             app = create_launchplane_fastapi_test_app(
                 state_dir=state_dir,
+                database_url=database_url,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
                 control_plane_root_path=root,
@@ -9284,21 +9286,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             cookie = _fastapi_signed_in_cookie(session_manager, role="admin")
 
-            with patch(
-                "control_plane.generic_web_promotion_http.dispatch_generic_web_promotion_workflow",
-                return_value=GenericWebPromotionWorkflowResult(
-                    product="sellyouroutboard",
-                    context="sellyouroutboard-testing",
-                    repository="cbusillo/sellyouroutboard",
-                    workflow_id="promote-prod.yml",
-                    ref="main",
-                    dry_run=False,
-                    bump="patch",
-                    run_id=25237186636,
-                    run_url="https://github.com/cbusillo/sellyouroutboard/actions/runs/25237186636",
-                    run_status="queued",
-                ),
-            ) as dispatch_mock:
+            with (
+                patch(
+                    "control_plane.generic_web_promotion_http.resolve_launchplane_github_token",
+                    return_value="github-token",
+                ) as token_mock,
+                patch(
+                    "control_plane.generic_web_promotion_http._workflow_dispatch_run_ids",
+                    return_value={25237186635},
+                ) as runs_mock,
+            ):
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -9318,15 +9315,24 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     authorization="",
                     headers=_fastapi_browser_mutation_headers(session_manager, cookie),
                 )
+            outbox_rows = store.list_outbox_delivery_records(states=("pending",))
+            store.close()
 
         self.assertEqual(status_code, 202)
         self.assertEqual(payload["result"]["repository"], "cbusillo/sellyouroutboard")
         self.assertEqual(payload["result"]["workflow_id"], "promote-prod.yml")
         self.assertFalse(payload["result"]["dry_run"])
-        self.assertEqual(payload["result"]["run_id"], 25237186636)
-        self.assertEqual(payload["records"], {})
+        self.assertEqual(payload["result"]["dispatch_status"], "pending")
+        self.assertEqual(payload["result"]["run_id"], 0)
+        self.assertIn("outbox_delivery_id", payload["records"])
+        self.assertEqual(len(outbox_rows), 1)
+        self.assertEqual(outbox_rows[0].delivery_id, payload["records"]["outbox_delivery_id"])
+        self.assertEqual(outbox_rows[0].kind, "github_workflow_dispatch")
+        self.assertEqual(outbox_rows[0].payload["credential_context"], "sellyouroutboard-testing")
+        self.assertEqual(outbox_rows[0].payload["previous_run_ids"], [25237186635])
         GenericWebPromotionWorkflowResponse.model_validate(payload)
-        dispatch_mock.assert_called_once()
+        token_mock.assert_called_once()
+        runs_mock.assert_called_once()
 
     def test_human_session_dispatches_generic_web_promotion_workflow_with_padded_lane_context(
         self,
@@ -9334,7 +9340,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
             session_manager = _fastapi_human_session_manager()
             profile_payload = _product_profile_payload_with_prod()
             profile_payload["lanes"] = tuple(
@@ -9359,6 +9367,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             app = create_launchplane_fastapi_test_app(
                 state_dir=state_dir,
+                database_url=database_url,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
                 control_plane_root_path=root,
@@ -9366,21 +9375,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             cookie = _fastapi_signed_in_cookie(session_manager, role="admin")
 
-            with patch(
-                "control_plane.generic_web_promotion_http.dispatch_generic_web_promotion_workflow",
-                return_value=GenericWebPromotionWorkflowResult(
-                    product="sellyouroutboard",
-                    context="sellyouroutboard-testing",
-                    repository="cbusillo/sellyouroutboard",
-                    workflow_id="promote-prod.yml",
-                    ref="main",
-                    dry_run=False,
-                    bump="patch",
-                    run_id=25237186636,
-                    run_url="https://github.com/cbusillo/sellyouroutboard/actions/runs/25237186636",
-                    run_status="queued",
+            with (
+                patch(
+                    "control_plane.generic_web_promotion_http.resolve_launchplane_github_token",
+                    return_value="github-token",
                 ),
-            ) as dispatch_mock:
+                patch(
+                    "control_plane.generic_web_promotion_http._workflow_dispatch_run_ids",
+                    return_value={25237186635},
+                ),
+            ):
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -9400,16 +9404,22 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     authorization="",
                     headers=_fastapi_browser_mutation_headers(session_manager, cookie),
                 )
+            outbox_rows = store.list_outbox_delivery_records(states=("pending",))
+            store.close()
 
         self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["run_id"], 25237186636)
-        dispatch_mock.assert_called_once()
+        self.assertEqual(payload["result"]["dispatch_status"], "pending")
+        self.assertEqual(payload["result"]["run_id"], 0)
+        self.assertEqual(len(outbox_rows), 1)
+        self.assertEqual(outbox_rows[0].aggregate_id, "sellyouroutboard:sellyouroutboard-testing")
 
     def test_generic_web_promotion_workflow_replays_idempotent_response(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload_with_prod())
             )
@@ -9431,6 +9441,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             app = create_launchplane_fastapi_test_app(
                 state_dir=state_dir,
+                database_url=database_url,
                 verifier=_StubVerifier(
                     _identity(
                         repository="cbusillo/sellyouroutboard",
@@ -9455,21 +9466,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 },
             }
 
-            with patch(
-                "control_plane.generic_web_promotion_http.dispatch_generic_web_promotion_workflow",
-                return_value=GenericWebPromotionWorkflowResult(
-                    product="sellyouroutboard",
-                    context="sellyouroutboard-testing",
-                    repository="cbusillo/sellyouroutboard",
-                    workflow_id="promote-prod.yml",
-                    ref="main",
-                    dry_run=False,
-                    bump="patch",
-                    run_id=25237186636,
-                    run_url="https://github.com/cbusillo/sellyouroutboard/actions/runs/25237186636",
-                    run_status="queued",
-                ),
-            ) as dispatch_mock:
+            with (
+                patch(
+                    "control_plane.generic_web_promotion_http.resolve_launchplane_github_token",
+                    return_value="github-token",
+                ) as token_mock,
+                patch(
+                    "control_plane.generic_web_promotion_http._workflow_dispatch_run_ids",
+                    return_value={25237186635},
+                ) as runs_mock,
+            ):
                 first_status_code, first_payload = _invoke_app(
                     app,
                     method="POST",
@@ -9484,14 +9490,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
                     payload=request_payload,
                     headers={"Idempotency-Key": "generic-web-promotion-workflow-replay"},
                 )
+            outbox_rows = store.list_outbox_delivery_records(states=("pending",))
+            store.close()
 
         self.assertEqual(first_status_code, 202)
         self.assertEqual(second_status_code, 202)
-        self.assertEqual(first_payload["records"], {})
-        self.assertEqual(second_payload["records"], {})
+        self.assertIn("outbox_delivery_id", first_payload["records"])
+        self.assertEqual(second_payload["records"], first_payload["records"])
+        self.assertEqual(len(outbox_rows), 1)
+        self.assertEqual(outbox_rows[0].delivery_id, first_payload["records"]["outbox_delivery_id"])
         self.assertTrue(second_payload["replayed"])
         self.assertEqual(second_payload["original_trace_id"], first_payload["trace_id"])
-        dispatch_mock.assert_called_once()
+        token_mock.assert_called_once()
+        runs_mock.assert_called_once()
 
     def test_generic_web_promotion_workflow_rejects_terminal_agent_bearer(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -9513,29 +9524,25 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 ),
             )
 
-            with patch(
-                "control_plane.generic_web_promotion_http.dispatch_generic_web_promotion_workflow"
-            ) as dispatch_mock:
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/drivers/generic-web/prod-promotion-workflow",
-                    payload={
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-promotion-workflow",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "workflow": {
                         "schema_version": 1,
                         "product": "sellyouroutboard",
-                        "workflow": {
-                            "schema_version": 1,
-                            "product": "sellyouroutboard",
-                            "context": "sellyouroutboard-testing",
-                            "dry_run": False,
-                        },
+                        "context": "sellyouroutboard-testing",
+                        "dry_run": False,
                     },
-                    authorization="Bearer terminal-agent-token",
-                )
+                },
+                authorization="Bearer terminal-agent-token",
+            )
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "authorization_denied")
-        dispatch_mock.assert_not_called()
 
     def test_generic_web_promotion_workflow_rejects_unauthorized_human(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -9580,7 +9587,9 @@ class LaunchplaneServiceTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            store = PostgresRecordStore(database_url=database_url)
+            store.ensure_schema()
             profile_payload = _product_profile_payload_with_prod()
             profile_payload["driver_id"] = "odoo"
             store.write_product_profile_record(
@@ -9604,6 +9613,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             app = create_launchplane_fastapi_test_app(
                 state_dir=state_dir,
+                database_url=database_url,
                 verifier=_StubVerifier(
                     _identity(
                         repository="cbusillo/odoo-tenant-cm",
@@ -9618,21 +9628,16 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
             )
 
-            with patch(
-                "control_plane.generic_web_promotion_http.dispatch_generic_web_promotion_workflow",
-                return_value=GenericWebPromotionWorkflowResult(
-                    product="sellyouroutboard",
-                    context="sellyouroutboard-testing",
-                    repository="cbusillo/sellyouroutboard",
-                    workflow_id="promote-prod.yml",
-                    ref="main",
-                    dry_run=False,
-                    bump="patch",
-                    run_id=25237186636,
-                    run_url="https://github.com/cbusillo/sellyouroutboard/actions/runs/25237186636",
-                    run_status="queued",
+            with (
+                patch(
+                    "control_plane.generic_web_promotion_http.resolve_launchplane_github_token",
+                    return_value="github-token",
                 ),
-            ) as dispatch_mock:
+                patch(
+                    "control_plane.generic_web_promotion_http._workflow_dispatch_run_ids",
+                    return_value={25237186635},
+                ),
+            ):
                 status_code, payload = _invoke_app(
                     app,
                     method="POST",
@@ -9648,12 +9653,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
                         },
                     },
                 )
+            outbox_rows = store.list_outbox_delivery_records(states=("pending",))
+            store.close()
 
         self.assertEqual(status_code, 202)
-        self.assertEqual(payload["result"]["run_id"], 25237186636)
-        dispatch_mock.assert_called_once()
-        _, kwargs = dispatch_mock.call_args
-        self.assertEqual(kwargs["profile"].driver_id, "odoo")
+        self.assertEqual(payload["result"]["dispatch_status"], "pending")
+        self.assertEqual(len(outbox_rows), 1)
+        self.assertEqual(outbox_rows[0].aggregate_id, "sellyouroutboard:sellyouroutboard-testing")
 
     def test_generic_web_promotion_workflow_rejects_unowned_context_before_authz(
         self,
@@ -9688,30 +9694,26 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             cookie = _fastapi_signed_in_cookie(session_manager, role="admin")
 
-            with patch(
-                "control_plane.generic_web_promotion_http.dispatch_generic_web_promotion_workflow"
-            ) as dispatch_mock:
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/drivers/generic-web/prod-promotion-workflow",
-                    payload={
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-promotion-workflow",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "workflow": {
                         "schema_version": 1,
                         "product": "sellyouroutboard",
-                        "workflow": {
-                            "schema_version": 1,
-                            "product": "sellyouroutboard",
-                            "context": "unowned-context",
-                            "dry_run": False,
-                        },
+                        "context": "unowned-context",
+                        "dry_run": False,
                     },
-                    authorization="",
-                    headers=_fastapi_browser_mutation_headers(session_manager, cookie),
-                )
+                },
+                authorization="",
+                headers=_fastapi_browser_mutation_headers(session_manager, cookie),
+            )
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
-        dispatch_mock.assert_not_called()
 
     def test_generic_web_promotion_workflow_rejects_token_unowned_context_before_authz(
         self,
@@ -9755,28 +9757,24 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 control_plane_root_path=root,
             )
 
-            with patch(
-                "control_plane.generic_web_promotion_http.dispatch_generic_web_promotion_workflow"
-            ) as dispatch_mock:
-                status_code, payload = _invoke_app(
-                    app,
-                    method="POST",
-                    path="/v1/drivers/generic-web/prod-promotion-workflow",
-                    payload={
+            status_code, payload = _invoke_app(
+                app,
+                method="POST",
+                path="/v1/drivers/generic-web/prod-promotion-workflow",
+                payload={
+                    "schema_version": 1,
+                    "product": "sellyouroutboard",
+                    "workflow": {
                         "schema_version": 1,
                         "product": "sellyouroutboard",
-                        "workflow": {
-                            "schema_version": 1,
-                            "product": "sellyouroutboard",
-                            "context": "unowned-context",
-                            "dry_run": False,
-                        },
+                        "context": "unowned-context",
+                        "dry_run": False,
                     },
-                )
+                },
+            )
 
         self.assertEqual(status_code, 403)
         self.assertEqual(payload["error"]["code"], "product_driver_mismatch")
-        dispatch_mock.assert_not_called()
 
     def test_generic_web_preview_inventory_route_writes_scan_from_driver_result(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:


### PR DESCRIPTION
## Summary
- add durable PostgreSQL outbox records, schema invariants, worker CLI, leased `FOR UPDATE SKIP LOCKED` claims, owner fencing, bounded backoff, and provider-marker reconciliation
- atomically enqueue generic-web GitHub workflow dispatches with idempotency evidence and public-ingress GitHub notifications with incident transitions
- scope dispatch dedupe to one identity/idempotency transition so later identical dispatches remain valid
- preserve direct email/Discord delivery in mixed notification policies and ensure resolved GitHub issues are actually closed after marker reconciliation
- reject secret-shaped payload fields and persist only bounded provider-safe error codes

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (1937 tests)
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff check and format check
- `pnpm --dir frontend validate`
- real PostgreSQL integration gate (30 tests, including concurrent enqueue dedupe)
- independent final review: SHIP

Closes #1691