### PR TITLE
Bind Odoo preview apply to service-issued plans

### DIFF
--- a/.github/actions/setup-odoo-preview-request-client/action.yml
+++ b/.github/actions/setup-odoo-preview-request-client/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: Dry-run plan file path for preview apply requests.
     required: false
     default: ""
+  plan-id:
+    description: Service-issued plan ID used as the preview apply idempotency key.
+    required: false
+    default: ""
   wait-for-deploy:
     description: Whether preview apply should wait for deploy completion.
     required: false

--- a/.github/actions/setup-odoo-preview-request-client/dist/index.js
+++ b/.github/actions/setup-odoo-preview-request-client/dist/index.js
@@ -62,6 +62,7 @@ function requestOptions() {
     source: getInput("source"),
     manifestFile: getInput("manifest-file"),
     dryRunPlanFile: getInput("dry-run-plan-file"),
+    planId: getInput("plan-id"),
     waitForDeploy: getInput("wait-for-deploy"),
     smokeCheck: getInput("smoke-check"),
     runId: getInput("run-id", { defaultValue: process.env.GITHUB_RUN_ID ?? "" }),

--- a/.github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs
+++ b/.github/actions/setup-odoo-preview-request-client/src/odoo-preview-request-client.mjs
@@ -189,6 +189,7 @@ export function buildOdooPreviewApplyInputsRequest(options = {}) {
 
 export function buildOdooPreviewApplyRequest(options = {}) {
   const facts = normalizeFacts(options);
+  const planId = requiredText(options.planId, "Odoo preview plan ID");
   const dryRunPlanFile = requiredText(
     options.dryRunPlanFile,
     "Odoo preview dry run plan file",
@@ -225,10 +226,7 @@ export function buildOdooPreviewApplyRequest(options = {}) {
       apply: applyPayload,
     },
     payloadJsonFiles,
-    idempotencyKey:
-      "odoo-preview-apply:" +
-      `${facts.product}:${previewRequestToken(facts)}:${facts.operation}:` +
-      `run-${facts.runId}-attempt-${facts.runAttempt}`,
+    idempotencyKey: planId,
     failResultPaths: ["result.status"],
   });
 }

--- a/.github/workflows/odoo-driver-route-smoke.yml
+++ b/.github/workflows/odoo-driver-route-smoke.yml
@@ -297,7 +297,7 @@ jobs:
           idempotency-key: >-
             odoo-driver-route-smoke:preview-apply-inputs:${{
             github.run_id }}:${{ github.run_attempt }}
-          expected-status: 202,403,503
+          expected-status: 202,403,409,503
           timeout-ms: "30000"
           response-output-file: ${{ steps.route_probes.outputs.preview_apply_inputs_response }}
           log-response-body: "false"
@@ -314,7 +314,7 @@ jobs:
           idempotency-key: >-
             odoo-driver-route-smoke:preview-apply:${{
             github.run_id }}:${{ github.run_attempt }}
-          expected-status: 202,403,503
+          expected-status: 202,403,409,503
           timeout-ms: "30000"
           response-output-file: ${{ steps.route_probes.outputs.preview_apply_response }}
           log-response-body: "false"

--- a/.github/workflows/reusable-odoo-preview.yml
+++ b/.github/workflows/reusable-odoo-preview.yml
@@ -481,6 +481,7 @@ jobs:
             inputs_status=result.status,
             preview_slug=result.preview_slug,
             preview_url=result.preview_url,
+            plan_id=result.plan_provenance.plan_id,
             error_message=result.error_message
 
       - name: Render Launchplane isolated preview apply request
@@ -494,6 +495,7 @@ jobs:
           preview-slug: ${{ steps.dry_run.outputs.preview_slug }}
           source-git-ref: ${{ steps.facts.outputs.source_git_ref }}
           dry-run-plan-file: ${{ steps.dry_run_payload.outputs.dry_run_plan_file }}
+          plan-id: ${{ steps.dry_run.outputs.plan_id }}
           manifest-file: ${{ steps.publish.outputs.manifest_file }}
           wait-for-deploy: ${{ inputs.wait_for_deploy }}
 
@@ -507,7 +509,7 @@ jobs:
           route-path: ${{ steps.launchplane_request.outputs.route-path }}
           payload: ${{ steps.launchplane_request.outputs.payload }}
           payload-json-files: ${{ steps.launchplane_request.outputs.payload-json-files }}
-          idempotency-key: ${{ steps.launchplane_request.outputs.idempotency-key }}
+          idempotency-key: ${{ steps.dry_run.outputs.plan_id }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
           fail-result-paths: ${{ steps.launchplane_request.outputs.fail-result-paths }}
           output-paths: >-
@@ -682,6 +684,7 @@ jobs:
             inputs_status=result.status,
             preview_slug=result.preview_slug,
             preview_url=result.preview_url,
+            plan_id=result.plan_provenance.plan_id,
             error_message=result.error_message
 
       - name: Render Launchplane isolated preview destroy request
@@ -696,6 +699,7 @@ jobs:
           preview-slug: ${{ steps.dry_run.outputs.preview_slug }}
           source-git-ref: ${{ steps.facts.outputs.source_git_ref }}
           dry-run-plan-file: ${{ steps.dry_run_payload.outputs.dry_run_plan_file }}
+          plan-id: ${{ steps.dry_run.outputs.plan_id }}
           wait-for-deploy: false
 
       - name: Request Launchplane isolated preview destroy
@@ -708,7 +712,7 @@ jobs:
           route-path: ${{ steps.launchplane_request.outputs.route-path }}
           payload: ${{ steps.launchplane_request.outputs.payload }}
           payload-json-files: ${{ steps.launchplane_request.outputs.payload-json-files }}
-          idempotency-key: ${{ steps.launchplane_request.outputs.idempotency-key }}
+          idempotency-key: ${{ steps.dry_run.outputs.plan_id }}
           timeout-ms: ${{ inputs['timeout-ms'] }}
           fail-result-paths: ${{ steps.launchplane_request.outputs.fail-result-paths }}
           output-paths: >-

--- a/.github/workflows/reusable-odoo-preview.yml
+++ b/.github/workflows/reusable-odoo-preview.yml
@@ -328,7 +328,7 @@ jobs:
 
       - name: Render Launchplane publish inputs request
         id: publish_inputs_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@191d840ce260a4bd25c931987324d8c041aa71c7 # main
         with:
           request-kind: artifact-publish-inputs
           product: ${{ inputs.product }}
@@ -451,7 +451,7 @@ jobs:
 
       - name: Render Launchplane isolated preview apply inputs request
         id: dry_run_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@191d840ce260a4bd25c931987324d8c041aa71c7 # main
         with:
           request-kind: preview-apply-inputs
           product: ${{ inputs.product }}
@@ -486,7 +486,7 @@ jobs:
 
       - name: Render Launchplane isolated preview apply request
         id: launchplane_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@191d840ce260a4bd25c931987324d8c041aa71c7 # main
         with:
           request-kind: preview-apply
           product: ${{ inputs.product }}
@@ -655,7 +655,7 @@ jobs:
 
       - name: Render Launchplane isolated preview destroy inputs request
         id: dry_run_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@191d840ce260a4bd25c931987324d8c041aa71c7 # main
         with:
           request-kind: preview-apply-inputs
           product: ${{ inputs.product }}
@@ -689,7 +689,7 @@ jobs:
 
       - name: Render Launchplane isolated preview destroy request
         id: launchplane_request
-        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@adcf937c6aef14e02478724040852d1d2a82a850 # main
+        uses: cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@191d840ce260a4bd25c931987324d8c041aa71c7 # main
         with:
           request-kind: preview-apply
           product: ${{ inputs.product }}

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -298,11 +298,15 @@ from control_plane.odoo_preview_apply_http import (
     OdooPreviewApplyInputsEnvelope,
     OdooPreviewApplyProductMismatchError,
     OdooPreviewApplyRouteDependencyError,
+    OdooPreviewPlanProvenanceError,
     build_odoo_preview_apply_inputs_result,
+    build_odoo_preview_plan_id,
     driver_result_contains_status,
     execute_odoo_preview_apply_result,
+    issue_odoo_preview_apply_plan,
     observe_odoo_preview_apply_result,
     resolve_odoo_preview_apply_profile,
+    validate_odoo_preview_issued_plan,
 )
 from control_plane.odoo_post_deploy_http import (
     ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE as _ODOO_CONFIG_PARAMETER_OVERRIDE_ROUTE,
@@ -394,6 +398,7 @@ from control_plane.workflows.odoo_stable_target_replacement import (
     OdooStableTargetReplacementStore,
     build_odoo_stable_target_replacement_plan,
 )
+from control_plane.workflows.odoo_preview_runtime import OdooPreviewApplyInputsResult
 from control_plane.contracts.product_environment_read_model import (
     ActionAllowed,
 )
@@ -1232,6 +1237,7 @@ class _OdooPreviewProviderMutationAdapter:
         record_store: object,
         profile: LaunchplaneProductProfileRecord,
         apply_request: OdooPreviewApplyEnvelope,
+        issued_plan: OdooPreviewApplyInputsResult,
         database_url: str | None,
         trace_id: str,
     ) -> None:
@@ -1239,6 +1245,7 @@ class _OdooPreviewProviderMutationAdapter:
         self._record_store = record_store
         self._profile = profile
         self._apply_request = apply_request
+        self._issued_plan = issued_plan
         self._database_url = database_url
         self._trace_id = trace_id
 
@@ -1293,6 +1300,7 @@ class _OdooPreviewProviderMutationAdapter:
                 record_store=self._record_store,
                 profile=self._profile,
                 request=self._apply_request,
+                issued_plan=self._issued_plan,
                 database_url=self._database_url,
                 provider_operation_title=provider_operation_title(provider_operation_key),
                 provider_effect_checkpoint=lease.checkpoint_effect,
@@ -4859,6 +4867,40 @@ def create_launchplane_fastapi_app(
                 ),
             )
 
+        normalized_idempotency_key = idempotency_key.strip()
+        if not normalized_idempotency_key:
+            raise _launchplane_http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="idempotency_key_required",
+                message="Odoo preview apply inputs require an Idempotency-Key header.",
+            )
+        if idempotency_capable_store(record_store) is None:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="plan_storage_required",
+                message="Odoo preview plan issuance requires durable idempotency storage.",
+            )
+        payload_fingerprint = idempotency_request_fingerprint(
+            route_path=_ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
+            payload=cast(dict[str, object], raw_payload),
+        )
+        plan_id = build_odoo_preview_plan_id(
+            scope=idempotency_scope(identity),
+            idempotency_key=normalized_idempotency_key,
+        )
+        replay_response = replay_stored_apply_idempotency(
+            record_store=record_store,
+            identity=identity,
+            route_path=_ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
+            idempotency_key=plan_id,
+            request_fingerprint_value=payload_fingerprint,
+            trace_id=trace_id,
+        )
+        if replay_response is not None:
+            return replay_response
+
         try:
             driver_result = build_odoo_preview_apply_inputs_result(
                 control_plane_root=resolved_control_plane_root,
@@ -4882,11 +4924,38 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
+        issued_plan = issue_odoo_preview_apply_plan(
+            result=driver_result,
+            plan_id=plan_id,
+        )
         response = accepted_evidence_response(
             trace_id=trace_id,
             records={},
-            result=driver_result,
+            result=issued_plan.model_dump(mode="json"),
         )
+        if issued_plan.status == "ready":
+            try:
+                store_apply_idempotency(
+                    record_store=record_store,
+                    identity=identity,
+                    route_path=_ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
+                    idempotency_key=plan_id,
+                    request_fingerprint_value=payload_fingerprint,
+                    trace_id=trace_id,
+                    response=response,
+                )
+            except Exception as write_error:
+                replay_response = replay_stored_apply_idempotency(
+                    record_store=record_store,
+                    identity=identity,
+                    route_path=_ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
+                    idempotency_key=plan_id,
+                    request_fingerprint_value=payload_fingerprint,
+                    trace_id=trace_id,
+                )
+                if replay_response is not None:
+                    return replay_response
+                raise write_error
         return response
 
     async def write_odoo_preview_apply(
@@ -4970,6 +5039,48 @@ def create_launchplane_fastapi_app(
                 code="idempotency_key_required",
                 message="Odoo preview apply requests require an Idempotency-Key header.",
             )
+        idempotency_store = idempotency_capable_store(record_store)
+        if idempotency_store is None:
+            raise _launchplane_http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="plan_storage_required",
+                message="Odoo preview apply requires durable plan storage.",
+            )
+        stored_plan_record = idempotency_store.read_idempotency_record(
+            scope=idempotency_scope(identity),
+            route_path=_ODOO_PREVIEW_APPLY_INPUTS_ROUTE,
+            idempotency_key=normalized_idempotency_key,
+        )
+        if stored_plan_record is None or stored_plan_record.state != "completed":
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="odoo_preview_plan_not_issued",
+                message="Odoo preview apply requires a matching service-issued plan.",
+            )
+        stored_plan_payload = stored_plan_record.response_payload.get("result")
+        try:
+            issued_plan = OdooPreviewApplyInputsResult.model_validate(stored_plan_payload)
+            service_apply_request = validate_odoo_preview_issued_plan(
+                plan_id=normalized_idempotency_key,
+                issued_plan=issued_plan,
+                request=apply_request,
+            )
+        except ValidationError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code="odoo_preview_plan_not_issued",
+                message="Stored Odoo preview plan evidence is invalid.",
+            ) from error
+        except OdooPreviewPlanProvenanceError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code=error.code,
+                message=str(error),
+            ) from error
         payload_fingerprint = idempotency_request_fingerprint(
             route_path=_ODOO_PREVIEW_APPLY_ROUTE,
             payload=cast(dict[str, object], raw_payload),
@@ -4978,7 +5089,8 @@ def create_launchplane_fastapi_app(
             control_plane_root=resolved_control_plane_root,
             record_store=record_store,
             profile=product_profile,
-            apply_request=apply_request,
+            apply_request=service_apply_request,
+            issued_plan=issued_plan,
             database_url=getattr(record_store, "database_url", None),
             trace_id=trace_id,
         )
@@ -4997,6 +5109,13 @@ def create_launchplane_fastapi_app(
                 ),
                 reconcile_message=("The Odoo preview apply requires reconciliation before retry."),
             )
