### PR TITLE
Add deterministic operator browser smoke

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -51,6 +51,7 @@
       "default": "uv run --extra dev mypy control_plane tests"
     },
     "build": {
+      "browser": "pnpm --dir frontend test:browser",
       "frontend": "pnpm --dir frontend validate",
       "container": "docker build -t launchplane-ci:test ."
     },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -299,6 +299,54 @@ jobs:
       - name: Validate frontend
         run: pnpm --dir frontend validate
 
+  frontend_browser_smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.10.0 --activate
+
+      - name: Resolve pnpm store path
+        id: pnpm-store
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore pnpm store
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: >-
+            ${{ runner.os }}-node-22-pnpm-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-node-22-pnpm-
+
+      - name: Install frontend dependencies
+        run: pnpm --dir frontend install --frozen-lockfile
+
+      - name: Install Chromium
+        run: pnpm --dir frontend exec playwright install --with-deps chromium
+
+      - name: Run browser smoke
+        run: pnpm --dir frontend test:browser
+
+      - name: Upload browser evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: browser-smoke-${{ github.run_attempt }}
+          path: tmp/browser-smoke
+          if-no-files-found: error
+          retention-days: 14
+
   test_timing_snapshot:
     if: >-
       github.event_name != 'pull_request' ||
@@ -546,6 +594,7 @@ jobs:
       - container_scan_fork
       - frontend_validate
       - frontend_validate_fork
+      - frontend_browser_smoke
       - test
       - test_fork
       - postgres_integration
@@ -563,6 +612,7 @@ jobs:
           CONTAINER_SCAN_FORK_RESULT: ${{ needs.container_scan_fork.result }}
           FRONTEND_VALIDATE_RESULT: ${{ needs.frontend_validate.result }}
           FRONTEND_VALIDATE_FORK_RESULT: ${{ needs.frontend_validate_fork.result }}
+          FRONTEND_BROWSER_SMOKE_RESULT: ${{ needs.frontend_browser_smoke.result }}
           TEST_RESULT: ${{ needs.test.result }}
           TEST_FORK_RESULT: ${{ needs.test_fork.result }}
           POSTGRES_INTEGRATION_RESULT: ${{ needs.postgres_integration.result }}
@@ -581,11 +631,13 @@ jobs:
             require_success static_checks "${STATIC_CHECKS_RESULT}"
             require_success container_scan "${CONTAINER_SCAN_RESULT}"
             require_success frontend_validate "${FRONTEND_VALIDATE_RESULT}"
+            require_success frontend_browser_smoke "${FRONTEND_BROWSER_SMOKE_RESULT}"
             require_success test "${TEST_RESULT}"
             require_success postgres_integration "${POSTGRES_INTEGRATION_RESULT}"
           else
             require_success static_checks_fork "${STATIC_CHECKS_FORK_RESULT}"
             require_success container_scan_fork "${CONTAINER_SCAN_FORK_RESULT}"
             require_success frontend_validate_fork "${FRONTEND_VALIDATE_FORK_RESULT}"
+            require_success frontend_browser_smoke "${FRONTEND_BROWSER_SMOKE_RESULT}"
             require_success test_fork "${TEST_FORK_RESULT}"
           fi

--- a/docs/style/testing.md
+++ b/docs/style/testing.md
@@ -94,6 +94,41 @@ integration command is the official production storage-semantics proof when a
 local or CI PostgreSQL service is available. Neither local command replaces CI's
 runner isolation, artifact retention, or required status checks.
 
