### PR TITLE
Make provider mutations durable and reconcilable

### DIFF
--- a/control_plane/contracts/idempotency_record.py
+++ b/control_plane/contracts/idempotency_record.py
@@ -28,6 +28,9 @@ class LaunchplaneIdempotencyRecord(BaseModel):
     lease_expires_at: str = ""
     attempt: int = Field(default=1, ge=1)
     reconciliation_key: str = ""
+    provider_target_key: str = ""
+    provider_effect_phase: str = ""
+    provider_effect_started_at: str = ""
     created_at: str = ""
     updated_at: str = ""
     response_status_code: int | None = Field(default=None, ge=100, le=599)
@@ -64,6 +67,21 @@ class LaunchplaneIdempotencyRecord(BaseModel):
             required=False,
         )
         self.reconciliation_key = self.reconciliation_key.strip()
+        self.provider_target_key = self.provider_target_key.strip()
+        if self.provider_target_key and not self.reconciliation_key:
+            raise ValueError("Provider target keys require a reconciliation key.")
+        self.provider_effect_phase = self.provider_effect_phase.strip()
+        self.provider_effect_started_at = _normalize_mutation_timestamp(
+            self.provider_effect_started_at,
+            field_name="provider_effect_started_at",
+            required=False,
+        )
+        if bool(self.provider_effect_phase) != bool(self.provider_effect_started_at):
+            raise ValueError(
+                "Provider effect checkpoints require both phase and started_at evidence."
+            )
+        if self.provider_effect_phase and not self.reconciliation_key:
+            raise ValueError("Provider effect checkpoints require a reconciliation key.")
         recorded_at = self.recorded_at.strip()
         self.created_at = _normalize_mutation_timestamp(
             self.created_at.strip() or recorded_at,
@@ -146,6 +164,7 @@ def build_launchplane_mutation_reservation(
     lease_expires_at: str,
     reserved_at: str,
     reconciliation_key: str = "",
+    provider_target_key: str = "",
 ) -> LaunchplaneIdempotencyRecord:
     normalized_scope = _normalize_required(scope, "Mutation reservation requires scope.")
     normalized_route_path = _normalize_required(
@@ -175,6 +194,7 @@ def build_launchplane_mutation_reservation(
         lease_owner=lease_owner,
         lease_expires_at=lease_expires_at,
         reconciliation_key=reconciliation_key,
+        provider_target_key=provider_target_key,
         created_at=reserved_at,
         updated_at=reserved_at,
     )

--- a/control_plane/dokploy.py
+++ b/control_plane/dokploy.py
@@ -770,7 +770,13 @@ def read_dokploy_config(
 
 
 def trigger_deployment(
-    *, host: str, token: str, target_type: str, target_id: str, no_cache: bool
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+    no_cache: bool,
+    title: str = "",
 ) -> None:
     if target_type == "compose":
         endpoint_path = "/api/compose.redeploy" if no_cache else "/api/compose.deploy"
@@ -780,7 +786,10 @@ def trigger_deployment(
         payload = {"applicationId": target_id}
     else:
         raise click.ClickException(f"Unsupported Dokploy target type: {target_type}")
-    if no_cache:
+    normalized_title = title.strip()
+    if normalized_title:
+        payload["title"] = normalized_title
+    elif no_cache:
         payload["title"] = "Manual redeploy (no-cache requested)"
     dokploy_request(host=host, token=token, path=endpoint_path, method="POST", payload=payload)
 
@@ -788,6 +797,19 @@ def trigger_deployment(
 def latest_deployment_for_target(
     *, host: str, token: str, target_type: str, target_id: str
 ) -> JsonObject | None:
+    return _latest_deployment_from_list(
+        list_deployments_for_target(
+            host=host,
+            token=token,
+            target_type=target_type,
+            target_id=target_id,
+        )
+    )
+
+
+def list_deployments_for_target(
+    *, host: str, token: str, target_type: str, target_id: str
+) -> list[JsonObject]:
     if target_type == "compose":
         compose_payload = dokploy_request(
             host=host,
@@ -797,11 +819,11 @@ def latest_deployment_for_target(
         )
         compose_payload_as_object = as_json_object(compose_payload)
         if compose_payload_as_object is None:
-            return None
+            return []
         deployments_payload = compose_payload_as_object.get("deployments")
         if not isinstance(deployments_payload, list):
-            return None
-        return _latest_deployment_from_list(_collect_object_items(deployments_payload))
+            return []
+        return _collect_object_items(deployments_payload)
 
     if target_type == "application":
         payload = dokploy_request(
@@ -810,9 +832,33 @@ def latest_deployment_for_target(
             path="/api/deployment.all",
             query={"applicationId": target_id},
         )
-        return _latest_deployment_from_list(extract_deployments(payload))
+        return extract_deployments(payload)
 
     raise click.ClickException(f"Unsupported Dokploy target type: {target_type}")
+
+
+def deployment_for_target_by_title(
+    *,
+    host: str,
+    token: str,
+    target_type: str,
+    target_id: str,
+    title: str,
+) -> JsonObject | None:
+    normalized_title = title.strip()
+    if not normalized_title:
+        raise click.ClickException("Dokploy deployment observation requires a title.")
+    matching_deployments = [
+        deployment
+        for deployment in list_deployments_for_target(
+            host=host,
+            token=token,
+            target_type=target_type,
+            target_id=target_id,
+        )
+        if str(deployment.get("title") or "").strip() == normalized_title
+    ]
+    return _latest_deployment_from_list(matching_deployments)
 
 
 def fetch_dokploy_target_payload(
@@ -1495,19 +1541,33 @@ def wait_for_target_deployment(
     target_id: str,
     before_key: str,
     timeout_seconds: int,
+    deployment_title: str = "",
 ) -> str:
     failure_message_prefix = (
         "Dokploy compose deployment failed"
         if target_type == "compose"
         else "Dokploy deployment failed"
     )
-    return _wait_for_deployment_status(
-        fetch_latest_deployment=lambda: latest_deployment_for_target(
+    normalized_deployment_title = deployment_title.strip()
+
+    def fetch_deployment() -> JsonObject | None:
+        if normalized_deployment_title:
+            return deployment_for_target_by_title(
+                host=host,
+                token=token,
+                target_type=target_type,
+                target_id=target_id,
+                title=normalized_deployment_title,
+            )
+        return latest_deployment_for_target(
             host=host,
             token=token,
             target_type=target_type,
             target_id=target_id,
-        ),
+        )
+
+    return _wait_for_deployment_status(
+        fetch_latest_deployment=fetch_deployment,
         before_key=before_key,
         timeout_seconds=timeout_seconds,
         failure_message_prefix=failure_message_prefix,
@@ -1667,6 +1727,8 @@ def run_compose_post_deploy_update(
     required_workflow_environment_keys: tuple[str, ...] = (),
     protected_shopify_store_keys: tuple[str, ...] = (),
     run_destructive_restore: bool = False,
+    before_provider_mutation: Callable[[str], None] | None = None,
+    deployment_title: str = "",
 ) -> dict[str, str]:
     compose_id = target_definition.target_id.strip()
     compose_name = (
@@ -1715,6 +1777,8 @@ def run_compose_post_deploy_update(
         target_definition.deploy_timeout_seconds or DEFAULT_DOKPLOY_DEPLOY_TIMEOUT_SECONDS
     )
     if desired_env_map != current_env_map:
+        if before_provider_mutation is not None:
+            before_provider_mutation("post_deploy_target_update")
         update_dokploy_target_env(
             host=host,
             token=token,
@@ -1729,21 +1793,42 @@ def run_compose_post_deploy_update(
             target_type="compose",
             target_id=compose_id,
         )
-        trigger_deployment(
-            host=host,
-            token=token,
-            target_type="compose",
-            target_id=compose_id,
-            no_cache=False,
-        )
-        wait_for_target_deployment(
-            host=host,
-            token=token,
-            target_type="compose",
-            target_id=compose_id,
-            before_key=deployment_key(latest_compose_deployment),
-            timeout_seconds=schedule_timeout_seconds,
-        )
+        if before_provider_mutation is not None:
+            before_provider_mutation("post_deploy_deploy_trigger")
+        if deployment_title:
+            trigger_deployment(
+                host=host,
+                token=token,
+                target_type="compose",
+                target_id=compose_id,
+                no_cache=False,
+                title=deployment_title,
+            )
+            wait_for_target_deployment(
+                host=host,
+                token=token,
+                target_type="compose",
+                target_id=compose_id,
+                before_key=deployment_key(latest_compose_deployment),
+                timeout_seconds=schedule_timeout_seconds,
+                deployment_title=deployment_title,
+            )
+        else:
+            trigger_deployment(
+                host=host,
+                token=token,
+                target_type="compose",
+                target_id=compose_id,
+                no_cache=False,
+            )
+            wait_for_target_deployment(
+                host=host,
+                token=token,
+                target_type="compose",
+                target_id=compose_id,
+                before_key=deployment_key(latest_compose_deployment),
+                timeout_seconds=schedule_timeout_seconds,
+            )
         target_payload = fetch_dokploy_target_payload(
             host=host,
             token=token,
@@ -1824,6 +1909,8 @@ def run_compose_post_deploy_update(
         "enabled": False,
         "timezone": "UTC",
     }
+    if before_provider_mutation is not None:
+        before_provider_mutation("post_deploy_schedule_upsert")
     schedule = upsert_dokploy_schedule(
         host=host,
         token=token,
@@ -1843,6 +1930,8 @@ def run_compose_post_deploy_update(
         token=token,
         schedule_id=schedule_id,
     )
+    if before_provider_mutation is not None:
+        before_provider_mutation("post_deploy_schedule_trigger")
     dokploy_request(
         host=host,
         token=token,
@@ -2180,6 +2269,12 @@ def deployment_key_from_wait_result(wait_result: str) -> str:
     return ""
 
 
+def deployment_status(deployment: JsonObject | None) -> str:
+    if deployment is None:
+        return ""
+    return _deployment_status(deployment)
+
+
 def dokploy_request(
     *,
     host: str,
@@ -2378,8 +2473,6 @@ def _wait_for_deployment_status(
                 raise click.ClickException(
                     f"{failure_message_prefix}: deployment={latest_key} status={latest_status}"
                 )
-            if not latest_status:
-                return f"deployment={latest_key} status=unknown"
         time.sleep(3)
 
     raise click.ClickException("Timed out waiting for Dokploy deployment status.")

--- a/control_plane/generic_web_deploy_http.py
+++ b/control_plane/generic_web_deploy_http.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from collections.abc import Callable
 from typing import cast
 
 from control_plane.contracts.product_profile_record import (
@@ -16,6 +17,10 @@ from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployStore,
     execute_generic_web_deploy,
     product_profile_uses_generic_web_base,
+)
+from control_plane.workflows.generic_web_deploy_provider import (
+    GenericWebDeployProvider,
+    GenericWebResolvedDeployTarget,
 )
 
 
@@ -76,6 +81,11 @@ def execute_generic_web_deploy_result(
     request: GenericWebDeployEnvelope,
     profile: LaunchplaneProductProfileRecord,
     lane: ProductLaneProfile,
+    deploy_provider: GenericWebDeployProvider | None = None,
+    resolved_deploy_target: GenericWebResolvedDeployTarget | None = None,
+    provider_operation_title: str = "",
+    deployment_record_id: str = "",
+    provider_effect_checkpoint: Callable[[str], None] | None = None,
 ) -> tuple[dict[str, object], dict[str, object]]:
     driver_result = execute_generic_web_deploy(
         control_plane_root=control_plane_root,
@@ -84,6 +94,11 @@ def execute_generic_web_deploy_result(
         profile=profile,
         lane=lane,
         post_deploy_executor=_generic_web_post_deploy_executor_for_profile(profile),
+        deploy_provider=deploy_provider,
+        resolved_deploy_target=resolved_deploy_target,
+        provider_operation_title=provider_operation_title,
+        deployment_record_id=deployment_record_id,
+        provider_effect_checkpoint=provider_effect_checkpoint,
     )
     result = _scrub_retired_target_type_alias(driver_result.model_dump(mode="json"))
     return {"deployment_record_id": driver_result.deployment_record_id}, result

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -96,6 +96,18 @@ from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
     build_launchplane_idempotency_record_id,
 )
+from control_plane.provider_operations import (
+    DurableProviderMutationAdapter,
+    DurableProviderOperationResult,
+    ProviderMutationOutcome,
+    ProviderMutationRejectedError,
+    ProviderMutationUnknownError,
+    ProviderObservation,
+    ProviderObservationOutcome,
+    ProviderOperationLease,
+    provider_operation_title,
+    run_durable_provider_operation,
+)
 from control_plane.contracts.data_provenance import DataProvenance, FreshnessStatus
 from control_plane.contracts.ingress_canary_route_record import IngressCanaryRouteRecord
 from control_plane.contracts.ingress_route_audit_record import (
@@ -186,6 +198,23 @@ from control_plane.generic_web_deploy_http import (
     execute_generic_web_deploy_result,
     resolve_generic_web_deploy_lane,
     should_store_generic_web_deploy_idempotency,
+)
+from control_plane.workflows.generic_web_deploy import (
+    GenericWebDeployStore,
+    normalize_generic_web_artifact_id,
+    record_observed_generic_web_deploy,
+)
+from control_plane.workflows.generic_web_deploy_provider import (
+    GenericWebDeployProvider,
+    GenericWebResolvedDeployTarget,
+    build_generic_web_provider_reconciliation_key,
+    build_generic_web_provider_target_key,
+    default_generic_web_deploy_provider,
+    generic_web_provider_deployment_succeeded,
+    resolve_generic_web_provider_reconciliation_target,
+)
+from control_plane.workflows.odoo_generic_web_post_deploy import (
+    generic_web_post_deploy_executor_for_driver_id,
 )
 from control_plane.generic_web_promotion_http import (
     GENERIC_WEB_PROD_PROMOTION_ACTION,
@@ -343,6 +372,7 @@ from control_plane.odoo_preview_apply_http import (
     build_odoo_preview_apply_inputs_result,
     driver_result_contains_status,
     execute_odoo_preview_apply_result,
+    observe_odoo_preview_apply_result,
     resolve_odoo_preview_apply_profile,
 )
 from control_plane.odoo_post_deploy_http import (
@@ -460,6 +490,7 @@ from control_plane.contracts.product_onboarding_manifest import ProductOnboardin
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductExpectedConfigProfile,
+    ProductLaneProfile,
     ProductRuntimeConfigRequirement,
     ProductSecretConfigRequirement,
 )
@@ -2065,6 +2096,286 @@ class AcceptedEvidenceResponse(BaseModel):
     result: dict[str, object] | None = None
     replayed: bool | None = None
     original_trace_id: str | None = None
+
+
+def _provider_operation_response_payload(
+    *,
+    trace_id: str,
+    records: Mapping[str, object],
+    result: dict[str, object],
+) -> dict[str, object]:
+    return AcceptedEvidenceResponse(
+        trace_id=trace_id,
+        records=dict(records),
+        result=result,
+    ).model_dump(mode="json", exclude_none=True)
+
+
+class _OdooPreviewProviderMutationAdapter:
+    def __init__(
+        self,
+        *,
+        control_plane_root: FilePath,
+        record_store: object,
+        profile: LaunchplaneProductProfileRecord,
+        apply_request: OdooPreviewApplyEnvelope,
+        database_url: str | None,
+        trace_id: str,
+    ) -> None:
+        self._control_plane_root = control_plane_root
+        self._record_store = record_store
+        self._profile = profile
+        self._apply_request = apply_request
+        self._database_url = database_url
+        self._trace_id = trace_id
+
+    def reconciliation_key(self) -> str:
+        plan = self._apply_request.apply.dry_run_plan
+        return (
+            f"dokploy:compose:{self._profile.preview.context.strip()}:{plan.compose_name.strip()}"
+        )
+
+    def target_key(self) -> str:
+        reconciliation_key = self.reconciliation_key()
+        return f"dokploy-provider-target:{hashlib.sha256(reconciliation_key.encode('utf-8')).hexdigest()}"
+
+    def observe(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+    ) -> ProviderObservation:
+        del reconciliation_key
+        observation_outcome, driver_result, retry_safe = observe_odoo_preview_apply_result(
+            control_plane_root_path=self._control_plane_root,
+            profile=self._profile,
+            request=self._apply_request,
+            database_url=self._database_url,
+            provider_operation_title=provider_operation_title(provider_operation_key),
+            provider_effect_phase=provider_effect_phase,
+        )
+        if driver_result is None:
+            return ProviderObservation(
+                outcome=cast(ProviderObservationOutcome, observation_outcome),
+                retry_safe=retry_safe,
+            )
+        driver_result.pop("provider_effect_attempted", None)
+        terminal_failure = str(driver_result.get("status", "")).strip() == "fail"
+        return ProviderObservation(
+            outcome="present",
+            response_status_code=502 if terminal_failure else 202,
+            response_payload=_provider_operation_response_payload(
+                trace_id=self._trace_id,
+                records={},
+                result=driver_result,
+            ),
+        )
+
+    def apply(
+        self, provider_operation_key: str, lease: ProviderOperationLease
+    ) -> ProviderMutationOutcome:
+        try:
+            driver_result = execute_odoo_preview_apply_result(
+                control_plane_root_path=self._control_plane_root,
+                record_store=self._record_store,
+                profile=self._profile,
+                request=self._apply_request,
+                database_url=self._database_url,
+                provider_operation_title=provider_operation_title(provider_operation_key),
+                provider_effect_checkpoint=lease.checkpoint_effect,
+                provider_lease_check=lease.assert_current,
+            )
+        except (
+            OdooPreviewApplyConfigError,
+            FileNotFoundError,
+            ValueError,
+            click.ClickException,
+        ) as error:
+            raise ProviderMutationRejectedError(error)
+        provider_effect_attempted = driver_result.pop("provider_effect_attempted", False) is True
+        driver_status = str(driver_result.get("status", "")).strip()
+        if driver_status == "fail" and provider_effect_attempted:
+            raise ProviderMutationUnknownError(
+                str(driver_result.get("error_message", "")).strip()
+                or "Odoo preview provider outcome requires reconciliation."
+            )
+        return ProviderMutationOutcome(
+            response_status_code=202,
+            response_payload=_provider_operation_response_payload(
+                trace_id=self._trace_id,
+                records={},
+                result=driver_result,
+            ),
+            durable=not driver_result_contains_status(driver_result, "blocked")
+            and driver_status != "fail",
+            provider_effect_performed=provider_effect_attempted,
+        )
+
+
+class _GenericWebDeployProviderMutationAdapter:
+    def __init__(
+        self,
+        *,
+        control_plane_root: FilePath,
+        record_store: object,
+        deploy_request: GenericWebDeployEnvelope,
+        profile: LaunchplaneProductProfileRecord,
+        lane: ProductLaneProfile,
+        trace_id: str,
+    ) -> None:
+        self._control_plane_root = control_plane_root
+        self._record_store = record_store
+        self._deploy_request = deploy_request
+        self._profile = profile
+        self._lane = lane
+        self._trace_id = trace_id
+        self._deploy_provider: GenericWebDeployProvider = default_generic_web_deploy_provider()
+        self._resolved_deploy_target: GenericWebResolvedDeployTarget | None = None
+
+    def _resolve_deploy_target(self) -> GenericWebResolvedDeployTarget:
+        if self._resolved_deploy_target is None:
+            deploy = self._deploy_request.deploy
+            self._resolved_deploy_target = self._deploy_provider.resolve_deploy_target(
+                control_plane_root=self._control_plane_root,
+                request_artifact_id=deploy.artifact_id,
+                request_source_git_ref=deploy.source_git_ref,
+                request_timeout_seconds=deploy.timeout_seconds,
+                request_no_cache=deploy.no_cache,
+                record_store=self._record_store,
+                profile=self._profile,
+                lane=self._lane,
+                normalized_artifact_id=normalize_generic_web_artifact_id(
+                    profile=self._profile,
+                    artifact_id=deploy.artifact_id,
+                ),
+                fallback_target_name=f"{self._profile.product}-{self._lane.instance}",
+            )
+        return self._resolved_deploy_target
+
+    def reconciliation_key(self) -> str:
+        return build_generic_web_provider_reconciliation_key(self._resolve_deploy_target())
+
+    def target_key(self) -> str:
+        return build_generic_web_provider_target_key(self._resolve_deploy_target())
+
+    def observe(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+    ) -> ProviderObservation:
+        try:
+            deploy = self._deploy_request.deploy
+            resolved_target = resolve_generic_web_provider_reconciliation_target(
+                reconciliation_key=reconciliation_key,
+                request_artifact_id=deploy.artifact_id,
+                request_source_git_ref=deploy.source_git_ref,
+                request_timeout_seconds=deploy.timeout_seconds,
+                request_no_cache=deploy.no_cache,
+                normalized_artifact_id=normalize_generic_web_artifact_id(
+                    profile=self._profile,
+                    artifact_id=deploy.artifact_id,
+                ),
+                lane=self._lane,
+            )
+            self._resolved_deploy_target = resolved_target
+            observation = self._deploy_provider.observe_artifact_deploy(
+                control_plane_root=self._control_plane_root,
+                resolved_deploy_target=resolved_target,
+                deployment_title=provider_operation_title(provider_operation_key),
+            )
+        except (FileNotFoundError, ValueError, click.ClickException):
+            return ProviderObservation(outcome="unknown")
+        if observation.outcome != "present":
+            if observation.outcome == "absent" and provider_effect_phase == "deploy_trigger":
+                return ProviderObservation(outcome="unknown")
+            return ProviderObservation(
+                outcome=observation.outcome,
+                retry_safe=(
+                    observation.outcome == "absent"
+                    and provider_effect_phase in {"", "target_update"}
+                ),
+            )
+        post_deploy_unobserved = (
+            generic_web_provider_deployment_succeeded(observation.deployment_status)
+            and generic_web_post_deploy_executor_for_driver_id(self._profile.driver_id) is not None
+        )
+        deployment_record_id = self._deployment_record_id(provider_operation_key)
+        if provider_effect_phase.startswith("post_deploy_"):
+            read_deployment_record = getattr(self._record_store, "read_deployment_record", None)
+            if not callable(read_deployment_record):
+                return ProviderObservation(outcome="unknown")
+            try:
+                read_deployment_record(deployment_record_id)
+            except FileNotFoundError:
+                return ProviderObservation(outcome="unknown")
+            post_deploy_unobserved = False
+        try:
+            records, driver_result = record_observed_generic_web_deploy(
+                record_store=cast(GenericWebDeployStore, self._record_store),
+                profile=self._profile,
+                lane=self._lane,
+                resolved_deploy_target=resolved_target,
+                observation=observation,
+                deployment_record_id=deployment_record_id,
+                post_deploy_unobserved=post_deploy_unobserved,
+            )
+        except (FileNotFoundError, ValueError, click.ClickException):
+            return ProviderObservation(outcome="unknown")
+        terminal_failure = str(driver_result.get("deploy_status", "")).strip() == "fail"
+        return ProviderObservation(
+            outcome="present",
+            response_status_code=502 if terminal_failure else 202,
+            response_payload=_provider_operation_response_payload(
+                trace_id=self._trace_id,
+                records=records,
+                result=driver_result,
+            ),
+        )
+
+    def _deployment_record_id(self, provider_operation_key: str) -> str:
+        operation_digest = hashlib.sha256(provider_operation_key.encode("utf-8")).hexdigest()[:24]
+        return (
+            f"deployment-provider-operation-{operation_digest}-"
+            f"{self._lane.context}-{self._lane.instance}"
+        )
+
+    def apply(
+        self, provider_operation_key: str, lease: ProviderOperationLease
+    ) -> ProviderMutationOutcome:
+        try:
+            records, result = execute_generic_web_deploy_result(
+                control_plane_root=self._control_plane_root,
+                record_store=self._record_store,
+                request=self._deploy_request,
+                profile=self._profile,
+                lane=self._lane,
+                provider_operation_title=provider_operation_title(provider_operation_key),
+                deployment_record_id=self._deployment_record_id(provider_operation_key),
+                deploy_provider=self._deploy_provider,
+                resolved_deploy_target=self._resolve_deploy_target(),
+                provider_effect_checkpoint=lease.checkpoint_effect,
+            )
+        except (FileNotFoundError, ValueError) as error:
+            raise ProviderMutationRejectedError(error)
+        except click.ClickException as error:
+            raise ProviderMutationUnknownError(str(error)) from error
+        provider_effect_attempted = result.pop("provider_effect_attempted", False) is True
+        if str(result.get("deploy_status", "")).strip() == "fail" and provider_effect_attempted:
+            raise ProviderMutationUnknownError(
+                str(result.get("error_message", "")).strip()
+                or "Generic web provider outcome requires reconciliation."
+            )
+        return ProviderMutationOutcome(
+            response_status_code=202,
+            response_payload=_provider_operation_response_payload(
+                trace_id=self._trace_id,
+                records=records,
+                result=result,
+            ),
+            durable=should_store_generic_web_deploy_idempotency(result),
+            provider_effect_performed=provider_effect_attempted,
+        )
 
 
 class ProductOnboardingApplyEnvelope(BaseModel):
@@ -4373,7 +4684,6 @@ def create_launchplane_fastapi_app(
 
     app = _LaunchplaneFastAPI(title="Launchplane API", version="0.1.0", lifespan=lifespan)
     app.add_middleware(BoundedRequestBodyMiddleware)
-    odoo_preview_apply_lock = asyncio.Lock()
     resolved_oauth_login_state_store = (
         oauth_login_state_store if oauth_login_state_store is not None else OAuthLoginStateStore()
     )
@@ -7041,99 +7351,72 @@ def create_launchplane_fastapi_app(
                 ),
             )
 
-        async with odoo_preview_apply_lock:
-            (
-                normalized_idempotency_key,
-                payload_fingerprint,
-                replay_response,
-            ) = await replay_apply_idempotency(
-                request=request,
+        normalized_idempotency_key = idempotency_key.strip()
+        if not normalized_idempotency_key:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Odoo preview apply requests require an Idempotency-Key header.",
+            )
+        payload_fingerprint = idempotency_request_fingerprint(
+            route_path=_ODOO_PREVIEW_APPLY_ROUTE,
+            payload=cast(dict[str, object], raw_payload),
+        )
+        adapter = _OdooPreviewProviderMutationAdapter(
+            control_plane_root=resolved_control_plane_root,
+            record_store=record_store,
+            profile=product_profile,
+            apply_request=apply_request,
+            database_url=getattr(record_store, "database_url", None),
+            trace_id=trace_id,
+        )
+        try:
+            return await run_provider_mutation(
                 record_store=record_store,
                 identity=identity,
                 route_path=_ODOO_PREVIEW_APPLY_ROUTE,
-                idempotency_key=idempotency_key,
+                idempotency_key=normalized_idempotency_key,
+                request_fingerprint=payload_fingerprint,
                 trace_id=trace_id,
-                check_replay=bool(idempotency_key.strip()),
+                adapter=adapter,
+                in_progress_message=(
+                    "A matching Odoo preview apply is already running. "
+                    "Retry with the same Idempotency-Key."
+                ),
+                reconcile_message=("The Odoo preview apply requires reconciliation before retry."),
             )
-            if replay_response is not None:
-                return replay_response
-
-            async def execute_apply_and_store() -> AcceptedEvidenceResponse:
-                driver_result = await asyncio.to_thread(
-                    execute_odoo_preview_apply_result,
-                    control_plane_root_path=resolved_control_plane_root,
-                    record_store=record_store,
-                    profile=product_profile,
-                    request=apply_request,
-                    database_url=getattr(record_store, "database_url", None),
-                )
-                response = accepted_evidence_response(
-                    trace_id=trace_id,
-                    records={},
-                    result=driver_result,
-                )
-                if not driver_result_contains_status(driver_result, "blocked"):
-                    store_apply_idempotency(
-                        record_store=record_store,
-                        identity=identity,
-                        route_path=_ODOO_PREVIEW_APPLY_ROUTE,
-                        idempotency_key=normalized_idempotency_key,
-                        request_fingerprint_value=payload_fingerprint,
-                        trace_id=trace_id,
-                        response=response,
-                    )
-                return response
-
-            apply_task = asyncio.create_task(
-                execute_apply_and_store(),
-                name=f"odoo-preview-apply:{trace_id}",
-            )
-            try:
-                return await asyncio.shield(apply_task)
-            except asyncio.CancelledError as cancellation:
-                while not apply_task.done():
-                    try:
-                        await asyncio.shield(apply_task)
-                    except asyncio.CancelledError:
-                        continue
-                    except Exception:
-                        _LOGGER.exception(
-                            "Odoo preview apply failed after request cancellation",
-                            extra={"trace_id": trace_id},
-                        )
-                        break
-                raise cancellation
-            except OdooPreviewApplyConfigError as error:
-                return JSONResponse(
-                    status_code=400,
-                    content={
-                        "status": "rejected",
-                        "trace_id": trace_id,
-                        "error": {
-                            "code": "odoo_preview_runtime_config_incomplete",
-                            "message": "Odoo preview apply runtime environment is incomplete.",
-                        },
-                        "details": {
-                            "context": error.context,
-                            "instance": error.instance,
-                            "missing_keys": list(error.missing_keys),
-                        },
+        except OdooPreviewApplyConfigError as error:
+            return JSONResponse(
+                status_code=400,
+                content={
+                    "status": "rejected",
+                    "trace_id": trace_id,
+                    "error": {
+                        "code": "odoo_preview_runtime_config_incomplete",
+                        "message": "Odoo preview apply runtime environment is incomplete.",
                     },
-                )
-            except FileNotFoundError as error:
-                raise _launchplane_http_error(
-                    status_code=404,
-                    trace_id=trace_id,
-                    code="not_found",
-                    message=f"No Launchplane route for {_ODOO_PREVIEW_APPLY_ROUTE}.",
-                ) from error
-            except (ValueError, click.ClickException) as error:
-                raise _launchplane_http_error(
-                    status_code=400,
-                    trace_id=trace_id,
-                    code="invalid_request",
-                    message="Request could not be completed.",
-                ) from error
+                    "details": {
+                        "context": error.context,
+                        "instance": error.instance,
+                        "missing_keys": list(error.missing_keys),
+                    },
+                },
+            )
+        except FileNotFoundError as error:
+            raise _launchplane_http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=f"No Launchplane route for {_ODOO_PREVIEW_APPLY_ROUTE}.",
+            ) from error
+        except (ValueError, click.ClickException) as error:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_request",
+                message="Request could not be completed.",
+            ) from error
 
     async def write_odoo_post_deploy(
         request: Request,
@@ -13388,6 +13671,140 @@ def create_launchplane_fastapi_app(
             }
         )
 
+    def require_provider_operation_store(
+        *, record_store: object, trace_id: str
+    ) -> PostgresRecordStore:
+        if not isinstance(record_store, PostgresRecordStore):
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message="Durable provider operations require Launchplane database storage.",
+            )
+        return record_store
+
+    def provider_mutation_http_response(
+        *,
+        result: DurableProviderOperationResult,
+        trace_id: str,
+        route_path: str,
+        in_progress_message: str,
+        reconcile_message: str,
+    ) -> AcceptedEvidenceResponse:
+        if result.status in {"completed", "unstored", "adopted"}:
+            if result.response_status_code >= 400:
+                raise _launchplane_http_error(
+                    status_code=result.response_status_code,
+                    trace_id=trace_id,
+                    code="provider_mutation_failed",
+                    message=_provider_mutation_failure_message(result.response_payload),
+                )
+            return AcceptedEvidenceResponse.model_validate(result.response_payload)
+        if result.status == "replayed":
+            if result.record is None:
+                raise RuntimeError("Replayed provider mutation requires a stored record.")
+            if (result.record.response_status_code or 0) >= 400:
+                raise _launchplane_http_error(
+                    status_code=result.record.response_status_code or 502,
+                    trace_id=trace_id,
+                    code="provider_mutation_failed",
+                    message=_provider_mutation_failure_message(result.record.response_payload),
+                )
+            return replay_idempotent_response(
+                trace_id=trace_id,
+                stored_record=result.record,
+                route_path=route_path,
+            )
+        if result.status == "conflict":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="idempotency_key_reused",
+                message=(
+                    "Idempotency-Key was already used for a different "
+                    "Launchplane request payload on this route."
+                ),
+            )
+        if result.status in {"in_progress", "target_busy"}:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="mutation_in_progress",
+                message=in_progress_message,
+            )
+        if result.status == "reconcile_required":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="mutation_reconciliation_required",
+                message=reconcile_message,
+            )
+        raise RuntimeError(f"Unsupported provider mutation status: {result.status}")
+
+    def _provider_mutation_failure_message(response_payload: Mapping[str, object]) -> str:
+        result_payload = response_payload.get("result")
+        if isinstance(result_payload, Mapping):
+            error_message = str(result_payload.get("error_message") or "").strip()
+            if error_message:
+                return error_message
+        return "Provider mutation completed with terminal failure evidence."
+
+    async def run_provider_mutation(
+        *,
+        record_store: object,
+        identity: LaunchplaneIdentity,
+        route_path: str,
+        idempotency_key: str,
+        request_fingerprint: str,
+        trace_id: str,
+        adapter: DurableProviderMutationAdapter,
+        in_progress_message: str,
+        reconcile_message: str,
+    ) -> AcceptedEvidenceResponse:
+        reservation_store = require_provider_operation_store(
+            record_store=record_store,
+            trace_id=trace_id,
+        )
+
+        def execute() -> DurableProviderOperationResult:
+            return run_durable_provider_operation(
+                store=reservation_store,
+                scope=idempotency_scope(identity),
+                route_path=route_path,
+                idempotency_key=idempotency_key,
+                request_fingerprint=request_fingerprint,
+                lease_owner=trace_id,
+                response_trace_id=trace_id,
+                adapter=adapter,
+            )
+
+        operation_task = asyncio.create_task(
+            asyncio.to_thread(execute),
+            name=f"provider-mutation:{trace_id}",
+        )
+        try:
+            result = await asyncio.shield(operation_task)
+        except asyncio.CancelledError as cancellation:
+            while not operation_task.done():
+                try:
+                    await asyncio.shield(operation_task)
+                except asyncio.CancelledError:
+                    continue
+                except Exception:
+                    _LOGGER.exception(
+                        "Provider mutation failed after request cancellation",
+                        extra={"trace_id": trace_id},
+                    )
+                    break
+            raise cancellation
+        return provider_mutation_http_response(
+            result=result,
+            trace_id=trace_id,
+            route_path=route_path,
+            in_progress_message=in_progress_message,
+            reconcile_message=reconcile_message,
+        )
+
     async def apply_product_config(
         request: Request,
         identity: Annotated[LaunchplaneIdentity, Depends(read_browser_mutation_identity)],
@@ -16409,28 +16826,41 @@ def create_launchplane_fastapi_app(
                     " for the requested product/context."
                 ),
             )
-        (
-            normalized_key,
-            payload_fingerprint,
-            replayed_response,
-        ) = await replay_apply_idempotency(
-            request=request,
-            record_store=record_store,
-            identity=identity,
+        normalized_key = idempotency_key.strip()
+        if not normalized_key:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Generic web deploy requests require an Idempotency-Key header.",
+            )
+        raw_payload = await request.json()
+        payload_fingerprint = idempotency_request_fingerprint(
             route_path=_GENERIC_WEB_DEPLOY_ROUTE,
-            idempotency_key=idempotency_key,
-            trace_id=trace_id,
-            check_replay=bool(idempotency_key.strip()),
+            payload=cast(dict[str, object], raw_payload),
         )
-        if replayed_response is not None:
-            return replayed_response
+        adapter = _GenericWebDeployProviderMutationAdapter(
+            control_plane_root=resolved_control_plane_root,
+            record_store=record_store,
+            deploy_request=deploy_request,
+            profile=profile,
+            lane=lane,
+            trace_id=trace_id,
+        )
         try:
-            records, result = execute_generic_web_deploy_result(
-                control_plane_root=resolved_control_plane_root,
+            return await run_provider_mutation(
                 record_store=record_store,
-                request=deploy_request,
-                profile=profile,
-                lane=lane,
+                identity=identity,
+                route_path=_GENERIC_WEB_DEPLOY_ROUTE,
+                idempotency_key=normalized_key,
+                request_fingerprint=payload_fingerprint,
+                trace_id=trace_id,
+                adapter=adapter,
+                in_progress_message=(
+                    "A matching generic web deploy is already running. "
+                    "Retry with the same Idempotency-Key."
+                ),
+                reconcile_message=("The generic web deploy requires reconciliation before retry."),
             )
         except FileNotFoundError as error:
             raise _launchplane_http_error(
@@ -16446,22 +16876,6 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        response = accepted_evidence_response(
-            trace_id=trace_id,
-            records=records,
-            result=result,
-        )
-        if should_store_generic_web_deploy_idempotency(result):
-            store_apply_idempotency(
-                record_store=record_store,
-                identity=identity,
-                route_path=_GENERIC_WEB_DEPLOY_ROUTE,
-                idempotency_key=normalized_key,
-                request_fingerprint_value=payload_fingerprint,
-                trace_id=trace_id,
-                response=response,
-            )
-        return response
 
     async def apply_generic_web_prod_promotion(
         request: Request,

--- a/control_plane/odoo_preview_apply_http.py
+++ b/control_plane/odoo_preview_apply_http.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
 import re
@@ -18,6 +19,7 @@ from control_plane.workflows.odoo_preview_runtime import (
     OdooPreviewDokployApplyRequest,
     build_odoo_preview_apply_inputs,
     execute_odoo_preview_dokploy_apply,
+    observe_odoo_preview_dokploy_apply,
 )
 
 
@@ -130,6 +132,9 @@ def execute_odoo_preview_apply_result(
     profile: LaunchplaneProductProfileRecord,
     request: OdooPreviewApplyEnvelope,
     database_url: str | None,
+    provider_operation_title: str = "",
+    provider_effect_checkpoint: Callable[[str], None] | None = None,
+    provider_lease_check: Callable[[], None] | None = None,
 ) -> dict[str, object]:
     if request.apply.dry_run_plan.repository.strip() != profile.repository.strip():
         raise ValueError("Odoo preview apply repository does not match product profile.")
@@ -154,8 +159,33 @@ def execute_odoo_preview_apply_result(
         control_plane_root=control_plane_root_path,
         request=service_apply_request,
         database_url=database_url,
+        provider_operation_title=provider_operation_title,
+        provider_effect_checkpoint=provider_effect_checkpoint,
+        provider_lease_check=provider_lease_check,
     )
     return driver_result.model_dump(mode="json")
+
+
+def observe_odoo_preview_apply_result(
+    *,
+    control_plane_root_path: Path,
+    profile: LaunchplaneProductProfileRecord,
+    request: OdooPreviewApplyEnvelope,
+    database_url: str | None,
+    provider_operation_title: str,
+    provider_effect_phase: str = "",
+) -> tuple[str, dict[str, object] | None, bool]:
+    observation = observe_odoo_preview_dokploy_apply(
+        control_plane_root=control_plane_root_path,
+        context_name=profile.preview.context,
+        request=request.apply,
+        database_url=database_url,
+        provider_operation_title=provider_operation_title,
+        provider_effect_phase=provider_effect_phase,
+    )
+    if observation.outcome != "present" or observation.result is None:
+        return observation.outcome, None, observation.retry_safe
+    return observation.outcome, observation.result.model_dump(mode="json"), False
 
 
 def driver_result_contains_status(

--- a/control_plane/provider_operations.py
+++ b/control_plane/provider_operations.py
@@ -1,0 +1,689 @@
+"""Shared durable provider-operation runner.
+
+Provider mutations (Dokploy compose applies, GitHub workflow dispatches, ingress
+applies) are non-repeatable effects. This module moves them behind the durable
+mutation-reservation model from ``control_plane.contracts.idempotency_record`` so
+that a process restart, a second instance, or a cancelled request can never
+produce a blind duplicate effect and can never erase operation state.
+
+The runner reserves a bounded lease and binds a deterministic provider
+reconciliation key before any effect begins. After the effect, it records
+terminal evidence. A crash or ambiguous provider outcome after key binding is an
+unknown outcome that transitions the reservation to ``reconcile_required`` rather
+than repeating the effect; provider-specific reconciliation stays behind the
+:class:`DurableProviderMutationAdapter` boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+from threading import Event, Lock, Thread
+from typing import Literal, NamedTuple, Protocol, runtime_checkable
+
+from control_plane.contracts.idempotency_record import (
+    LaunchplaneIdempotencyRecord,
+    complete_launchplane_mutation_reservation,
+)
+from control_plane.storage.postgres import (
+    MutationReservationAdoptionResult,
+    MutationReservationCompletionResult,
+    MutationReconciliationRetryResult,
+    MutationReservationReleaseResult,
+    MutationReservationResult,
+    MutationReservationUpdateResult,
+)
+
+
+ProviderObservationOutcome = Literal["present", "absent", "unknown"]
+
+DurableProviderOperationStatus = Literal[
+    "completed",
+    "unstored",
+    "adopted",
+    "replayed",
+    "conflict",
+    "target_busy",
+    "in_progress",
+    "reconcile_required",
+]
+
+
+class ProviderMutationRejectedError(Exception):
+    """Raised by an adapter when the provider effect definitely did not happen.
+
+    The adapter guarantees no provider state changed (for example a request that
+    failed local validation before any provider call). The runner releases the
+    fresh reservation and re-raises the underlying cause so the caller can map it
+    to a client error without leaving a poisoned reservation behind.
+    """
+
+    def __init__(self, cause: Exception) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+
+
+class ProviderMutationUnknownError(Exception):
+    """Raised by an adapter when the provider outcome is ambiguous.
+
+    The effect may or may not have taken hold (for example a timeout after
+    dispatch). The runner marks the reservation ``reconcile_required`` so the
+    effect is never blindly repeated.
+    """
+
+
+@dataclass(frozen=True)
+class ProviderMutationOutcome:
+    response_status_code: int
+    response_payload: dict[str, object] = field(default_factory=dict)
+    durable: bool = True
+    provider_effect_performed: bool = True
+
+
+@dataclass(frozen=True)
+class ProviderObservation:
+    outcome: ProviderObservationOutcome
+    response_status_code: int = 202
+    response_payload: dict[str, object] = field(default_factory=dict)
+    retry_safe: bool = False
+
+
+class ProviderOperationLease(Protocol):
+    def assert_current(self) -> None:
+        """Renew and verify the current reservation before provider work continues."""
+
+    def checkpoint_effect(self, phase: str) -> None:
+        """Fence and persist a provider mutation phase immediately before dispatch."""
+
+
+@runtime_checkable
+class DurableProviderMutationAdapter(Protocol):
+    def target_key(self) -> str:
+        """Return the stable key used to fence concurrent mutations of one target."""
+
+    def reconciliation_key(self) -> str:
+        """Return the deterministic key identifying the provider mutation target."""
+
+    def observe(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+    ) -> ProviderObservation:
+        """Report whether the bound provider effect is already present."""
+
+    def apply(
+        self, provider_operation_key: str, lease: ProviderOperationLease
+    ) -> ProviderMutationOutcome:
+        """Perform the provider mutation and return its terminal evidence."""
+
+
+class DurableProviderOperationStore(Protocol):
+    def reserve_mutation(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+        request_fingerprint: str,
+        lease_owner: str,
+        lease_seconds: int = ...,
+        reconciliation_key: str = ...,
+        provider_target_key: str = ...,
+    ) -> MutationReservationResult: ...
+
+    def complete_mutation_reservation(
+        self,
+        *,
+        completion: LaunchplaneIdempotencyRecord,
+    ) -> MutationReservationCompletionResult: ...
+
+    def renew_mutation_reservation(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        lease_seconds: int = ...,
+    ) -> MutationReservationUpdateResult: ...
+
+    def checkpoint_mutation_provider_effect(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        effect_phase: str,
+        lease_seconds: int = ...,
+    ) -> MutationReservationUpdateResult: ...
+
+    def mark_mutation_reconcile_required(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        reconciliation_key: str,
+    ) -> MutationReservationUpdateResult: ...
+
+    def adopt_reconciled_mutation(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        response_status_code: int,
+        response_trace_id: str,
+        response_payload: dict[str, object],
+    ) -> MutationReservationAdoptionResult: ...
+
+    def release_reserved_mutation(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+    ) -> MutationReservationReleaseResult: ...
+
+    def retry_reconciled_mutation(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        lease_owner: str,
+        lease_seconds: int = ...,
+    ) -> MutationReconciliationRetryResult: ...
+
+
+class DurableProviderOperationResult(NamedTuple):
+    status: DurableProviderOperationStatus
+    record: LaunchplaneIdempotencyRecord | None
+    response_status_code: int
+    response_payload: dict[str, object]
+    original_trace_id: str = ""
+
+
+def build_provider_operation_key(
+    *,
+    scope: str,
+    route_path: str,
+    idempotency_key: str,
+    request_fingerprint: str,
+    reconciliation_key: str,
+) -> str:
+    identity = "\x1f".join(
+        (
+            scope.strip(),
+            route_path.strip(),
+            idempotency_key.strip(),
+            request_fingerprint.strip(),
+            reconciliation_key.strip(),
+        )
+    )
+    if not all(identity.split("\x1f")):
+        raise ValueError("Provider operation keys require complete durable identity.")
+    return f"provider-operation:{hashlib.sha256(identity.encode('utf-8')).hexdigest()}"
+
+
+def provider_operation_title(provider_operation_key: str) -> str:
+    normalized_key = provider_operation_key.strip()
+    if not normalized_key:
+        raise ValueError("Provider operation titles require an operation key.")
+    digest = hashlib.sha256(normalized_key.encode("utf-8")).hexdigest()[:24]
+    return f"Launchplane operation {digest}"
+
+
+class _ProviderOperationLeaseLostError(RuntimeError):
+    pass
+
+
+class _ReservationHeartbeat:
+    def __init__(
+        self,
+        *,
+        store: DurableProviderOperationStore,
+        reservation: LaunchplaneIdempotencyRecord,
+        lease_seconds: int,
+        interval_seconds: float,
+    ) -> None:
+        self._store = store
+        self._reservation = reservation
+        self._lease_seconds = lease_seconds
+        self._interval_seconds = interval_seconds
+        self._stop_event = Event()
+        self._lock = Lock()
+        self._failure_status = ""
+        self._thread = Thread(
+            target=self._run,
+            name=f"provider-operation-heartbeat:{reservation.record_id}",
+            daemon=True,
+        )
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def stop(self) -> tuple[LaunchplaneIdempotencyRecord, str]:
+        self._stop_event.set()
+        self._thread.join()
+        with self._lock:
+            return self._reservation, self._failure_status
+
+    def assert_current(self) -> None:
+        with self._lock:
+            self._renew_locked()
+
+    def checkpoint_effect(self, phase: str) -> None:
+        normalized_phase = phase.strip()
+        if not normalized_phase:
+            raise ValueError("Provider effect checkpoints require a phase.")
+        with self._lock:
+            try:
+                checkpoint = self._store.checkpoint_mutation_provider_effect(
+                    reservation=self._reservation,
+                    effect_phase=normalized_phase,
+                    lease_seconds=self._lease_seconds,
+                )
+            except Exception as error:
+                self._failure_status = "error"
+                raise _ProviderOperationLeaseLostError(
+                    "Provider operation lease checkpoint failed."
+                ) from error
+            if checkpoint.status != "updated" or checkpoint.record is None:
+                self._failure_status = checkpoint.status
+                raise _ProviderOperationLeaseLostError(
+                    f"Provider operation lease checkpoint failed: {checkpoint.status}."
+                )
+            self._reservation = checkpoint.record
+            self._failure_status = ""
+
+    def _renew_locked(self) -> None:
+        try:
+            renewal = self._store.renew_mutation_reservation(
+                reservation=self._reservation,
+                lease_seconds=self._lease_seconds,
+            )
+        except Exception as error:
+            self._failure_status = "error"
+            raise _ProviderOperationLeaseLostError(
+                "Provider operation lease renewal failed."
+            ) from error
+        if renewal.status != "updated" or renewal.record is None:
+            self._failure_status = renewal.status
+            raise _ProviderOperationLeaseLostError(
+                f"Provider operation lease renewal failed: {renewal.status}."
+            )
+        self._reservation = renewal.record
+        self._failure_status = ""
+
+    def _run(self) -> None:
+        while not self._stop_event.wait(self._interval_seconds):
+            try:
+                with self._lock:
+                    self._renew_locked()
+            except _ProviderOperationLeaseLostError:
+                with self._lock:
+                    if self._failure_status != "error":
+                        return
+                continue
+
+
+def run_durable_provider_operation(
+    *,
+    store: DurableProviderOperationStore,
+    scope: str,
+    route_path: str,
+    idempotency_key: str,
+    request_fingerprint: str,
+    lease_owner: str,
+    response_trace_id: str,
+    adapter: DurableProviderMutationAdapter,
+    lease_seconds: int = 300,
+    heartbeat_interval_seconds: float | None = None,
+) -> DurableProviderOperationResult:
+    if lease_seconds < 1:
+        raise ValueError("Durable provider operation leases must be positive.")
+    resolved_heartbeat_interval = heartbeat_interval_seconds
+    if resolved_heartbeat_interval is None:
+        resolved_heartbeat_interval = max(0.1, min(30.0, lease_seconds / 3))
+    if resolved_heartbeat_interval <= 0:
+        raise ValueError("Durable provider operation heartbeat intervals must be positive.")
+    if resolved_heartbeat_interval >= lease_seconds:
+        raise ValueError("Durable provider operation heartbeats must run before lease expiry.")
+    provider_target_key = adapter.target_key().strip()
+    if not provider_target_key:
+        raise ValueError("Durable provider operations require a provider target key.")
+    reconciliation_key = adapter.reconciliation_key().strip()
+    if not reconciliation_key:
+        raise ValueError("Durable provider operations require a reconciliation key.")
+    normalized_response_trace_id = response_trace_id.strip()
+    if not normalized_response_trace_id:
+        raise ValueError("Durable provider operations require a response trace id.")
+
+    reservation_result = store.reserve_mutation(
+        scope=scope,
+        route_path=route_path,
+        idempotency_key=idempotency_key,
+        request_fingerprint=request_fingerprint,
+        lease_owner=lease_owner,
+        lease_seconds=lease_seconds,
+        reconciliation_key=reconciliation_key,
+        provider_target_key=provider_target_key,
+    )
+    decision = reservation_result.status
+    reservation = reservation_result.record
+
+    if decision == "replayed":
+        return _replayed_result(reservation)
+    if decision == "conflict":
+        return DurableProviderOperationResult("conflict", reservation, 409, {})
+    if decision == "target_busy":
+        return DurableProviderOperationResult("target_busy", reservation, 409, {})
+    if decision == "in_progress":
+        return DurableProviderOperationResult("in_progress", reservation, 409, {})
+    if decision == "reconcile_required":
+        return _reconcile(
+            store=store,
+            adapter=adapter,
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+            reconciliation_key=reconciliation_key,
+            response_trace_id=normalized_response_trace_id,
+            fallback_record=reservation,
+            lease_owner=lease_owner,
+            lease_seconds=lease_seconds,
+            heartbeat_interval_seconds=resolved_heartbeat_interval,
+        )
+    if decision != "acquired":
+        raise RuntimeError(f"Unsupported mutation reservation decision: {decision}")
+
+    provider_operation_key = build_provider_operation_key(
+        scope=scope,
+        route_path=route_path,
+        idempotency_key=idempotency_key,
+        request_fingerprint=request_fingerprint,
+        reconciliation_key=reconciliation_key,
+    )
+
+    return _apply_acquired(
+        store=store,
+        adapter=adapter,
+        reservation=reservation,
+        reconciliation_key=reconciliation_key,
+        provider_operation_key=provider_operation_key,
+        response_trace_id=normalized_response_trace_id,
+        lease_seconds=lease_seconds,
+        heartbeat_interval_seconds=resolved_heartbeat_interval,
+    )
+
+
+def _apply_acquired(
+    *,
+    store: DurableProviderOperationStore,
+    adapter: DurableProviderMutationAdapter,
+    reservation: LaunchplaneIdempotencyRecord,
+    reconciliation_key: str,
+    provider_operation_key: str,
+    response_trace_id: str,
+    lease_seconds: int,
+    heartbeat_interval_seconds: float,
+) -> DurableProviderOperationResult:
+    heartbeat = _ReservationHeartbeat(
+        store=store,
+        reservation=reservation,
+        lease_seconds=lease_seconds,
+        interval_seconds=heartbeat_interval_seconds,
+    )
+    heartbeat.start()
+    try:
+        outcome = adapter.apply(provider_operation_key, heartbeat)
+    except _ProviderOperationLeaseLostError:
+        current_reservation, _ = heartbeat.stop()
+        return _mark_reconcile_required(
+            store=store,
+            reservation=current_reservation,
+            reconciliation_key=reconciliation_key,
+        )
+    except ProviderMutationRejectedError as rejection:
+        current_reservation, _ = heartbeat.stop()
+        if current_reservation.provider_effect_started_at:
+            return _mark_reconcile_required(
+                store=store,
+                reservation=current_reservation,
+                reconciliation_key=reconciliation_key,
+            )
+        release = store.release_reserved_mutation(reservation=current_reservation)
+        if release.status == "released":
+            raise rejection.cause
+        return _mark_reconcile_required(
+            store=store,
+            reservation=current_reservation,
+            reconciliation_key=reconciliation_key,
+        )
+    except ProviderMutationUnknownError:
+        current_reservation, _ = heartbeat.stop()
+        return _mark_reconcile_required(
+            store=store,
+            reservation=current_reservation,
+            reconciliation_key=reconciliation_key,
+        )
+    except BaseException:
+        current_reservation, _ = heartbeat.stop()
+        _mark_reconcile_required(
+            store=store,
+            reservation=current_reservation,
+            reconciliation_key=reconciliation_key,
+        )
+        raise
+
+    current_reservation, _ = heartbeat.stop()
+
+    if outcome.provider_effect_performed and not current_reservation.provider_effect_started_at:
+        return _mark_reconcile_required(
+            store=store,
+            reservation=current_reservation,
+            reconciliation_key=reconciliation_key,
+        )
+
+    if not outcome.durable:
+        if current_reservation.provider_effect_started_at:
+            return _mark_reconcile_required(
+                store=store,
+                reservation=current_reservation,
+                reconciliation_key=reconciliation_key,
+            )
+        release = store.release_reserved_mutation(reservation=current_reservation)
+        if release.status != "released":
+            return _mark_reconcile_required(
+                store=store,
+                reservation=current_reservation,
+                reconciliation_key=reconciliation_key,
+            )
+        return DurableProviderOperationResult(
+            "unstored",
+            None,
+            outcome.response_status_code,
+            outcome.response_payload,
+        )
+
+    return _complete_or_adopt_outcome(
+        store=store,
+        reservation=current_reservation,
+        response_trace_id=response_trace_id,
+        outcome=outcome,
+    )
+
+
+def _complete_or_adopt_outcome(
+    *,
+    store: DurableProviderOperationStore,
+    reservation: LaunchplaneIdempotencyRecord,
+    response_trace_id: str,
+    outcome: ProviderMutationOutcome,
+) -> DurableProviderOperationResult:
+    completion = complete_launchplane_mutation_reservation(
+        reservation,
+        response_status_code=outcome.response_status_code,
+        response_trace_id=response_trace_id,
+        completed_at=reservation.updated_at,
+        response_payload=outcome.response_payload,
+    )
+    completion_result = store.complete_mutation_reservation(completion=completion)
+    if completion_result.status == "completed":
+        return DurableProviderOperationResult(
+            "completed",
+            completion_result.record,
+            outcome.response_status_code,
+            outcome.response_payload,
+        )
+    if completion_result.status == "replayed":
+        return _replayed_result(completion_result.record)
+    if completion_result.status == "reconcile_required":
+        adoption = store.adopt_reconciled_mutation(
+            reservation=reservation,
+            response_status_code=outcome.response_status_code,
+            response_trace_id=response_trace_id,
+            response_payload=outcome.response_payload,
+        )
+        if adoption.status == "adopted":
+            return DurableProviderOperationResult(
+                "adopted",
+                adoption.record,
+                outcome.response_status_code,
+                outcome.response_payload,
+            )
+        if adoption.status == "replayed":
+            return _replayed_result(adoption.record)
+    return DurableProviderOperationResult(
+        "reconcile_required",
+        completion_result.record,
+        409,
+        {},
+    )
+
+
+def _reconcile(
+    *,
+    store: DurableProviderOperationStore,
+    adapter: DurableProviderMutationAdapter,
+    scope: str,
+    route_path: str,
+    idempotency_key: str,
+    request_fingerprint: str,
+    reconciliation_key: str,
+    response_trace_id: str,
+    fallback_record: LaunchplaneIdempotencyRecord | None,
+    lease_owner: str,
+    lease_seconds: int,
+    heartbeat_interval_seconds: float,
+) -> DurableProviderOperationResult:
+    bound_reconciliation_key = (
+        fallback_record.reconciliation_key
+        if fallback_record is not None and fallback_record.reconciliation_key
+        else reconciliation_key
+    )
+    provider_operation_key = build_provider_operation_key(
+        scope=scope,
+        route_path=route_path,
+        idempotency_key=idempotency_key,
+        request_fingerprint=request_fingerprint,
+        reconciliation_key=bound_reconciliation_key,
+    )
+    provider_effect_phase = (
+        fallback_record.provider_effect_phase if fallback_record is not None else ""
+    )
+    observation = adapter.observe(
+        provider_operation_key,
+        provider_effect_phase,
+        bound_reconciliation_key,
+    )
+    provider_effect_started = bool(
+        fallback_record is not None and fallback_record.provider_effect_started_at
+    )
+    if observation.outcome == "absent" and (not provider_effect_started or observation.retry_safe):
+        if fallback_record is None:
+            return DurableProviderOperationResult(
+                "reconcile_required",
+                None,
+                409,
+                {},
+            )
+        retry = store.retry_reconciled_mutation(
+            reservation=fallback_record,
+            lease_owner=lease_owner,
+            lease_seconds=lease_seconds,
+        )
+        if retry.status == "replayed":
+            return _replayed_result(retry.record)
+        if retry.status == "acquired" and retry.record is not None:
+            return _apply_acquired(
+                store=store,
+                adapter=adapter,
+                reservation=retry.record,
+                reconciliation_key=bound_reconciliation_key,
+                provider_operation_key=provider_operation_key,
+                response_trace_id=response_trace_id,
+                lease_seconds=lease_seconds,
+                heartbeat_interval_seconds=heartbeat_interval_seconds,
+            )
+    if observation.outcome != "present":
+        return DurableProviderOperationResult(
+            "reconcile_required",
+            fallback_record,
+            409,
+            {},
+        )
+    if fallback_record is None:
+        return DurableProviderOperationResult(
+            "reconcile_required",
+            None,
+            409,
+            {},
+        )
+    adoption = store.adopt_reconciled_mutation(
+        reservation=fallback_record,
+        response_status_code=observation.response_status_code,
+        response_trace_id=response_trace_id,
+        response_payload=observation.response_payload,
+    )
+    if adoption.status == "adopted":
+        return DurableProviderOperationResult(
+            "adopted",
+            adoption.record,
+            observation.response_status_code,
+            observation.response_payload,
+        )
+    if adoption.status == "replayed":
+        return _replayed_result(adoption.record)
+    return DurableProviderOperationResult(
+        "reconcile_required",
+        adoption.record or fallback_record,
+        409,
+        {},
+    )
+
+
+def _mark_reconcile_required(
+    *,
+    store: DurableProviderOperationStore,
+    reservation: LaunchplaneIdempotencyRecord,
+    reconciliation_key: str,
+) -> DurableProviderOperationResult:
+    transition = store.mark_mutation_reconcile_required(
+        reservation=reservation,
+        reconciliation_key=reconciliation_key,
+    )
+    if transition.record is not None and transition.record.state == "completed":
+        return _replayed_result(transition.record)
+    if transition.status == "missing":
+        raise RuntimeError("Provider operation state disappeared during reconciliation.")
+    return DurableProviderOperationResult(
+        "reconcile_required",
+        transition.record or reservation,
+        409,
+        {},
+    )
+
+
+def _replayed_result(
+    record: LaunchplaneIdempotencyRecord | None,
+) -> DurableProviderOperationResult:
+    if record is None:
+        raise RuntimeError("Replayed mutation reservation requires a stored record.")
+    return DurableProviderOperationResult(
+        "replayed",
+        record,
+        record.response_status_code or 202,
+        dict(record.response_payload),
+        original_trace_id=record.response_trace_id,
+    )

--- a/control_plane/storage/migrations/versions/b4d6f8a0c2e4_fence_active_provider_mutations.py
+++ b/control_plane/storage/migrations/versions/b4d6f8a0c2e4_fence_active_provider_mutations.py
@@ -1,0 +1,108 @@
+"""fence active provider mutations
+
+Revision ID: b4d6f8a0c2e4
+Revises: a2b4c6d8e0f2
+Create Date: 2026-07-13 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "b4d6f8a0c2e4"
+down_revision: str | None = "a2b4c6d8e0f2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_idempotency_records"
+_INDEX = "launchplane_idempotency_active_reconciliation_idx"
+_TARGET_KEY_COLUMN = "provider_target_key"
+_ACTIVE_PREDICATE = "provider_target_key <> '' AND state IN ('running', 'reconcile_required')"
+
+
+def _index_exists() -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return _INDEX in {str(index["name"]) for index in inspector.get_indexes(_TABLE)}
+
+
+def _column_exists() -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return _TARGET_KEY_COLUMN in {str(column["name"]) for column in inspector.get_columns(_TABLE)}
+
+
+def _assert_no_active_target_collisions() -> None:
+    collision = (
+        op.get_bind()
+        .execute(
+            sa.text(
+                "SELECT provider_target_key, COUNT(*) AS claim_count "
+                "FROM launchplane_idempotency_records "
+                "WHERE provider_target_key <> '' "
+                "AND state IN ('running', 'reconcile_required') "
+                "GROUP BY provider_target_key "
+                "HAVING COUNT(*) > 1 "
+                "ORDER BY provider_target_key "
+                "LIMIT 1"
+            )
+        )
+        .mappings()
+        .first()
+    )
+    if collision is not None:
+        raise RuntimeError(
+            "Cannot fence active provider mutations while duplicate target claims exist: "
+            f"{collision['provider_target_key']!r} has {collision['claim_count']} claims. "
+            "Reconcile the duplicate claims before upgrading."
+        )
+
+
+def upgrade() -> None:
+    if not _column_exists():
+        op.add_column(
+            _TABLE,
+            sa.Column(
+                _TARGET_KEY_COLUMN,
+                sa.String(),
+                nullable=False,
+                server_default="",
+            ),
+        )
+    if op.get_bind().dialect.name == "postgresql":
+        op.execute(
+            sa.text(
+                "UPDATE launchplane_idempotency_records "
+                "SET provider_target_key = reconciliation_key, "
+                "payload = jsonb_set(payload, '{provider_target_key}', "
+                "to_jsonb(reconciliation_key), true) "
+                "WHERE reconciliation_key <> ''"
+            )
+        )
+    else:
+        op.execute(
+            sa.text(
+                "UPDATE launchplane_idempotency_records "
+                "SET provider_target_key = reconciliation_key, "
+                "payload = json_set(payload, '$.provider_target_key', reconciliation_key) "
+                "WHERE reconciliation_key <> ''"
+            )
+        )
+    _assert_no_active_target_collisions()
+    if not _index_exists():
+        op.create_index(
+            _INDEX,
+            _TABLE,
+            [_TARGET_KEY_COLUMN],
+            unique=True,
+            postgresql_where=sa.text(_ACTIVE_PREDICATE),
+            sqlite_where=sa.text(_ACTIVE_PREDICATE),
+        )
+
+
+def downgrade() -> None:
+    if _index_exists():
+        op.drop_index(_INDEX, table_name=_TABLE)
+    if _column_exists():
+        op.drop_column(_TABLE, _TARGET_KEY_COLUMN)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -158,6 +158,7 @@ MutationReservationDecision = Literal[
     "acquired",
     "replayed",
     "conflict",
+    "target_busy",
     "in_progress",
     "reconcile_required",
 ]
@@ -200,6 +201,29 @@ RouteBindingMutationStatus = Literal[
     "reservation_mismatch",
     "reservation_expired",
     "reconciliation_required",
+]
+MutationReservationAdoptionStatus = Literal[
+    "adopted",
+    "replayed",
+    "missing",
+    "conflict",
+    "not_reconcile_required",
+    "reservation_mismatch",
+]
+MutationReservationReleaseStatus = Literal[
+    "released",
+    "missing",
+    "not_running",
+    "owner_mismatch",
+    "reservation_mismatch",
+]
+MutationReconciliationRetryStatus = Literal[
+    "acquired",
+    "replayed",
+    "missing",
+    "conflict",
+    "not_reconcile_required",
+    "reservation_mismatch",
 ]
 
 
@@ -252,6 +276,21 @@ class OutboxDeliveryClaimResult(NamedTuple):
 class OutboxDeliveryCompletionResult(NamedTuple):
     status: OutboxDeliveryCompletionStatus
     record: OutboxDeliveryRecord | None = None
+
+
+class MutationReservationAdoptionResult(NamedTuple):
+    status: MutationReservationAdoptionStatus
+    record: LaunchplaneIdempotencyRecord | None = None
+
+
+class MutationReservationReleaseResult(NamedTuple):
+    status: MutationReservationReleaseStatus
+    record: LaunchplaneIdempotencyRecord | None = None
+
+
+class MutationReconciliationRetryResult(NamedTuple):
+    status: MutationReconciliationRetryStatus
+    record: LaunchplaneIdempotencyRecord | None = None
 
 
 @dataclass(frozen=True)
@@ -1366,6 +1405,17 @@ class LaunchplaneIdempotencyRow(Base):
             "lease_expires_at",
             "updated_at",
         ),
+        Index(
+            "launchplane_idempotency_active_reconciliation_idx",
+            "provider_target_key",
+            unique=True,
+            postgresql_where=text(
+                "provider_target_key <> '' AND state IN ('running', 'reconcile_required')"
+            ),
+            sqlite_where=text(
+                "provider_target_key <> '' AND state IN ('running', 'reconcile_required')"
+            ),
+        ),
     )
 
     record_id: Mapped[str] = mapped_column(String, primary_key=True)
@@ -1378,6 +1428,7 @@ class LaunchplaneIdempotencyRow(Base):
     lease_expires_at: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     attempt: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1")
     reconciliation_key: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    provider_target_key: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     created_at: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     updated_at: Mapped[str] = mapped_column(String, nullable=False, server_default="")
     response_status_code: Mapped[int | None] = mapped_column(Integer, nullable=True)
@@ -2348,6 +2399,7 @@ class PostgresRecordStore(HumanSessionStore):
             lease_expires_at=record.lease_expires_at,
             attempt=record.attempt,
             reconciliation_key=record.reconciliation_key,
+            provider_target_key=record.provider_target_key,
             created_at=record.created_at,
             updated_at=record.updated_at,
             response_status_code=record.response_status_code,
@@ -2367,6 +2419,7 @@ class PostgresRecordStore(HumanSessionStore):
         row.lease_expires_at = record.lease_expires_at
         row.attempt = record.attempt
         row.reconciliation_key = record.reconciliation_key
+        row.provider_target_key = record.provider_target_key
         row.created_at = record.created_at
         row.updated_at = record.updated_at
         row.response_status_code = record.response_status_code
@@ -2437,6 +2490,24 @@ class PostgresRecordStore(HumanSessionStore):
                 LaunchplaneIdempotencyRow.scope == scope,
                 LaunchplaneIdempotencyRow.route_path == route_path,
                 LaunchplaneIdempotencyRow.idempotency_key == idempotency_key,
+            )
+            .limit(1)
+        )
+        if for_update and not self.database_url.startswith("sqlite"):
+            statement = statement.with_for_update()
+        return statement
+
+    def _active_provider_target_statement(
+        self,
+        *,
+        provider_target_key: str,
+        for_update: bool = False,
+    ) -> Any:
+        statement = (
+            select(LaunchplaneIdempotencyRow)
+            .where(
+                LaunchplaneIdempotencyRow.provider_target_key == provider_target_key,
+                LaunchplaneIdempotencyRow.state.in_(("running", "reconcile_required")),
             )
             .limit(1)
         )
@@ -2527,6 +2598,9 @@ class PostgresRecordStore(HumanSessionStore):
             record.lease_expires_at,
             record.attempt,
             record.reconciliation_key,
+            record.provider_target_key,
+            record.provider_effect_phase,
+            record.provider_effect_started_at,
             record.created_at,
         )
 
@@ -2934,7 +3008,43 @@ class PostgresRecordStore(HumanSessionStore):
         lease_owner: str,
         lease_seconds: int = 300,
         reconciliation_key: str = "",
+        provider_target_key: str = "",
     ) -> MutationReservationResult:
+        return self._reserve_mutation(
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+            lease_owner=lease_owner,
+            lease_seconds=lease_seconds,
+            reconciliation_key=reconciliation_key,
+            provider_target_key=provider_target_key,
+            retry_missing_collision=True,
+        )
+
+    def _reserve_mutation(
+        self,
+        *,
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+        request_fingerprint: str,
+        lease_owner: str,
+        lease_seconds: int,
+        reconciliation_key: str,
+        provider_target_key: str,
+        retry_missing_collision: bool,
+    ) -> MutationReservationResult:
+        normalized_scope = scope.strip()
+        normalized_route_path = route_path.strip()
+        normalized_idempotency_key = idempotency_key.strip()
+        normalized_request_fingerprint = request_fingerprint.strip()
+        normalized_reconciliation_key = reconciliation_key.strip()
+        normalized_provider_target_key = (
+            provider_target_key.strip() or normalized_reconciliation_key
+        )
+        if normalized_provider_target_key and not normalized_reconciliation_key:
+            raise ValueError("Provider target keys require a reconciliation key.")
         insert_error: IntegrityError | None = None
         try:
             with self._session_factory() as session:
@@ -2952,6 +3062,7 @@ class PostgresRecordStore(HumanSessionStore):
                     ),
                     reserved_at=observed_at,
                     reconciliation_key=reconciliation_key,
+                    provider_target_key=normalized_provider_target_key,
                 )
                 session.add(self._idempotency_row(reservation))
                 session.commit()
@@ -2963,20 +3074,68 @@ class PostgresRecordStore(HumanSessionStore):
             self._begin_serialized_write(session)
             row = session.scalar(
                 self._idempotency_statement(
-                    scope=scope.strip(),
-                    route_path=route_path.strip(),
-                    idempotency_key=idempotency_key.strip(),
+                    scope=normalized_scope,
+                    route_path=normalized_route_path,
+                    idempotency_key=normalized_idempotency_key,
                     for_update=True,
                 )
             )
+            target_collision = False
+            if row is None and normalized_provider_target_key:
+                row = session.scalar(
+                    self._active_provider_target_statement(
+                        provider_target_key=normalized_provider_target_key,
+                        for_update=True,
+                    )
+                )
+                target_collision = row is not None
             if row is None:
+                if retry_missing_collision:
+                    session.rollback()
+                    return self._reserve_mutation(
+                        scope=scope,
+                        route_path=route_path,
+                        idempotency_key=idempotency_key,
+                        request_fingerprint=request_fingerprint,
+                        lease_owner=lease_owner,
+                        lease_seconds=lease_seconds,
+                        reconciliation_key=reconciliation_key,
+                        provider_target_key=provider_target_key,
+                        retry_missing_collision=False,
+                    )
                 assert insert_error is not None
                 raise insert_error
             current_record = self._read_payload(
                 model_type=LaunchplaneIdempotencyRecord,
                 payload=row.payload,
             )
-            if current_record.request_fingerprint != request_fingerprint.strip():
+            if target_collision:
+                if current_record.state == "running":
+                    observed_at = self._database_mutation_timestamp(session)
+                    if parse_launchplane_mutation_timestamp(
+                        current_record.lease_expires_at,
+                        field_name="lease_expires_at",
+                    ) <= parse_launchplane_mutation_timestamp(
+                        observed_at,
+                        field_name="observed_at",
+                    ):
+                        reconcile_record = self._updated_idempotency_record(
+                            current_record,
+                            state="reconcile_required",
+                            updated_at=observed_at,
+                            response_status_code=None,
+                            response_trace_id="",
+                            recorded_at="",
+                            response_payload={},
+                        )
+                        self._sync_idempotency_row(row, reconcile_record)
+                        session.commit()
+                        return MutationReservationResult(
+                            status="target_busy",
+                            record=reconcile_record,
+                        )
+                return MutationReservationResult(status="target_busy", record=current_record)
+            if current_record.request_fingerprint != normalized_request_fingerprint:
                 return MutationReservationResult(status="conflict", record=current_record)
             if current_record.state == "completed":
                 return MutationReservationResult(status="replayed", record=current_record)
@@ -3020,6 +3179,7 @@ class PostgresRecordStore(HumanSessionStore):
                 ),
                 attempt=current_record.attempt + 1,
                 reconciliation_key=reconciliation_key.strip(),
+                provider_target_key=normalized_provider_target_key,
                 updated_at=observed_at,
                 response_status_code=None,
                 response_trace_id="",
@@ -3142,6 +3302,78 @@ class PostgresRecordStore(HumanSessionStore):
             self._sync_idempotency_row(row, renewed_record)
             session.commit()
             return MutationReservationUpdateResult(status="updated", record=renewed_record)
+
+    def checkpoint_mutation_provider_effect(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        effect_phase: str,
+        lease_seconds: int = 300,
+    ) -> MutationReservationUpdateResult:
+        normalized_effect_phase = effect_phase.strip()
+        if reservation.state != "running" or not normalized_effect_phase:
+            raise ValueError("Provider effect checkpoints require a running reservation and phase.")
+        if not reservation.reconciliation_key:
+            raise ValueError("Provider effect checkpoints require a reconciliation key.")
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            row = session.scalar(
+                self._idempotency_statement(
+                    scope=reservation.scope,
+                    route_path=reservation.route_path,
+                    idempotency_key=reservation.idempotency_key,
+                    for_update=True,
+                )
+            )
+            if row is None:
+                return MutationReservationUpdateResult(status="missing")
+            current_record = self._read_payload(
+                model_type=LaunchplaneIdempotencyRecord,
+                payload=row.payload,
+            )
+            if current_record.state != "running":
+                return MutationReservationUpdateResult(
+                    status="not_running",
+                    record=current_record,
+                )
+            if current_record.lease_owner != reservation.lease_owner:
+                return MutationReservationUpdateResult(
+                    status="owner_mismatch",
+                    record=current_record,
+                )
+            if not self._mutation_reservation_matches(current_record, reservation):
+                return MutationReservationUpdateResult(
+                    status="reservation_mismatch",
+                    record=current_record,
+                )
+            checkpointed_at = self._database_mutation_timestamp(session)
+            if parse_launchplane_mutation_timestamp(
+                current_record.lease_expires_at,
+                field_name="lease_expires_at",
+            ) <= parse_launchplane_mutation_timestamp(
+                checkpointed_at,
+                field_name="checkpointed_at",
+            ):
+                return MutationReservationUpdateResult(
+                    status="lease_expired",
+                    record=current_record,
+                )
+            checkpointed_record = self._updated_idempotency_record(
+                current_record,
+                lease_expires_at=self._mutation_lease_expiry(
+                    observed_at=checkpointed_at,
+                    lease_seconds=lease_seconds,
+                ),
+                provider_effect_phase=normalized_effect_phase,
+                provider_effect_started_at=checkpointed_at,
+                updated_at=checkpointed_at,
+            )
+            self._sync_idempotency_row(row, checkpointed_record)
+            session.commit()
+            return MutationReservationUpdateResult(
+                status="updated",
+                record=checkpointed_record,
+            )
 
     def bind_mutation_reconciliation_key(
         self,
@@ -3321,16 +3553,6 @@ class PostgresRecordStore(HumanSessionStore):
                     status="replayed",
                     record=current_record,
                 )
-            if current_record.state == "reconcile_required":
-                return MutationReservationCompletionResult(
-                    status="reconcile_required",
-                    record=current_record,
-                )
-            if current_record.state != "running":
-                return MutationReservationCompletionResult(
-                    status="not_running",
-                    record=current_record,
-                )
             if current_record.lease_owner != completion.lease_owner:
                 return MutationReservationCompletionResult(
                     status="owner_mismatch",
@@ -3339,6 +3561,16 @@ class PostgresRecordStore(HumanSessionStore):
             if not self._mutation_reservation_matches(current_record, completion):
                 return MutationReservationCompletionResult(
                     status="reservation_mismatch",
+                    record=current_record,
+                )
+            if current_record.state == "reconcile_required":
+                return MutationReservationCompletionResult(
+                    status="reconcile_required",
+                    record=current_record,
+                )
+            if current_record.state != "running":
+                return MutationReservationCompletionResult(
+                    status="not_running",
                     record=current_record,
                 )
             completed_at = self._database_mutation_timestamp(session)
@@ -3375,6 +3607,190 @@ class PostgresRecordStore(HumanSessionStore):
             return MutationReservationCompletionResult(
                 status="completed",
                 record=stored_completion,
+            )
+
+    def adopt_reconciled_mutation(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        response_status_code: int,
+        response_trace_id: str,
+        response_payload: dict[str, Any],
+    ) -> MutationReservationAdoptionResult:
+        normalized_response_trace_id = response_trace_id.strip()
+        if not reservation.reconciliation_key or not normalized_response_trace_id:
+            raise ValueError(
+                "Reconciled mutation adoption requires reservation evidence and trace."
+            )
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            row = session.scalar(
+                self._idempotency_statement(
+                    scope=reservation.scope,
+                    route_path=reservation.route_path,
+                    idempotency_key=reservation.idempotency_key,
+                    for_update=True,
+                )
+            )
+            if row is None:
+                return MutationReservationAdoptionResult(status="missing")
+            current_record = self._read_payload(
+                model_type=LaunchplaneIdempotencyRecord,
+                payload=row.payload,
+            )
+            if current_record.request_fingerprint != reservation.request_fingerprint:
+                return MutationReservationAdoptionResult(
+                    status="conflict",
+                    record=current_record,
+                )
+            if current_record.state == "completed":
+                return MutationReservationAdoptionResult(
+                    status="replayed",
+                    record=current_record,
+                )
+            if current_record.state != "reconcile_required":
+                return MutationReservationAdoptionResult(
+                    status="not_reconcile_required",
+                    record=current_record,
+                )
+            if not self._mutation_reservation_matches(current_record, reservation):
+                return MutationReservationAdoptionResult(
+                    status="reservation_mismatch",
+                    record=current_record,
+                )
+            adopted_at = self._database_mutation_timestamp(session)
+            adopted_record = self._updated_idempotency_record(
+                current_record,
+                state="completed",
+                updated_at=adopted_at,
+                response_status_code=response_status_code,
+                response_trace_id=normalized_response_trace_id,
+                recorded_at=adopted_at,
+                response_payload=response_payload,
+            )
+            self._sync_idempotency_row(row, adopted_record)
+            session.commit()
+            return MutationReservationAdoptionResult(
+                status="adopted",
+                record=adopted_record,
+            )
+
+    def release_reserved_mutation(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+    ) -> MutationReservationReleaseResult:
+        if reservation.state != "running":
+            raise ValueError("Only running mutation reservations can be released.")
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            row = session.scalar(
+                self._idempotency_statement(
+                    scope=reservation.scope,
+                    route_path=reservation.route_path,
+                    idempotency_key=reservation.idempotency_key,
+                    for_update=True,
+                )
+            )
+            if row is None:
+                return MutationReservationReleaseResult(status="missing")
+            current_record = self._read_payload(
+                model_type=LaunchplaneIdempotencyRecord,
+                payload=row.payload,
+            )
+            if current_record.state != "running":
+                return MutationReservationReleaseResult(
+                    status="not_running",
+                    record=current_record,
+                )
+            if current_record.lease_owner != reservation.lease_owner:
+                return MutationReservationReleaseResult(
+                    status="owner_mismatch",
+                    record=current_record,
+                )
+            if not self._mutation_reservation_matches(current_record, reservation):
+                return MutationReservationReleaseResult(
+                    status="reservation_mismatch",
+                    record=current_record,
+                )
+            session.delete(row)
+            session.commit()
+            return MutationReservationReleaseResult(
+                status="released",
+                record=current_record,
+            )
+
+    def retry_reconciled_mutation(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        lease_owner: str,
+        lease_seconds: int = 300,
+    ) -> MutationReconciliationRetryResult:
+        if reservation.state != "reconcile_required":
+            raise ValueError("Reconciled mutation retry requires reconcile-required state.")
+        normalized_lease_owner = lease_owner.strip()
+        if not normalized_lease_owner:
+            raise ValueError("Reconciled mutation retry requires a lease owner.")
+        with self._session_factory() as session:
+            self._begin_serialized_write(session)
+            row = session.scalar(
+                self._idempotency_statement(
+                    scope=reservation.scope,
+                    route_path=reservation.route_path,
+                    idempotency_key=reservation.idempotency_key,
+                    for_update=True,
+                )
+            )
+            if row is None:
+                return MutationReconciliationRetryResult(status="missing")
+            current_record = self._read_payload(
+                model_type=LaunchplaneIdempotencyRecord,
+                payload=row.payload,
+            )
+            if current_record.request_fingerprint != reservation.request_fingerprint:
+                return MutationReconciliationRetryResult(
+                    status="conflict",
+                    record=current_record,
+                )
+            if current_record.state == "completed":
+                return MutationReconciliationRetryResult(
+                    status="replayed",
+                    record=current_record,
+                )
+            if current_record.state != "reconcile_required":
+                return MutationReconciliationRetryResult(
+                    status="not_reconcile_required",
+                    record=current_record,
+                )
+            if not self._mutation_reservation_matches(current_record, reservation):
+                return MutationReconciliationRetryResult(
+                    status="reservation_mismatch",
+                    record=current_record,
+                )
+            observed_at = self._database_mutation_timestamp(session)
+            retried_record = self._updated_idempotency_record(
+                current_record,
+                state="running",
+                lease_owner=normalized_lease_owner,
+                lease_expires_at=self._mutation_lease_expiry(
+                    observed_at=observed_at,
+                    lease_seconds=lease_seconds,
+                ),
+                attempt=current_record.attempt + 1,
+                provider_effect_phase="",
+                provider_effect_started_at="",
+                updated_at=observed_at,
+                response_status_code=None,
+                response_trace_id="",
+                recorded_at="",
+                response_payload={},
+            )
+            self._sync_idempotency_row(row, retried_record)
+            session.commit()
+            return MutationReconciliationRetryResult(
+                status="acquired",
+                record=retried_record,
             )
 
     def write_odoo_stable_bootstrap_operation_record(

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -8,7 +8,7 @@ from sqlalchemy import inspect, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
-EXPECTED_ALEMBIC_HEAD_REVISION = "a2b4c6d8e0f2"
+EXPECTED_ALEMBIC_HEAD_REVISION = "b4d6f8a0c2e4"
 
 
 class SchemaInspectorProtocol(Protocol):
@@ -140,6 +140,13 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
         "launchplane_idempotency_records",
         "launchplane_idempotency_state_lease_idx",
         ("state", "lease_expires_at", "updated_at"),
+    ),
+    CriticalIndex(
+        "launchplane_idempotency_records",
+        "launchplane_idempotency_active_reconciliation_idx",
+        ("provider_target_key",),
+        unique=True,
+        predicate_tokens=("provider_target_key", "running", "reconcile_required"),
     ),
     CriticalIndex(
         "launchplane_every_code_work_requests",

--- a/control_plane/workflows/dokploy_deploy.py
+++ b/control_plane/workflows/dokploy_deploy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from urllib.parse import urlsplit
 
 import click
@@ -18,6 +19,8 @@ def update_dokploy_target_artifact(
     target_id: str,
     artifact_id: str,
     runtime_identity: RuntimeIdentity | None = None,
+    before_provider_mutation: Callable[[str], None] | None = None,
+    effect_started: Callable[[], None] | None = None,
 ) -> None:
     target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
         host=host,
@@ -37,6 +40,10 @@ def update_dokploy_target_artifact(
                 str(target_payload.get("env") or ""),
                 updates=runtime_identity_env(runtime_identity),
             )
+            if before_provider_mutation is not None:
+                before_provider_mutation("target_update")
+            if effect_started is not None:
+                effect_started()
             control_plane_dokploy.update_dokploy_target_env(
                 host=host,
                 token=token,
@@ -45,6 +52,10 @@ def update_dokploy_target_artifact(
                 target_payload=target_payload,
                 env_text=env_text,
             )
+        if before_provider_mutation is not None:
+            before_provider_mutation("target_update")
+        if effect_started is not None:
+            effect_started()
         control_plane_dokploy.dokploy_request(
             host=host,
             token=token,
@@ -68,6 +79,10 @@ def update_dokploy_target_artifact(
                 **(runtime_identity_env(runtime_identity) if runtime_identity is not None else {}),
             },
         )
+        if before_provider_mutation is not None:
+            before_provider_mutation("target_update")
+        if effect_started is not None:
+            effect_started()
         control_plane_dokploy.update_dokploy_target_env(
             host=host,
             token=token,
@@ -173,6 +188,9 @@ def execute_dokploy_artifact_deploy(
     resolved_target: ResolvedTargetEvidence,
     deploy_timeout_seconds: int,
     runtime_identity: RuntimeIdentity | None = None,
+    deployment_title: str = "",
+    before_provider_mutation: Callable[[str], None] | None = None,
+    effect_started: Callable[[], None] | None = None,
 ) -> None:
     latest_before = control_plane_dokploy.latest_deployment_for_target(
         host=host,
@@ -187,19 +205,37 @@ def execute_dokploy_artifact_deploy(
         target_id=resolved_target.target_id,
         artifact_id=ship_request.artifact_id,
         runtime_identity=runtime_identity,
+        before_provider_mutation=before_provider_mutation,
+        effect_started=effect_started,
     )
+    if before_provider_mutation is not None:
+        before_provider_mutation("deploy_trigger")
+    if effect_started is not None:
+        effect_started()
     control_plane_dokploy.trigger_deployment(
         host=host,
         token=token,
         target_type=resolved_target.target_type,
         target_id=resolved_target.target_id,
         no_cache=ship_request.no_cache,
+        title=deployment_title,
     )
-    control_plane_dokploy.wait_for_target_deployment(
-        host=host,
-        token=token,
-        target_type=resolved_target.target_type,
-        target_id=resolved_target.target_id,
-        before_key=control_plane_dokploy.deployment_key(latest_before),
-        timeout_seconds=deploy_timeout_seconds,
-    )
+    if deployment_title:
+        control_plane_dokploy.wait_for_target_deployment(
+            host=host,
+            token=token,
+            target_type=resolved_target.target_type,
+            target_id=resolved_target.target_id,
+            before_key=control_plane_dokploy.deployment_key(latest_before),
+            timeout_seconds=deploy_timeout_seconds,
+            deployment_title=deployment_title,
+        )
+    else:
+        control_plane_dokploy.wait_for_target_deployment(
+            host=host,
+            token=token,
+            target_type=resolved_target.target_type,
+            target_id=resolved_target.target_id,
+            before_key=control_plane_dokploy.deployment_key(latest_before),
+            timeout_seconds=deploy_timeout_seconds,
+        )

--- a/control_plane/workflows/generic_web_deploy.py
+++ b/control_plane/workflows/generic_web_deploy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+import hashlib
 from pathlib import Path
 from typing import Callable, Literal, Protocol, cast
 
@@ -18,8 +20,14 @@ from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.drivers.registry import read_driver_descriptor
 from control_plane.workflows.generic_web_deploy_provider import GenericWebDeployProvider
+from control_plane.workflows.generic_web_deploy_provider import (
+    GenericWebProviderDeploymentObservation,
+)
 from control_plane.workflows.generic_web_deploy_provider import GenericWebResolvedDeployTarget
 from control_plane.workflows.generic_web_deploy_provider import default_generic_web_deploy_provider
+from control_plane.workflows.generic_web_deploy_provider import (
+    generic_web_provider_deployment_succeeded,
+)
 from control_plane.workflows.inventory import build_environment_inventory
 from control_plane.workflows.ship import (
     build_deployment_record,
@@ -30,6 +38,8 @@ from control_plane.workflows.ship import (
 
 class GenericWebDeployStore(Protocol):
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord: ...
+
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
 
     def write_deployment_record(self, record: DeploymentRecord) -> object: ...
 
@@ -75,6 +85,7 @@ class GenericWebDeployResult(BaseModel):
     target_category: DeployTargetCategory = "unknown"
     provider_id: str = ""
     provider_target_type: str = ""
+    provider_effect_attempted: bool = False
     post_deploy_status: Literal["pass", "fail", "skipped"] = "skipped"
     error_message: str = ""
 
@@ -147,8 +158,24 @@ class GenericWebPostDeployContext(BaseModel):
         return self
 
 
+@dataclass(frozen=True)
+class GenericWebPostDeployGuard:
+    provider_effect_checkpoint: Callable[[str], None] | None = None
+    deployment_title: str = ""
+
+    def checkpoint_effect(self, phase: str) -> None:
+        if self.provider_effect_checkpoint is not None:
+            self.provider_effect_checkpoint(phase)
+
+
 GenericWebPostDeployExecutor = Callable[
-    [Path, GenericWebDeployStore, GenericWebPostDeployContext], PostDeployUpdateEvidence
+    [
+        Path,
+        GenericWebDeployStore,
+        GenericWebPostDeployContext,
+        GenericWebPostDeployGuard,
+    ],
+    PostDeployUpdateEvidence,
 ]
 
 
@@ -161,11 +188,21 @@ def resolve_generic_web_profile_lane(
             f"Product {profile.product!r} is configured for driver {profile.driver_id!r}, "
             "not generic-web or a generic-web based driver."
         )
+    requested_instance = request.instance.strip()
     for lane in profile.lanes:
-        if lane.instance == request.instance:
-            return profile, lane
+        if lane.instance.strip() == requested_instance:
+            return profile, _canonical_generic_web_lane(lane)
     raise click.ClickException(
         f"Product {profile.product!r} has no generic-web lane for instance {request.instance!r}."
+    )
+
+
+def _canonical_generic_web_lane(lane: ProductLaneProfile) -> ProductLaneProfile:
+    return lane.model_copy(
+        update={
+            "context": lane.context.strip(),
+            "instance": lane.instance.strip(),
+        }
     )
 
 
@@ -360,7 +397,14 @@ def execute_generic_web_deploy(
     lane: ProductLaneProfile | None = None,
     post_deploy_executor: GenericWebPostDeployExecutor | None = None,
     deploy_provider: GenericWebDeployProvider | None = None,
+    resolved_deploy_target: GenericWebResolvedDeployTarget | None = None,
+    provider_operation_title: str = "",
+    deployment_record_id: str = "",
+    provider_effect_checkpoint: Callable[[str], None] | None = None,
 ) -> GenericWebDeployResult:
+    normalized_provider_operation_title = provider_operation_title.strip()
+    if provider_effect_checkpoint is not None and not normalized_provider_operation_title:
+        raise ValueError("Durable generic web deploys require a provider operation title.")
     resolved_deploy_provider = deploy_provider or default_generic_web_deploy_provider()
     resolved_profile = profile
     resolved_lane = lane
@@ -369,8 +413,9 @@ def execute_generic_web_deploy(
             record_store=record_store,
             request=request,
         )
+    resolved_lane = _canonical_generic_web_lane(resolved_lane)
 
-    record_id = generate_deployment_record_id(
+    record_id = deployment_record_id.strip() or generate_deployment_record_id(
         context_name=resolved_lane.context,
         instance_name=resolved_lane.instance,
     )
@@ -384,7 +429,7 @@ def execute_generic_web_deploy(
             lane=resolved_lane,
             deploy_provider=resolved_deploy_provider,
         )
-        resolved_deploy_target = _resolve_deploy_target(
+        prepared_deploy_target = resolved_deploy_target or _resolve_deploy_target(
             control_plane_root=control_plane_root,
             record_store=record_store,
             request=request,
@@ -392,8 +437,8 @@ def execute_generic_web_deploy(
             lane=resolved_lane,
             deploy_provider=resolved_deploy_provider,
         )
-        ship_request = resolved_deploy_target.ship_request
-        resolved_target = resolved_deploy_target.resolved_target
+        ship_request = prepared_deploy_target.ship_request
+        resolved_target = prepared_deploy_target.resolved_target
     except click.ClickException as exc:
         finished_at = utc_now_timestamp()
         if fallback_request is None:
@@ -429,18 +474,43 @@ def execute_generic_web_deploy(
         )
 
     deploy_completed = False
+    provider_effect_attempted = False
+    provider_deployment_observation: GenericWebProviderDeploymentObservation | None = None
     post_deploy_update = PostDeployUpdateEvidence()
+
+    def mark_provider_effect_started() -> None:
+        nonlocal provider_effect_attempted
+        provider_effect_attempted = True
+
     try:
         resolved_deploy_provider.execute_artifact_deploy(
             control_plane_root=control_plane_root,
-            resolved_deploy_target=resolved_deploy_target,
+            resolved_deploy_target=prepared_deploy_target,
             runtime_identity=_build_runtime_identity(
                 profile=resolved_profile,
                 lane=resolved_lane,
                 ship_request=ship_request,
                 deployment_record_id=record_id,
             ),
+            deployment_title=normalized_provider_operation_title,
+            before_provider_mutation=(provider_effect_checkpoint or (lambda _phase: None)),
+            effect_started=mark_provider_effect_started,
         )
+        if normalized_provider_operation_title:
+            provider_deployment_observation = resolved_deploy_provider.observe_artifact_deploy(
+                control_plane_root=control_plane_root,
+                resolved_deploy_target=prepared_deploy_target,
+                deployment_title=normalized_provider_operation_title,
+            )
+            if (
+                provider_deployment_observation.outcome != "present"
+                or not generic_web_provider_deployment_succeeded(
+                    provider_deployment_observation.deployment_status
+                )
+            ):
+                raise click.ClickException(
+                    "Generic web provider deployment did not return exact successful evidence."
+                )
         deploy_completed = True
         if post_deploy_executor is not None:
             post_deploy_update = _run_post_deploy_extension(
@@ -451,11 +521,17 @@ def execute_generic_web_deploy(
                     context=resolved_lane.context,
                     instance=resolved_lane.instance,
                     deployment_record_id=record_id,
-                    resolved_deploy_target=resolved_deploy_target,
+                    resolved_deploy_target=prepared_deploy_target,
                     artifact_id=ship_request.artifact_id,
                     source_git_ref=ship_request.source_git_ref,
                 ),
                 post_deploy_executor=post_deploy_executor,
+                guard=GenericWebPostDeployGuard(
+                    provider_effect_checkpoint=provider_effect_checkpoint,
+                    deployment_title=_generic_web_post_deploy_operation_title(
+                        normalized_provider_operation_title
+                    ),
+                ),
             )
             if post_deploy_update.status == "fail":
                 raise click.ClickException(
@@ -464,6 +540,21 @@ def execute_generic_web_deploy(
     except click.ClickException as exc:
         finished_at = utc_now_timestamp()
         deployment_status: Literal["pass", "fail"] = "pass" if deploy_completed else "fail"
+        recorded_deployment_id = (
+            provider_deployment_observation.deployment_id
+            if provider_deployment_observation is not None
+            else "control-plane-dokploy"
+        )
+        recorded_started_at = (
+            provider_deployment_observation.started_at
+            if provider_deployment_observation is not None
+            else started_at
+        )
+        recorded_finished_at = (
+            provider_deployment_observation.finished_at
+            if provider_deployment_observation is not None
+            else finished_at
+        )
         if deploy_completed and post_deploy_update.status == "skipped":
             post_deploy_update = PostDeployUpdateEvidence(
                 attempted=True,
@@ -476,7 +567,7 @@ def execute_generic_web_deploy(
                 lane=resolved_lane,
                 ship_request=ship_request,
                 deployment_record_id=record_id,
-                deployed_at=finished_at,
+                deployed_at=recorded_finished_at,
             )
             if deploy_completed
             else None
@@ -484,12 +575,12 @@ def execute_generic_web_deploy(
         deployment_record = build_deployment_record(
             request=ship_request,
             record_id=record_id,
-            deployment_id="control-plane-dokploy",
+            deployment_id=recorded_deployment_id,
             deployment_status=deployment_status,
-            started_at=started_at,
-            finished_at=finished_at,
+            started_at=recorded_started_at,
+            finished_at=recorded_finished_at,
             resolved_target=resolved_target,
-            deployed_target=resolved_deploy_target.deployed_target,
+            deployed_target=prepared_deploy_target.deployed_target,
             delegated_executor=resolved_deploy_provider.delegated_executor,
             post_deploy_update=post_deploy_update,
             runtime_identity=runtime_identity,
@@ -499,15 +590,15 @@ def execute_generic_web_deploy(
             record_store.write_environment_inventory(
                 build_environment_inventory(
                     deployment_record=deployment_record,
-                    updated_at=finished_at,
+                    updated_at=recorded_finished_at,
                 )
             )
-        target_fields = _deploy_result_target_fields(resolved_deploy_target=resolved_deploy_target)
+        target_fields = _deploy_result_target_fields(resolved_deploy_target=prepared_deploy_target)
         return GenericWebDeployResult(
             deployment_record_id=record_id,
             deploy_status=deployment_status,
-            deploy_started_at=started_at,
-            deploy_finished_at=finished_at,
+            deploy_started_at=recorded_started_at,
+            deploy_finished_at=recorded_finished_at,
             product=resolved_profile.product,
             context=resolved_lane.context,
             instance=resolved_lane.instance,
@@ -516,20 +607,36 @@ def execute_generic_web_deploy(
             target_category=target_fields.target_category,
             provider_id=target_fields.provider_id,
             provider_target_type=target_fields.provider_target_type,
+            provider_effect_attempted=provider_effect_attempted,
             post_deploy_status=_generic_web_deploy_post_deploy_status(post_deploy_update),
             error_message=str(exc),
         )
 
     finished_at = utc_now_timestamp()
+    recorded_deployment_id = (
+        provider_deployment_observation.deployment_id
+        if provider_deployment_observation is not None
+        else "control-plane-dokploy"
+    )
+    recorded_started_at = (
+        provider_deployment_observation.started_at
+        if provider_deployment_observation is not None
+        else started_at
+    )
+    recorded_finished_at = (
+        provider_deployment_observation.finished_at
+        if provider_deployment_observation is not None
+        else finished_at
+    )
     deployment_record = build_deployment_record(
         request=ship_request,
         record_id=record_id,
-        deployment_id="control-plane-dokploy",
+        deployment_id=recorded_deployment_id,
         deployment_status="pass",
-        started_at=started_at,
-        finished_at=finished_at,
+        started_at=recorded_started_at,
+        finished_at=recorded_finished_at,
         resolved_target=resolved_target,
-        deployed_target=resolved_deploy_target.deployed_target,
+        deployed_target=prepared_deploy_target.deployed_target,
         delegated_executor=resolved_deploy_provider.delegated_executor,
         post_deploy_update=post_deploy_update,
         runtime_identity=_build_runtime_identity(
@@ -537,22 +644,22 @@ def execute_generic_web_deploy(
             lane=resolved_lane,
             ship_request=ship_request,
             deployment_record_id=record_id,
-            deployed_at=finished_at,
+            deployed_at=recorded_finished_at,
         ),
     )
     record_store.write_deployment_record(deployment_record)
     record_store.write_environment_inventory(
         build_environment_inventory(
             deployment_record=deployment_record,
-            updated_at=finished_at,
+            updated_at=recorded_finished_at,
         )
     )
-    target_fields = _deploy_result_target_fields(resolved_deploy_target=resolved_deploy_target)
+    target_fields = _deploy_result_target_fields(resolved_deploy_target=prepared_deploy_target)
     return GenericWebDeployResult(
         deployment_record_id=record_id,
         deploy_status="pass",
-        deploy_started_at=started_at,
-        deploy_finished_at=finished_at,
+        deploy_started_at=recorded_started_at,
+        deploy_finished_at=recorded_finished_at,
         product=resolved_profile.product,
         context=resolved_lane.context,
         instance=resolved_lane.instance,
@@ -561,8 +668,114 @@ def execute_generic_web_deploy(
         target_category=target_fields.target_category,
         provider_id=target_fields.provider_id,
         provider_target_type=target_fields.provider_target_type,
+        provider_effect_attempted=provider_effect_attempted,
         post_deploy_status=_generic_web_deploy_post_deploy_status(post_deploy_update),
     )
+
+
+def record_observed_generic_web_deploy(
+    *,
+    record_store: GenericWebDeployStore,
+    profile: LaunchplaneProductProfileRecord,
+    lane: ProductLaneProfile,
+    resolved_deploy_target: GenericWebResolvedDeployTarget,
+    observation: GenericWebProviderDeploymentObservation,
+    deployment_record_id: str,
+    post_deploy_unobserved: bool,
+) -> tuple[dict[str, object], dict[str, object]]:
+    if observation.outcome != "present":
+        raise ValueError("Observed generic web deploy evidence must be present.")
+    lane = _canonical_generic_web_lane(lane)
+    deploy_status: Literal["pass", "fail"] = (
+        "pass"
+        if generic_web_provider_deployment_succeeded(observation.deployment_status)
+        else "fail"
+    )
+    ship_request = resolved_deploy_target.ship_request
+    try:
+        existing_record = record_store.read_deployment_record(deployment_record_id)
+    except FileNotFoundError:
+        existing_record = None
+    if existing_record is not None and (
+        existing_record.context != lane.context
+        or existing_record.instance != lane.instance
+        or existing_record.source_git_ref != ship_request.source_git_ref
+    ):
+        raise ValueError("Observed generic web deployment record identity does not match.")
+    started_at = observation.started_at
+    finished_at = observation.finished_at
+    deployment_id = observation.deployment_id
+    post_deploy_update = (
+        existing_record.post_deploy_update
+        if existing_record is not None
+        else PostDeployUpdateEvidence()
+    )
+    if post_deploy_unobserved and post_deploy_update.status == "skipped":
+        post_deploy_update = PostDeployUpdateEvidence(
+            attempted=True,
+            status="fail",
+            detail="Post-deploy extension was not durably observed after provider recovery.",
+        )
+    runtime_identity = existing_record.runtime_identity if existing_record is not None else None
+    if deploy_status == "pass" and runtime_identity is None:
+        runtime_identity = _build_runtime_identity(
+            profile=profile,
+            lane=lane,
+            ship_request=ship_request,
+            deployment_record_id=deployment_record_id,
+            deployed_at=finished_at,
+        )
+    if deploy_status == "fail":
+        runtime_identity = None
+    deployment_record = build_deployment_record(
+        request=ship_request,
+        record_id=deployment_record_id,
+        deployment_id=deployment_id,
+        deployment_status=deploy_status,
+        started_at=started_at,
+        finished_at=finished_at,
+        resolved_target=resolved_deploy_target.resolved_target,
+        deployed_target=resolved_deploy_target.deployed_target,
+        delegated_executor=(
+            existing_record.delegated_executor
+            if existing_record is not None
+            else "control-plane.dokploy"
+        ),
+        post_deploy_update=post_deploy_update,
+        runtime_identity=runtime_identity,
+    )
+    record_store.write_deployment_record(deployment_record)
+    if deploy_status == "pass":
+        record_store.write_environment_inventory(
+            build_environment_inventory(
+                deployment_record=deployment_record,
+                updated_at=deployment_record.deploy.finished_at or finished_at,
+            )
+        )
+    target_fields = _deploy_result_target_fields(resolved_deploy_target=resolved_deploy_target)
+    result = GenericWebDeployResult(
+        deployment_record_id=deployment_record_id,
+        deploy_status=deploy_status,
+        deploy_started_at=deployment_record.deploy.started_at or started_at,
+        deploy_finished_at=deployment_record.deploy.finished_at or finished_at,
+        product=profile.product,
+        context=lane.context,
+        instance=lane.instance,
+        target_name=target_fields.target_name,
+        target_id=target_fields.target_id,
+        target_category=target_fields.target_category,
+        provider_id=target_fields.provider_id,
+        provider_target_type=target_fields.provider_target_type,
+        post_deploy_status=_generic_web_deploy_post_deploy_status(
+            deployment_record.post_deploy_update
+        ),
+        error_message=(
+            deployment_record.post_deploy_update.detail
+            if deployment_record.post_deploy_update.status == "fail"
+            else observation.error_message
+        ),
+    )
+    return {"deployment_record_id": deployment_record_id}, result.model_dump(mode="json")
 
 
 def _generic_web_deploy_post_deploy_status(
@@ -589,12 +802,22 @@ def _run_post_deploy_extension(
     record_store: GenericWebDeployStore,
     context: GenericWebPostDeployContext,
     post_deploy_executor: GenericWebPostDeployExecutor,
+    guard: GenericWebPostDeployGuard,
 ) -> PostDeployUpdateEvidence:
     try:
+        guard.checkpoint_effect("post_deploy_started")
         return _terminal_post_deploy_update(
-            post_deploy_executor(control_plane_root, record_store, context)
+            post_deploy_executor(control_plane_root, record_store, context, guard)
         )
     except click.ClickException:
         raise
     except Exception as exc:
         raise click.ClickException(str(exc)) from exc
+
+
+def _generic_web_post_deploy_operation_title(provider_operation_title: str) -> str:
+    normalized_title = provider_operation_title.strip()
+    if not normalized_title:
+        return ""
+    digest = hashlib.sha256(normalized_title.encode("utf-8")).hexdigest()[:24]
+    return f"Launchplane post-deploy {digest}"

--- a/control_plane/workflows/generic_web_deploy_provider.py
+++ b/control_plane/workflows/generic_web_deploy_provider.py
@@ -1,16 +1,20 @@
 from __future__ import annotations
 
+import base64
+from collections.abc import Callable
+import hashlib
 from pathlib import Path
-from typing import Protocol, cast
+from typing import Literal, Protocol, cast
 
 import click
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane import runtime_environments as control_plane_runtime_environments
 from control_plane import secrets as control_plane_secrets
 from control_plane.contracts.deploy_target import (
     DeployedTargetReference,
+    DeployTargetCategory,
     DeployTargetCompatibilityType,
     ProviderTargetRecord,
 )
@@ -35,6 +39,161 @@ class GenericWebResolvedDeployTarget(BaseModel):
     resolved_target: ResolvedTargetEvidence
     deployed_target: DeployedTargetReference | None = None
     deploy_timeout_seconds: int = Field(ge=1)
+
+
+class GenericWebProviderReconciliationTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    context: str
+    instance: str
+    provider_id: str
+    target_category: DeployTargetCategory
+    provider_target_type: str
+    target_type: DeployTargetCompatibilityType
+    target_id: str
+    target_name: str
+    deploy_mode: str
+    provider_deploy_mode: str
+    deploy_timeout_seconds: int = Field(ge=1)
+
+
+_GENERIC_WEB_RECONCILIATION_KEY_PREFIX = "generic-web-provider-target:"
+_GENERIC_WEB_PROVIDER_SUCCESS_STATUSES = frozenset(
+    {"success", "succeeded", "done", "completed", "healthy", "finished"}
+)
+
+
+def generic_web_provider_deployment_succeeded(status: str) -> bool:
+    return status.strip().lower() in _GENERIC_WEB_PROVIDER_SUCCESS_STATUSES
+
+
+def build_generic_web_provider_target_key(
+    resolved_deploy_target: GenericWebResolvedDeployTarget,
+) -> str:
+    ship_request = resolved_deploy_target.ship_request
+    identity = "\x1f".join(
+        (
+            ship_request.provider_id,
+            ship_request.context,
+            ship_request.instance,
+            resolved_deploy_target.resolved_target.target_type,
+            resolved_deploy_target.resolved_target.target_id,
+        )
+    )
+    return f"generic-web-provider-target:{hashlib.sha256(identity.encode('utf-8')).hexdigest()}"
+
+
+def build_generic_web_provider_reconciliation_key(
+    resolved_deploy_target: GenericWebResolvedDeployTarget,
+) -> str:
+    ship_request = resolved_deploy_target.ship_request
+    snapshot = GenericWebProviderReconciliationTarget(
+        context=ship_request.context,
+        instance=ship_request.instance,
+        provider_id=ship_request.provider_id,
+        target_category=ship_request.target_category,
+        provider_target_type=ship_request.provider_target_type,
+        target_type=resolved_deploy_target.resolved_target.target_type,
+        target_id=resolved_deploy_target.resolved_target.target_id,
+        target_name=resolved_deploy_target.resolved_target.target_name,
+        deploy_mode=ship_request.deploy_mode,
+        provider_deploy_mode=ship_request.provider_deploy_mode,
+        deploy_timeout_seconds=resolved_deploy_target.deploy_timeout_seconds,
+    )
+    encoded = base64.urlsafe_b64encode(snapshot.model_dump_json().encode("utf-8")).decode("ascii")
+    return f"{_GENERIC_WEB_RECONCILIATION_KEY_PREFIX}{encoded.rstrip('=')}"
+
+
+def resolve_generic_web_provider_reconciliation_target(
+    *,
+    reconciliation_key: str,
+    request_artifact_id: str,
+    request_source_git_ref: str,
+    request_timeout_seconds: int | None,
+    request_no_cache: bool,
+    normalized_artifact_id: str,
+    lane: ProductLaneProfile,
+) -> GenericWebResolvedDeployTarget:
+    normalized_key = reconciliation_key.strip()
+    if not normalized_key.startswith(_GENERIC_WEB_RECONCILIATION_KEY_PREFIX):
+        raise ValueError("Generic web provider reconciliation key is invalid.")
+    encoded = normalized_key.removeprefix(_GENERIC_WEB_RECONCILIATION_KEY_PREFIX)
+    try:
+        decoded = base64.urlsafe_b64decode(encoded + "=" * (-len(encoded) % 4))
+        snapshot = GenericWebProviderReconciliationTarget.model_validate_json(decoded)
+    except Exception as error:
+        raise ValueError("Generic web provider reconciliation key is invalid.") from error
+    context_name = lane.context.strip()
+    instance_name = lane.instance.strip()
+    if snapshot.context != context_name or snapshot.instance != instance_name:
+        raise ValueError("Generic web provider reconciliation target does not match the lane.")
+    del request_artifact_id
+    ship_request = ShipRequest(
+        artifact_id=normalized_artifact_id,
+        context=context_name,
+        instance=instance_name,
+        source_git_ref=request_source_git_ref,
+        target_name=snapshot.target_name,
+        target_type=snapshot.target_type,
+        deploy_mode=snapshot.deploy_mode,
+        provider_id=snapshot.provider_id,
+        target_category=snapshot.target_category,
+        provider_target_type=snapshot.provider_target_type,
+        provider_deploy_mode=snapshot.provider_deploy_mode,
+        wait=True,
+        timeout_seconds=request_timeout_seconds,
+        verify_health=False,
+        no_cache=request_no_cache,
+        destination_health=HealthcheckEvidence(status="skipped"),
+    )
+    resolved_target = ResolvedTargetEvidence(
+        target_type=snapshot.target_type,
+        target_id=snapshot.target_id,
+        target_name=snapshot.target_name,
+    )
+    return GenericWebResolvedDeployTarget(
+        ship_request=ship_request,
+        resolved_target=resolved_target,
+        deployed_target=DeployedTargetReference(
+            provider_id=snapshot.provider_id,
+            target_category=snapshot.target_category,
+            target_id=snapshot.target_id,
+            display_name=snapshot.target_name,
+            provider_target_type=snapshot.provider_target_type,
+        ),
+        deploy_timeout_seconds=snapshot.deploy_timeout_seconds,
+    )
+
+
+class GenericWebProviderDeploymentObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    outcome: Literal["present", "absent", "unknown"]
+    deployment_status: str = ""
+    deployment_id: str = ""
+    started_at: str = ""
+    finished_at: str = ""
+    error_message: str = ""
+
+    @model_validator(mode="after")
+    def _validate_terminal_evidence(self) -> "GenericWebProviderDeploymentObservation":
+        if self.outcome != "present":
+            return self
+        required_evidence = {
+            "deployment_status": self.deployment_status,
+            "deployment_id": self.deployment_id,
+            "started_at": self.started_at,
+            "finished_at": self.finished_at,
+        }
+        missing = [name for name, value in required_evidence.items() if not value.strip()]
+        if missing:
+            raise ValueError(
+                "Observed generic web provider deployments require exact terminal evidence: "
+                + ", ".join(missing)
+                + "."
+            )
+        return self
 
 
 class DokployGenericWebDeployStore(control_plane_secrets.SecretReadStore, Protocol):
@@ -80,7 +239,18 @@ class GenericWebDeployProvider(Protocol):
         control_plane_root: Path,
         resolved_deploy_target: GenericWebResolvedDeployTarget,
         runtime_identity: RuntimeIdentity,
+        deployment_title: str,
+        before_provider_mutation: Callable[[str], None],
+        effect_started: Callable[[], None],
     ) -> None: ...
+
+    def observe_artifact_deploy(
+        self,
+        *,
+        control_plane_root: Path,
+        resolved_deploy_target: GenericWebResolvedDeployTarget,
+        deployment_title: str,
+    ) -> GenericWebProviderDeploymentObservation: ...
 
 
 class DokployGenericWebDeployProvider:
@@ -103,23 +273,25 @@ class DokployGenericWebDeployProvider:
     ) -> GenericWebResolvedDeployTarget:
         del request_artifact_id, profile
         dokploy_store = _require_dokploy_deploy_store(record_store)
+        context_name = lane.context.strip()
+        instance_name = lane.instance.strip()
         try:
             provider_target = dokploy_store.read_provider_target_record(
-                context_name=lane.context,
-                instance_name=lane.instance,
+                context_name=context_name,
+                instance_name=instance_name,
             )
         except FileNotFoundError as exc:
             raise click.ClickException(
                 "Missing provider-target authority for "
-                f"{lane.context}/{lane.instance}. Run provider-target audit/backfill before deploying."
+                f"{context_name}/{instance_name}. Run provider-target audit/backfill before deploying."
             ) from exc
         target_record = dokploy_store.read_dokploy_target_record(
-            context_name=lane.context,
-            instance_name=lane.instance,
+            context_name=context_name,
+            instance_name=instance_name,
         )
         target_id_record = dokploy_store.read_dokploy_target_id_record(
-            context_name=lane.context,
-            instance_name=lane.instance,
+            context_name=context_name,
+            instance_name=instance_name,
         )
         target_definition = _dokploy_target_definition_for_lane(
             target_record=target_record,
@@ -135,13 +307,13 @@ class DokployGenericWebDeployProvider:
 
         environment_values = _resolve_store_runtime_environment_values(
             record_store=dokploy_store,
-            context_name=lane.context,
-            instance_name=lane.instance,
+            context_name=context_name,
+            instance_name=instance_name,
             target_environment=target_definition.env,
         )
         configured_ship_mode = control_plane_dokploy.resolve_dokploy_ship_mode(
-            lane.context,
-            lane.instance,
+            context_name,
+            instance_name,
             environment_values,
         )
         deploy_mode = _resolve_dokploy_deploy_mode(
@@ -151,8 +323,8 @@ class DokployGenericWebDeployProvider:
         target_name = provider_target.display_name.strip() or fallback_target_name
         ship_request = ShipRequest(
             artifact_id=normalized_artifact_id,
-            context=lane.context,
-            instance=lane.instance,
+            context=context_name,
+            instance=instance_name,
             source_git_ref=request_source_git_ref,
             target_name=target_name,
             target_type=provider_target_type,
@@ -190,6 +362,9 @@ class DokployGenericWebDeployProvider:
         control_plane_root: Path,
         resolved_deploy_target: GenericWebResolvedDeployTarget,
         runtime_identity: RuntimeIdentity,
+        deployment_title: str,
+        before_provider_mutation: Callable[[str], None],
+        effect_started: Callable[[], None],
     ) -> None:
         host, token = control_plane_dokploy.read_dokploy_config(
             control_plane_root=control_plane_root
@@ -201,6 +376,70 @@ class DokployGenericWebDeployProvider:
             resolved_target=resolved_deploy_target.resolved_target,
             deploy_timeout_seconds=resolved_deploy_target.deploy_timeout_seconds,
             runtime_identity=runtime_identity,
+            deployment_title=deployment_title,
+            before_provider_mutation=before_provider_mutation,
+            effect_started=effect_started,
+        )
+
+    def observe_artifact_deploy(
+        self,
+        *,
+        control_plane_root: Path,
+        resolved_deploy_target: GenericWebResolvedDeployTarget,
+        deployment_title: str,
+    ) -> GenericWebProviderDeploymentObservation:
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root
+        )
+        target = resolved_deploy_target.resolved_target
+        deployment = control_plane_dokploy.deployment_for_target_by_title(
+            host=host,
+            token=token,
+            target_type=target.target_type,
+            target_id=target.target_id,
+            title=deployment_title,
+        )
+        status = control_plane_dokploy.deployment_status(deployment)
+        if deployment is None:
+            return GenericWebProviderDeploymentObservation(outcome="absent")
+        if status in {"", "pending", "queued", "running"}:
+            return GenericWebProviderDeploymentObservation(
+                outcome="unknown",
+                deployment_status=status,
+            )
+        if status not in {
+            "success",
+            "succeeded",
+            "done",
+            "completed",
+            "healthy",
+            "finished",
+            "failed",
+            "error",
+            "canceled",
+            "cancelled",
+            "killed",
+            "unhealthy",
+            "timeout",
+        }:
+            return GenericWebProviderDeploymentObservation(
+                outcome="unknown",
+                deployment_status=status,
+            )
+        assert deployment is not None
+        return GenericWebProviderDeploymentObservation(
+            outcome="present",
+            deployment_status=status,
+            deployment_id=control_plane_dokploy.deployment_key(deployment),
+            started_at=str(
+                deployment.get("startedAt") or deployment.get("started_at") or ""
+            ).strip(),
+            finished_at=str(
+                deployment.get("finishedAt") or deployment.get("finished_at") or ""
+            ).strip(),
+            error_message=str(
+                deployment.get("errorMessage") or deployment.get("error_message") or ""
+            ).strip(),
         )
 
 
@@ -246,8 +485,10 @@ def _resolve_store_runtime_environment_values(
     instance_name: str,
     target_environment: dict[str, str],
 ) -> dict[str, str]:
-    definition = control_plane_runtime_environments.load_optional_runtime_environment_definition_from_store(
-        record_store=record_store
+    definition = (
+        control_plane_runtime_environments.load_optional_runtime_environment_definition_from_store(
+            record_store=record_store
+        )
     )
     merged_values: dict[str, str] = {}
     if definition is not None:

--- a/control_plane/workflows/odoo_generic_web_post_deploy.py
+++ b/control_plane/workflows/odoo_generic_web_post_deploy.py
@@ -7,6 +7,7 @@ from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployStore,
     GenericWebPostDeployContext,
     GenericWebPostDeployExecutor,
+    GenericWebPostDeployGuard,
 )
 from control_plane.workflows.odoo_post_deploy import (
     OdooPostDeployRequest,
@@ -53,10 +54,13 @@ def execute_odoo_generic_web_post_deploy(
     control_plane_root: Path,
     record_store: GenericWebDeployStore,
     context: GenericWebPostDeployContext,
+    guard: GenericWebPostDeployGuard,
 ) -> PostDeployUpdateEvidence:
     result = execute_odoo_post_deploy(
         control_plane_root=control_plane_root,
         record_store=record_store,
         request=OdooPostDeployRequest(context=context.context, instance=context.instance),
+        provider_effect_checkpoint=guard.checkpoint_effect,
+        provider_operation_title=guard.deployment_title,
     )
     return post_deploy_evidence_from_odoo_result(result)

--- a/control_plane/workflows/odoo_post_deploy.py
+++ b/control_plane/workflows/odoo_post_deploy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Literal, Protocol, cast
 
@@ -161,6 +162,8 @@ def execute_odoo_post_deploy(
     request: OdooPostDeployRequest,
     env_file: Path | None = None,
     run_destructive_restore: bool = False,
+    provider_effect_checkpoint: Callable[[str], None] | None = None,
+    provider_operation_title: str = "",
 ) -> OdooPostDeployResult:
     typed_record_store = _require_record_store(record_store)
     odoo_override_record = _read_odoo_instance_override_record(
@@ -240,6 +243,8 @@ def execute_odoo_post_deploy(
                 required_workflow_environment_keys=required_workflow_environment_keys,
                 protected_shopify_store_keys=protected_shopify_store_keys,
                 run_destructive_restore=run_destructive_restore,
+                before_provider_mutation=provider_effect_checkpoint,
+                deployment_title=provider_operation_title,
             )
             or {}
         )

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import time
+from collections.abc import Callable
 from pathlib import Path
 from typing import Literal, Protocol, cast
 from urllib.error import HTTPError, URLError
@@ -1062,6 +1063,7 @@ class OdooPreviewDokployApplyResult(BaseModel):
     compose_id: str = ""
     compose_name: str
     created_compose: bool = False
+    provider_effect_attempted: bool = False
     domain_id: str = ""
     steps: tuple[OdooPreviewDokployApplyStep, ...] = ()
     rollback_errors: tuple[str, ...] = ()
@@ -1076,6 +1078,14 @@ class OdooPreviewDokployApplyResult(BaseModel):
         if self.status in {"blocked", "fail"} and not self.error_message:
             raise ValueError("blocked or failed Odoo preview apply result requires error_message")
         return self
+
+
+class OdooPreviewDokployObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    outcome: Literal["present", "absent", "unknown"]
+    result: OdooPreviewDokployApplyResult | None = None
+    retry_safe: bool = False
 
 
 def build_odoo_preview_dokploy_dry_run(
@@ -1170,6 +1180,9 @@ def execute_odoo_preview_dokploy_apply(
     control_plane_root: Path,
     request: OdooPreviewDokployApplyRequest,
     database_url: str | None = None,
+    provider_operation_title: str = "",
+    provider_effect_checkpoint: Callable[[str], None] | None = None,
+    provider_lease_check: Callable[[], None] | None = None,
 ) -> OdooPreviewDokployApplyResult:
     plan = request.dry_run_plan
     if plan.status != "ready":
@@ -1197,8 +1210,124 @@ def execute_odoo_preview_dokploy_apply(
         database_url=database_url,
     )
     if plan.operation == "destroy":
-        return _execute_destroy(host=host, token=token, request=request)
-    return _execute_refresh(host=host, token=token, request=request)
+        return _execute_destroy(
+            host=host,
+            token=token,
+            request=request,
+            provider_effect_checkpoint=provider_effect_checkpoint,
+        )
+    return _execute_refresh(
+        host=host,
+        token=token,
+        request=request,
+        provider_operation_title=provider_operation_title,
+        provider_effect_checkpoint=provider_effect_checkpoint,
+        provider_lease_check=provider_lease_check,
+    )
+
+
+def observe_odoo_preview_dokploy_apply(
+    *,
+    control_plane_root: Path,
+    context_name: str,
+    request: OdooPreviewDokployApplyRequest,
+    database_url: str | None,
+    provider_operation_title: str,
+    provider_effect_phase: str = "",
+) -> OdooPreviewDokployObservation:
+    plan = request.dry_run_plan
+    try:
+        host, token = control_plane_dokploy.read_dokploy_config(
+            control_plane_root=control_plane_root,
+            database_url=database_url,
+        )
+        if plan.operation == "destroy":
+            compose_still_exists = _compose_exists_by_id(
+                host=host,
+                token=token,
+                compose_id=plan.compose_ref,
+            )
+            if compose_still_exists:
+                retry_safe_phases = {"", "domain_delete"}
+                return OdooPreviewDokployObservation(
+                    outcome=("absent" if provider_effect_phase in retry_safe_phases else "unknown"),
+                    retry_safe=provider_effect_phase in retry_safe_phases,
+                )
+            return OdooPreviewDokployObservation(
+                outcome="present",
+                result=_apply_result(request=request, status="pass", compose_id=plan.compose_ref),
+            )
+        target = _discover_odoo_preview_target(
+            control_plane_root=control_plane_root,
+            context_name=context_name,
+            preview_slug=plan.preview_slug,
+            preview_url=plan.preview_url,
+            compose_name=plan.compose_name,
+            database_url=database_url,
+        )
+        if target is None:
+            retry_safe_phases = {"", "rollback_complete"}
+            return OdooPreviewDokployObservation(
+                outcome=("absent" if provider_effect_phase in retry_safe_phases else "unknown"),
+                retry_safe=provider_effect_phase in retry_safe_phases,
+            )
+        deployment = control_plane_dokploy.deployment_for_target_by_title(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=target.target_id,
+            title=provider_operation_title,
+        )
+        status = control_plane_dokploy.deployment_status(deployment)
+        if deployment is None:
+            retry_safe_phases = {"", "compose_create", "compose_update", "domain_ensure"}
+            return OdooPreviewDokployObservation(
+                outcome=("absent" if provider_effect_phase in retry_safe_phases else "unknown"),
+                retry_safe=provider_effect_phase in retry_safe_phases,
+            )
+        if status in {"", "pending", "queued", "running"}:
+            return OdooPreviewDokployObservation(outcome="unknown")
+        if status in {"success", "succeeded", "done", "completed", "healthy", "finished"}:
+            if request.smoke_check:
+                _wait_for_smoke_check(
+                    preview_url=plan.preview_url,
+                    health_path=request.health_path,
+                    timeout_seconds=request.timeout_seconds,
+                )
+            return OdooPreviewDokployObservation(
+                outcome="present",
+                result=_apply_result(
+                    request=request,
+                    status="pass",
+                    compose_id=target.target_id,
+                ),
+            )
+        if status in {
+            "failed",
+            "error",
+            "canceled",
+            "cancelled",
+            "killed",
+            "unhealthy",
+            "timeout",
+        }:
+            error_message = str(
+                (deployment or {}).get("errorMessage")
+                or (deployment or {}).get("error_message")
+                or f"Dokploy deployment finished with status {status}."
+            ).strip()
+            return OdooPreviewDokployObservation(
+                outcome="present",
+                result=_apply_result(
+                    request=request,
+                    status="fail",
+                    compose_id=target.target_id,
+                    error_message=error_message,
+                ),
+            )
+    except click.ClickException:
+        return OdooPreviewDokployObservation(outcome="unknown")
+    return OdooPreviewDokployObservation(outcome="unknown")
 
 
 def _missing_endpoint_paths(*, request: OdooPreviewDokployDryRunRequest) -> tuple[str, ...]:
@@ -1234,14 +1363,29 @@ def _missing_endpoint_paths(*, request: OdooPreviewDokployDryRunRequest) -> tupl
 
 
 def _execute_refresh(
-    *, host: str, token: str, request: OdooPreviewDokployApplyRequest
+    *,
+    host: str,
+    token: str,
+    request: OdooPreviewDokployApplyRequest,
+    provider_operation_title: str,
+    provider_effect_checkpoint: Callable[[str], None] | None,
+    provider_lease_check: Callable[[], None] | None,
 ) -> OdooPreviewDokployApplyResult:
     plan = request.dry_run_plan
     creating_compose = plan.compose_ref.startswith("${created.composeId:")
     created_compose_id = ""
     resolved_compose_id = ""
     domain_id = ""
+    deploy_triggered = False
+    provider_effect_attempted = False
     steps: list[OdooPreviewDokployApplyStep] = []
+
+    def checkpoint_provider_effect(phase: str) -> None:
+        nonlocal provider_effect_attempted
+        if provider_effect_checkpoint is not None:
+            provider_effect_checkpoint(phase)
+        provider_effect_attempted = True
+
     try:
         if creating_compose and not plan.template_compose_id:
             raise click.ClickException("Odoo preview compose create requires template_compose_id.")
@@ -1252,15 +1396,16 @@ def _execute_refresh(
             target_type="compose",
             target_id=source_compose_id,
         )
-        compose_id = _resolve_or_create_compose(
+        compose_id, created_compose = _resolve_or_create_compose(
             host=host,
             token=token,
             plan=plan,
             template_payload=target_payload,
             steps=steps,
+            provider_effect_checkpoint=checkpoint_provider_effect,
         )
         resolved_compose_id = compose_id
-        created_compose_id = compose_id if creating_compose else ""
+        created_compose_id = compose_id if created_compose else ""
         if creating_compose:
             target_payload = control_plane_dokploy.fetch_dokploy_target_payload(
                 host=host,
@@ -1275,6 +1420,7 @@ def _execute_refresh(
             publish_host_ports=False,
             domain_certificate_type=plan.domain_certificate_type,
         )
+        checkpoint_provider_effect("compose_update")
         control_plane_dokploy.sync_dokploy_compose_raw_source(
             host=host,
             token=token,
@@ -1286,6 +1432,7 @@ def _execute_refresh(
         steps.append(_step("compose_update_raw_source", compose_id))
 
         env_text = control_plane_dokploy.serialize_dokploy_env_text(request.environment_values)
+        checkpoint_provider_effect("compose_update")
         control_plane_dokploy.update_dokploy_target_env(
             host=host,
             token=token,
@@ -1296,6 +1443,7 @@ def _execute_refresh(
         )
         steps.append(_step("compose_update_env", compose_id))
 
+        checkpoint_provider_effect("domain_ensure")
         domain_id = control_plane_dokploy.ensure_compose_web_domain_route(
             host=host,
             token=token,
@@ -1312,23 +1460,46 @@ def _execute_refresh(
             target_type="compose",
             target_id=compose_id,
         )
-        control_plane_dokploy.trigger_deployment(
-            host=host,
-            token=token,
-            target_type="compose",
-            target_id=compose_id,
-            no_cache=plan.no_cache,
-        )
-        steps.append(_step("compose_deploy", compose_id))
-        if request.wait_for_deploy:
-            control_plane_dokploy.wait_for_target_deployment(
+        checkpoint_provider_effect("deploy_trigger")
+        deploy_triggered = True
+        if provider_operation_title:
+            control_plane_dokploy.trigger_deployment(
                 host=host,
                 token=token,
                 target_type="compose",
                 target_id=compose_id,
-                before_key=control_plane_dokploy.deployment_key(latest_before),
-                timeout_seconds=request.timeout_seconds,
+                no_cache=plan.no_cache,
+                title=provider_operation_title,
             )
+        else:
+            control_plane_dokploy.trigger_deployment(
+                host=host,
+                token=token,
+                target_type="compose",
+                target_id=compose_id,
+                no_cache=plan.no_cache,
+            )
+        steps.append(_step("compose_deploy", compose_id))
+        if request.wait_for_deploy:
+            if provider_operation_title:
+                control_plane_dokploy.wait_for_target_deployment(
+                    host=host,
+                    token=token,
+                    target_type="compose",
+                    target_id=compose_id,
+                    before_key=control_plane_dokploy.deployment_key(latest_before),
+                    timeout_seconds=request.timeout_seconds,
+                    deployment_title=provider_operation_title,
+                )
+            else:
+                control_plane_dokploy.wait_for_target_deployment(
+                    host=host,
+                    token=token,
+                    target_type="compose",
+                    target_id=compose_id,
+                    before_key=control_plane_dokploy.deployment_key(latest_before),
+                    timeout_seconds=request.timeout_seconds,
+                )
         if request.smoke_check:
             _wait_for_smoke_check(
                 preview_url=plan.preview_url,
@@ -1342,16 +1513,30 @@ def _execute_refresh(
             compose_id=compose_id,
             domain_id=domain_id,
             created_compose=bool(created_compose_id),
+            provider_effect_attempted=provider_effect_attempted,
             steps=tuple(steps),
         )
     except click.ClickException as exc:
-        rollback_errors = _rollback_created_runtime(
-            host=host,
-            token=token,
-            domain_id=domain_id if created_compose_id else "",
-            compose_id=created_compose_id,
-            delete_volumes=plan.delete_volumes,
-        )
+        rollback_errors: tuple[str, ...] = ()
+        if not deploy_triggered:
+            if created_compose_id and provider_effect_checkpoint is not None:
+                provider_effect_checkpoint("rollback_started")
+            elif provider_lease_check is not None:
+                provider_lease_check()
+            rollback_errors = _rollback_created_runtime(
+                host=host,
+                token=token,
+                domain_id=domain_id if created_compose_id else "",
+                compose_id=created_compose_id,
+                delete_volumes=plan.delete_volumes,
+                provider_effect_checkpoint=provider_effect_checkpoint,
+            )
+            if (
+                created_compose_id
+                and not rollback_errors
+                and provider_effect_checkpoint is not None
+            ):
+                provider_effect_checkpoint("rollback_complete")
         return _apply_result(
             request=request,
             status="fail",
@@ -1359,13 +1544,18 @@ def _execute_refresh(
             domain_id=domain_id,
             compose_id=resolved_compose_id,
             created_compose=bool(created_compose_id),
+            provider_effect_attempted=provider_effect_attempted,
             steps=tuple(steps),
             rollback_errors=rollback_errors,
         )
 
 
 def _execute_destroy(
-    *, host: str, token: str, request: OdooPreviewDokployApplyRequest
+    *,
+    host: str,
+    token: str,
+    request: OdooPreviewDokployApplyRequest,
+    provider_effect_checkpoint: Callable[[str], None] | None,
 ) -> OdooPreviewDokployApplyResult:
     plan = request.dry_run_plan
     compose_id = plan.compose_ref
@@ -1378,6 +1568,7 @@ def _execute_destroy(
         delete_volumes=plan.delete_volumes,
         continue_after_domain_cleanup_error=False,
         missing_resource_is_clean=True,
+        before_provider_mutation=provider_effect_checkpoint,
     )
     steps = tuple(
         _step(cast("OdooPreviewDokployOperationName", step.name), step.target)
@@ -1390,6 +1581,7 @@ def _execute_destroy(
             status="pass",
             compose_id=compose_id,
             domain_id=domain_id,
+            provider_effect_attempted=True,
             steps=steps,
         )
     return _apply_result(
@@ -1398,6 +1590,7 @@ def _execute_destroy(
         error_message="; ".join(destroy_result.cleanup_errors),
         compose_id=compose_id,
         domain_id=domain_id,
+        provider_effect_attempted=True,
         steps=steps,
     )
 
@@ -1409,16 +1602,26 @@ def _resolve_or_create_compose(
     plan: OdooPreviewDokployDryRunPlan,
     template_payload: JsonObject,
     steps: list[OdooPreviewDokployApplyStep],
-) -> str:
+    provider_effect_checkpoint: Callable[[str], None],
+) -> tuple[str, bool]:
     if not plan.compose_ref.startswith("${created.composeId:"):
-        return plan.compose_ref
+        return plan.compose_ref, False
     if not plan.environment_id:
         raise click.ClickException("Odoo preview compose create requires environment_id.")
+    existing_compose_id = _find_compose_id_by_environment_and_name(
+        host=host,
+        token=token,
+        environment_id=plan.environment_id,
+        compose_name=plan.compose_name,
+    )
+    if existing_compose_id:
+        return existing_compose_id, False
     server_id = str(template_payload.get("serverId") or "").strip()
     if not server_id:
         raise click.ClickException(
             "Odoo preview compose create requires the template compose serverId."
         )
+    provider_effect_checkpoint("compose_create")
     created = control_plane_dokploy.dokploy_request(
         host=host,
         token=token,
@@ -1440,7 +1643,109 @@ def _resolve_or_create_compose(
             f"Dokploy did not return composeId for Odoo preview compose {plan.compose_name!r}."
         )
     steps.append(_step("compose_create", plan.compose_name))
-    return compose_id
+    return compose_id, True
+
+
+def _find_compose_id_by_environment_and_name(
+    *,
+    host: str,
+    token: str,
+    environment_id: str,
+    compose_name: str,
+) -> str:
+    raw_projects = control_plane_dokploy.dokploy_request(
+        host=host,
+        token=token,
+        path="/api/project.all",
+    )
+    if not isinstance(raw_projects, list):
+        raise click.ClickException(
+            "Dokploy project inventory returned an invalid response payload."
+        )
+    matches: list[str] = []
+    for raw_project in raw_projects:
+        project = control_plane_dokploy.as_json_object(raw_project)
+        if project is None:
+            continue
+        raw_environments = project.get("environments")
+        if not isinstance(raw_environments, list):
+            continue
+        for raw_environment in raw_environments:
+            environment = control_plane_dokploy.as_json_object(raw_environment)
+            if environment is None:
+                continue
+            observed_environment_id = str(
+                environment.get("environmentId") or environment.get("id") or ""
+            ).strip()
+            if observed_environment_id != environment_id:
+                continue
+            raw_composes = environment.get("composes")
+            if not isinstance(raw_composes, list):
+                continue
+            for raw_compose in raw_composes:
+                compose = control_plane_dokploy.as_json_object(raw_compose)
+                if compose is None or str(compose.get("name") or "").strip() != compose_name:
+                    continue
+                compose_id = str(compose.get("composeId") or compose.get("id") or "").strip()
+                if compose_id and compose_id not in matches:
+                    matches.append(compose_id)
+    if not matches:
+        raw_search_matches = control_plane_dokploy.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/compose.search",
+            query={"q": compose_name, "limit": 25},
+        )
+        for compose in _iter_dokploy_search_composes(raw_search_matches):
+            if str(compose.get("name") or "").strip() != compose_name:
+                continue
+            compose_id = str(compose.get("composeId") or compose.get("id") or "").strip()
+            if not compose_id:
+                continue
+            observed_environment_id = _compose_environment_id(compose)
+            if not observed_environment_id:
+                compose_payload = control_plane_dokploy.fetch_dokploy_target_payload(
+                    host=host,
+                    token=token,
+                    target_type="compose",
+                    target_id=compose_id,
+                )
+                observed_environment_id = _compose_environment_id(compose_payload)
+            if observed_environment_id == environment_id and compose_id not in matches:
+                matches.append(compose_id)
+    if len(matches) > 1:
+        raise OdooPreviewTargetDiscoveryAmbiguousError(
+            f"Discovered multiple Odoo preview composes named {compose_name!r}."
+        )
+    return matches[0] if matches else ""
+
+
+def _compose_environment_id(compose: JsonObject) -> str:
+    environment = control_plane_dokploy.as_json_object(compose.get("environment"))
+    return str(
+        compose.get("environmentId")
+        or (environment or {}).get("environmentId")
+        or (environment or {}).get("id")
+        or ""
+    ).strip()
+
+
+def _compose_exists_by_id(*, host: str, token: str, compose_id: str) -> bool:
+    try:
+        payload = control_plane_dokploy.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=compose_id,
+        )
+    except click.ClickException as error:
+        if "failed (404):" in str(error):
+            return False
+        raise
+    observed_compose_id = str(payload.get("composeId") or payload.get("id") or "").strip()
+    if observed_compose_id != compose_id:
+        raise click.ClickException("Dokploy compose lookup returned the wrong compose.")
+    return True
 
 
 def _compose_domains(*, host: str, token: str, compose_id: str) -> tuple[JsonObject, ...]:
@@ -1481,16 +1786,26 @@ def _delete_compose(*, host: str, token: str, compose_id: str, delete_volumes: b
 
 
 def _rollback_created_runtime(
-    *, host: str, token: str, domain_id: str, compose_id: str, delete_volumes: bool
+    *,
+    host: str,
+    token: str,
+    domain_id: str,
+    compose_id: str,
+    delete_volumes: bool,
+    provider_effect_checkpoint: Callable[[str], None] | None = None,
 ) -> tuple[str, ...]:
     errors: list[str] = []
     if domain_id:
         try:
+            if provider_effect_checkpoint is not None:
+                provider_effect_checkpoint("rollback_domain_delete")
             _delete_domain(host=host, token=token, domain_id=domain_id)
         except click.ClickException as exc:
             errors.append(f"domain rollback failed: {exc}")
     if compose_id:
         try:
+            if provider_effect_checkpoint is not None:
+                provider_effect_checkpoint("rollback_compose_delete")
             _delete_compose(
                 host=host,
                 token=token,
@@ -1560,6 +1875,7 @@ def _apply_result(
     compose_id: str = "",
     domain_id: str = "",
     created_compose: bool = False,
+    provider_effect_attempted: bool = False,
     steps: tuple[OdooPreviewDokployApplyStep, ...] = (),
     rollback_errors: tuple[str, ...] = (),
     error_message: str = "",
@@ -1576,6 +1892,7 @@ def _apply_result(
         compose_id=compose_id,
         compose_name=plan.compose_name,
         created_compose=created_compose,
+        provider_effect_attempted=provider_effect_attempted,
         domain_id=domain_id,
         steps=steps,
         rollback_errors=rollback_errors,

--- a/control_plane/workflows/preview_resource_destroy.py
+++ b/control_plane/workflows/preview_resource_destroy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -37,6 +38,7 @@ def destroy_dokploy_preview_resource(
     delete_volumes: bool = False,
     continue_after_domain_cleanup_error: bool = True,
     missing_resource_is_clean: bool = False,
+    before_provider_mutation: Callable[[str], None] | None = None,
 ) -> PreviewResourceDestroyResult:
     normalized_resource_id = resource_id.strip()
     normalized_domain_host = domain_host.strip().lower()
@@ -56,6 +58,8 @@ def destroy_dokploy_preview_resource(
         )
         steps.append(PreviewResourceDestroyStep("domain_lookup", normalized_resource_id))
         for domain_id in domain_ids:
+            if before_provider_mutation is not None:
+                before_provider_mutation("domain_delete")
             _delete_domain(host=host, token=token, domain_id=domain_id)
             steps.append(PreviewResourceDestroyStep("domain_delete", domain_id))
     except click.ClickException as exc:
@@ -69,6 +73,8 @@ def destroy_dokploy_preview_resource(
             )
 
     try:
+        if before_provider_mutation is not None:
+            before_provider_mutation(f"{resource_type}_destroy")
         _delete_preview_resource(
             host=host,
             token=token,

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -202,6 +202,76 @@ actually closed after finding the marker, covering a crash between the marker
 comment and the close request. Email and Discord notification paths remain
 direct-delivery until they are explicitly migrated.
 
+## Durable Provider Operations
+
+Provider-backed routes that mutate an external system share the durable
+provider-operation runner (`control_plane/provider_operations.py`). The runner
+reserves and binds a deterministic provider reconciliation key before the effect
+begins, performs the effect through a provider adapter, and records terminal
+evidence only after the effect returns. Odoo preview apply
+(`/v1/drivers/odoo/preview-apply`) and generic web deploy
+(`/v1/drivers/generic-web/deploy`) are the first migrated provider routes; the
+former replaces the previous process-local apply lock. Both require an
+`Idempotency-Key` header and Launchplane database storage, and fail closed with
+`503 database_storage_required` on non-database stores.
+
+- A concurrent request with the same key while the effect runs returns `409
+  mutation_in_progress`; a completed effect replays; a different request
+  fingerprint returns `409 idempotency_key_reused`.
+- A stable provider-target key identifies the mutation target independently of
+  request timeout or deploy settings. A partial unique database fence allows
+  only one `running` or `reconcile_required` mutation for that target, including
+  requests that use a different `Idempotency-Key`. Completed operations release
+  the target fence. The separate reconciliation key can carry a richer
+  generic-web target snapshot, so recovery continues to observe the originally
+  selected target even if current authority records change before a restart.
+- Running effects renew their lease in the background. Completion uses the
+  latest fenced reservation snapshot; if the lease expires exactly as a
+  successful provider result returns, Launchplane adopts that direct terminal
+  evidence instead of repeating the effect.
+- Immediately before every provider write, the adapter checkpoints a named
+  provider-effect phase and renews the fenced reservation. A stale worker whose
+  claim was recovered cannot advance to another provider write because its next
+  checkpoint fails owner/reservation validation. Odoo preview create, update,
+  deploy, and destroy share one compose-name reconciliation key for the complete
+  lifecycle rather than changing the fence after Dokploy assigns a compose id.
+  Compensating rollback deletes and generic-web post-deploy environment,
+  deployment, schedule-upsert, and schedule-trigger writes use the same
+  per-write checkpoint rule.
+- A crash, timeout, or cancelled request after key binding leaves the durable
+  reservation in place. The next attempt sees the bound expired reservation as
+  `reconcile_required` and asks the provider adapter to observe the target. An
+  observed effect is adopted as terminal evidence without re-running. When the
+  adapter proves the exact operation marker is absent, Launchplane releases the
+  reconciled claim and retries once only when no provider effect was checkpointed
+  or the adapter explicitly marks the recorded phase safe to retry. Retry is an
+  atomic in-place attempt transition under the same target fence; stale
+  reconcilers cannot delete, retry, or adopt a newer attempt. A missing
+  marker after a deployment-trigger checkpoint remains unknown. Genuinely
+  unknown state stays `reconcile_required`; adapters are the only place
+  provider-specific reconciliation lives.
+- Migrated Dokploy adapters attach a deterministic, per-request operation title
+  to the provider deployment. Both the initial deployment wait and restart
+  reconciliation search for that exact marker; desired state or another recent
+  deployment is not treated as proof that this operation ran. Any generic-web
+  path that enables provider-effect checkpoints must supply this title before
+  provider work begins. A crash during a
+  checkpointed post-deploy phase stays `reconcile_required` unless the exact
+  provider marker can be observed; Launchplane does not synthesize terminal
+  success from the target's current desired state.
+- Odoo compose-create recovery checks both project inventory and compose search,
+  while destroy reconciliation reads the exact compose id. Generic-web recovery
+  repairs the deterministic deployment record and environment inventory before
+  adopting the operation, and preserves already-written post-deploy evidence.
+- An exact-marker deployment that finished failed, cancelled, unhealthy, or
+  timed out is terminal failure evidence, not a successful `202`. Launchplane
+  completes both fresh and recovered operations only with the provider
+  deployment id and provider start/finish timestamps, stores that evidence for
+  idempotent replay, and returns `502 provider_mutation_failed` for provider
+  failure. Incomplete terminal observations remain unknown.
+- Blocked plans and other non-durable results release the reservation instead of
+  storing replay evidence, so a corrected retry with the same key can proceed.
+
 ## Target Launchplane Ingress
 
 The target communication model is:

--- a/docs/records.md
+++ b/docs/records.md
@@ -114,6 +114,16 @@ unique in PostgreSQL. The typed lifecycle is:
   now unknown; automatic re-execution is forbidden until domain reconciliation
   proves the provider state.
 
+Provider-operation reservations additionally retain a stable
+`provider_target_key`, plus `provider_effect_phase` and
+`provider_effect_started_at`, in the typed payload.
+The phase is checkpointed under the current lease immediately before a provider
+write. It is part of transition identity, so a reservation snapshot from before
+the checkpoint cannot renew, complete, release, or advance provider work after a
+newer owner recovers the claim. The same rule covers compensating rollback
+deletes and multi-write post-deploy work; each external write advances the phase
+before dispatch instead of treating the enclosing workflow as one effect.
+
 Reservation attempts return typed `acquired`, `replayed`, `conflict`,
 `in_progress`, or `reconcile_required` decisions. A different request
 fingerprint always conflicts, including while the first request is running. An
@@ -218,6 +228,47 @@ Workflow dispatches only adopt an observed run when reclaiming an existing
 provider marker; a first attempt records its marker and sends rather than
 claiming an unrelated concurrent run. Resolved public-ingress notifications
 also ensure the GitHub issue is closed after marker reconciliation.
+
+## Durable Provider Operations
+
+The shared durable provider-operation runner (`control_plane/provider_operations`)
+implements this contract for external-effect routes. It reserves with the
+deterministic provider reconciliation key bound from the start, so `acquired`
+always means a brand-new attempt with no prior effect, while an expired bound
+reservation always resolves to `reconcile_required`. On the reconcile path the
+runner asks a provider adapter to observe the target: an observed effect is
+adopted into a completed reservation through `adopt_reconciled_mutation`. The
+adoption compares the exact observed attempt, phase, target key, and reservation
+identity, so a second instance can adopt another instance's effect without a
+stale observer completing a newer attempt. An unknown observation stays
+`reconcile_required`. A proven-absent observation may instead atomically advance
+the same reservation to a new attempt only when no provider phase was
+checkpointed or the adapter explicitly proves the recorded phase is retry-safe.
+An unknown observation never retries. A pre-effect rejection releases the fresh
+reservation through `release_reserved_mutation` (owner- and identity-fenced) so
+no poisoned claim is left behind. Odoo preview apply and generic web deploy are
+the first migrated provider routes; both require an `Idempotency-Key` and a
+database store. Provider-specific observation and reconciliation stay behind
+the adapter boundary.
+
+The `launchplane_idempotency_active_reconciliation_idx` partial unique index
+fences each provider target while its reservation is `running` or
+`reconcile_required`, regardless of caller idempotency key, using the promoted
+`provider_target_key` rather than the richer reconciliation snapshot. Migration
+backfills previously bound keys and aborts with an explicit reconciliation error
+if duplicate active claims would make the target fence ambiguous. The runner renews
+the bounded lease during blocking provider work and always completes from the
+latest reservation snapshot. Generic-web reconciliation keys embed a versioned
+snapshot of the resolved provider target, so restart recovery remains bound to
+the original target even if current authority records change. Provider operation
+markers are derived from the durable request identity and written into Dokploy
+deployment titles; both the initial wait and later observation use that exact
+marker rather than inferring success from similar target state. Adoption may
+store terminal failure response evidence as well as success, but only after the
+provider supplies the exact deployment id and start/finish timestamps. Fresh
+completion has the same evidence requirement as restart adoption; completed
+means the provider outcome is durable and replayable, not that the external
+deployment passed.
 
 ## ORM Query Boundary
 

--- a/tests/support/stores.py
+++ b/tests/support/stores.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from unittest.mock import patch
 
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
@@ -125,3 +126,47 @@ def _seed_tracked_target_records(
         )
     finally:
         store.close()
+
+
+def _seed_generic_web_deploy_target_records(
+    *,
+    store: PostgresRecordStore,
+    context: str,
+    instance: str,
+    target_id: str,
+    target_name: str,
+) -> None:
+    normalized_context = context.strip()
+    normalized_instance = instance.strip()
+    store.write_provider_target_record(
+        ProviderTargetRecord(
+            context=normalized_context,
+            instance=normalized_instance,
+            provider_id="dokploy",
+            target_category="application",
+            target_id=target_id,
+            display_name=target_name,
+            provider_target_type="application",
+            updated_at="2026-05-01T00:00:00Z",
+            source_label="test:generic-web-provider-target",
+        )
+    )
+    store.write_dokploy_target_record(
+        DokployTargetRecord(
+            context=normalized_context,
+            instance=normalized_instance,
+            target_type="application",
+            target_name=target_name,
+            updated_at="2026-05-01T00:00:00Z",
+            source_label="test:generic-web-provider-target",
+        )
+    )
+    store.write_dokploy_target_id_record(
+        DokployTargetIdRecord(
+            context=normalized_context,
+            instance=normalized_instance,
+            target_id=target_id,
+            updated_at="2026-05-01T00:00:00Z",
+            source_label="test:generic-web-provider-target",
+        )
+    )

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -138,6 +138,40 @@ class _FakeDokployTargetStore:
 
 
 class DokployConfigTests(unittest.TestCase):
+    def test_wait_for_target_deployment_tracks_exact_operation_title(self) -> None:
+        exact_deployment = {
+            "deploymentId": "deployment-exact",
+            "title": "Launchplane operation exact",
+            "status": "success",
+        }
+        with (
+            patch(
+                "control_plane.dokploy.deployment_for_target_by_title",
+                side_effect=(None, exact_deployment),
+            ) as exact_lookup,
+            patch(
+                "control_plane.dokploy.latest_deployment_for_target",
+                return_value={
+                    "deploymentId": "deployment-unrelated",
+                    "status": "success",
+                },
+            ) as latest_lookup,
+            patch("control_plane.dokploy.time.sleep"),
+        ):
+            result = control_plane_dokploy.wait_for_target_deployment(
+                host="https://dokploy.example",
+                token="token",
+                target_type="application",
+                target_id="application-one",
+                before_key="deployment-before",
+                timeout_seconds=30,
+                deployment_title="Launchplane operation exact",
+            )
+
+        self.assertEqual(result, "deployment=deployment-exact status=success")
+        self.assertEqual(exact_lookup.call_count, 2)
+        latest_lookup.assert_not_called()
+
     def test_odoo_target_replacement_plan_cli_requires_product(self) -> None:
         result = CliRunner().invoke(
             main,
@@ -2114,6 +2148,7 @@ domains = ["cm-testing.shinycomputers.com"]
             updated_env_payloads: list[str] = []
             schedule_payloads: list[dict[str, object]] = []
             request_paths: list[str] = []
+            effect_phases: list[str] = []
             override_payload_b64 = base64.b64encode(
                 json.dumps(
                     {"schema_version": 1, "context": "opw", "instance": "prod"},
@@ -2156,7 +2191,7 @@ domains = ["cm-testing.shinycomputers.com"]
                 patch(
                     "control_plane.dokploy.wait_for_target_deployment",
                     side_effect=lambda **_kwargs: None,
-                ),
+                ) as wait_target_deployment,
                 patch(
                     "control_plane.dokploy.find_matching_dokploy_schedule",
                     return_value=None,
@@ -2193,6 +2228,8 @@ domains = ["cm-testing.shinycomputers.com"]
                         LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY: "true",
                         "ONE_OFF_WORKFLOW_ONLY": "do-not-persist",
                     },
+                    before_provider_mutation=effect_phases.append,
+                    deployment_title="Launchplane post-deploy exact",
                 )
 
         self.assertEqual(len(updated_env_payloads), 1)
@@ -2217,6 +2254,19 @@ domains = ["cm-testing.shinycomputers.com"]
         self.assertIn("ONE_OFF_WORKFLOW_ONLY", str(schedule_payloads[0]["script"]))
         self.assertIn("/api/compose.deploy", request_paths)
         self.assertIn("/api/schedule.runManually", request_paths)
+        self.assertEqual(
+            effect_phases,
+            [
+                "post_deploy_target_update",
+                "post_deploy_deploy_trigger",
+                "post_deploy_schedule_upsert",
+                "post_deploy_schedule_trigger",
+            ],
+        )
+        self.assertEqual(
+            wait_target_deployment.call_args.kwargs["deployment_title"],
+            "Launchplane post-deploy exact",
+        )
 
     def test_run_compose_post_deploy_update_fails_when_runtime_override_env_does_not_persist(
         self,

--- a/tests/test_generic_web_deploy.py
+++ b/tests/test_generic_web_deploy.py
@@ -1,4 +1,6 @@
+from collections.abc import Callable
 from pathlib import Path
+from typing import cast
 import unittest
 from unittest.mock import patch
 
@@ -30,16 +32,28 @@ from control_plane.contracts.secret_record import (
 from control_plane.contracts.ship_request import ShipRequest
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane import secrets as control_plane_secrets
+from control_plane.generic_web_deploy_http import GenericWebDeployEnvelope
+from control_plane.http_app import _GenericWebDeployProviderMutationAdapter
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployRequest,
     GenericWebDeployStore,
     GenericWebPostDeployContext,
+    GenericWebPostDeployGuard,
     execute_generic_web_deploy,
     normalize_generic_web_artifact_id,
+    record_observed_generic_web_deploy,
     resolve_generic_web_profile_lane,
 )
 from control_plane.workflows.generic_web_deploy_provider import DokployGenericWebDeployProvider
-from control_plane.workflows.generic_web_deploy_provider import GenericWebResolvedDeployTarget
+from control_plane.workflows.generic_web_deploy_provider import (
+    GenericWebProviderDeploymentObservation,
+)
+from control_plane.workflows.generic_web_deploy_provider import (
+    GenericWebResolvedDeployTarget,
+    build_generic_web_provider_reconciliation_key,
+    resolve_generic_web_provider_reconciliation_target,
+)
+from control_plane.workflows.ship import build_deployment_record
 
 
 def _source_of_truth() -> DokploySourceOfTruth:
@@ -69,9 +83,23 @@ class _GenericWebDeployStore:
         return self.profile
 
     def write_deployment_record(self, record: DeploymentRecord) -> None:
+        self.deployments = [
+            existing for existing in self.deployments if existing.record_id != record.record_id
+        ]
         self.deployments.append(record)
 
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord:
+        for record in self.deployments:
+            if record.record_id == record_id:
+                return record
+        raise FileNotFoundError(record_id)
+
     def write_environment_inventory(self, record: EnvironmentInventory) -> None:
+        self.inventories = [
+            existing
+            for existing in self.inventories
+            if (existing.context, existing.instance) != (record.context, record.instance)
+        ]
         self.inventories.append(record)
 
 
@@ -325,12 +353,17 @@ def _missing_image_lane() -> ProductLaneProfile:
     )
 
 
-def _request(instance: str = "testing") -> GenericWebDeployRequest:
+def _request(
+    instance: str = "testing",
+    *,
+    timeout_seconds: int | None = None,
+) -> GenericWebDeployRequest:
     return GenericWebDeployRequest(
         product="sellyouroutboard",
         instance=instance,
         artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
         source_git_ref="abc123",
+        timeout_seconds=timeout_seconds,
     )
 
 
@@ -338,10 +371,22 @@ class _FakeGenericWebDeployProvider:
     provider_id = "fake-cloud"
     delegated_executor = "control-plane.fake-cloud"
 
-    def __init__(self, *, deploy_error: click.ClickException | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        deploy_error: click.ClickException | None = None,
+        observation: GenericWebProviderDeploymentObservation | None = None,
+        target_id: str = "target-123",
+        target_name: str = "sellyouroutboard-testing-app",
+    ) -> None:
         self.deploy_error = deploy_error
+        self.observation = observation or GenericWebProviderDeploymentObservation(outcome="unknown")
+        self.target_id = target_id
+        self.target_name = target_name
         self.resolved_targets: list[GenericWebResolvedDeployTarget] = []
         self.runtime_identities: list[RuntimeIdentity] = []
+        self.deployment_titles: list[str] = []
+        self.observed_target_ids: list[str] = []
 
     def resolve_deploy_target(
         self,
@@ -364,7 +409,7 @@ class _FakeGenericWebDeployProvider:
                 context=lane.context,
                 instance=lane.instance,
                 source_git_ref=request_source_git_ref,
-                target_name="sellyouroutboard-testing-app",
+                target_name=self.target_name,
                 target_type="application",
                 deploy_mode="fake-cloud-service-api",
                 provider_id=self.provider_id,
@@ -378,14 +423,14 @@ class _FakeGenericWebDeployProvider:
             ),
             resolved_target=ResolvedTargetEvidence(
                 target_type="application",
-                target_id="target-123",
-                target_name="sellyouroutboard-testing-app",
+                target_id=self.target_id,
+                target_name=self.target_name,
             ),
             deployed_target=DeployedTargetReference(
                 provider_id=self.provider_id,
                 target_category="service",
-                target_id="target-123",
-                display_name="sellyouroutboard-testing-app",
+                target_id=self.target_id,
+                display_name=self.target_name,
                 provider_target_type="managed-service",
             ),
             deploy_timeout_seconds=request_timeout_seconds or 600,
@@ -399,14 +444,76 @@ class _FakeGenericWebDeployProvider:
         control_plane_root: Path,
         resolved_deploy_target: GenericWebResolvedDeployTarget,
         runtime_identity: RuntimeIdentity,
+        deployment_title: str,
+        before_provider_mutation: Callable[[str], None],
+        effect_started: Callable[[], None],
     ) -> None:
         del control_plane_root, resolved_deploy_target
         self.runtime_identities.append(runtime_identity)
+        self.deployment_titles.append(deployment_title)
+        before_provider_mutation("deploy_trigger")
+        effect_started()
         if self.deploy_error is not None:
             raise self.deploy_error
 
+    def observe_artifact_deploy(
+        self,
+        *,
+        control_plane_root: Path,
+        resolved_deploy_target: GenericWebResolvedDeployTarget,
+        deployment_title: str,
+    ) -> GenericWebProviderDeploymentObservation:
+        del control_plane_root, deployment_title
+        self.observed_target_ids.append(resolved_deploy_target.resolved_target.target_id)
+        return self.observation
+
 
 class GenericWebDeployTests(unittest.TestCase):
+    def _provider_mutation_adapter(
+        self,
+        *,
+        profile: LaunchplaneProductProfileRecord,
+        store: _GenericWebDeployStore,
+        provider: _FakeGenericWebDeployProvider,
+        deploy_request: GenericWebDeployRequest | None = None,
+    ) -> _GenericWebDeployProviderMutationAdapter:
+        adapter = _GenericWebDeployProviderMutationAdapter(
+            control_plane_root=Path("."),
+            record_store=store,
+            deploy_request=GenericWebDeployEnvelope(
+                product=profile.product,
+                deploy=deploy_request or _request(),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            trace_id="generic-web-provider-test",
+        )
+        adapter._deploy_provider = provider
+        return adapter
+
+    def test_provider_target_key_is_stable_across_request_timeout_changes(self) -> None:
+        profile = _profile()
+        store = _GenericWebDeployStore(profile)
+        provider = _FakeGenericWebDeployProvider()
+        short_timeout = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=provider,
+            deploy_request=_request(timeout_seconds=300),
+        )
+        long_timeout = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=provider,
+            deploy_request=_request(timeout_seconds=600),
+        )
+
+        self.assertEqual(short_timeout.target_key(), long_timeout.target_key())
+        self.assertNotEqual(
+            short_timeout.reconciliation_key(),
+            long_timeout.reconciliation_key(),
+        )
+
     def test_normalize_generic_web_artifact_id_qualifies_bare_release_tag(self) -> None:
         artifact_id = normalize_generic_web_artifact_id(
             profile=_profile(),
@@ -666,13 +773,18 @@ class GenericWebDeployTests(unittest.TestCase):
     ) -> None:
         store = _GenericWebDeployStore(_profile())
         contexts: list[GenericWebPostDeployContext] = []
+        effect_phases: list[str] = []
+        post_deploy_titles: list[str] = []
 
         def post_deploy(
             _root: Path,
             _store: GenericWebDeployStore,
             context: GenericWebPostDeployContext,
+            guard: GenericWebPostDeployGuard,
         ) -> PostDeployUpdateEvidence:
             contexts.append(context)
+            post_deploy_titles.append(guard.deployment_title)
+            guard.checkpoint_effect("post_deploy_schedule_trigger")
             return PostDeployUpdateEvidence(
                 attempted=True,
                 status="pass",
@@ -684,11 +796,24 @@ class GenericWebDeployTests(unittest.TestCase):
             record_store=store,
             request=_request(),
             post_deploy_executor=post_deploy,
-            deploy_provider=_FakeGenericWebDeployProvider(),
+            deploy_provider=_FakeGenericWebDeployProvider(
+                observation=GenericWebProviderDeploymentObservation(
+                    outcome="present",
+                    deployment_status="success",
+                    deployment_id="deployment-provider-exact",
+                    started_at="2026-07-13T12:00:00Z",
+                    finished_at="2026-07-13T12:01:00Z",
+                )
+            ),
+            provider_operation_title="Launchplane operation generic-test",
+            provider_effect_checkpoint=effect_phases.append,
         )
 
         self.assertEqual(result.deploy_status, "pass")
         self.assertEqual(result.post_deploy_status, "pass")
+        self.assertEqual(result.deploy_started_at, "2026-07-13T12:00:00Z")
+        self.assertEqual(result.deploy_finished_at, "2026-07-13T12:01:00Z")
+        self.assertEqual(store.deployments[0].deploy.deployment_id, "deployment-provider-exact")
         self.assertEqual(store.deployments[0].post_deploy_update.status, "pass")
         self.assertEqual(store.inventories[0].post_deploy_update.status, "pass")
         self.assertEqual(len(contexts), 1)
@@ -699,6 +824,58 @@ class GenericWebDeployTests(unittest.TestCase):
         self.assertEqual(contexts[0].provider_id, "fake-cloud")
         self.assertEqual(contexts[0].provider_target_type, "managed-service")
         self.assertEqual(contexts[0].target_type, "application")
+        self.assertEqual(
+            effect_phases,
+            ["deploy_trigger", "post_deploy_started", "post_deploy_schedule_trigger"],
+        )
+        self.assertTrue(post_deploy_titles[0].startswith("Launchplane post-deploy "))
+
+    def test_execute_generic_web_deploy_canonicalizes_padded_lane_identity(self) -> None:
+        profile = _profile()
+        lane = profile.lanes[0]
+        padded_lane = lane.model_copy(
+            update={
+                "context": f"  {lane.context}  ",
+                "instance": f"  {lane.instance}  ",
+            }
+        )
+        store = _GenericWebDeployStore(profile)
+
+        result = execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=_request(),
+            profile=profile,
+            lane=padded_lane,
+            deploy_provider=_FakeGenericWebDeployProvider(
+                observation=GenericWebProviderDeploymentObservation(
+                    outcome="present",
+                    deployment_status="success",
+                    deployment_id="deployment-canonical-lane",
+                    started_at="2026-07-13T12:00:00Z",
+                    finished_at="2026-07-13T12:01:00Z",
+                )
+            ),
+            provider_operation_title="Launchplane operation canonical-lane",
+        )
+
+        self.assertEqual(result.context, lane.context)
+        self.assertEqual(result.instance, lane.instance)
+        self.assertEqual(store.deployments[0].context, lane.context)
+        self.assertEqual(store.deployments[0].instance, lane.instance)
+        assert store.deployments[0].runtime_identity is not None
+        self.assertEqual(store.deployments[0].runtime_identity.context, lane.context)
+        self.assertEqual(store.deployments[0].runtime_identity.instance, lane.instance)
+
+    def test_durable_generic_web_deploy_requires_operation_title(self) -> None:
+        with self.assertRaisesRegex(ValueError, "require a provider operation title"):
+            execute_generic_web_deploy(
+                control_plane_root=Path("."),
+                record_store=_GenericWebDeployStore(_profile()),
+                request=_request(),
+                deploy_provider=_FakeGenericWebDeployProvider(),
+                provider_effect_checkpoint=lambda _phase: None,
+            )
 
     def test_execute_generic_web_deploy_keeps_deploy_pass_when_post_deploy_extension_fails(
         self,
@@ -709,6 +886,7 @@ class GenericWebDeployTests(unittest.TestCase):
             _root: Path,
             _store: GenericWebDeployStore,
             _context: GenericWebPostDeployContext,
+            _guard: GenericWebPostDeployGuard,
         ) -> PostDeployUpdateEvidence:
             raise click.ClickException("post deploy failed")
 
@@ -745,6 +923,7 @@ class GenericWebDeployTests(unittest.TestCase):
             _root: Path,
             _store: GenericWebDeployStore,
             _context: GenericWebPostDeployContext,
+            _guard: GenericWebPostDeployGuard,
         ) -> PostDeployUpdateEvidence:
             raise RuntimeError("unexpected post deploy failure")
 
@@ -778,6 +957,7 @@ class GenericWebDeployTests(unittest.TestCase):
             _root: Path,
             _store: GenericWebDeployStore,
             _context: GenericWebPostDeployContext,
+            _guard: GenericWebPostDeployGuard,
         ) -> PostDeployUpdateEvidence:
             return PostDeployUpdateEvidence(
                 attempted=True,
@@ -935,7 +1115,324 @@ class GenericWebDeployTests(unittest.TestCase):
             )
 
         self.assertEqual(store.deployments, [])
-        self.assertEqual(store.inventories, [])
+
+    def test_record_observed_generic_web_deploy_repairs_missing_records(self) -> None:
+        profile = _profile(driver_id="odoo")
+        lane = profile.lanes[0]
+        store = _GenericWebDeployStore(profile)
+        provider = _FakeGenericWebDeployProvider()
+        request = _request()
+        resolved_target = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id=request.artifact_id,
+            request_source_git_ref=request.source_git_ref,
+            request_timeout_seconds=request.timeout_seconds,
+            request_no_cache=request.no_cache,
+            record_store=store,
+            profile=profile,
+            lane=lane,
+            normalized_artifact_id=request.artifact_id,
+            fallback_target_name="unused",
+        )
+
+        records, result = record_observed_generic_web_deploy(
+            record_store=store,
+            profile=profile,
+            lane=lane,
+            resolved_deploy_target=resolved_target,
+            observation=GenericWebProviderDeploymentObservation(
+                outcome="present",
+                deployment_status="success",
+                deployment_id="deployment-observed",
+                started_at="2026-07-13T12:00:00Z",
+                finished_at="2026-07-13T12:01:00Z",
+            ),
+            deployment_record_id="deployment-recovered",
+            post_deploy_unobserved=True,
+        )
+
+        self.assertEqual(records, {"deployment_record_id": "deployment-recovered"})
+        self.assertEqual(result["deploy_status"], "pass")
+        self.assertEqual(result["post_deploy_status"], "fail")
+        self.assertEqual(len(store.deployments), 1)
+        self.assertEqual(store.deployments[0].record_id, "deployment-recovered")
+        self.assertEqual(store.deployments[0].post_deploy_update.status, "fail")
+        self.assertEqual(len(store.inventories), 1)
+
+    def test_record_observed_generic_web_deploy_preserves_existing_post_deploy_evidence(
+        self,
+    ) -> None:
+        profile = _profile(driver_id="odoo")
+        lane = profile.lanes[0]
+        store = _GenericWebDeployStore(profile)
+        provider = _FakeGenericWebDeployProvider()
+        request = _request()
+
+        execute_generic_web_deploy(
+            control_plane_root=Path("."),
+            record_store=store,
+            request=request,
+            profile=profile,
+            lane=lane,
+            deploy_provider=provider,
+            deployment_record_id="deployment-existing",
+            post_deploy_executor=lambda _root, _store, _context, _guard: PostDeployUpdateEvidence(
+                attempted=True,
+                status="pass",
+                detail="post-deploy already completed",
+            ),
+        )
+        resolved_target = provider.resolved_targets[-1]
+        padded_lane = lane.model_copy(
+            update={
+                "context": f"  {lane.context}  ",
+                "instance": f"  {lane.instance}  ",
+            }
+        )
+
+        _, result = record_observed_generic_web_deploy(
+            record_store=store,
+            profile=profile,
+            lane=padded_lane,
+            resolved_deploy_target=resolved_target,
+            observation=GenericWebProviderDeploymentObservation(
+                outcome="present",
+                deployment_status="success",
+                deployment_id="deployment-observed",
+                started_at="2026-07-13T12:00:00Z",
+                finished_at="2026-07-13T12:01:00Z",
+            ),
+            deployment_record_id="deployment-existing",
+            post_deploy_unobserved=True,
+        )
+
+        self.assertEqual(result["post_deploy_status"], "pass")
+        self.assertEqual(result["context"], lane.context)
+        self.assertEqual(result["instance"], lane.instance)
+        self.assertEqual(result["error_message"], "")
+        self.assertEqual(len(store.deployments), 1)
+        self.assertEqual(store.deployments[0].post_deploy_update.status, "pass")
+        self.assertEqual(len(store.inventories), 1)
+
+    def test_provider_adapter_retries_absent_target_update_but_not_trigger(self) -> None:
+        profile = _profile()
+        store = _GenericWebDeployStore(profile)
+        provider = _FakeGenericWebDeployProvider(
+            observation=GenericWebProviderDeploymentObservation(outcome="absent")
+        )
+        adapter = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=provider,
+        )
+        reconciliation_key = adapter.reconciliation_key()
+
+        update_observation = adapter.observe(
+            "provider-operation:test",
+            "target_update",
+            reconciliation_key,
+        )
+        trigger_observation = adapter.observe(
+            "provider-operation:test",
+            "deploy_trigger",
+            reconciliation_key,
+        )
+
+        self.assertEqual(update_observation.outcome, "absent")
+        self.assertTrue(update_observation.retry_safe)
+        self.assertEqual(trigger_observation.outcome, "unknown")
+        self.assertFalse(trigger_observation.retry_safe)
+
+    def test_provider_adapter_rebinds_safe_retry_to_stored_target_snapshot(self) -> None:
+        profile = _profile()
+        store = _GenericWebDeployStore(profile)
+        original_provider = _FakeGenericWebDeployProvider(target_id="target-original")
+        original_adapter = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=original_provider,
+        )
+        original_key = original_adapter.reconciliation_key()
+        replacement_provider = _FakeGenericWebDeployProvider(
+            target_id="target-replacement",
+            observation=GenericWebProviderDeploymentObservation(outcome="absent"),
+        )
+        recovered_adapter = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=replacement_provider,
+        )
+        replacement_key = recovered_adapter.reconciliation_key()
+
+        observation = recovered_adapter.observe(
+            "provider-operation:test-rebind",
+            "target_update",
+            original_key,
+        )
+
+        self.assertNotEqual(replacement_key, original_key)
+        self.assertEqual(observation.outcome, "absent")
+        self.assertTrue(observation.retry_safe)
+        self.assertEqual(replacement_provider.observed_target_ids, ["target-original"])
+        self.assertEqual(recovered_adapter.reconciliation_key(), original_key)
+
+    def test_provider_adapter_repairs_failed_terminal_deployment_as_502(self) -> None:
+        profile = _profile()
+        store = _GenericWebDeployStore(profile)
+        provider = _FakeGenericWebDeployProvider(
+            observation=GenericWebProviderDeploymentObservation(
+                outcome="present",
+                deployment_status="failed",
+                deployment_id="deployment-failed",
+                started_at="2026-07-13T12:00:00Z",
+                finished_at="2026-07-13T12:01:00Z",
+                error_message="provider deployment failed",
+            )
+        )
+        adapter = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=provider,
+        )
+        reconciliation_key = adapter.reconciliation_key()
+
+        observation = adapter.observe(
+            "provider-operation:test-failed",
+            "deploy_trigger",
+            reconciliation_key,
+        )
+
+        self.assertEqual(observation.outcome, "present")
+        self.assertEqual(observation.response_status_code, 502)
+        result = cast(dict[str, object], observation.response_payload["result"])
+        self.assertEqual(result["deploy_status"], "fail")
+        self.assertEqual(result["error_message"], "provider deployment failed")
+        self.assertEqual(len(store.deployments), 1)
+        self.assertEqual(store.deployments[0].deploy.status, "fail")
+
+    def test_provider_adapter_repairs_placeholder_failure_with_observed_evidence(
+        self,
+    ) -> None:
+        profile = _profile()
+        store = _GenericWebDeployStore(profile)
+        provider = _FakeGenericWebDeployProvider(
+            observation=GenericWebProviderDeploymentObservation(
+                outcome="present",
+                deployment_status="failed",
+                deployment_id="deployment-failed-exact",
+                started_at="2026-07-13T12:00:00Z",
+                finished_at="2026-07-13T12:01:00Z",
+                error_message="provider deployment failed",
+            )
+        )
+        adapter = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=provider,
+        )
+        provider_operation_key = "provider-operation:test-failed-repair"
+        resolved_target = adapter._resolve_deploy_target()
+        deployment_record_id = adapter._deployment_record_id(provider_operation_key)
+        store.write_deployment_record(
+            build_deployment_record(
+                request=resolved_target.ship_request,
+                record_id=deployment_record_id,
+                deployment_id="control-plane-dokploy",
+                deployment_status="fail",
+                started_at="2026-07-13T11:59:00Z",
+                finished_at="2026-07-13T11:59:30Z",
+                resolved_target=resolved_target.resolved_target,
+                deployed_target=resolved_target.deployed_target,
+                delegated_executor=provider.delegated_executor,
+            )
+        )
+
+        observation = adapter.observe(
+            provider_operation_key,
+            "deploy_trigger",
+            adapter.reconciliation_key(),
+        )
+
+        self.assertEqual(observation.outcome, "present")
+        self.assertEqual(observation.response_status_code, 502)
+        repaired = store.read_deployment_record(deployment_record_id)
+        self.assertEqual(repaired.deploy.deployment_id, "deployment-failed-exact")
+        self.assertEqual(repaired.deploy.started_at, "2026-07-13T12:00:00Z")
+        self.assertEqual(repaired.deploy.finished_at, "2026-07-13T12:01:00Z")
+
+    def test_provider_adapter_keeps_post_deploy_phase_unknown_until_record_exists(
+        self,
+    ) -> None:
+        profile = _profile(driver_id="odoo")
+        store = _GenericWebDeployStore(profile)
+        provider = _FakeGenericWebDeployProvider(
+            observation=GenericWebProviderDeploymentObservation(
+                outcome="present",
+                deployment_status="success",
+                deployment_id="deployment-success",
+                started_at="2026-07-13T12:00:00Z",
+                finished_at="2026-07-13T12:01:00Z",
+            )
+        )
+        adapter = self._provider_mutation_adapter(
+            profile=profile,
+            store=store,
+            provider=provider,
+        )
+        reconciliation_key = adapter.reconciliation_key()
+
+        observation = adapter.observe(
+            "provider-operation:test-post-deploy",
+            "post_deploy_schedule_trigger",
+            reconciliation_key,
+        )
+
+        self.assertEqual(observation.outcome, "unknown")
+        self.assertEqual(store.deployments, [])
+
+    def test_present_provider_observation_requires_exact_terminal_evidence(self) -> None:
+        with self.assertRaisesRegex(ValueError, "deployment_id, started_at, finished_at"):
+            GenericWebProviderDeploymentObservation(
+                outcome="present",
+                deployment_status="failed",
+            )
+
+    def test_reconciliation_target_matches_canonicalized_lane_identity(self) -> None:
+        profile = _profile()
+        provider = _FakeGenericWebDeployProvider()
+        lane = profile.lanes[0]
+        request = _request()
+        resolved_target = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id=request.artifact_id,
+            request_source_git_ref=request.source_git_ref,
+            request_timeout_seconds=request.timeout_seconds,
+            request_no_cache=request.no_cache,
+            record_store=_GenericWebDeployStore(profile),
+            profile=profile,
+            lane=lane,
+            normalized_artifact_id=request.artifact_id,
+            fallback_target_name="unused",
+        )
+        padded_lane = lane.model_copy(
+            update={
+                "context": f"  {lane.context}  ",
+                "instance": f"  {lane.instance}  ",
+            }
+        )
+
+        recovered = resolve_generic_web_provider_reconciliation_target(
+            reconciliation_key=build_generic_web_provider_reconciliation_key(resolved_target),
+            request_artifact_id=request.artifact_id,
+            request_source_git_ref=request.source_git_ref,
+            request_timeout_seconds=request.timeout_seconds,
+            request_no_cache=request.no_cache,
+            normalized_artifact_id=request.artifact_id,
+            lane=padded_lane,
+        )
+
+        self.assertEqual(recovered.ship_request.context, lane.context)
+        self.assertEqual(recovered.ship_request.instance, lane.instance)
 
     def test_dokploy_provider_resolves_target_without_generic_web_dokploy_imports(
         self,
@@ -967,6 +1464,145 @@ class GenericWebDeployTests(unittest.TestCase):
         assert deployed_target is not None
         self.assertEqual(deployed_target.display_name, "provider-target-app")
         self.assertEqual(resolved.deploy_timeout_seconds, 45)
+
+    def test_dokploy_provider_observes_exact_terminal_operation_marker(self) -> None:
+        provider = DokployGenericWebDeployProvider()
+        store = _DokployGenericWebDeployStore(_profile())
+        resolved = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            request_source_git_ref="abc123",
+            request_timeout_seconds=45,
+            request_no_cache=True,
+            record_store=store,
+            profile=_profile(),
+            lane=_profile().lanes[0],
+            normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            fallback_target_name="fallback-target",
+        )
+        with (
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider."
+                "control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider."
+                "control_plane_dokploy.deployment_for_target_by_title",
+                return_value={
+                    "deploymentId": "deployment-123",
+                    "title": "Launchplane operation abc",
+                    "status": "done",
+                    "startedAt": "2026-07-13T01:00:00Z",
+                    "finishedAt": "2026-07-13T01:01:00Z",
+                },
+            ) as observe_deployment,
+        ):
+            observation = provider.observe_artifact_deploy(
+                control_plane_root=Path("."),
+                resolved_deploy_target=resolved,
+                deployment_title="Launchplane operation abc",
+            )
+
+        self.assertEqual(observation.outcome, "present")
+        self.assertEqual(observation.deployment_status, "done")
+        self.assertEqual(observation.deployment_id, "deployment-123")
+        observe_deployment.assert_called_once_with(
+            host="https://dokploy.example",
+            token="token",
+            target_type="application",
+            target_id="target-123",
+            title="Launchplane operation abc",
+        )
+
+    def test_dokploy_provider_reports_missing_operation_marker_as_absent(self) -> None:
+        provider = DokployGenericWebDeployProvider()
+        store = _DokployGenericWebDeployStore(_profile())
+        resolved = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            request_source_git_ref="abc123",
+            request_timeout_seconds=45,
+            request_no_cache=False,
+            record_store=store,
+            profile=_profile(),
+            lane=_profile().lanes[0],
+            normalized_artifact_id="ghcr.io/cbusillo/sellyouroutboard@sha256:abc123",
+            fallback_target_name="fallback-target",
+        )
+        with (
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider."
+                "control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.generic_web_deploy_provider."
+                "control_plane_dokploy.deployment_for_target_by_title",
+                return_value=None,
+            ),
+        ):
+            observation = provider.observe_artifact_deploy(
+                control_plane_root=Path("."),
+                resolved_deploy_target=resolved,
+                deployment_title="Launchplane operation missing",
+            )
+
+        self.assertEqual(observation.outcome, "absent")
+
+    def test_reconciliation_key_reconstructs_original_target_after_authority_change(
+        self,
+    ) -> None:
+        profile = _profile()
+        lane = profile.lanes[0]
+        request = _request()
+        store = _DokployGenericWebDeployStore(profile)
+        provider = DokployGenericWebDeployProvider()
+        original = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id=request.artifact_id,
+            request_source_git_ref=request.source_git_ref,
+            request_timeout_seconds=request.timeout_seconds,
+            request_no_cache=request.no_cache,
+            record_store=store,
+            profile=profile,
+            lane=lane,
+            normalized_artifact_id=request.artifact_id,
+            fallback_target_name="fallback-target",
+        )
+        reconciliation_key = build_generic_web_provider_reconciliation_key(original)
+        store.provider_target = store.provider_target.model_copy(
+            update={"target_id": "target-replacement", "display_name": "replacement-target"}
+        )
+        store.dokploy_target_id = store.dokploy_target_id.model_copy(
+            update={"target_id": "target-replacement"}
+        )
+
+        current = provider.resolve_deploy_target(
+            control_plane_root=Path("."),
+            request_artifact_id=request.artifact_id,
+            request_source_git_ref=request.source_git_ref,
+            request_timeout_seconds=request.timeout_seconds,
+            request_no_cache=request.no_cache,
+            record_store=store,
+            profile=profile,
+            lane=lane,
+            normalized_artifact_id=request.artifact_id,
+            fallback_target_name="fallback-target",
+        )
+        recovered = resolve_generic_web_provider_reconciliation_target(
+            reconciliation_key=reconciliation_key,
+            request_artifact_id=request.artifact_id,
+            request_source_git_ref=request.source_git_ref,
+            request_timeout_seconds=request.timeout_seconds,
+            request_no_cache=request.no_cache,
+            normalized_artifact_id=request.artifact_id,
+            lane=lane,
+        )
+
+        self.assertEqual(current.resolved_target.target_id, "target-replacement")
+        self.assertEqual(recovered.resolved_target.target_id, "target-123")
+        self.assertEqual(recovered.resolved_target.target_name, "provider-target-app")
 
     def test_dokploy_provider_blocks_missing_provider_target_authority(self) -> None:
         class MissingProviderTargetStore(_DokployGenericWebDeployStore):

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -18,7 +18,7 @@ from control_plane.contracts.odoo_instance_override_record import (
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
-from control_plane.http_app import create_launchplane_fastapi_app
+from control_plane.http_app import create_launchplane_fastapi_app, idempotency_scope
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
@@ -813,6 +813,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
             event_name="workflow_dispatch",
         )
 
+    def _reservation_store(self, root: Path) -> PostgresRecordStore:
+        store = PostgresRecordStore(database_url=_sqlite_database_url(root / "launchplane.sqlite3"))
+        store.ensure_schema()
+        store.write_product_profile_record(
+            LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
+        )
+        return store
+
     def _profile_store(
         self,
         database_url: str,
@@ -1379,10 +1387,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
     async def test_odoo_preview_apply_keeps_health_responsive_during_provider_wait(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
+            store = self._reservation_store(root)
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(
                     self._identity(
@@ -1428,7 +1433,11 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 side_effect=blocking_apply,
             ):
                 apply_task = asyncio.create_task(
-                    _post_odoo_preview_apply(app, _ready_odoo_preview_apply_payload())
+                    _post_odoo_preview_apply(
+                        app,
+                        _ready_odoo_preview_apply_payload(),
+                        idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:health",
+                    )
                 )
                 try:
                     self.assertTrue(await asyncio.to_thread(apply_started.wait, 5))
@@ -1448,10 +1457,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
     async def test_odoo_preview_apply_records_result_after_caller_cancellation(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
+            store = self._reservation_store(root)
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(
                     self._identity(
@@ -1509,24 +1515,21 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 await asyncio.sleep(0.1)
                 self.assertFalse(first_apply_task.done())
                 first_apply_task.cancel()
-                second_apply_task = asyncio.create_task(
-                    _post_odoo_preview_apply(
-                        app,
-                        _ready_odoo_preview_apply_payload(),
-                        idempotency_key=idempotency_key,
-                    )
+                in_progress_response = await _post_odoo_preview_apply(
+                    app,
+                    _ready_odoo_preview_apply_payload(),
+                    idempotency_key=idempotency_key,
                 )
-                try:
-                    await asyncio.sleep(0.1)
-                    self.assertFalse(first_apply_task.done())
-                    self.assertFalse(second_apply_task.done())
-                    self.assertEqual(apply_driver.call_count, 1)
-                finally:
-                    release_apply.set()
+                self.assertEqual(in_progress_response.status_code, 409)
+                self.assertEqual(
+                    in_progress_response.json()["error"]["code"],
+                    "mutation_in_progress",
+                )
+                self.assertEqual(apply_driver.call_count, 1)
+                release_apply.set()
 
                 with self.assertRaises(asyncio.CancelledError):
                     await asyncio.wait_for(first_apply_task, timeout=5)
-                second_response = await asyncio.wait_for(second_apply_task, timeout=5)
                 replay_response = await _post_odoo_preview_apply(
                     app,
                     _ready_odoo_preview_apply_payload(),
@@ -1535,10 +1538,133 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertFalse(apply_wait_timed_out.is_set())
         self.assertEqual(apply_driver.call_count, 1)
-        self.assertEqual(second_response.status_code, 202)
-        self.assertTrue(second_response.json()["replayed"])
         self.assertEqual(replay_response.status_code, 202)
         self.assertTrue(replay_response.json()["replayed"])
+        self.assertEqual(replay_response.json()["result"]["status"], "pass")
+
+    async def test_odoo_preview_post_dispatch_failure_requires_reconciliation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(
+                    self._identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                authz_policy=self._policy(
+                    actions=("odoo_preview_apply.execute",),
+                    repository="cbusillo/launchplane",
+                    workflow_ref=(
+                        "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
+                        "@refs/heads/main"
+                    ),
+                ),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            failed_result = {
+                "status": "fail",
+                "operation": "refresh",
+                "product": "odoo-tenant-cm",
+                "repository": "cbusillo/odoo-tenant-cm",
+                "preview_slug": "pr-42",
+                "preview_url": "https://pr-42.cm-preview.example.test",
+                "domain_host": "pr-42.cm-preview.example.test",
+                "compose_name": "cm-odoo-preview-pr-42",
+                "provider_effect_attempted": True,
+                "error_message": "Timed out waiting for Dokploy deployment status.",
+            }
+            first_key = "odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:timeout"
+            with patch(
+                "control_plane.http_app.execute_odoo_preview_apply_result",
+                return_value=failed_result,
+            ) as apply_driver:
+                first_response = await _post_odoo_preview_apply(
+                    app,
+                    _ready_odoo_preview_apply_payload(),
+                    idempotency_key=first_key,
+                )
+                second_payload = _ready_odoo_preview_apply_payload()
+                second_plan = cast(
+                    dict[str, object],
+                    cast(dict[str, object], second_payload["apply"])["dry_run_plan"],
+                )
+                second_plan["compose_ref"] = "compose-cm-pr-42-existing"
+                second_plan["environment_id"] = ""
+                second_response = await _post_odoo_preview_apply(
+                    app,
+                    second_payload,
+                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:second",
+                )
+
+            reconcile_stored = store.read_idempotency_record(
+                scope=idempotency_scope(
+                    self._identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                route_path="/v1/drivers/odoo/preview-apply",
+                idempotency_key=first_key,
+            )
+            observed_failure = dict(failed_result)
+            observed_failure.pop("provider_effect_attempted", None)
+            with patch(
+                "control_plane.http_app.observe_odoo_preview_apply_result",
+                return_value=("present", observed_failure, False),
+            ) as observe_driver:
+                recovered_response = await _post_odoo_preview_apply(
+                    app,
+                    _ready_odoo_preview_apply_payload(),
+                    idempotency_key=first_key,
+                )
+                replayed_failure_response = await _post_odoo_preview_apply(
+                    app,
+                    _ready_odoo_preview_apply_payload(),
+                    idempotency_key=first_key,
+                )
+            stored = store.read_idempotency_record(
+                scope=idempotency_scope(
+                    self._identity(
+                        repository="cbusillo/launchplane",
+                        workflow_ref=(
+                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
+                            "@refs/heads/main"
+                        ),
+                    )
+                ),
+                route_path="/v1/drivers/odoo/preview-apply",
+                idempotency_key=first_key,
+            )
+
+        self.assertEqual(first_response.status_code, 409)
+        self.assertEqual(
+            first_response.json()["error"]["code"],
+            "mutation_reconciliation_required",
+        )
+        self.assertEqual(second_response.status_code, 409)
+        self.assertEqual(second_response.json()["error"]["code"], "mutation_in_progress")
+        self.assertEqual(apply_driver.call_count, 1)
+        assert reconcile_stored is not None
+        self.assertEqual(reconcile_stored.state, "reconcile_required")
+        self.assertEqual(recovered_response.status_code, 502)
+        self.assertEqual(
+            recovered_response.json()["error"]["code"],
+            "provider_mutation_failed",
+        )
+        self.assertEqual(replayed_failure_response.status_code, 502)
+        self.assertEqual(observe_driver.call_count, 1)
+        assert stored is not None
+        self.assertEqual(stored.state, "completed")
+        self.assertEqual(stored.response_status_code, 502)
 
     async def test_odoo_preview_destroy_apply_allows_missing_image_reference(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1616,10 +1742,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
     async def test_odoo_preview_apply_does_not_replay_blocked_idempotency(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
+            store = self._reservation_store(root)
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(
                     self._identity(
@@ -1711,10 +1834,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
     async def test_odoo_preview_apply_replays_non_blocked_idempotency(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
+            store = self._reservation_store(root)
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(
                     self._identity(
@@ -1805,10 +1925,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
     async def test_odoo_preview_apply_handler_file_miss_is_not_found(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
-            store.write_product_profile_record(
-                LaunchplaneProductProfileRecord.model_validate(_odoo_preview_profile_payload())
-            )
+            store = self._reservation_store(root)
             app = create_launchplane_fastapi_app(
                 verifier=_StubVerifier(
                     self._identity(
@@ -1858,6 +1975,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
                         },
                     },
+                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:file-miss",
                 )
 
         self.assertEqual(response.status_code, 404)

--- a/tests/test_odoo_generic_web_post_deploy.py
+++ b/tests/test_odoo_generic_web_post_deploy.py
@@ -15,6 +15,7 @@ from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.workflows.generic_web_deploy import (
     GenericWebDeployStore,
     GenericWebPostDeployContext,
+    GenericWebPostDeployGuard,
 )
 from control_plane.workflows.odoo_generic_web_post_deploy import (
     execute_odoo_generic_web_post_deploy,
@@ -60,6 +61,7 @@ class OdooGenericWebPostDeployTests(unittest.TestCase):
                     Path("."),
                     cast(GenericWebDeployStore, store),
                     context,
+                    GenericWebPostDeployGuard(deployment_title="post-deploy-title"),
                 )
 
         self.assertTrue(evidence.attempted)
@@ -75,6 +77,10 @@ class OdooGenericWebPostDeployTests(unittest.TestCase):
         request = post_deploy.call_args.kwargs["request"]
         self.assertEqual(request.context, "cm")
         self.assertEqual(request.instance, "prod")
+        self.assertEqual(
+            post_deploy.call_args.kwargs["provider_operation_title"],
+            "post-deploy-title",
+        )
 
     def test_preserves_failure_detail(self) -> None:
         context = _context()
@@ -96,6 +102,7 @@ class OdooGenericWebPostDeployTests(unittest.TestCase):
                     Path("."),
                     cast(GenericWebDeployStore, store),
                     context,
+                    GenericWebPostDeployGuard(),
                 )
 
         self.assertTrue(evidence.attempted)

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -38,7 +38,9 @@ from control_plane.workflows.odoo_preview_runtime import (
     build_odoo_preview_apply_workflow_request,
     build_odoo_preview_artifact_publish_inputs_workflow_request,
     execute_odoo_preview_dokploy_apply,
+    observe_odoo_preview_dokploy_apply,
     _preview_runtime_bindings,
+    _rollback_created_runtime,
     _wait_for_smoke_check,
 )
 
@@ -337,6 +339,35 @@ def _patched_apply_inputs_runtime(*, dokploy_side_effect: object) -> Iterator[No
 
 
 class OdooPreviewDokployDryRunTests(unittest.TestCase):
+    def test_rollback_rechecks_fence_before_each_delete(self) -> None:
+        phases: list[str] = []
+
+        def checkpoint(phase: str) -> None:
+            phases.append(phase)
+            if phase == "rollback_compose_delete":
+                raise RuntimeError("reservation recovered")
+
+        with (
+            patch("control_plane.workflows.odoo_preview_runtime._delete_domain") as delete_domain,
+            patch("control_plane.workflows.odoo_preview_runtime._delete_compose") as delete_compose,
+            self.assertRaisesRegex(RuntimeError, "reservation recovered"),
+        ):
+            _rollback_created_runtime(
+                host="https://dokploy.example",
+                token="token",
+                domain_id="domain-one",
+                compose_id="compose-one",
+                delete_volumes=True,
+                provider_effect_checkpoint=checkpoint,
+            )
+
+        self.assertEqual(
+            phases,
+            ["rollback_domain_delete", "rollback_compose_delete"],
+        )
+        delete_domain.assert_called_once()
+        delete_compose.assert_not_called()
+
     def test_builds_artifact_publish_inputs_workflow_request_shape(self) -> None:
         request = build_odoo_preview_artifact_publish_inputs_workflow_request(
             facts=_workflow_facts()
@@ -1596,6 +1627,8 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
 
         def _fake_dokploy_request(**kwargs: object) -> object:
             requests.append(dict(kwargs))
+            if kwargs["path"] == "/api/project.all":
+                return []
             if kwargs["path"] == "/api/compose.create":
                 return {"composeId": "compose-cm-pr-45"}
             return {}
@@ -1660,10 +1693,13 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(result.status, "pass")
         self.assertEqual(result.compose_id, "compose-cm-pr-45")
         self.assertTrue(result.created_compose)
-        self.assertEqual([request["path"] for request in requests], ["/api/compose.create"])
+        self.assertEqual(
+            [request["path"] for request in requests],
+            ["/api/project.all", "/api/compose.search", "/api/compose.create"],
+        )
         fetch_targets = [call.kwargs["target_id"] for call in fetch_target_payload.call_args_list]
         self.assertEqual(fetch_targets, ["compose-template", "compose-cm-pr-45"])
-        create_payload = requests[0]["payload"]
+        create_payload = requests[2]["payload"]
         self.assertIsInstance(create_payload, dict)
         assert isinstance(create_payload, dict)
         self.assertEqual(create_payload["environmentId"], "env-cm-preview")
@@ -1692,6 +1728,256 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         )
         wait_deploy.assert_called_once()
         smoke_check.assert_called_once()
+
+    def test_observe_refresh_adopts_exact_terminal_deployment_marker(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+        request = OdooPreviewDokployApplyRequest(
+            dry_run_plan=dry_run,
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            environment_values=_environment_values(),
+            smoke_check=False,
+        )
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._discover_odoo_preview_target",
+                return_value=_target(),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy."
+                "deployment_for_target_by_title",
+                return_value={
+                    "deploymentId": "deployment-cm-pr-45",
+                    "title": "Launchplane operation abc",
+                    "status": "done",
+                },
+            ) as observe_deployment,
+        ):
+            observation = observe_odoo_preview_dokploy_apply(
+                control_plane_root=Path("."),
+                context_name="cm-preview",
+                request=request,
+                database_url=None,
+                provider_operation_title="Launchplane operation abc",
+            )
+
+        self.assertEqual(observation.outcome, "present")
+        assert observation.result is not None
+        self.assertEqual(observation.result.status, "pass")
+        self.assertEqual(observation.result.compose_id, "compose-cm-pr-45")
+        observe_deployment.assert_called_once_with(
+            host="https://dokploy.example",
+            token="token",
+            target_type="compose",
+            target_id="compose-cm-pr-45",
+            title="Launchplane operation abc",
+        )
+
+    def test_apply_create_plan_adopts_existing_compose_before_retry(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(),
+                endpoint_spec=_endpoint_spec(),
+                environment_id="env-cm-preview",
+                template_compose_id="compose-template",
+            )
+        )
+
+        def _fake_dokploy_request(**kwargs: object) -> object:
+            if kwargs["path"] == "/api/project.all":
+                return []
+            if kwargs["path"] == "/api/compose.search":
+                return [
+                    {
+                        "composeId": "compose-cm-pr-45-existing",
+                        "name": dry_run.compose_name,
+                        "environmentId": "env-cm-preview",
+                    }
+                ]
+            if kwargs["path"] == "/api/compose.create":
+                self.fail("existing compose must be adopted instead of recreated")
+            return {}
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.dokploy_request",
+                side_effect=_fake_dokploy_request,
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=(
+                    {
+                        "composeId": "compose-template",
+                        "environmentId": "env-cm-preview",
+                        "serverId": "server-nonprod",
+                    },
+                    {
+                        "composeId": "compose-cm-pr-45-existing",
+                        "environmentId": "env-cm-preview",
+                        "serverId": "server-nonprod",
+                    },
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.sync_dokploy_compose_raw_source",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.update_dokploy_target_env",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.ensure_compose_web_domain_route",
+                return_value="domain-cm-pr-45",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.latest_deployment_for_target",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.trigger_deployment",
+            ) as trigger_deployment,
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.wait_for_target_deployment",
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._wait_for_smoke_check",
+            ),
+        ):
+            result = execute_odoo_preview_dokploy_apply(
+                control_plane_root=Path("."),
+                request=OdooPreviewDokployApplyRequest(
+                    dry_run_plan=dry_run,
+                    image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                    environment_values=_environment_values(),
+                ),
+                provider_operation_title="Launchplane operation retry",
+            )
+
+        self.assertEqual(result.status, "pass")
+        self.assertEqual(result.compose_id, "compose-cm-pr-45-existing")
+        self.assertFalse(result.created_compose)
+        self.assertNotIn("compose_create", [step.name for step in result.steps])
+        trigger_deployment.assert_called_once_with(
+            host="https://dokploy.example",
+            token="token",
+            target_type="compose",
+            target_id="compose-cm-pr-45-existing",
+            no_cache=False,
+            title="Launchplane operation retry",
+        )
+
+    def test_observe_destroy_does_not_treat_domain_cleanup_as_compose_deletion(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(operation="destroy", target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+        request = OdooPreviewDokployApplyRequest(dry_run_plan=dry_run)
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.fetch_dokploy_target_payload",
+                return_value={"composeId": "compose-cm-pr-45"},
+            ),
+        ):
+            observation = observe_odoo_preview_dokploy_apply(
+                control_plane_root=Path("."),
+                context_name="cm-preview",
+                request=request,
+                database_url=None,
+                provider_operation_title="Launchplane operation destroy",
+            )
+
+        self.assertEqual(observation.outcome, "absent")
+        self.assertIsNone(observation.result)
+
+    def test_observe_destroy_adopts_exact_missing_compose(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(operation="destroy", target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+        request = OdooPreviewDokployApplyRequest(dry_run_plan=dry_run)
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.fetch_dokploy_target_payload",
+                side_effect=click.ClickException(
+                    "Dokploy API GET /api/compose.one failed (404): Not Found"
+                ),
+            ),
+        ):
+            observation = observe_odoo_preview_dokploy_apply(
+                control_plane_root=Path("."),
+                context_name="cm-preview",
+                request=request,
+                database_url=None,
+                provider_operation_title="Launchplane operation destroy",
+                provider_effect_phase="compose_destroy",
+            )
+
+        self.assertEqual(observation.outcome, "present")
+        assert observation.result is not None
+        self.assertEqual(observation.result.status, "pass")
+
+    def test_observe_refresh_does_not_retry_missing_marker_after_trigger_checkpoint(
+        self,
+    ) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+        request = OdooPreviewDokployApplyRequest(
+            dry_run_plan=dry_run,
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+            environment_values=_environment_values(),
+        )
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._discover_odoo_preview_target",
+                return_value=_target(),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.deployment_for_target_by_title",
+                return_value=None,
+            ),
+        ):
+            observation = observe_odoo_preview_dokploy_apply(
+                control_plane_root=Path("."),
+                context_name="cm-preview",
+                request=request,
+                database_url=None,
+                provider_operation_title="Launchplane operation deploy",
+                provider_effect_phase="deploy_trigger",
+            )
+
+        self.assertEqual(observation.outcome, "unknown")
+        self.assertFalse(observation.retry_safe)
 
     def test_apply_create_blocks_missing_template_compose_id_before_provider_fetch(
         self,
@@ -1841,6 +2127,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             ),
             patch(
                 "control_plane.workflows.odoo_preview_runtime.control_plane_dokploy.dokploy_request",
+                return_value=[],
             ) as dokploy_request,
         ):
             result = execute_odoo_preview_dokploy_apply(
@@ -1854,7 +2141,10 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
 
         self.assertEqual(result.status, "fail")
         self.assertIn("serverId", result.error_message)
-        dokploy_request.assert_not_called()
+        self.assertEqual(
+            [call.kwargs["path"] for call in dokploy_request.call_args_list],
+            ["/api/project.all", "/api/compose.search"],
+        )
 
     def test_apply_destroy_deletes_domain_then_compose_with_volumes(self) -> None:
         dry_run = build_odoo_preview_dokploy_dry_run(

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -52,6 +52,13 @@ from control_plane.contracts.route_binding_record import (
     RouteBindingSource,
     RouteBindingTls,
 )
+from control_plane.provider_operations import (
+    DurableProviderOperationResult,
+    ProviderMutationOutcome,
+    ProviderObservation,
+    ProviderOperationLease,
+    run_durable_provider_operation,
+)
 from control_plane.storage.postgres import (
     DbOnlyMutationRequest,
     MutationReservationResult,
@@ -408,6 +415,16 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
             idempotency_indexes["launchplane_idempotency_scope_route_key_idx"]["unique"]
         )
         self.assertFalse(idempotency_indexes["launchplane_idempotency_state_lease_idx"]["unique"])
+        self.assertTrue(
+            idempotency_indexes["launchplane_idempotency_active_reconciliation_idx"]["unique"]
+        )
+        self.assertEqual(
+            idempotency_indexes["launchplane_idempotency_active_reconciliation_idx"][
+                "column_names"
+            ],
+            ["provider_target_key"],
+        )
+        self.assertIn("provider_target_key", idempotency_columns)
         self.assertTrue(indexes["launchplane_odoo_bootstrap_active_lane_uidx"]["unique"])
 
     def test_mutation_reservation_migration_backfills_existing_postgres_rows(self) -> None:
@@ -482,6 +499,145 @@ class RealPostgresSchemaIntegrationTests(unittest.TestCase):
         self.assertEqual(promoted["attempt"], 1)
         self.assertEqual(promoted["created_at"], "2026-07-12T00:00:00Z")
         self.assertEqual(promoted["updated_at"], "2026-07-12T00:00:00Z")
+
+    def test_provider_target_fence_migration_backfills_existing_active_rows(self) -> None:
+        with _isolated_postgres_database() as database_url:
+            alembic_command.upgrade(_alembic_config(database_url), "a2b4c6d8e0f2")
+            reconciliation_key = "dokploy:compose:existing-provider-target"
+            payload = {
+                "schema_version": 2,
+                "record_id": "mutation-reservation-existing-provider-target",
+                "scope": "github-actions:provider-target-migration",
+                "route_path": "/v1/test/provider-target",
+                "idempotency_key": "provider-target-existing",
+                "request_fingerprint": "provider-target-fingerprint",
+                "state": "reconcile_required",
+                "lease_owner": "worker-a",
+                "lease_expires_at": "",
+                "attempt": 1,
+                "reconciliation_key": reconciliation_key,
+                "provider_effect_phase": "",
+                "provider_effect_started_at": "",
+                "created_at": "2026-07-12T00:00:00Z",
+                "updated_at": "2026-07-12T00:00:00Z",
+                "response_status_code": None,
+                "response_trace_id": "",
+                "recorded_at": "",
+                "response_payload": {},
+            }
+            engine = create_engine(database_url)
+            with engine.begin() as connection:
+                connection.execute(
+                    text(
+                        "INSERT INTO launchplane_idempotency_records "
+                        "(record_id, scope, route_path, idempotency_key, request_fingerprint, "
+                        "state, lease_owner, lease_expires_at, attempt, reconciliation_key, "
+                        "created_at, updated_at, response_status_code, response_trace_id, "
+                        "recorded_at, payload) VALUES "
+                        "(:record_id, :scope, :route_path, :idempotency_key, "
+                        ":request_fingerprint, 'reconcile_required', 'worker-a', '', 1, "
+                        ":reconciliation_key, :created_at, :updated_at, NULL, '', '', "
+                        "CAST(:payload AS jsonb))"
+                    ),
+                    {
+                        "record_id": payload["record_id"],
+                        "scope": payload["scope"],
+                        "route_path": payload["route_path"],
+                        "idempotency_key": payload["idempotency_key"],
+                        "request_fingerprint": payload["request_fingerprint"],
+                        "reconciliation_key": reconciliation_key,
+                        "created_at": payload["created_at"],
+                        "updated_at": payload["updated_at"],
+                        "payload": json.dumps(payload),
+                    },
+                )
+            engine.dispose()
+
+            _upgrade_empty_database_to_head(database_url)
+            store = PostgresRecordStore(database_url=database_url)
+            try:
+                store.verify_schema()
+                loaded = store.read_idempotency_record(
+                    scope=str(payload["scope"]),
+                    route_path=str(payload["route_path"]),
+                    idempotency_key=str(payload["idempotency_key"]),
+                )
+                blocked = store.reserve_mutation(
+                    scope="github-actions:provider-target-migration",
+                    route_path="/v1/test/provider-target",
+                    idempotency_key="provider-target-contender",
+                    request_fingerprint="provider-target-contender-fingerprint",
+                    lease_owner="worker-b",
+                    reconciliation_key=reconciliation_key,
+                )
+            finally:
+                store.close()
+
+        self.assertIsNotNone(loaded)
+        assert loaded is not None
+        self.assertEqual(loaded.provider_target_key, reconciliation_key)
+        self.assertEqual(blocked.status, "target_busy")
+
+    def test_provider_target_fence_migration_fails_closed_on_duplicate_claims(self) -> None:
+        with _isolated_postgres_database() as database_url:
+            alembic_command.upgrade(_alembic_config(database_url), "a2b4c6d8e0f2")
+            reconciliation_key = "dokploy:compose:duplicate-provider-target"
+            engine = create_engine(database_url)
+            with engine.begin() as connection:
+                for index in (1, 2):
+                    payload = {
+                        "schema_version": 2,
+                        "record_id": f"mutation-reservation-duplicate-target-{index}",
+                        "scope": f"github-actions:duplicate-target-{index}",
+                        "route_path": "/v1/test/provider-target",
+                        "idempotency_key": f"provider-target-duplicate-{index}",
+                        "request_fingerprint": f"provider-target-fingerprint-{index}",
+                        "state": "reconcile_required",
+                        "lease_owner": f"worker-{index}",
+                        "lease_expires_at": "",
+                        "attempt": 1,
+                        "reconciliation_key": reconciliation_key,
+                        "provider_effect_phase": "",
+                        "provider_effect_started_at": "",
+                        "created_at": "2026-07-12T00:00:00Z",
+                        "updated_at": "2026-07-12T00:00:00Z",
+                        "response_status_code": None,
+                        "response_trace_id": "",
+                        "recorded_at": "",
+                        "response_payload": {},
+                    }
+                    connection.execute(
+                        text(
+                            "INSERT INTO launchplane_idempotency_records "
+                            "(record_id, scope, route_path, idempotency_key, "
+                            "request_fingerprint, state, lease_owner, lease_expires_at, "
+                            "attempt, reconciliation_key, created_at, updated_at, "
+                            "response_status_code, response_trace_id, recorded_at, payload) "
+                            "VALUES (:record_id, :scope, :route_path, :idempotency_key, "
+                            ":request_fingerprint, 'reconcile_required', :lease_owner, '', 1, "
+                            ":reconciliation_key, :created_at, :updated_at, NULL, '', '', "
+                            "CAST(:payload AS jsonb))"
+                        ),
+                        {
+                            "record_id": payload["record_id"],
+                            "scope": payload["scope"],
+                            "route_path": payload["route_path"],
+                            "idempotency_key": payload["idempotency_key"],
+                            "request_fingerprint": payload["request_fingerprint"],
+                            "lease_owner": payload["lease_owner"],
+                            "reconciliation_key": reconciliation_key,
+                            "created_at": payload["created_at"],
+                            "updated_at": payload["updated_at"],
+                            "payload": json.dumps(payload),
+                        },
+                    )
+            engine.dispose()
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "Cannot fence active provider mutations while duplicate target claims exist",
+            ):
+                _upgrade_empty_database_to_head(database_url)
 
     def test_startup_verification_fails_closed_when_critical_index_is_missing(
         self,
@@ -1544,6 +1700,308 @@ def _column_type(engine: Engine, *, table_name: str, column_name: str) -> str:
                 {"table_name": table_name, "column_name": column_name},
             ).scalar_one()
         )
+
+
+_PROVIDER_OPERATION_SCOPE = "github-actions:provider-operation-integration"
+_PROVIDER_OPERATION_ROUTE = "/v1/drivers/provider-operation-integration"
+_PROVIDER_OPERATION_KEY = "provider-operation:integration:1"
+_PROVIDER_OPERATION_FINGERPRINT = "provider-operation-integration-fingerprint"
+_PROVIDER_OPERATION_RECONCILIATION_KEY = "dokploy-compose:integration-preview"
+_PROVIDER_OPERATION_TARGET_KEY = "dokploy-target:integration-preview"
+
+
+class _IntegrationProviderAdapter:
+    def __init__(
+        self,
+        *,
+        started: threading.Event | None = None,
+        release: threading.Event | None = None,
+        observation: ProviderObservation | None = None,
+    ) -> None:
+        self._started = started
+        self._release = release
+        self._observation = observation or ProviderObservation(outcome="unknown")
+        self.apply_calls = 0
+        self.observe_calls = 0
+
+    def reconciliation_key(self) -> str:
+        return _PROVIDER_OPERATION_RECONCILIATION_KEY
+
+    def target_key(self) -> str:
+        return _PROVIDER_OPERATION_TARGET_KEY
+
+    def observe(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+    ) -> ProviderObservation:
+        del provider_operation_key, provider_effect_phase, reconciliation_key
+        self.observe_calls += 1
+        return self._observation
+
+    def apply(
+        self, provider_operation_key: str, lease: ProviderOperationLease
+    ) -> ProviderMutationOutcome:
+        del provider_operation_key
+        self.apply_calls += 1
+        lease.checkpoint_effect("integration_effect")
+        if self._started is not None:
+            self._started.set()
+        if self._release is not None and not self._release.wait(timeout=5):
+            raise AssertionError("provider apply was not released")
+        return ProviderMutationOutcome(
+            response_status_code=202,
+            response_payload={"trace_id": "integration-effect", "status": "accepted"},
+        )
+
+
+def _run_integration_provider_operation(
+    store: PostgresRecordStore,
+    adapter: _IntegrationProviderAdapter,
+    *,
+    lease_owner: str,
+    response_trace_id: str,
+    lease_seconds: int = 300,
+    heartbeat_interval_seconds: float | None = None,
+    idempotency_key: str = _PROVIDER_OPERATION_KEY,
+    request_fingerprint: str = _PROVIDER_OPERATION_FINGERPRINT,
+) -> DurableProviderOperationResult:
+    return run_durable_provider_operation(
+        store=store,
+        scope=_PROVIDER_OPERATION_SCOPE,
+        route_path=_PROVIDER_OPERATION_ROUTE,
+        idempotency_key=idempotency_key,
+        request_fingerprint=request_fingerprint,
+        lease_owner=lease_owner,
+        response_trace_id=response_trace_id,
+        adapter=adapter,
+        lease_seconds=lease_seconds,
+        heartbeat_interval_seconds=heartbeat_interval_seconds,
+    )
+
+
+class RealPostgresProviderOperationTests(unittest.TestCase):
+    def test_two_instances_apply_provider_effect_exactly_once(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            try:
+                started = threading.Event()
+                release = threading.Event()
+                holder = _IntegrationProviderAdapter(started=started, release=release)
+                holder_result: dict[str, DurableProviderOperationResult] = {}
+
+                def run_holder() -> None:
+                    holder_result["value"] = _run_integration_provider_operation(
+                        store,
+                        holder,
+                        lease_owner="instance-a",
+                        response_trace_id="integration-trace-a",
+                    )
+
+                holder_thread = threading.Thread(target=run_holder)
+                holder_thread.start()
+                try:
+                    self.assertTrue(started.wait(5))
+                    second = _IntegrationProviderAdapter()
+                    second_result = _run_integration_provider_operation(
+                        second_store,
+                        second,
+                        lease_owner="instance-b",
+                        response_trace_id="integration-trace-b",
+                    )
+                    self.assertEqual(second_result.status, "in_progress")
+                    self.assertEqual(second.apply_calls, 0)
+                finally:
+                    release.set()
+                    holder_thread.join(5)
+
+                self.assertEqual(holder_result["value"].status, "completed")
+                self.assertEqual(holder.apply_calls, 1)
+                stored = store.read_idempotency_record(
+                    scope=_PROVIDER_OPERATION_SCOPE,
+                    route_path=_PROVIDER_OPERATION_ROUTE,
+                    idempotency_key=_PROVIDER_OPERATION_KEY,
+                )
+                assert stored is not None
+                self.assertEqual(stored.state, "completed")
+            finally:
+                second_store.close()
+
+    def test_different_idempotency_key_cannot_bypass_active_target_fence(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            first = store.reserve_mutation(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key="provider-operation:integration:first",
+                request_fingerprint="provider-operation-integration-first",
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_PROVIDER_OPERATION_RECONCILIATION_KEY,
+                provider_target_key=_PROVIDER_OPERATION_TARGET_KEY,
+            )
+            second = _run_integration_provider_operation(
+                store,
+                _IntegrationProviderAdapter(),
+                lease_owner="instance-b",
+                response_trace_id="integration-trace-b",
+                idempotency_key="provider-operation:integration:second",
+                request_fingerprint="provider-operation-integration-second",
+            )
+
+        self.assertEqual(first.status, "acquired")
+        self.assertEqual(second.status, "target_busy")
+
+    def test_heartbeats_hold_target_fence_past_original_lease(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            second_store = PostgresRecordStore(database_url=store.database_url)
+            started = threading.Event()
+            release = threading.Event()
+            holder = _IntegrationProviderAdapter(started=started, release=release)
+            holder_result: dict[str, DurableProviderOperationResult] = {}
+
+            def run_holder() -> None:
+                holder_result["value"] = _run_integration_provider_operation(
+                    store,
+                    holder,
+                    lease_owner="instance-a",
+                    response_trace_id="integration-trace-a",
+                    lease_seconds=2,
+                    heartbeat_interval_seconds=0.2,
+                )
+
+            holder_thread = threading.Thread(target=run_holder)
+            holder_thread.start()
+            try:
+                self.assertTrue(started.wait(5))
+                time.sleep(2.2)
+                second_result = _run_integration_provider_operation(
+                    second_store,
+                    _IntegrationProviderAdapter(),
+                    lease_owner="instance-b",
+                    response_trace_id="integration-trace-b",
+                )
+                self.assertEqual(second_result.status, "in_progress")
+            finally:
+                release.set()
+                holder_thread.join(5)
+                second_store.close()
+
+            self.assertEqual(holder_result["value"].status, "completed")
+
+    def test_restart_adopts_observed_effect_without_reapplying(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            reservation = store.reserve_mutation(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key=_PROVIDER_OPERATION_KEY,
+                request_fingerprint=_PROVIDER_OPERATION_FINGERPRINT,
+                lease_owner="instance-a",
+                lease_seconds=1,
+                reconciliation_key=_PROVIDER_OPERATION_RECONCILIATION_KEY,
+                provider_target_key=_PROVIDER_OPERATION_TARGET_KEY,
+            )
+            self.assertEqual(reservation.status, "acquired")
+            time.sleep(1.2)
+
+            recovery = _IntegrationProviderAdapter(
+                observation=ProviderObservation(
+                    outcome="present",
+                    response_status_code=202,
+                    response_payload={"trace_id": "adopted", "status": "accepted"},
+                )
+            )
+            adopted = _run_integration_provider_operation(
+                store,
+                recovery,
+                lease_owner="instance-b",
+                response_trace_id="integration-trace-b",
+            )
+
+            self.assertEqual(adopted.status, "adopted")
+            self.assertEqual(recovery.apply_calls, 0)
+            stored = store.read_idempotency_record(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key=_PROVIDER_OPERATION_KEY,
+            )
+            assert stored is not None
+            self.assertEqual(stored.state, "completed")
+
+    def test_reconcile_required_fails_closed_when_effect_unknown(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            reservation = store.reserve_mutation(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key=_PROVIDER_OPERATION_KEY,
+                request_fingerprint=_PROVIDER_OPERATION_FINGERPRINT,
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_PROVIDER_OPERATION_RECONCILIATION_KEY,
+                provider_target_key=_PROVIDER_OPERATION_TARGET_KEY,
+            )
+            store.mark_mutation_reconcile_required(
+                reservation=reservation.record,
+                reconciliation_key=_PROVIDER_OPERATION_RECONCILIATION_KEY,
+            )
+
+            recovery = _IntegrationProviderAdapter(
+                observation=ProviderObservation(outcome="unknown")
+            )
+            result = _run_integration_provider_operation(
+                store,
+                recovery,
+                lease_owner="instance-b",
+                response_trace_id="integration-trace-b",
+            )
+
+            self.assertEqual(result.status, "reconcile_required")
+            self.assertEqual(recovery.apply_calls, 0)
+            stored = store.read_idempotency_record(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key=_PROVIDER_OPERATION_KEY,
+            )
+            assert stored is not None
+            self.assertEqual(stored.state, "reconcile_required")
+
+    def test_reconcile_absent_releases_and_reapplies_once(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            reservation = store.reserve_mutation(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key=_PROVIDER_OPERATION_KEY,
+                request_fingerprint=_PROVIDER_OPERATION_FINGERPRINT,
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_PROVIDER_OPERATION_RECONCILIATION_KEY,
+                provider_target_key=_PROVIDER_OPERATION_TARGET_KEY,
+            )
+            store.mark_mutation_reconcile_required(
+                reservation=reservation.record,
+                reconciliation_key=_PROVIDER_OPERATION_RECONCILIATION_KEY,
+            )
+            recovery = _IntegrationProviderAdapter(
+                observation=ProviderObservation(outcome="absent")
+            )
+
+            result = _run_integration_provider_operation(
+                store,
+                recovery,
+                lease_owner="instance-b",
+                response_trace_id="integration-trace-b",
+            )
+
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(recovery.observe_calls, 1)
+            self.assertEqual(recovery.apply_calls, 1)
+            stored = store.read_idempotency_record(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key=_PROVIDER_OPERATION_KEY,
+            )
+            assert stored is not None
+            self.assertEqual(stored.state, "completed")
 
 
 if __name__ == "__main__":

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -2264,6 +2264,241 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(replayed.record.state, "completed")
         self.assertEqual(replayed.record.response_trace_id, "trace-mutation-completed")
 
+    def test_active_reconciliation_key_fences_other_idempotency_keys(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            clock = {"now": "2026-07-12T01:00:00Z"}
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: clock["now"],
+            ):
+                first = store.reserve_mutation(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:first",
+                    request_fingerprint="mutation-fingerprint-a",
+                    lease_owner="worker-a",
+                    lease_seconds=300,
+                    reconciliation_key="dokploy:compose:target-123",
+                )
+                blocked = store.reserve_mutation(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:second",
+                    request_fingerprint="mutation-fingerprint-b",
+                    lease_owner="worker-b",
+                    lease_seconds=300,
+                    reconciliation_key="dokploy:compose:target-123",
+                )
+                completion = complete_launchplane_mutation_reservation(
+                    first.record,
+                    response_status_code=202,
+                    response_trace_id="trace-target-first",
+                    completed_at=clock["now"],
+                    response_payload={"status": "accepted"},
+                )
+                completed = store.complete_mutation_reservation(completion=completion)
+                later = store.reserve_mutation(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:third",
+                    request_fingerprint="mutation-fingerprint-c",
+                    lease_owner="worker-c",
+                    lease_seconds=300,
+                    reconciliation_key="dokploy:compose:target-123",
+                )
+            store.close()
+
+        self.assertEqual(first.status, "acquired")
+        self.assertEqual(blocked.status, "target_busy")
+        self.assertEqual(blocked.record.idempotency_key, "mutation:target:first")
+        self.assertEqual(completed.status, "completed")
+        self.assertEqual(later.status, "acquired")
+
+    def test_provider_effect_checkpoint_fences_stale_reservation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            reservation = store.reserve_mutation(
+                scope="github-actions:mutation-test",
+                route_path="/v1/test/mutation",
+                idempotency_key="mutation:effect-checkpoint",
+                request_fingerprint="mutation-fingerprint-a",
+                lease_owner="worker-a",
+                lease_seconds=300,
+                reconciliation_key="dokploy:compose:target-checkpoint",
+            ).record
+            checkpointed = store.checkpoint_mutation_provider_effect(
+                reservation=reservation,
+                effect_phase="deploy_trigger",
+                lease_seconds=300,
+            )
+            stale_renewal = store.renew_mutation_reservation(
+                reservation=reservation,
+                lease_seconds=300,
+            )
+            store.close()
+
+        self.assertEqual(checkpointed.status, "updated")
+        assert checkpointed.record is not None
+        self.assertEqual(checkpointed.record.provider_effect_phase, "deploy_trigger")
+        self.assertTrue(checkpointed.record.provider_effect_started_at)
+        self.assertEqual(stale_renewal.status, "reservation_mismatch")
+
+    def test_stale_completion_cannot_adopt_newer_reconcile_required_attempt(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            first = store.reserve_mutation(
+                scope="github-actions:mutation-test",
+                route_path="/v1/test/mutation",
+                idempotency_key="mutation:late-completion",
+                request_fingerprint="mutation-fingerprint-a",
+                lease_owner="worker-a",
+                lease_seconds=300,
+                reconciliation_key="dokploy:compose:target-late-completion",
+            ).record
+            first_reconcile = store.mark_mutation_reconcile_required(
+                reservation=first,
+                reconciliation_key=first.reconciliation_key,
+            )
+            assert first_reconcile.record is not None
+            retried = store.retry_reconciled_mutation(
+                reservation=first_reconcile.record,
+                lease_owner="worker-b",
+                lease_seconds=300,
+            )
+            assert retried.record is not None
+            second = retried.record
+            second_reconcile = store.mark_mutation_reconcile_required(
+                reservation=second,
+                reconciliation_key=second.reconciliation_key,
+            )
+            stale_retry = store.retry_reconciled_mutation(
+                reservation=first_reconcile.record,
+                lease_owner="worker-c",
+                lease_seconds=300,
+            )
+            stale_completion = complete_launchplane_mutation_reservation(
+                first,
+                response_status_code=202,
+                response_trace_id="trace-worker-a",
+                completed_at=first.updated_at,
+                response_payload={"status": "accepted"},
+            )
+            completion_result = store.complete_mutation_reservation(completion=stale_completion)
+            store.close()
+
+        self.assertEqual(retried.status, "acquired")
+        self.assertEqual(second.attempt, first.attempt + 1)
+        self.assertEqual(second_reconcile.status, "updated")
+        self.assertEqual(stale_retry.status, "reservation_mismatch")
+        self.assertEqual(completion_result.status, "owner_mismatch")
+        assert completion_result.record is not None
+        self.assertEqual(completion_result.record.lease_owner, "worker-b")
+        self.assertEqual(completion_result.record.state, "reconcile_required")
+
+    def test_reservation_retries_when_active_collision_completes_before_lookup(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            owner_store = PostgresRecordStore(database_url=database_url)
+            owner_store.ensure_schema()
+            contender_store = PostgresRecordStore(database_url=database_url)
+            incumbent = owner_store.reserve_mutation(
+                scope="github-actions:mutation-test",
+                route_path="/v1/test/mutation",
+                idempotency_key="mutation:collision:first",
+                request_fingerprint="mutation-fingerprint-a",
+                lease_owner="worker-a",
+                lease_seconds=300,
+                reconciliation_key="dokploy:compose:target-collision",
+            ).record
+            original_begin = contender_store._begin_serialized_write
+            begin_calls = 0
+
+            def begin_after_incumbent_release(session: object) -> None:
+                nonlocal begin_calls
+                begin_calls += 1
+                if begin_calls == 2:
+                    released = owner_store.release_reserved_mutation(reservation=incumbent)
+                    self.assertEqual(released.status, "released")
+                original_begin(session)
+
+            with patch.object(
+                contender_store,
+                "_begin_serialized_write",
+                side_effect=begin_after_incumbent_release,
+            ):
+                acquired = contender_store.reserve_mutation(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:collision:second",
+                    request_fingerprint="mutation-fingerprint-b",
+                    lease_owner="worker-b",
+                    lease_seconds=300,
+                    reconciliation_key="dokploy:compose:target-collision",
+                )
+            owner_store.close()
+            contender_store.close()
+
+        self.assertEqual(acquired.status, "acquired")
+        self.assertEqual(acquired.record.idempotency_key, "mutation:collision:second")
+        self.assertGreaterEqual(begin_calls, 3)
+
+    def test_reconcile_required_target_stays_fenced(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            first = store.reserve_mutation(
+                scope="github-actions:mutation-test",
+                route_path="/v1/test/mutation",
+                idempotency_key="mutation:target:unknown",
+                request_fingerprint="mutation-fingerprint-a",
+                lease_owner="worker-a",
+                lease_seconds=300,
+                reconciliation_key="dokploy:compose:target-unknown",
+            )
+            marked = store.mark_mutation_reconcile_required(
+                reservation=first.record,
+                reconciliation_key="dokploy:compose:target-unknown",
+            )
+            blocked = store.reserve_mutation(
+                scope="github-actions:mutation-test",
+                route_path="/v1/test/mutation",
+                idempotency_key="mutation:target:replacement",
+                request_fingerprint="mutation-fingerprint-b",
+                lease_owner="worker-b",
+                lease_seconds=300,
+                reconciliation_key="dokploy:compose:target-unknown",
+            )
+            store.close()
+
+        self.assertEqual(marked.status, "updated")
+        self.assertEqual(blocked.status, "target_busy")
+        self.assertEqual(blocked.record.state, "reconcile_required")
+
     def test_db_only_mutation_preflight_releases_expired_unbound_reservation(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(

--- a/tests/test_preview_resource_destroy.py
+++ b/tests/test_preview_resource_destroy.py
@@ -1,4 +1,5 @@
 import unittest
+from collections.abc import Callable
 from unittest.mock import patch
 
 import click
@@ -25,6 +26,7 @@ def _run_destroy_with_fake_requests(
     delete_volumes: bool = False,
     continue_after_domain_cleanup_error: bool = True,
     missing_resource_is_clean: bool = False,
+    before_provider_mutation: Callable[[str], None] | None = None,
 ) -> PreviewResourceDestroyResult:
     def _fake_dokploy_request(**kwargs: object) -> object:
         requests.append(dict(kwargs))
@@ -46,6 +48,7 @@ def _run_destroy_with_fake_requests(
             delete_volumes=delete_volumes,
             continue_after_domain_cleanup_error=continue_after_domain_cleanup_error,
             missing_resource_is_clean=missing_resource_is_clean,
+            before_provider_mutation=before_provider_mutation,
         )
 
 
@@ -160,6 +163,34 @@ class PreviewResourceDestroyTests(unittest.TestCase):
         self.assertEqual(
             [step.name for step in result.steps],
             ["domain_lookup", "compose_delete"],
+        )
+
+    def test_destroy_rechecks_fence_before_each_provider_write(self) -> None:
+        requests: list[dict[str, object]] = []
+        phases: list[str] = []
+
+        def checkpoint(phase: str) -> None:
+            phases.append(phase)
+            if phase == "compose_destroy":
+                raise RuntimeError("reservation recovered")
+
+        with self.assertRaisesRegex(RuntimeError, "reservation recovered"):
+            _run_destroy_with_fake_requests(
+                requests=requests,
+                response_by_path={
+                    "/api/domain.byComposeId": [
+                        {"domainId": "domain-one", "host": "pr-45.example.test"}
+                    ]
+                },
+                resource_type="compose",
+                resource_id="compose-one",
+                before_provider_mutation=checkpoint,
+            )
+
+        self.assertEqual(phases, ["domain_delete", "compose_destroy"])
+        self.assertEqual(
+            [request["path"] for request in requests],
+            ["/api/domain.byComposeId", "/api/domain.delete"],
         )
 
 

--- a/tests/test_provider_operations.py
+++ b/tests/test_provider_operations.py
@@ -1,0 +1,684 @@
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from threading import Event, Thread
+import time
+import unittest
+from unittest.mock import patch
+
+from control_plane.provider_operations import (
+    DurableProviderOperationResult,
+    ProviderMutationOutcome,
+    ProviderMutationRejectedError,
+    ProviderMutationUnknownError,
+    ProviderObservation,
+    ProviderOperationLease,
+    run_durable_provider_operation,
+)
+from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+_SCOPE = "github-actions:provider-operation-test"
+_ROUTE = "/v1/test/provider-operation"
+_KEY = "provider-op:test:1"
+_FINGERPRINT = "provider-op-fingerprint-a"
+_RECONCILIATION_KEY = "dokploy-compose:preview-abc"
+
+
+def _sqlite_database_url(database_path: Path) -> str:
+    return f"sqlite+pysqlite:///{database_path}"
+
+
+class _FakeAdapter:
+    def __init__(
+        self,
+        *,
+        reconciliation_key: str = _RECONCILIATION_KEY,
+        apply_outcome: ProviderMutationOutcome | None = None,
+        apply_error: BaseException | None = None,
+        observation: ProviderObservation | None = None,
+        apply_delay_seconds: float = 0,
+        apply_started: Event | None = None,
+        apply_release: Event | None = None,
+        checkpoint_before_rejection: bool = False,
+    ) -> None:
+        self._reconciliation_key = reconciliation_key
+        self._apply_outcome = apply_outcome or ProviderMutationOutcome(
+            response_status_code=202,
+            response_payload={"trace_id": "provider-op-effect", "status": "accepted"},
+        )
+        self._apply_error = apply_error
+        self._observation = observation or ProviderObservation(outcome="unknown")
+        self._apply_delay_seconds = apply_delay_seconds
+        self._apply_started = apply_started
+        self._apply_release = apply_release
+        self._checkpoint_before_rejection = checkpoint_before_rejection
+        self.apply_calls = 0
+        self.observe_calls = 0
+        self.provider_operation_keys: list[str] = []
+        self.observed_effect_phases: list[str] = []
+        self.observed_reconciliation_keys: list[str] = []
+
+    def reconciliation_key(self) -> str:
+        return self._reconciliation_key
+
+    def target_key(self) -> str:
+        return f"provider-target:{self._reconciliation_key}"
+
+    def observe(
+        self,
+        provider_operation_key: str,
+        provider_effect_phase: str,
+        reconciliation_key: str,
+    ) -> ProviderObservation:
+        self.provider_operation_keys.append(provider_operation_key)
+        self.observed_effect_phases.append(provider_effect_phase)
+        self.observed_reconciliation_keys.append(reconciliation_key)
+        self.observe_calls += 1
+        return self._observation
+
+    def apply(
+        self, provider_operation_key: str, lease: ProviderOperationLease
+    ) -> ProviderMutationOutcome:
+        self.provider_operation_keys.append(provider_operation_key)
+        self.apply_calls += 1
+        if (
+            not isinstance(self._apply_error, ProviderMutationRejectedError)
+            or self._checkpoint_before_rejection
+        ) and (self._apply_error is not None or self._apply_outcome.provider_effect_performed):
+            lease.checkpoint_effect("test_effect")
+        if self._apply_started is not None:
+            self._apply_started.set()
+        if self._apply_release is not None:
+            self._apply_release.wait(timeout=5)
+        if self._apply_delay_seconds:
+            time.sleep(self._apply_delay_seconds)
+        if self._apply_error is not None:
+            raise self._apply_error
+        return self._apply_outcome
+
+
+class _StoreFixture:
+    def __init__(self, directory: str) -> None:
+        self.store = PostgresRecordStore(
+            database_url=_sqlite_database_url(Path(directory) / "launchplane.sqlite3")
+        )
+        self.store.ensure_schema()
+
+    def run(
+        self,
+        adapter: _FakeAdapter,
+        *,
+        lease_owner: str = "instance-a",
+        response_trace_id: str = "provider-op-trace-a",
+        lease_seconds: int = 300,
+        heartbeat_interval_seconds: float | None = None,
+    ) -> DurableProviderOperationResult:
+        return run_durable_provider_operation(
+            store=self.store,
+            scope=_SCOPE,
+            route_path=_ROUTE,
+            idempotency_key=_KEY,
+            request_fingerprint=_FINGERPRINT,
+            lease_owner=lease_owner,
+            response_trace_id=response_trace_id,
+            adapter=adapter,
+            lease_seconds=lease_seconds,
+            heartbeat_interval_seconds=heartbeat_interval_seconds,
+        )
+
+    def maybe_stored(self) -> LaunchplaneIdempotencyRecord | None:
+        return self.store.read_idempotency_record(
+            scope=_SCOPE,
+            route_path=_ROUTE,
+            idempotency_key=_KEY,
+        )
+
+    def stored(self) -> LaunchplaneIdempotencyRecord:
+        record = self.maybe_stored()
+        assert record is not None
+        return record
+
+
+class DurableProviderOperationRunnerTests(unittest.TestCase):
+    def test_fresh_acquire_applies_once_and_completes(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter()
+
+            result = fixture.run(adapter)
+
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(adapter.apply_calls, 1)
+            self.assertEqual(adapter.observe_calls, 0)
+            stored = fixture.stored()
+            self.assertEqual(getattr(stored, "state"), "completed")
+            self.assertEqual(getattr(stored, "reconciliation_key"), _RECONCILIATION_KEY)
+            self.assertEqual(
+                getattr(stored, "response_payload"),
+                {"trace_id": "provider-op-effect", "status": "accepted"},
+            )
+            self.assertEqual(len(adapter.provider_operation_keys), 1)
+            self.assertTrue(adapter.provider_operation_keys[0].startswith("provider-operation:"))
+
+    def test_long_apply_renews_lease_and_completes_with_latest_reservation(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter(apply_delay_seconds=0.05)
+            with patch.object(
+                fixture.store,
+                "renew_mutation_reservation",
+                wraps=fixture.store.renew_mutation_reservation,
+            ) as renew:
+                result = fixture.run(
+                    adapter,
+                    lease_seconds=2,
+                    heartbeat_interval_seconds=0.01,
+                )
+
+            self.assertEqual(result.status, "completed")
+            self.assertGreaterEqual(renew.call_count, 1)
+
+    def test_successful_outcome_survives_transient_heartbeat_failure(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter(apply_delay_seconds=0.03)
+            with patch.object(
+                fixture.store,
+                "renew_mutation_reservation",
+                side_effect=RuntimeError("temporary database outage"),
+            ):
+                result = fixture.run(
+                    adapter,
+                    lease_seconds=2,
+                    heartbeat_interval_seconds=0.01,
+                )
+
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(fixture.stored().state, "completed")
+
+    def test_active_target_fence_blocks_different_idempotency_key(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter()
+            fixture.store.reserve_mutation(
+                scope=_SCOPE,
+                route_path=_ROUTE,
+                idempotency_key="provider-op:other-key",
+                request_fingerprint="provider-op-fingerprint-b",
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_RECONCILIATION_KEY,
+                provider_target_key=adapter.target_key(),
+            )
+
+            result = fixture.run(adapter, lease_owner="instance-b")
+
+            self.assertEqual(result.status, "target_busy")
+            self.assertEqual(adapter.apply_calls, 0)
+
+    def test_replays_completed_operation_without_reapplying(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            first = _FakeAdapter()
+            fixture.run(first)
+
+            second = _FakeAdapter()
+            result = fixture.run(
+                second,
+                lease_owner="instance-b",
+                response_trace_id="provider-op-trace-b",
+            )
+
+            self.assertEqual(result.status, "replayed")
+            self.assertEqual(second.apply_calls, 0)
+            self.assertEqual(result.original_trace_id, "provider-op-trace-a")
+            self.assertEqual(
+                result.response_payload,
+                {"trace_id": "provider-op-effect", "status": "accepted"},
+            )
+
+    def test_second_instance_sees_in_progress_and_does_not_apply(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            fixture.store.reserve_mutation(
+                scope=_SCOPE,
+                route_path=_ROUTE,
+                idempotency_key=_KEY,
+                request_fingerprint=_FINGERPRINT,
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_RECONCILIATION_KEY,
+            )
+
+            second = _FakeAdapter()
+            result = fixture.run(
+                second,
+                lease_owner="instance-b",
+                response_trace_id="provider-op-trace-b",
+            )
+
+            self.assertEqual(result.status, "in_progress")
+            self.assertEqual(second.apply_calls, 0)
+
+    def test_crash_then_reconcile_adopts_observed_effect_without_reapplying(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            crashed = _FakeAdapter(apply_error=RuntimeError("process died mid-apply"))
+            with self.assertRaises(RuntimeError):
+                fixture.run(crashed)
+            stored = fixture.stored()
+            fixture.store.mark_mutation_reconcile_required(
+                reservation=stored,
+                reconciliation_key=_RECONCILIATION_KEY,
+            )
+
+            recovery = _FakeAdapter(
+                observation=ProviderObservation(
+                    outcome="present",
+                    response_status_code=202,
+                    response_payload={"trace_id": "adopted", "status": "accepted"},
+                )
+            )
+            result = fixture.run(
+                recovery,
+                lease_owner="instance-b",
+                response_trace_id="provider-op-trace-b",
+            )
+
+            self.assertEqual(result.status, "adopted")
+            self.assertEqual(recovery.apply_calls, 0)
+            self.assertEqual(recovery.observe_calls, 1)
+            self.assertEqual(getattr(fixture.stored(), "state"), "completed")
+
+    def test_reconcile_uses_stored_target_key_after_adapter_authority_changes(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            reservation = fixture.store.reserve_mutation(
+                scope=_SCOPE,
+                route_path=_ROUTE,
+                idempotency_key=_KEY,
+                request_fingerprint=_FINGERPRINT,
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_RECONCILIATION_KEY,
+            ).record
+            fixture.store.mark_mutation_reconcile_required(
+                reservation=reservation,
+                reconciliation_key=_RECONCILIATION_KEY,
+            )
+            recovery = _FakeAdapter(
+                reconciliation_key="dokploy-compose:replacement-target",
+                observation=ProviderObservation(
+                    outcome="present",
+                    response_status_code=202,
+                    response_payload={"trace_id": "adopted", "status": "accepted"},
+                ),
+            )
+
+            result = fixture.run(
+                recovery,
+                lease_owner="instance-b",
+                response_trace_id="provider-op-trace-b",
+            )
+
+            self.assertEqual(result.status, "adopted")
+            self.assertEqual(recovery.apply_calls, 0)
+            self.assertEqual(recovery.observed_reconciliation_keys, [_RECONCILIATION_KEY])
+
+    def test_reconcile_stays_fail_closed_when_effect_unknown(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            crashed = _FakeAdapter(apply_error=RuntimeError("process died mid-apply"))
+            with self.assertRaises(RuntimeError):
+                fixture.run(crashed)
+            fixture.store.mark_mutation_reconcile_required(
+                reservation=fixture.stored(),
+                reconciliation_key=_RECONCILIATION_KEY,
+            )
+
+            recovery = _FakeAdapter(observation=ProviderObservation(outcome="unknown"))
+            result = fixture.run(
+                recovery,
+                lease_owner="instance-b",
+                response_trace_id="provider-op-trace-b",
+            )
+
+            self.assertEqual(result.status, "reconcile_required")
+            self.assertEqual(recovery.apply_calls, 0)
+            self.assertEqual(getattr(fixture.stored(), "state"), "reconcile_required")
+
+    def test_reconcile_retries_once_when_adapter_proves_effect_absent(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            reservation = fixture.store.reserve_mutation(
+                scope=_SCOPE,
+                route_path=_ROUTE,
+                idempotency_key=_KEY,
+                request_fingerprint=_FINGERPRINT,
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_RECONCILIATION_KEY,
+            ).record
+            fixture.store.mark_mutation_reconcile_required(
+                reservation=reservation,
+                reconciliation_key=_RECONCILIATION_KEY,
+            )
+            adapter = _FakeAdapter(observation=ProviderObservation(outcome="absent"))
+
+            result = fixture.run(adapter, lease_owner="instance-b")
+
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(adapter.observe_calls, 1)
+            self.assertEqual(adapter.apply_calls, 1)
+            self.assertEqual(fixture.stored().state, "completed")
+
+    def test_effect_checkpoint_blocks_absent_retry_while_stale_worker_can_finish(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as directory:
+            holder_fixture = _StoreFixture(directory)
+            recovery_fixture = _StoreFixture(directory)
+            apply_started = Event()
+            release_apply = Event()
+            holder = _FakeAdapter(
+                apply_started=apply_started,
+                apply_release=release_apply,
+            )
+            holder_result: dict[str, DurableProviderOperationResult] = {}
+
+            def run_holder() -> None:
+                holder_result["result"] = holder_fixture.run(
+                    holder,
+                    lease_seconds=1,
+                    heartbeat_interval_seconds=0.1,
+                )
+
+            with patch.object(
+                holder_fixture.store,
+                "renew_mutation_reservation",
+                side_effect=RuntimeError("database unavailable"),
+            ):
+                holder_thread = Thread(target=run_holder)
+                holder_thread.start()
+                self.assertTrue(apply_started.wait(timeout=2))
+                time.sleep(1.1)
+
+                recovery = _FakeAdapter(observation=ProviderObservation(outcome="absent"))
+                recovery_result = recovery_fixture.run(
+                    recovery,
+                    lease_owner="instance-b",
+                    response_trace_id="provider-op-trace-b",
+                    lease_seconds=1,
+                    heartbeat_interval_seconds=0.1,
+                )
+
+                self.assertEqual(recovery_result.status, "reconcile_required")
+                self.assertEqual(recovery.apply_calls, 0)
+                self.assertEqual(recovery.observed_effect_phases, ["test_effect"])
+                release_apply.set()
+                holder_thread.join(timeout=5)
+
+            self.assertFalse(holder_thread.is_alive())
+            self.assertIn(holder_result["result"].status, {"adopted", "replayed"})
+            self.assertEqual(holder.apply_calls, 1)
+
+    def test_unknown_outcome_marks_reconcile_required(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter(
+                apply_error=ProviderMutationUnknownError("timed out after dispatch"),
+            )
+
+            result = fixture.run(adapter)
+
+            self.assertEqual(result.status, "reconcile_required")
+            self.assertEqual(adapter.apply_calls, 1)
+            stored = fixture.stored()
+            self.assertEqual(getattr(stored, "state"), "reconcile_required")
+            self.assertEqual(getattr(stored, "reconciliation_key"), _RECONCILIATION_KEY)
+
+    def test_cancellation_leaves_running_reservation_intact(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter(apply_error=KeyboardInterrupt())
+
+            with self.assertRaises(KeyboardInterrupt):
+                fixture.run(adapter)
+
+            stored = fixture.stored()
+            self.assertIsNotNone(stored)
+            self.assertEqual(getattr(stored, "state"), "reconcile_required")
+            self.assertEqual(getattr(stored, "reconciliation_key"), _RECONCILIATION_KEY)
+            self.assertIsNone(getattr(stored, "response_status_code"))
+
+    def test_rejected_effect_releases_reservation_and_reraises(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            cause = ValueError("request failed local validation before any effect")
+            adapter = _FakeAdapter(apply_error=ProviderMutationRejectedError(cause))
+
+            with self.assertRaises(ValueError):
+                fixture.run(adapter)
+
+            self.assertIsNone(fixture.maybe_stored())
+
+    def test_rejected_effect_after_checkpoint_requires_reconciliation(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            cause = ValueError("provider response could not be parsed after dispatch")
+            adapter = _FakeAdapter(
+                apply_error=ProviderMutationRejectedError(cause),
+                checkpoint_before_rejection=True,
+            )
+
+            result = fixture.run(adapter)
+
+            self.assertEqual(result.status, "reconcile_required")
+            stored = fixture.stored()
+            self.assertEqual(stored.state, "reconcile_required")
+            self.assertEqual(stored.provider_effect_phase, "test_effect")
+
+    def test_non_durable_outcome_after_checkpoint_requires_reconciliation(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter(
+                apply_outcome=ProviderMutationOutcome(
+                    response_status_code=409,
+                    response_payload={"status": "blocked"},
+                    durable=False,
+                    provider_effect_performed=True,
+                )
+            )
+
+            result = fixture.run(adapter)
+
+            self.assertEqual(result.status, "reconcile_required")
+            self.assertEqual(fixture.stored().state, "reconcile_required")
+
+    def test_conflicting_fingerprint_is_rejected(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            with self.assertRaises(RuntimeError):
+                fixture.run(_FakeAdapter(apply_error=RuntimeError("holds the lease")))
+
+            conflict = run_durable_provider_operation(
+                store=fixture.store,
+                scope=_SCOPE,
+                route_path=_ROUTE,
+                idempotency_key=_KEY,
+                request_fingerprint="a-different-payload-fingerprint",
+                lease_owner="instance-b",
+                response_trace_id="provider-op-trace-b",
+                adapter=_FakeAdapter(),
+            )
+
+            self.assertEqual(conflict.status, "conflict")
+
+
+class MutationReservationAdoptionStorageTests(unittest.TestCase):
+    def _reconcile_required_store(
+        self, directory: str
+    ) -> tuple[PostgresRecordStore, LaunchplaneIdempotencyRecord]:
+        store = PostgresRecordStore(
+            database_url=_sqlite_database_url(Path(directory) / "launchplane.sqlite3")
+        )
+        store.ensure_schema()
+        reservation = store.reserve_mutation(
+            scope=_SCOPE,
+            route_path=_ROUTE,
+            idempotency_key=_KEY,
+            request_fingerprint=_FINGERPRINT,
+            lease_owner="instance-a",
+            lease_seconds=300,
+            reconciliation_key=_RECONCILIATION_KEY,
+        ).record
+        marked = store.mark_mutation_reconcile_required(
+            reservation=reservation,
+            reconciliation_key=_RECONCILIATION_KEY,
+        )
+        assert marked.record is not None
+        return store, marked.record
+
+    def test_adopts_reconcile_required_with_matching_key(self) -> None:
+        with TemporaryDirectory() as directory:
+            store, reservation = self._reconcile_required_store(directory)
+
+            adoption = store.adopt_reconciled_mutation(
+                reservation=reservation,
+                response_status_code=202,
+                response_trace_id="adopting-instance",
+                response_payload={"status": "accepted"},
+            )
+
+            self.assertEqual(adoption.status, "adopted")
+            self.assertEqual(getattr(adoption.record, "state"), "completed")
+
+    def test_adoption_rejects_reservation_mismatch(self) -> None:
+        with TemporaryDirectory() as directory:
+            store, reservation = self._reconcile_required_store(directory)
+            mismatched_reservation = LaunchplaneIdempotencyRecord.model_validate(
+                {
+                    **reservation.model_dump(mode="json"),
+                    "reconciliation_key": "dokploy-compose:some-other-target",
+                }
+            )
+
+            adoption = store.adopt_reconciled_mutation(
+                reservation=mismatched_reservation,
+                response_status_code=202,
+                response_trace_id="adopting-instance",
+                response_payload={"status": "accepted"},
+            )
+
+            self.assertEqual(adoption.status, "reservation_mismatch")
+            self.assertEqual(
+                getattr(
+                    store.read_idempotency_record(
+                        scope=_SCOPE,
+                        route_path=_ROUTE,
+                        idempotency_key=_KEY,
+                    ),
+                    "state",
+                ),
+                "reconcile_required",
+            )
+
+    def test_adoption_conflicts_on_fingerprint_mismatch(self) -> None:
+        with TemporaryDirectory() as directory:
+            store, reservation = self._reconcile_required_store(directory)
+            mismatched_reservation = LaunchplaneIdempotencyRecord.model_validate(
+                {
+                    **reservation.model_dump(mode="json"),
+                    "request_fingerprint": "mismatched-fingerprint",
+                }
+            )
+
+            adoption = store.adopt_reconciled_mutation(
+                reservation=mismatched_reservation,
+                response_status_code=202,
+                response_trace_id="adopting-instance",
+                response_payload={"status": "accepted"},
+            )
+
+            self.assertEqual(adoption.status, "conflict")
+
+    def test_stale_observation_cannot_adopt_newer_reconcile_required_attempt(self) -> None:
+        with TemporaryDirectory() as directory:
+            store, first_reconcile = self._reconcile_required_store(directory)
+            retry = store.retry_reconciled_mutation(
+                reservation=first_reconcile,
+                lease_owner="instance-b",
+                lease_seconds=300,
+            )
+            assert retry.record is not None
+            second_reconcile = store.mark_mutation_reconcile_required(
+                reservation=retry.record,
+                reconciliation_key=retry.record.reconciliation_key,
+            )
+
+            adoption = store.adopt_reconciled_mutation(
+                reservation=first_reconcile,
+                response_status_code=202,
+                response_trace_id="stale-observer",
+                response_payload={"status": "accepted"},
+            )
+
+            self.assertEqual(second_reconcile.status, "updated")
+            self.assertEqual(adoption.status, "reservation_mismatch")
+            assert adoption.record is not None
+            self.assertEqual(adoption.record.attempt, first_reconcile.attempt + 1)
+            self.assertEqual(adoption.record.state, "reconcile_required")
+
+    def test_release_removes_own_running_reservation(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(directory) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            reservation = store.reserve_mutation(
+                scope=_SCOPE,
+                route_path=_ROUTE,
+                idempotency_key=_KEY,
+                request_fingerprint=_FINGERPRINT,
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_RECONCILIATION_KEY,
+            ).record
+
+            release = store.release_reserved_mutation(reservation=reservation)
+
+            self.assertEqual(release.status, "released")
+            self.assertIsNone(
+                store.read_idempotency_record(scope=_SCOPE, route_path=_ROUTE, idempotency_key=_KEY)
+            )
+
+    def test_release_refuses_foreign_owner(self) -> None:
+        with TemporaryDirectory() as directory:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(Path(directory) / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
+            reservation = store.reserve_mutation(
+                scope=_SCOPE,
+                route_path=_ROUTE,
+                idempotency_key=_KEY,
+                request_fingerprint=_FINGERPRINT,
+                lease_owner="instance-a",
+                lease_seconds=300,
+                reconciliation_key=_RECONCILIATION_KEY,
+            ).record
+            foreign = reservation.model_copy(update={"lease_owner": "instance-b"})
+
+            release = store.release_reserved_mutation(reservation=foreign)
+
+            self.assertEqual(release.status, "owner_mismatch")
+            self.assertIsNotNone(
+                store.read_idempotency_record(scope=_SCOPE, route_path=_ROUTE, idempotency_key=_KEY)
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -150,6 +150,7 @@ from tests.support.profiles import (
     _generic_site_profile_payload,
 )
 from tests.support.stores import (
+    _seed_generic_web_deploy_target_records,
     _sqlite_database_url,
     _seed_tracked_target_records,
 )
@@ -7125,9 +7126,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
     def test_generic_web_deploy_route_uses_profile_lane_for_authorization(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            _seed_generic_web_deploy_target_records(
+                store=store,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-syo-testing",
+                target_name="syo-testing",
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -7146,6 +7157,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 }
             )
             app = create_launchplane_fastapi_test_app(
+                local_record_store_for_tests=store,
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
@@ -7185,11 +7197,21 @@ class LaunchplaneServiceTests(unittest.TestCase):
     def test_generic_web_deploy_route_accepts_base_driver_product(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
             profile_payload = _product_profile_payload()
             profile_payload["driver_id"] = "odoo"
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            _seed_generic_web_deploy_target_records(
+                store=store,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-syo-testing",
+                target_name="syo-testing",
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -7208,6 +7230,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 }
             )
             app = create_launchplane_fastapi_test_app(
+                local_record_store_for_tests=store,
                 state_dir=root / "state",
                 verifier=_StubVerifier(
                     _identity(
@@ -7263,9 +7286,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
     ) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            _seed_generic_web_deploy_target_records(
+                store=store,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-syo-testing",
+                target_name="syo-testing",
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -7284,6 +7317,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 }
             )
             app = create_launchplane_fastapi_test_app(
+                local_record_store_for_tests=store,
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
@@ -7324,9 +7358,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            _seed_generic_web_deploy_target_records(
+                store=store,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-syo-testing",
+                target_name="syo-testing",
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -7345,6 +7389,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 }
             )
             app = create_launchplane_fastapi_test_app(
+                local_record_store_for_tests=store,
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
@@ -7412,9 +7457,19 @@ class LaunchplaneServiceTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(_product_profile_payload())
+            )
+            _seed_generic_web_deploy_target_records(
+                store=store,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-syo-testing",
+                target_name="syo-testing",
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -7434,6 +7489,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             identity = _identity()
             app = create_launchplane_fastapi_test_app(
+                local_record_store_for_tests=store,
                 state_dir=state_dir,
                 verifier=_StubVerifier(identity),
                 authz_policy=policy,
@@ -7620,7 +7676,10 @@ class LaunchplaneServiceTests(unittest.TestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             state_dir = root / "state"
-            store = FilesystemRecordStore(state_dir=state_dir)
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
             profile_payload = _product_profile_payload()
             profile_payload["lanes"] = tuple(
                 {**lane, "context": f"  {lane['context']}  "}
@@ -7628,6 +7687,13 @@ class LaunchplaneServiceTests(unittest.TestCase):
             )
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(profile_payload)
+            )
+            _seed_generic_web_deploy_target_records(
+                store=store,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-syo-testing",
+                target_name="syo-testing",
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -7646,6 +7712,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 }
             )
             app = create_launchplane_fastapi_test_app(
+                local_record_store_for_tests=store,
                 state_dir=state_dir,
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,
@@ -8257,11 +8324,21 @@ class LaunchplaneServiceTests(unittest.TestCase):
     def test_generic_web_deploy_route_resolves_literal_generic_web_profile(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
-            store = FilesystemRecordStore(state_dir=root / "state")
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(root / "launchplane.sqlite3")
+            )
+            store.ensure_schema()
             store.write_product_profile_record(
                 LaunchplaneProductProfileRecord.model_validate(
                     _product_profile_payload("generic-web")
                 )
+            )
+            _seed_generic_web_deploy_target_records(
+                store=store,
+                context="generic-web-testing",
+                instance="testing",
+                target_id="app-generic-web-testing",
+                target_name="generic-web-testing",
             )
             policy = LaunchplaneAuthzPolicy.model_validate(
                 {
@@ -8280,6 +8357,7 @@ class LaunchplaneServiceTests(unittest.TestCase):
                 }
             )
             app = create_launchplane_fastapi_test_app(
+                local_record_store_for_tests=store,
                 state_dir=root / "state",
                 verifier=_StubVerifier(_identity()),
                 authz_policy=policy,


### PR DESCRIPTION
## Summary
- add a shared durable provider-operation runner with deterministic operation identity, stable provider-target fencing, lease heartbeats, per-write effect checkpoints, exact-attempt CAS retry/adoption, and fail-closed reconciliation
- migrate Odoo preview apply/destroy and generic-web deploy, including exact Dokploy operation titles, bound target snapshots, exact terminal provider evidence, rollback/post-deploy fencing, and terminal failure replay
- add the PostgreSQL target-fence migration, schema verification, migration collision preflight, real two-instance/restart coverage, and operator/record documentation

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` — 1,967 targets passed
- `LAUNCHPLANE_TEST_POSTGRES_URL=postgresql+psycopg://... uv run --extra dev launchplane ci postgres-integration` — 38 tests passed
- `uv run --extra dev mypy ...` — 26 changed source/test files passed
- `uv run --extra dev ruff check --no-fix ...` — passed
- `uv run --extra dev ruff format --check ...` — passed
- `pnpm --dir frontend validate` — passed
- `uv run launchplane service audit-config-authority --control-plane-root .` — status `ok`
- `git diff --check` — passed

Closes #1690