+        except OdooPreviewPlanProvenanceError as error:
+            raise _launchplane_http_error(
+                status_code=409,
+                trace_id=trace_id,
+                code=error.code,
+                message=str(error),
+            ) from error
         except OdooPreviewApplyConfigError as error:
             return JSONResponse(
                 status_code=400,

--- a/control_plane/odoo_preview_apply_http.py
+++ b/control_plane/odoo_preview_apply_http.py
@@ -1,4 +1,6 @@
 from collections.abc import Callable
+from datetime import datetime, timedelta, timezone
+import hashlib
 from pathlib import Path
 from typing import Any, cast
 import re
@@ -15,17 +17,21 @@ from control_plane.drivers.dispatch import (
 from control_plane.drivers.registry import read_driver_descriptor
 from control_plane.workflows.odoo_preview_runtime import (
     ODOO_PREVIEW_REQUIRED_ENV_KEYS,
+    OdooPreviewApplyInputsResult,
+    OdooPreviewApplyPlanProvenance,
     OdooPreviewApplyInputsRequest,
     OdooPreviewDokployApplyRequest,
     build_odoo_preview_apply_inputs,
     execute_odoo_preview_dokploy_apply,
     observe_odoo_preview_dokploy_apply,
+    odoo_preview_apply_plan_sha256,
 )
 
 
 ODOO_PREVIEW_APPLY_ROUTE = "/v1/drivers/odoo/preview-apply"
 ODOO_PREVIEW_APPLY_INPUTS_ROUTE = "/v1/drivers/odoo/preview-apply-inputs"
 ODOO_DRIVER_ID = "odoo"
+ODOO_PREVIEW_PLAN_TTL_SECONDS = 30 * 60
 
 
 class OdooPreviewApplyProductMismatchError(ValueError):
@@ -34,6 +40,12 @@ class OdooPreviewApplyProductMismatchError(ValueError):
 
 class OdooPreviewApplyRouteDependencyError(ValueError):
     pass
+
+
+class OdooPreviewPlanProvenanceError(ValueError):
+    def __init__(self, *, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class OdooPreviewApplyConfigError(click.ClickException):
@@ -123,31 +135,190 @@ def build_odoo_preview_apply_inputs_result(
     return driver_result.model_dump(mode="json")
 
 
+def build_odoo_preview_plan_id(*, scope: str, idempotency_key: str) -> str:
+    normalized_scope = scope.strip()
+    normalized_idempotency_key = idempotency_key.strip()
+    if not normalized_scope or not normalized_idempotency_key:
+        raise ValueError("Odoo preview plan ids require scope and idempotency key.")
+    digest = hashlib.sha256(
+        "\x1f".join(("odoo-preview-plan-v1", normalized_scope, normalized_idempotency_key)).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+    return f"odoo-preview-plan-{digest}"
+
+
+def issue_odoo_preview_apply_plan(
+    *,
+    result: dict[str, object] | OdooPreviewApplyInputsResult,
+    plan_id: str,
+    issued_at: datetime | None = None,
+) -> OdooPreviewApplyInputsResult:
+    planned_result = (
+        result
+        if isinstance(result, OdooPreviewApplyInputsResult)
+        else OdooPreviewApplyInputsResult.model_validate(result)
+    )
+    if planned_result.status != "ready":
+        return planned_result
+    resolved_issued_at = issued_at or datetime.now(timezone.utc)
+    if resolved_issued_at.tzinfo is None:
+        raise ValueError("Odoo preview plan issuance requires a timezone-aware timestamp.")
+    resolved_issued_at = resolved_issued_at.astimezone(timezone.utc)
+    provenance = OdooPreviewApplyPlanProvenance(
+        plan_id=plan_id,
+        plan_sha256=odoo_preview_apply_plan_sha256(planned_result),
+        issued_at=resolved_issued_at,
+        expires_at=resolved_issued_at + timedelta(seconds=ODOO_PREVIEW_PLAN_TTL_SECONDS),
+    )
+    return planned_result.model_copy(update={"plan_provenance": provenance})
+
+
+def validate_odoo_preview_issued_plan(
+    *,
+    plan_id: str,
+    issued_plan: OdooPreviewApplyInputsResult,
+    request: OdooPreviewApplyEnvelope,
+) -> OdooPreviewApplyEnvelope:
+    provenance = issued_plan.plan_provenance
+    if issued_plan.status != "ready" or provenance is None:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_not_issued",
+            message="Odoo preview apply requires a service-issued ready plan.",
+        )
+    if provenance.plan_id != plan_id:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_mismatch",
+            message="Odoo preview apply plan identity does not match issued provenance.",
+        )
+    if odoo_preview_apply_plan_sha256(issued_plan) != provenance.plan_sha256:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_mismatch",
+            message="Stored Odoo preview plan evidence failed its provenance fingerprint.",
+        )
+    if request.product != issued_plan.product:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_mismatch",
+            message="Odoo preview apply product does not match the issued plan.",
+        )
+    if request.apply.dry_run_plan != issued_plan.dry_run_plan:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_mismatch",
+            message="Odoo preview apply routing plan does not match the service-issued plan.",
+        )
+    if (
+        request.apply.manifest != issued_plan.plan_request.manifest
+        or request.apply.image_reference != issued_plan.plan_request.image_reference
+    ):
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_mismatch",
+            message="Odoo preview apply artifact does not match the service-issued plan.",
+        )
+    service_apply_request = request.apply.model_copy(
+        update={
+            "dry_run_plan": issued_plan.dry_run_plan,
+            "manifest": issued_plan.plan_request.manifest,
+            "image_reference": issued_plan.plan_request.image_reference,
+        }
+    )
+    return request.model_copy(update={"apply": service_apply_request})
+
+
+def refresh_odoo_preview_issued_plan(
+    *,
+    control_plane_root: Path,
+    record_store: object,
+    profile: LaunchplaneProductProfileRecord,
+    request: OdooPreviewApplyEnvelope,
+    issued_plan: OdooPreviewApplyInputsResult,
+    database_url: str | None,
+    observed_at: datetime | None = None,
+) -> OdooPreviewApplyEnvelope:
+    provenance = issued_plan.plan_provenance
+    if provenance is None:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_not_issued",
+            message="Odoo preview apply requires service-issued plan provenance.",
+        )
+    resolved_observed_at = observed_at or datetime.now(timezone.utc)
+    if resolved_observed_at.tzinfo is None:
+        raise ValueError("Odoo preview plan validation requires a timezone-aware timestamp.")
+    resolved_observed_at = resolved_observed_at.astimezone(timezone.utc)
+    if resolved_observed_at < provenance.issued_at:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_mismatch",
+            message="Odoo preview plan issuance timestamp is in the future.",
+        )
+    if resolved_observed_at >= provenance.expires_at:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_expired",
+            message="Odoo preview plan has expired; request fresh apply inputs.",
+        )
+    try:
+        current_plan = build_odoo_preview_apply_inputs(
+            control_plane_root=control_plane_root,
+            record_store=cast(Any, record_store),
+            profile=profile,
+            request=issued_plan.plan_request,
+            database_url=database_url,
+        )
+    except (FileNotFoundError, click.ClickException) as error:
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_stale",
+            message="Odoo preview plan authority could not be revalidated.",
+        ) from error
+    if (
+        current_plan.status != "ready"
+        or odoo_preview_apply_plan_sha256(current_plan) != provenance.plan_sha256
+    ):
+        raise OdooPreviewPlanProvenanceError(
+            code="odoo_preview_plan_stale",
+            message="Odoo preview plan no longer matches current service authority.",
+        )
+    current_apply_request = request.apply.model_copy(
+        update={
+            "dry_run_plan": current_plan.dry_run_plan,
+            "manifest": current_plan.plan_request.manifest,
+            "image_reference": current_plan.plan_request.image_reference,
+        }
+    )
+    return request.model_copy(update={"apply": current_apply_request})
+
+
 def execute_odoo_preview_apply_result(
     *,
     control_plane_root_path: Path,
     record_store: object,
     profile: LaunchplaneProductProfileRecord,
     request: OdooPreviewApplyEnvelope,
+    issued_plan: OdooPreviewApplyInputsResult,
     database_url: str | None,
     provider_operation_title: str = "",
     provider_effect_checkpoint: Callable[[str], None] | None = None,
     provider_lease_check: Callable[[], None] | None = None,
 ) -> dict[str, object]:
-    if request.apply.dry_run_plan.repository.strip() != profile.repository.strip():
+    current_request = refresh_odoo_preview_issued_plan(
+        control_plane_root=control_plane_root_path,
+        record_store=record_store,
+        profile=profile,
+        request=request,
+        issued_plan=issued_plan,
+        database_url=database_url,
+    )
+    if current_request.apply.dry_run_plan.repository.strip() != profile.repository.strip():
         raise ValueError("Odoo preview apply repository does not match product profile.")
     resolved_environment_values = _odoo_preview_service_environment_values(
         control_plane_root_path=control_plane_root_path,
         profile=profile,
-        apply_request=request.apply,
+        apply_request=current_request.apply,
         database_url=database_url,
     )
-    service_dry_run_plan = request.apply.dry_run_plan.model_copy(
+    service_dry_run_plan = current_request.apply.dry_run_plan.model_copy(
         update={
             "domain_certificate_type": profile.preview.domain_certificate_type,
         }
     )
-    service_apply_request = request.apply.model_copy(
+    service_apply_request = current_request.apply.model_copy(
         update={
             "dry_run_plan": service_dry_run_plan,
             "environment_values": resolved_environment_values,

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 import time
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal, Protocol, cast
 from urllib.error import HTTPError, URLError
@@ -237,6 +240,7 @@ def build_odoo_preview_apply_workflow_request(
     *,
     facts: OdooPreviewWorkflowRequestFacts,
     dry_run_plan_file: str,
+    plan_id: str,
     manifest_file: str = "",
     wait_for_deploy: bool = True,
     smoke_check: bool | None = None,
@@ -245,6 +249,7 @@ def build_odoo_preview_apply_workflow_request(
         dry_run_plan_file,
         "Odoo preview apply request requires dry_run_plan_file.",
     )
+    plan_id = _required_text(plan_id, "Odoo preview apply request requires plan_id.")
     if facts.operation == "refresh" and not manifest_file.strip():
         raise ValueError("Odoo preview refresh apply request requires manifest_file.")
     payload_json_files = {"apply.dry_run_plan": dry_run_plan_file}
@@ -264,11 +269,7 @@ def build_odoo_preview_apply_workflow_request(
             "apply": apply_payload,
         },
         payload_json_files=payload_json_files,
-        idempotency_key=(
-            "odoo-preview-apply:"
-            f"{facts.product}:{_preview_request_token(facts)}:{facts.operation}:"
-            f"run-{facts.run_id}-attempt-{facts.run_attempt}"
-        ),
+        idempotency_key=plan_id,
         fail_result_paths=("result.status",),
     )
 
@@ -324,6 +325,32 @@ class OdooPreviewApplyInputsRequest(BaseModel):
         return self
 
 
+class OdooPreviewApplyPlanProvenance(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    plan_id: str
+    plan_sha256: str
+    issued_at: datetime
+    expires_at: datetime
+
+    @model_validator(mode="after")
+    def _normalize_provenance(self) -> "OdooPreviewApplyPlanProvenance":
+        self.plan_id = _required_text(self.plan_id, "Odoo preview plan provenance requires plan_id")
+        self.plan_sha256 = self.plan_sha256.strip().lower()
+        if len(self.plan_sha256) != 64 or any(
+            character not in "0123456789abcdef" for character in self.plan_sha256
+        ):
+            raise ValueError("Odoo preview plan provenance requires a SHA-256 fingerprint")
+        if self.issued_at.tzinfo is None or self.expires_at.tzinfo is None:
+            raise ValueError("Odoo preview plan provenance timestamps require UTC offsets")
+        self.issued_at = self.issued_at.astimezone(timezone.utc)
+        self.expires_at = self.expires_at.astimezone(timezone.utc)
+        if self.expires_at <= self.issued_at:
+            raise ValueError("Odoo preview plan provenance must expire after issuance")
+        return self
+
+
 class OdooPreviewApplyInputsResult(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -335,8 +362,10 @@ class OdooPreviewApplyInputsResult(BaseModel):
     preview_slug: str
     preview_url: str
     repository: str
+    plan_request: OdooPreviewApplyInputsRequest
     runtime_plan: OdooPreviewRuntimePlan
     dry_run_plan: OdooPreviewDokployDryRunPlan
+    plan_provenance: OdooPreviewApplyPlanProvenance | None = None
     source: str
     error_message: str = ""
 
@@ -357,8 +386,24 @@ class OdooPreviewApplyInputsResult(BaseModel):
         self.repository = _required_text(
             self.repository, "Odoo preview apply inputs result requires repository"
         )
+        if self.plan_request.product != self.product:
+            raise ValueError("Odoo preview apply inputs result requires matching plan product")
+        if self.plan_request.operation != self.operation:
+            raise ValueError("Odoo preview apply inputs result requires matching plan operation")
+        if self.dry_run_plan.product != self.product:
+            raise ValueError("Odoo preview apply inputs result requires matching dry-run product")
+        if self.dry_run_plan.operation != self.operation:
+            raise ValueError("Odoo preview apply inputs result requires matching dry-run operation")
+        if self.status == "blocked" and self.plan_provenance is not None:
+            raise ValueError("Blocked Odoo preview plans cannot include apply provenance")
         self.error_message = self.error_message.strip()
         return self
+
+
+def odoo_preview_apply_plan_sha256(result: OdooPreviewApplyInputsResult) -> str:
+    payload = result.model_dump(mode="json", exclude={"plan_provenance"})
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
 def build_odoo_preview_apply_inputs(
@@ -491,6 +536,7 @@ def build_odoo_preview_apply_inputs(
         preview_slug=preview_slug,
         preview_url=preview_url,
         repository=profile.repository,
+        plan_request=request.model_copy(deep=True),
         runtime_plan=runtime_plan,
         dry_run_plan=dry_run_plan,
         source=request.source,

--- a/docs/operator-experience.md
+++ b/docs/operator-experience.md
@@ -63,6 +63,10 @@ refresh one through a reviewed plan, verify health and runtime identity,
 destroy it, and confirm that no provider or Launchplane inventory remains
 orphaned. Apply, destroy, and report-only reconciliation are one understandable
 journey.
+Reviewed Odoo preview plans are service-issued, short-lived, and bound to their
+artifact and provider-routing evidence. If that evidence changes or the plan
+expires, the UI must present a stale-plan result and obtain a new plan rather
+than offering a force-apply control.
 
 ### Promote A Verified Release
 

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -199,9 +199,10 @@ adapters, not product-repo authority.
 Launchplane also owns the reusable request-shape builders for Odoo tenant
 preview workflows. Tenant repos may keep thin adapter jobs for checkout, image
 publication, runner selection, and product smoke facts, but the route paths,
-payload skeletons, JSON-file bindings, fail-result paths, and run-scoped
-idempotency keys for `artifact-publish-inputs`, `preview-apply-inputs`, and
-`preview-apply` are Launchplane contract fixtures. New or migrated tenant
+payload skeletons, JSON-file bindings, fail-result paths, run-scoped inputs
+keys, and service-issued apply key for `artifact-publish-inputs`,
+`preview-apply-inputs`, and `preview-apply` are Launchplane contract fixtures.
+New or migrated tenant
 preview workflows should install
 `cbusillo/launchplane/.github/actions/setup-odoo-preview-request-client@main`
 and either use its `request-kind` render mode or import the generated ESM client
@@ -245,6 +246,22 @@ artifact/revision evidence, and module install/update evidence. Product
 workflows should treat the Odoo refresh route's `refresh_status="pass"` as the
 ready-to-comment signal instead of independently deciding readiness from raw
 health checks.
+
+Ready Odoo apply-inputs responses also include the normalized `plan_request`
+and `plan_provenance`: a service-derived plan id, canonical SHA-256 fingerprint,
+issuance time, and 30-minute expiry. Launchplane persists that response under the
+calling identity and requires the returned plan id as the `preview-apply`
+`Idempotency-Key`; workflows must not derive a replacement apply key. Apply
+loads the persisted result, requires the caller's dry-run plan and artifact to
+match exactly, rejects missing, mismatched, or expired provenance, and rebuilds
+the plan from current Launchplane records and current provider discovery before
+the first provider effect. Any changed profile, runtime routing, template target,
+environment id, or discovered preview target makes the plan stale and requires
+new apply inputs. Completed exact retries replay the stored apply response, and
+uncertain operations reconcile against the originally issued plan instead of
+replanning into another effect. Blocked apply-inputs responses have no apply
+provenance and are not persisted as issued plans, so a later retry can re-evaluate
+recovered dependencies.
 If a later browser or product-specific smoke workflow needs to publish common
 preview evidence, it should call
 `cbusillo/launchplane/.github/workflows/reusable-generic-web-preview-verification.yml@main`

--- a/docs/records.md
+++ b/docs/records.md
@@ -104,6 +104,13 @@ backfilled as `completed`; reservation-backed routes add promoted state, lease,
 attempt, owner, reconciliation-key, and timestamp columns while retaining the
 typed payload as the complete evidence envelope.
 
+The same table stores ready Odoo preview apply-inputs issuance evidence. The
+service derives a plan id from caller scope plus the inputs idempotency key,
+persists the normalized plan request, runtime plan, provider dry-run plan,
+fingerprint, and expiry under that id, and requires the id as the later apply
+key. This reuses completed-response storage rather than adding a second plan
+table; blocked plans are not issuance records.
+
 Reservation identity is `(scope, route_path, idempotency_key)` and remains
 unique in PostgreSQL. The typed lifecycle is:
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2215,13 +2215,15 @@ and website-bootstrap override are native FastAPI routes too. They preserve
 product-profile driver validation, lane-scoped authorization, optional
 `Idempotency-Key` replay/conflict behavior, post-deploy transition records, and
 Odoo instance override record merge behavior. Odoo preview apply inputs and
-preview apply are also owned by native FastAPI. They preserve preview-context authorization,
-runtime-environment dependency classification, and the
+preview apply are also owned by native FastAPI. They preserve preview-context
+authorization, runtime-environment dependency classification, and the
 `odoo_preview_runtime_config_incomplete` details envelope for apply requests
-whose template runtime records are incomplete. Preview apply inputs remains
-uncached/non-idempotent, while preview apply keeps optional `Idempotency-Key`
-replay/conflict behavior for non-blocked results and skips blocked-result
-storage so retries can observe changed runtime/provider state. The smoke also
+whose template runtime records are incomplete. Ready preview apply inputs are
+persisted as identity-scoped issued plans; blocked inputs remain unstored so a
+retry can observe recovered runtime/provider state. Preview apply requires the
+service-issued plan id as its `Idempotency-Key`, validates exact plan and artifact
+continuity, and recomputes current plan authority before a fresh provider effect.
+The smoke also
 sends authenticated GitHub OIDC probes to `/v1/drivers/odoo/preview-apply-inputs`,
 `/v1/drivers/odoo/preview-apply`, and `/v1/previews/pr-feedback`.
 
@@ -2400,10 +2402,13 @@ retries do not collide. The regular cleanup workflow uses
 - generic-web preview destroy driver:
   `generic-web-preview-destroy:<product>:<anchor_pr_number>`
 - Odoo isolated preview apply-inputs driver:
-  none; apply-inputs remains uncached/non-idempotent so blocked input derivation
-  can be retried against changed runtime/provider records.
+  `odoo-preview-apply-inputs:<product>:<preview>:<source-or-destroy>:<run-attempt>`;
+  ready responses are persisted under the service-derived plan id, while blocked
+  input derivation remains unstored so it can be retried against changed
+  runtime/provider records.
 - Odoo isolated preview apply driver:
-  `odoo-preview-apply:<product>:<preview_slug>:<operation>:<sha-or-destroy>`
+  the `plan_provenance.plan_id` returned by preview apply-inputs; callers must
+  not synthesize a separate apply key.
 
 Generic-web product workflow clients live in product repositories as thin
 Launchplane callers until Launchplane provides a shared distributable helper.
@@ -2561,10 +2566,16 @@ If the service-side runtime contract is incomplete before any provider mutation,
 the route returns `odoo_preview_runtime_config_incomplete` with the affected
 context, instance, and missing key names only; it never returns runtime values or
 secret material.
-The route is idempotency-keyed for non-blocked apply results and intended for
-approved non-production Odoo preview targets while the isolated runtime migration
-is being exercised. Blocked apply results are not stored as idempotency responses
-so retries can recompute after runtime or provider dependencies recover.
+The preceding `preview-apply-inputs` call persists each ready plan with its
+normalized source/artifact request, canonical fingerprint, and 30-minute expiry.
+Its returned plan id is the only accepted apply idempotency key. Apply rejects
+unissued ids, caller changes to provider routing or artifact identity, expired
+plans, and plans whose fresh service-side recomputation differs. These checks run
+before provider effects; a rejected fresh reservation is released. Completed
+exact retries still replay their response, while reconciliation observes the
+stored original plan instead of creating a new effect. Blocked apply results are
+not stored as completed apply responses so retries can recompute after runtime or
+provider dependencies recover.
 
 For Odoo preview smoke follow-ups,
 `POST /v1/drivers/generic-web/preview-verification` accepts the product,

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timedelta, timezone
 import json
 import unittest
 from pathlib import Path
@@ -15,17 +16,28 @@ from control_plane.contracts.odoo_instance_override_record import (
     OdooInstanceOverrideRecord,
     OdooOverrideValue,
 )
+from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
+from control_plane.contracts.odoo_preview_runtime_plan import OdooPreviewRuntimePlan
 from control_plane.contracts.runtime_environment_record import RuntimeEnvironmentRecord
 from control_plane.dokploy import DokploySourceOfTruth, DokployTargetDefinition
 from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
 from control_plane.http_app import create_launchplane_fastapi_app, idempotency_scope
+from control_plane.odoo_preview_apply_http import (
+    ODOO_PREVIEW_PLAN_TTL_SECONDS,
+    OdooPreviewApplyEnvelope,
+    issue_odoo_preview_apply_plan,
+)
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from control_plane.storage.filesystem import FilesystemRecordStore
 from control_plane.storage.postgres import PostgresRecordStore
 from control_plane.workflows.odoo_artifact_publish import OdooArtifactPublishResult
 from control_plane.workflows.odoo_app_maintenance import OdooAppMaintenanceResult
 from control_plane.workflows.odoo_post_deploy import OdooPostDeployResult
-from control_plane.workflows.odoo_preview_runtime import OdooPreviewDokployApplyResult
+from control_plane.workflows.odoo_preview_runtime import (
+    OdooPreviewApplyInputsRequest,
+    OdooPreviewApplyInputsResult,
+    OdooPreviewDokployApplyResult,
+)
 from control_plane.workflows.odoo_prod_backup_gate import OdooProdBackupGateResult
 from control_plane.workflows.odoo_prod_promotion import OdooProdPromotionResult
 from control_plane.workflows.odoo_prod_promotion_inputs import OdooProdPromotionInputsResult
@@ -62,8 +74,8 @@ from tests.support.stores import (
 )
 
 
-def _ready_odoo_preview_apply_payload() -> dict[str, object]:
-    return {
+def _ready_odoo_preview_apply_payload(*, include_manifest: bool = False) -> dict[str, object]:
+    payload: dict[str, object] = {
         "schema_version": 1,
         "product": "odoo-tenant-cm",
         "apply": {
@@ -84,6 +96,41 @@ def _ready_odoo_preview_apply_payload() -> dict[str, object]:
             "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
             "wait_for_deploy": True,
             "smoke_check": True,
+        },
+    }
+    if include_manifest:
+        apply = cast(dict[str, object], payload["apply"])
+        apply["manifest"] = {
+            "artifact_id": "artifact-cm-preview",
+            "source_commit": "abc123",
+            "enterprise_base_digest": "sha256:enterprise",
+            "image": {
+                "repository": "ghcr.io/cbusillo/odoo-tenant-cm",
+                "digest": "sha256:abc123",
+            },
+        }
+    return payload
+
+
+def _ready_odoo_preview_destroy_payload() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "product": "odoo-tenant-cm",
+        "apply": {
+            "dry_run_plan": {
+                "status": "ready",
+                "operation": "destroy",
+                "product": "odoo-tenant-cm",
+                "repository": "cbusillo/odoo-tenant-cm",
+                "preview_slug": "pr-42",
+                "preview_url": "https://pr-42.cm-preview.example.test",
+                "domain_host": "pr-42.cm-preview.example.test",
+                "compose_ref": "compose-cm-pr-42",
+                "compose_name": "cm-odoo-preview-pr-42",
+                "summary": "ready isolated Odoo preview destroy",
+            },
+            "wait_for_deploy": False,
+            "smoke_check": False,
         },
     }
 
@@ -837,6 +884,82 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         )
         return store
 
+    def _planned_preview_result(self, payload: dict[str, object]) -> OdooPreviewApplyInputsResult:
+        apply_request = OdooPreviewApplyEnvelope.model_validate(payload)
+        dry_run_plan = apply_request.apply.dry_run_plan
+        plan_request = OdooPreviewApplyInputsRequest(
+            product=apply_request.product,
+            operation=dry_run_plan.operation,
+            pr_number=42,
+            preview_slug=dry_run_plan.preview_slug,
+            preview_url=dry_run_plan.preview_url,
+            image_reference=apply_request.apply.image_reference,
+            manifest=apply_request.apply.manifest,
+            source_git_ref="abc123" if dry_run_plan.operation == "refresh" else "",
+            source="test-issued-plan",
+        )
+        return OdooPreviewApplyInputsResult(
+            status="ready",
+            product=apply_request.product,
+            context="cm",
+            template_instance="testing",
+            operation=dry_run_plan.operation,
+            preview_slug=dry_run_plan.preview_slug,
+            preview_url=dry_run_plan.preview_url,
+            repository=dry_run_plan.repository,
+            plan_request=plan_request,
+            runtime_plan=OdooPreviewRuntimePlan(
+                status="ready",
+                operation=dry_run_plan.operation,
+                product=apply_request.product,
+                repository=dry_run_plan.repository,
+                pr_number=42,
+                preview_slug=dry_run_plan.preview_slug,
+                preview_url=dry_run_plan.preview_url,
+                strategy="isolated_dokploy_compose",
+                summary="ready test Odoo preview runtime plan",
+            ),
+            dry_run_plan=dry_run_plan,
+            source="test-issued-plan",
+        )
+
+    def _store_issued_preview_plan(
+        self,
+        *,
+        store: PostgresRecordStore,
+        identity: GitHubActionsIdentity,
+        payload: dict[str, object],
+        plan_id: str = "odoo-preview-plan-test",
+        issued_at: datetime | None = None,
+    ) -> str:
+        issued_plan = issue_odoo_preview_apply_plan(
+            result=self._planned_preview_result(payload),
+            plan_id=plan_id,
+            issued_at=issued_at,
+        )
+        provenance = issued_plan.plan_provenance
+        assert provenance is not None
+        recorded_at = provenance.issued_at.isoformat().replace("+00:00", "Z")
+        store.write_idempotency_record(
+            LaunchplaneIdempotencyRecord(
+                record_id=f"idempotency-{plan_id}",
+                scope=idempotency_scope(identity),
+                route_path="/v1/drivers/odoo/preview-apply-inputs",
+                idempotency_key=plan_id,
+                request_fingerprint="test-issued-plan-request",
+                response_status_code=202,
+                response_trace_id="trace-issued-plan",
+                recorded_at=recorded_at,
+                response_payload={
+                    "status": "accepted",
+                    "trace_id": "trace-issued-plan",
+                    "records": {},
+                    "result": issued_plan.model_dump(mode="json"),
+                },
+            )
+        )
+        return plan_id
+
     async def test_odoo_preview_apply_inputs_derives_runtime_and_dry_run_plans(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
@@ -928,6 +1051,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             },
                         },
                     },
+                    idempotency_key="odoo-preview-inputs-test-refresh",
                 )
 
         self.assertEqual(response.status_code, 202)
@@ -939,6 +1063,9 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["dry_run_plan"]["status"], "ready")
         self.assertEqual(result["dry_run_plan"]["environment_id"], "env-cm-preview")
         self.assertEqual(result["dry_run_plan"]["domain_certificate_type"], "letsencrypt")
+        self.assertEqual(result["plan_request"]["manifest"]["source_commit"], "abc123")
+        self.assertTrue(result["plan_provenance"]["plan_id"].startswith("odoo-preview-plan-"))
+        self.assertEqual(len(result["plan_provenance"]["plan_sha256"]), 64)
         self.assertNotIn("template-db-secret", json.dumps(response.json()))
 
     async def test_odoo_preview_apply_inputs_builds_destroy_for_discovered_target(
@@ -1036,6 +1163,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             "pr_number": 42,
                         },
                     },
+                    idempotency_key="odoo-preview-inputs-test-destroy",
                 )
 
         self.assertEqual(response.status_code, 202)
@@ -1044,6 +1172,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["runtime_plan"]["target"]["target_id"], "compose-cm-pr-42")
         self.assertEqual(result["dry_run_plan"]["compose_ref"], "compose-cm-pr-42")
         self.assertEqual(result["dry_run_plan"]["operation"], "destroy")