+## Browser smoke
+
+Run the deterministic operator-journey smoke separately from the frontend unit,
+type, OpenAPI, and production-build gate:
+
+```bash
+pnpm --dir frontend exec playwright install chromium
+pnpm --dir frontend test:browser
+```
+
+The Playwright suite starts the Vite development server and uses only the
+repo-local `?fixture=products` evidence source for signed-in journeys. Anonymous
+authentication is simulated by intercepting only `/v1/auth/session`; no product
+or runtime mutation reaches a deployed Launchplane service. The suite exercises
+the rendered authentication prompt, product workspace, environment diagnostics,
+an honest product-inventory error, an honestly blocked action, and a dry-run
+confirmation without submitting the apply. Each journey runs at desktop and
+narrow widths, checks route-heading and keyboard focus behavior, rejects
+duplicate document IDs, and fails on unexpected mutation requests, console
+errors, uncaught page errors, failed requests, or HTTP error responses.
+
+Screenshots, traces, and failure evidence are written under
+`tmp/browser-smoke/`. CI uploads that directory from the dedicated hosted browser
+job. Every run clears prior evidence first and verifies the complete desktop and
+narrow screenshot set before passing. These screenshots are review evidence
+rather than pixel-diff baselines, so intentional visual changes do not require
+snapshot churn.
+
+Development fixtures remain excluded from production authority. `pnpm --dir
+frontend validate` still runs the independent production build and
+`assert-production-fixtures.mjs` scan; browser smoke does not weaken or replace
+that proof. Deployed OIDC smoke remains a separate non-destructive evidence
+layer because it validates service authentication and deployment wiring rather
+than deterministic UI behavior.
+
 Workflow contract tests should parse workflow YAML through
 `tests/support/workflows.py` and assert named invariants instead of mirroring
 large YAML snippets, substring counts, or indentation-sensitive job fragments.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "preview": "vite preview --host 127.0.0.1",
     "check:openapi-drift": "node scripts/check-openapi-drift.mjs",
     "test": "node --experimental-strip-types --import ./tests/register-typescript.mjs --test tests/*.test.mjs",
+    "test:browser": "node scripts/prepare-browser-smoke.mjs && playwright test && node scripts/assert-browser-smoke-artifacts.mjs",
     "typecheck": "tsc --noEmit",
     "validate": "pnpm test && pnpm check:openapi-drift && pnpm build"
   },
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@hey-api/openapi-ts": "0.99.0",
+    "@playwright/test": "1.61.1",
     "@vitejs/plugin-react": "6.0.1",
     "@types/react": "19.2.14",
     "@types/react-dom": "19.2.3",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from "@playwright/test";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const frontendRoot = dirname(fileURLToPath(import.meta.url));
+const artifactRoot = resolve(frontendRoot, "../tmp/browser-smoke");
+
+export default defineConfig({
+  testDir: "./tests/browser",
+  testMatch: "**/*.spec.ts",
+  outputDir: resolve(artifactRoot, "test-results"),
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  forbidOnly: Boolean(process.env.CI),
+  reporter: "line",
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    colorScheme: "dark",
+    locale: "en-US",
+    reducedMotion: "reduce",
+    screenshot: "only-on-failure",
+    timezoneId: "UTC",
+    trace: "retain-on-failure",
+    video: "off",
+  },
+  projects: [
+    {
+      name: "desktop",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1440, height: 1000 },
+      },
+    },
+    {
+      name: "narrow",
+      use: {
+        ...devices["Desktop Chrome"],
+        isMobile: false,
+        viewport: { width: 390, height: 844 },
+      },
+    },
+  ],
+  webServer: {
+    command: "pnpm exec vite --host 127.0.0.1 --port 4173 --strictPort",
+    url: "http://127.0.0.1:4173/ui/",
+    reuseExistingServer: false,
+    timeout: 120_000,
+  },
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@hey-api/openapi-ts':
         specifier: 0.99.0
         version: 0.99.0(typescript@6.0.3)
+      '@playwright/test':
+        specifier: 1.61.1
+        version: 1.61.1
       '@types/react':
         specifier: 19.2.14
         version: 19.2.14
@@ -88,6 +91,11 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -290,6 +298,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -434,6 +447,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
@@ -639,6 +662,10 @@ snapshots:
 
   '@oxc-project/types@0.133.0': {}
 
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
+
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
 
@@ -776,6 +803,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -880,6 +910,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pkg-types@2.3.1:
     dependencies:

--- a/frontend/scripts/assert-browser-smoke-artifacts.mjs
+++ b/frontend/scripts/assert-browser-smoke-artifacts.mjs
@@ -1,0 +1,41 @@
+import { statSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const screenshotDir = fileURLToPath(
+  new URL("../../tmp/browser-smoke/screenshots/", import.meta.url),
+);
+const projects = ["desktop", "narrow"];
+const journeys = [
+  "anonymous-auth-prompt",
+  "product-inventory-error",
+  "product-workspace",
+  "environment-diagnostics",
+  "blocked-action",
+  "safe-change-confirmation",
+];
+const missingArtifacts = [];
+
+for (const project of projects) {
+  for (const journey of journeys) {
+    const screenshotPath = join(screenshotDir, project, `${journey}.png`);
+    try {
+      const screenshot = statSync(screenshotPath);
+      if (!screenshot.isFile() || screenshot.size === 0) {
+        missingArtifacts.push(screenshotPath);
+      }
+    } catch {
+      missingArtifacts.push(screenshotPath);
+    }
+  }
+}
+
+if (missingArtifacts.length) {
+  throw new Error(
+    `Browser smoke did not produce fresh screenshot evidence:\n${missingArtifacts.join("\n")}`,
+  );
+}
+
+console.log(
+  `Verified ${projects.length * journeys.length} browser smoke screenshots.`,
+);

--- a/frontend/scripts/prepare-browser-smoke.mjs
+++ b/frontend/scripts/prepare-browser-smoke.mjs
@@ -1,0 +1,8 @@
+import { rmSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const artifactDir = fileURLToPath(
+  new URL("../../tmp/browser-smoke/", import.meta.url),
+);
+
+rmSync(artifactDir, { force: true, recursive: true });

--- a/frontend/src/ProductOps.tsx
+++ b/frontend/src/ProductOps.tsx
@@ -60,6 +60,20 @@ export function ProductIndexRoute({
 }) {
   const products = resource.data ?? [];
   const loading = resource.status === "idle" || resource.status === "loading";
+  const viewState =
+    loading && !products.length
+      ? "loading"
+      : resource.status === "error" && !products.length
+        ? "error"
+        : resource.status === "ready" && !products.length
+          ? "empty"
+          : "ready";
+
+  useEffect(() => {
+    document.querySelector<HTMLElement>("[data-route-heading]")?.focus({
+      preventScroll: true,
+    });
+  }, [viewState]);
 
   if (loading && !products.length) {
     return <ProductIndexSkeleton />;

--- a/frontend/tests/browser/operator-journeys.spec.ts
+++ b/frontend/tests/browser/operator-journeys.spec.ts
@@ -1,0 +1,358 @@
+import {
+  expect,
+  test,
+  type ConsoleMessage,
+  type Page,
+  type TestInfo,
+} from "@playwright/test";
+import { mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface AllowedHttpFailure {
+  pathname: string;
+  status: number;
+}
+
+interface BrowserDiagnosticsOptions {
+  allowedHttpFailures?: AllowedHttpFailure[];
+}
+
+const frontendRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const screenshotRoot = resolve(
+  frontendRoot,
+  "../tmp/browser-smoke/screenshots",
+);
+
+test.describe("operator journeys", () => {
+  test("anonymous operator receives the authentication prompt", async ({
+    page,
+  }, testInfo) => {
+    await page.route("**/v1/auth/session", async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          status: "rejected",
+          trace_id: "browser-smoke-auth-required",
+          error: {
+            code: "authentication_required",
+            message: "Authentication is required.",
+          },
+        }),
+      });
+    });
+    const diagnostics = monitorBrowser(page, {
+      allowedHttpFailures: [{ pathname: "/v1/auth/session", status: 401 }],
+    });
+
+    await page.goto("/ui/products");
+
+    const heading = page.getByRole("heading", {
+      level: 1,
+      name: "Sign in to operate products",
+    });
+    await expect(heading).toBeVisible();
+    await expect(page.getByRole("main")).toBeVisible();
+    await expect(page.locator('[aria-live="polite"]')).toBeVisible();
+    const signIn = page.getByRole("link", { name: "Sign in with GitHub" });
+    await expect(signIn).toHaveAttribute(
+      "href",
+      /\/auth\/github\/login\?return_to=/,
+    );
+    await page.keyboard.press("Tab");
+    await expect(signIn).toBeFocused();
+    await assertDocumentBasics(page);
+    await captureScreenshot(page, testInfo, "anonymous-auth-prompt");
+    diagnostics.assertClean();
+  });
+
+  test("operator sees an honest product inventory error", async ({
+    page,
+  }, testInfo) => {
+    const diagnostics = monitorBrowser(page);
+
+    await page.goto("/ui/products?fixture=error");
+
+    await expect(
+      page.getByRole("heading", {
+        level: 1,
+        name: "Product inventory unavailable",
+      }),
+    ).toBeFocused();
+    await expect(
+      page.getByText(
+        "The fixture product inventory is intentionally unavailable.",
+      ),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Retry" })).toBeVisible();
+    await assertDocumentBasics(page);
+    await captureScreenshot(page, testInfo, "product-inventory-error");
+    diagnostics.assertClean();
+  });
+
+  test("operator enters the product workspace by keyboard", async ({
+    page,
+  }, testInfo) => {
+    const diagnostics = monitorBrowser(page);
+
+    await page.goto("/ui/products?fixture=products");
+
+    const productsHeading = page.getByRole("heading", {
+      level: 1,
+      name: "Products",
+    });
+    await expect(productsHeading).toBeFocused();
+    const atlasLink = page
+      .getByRole("list", { name: "Launchplane products" })
+      .getByRole("link", { name: /Atlas Commerce/ });
+    await expect(atlasLink).toBeVisible();
+    await atlasLink.focus();
+    await page.keyboard.press("Enter");
+    const workspaceHeading = page.getByRole("heading", {
+      level: 1,
+      name: "Atlas Commerce",
+    });
+    await expect(workspaceHeading).toBeFocused();
+    await expect(
+      page.getByRole("link", { name: /Production/ }).first(),
+    ).toBeVisible();
+    await assertDocumentBasics(page);
+    await captureScreenshot(page, testInfo, "product-workspace");
+    diagnostics.assertClean();
+  });
+
+  test("operator can diagnose recorded environment evidence", async ({
+    page,
+  }, testInfo) => {
+    const diagnostics = monitorBrowser(page);
+
+    await page.goto(
+      "/ui/products/atlas-commerce/environments/prod/diagnostics?fixture=products",
+    );
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Diagnostics" }),
+    ).toBeFocused();
+    await expect(
+      page.getByRole("heading", { name: "Technical evidence and identifiers" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Provider-recorded topology" }),
+    ).toBeVisible();
+    await expect(
+      page.getByText("TLS terminator", { exact: true }),
+    ).toBeVisible();
+    await assertDocumentBasics(page);
+    await captureScreenshot(page, testInfo, "environment-diagnostics");
+    diagnostics.assertClean();
+  });
+
+  test("operator sees an honest blocked action", async ({ page }, testInfo) => {
+    const diagnostics = monitorBrowser(page);
+
+    await page.goto(
+      "/ui/products/atlas-commerce/environments/prod/actions?fixture=products",
+    );
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Actions" }),
+    ).toBeFocused();
+    const blockedAction = page.getByRole("listitem").filter({
+      has: page.getByRole("heading", { name: "Dispatch promote workflow" }),
+    });
+    await expect(
+      blockedAction.getByText("Launchplane blockers", { exact: true }),
+    ).toBeVisible();
+    await expect(
+      blockedAction.getByText("Caller is not authorized for this action.", {
+        exact: true,
+      }),
+    ).toBeVisible();
+    await expect(
+      blockedAction.getByText("Blocked", { exact: true }),
+    ).toBeVisible();
+    await assertDocumentBasics(page);
+    await captureScreenshot(page, testInfo, "blocked-action");
+    diagnostics.assertClean();
+  });
+
+  test("operator reaches confirmation without applying a change", async ({
+    page,
+  }, testInfo) => {
+    const diagnostics = monitorBrowser(page);
+
+    await page.goto(
+      "/ui/products/atlas-commerce/environments/prod/runtime-settings?fixture=products",
+    );
+
+    await expect(
+      page.getByRole("heading", { level: 1, name: "Runtime settings" }),
+    ).toBeFocused();
+    const publicOriginField = page
+      .locator(".product-config-field")
+      .filter({ hasText: "PUBLIC_ORIGIN" });
+    await publicOriginField.getByRole("checkbox").check();
+    await publicOriginField
+      .getByLabel("New value")
+      .fill("https://example.invalid");
+    await page
+      .getByLabel("Change reason")
+      .fill("Verify the deterministic browser dry-run.");
+    await page.getByRole("button", { name: "Run dry-run" }).click();
+
+    const confirmation = page.getByRole("region", {
+      name: "Apply confirmation",
+    });
+    await expect(
+      confirmation.getByRole("heading", {
+        name: "Confirm the reviewed change",
+      }),
+    ).toBeVisible();
+    await expect(confirmation.getByRole("checkbox")).not.toBeChecked();
+    await expect(
+      confirmation.getByRole("button", { name: "Apply reviewed change" }),
+    ).toBeDisabled();
+    await expect(
+      page.getByText("Dry-run evidence", { exact: true }),
+    ).toBeVisible();
+    await assertDocumentBasics(page);
+    await captureScreenshot(page, testInfo, "safe-change-confirmation");
+    diagnostics.assertClean();
+  });
+});
+
+function monitorBrowser(
+  page: Page,
+  options: BrowserDiagnosticsOptions = {},
+): { assertClean: () => void } {
+  const consoleErrors: string[] = [];
+  const pageErrors: string[] = [];
+  const requestFailures: string[] = [];
+  const responseFailures: string[] = [];
+  const mutationRequests: string[] = [];
+  const allowedHttpFailures = options.allowedHttpFailures ?? [];
+
+  page.on("console", (message) => {
+    if (
+      message.type() !== "error" ||
+      isAllowedConsoleError(message, allowedHttpFailures)
+    ) {
+      return;
+    }
+    consoleErrors.push(
+      `${message.location().url || "page"}: ${message.text()}`,
+    );
+  });
+  page.on("pageerror", (error) =>
+    pageErrors.push(error.stack ?? error.message),
+  );
+  page.on("request", (request) => {
+    if (request.method() !== "GET" && request.method() !== "HEAD") {
+      const url = new URL(request.url());
+      mutationRequests.push(`${request.method()} ${url.pathname}`);
+    }
+  });
+  page.on("requestfailed", (request) => {
+    const url = new URL(request.url());
+    const failure = request.failure()?.errorText ?? "unknown failure";
+    if (
+      url.pathname === "/v1/auth/session" &&
+      allowedHttpFailures.some(({ pathname }) => pathname === url.pathname) &&
+      failure.includes("ERR_ABORTED")
+    ) {
+      return;
+    }
+    requestFailures.push(`${request.method()} ${url.pathname}: ${failure}`);
+  });
+  page.on("response", (response) => {
+    if (response.status() < 400) {
+      return;
+    }
+    const url = new URL(response.url());
+    const allowed = allowedHttpFailures.some(
+      ({ pathname, status }) =>
+        pathname === url.pathname && status === response.status(),
+    );
+    if (!allowed) {
+      responseFailures.push(
+        `${response.status()} ${response.request().method()} ${url.pathname}`,
+      );
+    }
+  });
+
+  return {
+    assertClean() {
+      expect(consoleErrors, "unexpected browser console errors").toEqual([]);
+      expect(pageErrors, "unexpected uncaught page errors").toEqual([]);
+      expect(mutationRequests, "unexpected browser mutation requests").toEqual(
+        [],
+      );
+      expect(requestFailures, "unexpected failed browser requests").toEqual([]);
+      expect(responseFailures, "unexpected HTTP error responses").toEqual([]);
+    },
+  };
+}
+
+function isAllowedConsoleError(
+  message: ConsoleMessage,
+  allowedHttpFailures: AllowedHttpFailure[],
+): boolean {
+  if (!message.text().includes("Failed to load resource")) {
+    return false;
+  }
+  const locationUrl = message.location().url;
+  if (!locationUrl) {
+    return false;
+  }
+  const location = new URL(locationUrl);
+  return allowedHttpFailures.some(
+    ({ pathname, status }) =>
+      pathname === location.pathname && message.text().includes(String(status)),
+  );
+}
+
+async function assertDocumentBasics(page: Page): Promise<void> {
+  await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
+  const duplicateIds = await page.locator("[id]").evaluateAll((elements) => {
+    const counts = new Map<string, number>();
+    for (const element of elements) {
+      const id = element.id;
+      counts.set(id, (counts.get(id) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .filter(([, count]) => count > 1)
+      .map(([id]) => id)
+      .sort();
+  });
+  expect(duplicateIds, "duplicate document IDs").toEqual([]);
+}
+
+async function captureScreenshot(
+  page: Page,
+  testInfo: TestInfo,
+  name: string,
+): Promise<void> {
+  const screenshotPath = resolve(
+    screenshotRoot,
+    testInfo.project.name,
+    `${name}.png`,
+  );
+  await mkdir(dirname(screenshotPath), { recursive: true });
+  await page.evaluate(() => {
+    document.querySelector<HTMLElement>("[data-route-heading]")?.focus({
+      preventScroll: true,
+    });
+    window.scrollTo(0, 0);
+  });
+  await page.screenshot({
+    path: screenshotPath,
+    animations: "disabled",
+    caret: "hide",
+    fullPage: true,
+  });
+  await testInfo.attach(name, {
+    path: screenshotPath,
+    contentType: "image/png",
+  });
+}

--- a/tests/support/workflows.py
+++ b/tests/support/workflows.py
@@ -419,6 +419,66 @@ def check_security_policy_runs_for_all_pull_requests(
     return checker.violations
 
 
+def check_frontend_browser_smoke(
+    workflow: Workflow,
+) -> tuple[WorkflowInvariantViolation, ...]:
+    checker = WorkflowInvariantChecker(workflow)
+    invariant = "frontend-browser-smoke"
+    job_id = "frontend_browser_smoke"
+    job = workflow.job(job_id)
+    checker.require(bool(job), invariant, f"missing {job_id} job")
+    checker.require(
+        tuple(_runner_labels(job.get("runs-on"))) == UBUNTU_HOSTED_RUNNER,
+        invariant,
+        f"{job_id} must run on ubuntu-latest",
+    )
+    checker.require(
+        not _string_value(job.get("if")),
+        invariant,
+        f"{job_id} must run for same-repository and fork pull requests",
+    )
+    install_step = workflow.step_named(job_id, "Install Chromium")
+    checker.require(install_step is not None, invariant, "missing Install Chromium step")
+    if install_step is not None:
+        checker.require(
+            "playwright install --with-deps chromium" in install_step.run,
+            invariant,
+            "Chromium install must include hosted-runner dependencies",
+        )
+    run_step = workflow.step_named(job_id, "Run browser smoke")
+    checker.require(run_step is not None, invariant, "missing Run browser smoke step")
+    if run_step is not None:
+        checker.require(
+            run_step.run == "pnpm --dir frontend test:browser",
+            invariant,
+            "browser smoke command drifted",
+        )
+    upload_step = workflow.step_named(job_id, "Upload browser evidence")
+    checker.require(upload_step is not None, invariant, "missing browser evidence upload")
+    if upload_step is not None:
+        checker.require(
+            upload_step.uses.startswith("actions/upload-artifact@"),
+            invariant,
+            "browser evidence must use upload-artifact",
+        )
+        checker.require(
+            _normalize_expression(_string_value(upload_step.data.get("if"))) == "always()",
+            invariant,
+            "browser evidence must upload after failures",
+        )
+        _require_step_with(
+            checker,
+            upload_step,
+            invariant,
+            {
+                "path": "tmp/browser-smoke",
+                "if-no-files-found": "error",
+                "retention-days": "14",
+            },
+        )
+    return checker.violations
+
+
 def check_ci_aggregate_gate(workflow: Workflow) -> tuple[WorkflowInvariantViolation, ...]:
     checker = WorkflowInvariantChecker(workflow)
     invariant = "aggregate-ci-gate"
@@ -429,6 +489,7 @@ def check_ci_aggregate_gate(workflow: Workflow) -> tuple[WorkflowInvariantViolat
         "container_scan_fork",
         "frontend_validate",
         "frontend_validate_fork",
+        "frontend_browser_smoke",
         "test",
         "test_fork",
         "postgres_integration",
@@ -442,6 +503,7 @@ def check_ci_aggregate_gate(workflow: Workflow) -> tuple[WorkflowInvariantViolat
         "CONTAINER_SCAN_FORK_RESULT",
         "FRONTEND_VALIDATE_RESULT",
         "FRONTEND_VALIDATE_FORK_RESULT",
+        "FRONTEND_BROWSER_SMOKE_RESULT",
         "TEST_RESULT",
         "TEST_FORK_RESULT",
         "POSTGRES_INTEGRATION_RESULT",
@@ -485,6 +547,26 @@ def check_ci_aggregate_gate(workflow: Workflow) -> tuple[WorkflowInvariantViolat
             "require_success test_fork",
         ):
             checker.require(required in step.run, invariant, f"ci_gate script missing {required!r}")
+        browser_gate = 'require_success frontend_browser_smoke "${FRONTEND_BROWSER_SMOKE_RESULT}"'
+        branch_marker = 'if [ "${HEAD_REPOSITORY}" = "${BASE_REPOSITORY}" ]; then'
+        _, branch_separator, branch_tail = step.run.partition(branch_marker)
+        same_repo_block, else_separator, fork_tail = branch_tail.partition("\nelse\n")
+        fork_block, fi_separator, _ = fork_tail.partition("\nfi")
+        checker.require(
+            bool(branch_separator and else_separator and fi_separator),
+            invariant,
+            "ci_gate same-repository and fork branch structure drifted",
+        )
+        checker.require(
+            browser_gate in same_repo_block,
+            invariant,
+            "ci_gate same-repository path must require browser smoke",
+        )
+        checker.require(
+            browser_gate in fork_block,
+            invariant,
+            "ci_gate fork path must require browser smoke",
+        )
     return checker.violations
 
 

--- a/tests/test_docs_contracts.py
+++ b/tests/test_docs_contracts.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from tests.support.workflows import WorkflowInvariantViolation
 from tests.support.workflows import check_ci_aggregate_gate
+from tests.support.workflows import check_frontend_browser_smoke
 from tests.support.workflows import check_fork_runner_isolation
 from tests.support.workflows import check_security_aggregate_gate
 from tests.support.workflows import check_unittest_timing_snapshot
@@ -81,6 +82,20 @@ class DocsContractsTests(TestCase):
         self.assertIn("12 shards with a 20-test/30-second split threshold", testing_docs)
         self.assertIn("GitHub Actions remains the source of truth", testing_docs)
         _assert_no_workflow_violations(self, check_unittest_timing_snapshot(ci_workflow))
+
+    def test_frontend_browser_smoke_is_documented_and_wired(self) -> None:
+        metadata = json.loads(Path(".github/github.json").read_text(encoding="utf-8"))
+        ci_workflow = load_workflow(".github/workflows/ci.yml")
+        testing_docs = Path("docs/style/testing.md").read_text(encoding="utf-8")
+
+        self.assertEqual(
+            "pnpm --dir frontend test:browser",
+            metadata["qualityGate"]["build"]["browser"],
+        )
+        self.assertIn("pnpm --dir frontend test:browser", testing_docs)
+        self.assertIn("repo-local `?fixture=products`", testing_docs)
+        self.assertIn("Deployed OIDC smoke remains a separate", testing_docs)
+        _assert_no_workflow_violations(self, check_frontend_browser_smoke(ci_workflow))
 
     def test_frontend_openapi_codegen_gates_are_documented_and_wired(self) -> None:
         metadata = json.loads(Path(".github/github.json").read_text(encoding="utf-8"))

--- a/tests/test_workflow_invariants.py
+++ b/tests/test_workflow_invariants.py
@@ -2,7 +2,9 @@ import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from tests.support.workflows import check_ci_aggregate_gate
 from tests.support.workflows import check_fork_runner_isolation
+from tests.support.workflows import check_frontend_browser_smoke
 from tests.support.workflows import check_launchplane_request_contract
 from tests.support.workflows import load_workflow
 
@@ -65,6 +67,54 @@ class WorkflowInvariantCheckerTests(unittest.TestCase):
         )
 
         self.assertEqual([], [str(violation) for violation in violations])
+
+    def test_browser_smoke_must_run_for_fork_pull_requests(self) -> None:
+        workflow_text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        job_header = "  frontend_browser_smoke:\n    runs-on: ubuntu-latest\n"
+        self.assertIn(job_header, workflow_text)
+        drifted_workflow = workflow_text.replace(
+            job_header,
+            "  frontend_browser_smoke:\n"
+            "    if: github.event_name != 'pull_request'\n"
+            "    runs-on: ubuntu-latest\n",
+            1,
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            workflow_path = Path(temp_dir) / "ci.yml"
+            workflow_path.write_text(drifted_workflow, encoding="utf-8")
+            workflow = load_workflow(workflow_path)
+
+        violations = check_frontend_browser_smoke(workflow)
+
+        self.assertTrue(
+            any("same-repository and fork pull requests" in item.message for item in violations)
+        )
+
+    def test_ci_gate_must_require_browser_smoke_on_both_paths(self) -> None:
+        workflow_text = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+        browser_gate = (
+            "            require_success frontend_browser_smoke "
+            '"${FRONTEND_BROWSER_SMOKE_RESULT}"\n'
+        )
+        self.assertEqual(2, workflow_text.count(browser_gate))
+        prefix, suffix = workflow_text.rsplit(browser_gate, 1)
+        drifted_workflow = (prefix + suffix).replace(
+            browser_gate,
+            browser_gate + browser_gate,
+            1,
+        )
+
+        with TemporaryDirectory() as temp_dir:
+            workflow_path = Path(temp_dir) / "ci.yml"
+            workflow_path.write_text(drifted_workflow, encoding="utf-8")
+            workflow = load_workflow(workflow_path)
+
+        violations = check_ci_aggregate_gate(workflow)
+
+        self.assertTrue(
+            any("fork path must require browser smoke" in item.message for item in violations)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add deterministic Playwright journeys for anonymous auth, product errors/workspaces, environment diagnostics, blocked actions, and safe dry-run confirmation at desktop and narrow widths
- fail on unexpected browser errors, failed requests, HTTP failures, or mutation requests while producing and verifying 12 fresh screenshot artifacts
- run browser smoke on a hosted Chromium CI job for same-repository and fork PRs, with branch-aware aggregate-gate contracts
- restore product-index and inventory-error heading focus after async skeleton replacement without stealing focus during background refreshes
- document the dev-fixture, production-exclusion, artifact, and deployed-OIDC boundaries

## Validation
- `pnpm --dir frontend test:browser`
- `pnpm --dir frontend validate`
- `uv run --extra dev python -m unittest tests.test_workflow_invariants tests.test_docs_contracts tests.test_github_actions_security`
- `uv run --extra dev launchplane ci unittest-shard local` (2,101 targets, 12/12 shards)
- targeted Ruff, Ruff format, mypy, Prettier, and `git diff --check`
- JetBrains changed-files inspection: clean, zero findings
- desktop and narrow screenshots visually reviewed
- independent agent re-review: SHIP, no P0-P2 findings

Closes #1701