+        self.assertTrue(result["plan_provenance"]["plan_id"].startswith("odoo-preview-plan-"))
 
     async def test_odoo_preview_apply_inputs_handler_file_miss_is_not_found(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1074,12 +1203,13 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
                         },
                     },
+                    idempotency_key="odoo-preview-inputs-test-file-miss",
                 )
 
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json()["error"]["code"], "not_found")
 
-    async def test_odoo_preview_apply_inputs_ignores_idempotency_key(self) -> None:
+    async def test_odoo_preview_apply_inputs_replays_service_issued_plan(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = FilesystemRecordStore(state_dir=root / "state")
@@ -1101,21 +1231,11 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
                 },
             }
+            planned_result = self._planned_preview_result(_ready_odoo_preview_apply_payload())
 
             with patch(
                 "control_plane.http_app.build_odoo_preview_apply_inputs_result",
-                side_effect=(
-                    {
-                        "status": "blocked",
-                        "product": "odoo-tenant-cm",
-                        "source": "first",
-                    },
-                    {
-                        "status": "ready",
-                        "product": "odoo-tenant-cm",
-                        "source": "second",
-                    },
-                ),
+                return_value=planned_result.model_dump(mode="json"),
             ) as build_inputs:
                 first_response = await _post_odoo_preview_apply_inputs(
                     app,
@@ -1129,10 +1249,243 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 )
 
         self.assertEqual(first_response.status_code, 202)
-        self.assertEqual(first_response.json()["result"]["source"], "first")
+        first_result = first_response.json()["result"]
+        self.assertEqual(first_result["source"], "test-issued-plan")
+        self.assertTrue(first_result["plan_provenance"]["plan_id"].startswith("odoo-preview-plan-"))
         self.assertEqual(second_response.status_code, 202)
-        self.assertEqual(second_response.json()["result"]["source"], "second")
-        self.assertEqual(build_inputs.call_count, 2)
+        second_payload = second_response.json()
+        self.assertTrue(second_payload["replayed"])
+        self.assertEqual(second_payload["result"], first_result)
+        build_inputs.assert_called_once()
+
+    async def test_odoo_preview_apply_rejects_unissued_plan_before_provider(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            identity = self._identity()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
+                authz_policy=self._policy(actions=("odoo_preview_apply.execute",)),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            with patch("control_plane.http_app.execute_odoo_preview_apply_result") as apply_driver:
+                response = await _post_odoo_preview_apply(
+                    app,
+                    _ready_odoo_preview_apply_payload(),
+                    idempotency_key="odoo-preview-plan-not-issued",
+                )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "odoo_preview_plan_not_issued")
+        apply_driver.assert_not_called()
+
+    async def test_odoo_preview_apply_rejects_tampered_plan_before_provider(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            identity = self._identity()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
+                authz_policy=self._policy(actions=("odoo_preview_apply.execute",)),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            issued_payload = _ready_odoo_preview_apply_payload()
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=issued_payload,
+            )
+            tampered_payload = json.loads(json.dumps(issued_payload))
+            tampered_plan = cast(
+                dict[str, object],
+                cast(dict[str, object], tampered_payload["apply"])["dry_run_plan"],
+            )
+            tampered_plan["compose_name"] = "forged-compose"
+
+            with patch("control_plane.http_app.execute_odoo_preview_apply_result") as apply_driver:
+                response = await _post_odoo_preview_apply(
+                    app,
+                    tampered_payload,
+                    idempotency_key=plan_id,
+                )
+            stored_apply = store.read_idempotency_record(
+                scope=idempotency_scope(identity),
+                route_path="/v1/drivers/odoo/preview-apply",
+                idempotency_key=plan_id,
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "odoo_preview_plan_mismatch")
+        self.assertIsNone(stored_apply)
+        apply_driver.assert_not_called()
+
+    async def test_odoo_preview_apply_rejects_expired_plan_before_provider_effect(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            identity = self._identity()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
+                authz_policy=self._policy(actions=("odoo_preview_apply.execute",)),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            payload = _ready_odoo_preview_apply_payload()
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=payload,
+                issued_at=datetime.now(timezone.utc)
+                - timedelta(seconds=ODOO_PREVIEW_PLAN_TTL_SECONDS + 1),
+            )
+
+            with patch(
+                "control_plane.odoo_preview_apply_http.execute_odoo_preview_dokploy_apply"
+            ) as apply_driver:
+                response = await _post_odoo_preview_apply(
+                    app,
+                    payload,
+                    idempotency_key=plan_id,
+                )
+            stored_apply = store.read_idempotency_record(
+                scope=idempotency_scope(identity),
+                route_path="/v1/drivers/odoo/preview-apply",
+                idempotency_key=plan_id,
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "odoo_preview_plan_expired")
+        self.assertIsNone(stored_apply)
+        apply_driver.assert_not_called()
+
+    async def test_odoo_preview_apply_replays_completed_result_after_plan_expiry(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            identity = self._identity()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
+                authz_policy=self._policy(actions=("odoo_preview_apply.execute",)),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            payload = _ready_odoo_preview_apply_payload()
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=payload,
+            )
+
+            with patch(
+                "control_plane.http_app.execute_odoo_preview_apply_result",
+                return_value={
+                    "status": "pass",
+                    "operation": "refresh",
+                    "product": "odoo-tenant-cm",
+                    "repository": "cbusillo/odoo-tenant-cm",
+                    "preview_slug": "pr-42",
+                    "preview_url": "https://pr-42.cm-preview.example.test",
+                    "domain_host": "pr-42.cm-preview.example.test",
+                    "compose_name": "cm-odoo-preview-pr-42",
+                },
+            ) as apply_driver:
+                first_response = await _post_odoo_preview_apply(
+                    app,
+                    payload,
+                    idempotency_key=plan_id,
+                )
+                plan_record = store.read_idempotency_record(
+                    scope=idempotency_scope(identity),
+                    route_path="/v1/drivers/odoo/preview-apply-inputs",
+                    idempotency_key=plan_id,
+                )
+                assert plan_record is not None
+                issued_plan = OdooPreviewApplyInputsResult.model_validate(
+                    plan_record.response_payload["result"]
+                )
+                provenance = issued_plan.plan_provenance
+                assert provenance is not None
+                expired_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+                expired_plan = issued_plan.model_copy(
+                    update={
+                        "plan_provenance": provenance.model_copy(
+                            update={
+                                "issued_at": expired_at
+                                - timedelta(seconds=ODOO_PREVIEW_PLAN_TTL_SECONDS),
+                                "expires_at": expired_at,
+                            }
+                        )
+                    }
+                )
+                expired_response_payload = dict(plan_record.response_payload)
+                expired_response_payload["result"] = expired_plan.model_dump(mode="json")
+                store.write_idempotency_record(
+                    plan_record.model_copy(update={"response_payload": expired_response_payload})
+                )
+                replay_response = await _post_odoo_preview_apply(
+                    app,
+                    payload,
+                    idempotency_key=plan_id,
+                )
+
+        self.assertEqual(first_response.status_code, 202)
+        self.assertEqual(replay_response.status_code, 202)
+        self.assertTrue(replay_response.json()["replayed"])
+        apply_driver.assert_called_once()
+
+    async def test_odoo_preview_apply_rejects_stale_recomputed_plan(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            identity = self._identity()
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
+                authz_policy=self._policy(actions=("odoo_preview_apply.execute",)),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            payload = _ready_odoo_preview_apply_payload()
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=payload,
+            )
+            current_plan = self._planned_preview_result(payload)
+            current_plan = current_plan.model_copy(
+                update={
+                    "dry_run_plan": current_plan.dry_run_plan.model_copy(
+                        update={"environment_id": "env-changed"}
+                    )
+                }
+            )
+
+            with (
+                patch(
+                    "control_plane.odoo_preview_apply_http.build_odoo_preview_apply_inputs",
+                    return_value=current_plan,
+                ),
+                patch(
+                    "control_plane.odoo_preview_apply_http.execute_odoo_preview_dokploy_apply"
+                ) as apply_driver,
+            ):
+                response = await _post_odoo_preview_apply(
+                    app,
+                    payload,
+                    idempotency_key=plan_id,
+                )
+            stored_apply = store.read_idempotency_record(
+                scope=idempotency_scope(identity),
+                route_path="/v1/drivers/odoo/preview-apply",
+                idempotency_key=plan_id,
+            )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(response.json()["error"]["code"], "odoo_preview_plan_stale")
+        self.assertIsNone(stored_apply)
+        apply_driver.assert_not_called()
 
     async def test_odoo_preview_apply_blocks_missing_service_runtime_environment(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1149,16 +1502,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     source_label="test",
                 )
             )
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1170,21 +1521,32 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=_ready_odoo_preview_apply_payload(),
+            )
 
-            with patch(
-                "control_plane.odoo_preview_apply_http.execute_odoo_preview_dokploy_apply",
-                return_value=OdooPreviewDokployApplyResult(
-                    status="pass",
-                    operation="refresh",
-                    product="odoo-tenant-cm",
-                    repository="cbusillo/odoo-tenant-cm",
-                    preview_slug="pr-42",
-                    preview_url="https://pr-42.cm-preview.example.test",
-                    domain_host="pr-42.cm-preview.example.test",
-                    compose_id="compose-cm-pr-42",
-                    compose_name="cm-odoo-preview-pr-42",
+            with (
+                patch(
+                    "control_plane.odoo_preview_apply_http.refresh_odoo_preview_issued_plan",
+                    side_effect=lambda **kwargs: kwargs["request"],
                 ),
-            ) as apply_driver:
+                patch(
+                    "control_plane.odoo_preview_apply_http.execute_odoo_preview_dokploy_apply",
+                    return_value=OdooPreviewDokployApplyResult(
+                        status="pass",
+                        operation="refresh",
+                        product="odoo-tenant-cm",
+                        repository="cbusillo/odoo-tenant-cm",
+                        preview_slug="pr-42",
+                        preview_url="https://pr-42.cm-preview.example.test",
+                        domain_host="pr-42.cm-preview.example.test",
+                        compose_id="compose-cm-pr-42",
+                        compose_name="cm-odoo-preview-pr-42",
+                    ),
+                ) as apply_driver,
+            ):
                 response = await _post_odoo_preview_apply(
                     app,
                     {
@@ -1210,7 +1572,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             "smoke_check": False,
                         },
                     },
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123",
+                    idempotency_key=plan_id,
                 )
 
         payload = response.json()
@@ -1246,16 +1608,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     source_label="test",
                 )
             )
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1267,6 +1627,11 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=_ready_odoo_preview_apply_payload(include_manifest=True),
+            )
             with (
                 patch.dict(
                     "os.environ",
@@ -1274,6 +1639,10 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                         control_plane_secrets.LAUNCHPLANE_SECRET_MASTER_KEY_ENV_VAR: "test-master-key"
                     },
                     clear=True,
+                ),
+                patch(
+                    "control_plane.odoo_preview_apply_http.refresh_odoo_preview_issued_plan",
+                    side_effect=lambda **kwargs: kwargs["request"],
                 ),
                 patch(
                     "control_plane.odoo_preview_apply_http.execute_odoo_preview_dokploy_apply",
@@ -1329,7 +1698,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             "smoke_check": False,
                         },
                     },
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123",
+                    idempotency_key=plan_id,
                 )
 
         payload = response.json()
@@ -1386,16 +1755,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = self._reservation_store(root)
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1406,6 +1773,11 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 record_store_factory=lambda: store,
                 control_plane_root_path=root,
+            )
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=_ready_odoo_preview_apply_payload(),
             )
             apply_started = Event()
             release_apply = Event()
@@ -1434,7 +1806,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     _post_odoo_preview_apply(
                         app,
                         _ready_odoo_preview_apply_payload(),
-                        idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:health",
+                        idempotency_key=plan_id,
                     )
                 )
                 try:
@@ -1456,16 +1828,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = self._reservation_store(root)
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1476,6 +1846,11 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 record_store_factory=lambda: store,
                 control_plane_root_path=root,
+            )
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=_ready_odoo_preview_apply_payload(),
             )
             apply_started = Event()
             release_apply = Event()
@@ -1496,7 +1871,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     "compose_name": "cm-odoo-preview-pr-42",
                 }
 
-            idempotency_key = "odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123"
+            idempotency_key = plan_id
             with patch(
                 "control_plane.http_app.execute_odoo_preview_apply_result",
                 side_effect=blocking_apply,
@@ -1544,16 +1919,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = self._reservation_store(root)
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1577,7 +1950,12 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 "provider_effect_attempted": True,
                 "error_message": "Timed out waiting for Dokploy deployment status.",
             }
-            first_key = "odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:timeout"
+            first_key = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=_ready_odoo_preview_apply_payload(),
+                plan_id="odoo-preview-plan-timeout",
+            )
             with patch(
                 "control_plane.http_app.execute_odoo_preview_apply_result",
                 return_value=failed_result,
@@ -1594,22 +1972,20 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 )
                 second_plan["compose_ref"] = "compose-cm-pr-42-existing"
                 second_plan["environment_id"] = ""
+                second_key = self._store_issued_preview_plan(
+                    store=store,
+                    identity=identity,
+                    payload=second_payload,
+                    plan_id="odoo-preview-plan-second",
+                )
                 second_response = await _post_odoo_preview_apply(
                     app,
                     second_payload,
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:second",
+                    idempotency_key=second_key,
                 )
 
             reconcile_stored = store.read_idempotency_record(
-                scope=idempotency_scope(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
-                ),
+                scope=idempotency_scope(identity),
                 route_path="/v1/drivers/odoo/preview-apply",
                 idempotency_key=first_key,
             )
@@ -1630,15 +2006,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     idempotency_key=first_key,
                 )
             stored = store.read_idempotency_record(
-                scope=idempotency_scope(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
-                ),
+                scope=idempotency_scope(identity),
                 route_path="/v1/drivers/odoo/preview-apply",
                 idempotency_key=first_key,
             )
@@ -1669,16 +2037,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
             root = Path(temporary_directory_name)
             database_url = _sqlite_database_url(root / "launchplane.sqlite3")
             store = self._profile_store(database_url)
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1690,21 +2056,32 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 record_store_factory=lambda: store,
                 control_plane_root_path=root,
             )
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=_ready_odoo_preview_destroy_payload(),
+            )
 
-            with patch(
-                "control_plane.odoo_preview_apply_http.execute_odoo_preview_dokploy_apply",
-                return_value=OdooPreviewDokployApplyResult(
-                    status="pass",
-                    operation="destroy",
-                    product="odoo-tenant-cm",
-                    repository="cbusillo/odoo-tenant-cm",
-                    preview_slug="pr-42",
-                    preview_url="https://pr-42.cm-preview.example.test",
-                    domain_host="pr-42.cm-preview.example.test",
-                    compose_id="compose-cm-pr-42",
-                    compose_name="cm-odoo-preview-pr-42",
+            with (
+                patch(
+                    "control_plane.odoo_preview_apply_http.refresh_odoo_preview_issued_plan",
+                    side_effect=lambda **kwargs: kwargs["request"],
                 ),
-            ) as apply_driver:
+                patch(
+                    "control_plane.odoo_preview_apply_http.execute_odoo_preview_dokploy_apply",
+                    return_value=OdooPreviewDokployApplyResult(
+                        status="pass",
+                        operation="destroy",
+                        product="odoo-tenant-cm",
+                        repository="cbusillo/odoo-tenant-cm",
+                        preview_slug="pr-42",
+                        preview_url="https://pr-42.cm-preview.example.test",
+                        domain_host="pr-42.cm-preview.example.test",
+                        compose_id="compose-cm-pr-42",
+                        compose_name="cm-odoo-preview-pr-42",
+                    ),
+                ) as apply_driver,
+            ):
                 response = await _post_odoo_preview_apply(
                     app,
                     {
@@ -1727,7 +2104,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             "smoke_check": False,
                         },
                     },
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:destroy:abc123",
+                    idempotency_key=plan_id,
                 )
 
         self.assertEqual(response.status_code, 202)
@@ -1741,16 +2118,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = self._reservation_store(root)
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1785,6 +2160,11 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                     "smoke_check": False,
                 },
             }
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=payload,
+            )
 
             with patch(
                 "control_plane.http_app.execute_odoo_preview_apply_result",
@@ -1815,12 +2195,12 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 first_response = await _post_odoo_preview_apply(
                     app,
                     payload,
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123",
+                    idempotency_key=plan_id,
                 )
                 second_response = await _post_odoo_preview_apply(
                     app,
                     payload,
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123",
+                    idempotency_key=plan_id,
                 )
 
         self.assertEqual(first_response.status_code, 202)
@@ -1833,16 +2213,14 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = self._reservation_store(root)
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1881,6 +2259,11 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
             cast(dict[str, object], changed_payload["apply"])["image_reference"] = (
                 "ghcr.io/cbusillo/odoo-tenant-cm@sha256:def456"
             )
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=payload,
+            )
 
             with patch(
                 "control_plane.http_app.execute_odoo_preview_apply_result",
@@ -1898,17 +2281,17 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 first_response = await _post_odoo_preview_apply(
                     app,
                     payload,
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123",
+                    idempotency_key=plan_id,
                 )
                 second_response = await _post_odoo_preview_apply(
                     app,
                     payload,
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123",
+                    idempotency_key=plan_id,
                 )
                 conflict_response = await _post_odoo_preview_apply(
                     app,
                     changed_payload,
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:abc123",
+                    idempotency_key=plan_id,
                 )
 
         self.assertEqual(first_response.status_code, 202)
@@ -1917,23 +2300,21 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(second_response.json()["replayed"], True)
         self.assertEqual(second_response.json()["result"]["status"], "pass")
         self.assertEqual(conflict_response.status_code, 409)
-        self.assertEqual(conflict_response.json()["error"]["code"], "idempotency_key_reused")
+        self.assertEqual(conflict_response.json()["error"]["code"], "odoo_preview_plan_mismatch")
         apply_driver.assert_called_once()
 
     async def test_odoo_preview_apply_handler_file_miss_is_not_found(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)
             store = self._reservation_store(root)
-            app = create_launchplane_fastapi_app(
-                verifier=_StubVerifier(
-                    self._identity(
-                        repository="cbusillo/launchplane",
-                        workflow_ref=(
-                            "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
-                            "@refs/heads/main"
-                        ),
-                    )
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
                 ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
                 authz_policy=self._policy(
                     actions=("odoo_preview_apply.execute",),
                     repository="cbusillo/launchplane",
@@ -1944,6 +2325,11 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                 ),
                 record_store_factory=lambda: store,
                 control_plane_root_path=root,
+            )
+            plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=_ready_odoo_preview_apply_payload(),
             )
 
             with patch(
@@ -1973,7 +2359,7 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
                             "image_reference": "ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
                         },
                     },
-                    idempotency_key="odoo-preview-apply:odoo-tenant-cm:pr-42:refresh:file-miss",
+                    idempotency_key=plan_id,
                 )
 
         self.assertEqual(response.status_code, 404)

--- a/tests/test_odoo_preview_request_client_action.py
+++ b/tests/test_odoo_preview_request_client_action.py
@@ -202,6 +202,7 @@ console.log(Object.keys(client).sort().join(','));
                     "OPERATION": "destroy",
                     "PR-NUMBER": "42",
                     "DRY-RUN-PLAN-FILE": "/tmp/destroy-dry-run.json",
+                    "PLAN-ID": "odoo-preview-plan-test",
                     "WAIT-FOR-DEPLOY": "false",
                     "SMOKE-CHECK": "false",
                     "RUN-ID": "456",
@@ -217,10 +218,7 @@ console.log(Object.keys(client).sort().join(','));
             )
             self.assertEqual(outputs["fail-result-paths"], "result.status")
             self.assertEqual(outputs["response-output-path"], "")
-            self.assertEqual(
-                outputs["idempotency-key"],
-                "odoo-preview-apply:odoo-tenant-cm-website:pr-42:destroy:run-456-attempt-2",
-            )
+            self.assertEqual(outputs["idempotency-key"], "odoo-preview-plan-test")
             self.assertEqual(
                 json.loads(outputs["payload"])["apply"],
                 {"timeout_seconds": 600, "wait_for_deploy": False, "smoke_check": False},
@@ -242,6 +240,7 @@ console.log(Object.keys(client).sort().join(','));
                     "PREVIEW-SLUG": "preview-42",
                     "SOURCE-GIT-REF": "abc123",
                     "DRY-RUN-PLAN-FILE": "/tmp/dry-run.json",
+                    "PLAN-ID": "odoo-preview-plan-test",
                     "MANIFEST-FILE": "/tmp/preview-artifact.json",
                     "RUN-ID": "456",
                     "RUN-ATTEMPT": "2",
@@ -257,10 +256,7 @@ console.log(Object.keys(client).sort().join(','));
             )
             self.assertEqual(outputs["fail-result-paths"], "result.status")
             self.assertEqual(outputs["response-output-path"], "")
-            self.assertEqual(
-                outputs["idempotency-key"],
-                "odoo-preview-apply:odoo-tenant-cm-website:preview-42:refresh:run-456-attempt-2",
-            )
+            self.assertEqual(outputs["idempotency-key"], "odoo-preview-plan-test")
             self.assertEqual(
                 json.loads(outputs["payload"]),
                 {
@@ -415,6 +411,7 @@ const apply = client.buildOdooPreviewApplyRequest({
   operation: 'destroy',
   prNumber: 42,
   dryRunPlanFile: '/tmp/dry-run.json',
+  planId: 'odoo-preview-plan-test',
   runId: '456',
   runAttempt: '2',
 });
@@ -433,10 +430,7 @@ console.log(JSON.stringify({ inputs, apply }));
             payload["apply"]["payloadJsonFiles"], {"apply.dry_run_plan": "/tmp/dry-run.json"}
         )
         self.assertNotIn("smoke_check", payload["apply"]["payload"]["apply"])
-        self.assertEqual(
-            payload["apply"]["idempotencyKey"],
-            "odoo-preview-apply:odoo-tenant-cm-website:pr-42:destroy:run-456-attempt-2",
-        )
+        self.assertEqual(payload["apply"]["idempotencyKey"], "odoo-preview-plan-test")
 
     def test_client_preserves_manual_apply_boolean_overrides(self) -> None:
         with TemporaryDirectory() as temporary_directory:
@@ -454,6 +448,7 @@ const request = client.buildOdooPreviewApplyRequest({
   prNumber: 42,
   sourceGitRef: 'abc123',
   dryRunPlanFile: '/tmp/dry-run.json',
+  planId: 'odoo-preview-plan-test',
   manifestFile: '/tmp/preview-artifact.json',
   waitForDeploy: 'false',
   smokeCheck: 'true',
@@ -490,6 +485,7 @@ const request = client.buildOdooPreviewApplyRequest({
   prNumber: 42,
   sourceGitRef: 'abc123',
   dryRunPlanFile: '/tmp/dry-run.json',
+  planId: 'odoo-preview-plan-test',
   manifestFile: '/tmp/preview-artifact.json',
   runId: '456',
   runAttempt: '2',
@@ -524,6 +520,7 @@ client.buildOdooPreviewApplyRequest({
   prNumber: 42,
   sourceGitRef: 'abc123',
   dryRunPlanFile: '/tmp/dry-run.json',
+  planId: 'odoo-preview-plan-test',
   manifestFile: '/tmp/preview-artifact.json',
   waitForDeploy: 'sometimes',
   runId: '456',
@@ -564,6 +561,7 @@ client.buildOdooPreviewApplyRequest({
   prNumber: 42,
   sourceGitRef: 'abc123',
   dryRunPlanFile: '/tmp/dry-run.json',
+  planId: 'odoo-preview-plan-test',
   runId: '456',
   runAttempt: '2',
 });

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -488,6 +488,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         request = build_odoo_preview_apply_workflow_request(
             facts=_workflow_facts(),
             dry_run_plan_file="/tmp/dry-run.json",
+            plan_id="odoo-preview-plan-test",
             manifest_file="/tmp/preview-artifact.json",
         )
 
@@ -510,15 +511,13 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
                 "apply.manifest": "/tmp/preview-artifact.json",
             },
         )
-        self.assertEqual(
-            request.idempotency_key,
-            "odoo-preview-apply:odoo-tenant-cm-website:pr-42:refresh:run-456-attempt-2",
-        )
+        self.assertEqual(request.idempotency_key, "odoo-preview-plan-test")
 
     def test_preview_apply_workflow_request_accepts_manual_apply_overrides(self) -> None:
         request = build_odoo_preview_apply_workflow_request(
             facts=_workflow_facts(),
             dry_run_plan_file="/tmp/dry-run.json",
+            plan_id="odoo-preview-plan-test",
             manifest_file="/tmp/preview-artifact.json",
             wait_for_deploy=False,
             smoke_check=True,
@@ -533,6 +532,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         request = build_odoo_preview_apply_workflow_request(
             facts=_workflow_facts(),
             dry_run_plan_file="/tmp/dry-run.json",
+            plan_id="odoo-preview-plan-test",
             manifest_file="/tmp/preview-artifact.json",
             smoke_check=False,
         )
@@ -545,6 +545,7 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         request = build_odoo_preview_apply_workflow_request(
             facts=_workflow_facts(operation="destroy"),
             dry_run_plan_file="/tmp/destroy-dry-run.json",
+            plan_id="odoo-preview-plan-test",
         )
 
         self.assertEqual(
@@ -553,16 +554,14 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         apply = cast(dict[str, object], request.payload["apply"])
         self.assertIsInstance(apply, dict)
         self.assertNotIn("smoke_check", apply)
-        self.assertEqual(
-            request.idempotency_key,
-            "odoo-preview-apply:odoo-tenant-cm-website:pr-42:destroy:run-456-attempt-2",
-        )
+        self.assertEqual(request.idempotency_key, "odoo-preview-plan-test")
 
     def test_refresh_preview_apply_request_requires_manifest(self) -> None:
         with self.assertRaisesRegex(ValueError, "requires manifest_file"):
             build_odoo_preview_apply_workflow_request(
                 facts=_workflow_facts(),
                 dry_run_plan_file="/tmp/dry-run.json",
+                plan_id="odoo-preview-plan-test",
             )
 
     def test_preview_apply_workflow_request_requires_dry_run_plan_file(self) -> None:
@@ -570,6 +569,16 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
             build_odoo_preview_apply_workflow_request(
                 facts=_workflow_facts(),
                 dry_run_plan_file=" ",
+                plan_id="odoo-preview-plan-test",
+                manifest_file="/tmp/preview-artifact.json",
+            )
+
+    def test_preview_apply_workflow_request_requires_plan_id(self) -> None:
+        with self.assertRaisesRegex(ValueError, "requires plan_id"):
+            build_odoo_preview_apply_workflow_request(
+                facts=_workflow_facts(),
+                dry_run_plan_file="/tmp/dry-run.json",
+                plan_id=" ",
                 manifest_file="/tmp/preview-artifact.json",
             )
 

--- a/tests/test_product_onboarding.py
+++ b/tests/test_product_onboarding.py
@@ -1259,7 +1259,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertEqual(workflow_text.count("          request-kind: preview-apply\n"), 2)
         self.assertIn("steps.publish_inputs_request.outputs.route-path", workflow_text)
         self.assertIn("steps.dry_run_request.outputs.payload-json-files", workflow_text)
-        self.assertIn("steps.launchplane_request.outputs.idempotency-key", workflow_text)
+        self.assertIn("idempotency-key: ${{ steps.dry_run.outputs.plan_id }}", workflow_text)
         self.assertIn("image_repository=result.image_repository", workflow_text)
         self.assertIn("preview_slug=result.preview_slug", workflow_text)
         self.assertIn("refresh_image_reference", workflow_text)
@@ -1311,6 +1311,12 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertNotIn("odoo-preview-apply:", workflow_text)
         self.assertNotIn("odoo-preview-apply-inputs:", workflow_text)
         self.assertNotIn("odoo-artifact-publish-inputs:", workflow_text)
+        self.assertIn("plan-id: ${{ steps.dry_run.outputs.plan_id }}", workflow_text)
+        self.assertIn("plan_id=result.plan_provenance.plan_id", workflow_text)
+        self.assertEqual(
+            workflow_text.count("idempotency-key: ${{ steps.dry_run.outputs.plan_id }}"),
+            2,
+        )
         self.assertNotIn("disable_odoo_online", workflow_text)
         self.assertNotIn("devkit_repository:", workflow_text)
         self.assertNotIn("shared_addons_repository:", workflow_text)
@@ -1366,7 +1372,7 @@ class ProductOnboardingTests(unittest.TestCase):
         self.assertIn("/v1/drivers/odoo/preview-apply-inputs", workflow_text)
         self.assertIn("/v1/drivers/odoo/preview-apply", workflow_text)
         self.assertIn("/v1/previews/pr-feedback", workflow_text)
-        self.assertIn("expected-status: 202,403,503", workflow_text)
+        self.assertIn("expected-status: 202,403,409,503", workflow_text)
         self.assertIn('expected-status: "202"', workflow_text)
         self.assertEqual(workflow_text.count('timeout-ms: "30000"'), 3)
         self.assertIn(


### PR DESCRIPTION
## Summary
- persist ready Odoo preview apply-inputs as identity-scoped issued-plan evidence with a canonical fingerprint and 30-minute expiry
- require the service-issued plan id as the apply idempotency key, validate exact routing/artifact continuity, and recompute current authority before a fresh provider effect
- preserve completed replay and reconciliation semantics, update the reusable workflow/request client, and document the provenance contract

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (2,116 targets)
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- changed-file `ruff format --check`
- `pnpm --dir frontend check:openapi-drift`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains changed-files inspection: clean

## Notes
- Repository-wide `ruff format --check .` still reports 32 pre-existing unrelated files; all files changed by this PR pass formatting.

Closes #1668