### PR TITLE
Enforce instance-aware driver authorization

### DIFF
--- a/control_plane/agent_context_service.py
+++ b/control_plane/agent_context_service.py
@@ -12,7 +12,11 @@ from control_plane.contracts.preview_readiness_read_model import (
     build_preview_readiness_read_model,
 )
 from control_plane.contracts.product_environment_read_model import ActionAllowed
-from control_plane.service_auth import LaunchplaneAuthzPolicy, LaunchplaneIdentity
+from control_plane.service_auth import (
+    AuthorizationTarget,
+    LaunchplaneAuthzPolicy,
+    LaunchplaneIdentity,
+)
 from control_plane.work_graph_service import (
     WorkGraphPlanningFactsProvider,
     WorkGraphWorkRequestStore,
@@ -122,18 +126,29 @@ def agent_context_allowed(
         action="product_environment.read",
         product="launchplane",
         context=LAUNCHPLANE_SERVICE_CONTEXT,
+        target=AuthorizationTarget(scope="context"),
     )
 
 
 def agent_context_action_allowed(
     *, authz_policy: LaunchplaneAuthzPolicy, identity: LaunchplaneIdentity
 ) -> ActionAllowed:
-    def action_allowed(requested_action: str, requested_product: str, requested_context: str) -> bool:
+    def action_allowed(
+        requested_action: str,
+        requested_product: str,
+        requested_context: str,
+        requested_instances: tuple[str, ...],
+    ) -> bool:
         return authz_policy.allows(
             identity=identity,
             action=requested_action,
             product=requested_product,
             context=requested_context,
+            target=(
+                AuthorizationTarget(scope="instance", instances=requested_instances)
+                if requested_instances
+                else AuthorizationTarget(scope="context")
+            ),
         )
 
     return action_allowed

--- a/control_plane/authz_grant_service.py
+++ b/control_plane/authz_grant_service.py
@@ -3,14 +3,20 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Literal, Protocol
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
+from control_plane.authz_scope import (
+    exclusively_instance_scoped_authz_actions,
+    instance_scoped_authz_actions,
+)
 from control_plane.contracts.authz_policy_record import (
     LaunchplaneAuthzPolicyRecord,
     authz_policy_sha256,
     build_authz_policy_record_id,
 )
 from control_plane.service_auth import (
+    AuthzInstanceSelectors,
+    AuthzPolicySchemaVersion,
     GitHubActionsIdentity,
     GitHubActionsPolicyRule,
     GitHubHumanPolicyRule,
@@ -27,6 +33,28 @@ from control_plane.service_auth import (
 
 
 TimestampProvider = Callable[[], str]
+
+
+def _validate_instance_scoped_grant(
+    *,
+    schema_version: AuthzPolicySchemaVersion,
+    actions: tuple[str, ...],
+    instances: tuple[str, ...],
+) -> None:
+    if schema_version == 1:
+        if instances:
+            raise ValueError("Schema-v1 authz grants cannot declare instances.")
+        return
+    requested_actions = set(actions)
+    instance_actions = instance_scoped_authz_actions()
+    exclusively_instance_actions = exclusively_instance_scoped_authz_actions()
+    if requested_actions & exclusively_instance_actions and not instances:
+        raise ValueError("Schema-v2 instance-scoped authz grants require instances.")
+    non_instance_actions = requested_actions - instance_actions
+    if instances and non_instance_actions:
+        raise ValueError(
+            "Schema-v2 authz grants can only declare instances for instance-scoped actions."
+        )
 
 
 class AuthzPolicyRecordStore(Protocol):
@@ -51,6 +79,7 @@ class AuthzPolicyGitHubActionsGrant(BaseModel):
     environments: tuple[str, ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...]
     source_label: str = "service:authz-policy-grant"
 
@@ -70,6 +99,7 @@ class AuthzPolicyGitHubActionsGrant(BaseModel):
         self.environments = self._normalized_tuple(self.environments)
         self.products = self._normalized_tuple(self.products)
         self.contexts = self._normalized_tuple(self.contexts)
+        self.instances = self._normalized_tuple(self.instances)
         self.actions = self._normalized_tuple(self.actions)
         if not self.actions:
             raise ValueError("Authz policy grant requires at least one action.")
@@ -86,6 +116,7 @@ class AuthzPolicyGitHubActionsGrant(BaseModel):
             environments=self.environments,
             products=self.products,
             contexts=self.contexts,
+            instances=self.instances,
             actions=self.actions,
         )
 
@@ -93,7 +124,7 @@ class AuthzPolicyGitHubActionsGrant(BaseModel):
 class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(default=1, ge=1)
+    schema_version: AuthzPolicySchemaVersion = 1
     product: str
     mode: Literal["dry_run", "apply"] = "apply"
     reason: str = ""
@@ -109,13 +140,18 @@ class AuthzPolicyGitHubActionsGrantEnvelope(BaseModel):
         self.related_issue = self.related_issue.strip()
         if self.mode == "apply" and not self.reason:
             raise ValueError("Authz policy grant apply requires reason.")
+        _validate_instance_scoped_grant(
+            schema_version=self.schema_version,
+            actions=self.grant.actions,
+            instances=self.grant.instances,
+        )
         return self
 
 
 class AuthzPolicyGitHubActionsRemovalEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(default=1, ge=1)
+    schema_version: AuthzPolicySchemaVersion = 1
     product: str
     mode: Literal["dry_run", "apply"] = "dry_run"
     reason: str = ""
@@ -131,6 +167,11 @@ class AuthzPolicyGitHubActionsRemovalEnvelope(BaseModel):
         self.related_issue = self.related_issue.strip()
         if self.mode == "apply" and not self.reason:
             raise ValueError("Authz policy removal apply requires reason.")
+        _validate_instance_scoped_grant(
+            schema_version=self.schema_version,
+            actions=self.removal.actions,
+            instances=self.removal.instances,
+        )
         return self
 
 
@@ -143,6 +184,7 @@ class AuthzPolicyGitHubHumanGrant(BaseModel):
     roles: tuple[Literal["read_only", "admin"], ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...]
     source_label: str = "service:authz-human-policy-grant"
 
@@ -157,6 +199,7 @@ class AuthzPolicyGitHubHumanGrant(BaseModel):
         self.teams = self._normalized_tuple(self.teams)
         self.products = self._normalized_tuple(self.products)
         self.contexts = self._normalized_tuple(self.contexts)
+        self.instances = self._normalized_tuple(self.instances)
         self.actions = self._normalized_tuple(self.actions)
         if not (self.logins or self.organizations or self.teams):
             raise ValueError("Authz human policy grant requires a login, organization, or team.")
@@ -173,6 +216,7 @@ class AuthzPolicyGitHubHumanGrant(BaseModel):
             roles=self.roles,
             products=self.products,
             contexts=self.contexts,
+            instances=self.instances,
             actions=self.actions,
         )
 
@@ -180,7 +224,7 @@ class AuthzPolicyGitHubHumanGrant(BaseModel):
 class AuthzPolicyGitHubHumanGrantEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(default=1, ge=1)
+    schema_version: AuthzPolicySchemaVersion = 1
     product: str
     mode: Literal["dry_run", "apply"] = "apply"
     reason: str = ""
@@ -196,6 +240,11 @@ class AuthzPolicyGitHubHumanGrantEnvelope(BaseModel):
         self.related_issue = self.related_issue.strip()
         if self.mode == "apply" and not self.reason:
             raise ValueError("Authz human policy grant apply requires reason.")
+        _validate_instance_scoped_grant(
+            schema_version=self.schema_version,
+            actions=self.grant.actions,
+            instances=self.grant.instances,
+        )
         return self
 
 
@@ -206,6 +255,7 @@ class AuthzPolicyTerminalAgentGrant(BaseModel):
     token_labels: tuple[str, ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...]
     source_label: str = "service:authz-terminal-agent-policy-grant"
 
@@ -219,6 +269,7 @@ class AuthzPolicyTerminalAgentGrant(BaseModel):
         self.token_labels = self._normalized_tuple(self.token_labels)
         self.products = self._normalized_tuple(self.products)
         self.contexts = self._normalized_tuple(self.contexts)
+        self.instances = self._normalized_tuple(self.instances)
         self.actions = self._normalized_tuple(self.actions)
         if not self.subjects:
             raise ValueError("Authz terminal-agent policy grant requires a subject.")
@@ -235,6 +286,7 @@ class AuthzPolicyTerminalAgentGrant(BaseModel):
             token_labels=self.token_labels,
             products=self.products,
             contexts=self.contexts,
+            instances=self.instances,
             actions=self.actions,
         )
 
@@ -242,7 +294,7 @@ class AuthzPolicyTerminalAgentGrant(BaseModel):
 class AuthzPolicyTerminalAgentGrantEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(default=1, ge=1)
+    schema_version: AuthzPolicySchemaVersion = 1
     product: str
     mode: Literal["dry_run", "apply"] = "apply"
     reason: str = ""
@@ -260,6 +312,11 @@ class AuthzPolicyTerminalAgentGrantEnvelope(BaseModel):
         self.related_issue = self.related_issue.strip()
         if self.mode == "apply" and not self.reason:
             raise ValueError("Authz terminal-agent policy grant apply requires reason.")
+        _validate_instance_scoped_grant(
+            schema_version=self.schema_version,
+            actions=self.grant.actions,
+            instances=self.grant.instances,
+        )
         return self
 
 
@@ -270,6 +327,7 @@ class AuthzPolicyLocalOperatorGrant(BaseModel):
     token_labels: tuple[str, ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...]
     source_label: str = "service:authz-local-operator-policy-grant"
 
@@ -283,6 +341,7 @@ class AuthzPolicyLocalOperatorGrant(BaseModel):
         self.token_labels = self._normalized_tuple(self.token_labels)
         self.products = self._normalized_tuple(self.products)
         self.contexts = self._normalized_tuple(self.contexts)
+        self.instances = self._normalized_tuple(self.instances)
         self.actions = self._normalized_tuple(self.actions)
         if not self.subjects:
             raise ValueError("Authz local-operator policy grant requires a subject.")
@@ -299,6 +358,7 @@ class AuthzPolicyLocalOperatorGrant(BaseModel):
             token_labels=self.token_labels,
             products=self.products,
             contexts=self.contexts,
+            instances=self.instances,
             actions=self.actions,
         )
 
@@ -306,7 +366,7 @@ class AuthzPolicyLocalOperatorGrant(BaseModel):
 class AuthzPolicyLocalOperatorGrantEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(default=1, ge=1)
+    schema_version: AuthzPolicySchemaVersion = 1
     product: str
     mode: Literal["dry_run", "apply"] = "apply"
     reason: str = ""
@@ -324,6 +384,11 @@ class AuthzPolicyLocalOperatorGrantEnvelope(BaseModel):
         self.related_issue = self.related_issue.strip()
         if self.mode == "apply" and not self.reason:
             raise ValueError("Authz local-operator policy grant apply requires reason.")
+        _validate_instance_scoped_grant(
+            schema_version=self.schema_version,
+            actions=self.grant.actions,
+            instances=self.grant.instances,
+        )
         return self
 
 
@@ -334,6 +399,7 @@ class AuthzPolicyLocalAdminGrant(BaseModel):
     token_labels: tuple[str, ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...]
     source_label: str = "service:authz-local-admin-policy-grant"
 
@@ -347,6 +413,7 @@ class AuthzPolicyLocalAdminGrant(BaseModel):
         self.token_labels = self._normalized_tuple(self.token_labels)
         self.products = self._normalized_tuple(self.products)
         self.contexts = self._normalized_tuple(self.contexts)
+        self.instances = self._normalized_tuple(self.instances)
         self.actions = self._normalized_tuple(self.actions)
         if not self.subjects:
             raise ValueError("Authz local-admin policy grant requires a subject.")
@@ -363,6 +430,7 @@ class AuthzPolicyLocalAdminGrant(BaseModel):
             token_labels=self.token_labels,
             products=self.products,
             contexts=self.contexts,
+            instances=self.instances,
             actions=self.actions,
         )
 
@@ -370,7 +438,7 @@ class AuthzPolicyLocalAdminGrant(BaseModel):
 class AuthzPolicyLocalAdminGrantEnvelope(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(default=1, ge=1)
+    schema_version: AuthzPolicySchemaVersion = 1
     product: str
     mode: Literal["dry_run", "apply"] = "apply"
     reason: str = ""
@@ -386,6 +454,11 @@ class AuthzPolicyLocalAdminGrantEnvelope(BaseModel):
         self.related_issue = self.related_issue.strip()
         if self.mode == "apply" and not self.reason:
             raise ValueError("Authz local-admin policy grant apply requires reason.")
+        _validate_instance_scoped_grant(
+            schema_version=self.schema_version,
+            actions=self.grant.actions,
+            instances=self.grant.instances,
+        )
         return self
 
 
@@ -609,6 +682,7 @@ def authz_policy_grant_response_audit_payload(
                 "event_names": requested_grant.get("event_names") or (),
                 "products": requested_grant.get("products") or (),
                 "contexts": requested_grant.get("contexts") or (),
+                "instances": requested_grant.get("instances") or (),
                 "actions": requested_grant.get("actions") or (),
             }
         elif "subjects" in requested_grant or "token_labels" in requested_grant:
@@ -619,6 +693,7 @@ def authz_policy_grant_response_audit_payload(
                 "token_label_count": len(requested_grant.get("token_labels") or ()),
                 "products": requested_grant.get("products") or (),
                 "contexts": requested_grant.get("contexts") or (),
+                "instances": requested_grant.get("instances") or (),
                 "actions": requested_grant.get("actions") or (),
             }
         else:
@@ -630,6 +705,7 @@ def authz_policy_grant_response_audit_payload(
                 "roles": requested_grant.get("roles") or (),
                 "products": requested_grant.get("products") or (),
                 "contexts": requested_grant.get("contexts") or (),
+                "instances": requested_grant.get("instances") or (),
                 "actions": requested_grant.get("actions") or (),
             }
     return response_audit
@@ -649,6 +725,7 @@ def authz_policy_github_actions_removal_response_audit_payload(
             "event_names": requested_removal.get("event_names") or (),
             "products": requested_removal.get("products") or (),
             "contexts": requested_removal.get("contexts") or (),
+            "instances": requested_removal.get("instances") or (),
             "actions": requested_removal.get("actions") or (),
         }
     return response_audit
@@ -1264,6 +1341,14 @@ def execute_authz_policy_route(
     trace_id: str,
     now_timestamp: TimestampProvider,
 ) -> AuthzPolicyRouteResult:
+    active_records = record_store.list_authz_policy_records(status="active", limit=1)
+    if not active_records:
+        raise ValueError("No active Launchplane authz policy record found.")
+    active_schema_version = active_records[0].policy.schema_version
+    if request.schema_version != active_schema_version:
+        raise ValueError(
+            "Authz policy request schema_version must match the active policy schema_version."
+        )
     write_result: (
         tuple[
             LaunchplaneAuthzPolicy,

--- a/control_plane/authz_scope.py
+++ b/control_plane/authz_scope.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+
+_NON_DESCRIPTOR_INSTANCE_SCOPED_AUTHZ_ACTIONS = frozenset(
+    {
+        "backup_gate.write",
+        "deployment.read",
+        "inventory.read",
+        "promotion.write",
+        "promotion.read",
+        "target_logs.read",
+    }
+)
+_DUAL_SCOPE_AUTHZ_ACTIONS = frozenset(
+    {
+        "driver.read",
+        "operations.read",
+        "product_config.apply",
+        "product_config.plan",
+        "product_environment.read",
+        "secret.list",
+        "secret.read",
+    }
+)
+
+
+@lru_cache(maxsize=1)
+def instance_scoped_authz_actions() -> frozenset[str]:
+    from control_plane.drivers.registry import instance_scoped_driver_authz_actions
+
+    return (
+        instance_scoped_driver_authz_actions()
+        | _NON_DESCRIPTOR_INSTANCE_SCOPED_AUTHZ_ACTIONS
+        | _DUAL_SCOPE_AUTHZ_ACTIONS
+    )
+
+
+@lru_cache(maxsize=1)
+def exclusively_instance_scoped_authz_actions() -> frozenset[str]:
+    return instance_scoped_authz_actions() - _DUAL_SCOPE_AUTHZ_ACTIONS

--- a/control_plane/cli_policy_profiles.py
+++ b/control_plane/cli_policy_profiles.py
@@ -374,6 +374,13 @@ def authz_policies_import_toml(
     default="",
     help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
 )
+@click.option(
+    "--schema-version",
+    type=click.IntRange(1, 2),
+    default=1,
+    show_default=True,
+    help="Grant contract version. Use 2 only after the active policy is migrated to schema v2.",
+)
 @click.option("--repository", required=True, help="GitHub owner/repo grant target.")
 @click.option(
     "--workflow-ref", "workflow_refs", multiple=True, help="Allowed workflow_ref pattern."
@@ -389,6 +396,7 @@ def authz_policies_import_toml(
 @click.option("--environment", "environments", multiple=True, help="Allowed GitHub environment.")
 @click.option("--product", "products", multiple=True, required=True, help="Allowed product.")
 @click.option("--context", "contexts", multiple=True, help="Allowed Launchplane context.")
+@click.option("--instance", "instances", multiple=True, help="Allowed Launchplane instance.")
 @click.option(
     "--action", "actions", multiple=True, required=True, help="Allowed Launchplane action."
 )
@@ -408,6 +416,7 @@ def authz_policies_grant_workflow(
     service_url: str,
     bearer_token_env: str,
     session_cookie: str,
+    schema_version: int,
     repository: str,
     workflow_refs: tuple[str, ...],
     job_workflow_refs: tuple[str, ...],
@@ -416,6 +425,7 @@ def authz_policies_grant_workflow(
     environments: tuple[str, ...],
     products: tuple[str, ...],
     contexts: tuple[str, ...],
+    instances: tuple[str, ...],
     actions: tuple[str, ...],
     reason: str,
     related_issue: str,
@@ -432,7 +442,7 @@ def authz_policies_grant_workflow(
                 f"{token_env_key} is required unless --session-cookie is provided."
             )
     payload = {
-        "schema_version": 1,
+        "schema_version": schema_version,
         "product": "launchplane",
         "mode": mode,
         "reason": reason,
@@ -446,6 +456,7 @@ def authz_policies_grant_workflow(
             "environments": list(environments),
             "products": list(products),
             "contexts": list(contexts),
+            "instances": list(instances),
             "actions": list(actions),
             "source_label": source_label,
         },
@@ -478,6 +489,13 @@ def authz_policies_grant_workflow(
     default="",
     help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
 )
+@click.option(
+    "--schema-version",
+    type=click.IntRange(1, 2),
+    default=1,
+    show_default=True,
+    help="Removal contract version. Use 2 only after the active policy is migrated to schema v2.",
+)
 @click.option("--repository", required=True, help="GitHub owner/repo rule target.")
 @click.option("--workflow-ref", "workflow_refs", multiple=True, help="Exact workflow_ref pattern.")
 @click.option(
@@ -491,6 +509,7 @@ def authz_policies_grant_workflow(
 @click.option("--environment", "environments", multiple=True, help="Exact GitHub environment.")
 @click.option("--product", "products", multiple=True, required=True, help="Exact product.")
 @click.option("--context", "contexts", multiple=True, help="Exact Launchplane context.")
+@click.option("--instance", "instances", multiple=True, help="Exact Launchplane instance.")
 @click.option("--action", "actions", multiple=True, required=True, help="Exact Launchplane action.")
 @click.option("--reason", default="", help="Required audit reason when --apply is used.")
 @click.option(
@@ -508,6 +527,7 @@ def authz_policies_remove_workflow_rule(
     service_url: str,
     bearer_token_env: str,
     session_cookie: str,
+    schema_version: int,
     repository: str,
     workflow_refs: tuple[str, ...],
     job_workflow_refs: tuple[str, ...],
@@ -516,6 +536,7 @@ def authz_policies_remove_workflow_rule(
     environments: tuple[str, ...],
     products: tuple[str, ...],
     contexts: tuple[str, ...],
+    instances: tuple[str, ...],
     actions: tuple[str, ...],
     reason: str,
     related_issue: str,
@@ -532,7 +553,7 @@ def authz_policies_remove_workflow_rule(
                 f"{token_env_key} is required unless --session-cookie is provided."
             )
     payload = {
-        "schema_version": 1,
+        "schema_version": schema_version,
         "product": "launchplane",
         "mode": mode,
         "reason": reason,
@@ -546,6 +567,7 @@ def authz_policies_remove_workflow_rule(
             "environments": list(environments),
             "products": list(products),
             "contexts": list(contexts),
+            "instances": list(instances),
             "actions": list(actions),
             "source_label": source_label,
         },
@@ -578,6 +600,13 @@ def authz_policies_remove_workflow_rule(
     default="",
     help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
 )
+@click.option(
+    "--schema-version",
+    type=click.IntRange(1, 2),
+    default=1,
+    show_default=True,
+    help="Grant contract version. Use 2 only after the active policy is migrated to schema v2.",
+)
 @click.option("--login", "logins", multiple=True, help="Allowed GitHub login.")
 @click.option("--organization", "organizations", multiple=True, help="Allowed GitHub organization.")
 @click.option("--team", "teams", multiple=True, help="Allowed GitHub team.")
@@ -590,6 +619,7 @@ def authz_policies_remove_workflow_rule(
 )
 @click.option("--product", "products", multiple=True, required=True, help="Allowed product.")
 @click.option("--context", "contexts", multiple=True, help="Allowed Launchplane context.")
+@click.option("--instance", "instances", multiple=True, help="Allowed Launchplane instance.")
 @click.option(
     "--action", "actions", multiple=True, required=True, help="Allowed Launchplane action."
 )
@@ -609,12 +639,14 @@ def authz_policies_grant_human(
     service_url: str,
     bearer_token_env: str,
     session_cookie: str,
+    schema_version: int,
     logins: tuple[str, ...],
     organizations: tuple[str, ...],
     teams: tuple[str, ...],
     roles: tuple[str, ...],
     products: tuple[str, ...],
     contexts: tuple[str, ...],
+    instances: tuple[str, ...],
     actions: tuple[str, ...],
     reason: str,
     related_issue: str,
@@ -631,7 +663,7 @@ def authz_policies_grant_human(
                 f"{token_env_key} is required unless --session-cookie is provided."
             )
     payload = {
-        "schema_version": 1,
+        "schema_version": schema_version,
         "product": "launchplane",
         "mode": mode,
         "reason": reason,
@@ -643,6 +675,7 @@ def authz_policies_grant_human(
             "roles": list(roles),
             "products": list(products),
             "contexts": list(contexts),
+            "instances": list(instances),
             "actions": list(actions),
             "source_label": source_label,
         },
@@ -676,6 +709,13 @@ def authz_policies_grant_human(
     help="Launchplane browser session cookie. Use instead of --bearer-token-env.",
 )
 @click.option(
+    "--schema-version",
+    type=click.IntRange(1, 2),
+    default=1,
+    show_default=True,
+    help="Grant contract version. Use 2 only after the active policy is migrated to schema v2.",
+)
+@click.option(
     "--subject", "subjects", multiple=True, required=True, help="Allowed terminal-agent subject."
 )
 @click.option(
@@ -687,6 +727,7 @@ def authz_policies_grant_human(
 )
 @click.option("--product", "products", multiple=True, required=True, help="Allowed product.")
 @click.option("--context", "contexts", multiple=True, help="Allowed Launchplane context.")
+@click.option("--instance", "instances", multiple=True, help="Allowed Launchplane instance.")
 @click.option(
     "--action", "actions", multiple=True, required=True, help="Allowed Launchplane action."
 )
@@ -706,10 +747,12 @@ def authz_policies_grant_terminal_agent(
     service_url: str,
     bearer_token_env: str,
     session_cookie: str,
+    schema_version: int,
     subjects: tuple[str, ...],
     token_labels: tuple[str, ...],
     products: tuple[str, ...],
     contexts: tuple[str, ...],
+    instances: tuple[str, ...],
     actions: tuple[str, ...],
     reason: str,
     related_issue: str,
@@ -726,7 +769,7 @@ def authz_policies_grant_terminal_agent(
                 f"{token_env_key} is required unless --session-cookie is provided."
             )
     payload = {
-        "schema_version": 1,
+        "schema_version": schema_version,
         "product": "launchplane",
         "mode": mode,
         "reason": reason,
@@ -736,6 +779,7 @@ def authz_policies_grant_terminal_agent(
             "token_labels": list(token_labels),
             "products": list(products),
             "contexts": list(contexts),
+            "instances": list(instances),
             "actions": list(actions),
             "source_label": source_label,
         },

--- a/control_plane/contracts/product_environment_read_model.py
+++ b/control_plane/contracts/product_environment_read_model.py
@@ -44,7 +44,7 @@ from control_plane.drivers.registry import (
 )
 
 
-ActionAllowed = Callable[[str, str, str], bool]
+ActionAllowed = Callable[[str, str, str, tuple[str, ...]], bool]
 ProductSecretBindingTrustState = FreshnessStatus | Literal["disabled"]
 ProductConfigItemStatus = Literal[
     "configured",
@@ -526,6 +526,7 @@ def build_product_site_overview(
         action_allowed=action_allowed,
         include_unsupported=True,
         context_resolver=_product_action_context_resolver(profile=profile),
+        instances_resolver=_product_action_instances_resolver(profile=profile),
     )
     warnings = tuple(warning for warning in (descriptor_warning,) if warning)
     trust_state = _combine_trust_states(
@@ -611,6 +612,7 @@ def build_product_environment_detail(
             action_allowed=action_allowed,
             include_unsupported=True,
             context_resolver=_lane_context_resolver(context=lane.context),
+            instances_resolver=_lane_instances_resolver(instance=lane.instance),
         ),
         warnings=warnings,
         trust_state=_combine_trust_states(
@@ -682,7 +684,12 @@ def build_product_environment_config_status(
     )
 
 
-def _deny_action(_action: str, _product: str, _context: str) -> bool:
+def _deny_action(
+    _action: str,
+    _product: str,
+    _context: str,
+    _instances: tuple[str, ...],
+) -> bool:
     return False
 
 
@@ -714,6 +721,7 @@ def _product_config_write_availability(
             input_kind="runtime_settings",
             product=profile.product,
             context=lane.context,
+            instance=lane.instance,
             route_path=route_path,
             confirmation_text=confirmation_text,
             base_blockers=runtime_reasons,
@@ -727,6 +735,7 @@ def _product_config_write_availability(
             input_kind="managed_secrets",
             product=profile.product,
             context=lane.context,
+            instance=lane.instance,
             route_path=route_path,
             confirmation_text=confirmation_text,
             base_blockers=secret_reasons,
@@ -767,6 +776,7 @@ def _product_config_input_write_availability(
     input_kind: ProductConfigInputKind,
     product: str,
     context: str,
+    instance: str,
     route_path: str,
     confirmation_text: str,
     base_blockers: tuple[str, ...],
@@ -775,9 +785,9 @@ def _product_config_input_write_availability(
 ) -> ProductConfigInputWriteAvailability:
     plan_blockers = list(base_blockers)
     apply_blockers = list(base_blockers)
-    if not action_allowed("product_config.plan", product, context):
+    if not action_allowed("product_config.plan", product, context, (instance,)):
         plan_blockers.append("Caller is not authorized to plan product configuration.")
-    if not action_allowed("product_config.apply", product, context):
+    if not action_allowed("product_config.apply", product, context, (instance,)):
         apply_blockers.append("Caller is not authorized to apply product configuration.")
     return ProductConfigInputWriteAvailability(
         input_kind=input_kind,
@@ -1360,9 +1370,37 @@ def _product_action_context_resolver(
     return resolve
 
 
+def _product_action_instances_resolver(
+    *, profile: LaunchplaneProductProfileRecord
+) -> Callable[[DriverActionDescriptor], tuple[str, ...]]:
+    def resolve(action: DriverActionDescriptor) -> tuple[str, ...]:
+        if action.scope != "instance":
+            return ()
+        authorization_context = _product_action_authorization_context(
+            profile=profile,
+            action=action,
+        )
+        return tuple(
+            lane.instance
+            for lane in profile.lanes
+            if lane.context == authorization_context and lane.instance
+        )
+
+    return resolve
+
+
 def _lane_context_resolver(*, context: str) -> Callable[[DriverActionDescriptor], str]:
     def resolve(_action: DriverActionDescriptor) -> str:
         return context
+
+    return resolve
+
+
+def _lane_instances_resolver(
+    *, instance: str
+) -> Callable[[DriverActionDescriptor], tuple[str, ...]]:
+    def resolve(action: DriverActionDescriptor) -> tuple[str, ...]:
+        return (instance,) if action.scope == "instance" else ()
 
     return resolve
 
@@ -1429,6 +1467,7 @@ def _build_environment_summary(
             action_allowed=action_allowed,
             include_unsupported=False,
             context_resolver=_lane_context_resolver(context=lane.context),
+            instances_resolver=_lane_instances_resolver(instance=lane.instance),
         ),
     )
 
@@ -1603,6 +1642,7 @@ def _action_availability(
     action_allowed: ActionAllowed,
     include_unsupported: bool,
     context_resolver: Callable[[DriverActionDescriptor], str],
+    instances_resolver: Callable[[DriverActionDescriptor], tuple[str, ...]],
 ) -> tuple[ProductActionAvailability, ...]:
     descriptor_actions = {
         action.action_id: action
@@ -1635,6 +1675,7 @@ def _action_availability(
                 profile=profile,
                 product=product,
                 authorization_context=context_resolver(descriptor_action),
+                authorization_instances=instances_resolver(descriptor_action),
                 previews_enabled=previews_enabled,
                 action_allowed=action_allowed,
             )
@@ -1648,6 +1689,7 @@ def _availability_for_descriptor_action(
     profile: LaunchplaneProductProfileRecord,
     product: str,
     authorization_context: str,
+    authorization_instances: tuple[str, ...],
     previews_enabled: bool,
     action_allowed: ActionAllowed,
 ) -> ProductActionAvailability:
@@ -1662,7 +1704,12 @@ def _availability_for_descriptor_action(
     authz_action = action.authz_action or ACTION_AUTHZ_BY_ROUTE.get(
         action.route_path, action.action_id
     )
-    if not action_allowed(authz_action, product, authorization_context):
+    if not action_allowed(
+        authz_action,
+        product,
+        authorization_context,
+        authorization_instances,
+    ):
         disabled_reasons.append("Caller is not authorized for this action.")
     return ProductActionAvailability(
         action_id=action.action_id,

--- a/control_plane/drivers/native_routes.py
+++ b/control_plane/drivers/native_routes.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
-from typing import cast
+from typing import Protocol, cast
 
+from control_plane.contracts.driver_descriptor import DriverActionScope
 from control_plane.drivers.generic_web_dispatch import (
     _GENERIC_WEB_DEPLOY_ROUTE,
     _GENERIC_WEB_PROD_PROMOTION_ROUTE,
@@ -63,6 +64,7 @@ from control_plane.verireel_read_http import (
     _VERIREEL_STABLE_ENVIRONMENT_ROUTE,
     _VERIREEL_TESTING_VERIFICATION_ROUTE,
 )
+from control_plane.service_auth import AuthorizationTarget, LaunchplaneIdentity
 
 _NATIVE_FASTAPI_DRIVER_ROUTE_PATHS = frozenset(
     {
@@ -123,7 +125,20 @@ class _DriverRouteMetadata:
     method: str
     authz_action: str
     alternate_authz_actions: tuple[str, ...]
+    scope: DriverActionScope
     operator_visible: bool
+
+
+class _AuthorizationAllows(Protocol):
+    def __call__(
+        self,
+        *,
+        identity: LaunchplaneIdentity,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None,
+    ) -> bool: ...
 
 
 def _fastapi_route_paths_by_method(app: object, method: str) -> frozenset[str]:
@@ -190,6 +205,7 @@ def _driver_route_metadata_from_descriptors() -> dict[str, _DriverRouteMetadata]
                 method=method,
                 authz_action=authz_action,
                 alternate_authz_actions=alternate_authz_actions,
+                scope=action.scope,
                 operator_visible=action.operator_visible,
             )
     return route_metadata
@@ -246,6 +262,29 @@ def _native_driver_route_metadata_for_handler(endpoint: object) -> _DriverRouteM
 
 def _native_driver_route_authz_action(endpoint: object) -> str:
     return _native_driver_route_metadata_for_handler(endpoint).authz_action
+
+
+def _native_driver_route_authorization_allows(
+    *,
+    endpoint: object,
+    authorization_allows: _AuthorizationAllows,
+    identity: LaunchplaneIdentity,
+    product: str,
+    context: str,
+    instances: tuple[str, ...] = (),
+) -> bool:
+    route_metadata = _native_driver_route_metadata_for_handler(endpoint)
+    try:
+        target = AuthorizationTarget(scope=route_metadata.scope, instances=instances)
+    except ValueError:
+        return False
+    return authorization_allows(
+        identity=identity,
+        action=route_metadata.authz_action,
+        product=product,
+        context=context,
+        target=target,
+    )
 
 
 def _native_driver_route_alternate_authz_action(endpoint: object) -> str:

--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -947,6 +947,17 @@ def list_driver_descriptors() -> tuple[DriverDescriptor, ...]:
     return _DESCRIPTORS
 
 
+def instance_scoped_driver_authz_actions() -> frozenset[str]:
+    return frozenset(
+        authz_action
+        for descriptor in list_driver_descriptors()
+        for action in descriptor.actions
+        if action.scope == "instance"
+        for authz_action in (action.authz_action, *action.alternate_authz_actions)
+        if authz_action
+    )
+
+
 def read_driver_descriptor(driver_id: str) -> DriverDescriptor:
     normalized_driver_id = driver_id.strip()
     for descriptor in _DESCRIPTORS:

--- a/control_plane/generic_web_promotion_http.py
+++ b/control_plane/generic_web_promotion_http.py
@@ -191,18 +191,29 @@ def resolve_generic_web_promotion_destination_lane(
 
 def resolve_generic_web_promotion_workflow_lane(
     *, record_store: object, product: str, context: str
-) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile]:
+) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile, tuple[str, ...]]:
     profile = _read_generic_web_promotion_profile(
         record_store=record_store,
         product=product,
     )
     normalized_context = context.strip()
-    for lane in profile.lanes:
-        if lane.context.strip() == normalized_context:
-            return profile, lane
-    raise GenericWebPromotionProductMismatchError(
-        "Product profile does not own the requested driver lane."
+    matching_lane = next(
+        (lane for lane in profile.lanes if lane.context.strip() == normalized_context),
+        None,
     )
+    if matching_lane is None:
+        raise GenericWebPromotionProductMismatchError(
+            "Product profile does not own the requested driver lane."
+        )
+    lanes_by_instance = {lane.instance.strip(): lane for lane in profile.lanes}
+    affected_instances = tuple(
+        instance for instance in ("testing", "prod") if instance in lanes_by_instance
+    )
+    if affected_instances != ("testing", "prod"):
+        raise GenericWebPromotionProductMismatchError(
+            "Product profile does not expose testing and prod promotion lanes."
+        )
+    return profile, matching_lane, affected_instances
 
 
 def validate_generic_web_prod_promotion_lanes(

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -484,6 +484,7 @@ from control_plane.runtime_key_safety import (
 )
 from control_plane.service_auth import (
     AgentAuthzDecision,
+    AuthorizationTarget,
     BearerIdentityConfig,
     GitHubActionsIdentity,
     GitHubHumanIdentity,
@@ -3422,12 +3423,14 @@ def create_launchplane_fastapi_app(
         action: str,
         product: str,
         context: str,
+        target: AuthorizationTarget | None = None,
     ) -> bool:
         return resolved_authz_policy_runtime.policy.allows(
             identity=identity,
             action=action,
             product=product,
             context=context,
+            target=target,
         )
 
     read_route_dependencies = ReadRouteDependencies(
@@ -3469,12 +3472,18 @@ def create_launchplane_fastapi_app(
             requested_action: str,
             requested_product: str,
             requested_context: str,
+            requested_instances: tuple[str, ...],
         ) -> bool:
             return resolved_authz_policy_runtime.policy.allows(
                 identity=identity,
                 action=requested_action,
                 product=requested_product,
                 context=requested_context,
+                target=(
+                    AuthorizationTarget(scope="instance", instances=requested_instances)
+                    if requested_instances
+                    else AuthorizationTarget(scope="context")
+                ),
             )
 
         return action_allowed
@@ -3494,6 +3503,7 @@ def create_launchplane_fastapi_app(
             action="launchplane_service.read",
             product="launchplane",
             context=_LAUNCHPLANE_SERVICE_CONTEXT,
+            target=AuthorizationTarget(scope="context"),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -4597,11 +4607,13 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else publish_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_artifact_publish,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_artifact_publish),
             product=authorization_product,
             context=publish_request.publish.context,
+            instances=(publish_request.publish.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -4723,13 +4735,13 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_artifact_publish_inputs,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                write_odoo_artifact_publish_inputs
-            ),
             product=inputs_request.product,
             context=inputs_request.inputs.context,
+            instances=(inputs_request.inputs.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -4856,9 +4868,10 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_preview_apply_inputs,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_preview_apply_inputs),
             product=product_profile.product,
             context=product_profile.preview.context,
         ):
@@ -5020,9 +5033,10 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_preview_apply,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_preview_apply),
             product=product_profile.product,
             context=product_profile.preview.context,
         ):
@@ -5213,11 +5227,13 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else post_deploy_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_post_deploy,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_post_deploy),
             product=authorization_product,
             context=post_deploy_request.post_deploy.context,
+            instances=(post_deploy_request.post_deploy.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -5344,11 +5360,13 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else maintenance_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_app_maintenance,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_app_maintenance),
             product=authorization_product,
             context=maintenance_request.maintenance.context,
+            instances=(maintenance_request.maintenance.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -5476,13 +5494,13 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else override_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_config_parameter_override,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                write_odoo_config_parameter_override
-            ),
             product=authorization_product,
             context=override_request.override.context,
+            instances=(override_request.override.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -5608,13 +5626,13 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else override_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_website_bootstrap_override,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                write_odoo_website_bootstrap_override
-            ),
             product=authorization_product,
             context=override_request.override.context,
+            instances=(override_request.override.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -5740,11 +5758,13 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else backup_gate_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_prod_backup_gate,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_prod_backup_gate),
             product=authorization_product,
             context=backup_gate_request.backup_gate.context,
+            instances=(backup_gate_request.backup_gate.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -5871,11 +5891,13 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_stable_bootstrap,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_stable_bootstrap),
             product=bootstrap_request.product,
             context=bootstrap_request.bootstrap.context,
+            instances=(bootstrap_request.bootstrap.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -6001,13 +6023,13 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_target_replacement_plan,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                write_odoo_target_replacement_plan
-            ),
             product=plan_request.product,
             context=lane.context,
+            instances=(lane.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -6100,13 +6122,13 @@ def create_launchplane_fastapi_app(
                 message="Request could not be completed.",
             ) from error
 
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_target_replacement_apply,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                write_odoo_target_replacement_apply
-            ),
             product=apply_request.product,
             context=lane.context,
+            instances=(lane.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -6238,11 +6260,13 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else rollback_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_prod_rollback,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_prod_rollback),
             product=authorization_product,
             context=rollback_request.rollback.context,
+            instances=(rollback_request.rollback.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -6368,11 +6392,16 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else promotion_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_prod_promotion,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_prod_promotion),
             product=authorization_product,
             context=promotion_request.promotion.context,
+            instances=(
+                promotion_request.promotion.from_instance,
+                promotion_request.promotion.to_instance,
+            ),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -6500,13 +6529,16 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else inputs_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_prod_promotion_inputs,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                write_odoo_prod_promotion_inputs
-            ),
             product=authorization_product,
             context=inputs_request.inputs.context,
+            instances=(
+                inputs_request.inputs.from_instance,
+                inputs_request.inputs.to_instance,
+            ),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -6636,11 +6668,13 @@ def create_launchplane_fastapi_app(
         authorization_product = (
             product_profile.product if product_profile is not None else run_request.product
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_odoo_prod_promotion_run,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_odoo_prod_promotion_run),
             product=authorization_product,
             context=run_request.run.context,
+            instances=(run_request.run.from_instance, run_request.run.to_instance),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -9493,6 +9527,12 @@ def create_launchplane_fastapi_app(
             action=action,
             product=product_config_request.product,
             context=product_config_request.context,
+            target=AuthorizationTarget(
+                scope="instance" if product_config_request.instance else "context",
+                instances=(product_config_request.instance,)
+                if product_config_request.instance
+                else (),
+            ),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -9792,6 +9832,7 @@ def create_launchplane_fastapi_app(
             action=action,
             product=profile.product,
             context=lane.context,
+            target=AuthorizationTarget(scope="instance", instances=(lane.instance,)),
         ):
             raise _launchplane_http_error(
                 status_code=404,
@@ -9868,6 +9909,7 @@ def create_launchplane_fastapi_app(
             action=action,
             product=profile.product,
             context=lane.context,
+            target=AuthorizationTarget(scope="instance", instances=(lane.instance,)),
         ):
             raise _launchplane_http_error(
                 status_code=404,
@@ -9890,12 +9932,18 @@ def create_launchplane_fastapi_app(
                 record_store=record_store,
                 product=product,
                 destination_environment=environment,
-                action_allowed=lambda action, requested_product, context: (
+                action_allowed=lambda action, requested_product, context, instances: (
                     resolved_authz_policy_runtime.policy.allows(
                         identity=identity,
                         action=action,
                         product=requested_product,
                         context=context,
+                        target=AuthorizationTarget(
+                            scope="instance",
+                            instances=instances,
+                        )
+                        if instances
+                        else AuthorizationTarget(scope="context"),
                     )
                 ),
                 workflow_credentials_ready=lambda context: bool(
@@ -12714,11 +12762,13 @@ def create_launchplane_fastapi_app(
             raise_verireel_product_mismatch_error(trace_id=trace_id, error=error)
         except (ValueError, click.ClickException) as error:
             raise_verireel_invalid_request_error(trace_id=trace_id, error=error)
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_prod_deploy,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_verireel_prod_deploy),
             product=authorization_product,
             context=authorization_context,
+            instances=(deploy_request.deploy.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -12798,11 +12848,13 @@ def create_launchplane_fastapi_app(
             raise_verireel_product_mismatch_error(trace_id=trace_id, error=error)
         except (ValueError, click.ClickException) as error:
             raise_verireel_invalid_request_error(trace_id=trace_id, error=error)
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_prod_backup_gate,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_verireel_prod_backup_gate),
             product=authorization_product,
             context=authorization_context,
+            instances=(backup_gate_request.backup_gate.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -12887,11 +12939,16 @@ def create_launchplane_fastapi_app(
             raise_verireel_product_mismatch_error(trace_id=trace_id, error=error)
         except (ValueError, click.ClickException) as error:
             raise_verireel_invalid_request_error(trace_id=trace_id, error=error)
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_prod_promotion,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_verireel_prod_promotion),
             product=authorization_product,
             context=authorization_context,
+            instances=(
+                promotion_request.promotion.from_instance,
+                promotion_request.promotion.to_instance,
+            ),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -12971,11 +13028,13 @@ def create_launchplane_fastapi_app(
             raise_verireel_product_mismatch_error(trace_id=trace_id, error=error)
         except (ValueError, click.ClickException) as error:
             raise_verireel_invalid_request_error(trace_id=trace_id, error=error)
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_prod_rollback,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_verireel_prod_rollback),
             product=authorization_product,
             context=authorization_context,
+            instances=(rollback_request.rollback.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -13065,11 +13124,13 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_testing_deploy,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_verireel_testing_deploy),
             product=authorization_product,
             context=authorization_context,
+            instances=(deploy_request.deploy.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -13155,11 +13216,13 @@ def create_launchplane_fastapi_app(
                 code="product_driver_mismatch",
                 message="Product is not configured for the requested driver route.",
             ) from error
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_app_maintenance,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_verireel_app_maintenance),
             product=authorization_product,
             context=authorization_context,
+            instances=(maintenance_request.maintenance.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -13251,13 +13314,13 @@ def create_launchplane_fastapi_app(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_testing_verification,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_verireel_testing_verification
-            ),
             product=authorization_product,
             context=authorization_context,
+            instances=(verification_request.verification.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -13341,13 +13404,13 @@ def create_launchplane_fastapi_app(
                 code="product_driver_mismatch",
                 message="Product is not configured for the requested driver route.",
             ) from error
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=read_verireel_stable_environment,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                read_verireel_stable_environment
-            ),
             product=authorization_product,
             context=authorization_context,
+            instances=(environment_request.environment.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -13401,13 +13464,13 @@ def create_launchplane_fastapi_app(
                 code="product_driver_mismatch",
                 message="Product is not configured for the requested driver route.",
             ) from error
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=run_verireel_runtime_verification,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                run_verireel_runtime_verification
-            ),
             product=authorization_product,
             context=authorization_context,
+            instances=(verification_request.verification.instance,),
         ):
             raise _launchplane_http_error(
                 status_code=403,
@@ -13464,9 +13527,10 @@ def create_launchplane_fastapi_app(
                 message="Product is not configured for the requested driver route.",
             ) from error
         authorization_context = inventory_request.inventory.context.strip() or authorization_context
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=read_verireel_preview_inventory,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(read_verireel_preview_inventory),
             product=authorization_product,
             context=authorization_context,
         ):
@@ -13525,9 +13589,10 @@ def create_launchplane_fastapi_app(
                 message="Product is not configured for the requested driver route.",
             ) from error
         authorization_context = refresh_request.refresh.context.strip() or authorization_context
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_preview_refresh,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_verireel_preview_refresh),
             product=authorization_product,
             context=authorization_context,
         ):
@@ -13627,9 +13692,10 @@ def create_launchplane_fastapi_app(
                 message="Product is not configured for the requested driver route.",
             ) from error
         authorization_context = destroy_request.destroy.context.strip() or authorization_context
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_preview_destroy,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_verireel_preview_destroy),
             product=authorization_product,
             context=authorization_context,
         ):
@@ -13723,11 +13789,10 @@ def create_launchplane_fastapi_app(
         authorization_context = (
             verification_request.verification.context.strip() or authorization_context
         )
-        if not resolved_authz_policy_runtime.policy.allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_verireel_preview_verification,
+            authorization_allows=resolved_authz_policy_runtime.policy.allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_verireel_preview_verification
-            ),
             product=authorization_product,
             context=authorization_context,
         ):

--- a/control_plane/http_routes/drivers.py
+++ b/control_plane/http_routes/drivers.py
@@ -37,7 +37,7 @@ from control_plane.odoo_stable_bootstrap_http import ODOO_STABLE_BOOTSTRAP_ROUTE
 from control_plane.odoo_target_replacement_apply_http import (
     ODOO_TARGET_REPLACEMENT_APPLY_ROUTE,
 )
-from control_plane.service_auth import LaunchplaneIdentity
+from control_plane.service_auth import AuthorizationTarget, LaunchplaneIdentity
 from control_plane.storage.postgres import PostgresRecordStore
 
 _LAUNCHPLANE_DRIVER_READ_PRODUCT = "launchplane"
@@ -263,12 +263,17 @@ def _ensure_driver_read_allowed(
     identity: LaunchplaneIdentity,
     trace_id: str,
     context: str = _LAUNCHPLANE_DRIVER_READ_CONTEXT,
+    instance: str = "",
 ) -> None:
     if not dependencies.authorization_allows(
         identity=identity,
         action="driver.read",
         product=_LAUNCHPLANE_DRIVER_READ_PRODUCT,
         context=context,
+        target=AuthorizationTarget(
+            scope="instance" if instance else "context",
+            instances=(instance,) if instance else (),
+        ),
     ):
         raise dependencies.http_error(
             status_code=403,
@@ -311,6 +316,7 @@ def register_operation_status_read_routes(
             action=native_routes._descriptor_driver_route_authz_action(ODOO_STABLE_BOOTSTRAP_ROUTE),
             product=operation.product,
             context=operation.context,
+            target=AuthorizationTarget(scope="instance", instances=(operation.instance,)),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -362,6 +368,7 @@ def register_operation_status_read_routes(
             ),
             product=operation.product,
             context=operation.context,
+            target=AuthorizationTarget(scope="instance", instances=(operation.instance,)),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -484,6 +491,7 @@ def register_driver_descriptor_read_routes(
             identity=identity,
             trace_id=trace_id,
             context=context,
+            instance=instance,
         )
         view = build_driver_context_view(
             record_store=record_store,
@@ -661,6 +669,7 @@ def register_tracked_target_log_read_routes(
             action="target_logs.read",
             product="launchplane",
             context=context,
+            target=AuthorizationTarget(scope="instance", instances=(instance,)),
         ):
             raise common.http_error(
                 status_code=403,

--- a/control_plane/http_routes/evidence.py
+++ b/control_plane/http_routes/evidence.py
@@ -46,7 +46,7 @@ from control_plane.launchplane_mutations import (
     apply_launchplane_destroy_preview,
     apply_launchplane_generation_evidence,
 )
-from control_plane.service_auth import LaunchplaneIdentity
+from control_plane.service_auth import AuthorizationTarget, LaunchplaneIdentity
 from control_plane.workflows.evidence_ingestion import (
     EvidenceIngestionStore,
     PromotionEvidenceValidationError,
@@ -325,6 +325,10 @@ def register_evidence_write_routes(
             action="deployment.write",
             product=deployment_request.product,
             context=deployment_request.deployment.context,
+            target=AuthorizationTarget(
+                scope="instance",
+                instances=(deployment_request.deployment.instance,),
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -411,6 +415,10 @@ def register_evidence_write_routes(
             action="backup_gate.write",
             product=backup_gate_request.product,
             context=backup_gate_request.backup_gate.context,
+            target=AuthorizationTarget(
+                scope="instance",
+                instances=(backup_gate_request.backup_gate.instance,),
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -494,6 +502,13 @@ def register_evidence_write_routes(
             action="promotion.write",
             product=promotion_request.product,
             context=promotion_request.promotion.context,
+            target=AuthorizationTarget(
+                scope="instance",
+                instances=(
+                    promotion_request.promotion.from_instance,
+                    promotion_request.promotion.to_instance,
+                ),
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,

--- a/control_plane/http_routes/generic_web.py
+++ b/control_plane/http_routes/generic_web.py
@@ -504,7 +504,7 @@ def build_generic_web_write_route_handlers(
                 record_store=record_store,
                 product=profile.product,
                 destination_environment=lane.instance,
-                action_allowed=lambda _action, _product, _context: True,
+                action_allowed=lambda _action, _product, _context, _instances: True,
                 workflow_credentials_ready=lambda _context: True,
             )
         except (AttributeError, FileNotFoundError, ValueError, click.ClickException) as error:
@@ -633,11 +633,13 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_generic_web_rollback_plan,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_generic_web_rollback_plan),
             product=rollback_request.product,
             context=lane.context,
+            instances=(lane.instance,),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -757,11 +759,13 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=write_generic_web_rollback,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(write_generic_web_rollback),
             product=rollback_request.product,
             context=lane.context,
+            instances=(lane.instance,),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -862,11 +866,10 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_preview_desired_state,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_generic_web_preview_desired_state
-            ),
             product=profile.product,
             context=profile.preview.context,
         ):
@@ -960,11 +963,10 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_preview_inventory,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_generic_web_preview_inventory
-            ),
             product=profile.product,
             context=profile.preview.context,
         ):
@@ -1027,11 +1029,10 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_preview_readiness,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_generic_web_preview_readiness
-            ),
             product=profile.product,
             context=profile.preview.context,
         ):
@@ -1096,11 +1097,10 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_preview_refresh,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_generic_web_preview_refresh
-            ),
             product=profile.product,
             context=profile.preview.context,
         ):
@@ -1191,11 +1191,10 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_preview_destroy,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_generic_web_preview_destroy
-            ),
             product=profile.product,
             context=profile.preview.context,
         ):
@@ -1287,11 +1286,13 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_deploy,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(apply_generic_web_deploy),
             product=profile.product,
             context=lane.context,
+            instances=(lane.instance,),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -1409,13 +1410,16 @@ def build_generic_web_write_route_handlers(
                 code="authorization_denied",
                 message="Launchplane UI can only dry-run generic-web prod promotions.",
             )
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_prod_promotion,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_generic_web_prod_promotion
-            ),
             product=profile.product,
             context=lane.context.strip(),
+            instances=(
+                promotion_request.promotion.from_instance,
+                promotion_request.promotion.to_instance,
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -1607,7 +1611,7 @@ def build_generic_web_write_route_handlers(
                 ),
             )
         try:
-            profile, lane = resolve_generic_web_promotion_workflow_lane(
+            profile, lane, affected_instances = resolve_generic_web_promotion_workflow_lane(
                 record_store=record_store,
                 product=workflow_request.product,
                 context=workflow_request.workflow.context,
@@ -1631,13 +1635,13 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=dispatch_generic_web_prod_promotion_workflow,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                dispatch_generic_web_prod_promotion_workflow
-            ),
             product=profile.product,
             context=lane.context.strip(),
+            instances=affected_instances,
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -1755,13 +1759,13 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_stable_verification,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_generic_web_stable_verification
-            ),
             product=profile.product,
             context=lane.context,
+            instances=(lane.instance,),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -1849,11 +1853,10 @@ def build_generic_web_write_route_handlers(
                 code="invalid_request",
                 message="Request could not be completed.",
             ) from error
-        if not dependencies.authorization_allows(
+        if not native_routes._native_driver_route_authorization_allows(
+            endpoint=apply_generic_web_preview_verification,
+            authorization_allows=dependencies.authorization_allows,
             identity=identity,
-            action=native_routes._native_driver_route_authz_action(
-                apply_generic_web_preview_verification
-            ),
             product=profile.product,
             context=profile.preview.context,
         ):

--- a/control_plane/http_routes/operational_records.py
+++ b/control_plane/http_routes/operational_records.py
@@ -14,7 +14,7 @@ from control_plane.http_routes.support import (
     ApiRouteRegistrar,
     ReadRouteDependencies,
 )
-from control_plane.service_auth import LaunchplaneIdentity
+from control_plane.service_auth import AuthorizationTarget, LaunchplaneIdentity
 from control_plane.storage.factory import storage_backend_name
 
 
@@ -275,6 +275,10 @@ def register_deployment_promotion_read_routes(
             action="deployment.read",
             product="launchplane",
             context=deployment.context,
+            target=AuthorizationTarget(
+                scope="instance",
+                instances=(deployment.instance,),
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -312,6 +316,10 @@ def register_deployment_promotion_read_routes(
             action="promotion.read",
             product="launchplane",
             context=promotion.context,
+            target=AuthorizationTarget(
+                scope="instance",
+                instances=(promotion.from_instance, promotion.to_instance),
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -370,6 +378,7 @@ def register_inventory_operation_read_routes(
             action="inventory.read",
             product="launchplane",
             context=context,
+            target=AuthorizationTarget(scope="instance", instances=(instance,)),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -402,6 +411,10 @@ def register_inventory_operation_read_routes(
             action="inventory.read",
             product="launchplane",
             context=inventory.context,
+            target=AuthorizationTarget(
+                scope="instance",
+                instances=(inventory.instance,),
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -422,6 +435,7 @@ def register_inventory_operation_read_routes(
             action="operations.read",
             product="launchplane",
             context=context,
+            target=AuthorizationTarget(scope="context"),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -455,6 +469,34 @@ def register_inventory_operation_read_routes(
                 code="database_storage_required",
                 message=str(error),
             ) from error
+        stable_instances = tuple(
+            sorted(
+                {
+                    *(record.instance for record in inventory),
+                    *(record.instance for record in recent_deployments),
+                    *(record.from_instance for record in recent_promotions),
+                    *(record.to_instance for record in recent_promotions),
+                }
+            )
+        )
+        target = (
+            AuthorizationTarget(scope="instance", instances=stable_instances)
+            if stable_instances
+            else AuthorizationTarget(scope="context")
+        )
+        if not dependencies.authorization_allows(
+            identity=identity,
+            action="operations.read",
+            product="launchplane",
+            context=context,
+            target=target,
+        ):
+            raise dependencies.http_error(
+                status_code=403,
+                trace_id=trace_id,
+                code="authorization_denied",
+                message="Workflow cannot read recent operations for the requested context.",
+            )
         return RecentOperationsResponse(
             trace_id=trace_id,
             context=context,
@@ -514,6 +556,10 @@ def register_managed_secret_read_routes(
             action="secret.list",
             product=LAUNCHPLANE_SERVICE_CONTEXT,
             context=context,
+            target=AuthorizationTarget(
+                scope="instance" if instance else "context",
+                instances=(instance,) if instance else (),
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,
@@ -613,6 +659,10 @@ def register_managed_secret_read_routes(
             action="secret.read",
             product=LAUNCHPLANE_SERVICE_CONTEXT,
             context=secret_status.context,
+            target=AuthorizationTarget(
+                scope="instance" if secret_status.instance else "context",
+                instances=(secret_status.instance,) if secret_status.instance else (),
+            ),
         ):
             raise dependencies.http_error(
                 status_code=403,

--- a/control_plane/http_routes/products.py
+++ b/control_plane/http_routes/products.py
@@ -34,7 +34,11 @@ from control_plane.http_routes.support import (
     ApiRouteRegistrar,
     ReadRouteDependencies,
 )
-from control_plane.service_auth import LaunchplaneIdentity, TerminalAgentIdentity
+from control_plane.service_auth import (
+    AuthorizationTarget,
+    LaunchplaneIdentity,
+    TerminalAgentIdentity,
+)
 from control_plane.product_promotion_http import (
     PRODUCT_PROMOTION_STATUS_ROUTE,
     PRODUCT_PROMOTION_WORKFLOW_STATUS_ROUTE,
@@ -343,6 +347,7 @@ def _build_product_environment_read_result(
         requested_action: str,
         requested_product: str,
         requested_context: str,
+        requested_instances: tuple[str, ...],
     ) -> bool:
         if requested_action.startswith("product_config.") and isinstance(
             identity, TerminalAgentIdentity
@@ -353,6 +358,14 @@ def _build_product_environment_read_result(
             action=requested_action,
             product=requested_product,
             context=requested_context,
+            target=(
+                AuthorizationTarget(
+                    scope="instance",
+                    instances=requested_instances,
+                )
+                if requested_instances
+                else AuthorizationTarget(scope="context")
+            ),
         )
 
     try:
@@ -401,6 +414,14 @@ def _require_product_environment_result_authorization(
         action="product_environment.read",
         product=result.authorization_product,
         context=result.authorization_context,
+        target=(
+            AuthorizationTarget(
+                scope="instance",
+                instances=result.authorization_instances,
+            )
+            if result.authorization_instances
+            else AuthorizationTarget(scope="context")
+        ),
     ):
         return
     raise dependencies.http_error(
@@ -423,6 +444,7 @@ def _require_agent_context_read_authorization(
         action="product_environment.read",
         product=LAUNCHPLANE_SERVICE_CONTEXT,
         context=LAUNCHPLANE_SERVICE_CONTEXT,
+        target=AuthorizationTarget(scope="context"),
     ):
         return
     raise dependencies.http_error(
@@ -626,12 +648,18 @@ def register_agent_context_read_routes(
             requested_action: str,
             requested_product: str,
             requested_context: str,
+            requested_instances: tuple[str, ...],
         ) -> bool:
             return common.authorization_allows(
                 identity=identity,
                 action=requested_action,
                 product=requested_product,
                 context=requested_context,
+                target=(
+                    AuthorizationTarget(scope="instance", instances=requested_instances)
+                    if requested_instances
+                    else AuthorizationTarget(scope="context")
+                ),
             )
 
         context = build_agent_context_service_payload(
@@ -688,12 +716,18 @@ def register_product_environment_read_routes(
             requested_action: str,
             requested_product: str,
             requested_context: str,
+            requested_instances: tuple[str, ...],
         ) -> bool:
             return common.authorization_allows(
                 identity=identity,
                 action=requested_action,
                 product=requested_product,
                 context=requested_context,
+                target=(
+                    AuthorizationTarget(scope="instance", instances=requested_instances)
+                    if requested_instances
+                    else AuthorizationTarget(scope="context")
+                ),
             )
 
         if not common.authorization_allows(
@@ -701,6 +735,7 @@ def register_product_environment_read_routes(
             action="product_environment.read",
             product=LAUNCHPLANE_SERVICE_CONTEXT,
             context=LAUNCHPLANE_SERVICE_CONTEXT,
+            target=AuthorizationTarget(scope="context"),
         ):
             raise common.http_error(
                 status_code=403,
@@ -1192,11 +1227,22 @@ def register_product_promotion_status_read_routes(
                 code="not_found",
                 message="Product promotion status was not found.",
             ) from error
+        source_lane = next(
+            (candidate for candidate in profile.lanes if candidate.instance == "testing"),
+            None,
+        )
+        authorization_instances = (
+            (source_lane.instance, lane.instance) if source_lane is not None else (lane.instance,)
+        )
         if not common.authorization_allows(
             identity=identity,
             action="product_environment.read",
             product=profile.product,
             context=lane.context,
+            target=AuthorizationTarget(
+                scope="instance",
+                instances=authorization_instances,
+            ),
         ):
             raise common.http_error(
                 status_code=404,
@@ -1205,12 +1251,22 @@ def register_product_promotion_status_read_routes(
                 message="Product promotion status was not found.",
             )
 
-        def action_allowed(action: str, requested_product: str, context: str) -> bool:
+        def action_allowed(
+            action: str,
+            requested_product: str,
+            context: str,
+            instances: tuple[str, ...],
+        ) -> bool:
             return common.authorization_allows(
                 identity=identity,
                 action=action,
                 product=requested_product,
                 context=context,
+                target=(
+                    AuthorizationTarget(scope="instance", instances=instances)
+                    if instances
+                    else AuthorizationTarget(scope="context")
+                ),
             )
 
         try:

--- a/control_plane/http_routes/support.py
+++ b/control_plane/http_routes/support.py
@@ -5,7 +5,7 @@ from typing import Any, Protocol
 from fastapi import HTTPException
 from pydantic import BaseModel
 
-from control_plane.service_auth import LaunchplaneIdentity
+from control_plane.service_auth import AuthorizationTarget, LaunchplaneIdentity
 
 LAUNCHPLANE_SERVICE_CONTEXT = "launchplane"
 
@@ -27,6 +27,7 @@ class AuthorizationAllows(Protocol):
         action: str,
         product: str,
         context: str,
+        target: AuthorizationTarget | None = None,
     ) -> bool: ...
 
 

--- a/control_plane/product_promotion_http.py
+++ b/control_plane/product_promotion_http.py
@@ -277,7 +277,7 @@ def build_product_promotion_status(
     record_store: object,
     product: str,
     destination_environment: str,
-    action_allowed: Callable[[str, str, str], bool],
+    action_allowed: Callable[[str, str, str, tuple[str, ...]], bool],
     workflow_credentials_ready: Callable[[str], bool],
     now: datetime | None = None,
 ) -> tuple[LaunchplaneProductProfileRecord, ProductLaneProfile, ProductPromotionStatus]:
@@ -322,12 +322,14 @@ def build_product_promotion_status(
         "generic_web_prod_promotion.execute",
         profile.product,
         destination_lane.context,
+        (source_lane.instance, destination_lane.instance),
     ):
         direct_blockers.append("Caller is not authorized to dry-run generic-web promotion.")
     if not action_allowed(
         "generic_web_prod_promotion.dispatch",
         profile.product,
         destination_lane.context,
+        (source_lane.instance, destination_lane.instance),
     ):
         workflow_blockers.append("Caller is not authorized to dispatch the promotion workflow.")
     trust_state = _promotion_trust_state(

--- a/control_plane/product_read_service.py
+++ b/control_plane/product_read_service.py
@@ -23,6 +23,7 @@ class ProductEnvironmentReadServiceResult:
     payload: dict[str, object]
     authorization_product: str
     authorization_context: str
+    authorization_instances: tuple[str, ...]
     denial_message: str
 
 
@@ -106,6 +107,7 @@ def build_product_environment_read_service_result(
             payload={"activity": activity.model_dump(mode="json")},
             authorization_product=activity.product,
             authorization_context="launchplane",
+            authorization_instances=(),
             denial_message="Workflow cannot read the requested product activity.",
         )
 
@@ -136,6 +138,7 @@ def build_product_environment_read_service_result(
             payload={"config_status": config_status.model_dump(mode="json")},
             authorization_product=config_status.product,
             authorization_context=config_status.context,
+            authorization_instances=(config_status.environment,),
             denial_message="Workflow cannot read the requested product environment config status.",
         )
 
@@ -156,6 +159,7 @@ def build_product_environment_read_service_result(
             payload={"environment": detail.model_dump(mode="json")},
             authorization_product=detail.product,
             authorization_context=detail.context,
+            authorization_instances=(detail.environment,),
             denial_message="Workflow cannot read the requested product environment.",
         )
 
@@ -169,6 +173,9 @@ def build_product_environment_read_service_result(
             payload=_product_environments_payload(overview),
             authorization_product=overview.product,
             authorization_context="launchplane",
+            authorization_instances=tuple(
+                environment.environment for environment in overview.environments
+            ),
             denial_message="Workflow cannot list the requested product environments.",
         )
 
@@ -182,6 +189,9 @@ def build_product_environment_read_service_result(
             payload={"product": overview.model_dump(mode="json")},
             authorization_product=overview.product,
             authorization_context="launchplane",
+            authorization_instances=tuple(
+                environment.environment for environment in overview.environments
+            ),
             denial_message="Workflow cannot read the requested product overview.",
         )
 

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -6,10 +6,22 @@ import secrets
 import tomllib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal, Protocol
+from typing import Annotated, Any, Literal, Protocol, cast
 
 import jwt
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    SerializerFunctionWrapHandler,
+    model_serializer,
+    model_validator,
+)
+
+from control_plane.authz_scope import (
+    exclusively_instance_scoped_authz_actions,
+    instance_scoped_authz_actions,
+)
 
 
 GITHUB_ACTIONS_OIDC_ISSUER = "https://token.actions.githubusercontent.com"
@@ -66,6 +78,8 @@ LaunchplaneIdentity = (
     | LocalOperatorIdentity
     | LocalAdminIdentity
 )
+AuthorizationScope = Literal["global", "context", "instance", "preview"]
+AuthzPolicySchemaVersion = Literal[1, 2]
 AgentConsumerSubjectType = Literal[
     "github_actions", "github_human", "terminal_agent", "local_operator", "local_admin"
 ]
@@ -85,6 +99,54 @@ AgentConsumerActionSafety = Literal[
     "policy_admin",
 ]
 AgentAuthzDecision = Literal["allowed", "denied"]
+
+
+def _validated_instance_selectors(instances: tuple[str, ...]) -> tuple[str, ...]:
+    normalized_instances = tuple(
+        dict.fromkeys(instance.strip() for instance in instances if instance.strip())
+    )
+    if "*" in normalized_instances and normalized_instances != ("*",):
+        raise ValueError("Authz instance wildcard must be the only instance selector.")
+    for instance in normalized_instances:
+        if instance != "*" and any(character in instance for character in "*?[]"):
+            raise ValueError("Authz instance selectors must be exact or the lone '*' wildcard.")
+    return normalized_instances
+
+
+AuthzInstanceSelectors = Annotated[
+    tuple[str, ...],
+    AfterValidator(_validated_instance_selectors),
+]
+
+
+class AuthorizationTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    scope: AuthorizationScope
+    instances: AuthzInstanceSelectors = ()
+
+    @model_validator(mode="after")
+    def _validate_scope(self) -> "AuthorizationTarget":
+        if self.scope == "instance" and not self.instances:
+            raise ValueError("Instance-scoped authorization requires at least one instance.")
+        if self.scope != "instance" and self.instances:
+            raise ValueError("Only instance-scoped authorization can declare instances.")
+        return self
+
+
+def _instances_allowed(
+    *,
+    allowed_instances: AuthzInstanceSelectors,
+    target: AuthorizationTarget | None,
+    schema_version: AuthzPolicySchemaVersion,
+) -> bool:
+    if target is None or target.scope != "instance":
+        return not allowed_instances
+    if not allowed_instances:
+        return schema_version == 1
+    if allowed_instances == ("*",):
+        return True
+    return set(target.instances).issubset(allowed_instances)
 
 
 class TokenVerifier(Protocol):
@@ -233,6 +295,7 @@ class GitHubActionsPolicyRule(BaseModel):
     environments: tuple[str, ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...] = ()
 
     @staticmethod
@@ -241,7 +304,14 @@ class GitHubActionsPolicyRule(BaseModel):
         return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
 
     def allows(
-        self, *, identity: GitHubActionsIdentity, action: str, product: str, context: str
+        self,
+        *,
+        identity: GitHubActionsIdentity,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None = None,
+        schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
         if self.repository.strip() != identity.repository:
             return False
@@ -263,6 +333,12 @@ class GitHubActionsPolicyRule(BaseModel):
             return False
         if self.contexts and not self._matches_claim(context, self.contexts):
             return False
+        if not _instances_allowed(
+            allowed_instances=self.instances,
+            target=target,
+            schema_version=schema_version,
+        ):
+            return False
         if self.actions and action not in self.actions:
             return False
         return True
@@ -277,6 +353,7 @@ class GitHubHumanPolicyRule(BaseModel):
     roles: tuple[Literal["read_only", "admin"], ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...] = ()
 
     @staticmethod
@@ -293,7 +370,14 @@ class GitHubHumanPolicyRule(BaseModel):
         )
 
     def allows(
-        self, *, identity: GitHubHumanIdentity, action: str, product: str, context: str
+        self,
+        *,
+        identity: GitHubHumanIdentity,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None = None,
+        schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
         if self.logins and not self._matches_any(identity.login, self.logins):
             return False
@@ -306,6 +390,12 @@ class GitHubHumanPolicyRule(BaseModel):
         if self.products and product not in self.products:
             return False
         if self.contexts and context not in self.contexts:
+            return False
+        if not _instances_allowed(
+            allowed_instances=self.instances,
+            target=target,
+            schema_version=schema_version,
+        ):
             return False
         if self.actions and action not in self.actions:
             return False
@@ -337,6 +427,7 @@ class TerminalAgentPolicyRule(BaseModel):
     token_labels: tuple[str, ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...] = ()
 
     @staticmethod
@@ -345,7 +436,14 @@ class TerminalAgentPolicyRule(BaseModel):
         return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
 
     def allows(
-        self, *, identity: TerminalAgentIdentity, action: str, product: str, context: str
+        self,
+        *,
+        identity: TerminalAgentIdentity,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None = None,
+        schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
         if self.subjects and not self._matches_any(identity.subject, self.subjects):
             return False
@@ -354,6 +452,12 @@ class TerminalAgentPolicyRule(BaseModel):
         if self.products and product not in self.products:
             return False
         if self.contexts and context not in self.contexts:
+            return False
+        if not _instances_allowed(
+            allowed_instances=self.instances,
+            target=target,
+            schema_version=schema_version,
+        ):
             return False
         if self.actions and action not in self.actions:
             return False
@@ -367,6 +471,7 @@ class LocalOperatorPolicyRule(BaseModel):
     token_labels: tuple[str, ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...] = ()
 
     @staticmethod
@@ -375,7 +480,14 @@ class LocalOperatorPolicyRule(BaseModel):
         return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
 
     def allows(
-        self, *, identity: LocalOperatorIdentity, action: str, product: str, context: str
+        self,
+        *,
+        identity: LocalOperatorIdentity,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None = None,
+        schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
         if self.subjects and not self._matches_any(identity.subject, self.subjects):
             return False
@@ -384,6 +496,12 @@ class LocalOperatorPolicyRule(BaseModel):
         if self.products and not self._matches_any(product, self.products):
             return False
         if self.contexts and not self._matches_any(context, self.contexts):
+            return False
+        if not _instances_allowed(
+            allowed_instances=self.instances,
+            target=target,
+            schema_version=schema_version,
+        ):
             return False
         if self.actions and action not in self.actions:
             return False
@@ -397,6 +515,7 @@ class LocalAdminPolicyRule(BaseModel):
     token_labels: tuple[str, ...] = ()
     products: tuple[str, ...] = ()
     contexts: tuple[str, ...] = ()
+    instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...] = ()
 
     @staticmethod
@@ -405,7 +524,14 @@ class LocalAdminPolicyRule(BaseModel):
         return any(fnmatchcase(normalized_value, allowed_value) for allowed_value in allowed_values)
 
     def allows(
-        self, *, identity: LocalAdminIdentity, action: str, product: str, context: str
+        self,
+        *,
+        identity: LocalAdminIdentity,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None = None,
+        schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
         if self.subjects and not self._matches_any(identity.subject, self.subjects):
             return False
@@ -414,6 +540,12 @@ class LocalAdminPolicyRule(BaseModel):
         if self.products and not self._matches_any(product, self.products):
             return False
         if self.contexts and not self._matches_any(context, self.contexts):
+            return False
+        if not _instances_allowed(
+            allowed_instances=self.instances,
+            target=target,
+            schema_version=schema_version,
+        ):
             return False
         if self.actions and action not in self.actions:
             return False
@@ -601,40 +733,131 @@ def agent_authz_audit(
 class LaunchplaneAuthzPolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
-    schema_version: int = Field(default=1, ge=1)
+    schema_version: AuthzPolicySchemaVersion = 1
     github_actions: tuple[GitHubActionsPolicyRule, ...] = ()
     github_humans: tuple[GitHubHumanPolicyRule, ...] = ()
     terminal_agents: tuple[TerminalAgentPolicyRule, ...] = ()
     local_operators: tuple[LocalOperatorPolicyRule, ...] = ()
     local_admins: tuple[LocalAdminPolicyRule, ...] = ()
 
+    @model_validator(mode="after")
+    def _validate_instance_rule_schema(self) -> "LaunchplaneAuthzPolicy":
+        instance_actions = instance_scoped_authz_actions()
+        exclusively_instance_actions = exclusively_instance_scoped_authz_actions()
+        for rules in (
+            self.github_actions,
+            self.github_humans,
+            self.terminal_agents,
+            self.local_operators,
+            self.local_admins,
+        ):
+            for rule in rules:
+                if self.schema_version == 1 and rule.instances:
+                    raise ValueError("Schema-v1 authz policy rules cannot declare instances.")
+                if self.schema_version != 2 or not rule.actions:
+                    continue
+                requested_actions = set(rule.actions)
+                if requested_actions & exclusively_instance_actions and not rule.instances:
+                    raise ValueError(
+                        "Schema-v2 instance-scoped authz policy rules require instances."
+                    )
+                if rule.instances and requested_actions - instance_actions:
+                    raise ValueError(
+                        "Schema-v2 authz policy rules can only declare instances for "
+                        "instance-scoped actions."
+                    )
+        return self
+
+    @model_serializer(mode="wrap")
+    def _serialize_policy(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        payload = cast(dict[str, Any], handler(self))
+        if self.schema_version == 1:
+            for rule_collection_name in (
+                "github_actions",
+                "github_humans",
+                "terminal_agents",
+                "local_operators",
+                "local_admins",
+            ):
+                for rule in payload.get(rule_collection_name, ()):
+                    rule.pop("instances", None)
+        return payload
+
     def allows(
-        self, *, identity: LaunchplaneIdentity, action: str, product: str, context: str
+        self,
+        *,
+        identity: LaunchplaneIdentity,
+        action: str,
+        product: str,
+        context: str,
+        target: AuthorizationTarget | None = None,
     ) -> bool:
+        resolved_target = target or AuthorizationTarget(scope="context")
+        if (
+            self.schema_version == 2
+            and action in exclusively_instance_scoped_authz_actions()
+            and resolved_target.scope != "instance"
+        ):
+            return False
         if isinstance(identity, GitHubHumanIdentity):
             if identity.role == "read_only" and not limited_remote_user_action_allowed(action):
                 return False
             return any(
-                rule.allows(identity=identity, action=action, product=product, context=context)
+                rule.allows(
+                    identity=identity,
+                    action=action,
+                    product=product,
+                    context=context,
+                    target=resolved_target,
+                    schema_version=self.schema_version,
+                )
                 for rule in self.github_humans
             )
         if isinstance(identity, TerminalAgentIdentity):
             return any(
-                rule.allows(identity=identity, action=action, product=product, context=context)
+                rule.allows(
+                    identity=identity,
+                    action=action,
+                    product=product,
+                    context=context,
+                    target=resolved_target,
+                    schema_version=self.schema_version,
+                )
                 for rule in self.terminal_agents
             )
         if isinstance(identity, LocalOperatorIdentity):
             return local_operator_identity_valid(identity=identity, action=action) and any(
-                rule.allows(identity=identity, action=action, product=product, context=context)
+                rule.allows(
+                    identity=identity,
+                    action=action,
+                    product=product,
+                    context=context,
+                    target=resolved_target,
+                    schema_version=self.schema_version,
+                )
                 for rule in self.local_operators
             )
         if isinstance(identity, LocalAdminIdentity):
             return local_admin_identity_valid(identity=identity, action=action) and any(
-                rule.allows(identity=identity, action=action, product=product, context=context)
+                rule.allows(
+                    identity=identity,
+                    action=action,
+                    product=product,
+                    context=context,
+                    target=resolved_target,
+                    schema_version=self.schema_version,
+                )
                 for rule in self.local_admins
             )
         return any(
-            rule.allows(identity=identity, action=action, product=product, context=context)
+            rule.allows(
+                identity=identity,
+                action=action,
+                product=product,
+                context=context,
+                target=resolved_target,
+                schema_version=self.schema_version,
+            )
             for rule in self.github_actions
         )
 
@@ -660,6 +883,62 @@ class LaunchplaneAuthzPolicy(BaseModel):
         ):
             return "read_only"
         return None
+
+
+def migrate_authz_policy_to_schema_v2(
+    policy: LaunchplaneAuthzPolicy,
+) -> LaunchplaneAuthzPolicy:
+    if policy.schema_version == 2:
+        return policy
+
+    exclusively_instance_actions = exclusively_instance_scoped_authz_actions()
+    instance_actions = instance_scoped_authz_actions()
+
+    def migrated_rules(rule: Any) -> tuple[Any, ...]:
+        if not rule.actions:
+            return (
+                rule.model_copy(update={"instances": ()}),
+                rule.model_copy(update={"instances": ("*",)}),
+            )
+        context_actions = tuple(
+            action for action in rule.actions if action not in exclusively_instance_actions
+        )
+        scoped_instance_actions = tuple(
+            action for action in rule.actions if action in instance_actions
+        )
+        migrated: list[Any] = []
+        if context_actions:
+            migrated.append(rule.model_copy(update={"actions": context_actions, "instances": ()}))
+        if scoped_instance_actions:
+            migrated.append(
+                rule.model_copy(update={"actions": scoped_instance_actions, "instances": ("*",)})
+            )
+        return tuple(migrated)
+
+    return LaunchplaneAuthzPolicy(
+        schema_version=2,
+        github_actions=tuple(
+            migrated_rule
+            for rule in policy.github_actions
+            for migrated_rule in migrated_rules(rule)
+        ),
+        github_humans=tuple(
+            migrated_rule for rule in policy.github_humans for migrated_rule in migrated_rules(rule)
+        ),
+        terminal_agents=tuple(
+            migrated_rule
+            for rule in policy.terminal_agents
+            for migrated_rule in migrated_rules(rule)
+        ),
+        local_operators=tuple(
+            migrated_rule
+            for rule in policy.local_operators
+            for migrated_rule in migrated_rules(rule)
+        ),
+        local_admins=tuple(
+            migrated_rule for rule in policy.local_admins for migrated_rule in migrated_rules(rule)
+        ),
+    )
 
 
 def parse_authz_policy_toml(policy_toml: str) -> LaunchplaneAuthzPolicy:

--- a/control_plane/work_graph_service.py
+++ b/control_plane/work_graph_service.py
@@ -102,7 +102,7 @@ def build_work_graph_snapshot_service_payload(
     readable_product_profiles = tuple(
         profile
         for profile in product_store.list_product_profile_records()
-        if action_allowed("product_environment.read", profile.product, "launchplane")
+        if action_allowed("product_environment.read", profile.product, "launchplane", ())
     )
     planning_issue_facts = planning_facts_provider() if planning_facts_provider is not None else ()
     repo_mapping = build_repo_product_mapping_from_records(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -103,7 +103,9 @@ All endpoints are authenticated and use action `driver.read`.
 - `GET /v1/contexts/{context}/instances/{instance}/driver-view`
 
 Discovery endpoints authorize against Launchplane context `launchplane`.
-Context/instance views authorize against the requested context.
+Context views authorize against the requested context. Instance views authorize
+against the requested context and exact instance; a rule for another lane in
+the same context does not authorize the read.
 
 The view endpoints return provider-neutral descriptors plus repository-backed
 read state. They do not execute actions, reveal secret values, or ask the UI to
@@ -468,8 +470,12 @@ provider concepts, as the future GUI-facing action surface.
 Descriptor actions are the runtime source of truth for native driver route
 method, primary authorization action, alternate authorization actions, and
 operator visibility. Native FastAPI handlers bind this metadata when the route
-is registered and read authorization actions from that binding instead of
-declaring route-local action strings. If one route has multiple service modes
+is registered and read authorization actions and scope from that binding
+instead of declaring route-local action strings. Instance-scoped handlers must
+resolve and submit every affected lane to the central authorization helper;
+startup and contract coverage reject a descriptor/handler pair that drops the
+instance target. Promotion actions submit both source and destination lanes.
+If one route has multiple service modes
 with distinct authorization checks, declare the non-primary checks in
 `alternate_authz_actions`; the ingress driver uses its single alternate action
 for dry-run requests and its primary action for apply requests. Some service

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -405,6 +405,23 @@ stores audit metadata, and reloads the current service worker's active policy.
 Launchplane self-deploy authority is separate and does not authorize authz
 policy grant maintenance.
 
+Authz policy schema v1 remains the compatibility contract for an active v1
+policy and retains its existing product/context breadth. Schema v2 adds exact
+instance selectors to every principal rule and grant contract. Selectors are
+exact names or the lone `*` wildcard; an empty schema-v2 selector authorizes
+non-instance scope only and is never an implicit instance wildcard. Actions
+that can operate at either context or instance scope, such as `driver.read` and
+`product_environment.read`, use separate context and instance rules. Promotion
+and other multi-lane decisions require every affected instance.
+
+Grant and removal requests must use the same schema version as the active
+policy. The CLI therefore defaults to `--schema-version 1`; after an operator
+has explicitly migrated and activated a schema-v2 policy, pass
+`--schema-version 2 --instance <lane>`. Migration splits mixed or actionless v1
+rules into explicit context and `*` instance representations so their current
+breadth is preserved without teaching new schema-v2 rules that an empty
+selector means all instances.
+
 When the CLI uses `--session-cookie`, it first reads `GET /v1/auth/session` and
 then sends the returned single-use CSRF token with strict same-origin fetch
 metadata. Use the configured public Launchplane URL so its origin matches

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2278,9 +2278,9 @@ read-model contract documented in [driver-descriptors.md](driver-descriptors.md)
 
 The descriptor and driver-view routes use action `driver.read` and are native
 FastAPI routes. Descriptor discovery authorizes against context `launchplane`;
-context and instance views authorize against the requested context. These routes
-expose Launchplane capabilities and repository-backed read state, not
-runtime-provider primitives.
+context views authorize against the requested context, and instance views also
+authorize the exact requested instance. These routes expose Launchplane
+capabilities and repository-backed read state, not runtime-provider primitives.
 
 The logs route is the exception to the `driver.read` action because it reads live
 provider output. It is a native FastAPI route, uses action `target_logs.read`,
@@ -2293,6 +2293,11 @@ Launchplane verifies the selected deployment belongs to the requested tracked
 target before reading its detached log id. Provider failures expose only a
 bounded redacted operation label/detail, and the manual workflow preserves the
 redacted response artifact before reporting failure.
+
+Authorization policy schema v2 treats these instance targets as first-class
+selectors. An exact grant for `testing` cannot read `prod` logs or driver state
+even when both lanes share one context. Multi-lane operations must satisfy the
+rule for every resolved instance.
 
 The preview driver cut stays intentionally narrow but keeps topology in
 Launchplane: Launchplane owns preview URL derivation from the

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -20274,6 +20274,14 @@
                         "title": "Event Names",
                         "type": "array"
                       },
+                      "instances": {
+                        "default": [],
+                        "items": {
+                          "type": "string"
+                        },
+                        "title": "Instances",
+                        "type": "array"
+                      },
                       "job_workflow_refs": {
                         "default": [],
                         "items": {
@@ -20354,7 +20362,10 @@
                   },
                   "schema_version": {
                     "default": 1,
-                    "minimum": 1,
+                    "enum": [
+                      1,
+                      2
+                    ],
                     "title": "Schema Version",
                     "type": "integer"
                   }
@@ -20509,6 +20520,14 @@
                         "title": "Event Names",
                         "type": "array"
                       },
+                      "instances": {
+                        "default": [],
+                        "items": {
+                          "type": "string"
+                        },
+                        "title": "Instances",
+                        "type": "array"
+                      },
                       "job_workflow_refs": {
                         "default": [],
                         "items": {
@@ -20589,7 +20608,10 @@
                   },
                   "schema_version": {
                     "default": 1,
-                    "minimum": 1,
+                    "enum": [
+                      1,
+                      2
+                    ],
                     "title": "Schema Version",
                     "type": "integer"
                   }
@@ -20728,6 +20750,14 @@
                         "title": "Contexts",
                         "type": "array"
                       },
+                      "instances": {
+                        "default": [],
+                        "items": {
+                          "type": "string"
+                        },
+                        "title": "Instances",
+                        "type": "array"
+                      },
                       "logins": {
                         "default": [],
                         "items": {
@@ -20815,7 +20845,10 @@
                   },
                   "schema_version": {
                     "default": 1,
-                    "minimum": 1,
+                    "enum": [
+                      1,
+                      2
+                    ],
                     "title": "Schema Version",
                     "type": "integer"
                   }
@@ -20954,6 +20987,14 @@
                         "title": "Contexts",
                         "type": "array"
                       },
+                      "instances": {
+                        "default": [],
+                        "items": {
+                          "type": "string"
+                        },
+                        "title": "Instances",
+                        "type": "array"
+                      },
                       "products": {
                         "default": [],
                         "items": {
@@ -21021,7 +21062,10 @@
                   },
                   "schema_version": {
                     "default": 1,
-                    "minimum": 1,
+                    "enum": [
+                      1,
+                      2
+                    ],
                     "title": "Schema Version",
                     "type": "integer"
                   }
@@ -21160,6 +21204,14 @@
                         "title": "Contexts",
                         "type": "array"
                       },
+                      "instances": {
+                        "default": [],
+                        "items": {
+                          "type": "string"
+                        },
+                        "title": "Instances",
+                        "type": "array"
+                      },
                       "products": {
                         "default": [],
                         "items": {
@@ -21227,7 +21279,10 @@
                   },
                   "schema_version": {
                     "default": 1,
-                    "minimum": 1,
+                    "enum": [
+                      1,
+                      2
+                    ],
                     "title": "Schema Version",
                     "type": "integer"
                   }
@@ -21366,6 +21421,14 @@
                         "title": "Contexts",
                         "type": "array"
                       },
+                      "instances": {
+                        "default": [],
+                        "items": {
+                          "type": "string"
+                        },
+                        "title": "Instances",
+                        "type": "array"
+                      },
                       "products": {
                         "default": [],
                         "items": {
@@ -21433,7 +21496,10 @@
                   },
                   "schema_version": {
                     "default": 1,
-                    "minimum": 1,
+                    "enum": [
+                      1,
+                      2
+                    ],
                     "title": "Schema Version",
                     "type": "integer"
                   }

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -360,7 +360,7 @@ def _product_environment_read_policy(
                     "contexts": list(allowed_contexts),
                     "actions": list(actions),
                 }
-            ]
+            ],
         }
     )
 
@@ -383,7 +383,7 @@ def _work_graph_read_policy(
                     "contexts": list(contexts),
                     "actions": ["work_graph.rank", "product_environment.read"],
                 }
-            ]
+            ],
         }
     )
 
@@ -399,7 +399,7 @@ def _github_human_work_graph_rank_policy() -> LaunchplaneAuthzPolicy:
                     "contexts": ["launchplane"],
                     "actions": ["work_graph.rank"],
                 }
-            ]
+            ],
         }
     )
 
@@ -415,7 +415,7 @@ def _terminal_agent_work_graph_rank_policy() -> LaunchplaneAuthzPolicy:
                     "contexts": ["launchplane"],
                     "actions": ["work_graph.rank"],
                 }
-            ]
+            ],
         }
     )
 
@@ -431,7 +431,7 @@ def _terminal_agent_merge_train_pr_feedback_policy() -> LaunchplaneAuthzPolicy:
                     "contexts": ["launchplane"],
                     "actions": ["merge_train.pr_feedback"],
                 }
-            ]
+            ],
         }
     )
 
@@ -447,7 +447,7 @@ def _terminal_agent_merge_train_run_once_policy() -> LaunchplaneAuthzPolicy:
                     "contexts": ["launchplane"],
                     "actions": ["merge_train.run_once"],
                 }
-            ]
+            ],
         }
     )
 
@@ -463,7 +463,7 @@ def _local_operator_work_graph_rank_policy() -> LaunchplaneAuthzPolicy:
                     "contexts": ["launchplane"],
                     "actions": ["work_graph.rank"],
                 }
-            ]
+            ],
         }
     )
 
@@ -484,18 +484,25 @@ def _local_admin_work_graph_rank_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
-def _driver_read_policy(*, context: str = "launchplane") -> LaunchplaneAuthzPolicy:
+def _driver_read_policy(
+    *,
+    context: str = "launchplane",
+    instances: tuple[str, ...] = (),
+    schema_version: int = 1,
+) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
+            "schema_version": schema_version,
             "local_operators": [
                 {
                     "subjects": ["local-owner-agent"],
                     "token_labels": ["local-owner-read"],
                     "products": ["launchplane"],
                     "contexts": [context],
+                    "instances": list(instances),
                     "actions": ["driver.read"],
                 }
-            ]
+            ],
         }
     )
 
@@ -508,9 +515,15 @@ def _backup_gate_write_identity() -> GitHubActionsIdentity:
     )
 
 
-def _backup_gate_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+def _backup_gate_write_policy(
+    *,
+    context: str,
+    instances: tuple[str, ...] = (),
+    schema_version: int = 1,
+) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
+            "schema_version": schema_version,
             "github_actions": [
                 {
                     "repository": "every/example-site",
@@ -520,9 +533,10 @@ def _backup_gate_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
                     "event_names": ["workflow_dispatch"],
                     "products": ["example-site"],
                     "contexts": [context],
+                    "instances": list(instances),
                     "actions": ["backup_gate.write"],
                 }
-            ]
+            ],
         }
     )
 
@@ -588,9 +602,15 @@ def _promotion_write_identity() -> GitHubActionsIdentity:
     )
 
 
-def _promotion_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+def _promotion_write_policy(
+    *,
+    context: str,
+    instances: tuple[str, ...] = (),
+    schema_version: int = 1,
+) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
+            "schema_version": schema_version,
             "github_actions": [
                 {
                     "repository": "every/example-site",
@@ -600,9 +620,10 @@ def _promotion_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
                     "event_names": ["workflow_dispatch"],
                     "products": ["example-site"],
                     "contexts": [context],
+                    "instances": list(instances),
                     "actions": ["promotion.write"],
                 }
-            ]
+            ],
         }
     )
 
@@ -1269,9 +1290,15 @@ def _deployment_write_identity() -> GitHubActionsIdentity:
     )
 
 
-def _deployment_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
+def _deployment_write_policy(
+    *,
+    context: str,
+    instances: tuple[str, ...] = (),
+    schema_version: int = 1,
+) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
+            "schema_version": schema_version,
             "github_actions": [
                 {
                     "repository": "every/example-site",
@@ -1281,9 +1308,10 @@ def _deployment_write_policy(*, context: str) -> LaunchplaneAuthzPolicy:
                     "event_names": ["workflow_dispatch"],
                     "products": ["example-site"],
                     "contexts": [context],
+                    "instances": list(instances),
                     "actions": ["deployment.write"],
                 }
-            ]
+            ],
         }
     )
 
@@ -1293,9 +1321,12 @@ def _record_read_policy(
     action: str,
     context: str,
     extra_actions: tuple[str, ...] = (),
+    instances: tuple[str, ...] = (),
+    schema_version: int = 1,
 ) -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {
+            "schema_version": schema_version,
             "github_actions": [
                 {
                     "repository": "every/verireel",
@@ -1305,9 +1336,10 @@ def _record_read_policy(
                     "event_names": ["pull_request"],
                     "products": ["launchplane"],
                     "contexts": [context],
+                    "instances": list(instances),
                     "actions": [action, *extra_actions],
                 }
-            ]
+            ],
         }
     )
 
@@ -2552,19 +2584,23 @@ def _github_human_product_config_policy(
     product: str = "sellyouroutboard",
     context: str = "sellyouroutboard",
     role: str = "admin",
+    instances: tuple[str, ...] = (),
+    schema_version: int = 1,
 ) -> LaunchplaneAuthzPolicy:
     allowed_actions = actions if actions is not None else (action,)
     return LaunchplaneAuthzPolicy.model_validate(
         {
+            "schema_version": schema_version,
             "github_humans": [
                 {
                     "logins": ["example-operator"],
                     "roles": [role],
                     "products": [product],
                     "contexts": [context],
+                    "instances": list(instances),
                     "actions": list(allowed_actions),
                 }
-            ]
+            ],
         }
     )
 
@@ -2755,10 +2791,13 @@ def _odoo_operation_status_policy(
     actions: tuple[str, ...] = (),
     products: tuple[str, ...] = ("odoo-tenant-cm",),
     contexts: tuple[str, ...] = ("cm",),
+    instances: tuple[str, ...] = (),
+    schema_version: int = 1,
 ) -> LaunchplaneAuthzPolicy:
     resolved_actions = actions or (action,)
     return LaunchplaneAuthzPolicy.model_validate(
         {
+            "schema_version": schema_version,
             "github_actions": [
                 {
                     "repository": "cbusillo/launchplane",
@@ -2768,9 +2807,10 @@ def _odoo_operation_status_policy(
                     "event_names": ["workflow_dispatch"],
                     "products": list(products),
                     "contexts": list(contexts),
+                    "instances": list(instances),
                     "actions": list(resolved_actions),
                 }
-            ]
+            ],
         }
     )
 

--- a/tests/test_authz_grant_service.py
+++ b/tests/test_authz_grant_service.py
@@ -4,15 +4,21 @@ import json
 import unittest
 from typing import cast
 
+from pydantic import ValidationError
+
 from control_plane.authz_grant_service import (
     AuthzPolicyGitHubActionsGrant,
     AuthzPolicyGitHubActionsGrantEnvelope,
     AuthzPolicyGitHubActionsRemovalEnvelope,
     AuthzPolicyGitHubHumanGrant,
     AuthzPolicyGitHubHumanGrantEnvelope,
+    AuthzPolicyLocalAdminGrantEnvelope,
+    AuthzPolicyLocalOperatorGrantEnvelope,
+    AuthzPolicyTerminalAgentGrantEnvelope,
     authz_policy_grant_response_audit_payload,
     build_authz_policy_github_actions_removal_service_result,
     build_authz_policy_grant_service_result,
+    execute_authz_policy_route,
     plan_github_actions_authz_policy_removal,
     plan_github_actions_authz_policy_grant,
     plan_github_human_authz_policy_grant,
@@ -152,6 +158,205 @@ def _human_grant_request(mode: str = "apply") -> AuthzPolicyGitHubHumanGrantEnve
 
 
 class AuthzGrantServiceTests(unittest.TestCase):
+    def test_route_request_schema_must_match_active_policy_schema(self) -> None:
+        request = AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+            {
+                "schema_version": 2,
+                "product": "launchplane",
+                "mode": "dry_run",
+                "grant": {
+                    "repository": "cbusillo/launchplane",
+                    "actions": ["product_profile.read"],
+                },
+            }
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "must match the active policy schema_version",
+        ):
+            execute_authz_policy_route(
+                record_store=_AuthzPolicyStore((_active_record(),)),
+                request=request,
+                identity=_identity(),
+                trace_id="trace-schema-mismatch",
+                now_timestamp=lambda: "2026-07-18T00:00:00Z",
+            )
+
+    def test_schema_v2_instance_scoped_grants_require_instances_for_every_principal(
+        self,
+    ) -> None:
+        grants = (
+            (
+                AuthzPolicyGitHubActionsGrantEnvelope,
+                {"repository": "cbusillo/odoo-tenant", "actions": ["deployment.write"]},
+            ),
+            (
+                AuthzPolicyGitHubHumanGrantEnvelope,
+                {
+                    "logins": ["alice"],
+                    "roles": ["admin"],
+                    "actions": ["deployment.write"],
+                },
+            ),
+            (
+                AuthzPolicyTerminalAgentGrantEnvelope,
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-read"],
+                    "actions": ["deployment.write"],
+                },
+            ),
+            (
+                AuthzPolicyLocalOperatorGrantEnvelope,
+                {
+                    "subjects": ["local-owner-agent"],
+                    "token_labels": ["local-owner-write"],
+                    "actions": ["deployment.write"],
+                },
+            ),
+            (
+                AuthzPolicyLocalAdminGrantEnvelope,
+                {
+                    "subjects": ["local-owner-admin"],
+                    "token_labels": ["local-owner-admin"],
+                    "actions": ["deployment.write"],
+                },
+            ),
+        )
+        for envelope_type, grant in grants:
+            with self.subTest(envelope_type=envelope_type.__name__):
+                payload = {
+                    "schema_version": 2,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "grant": grant,
+                }
+                with self.assertRaisesRegex(
+                    ValidationError,
+                    "instance-scoped authz grants require instances",
+                ):
+                    envelope_type.model_validate(payload)
+
+                payload["grant"] = {**grant, "instances": ["testing"]}
+                envelope = envelope_type.model_validate(payload)
+                self.assertEqual(envelope.grant.to_policy_rule().instances, ("testing",))
+
+    def test_schema_v1_preserves_legacy_instance_grant_shape(self) -> None:
+        envelope = AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+            {
+                "schema_version": 1,
+                "product": "launchplane",
+                "mode": "dry_run",
+                "grant": {
+                    "repository": "cbusillo/odoo-tenant",
+                    "actions": ["deployment.write"],
+                },
+            }
+        )
+
+        self.assertEqual(envelope.grant.instances, ())
+
+    def test_schema_v1_rejects_instance_selectors(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "Schema-v1 authz grants cannot declare instances",
+        ):
+            AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+                {
+                    "schema_version": 1,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "grant": {
+                        "repository": "cbusillo/odoo-tenant",
+                        "instances": ["testing"],
+                        "actions": ["deployment.write"],
+                    },
+                }
+            )
+
+    def test_schema_v2_instance_scoped_removal_requires_instances(self) -> None:
+        payload = {
+            "schema_version": 2,
+            "product": "launchplane",
+            "mode": "dry_run",
+            "removal": {
+                "repository": "cbusillo/odoo-tenant",
+                "actions": ["deployment.write"],
+            },
+        }
+
+        with self.assertRaisesRegex(
+            ValidationError,
+            "instance-scoped authz grants require instances",
+        ):
+            AuthzPolicyGitHubActionsRemovalEnvelope.model_validate(payload)
+
+        removal = cast(dict[str, object], payload["removal"])
+        removal["instances"] = ["testing"]
+        envelope = AuthzPolicyGitHubActionsRemovalEnvelope.model_validate(payload)
+        self.assertEqual(envelope.removal.instances, ("testing",))
+
+    def test_schema_v2_dual_scope_grants_support_context_or_exact_instance(self) -> None:
+        context_envelope = AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+            {
+                "schema_version": 2,
+                "product": "launchplane",
+                "mode": "dry_run",
+                "grant": {
+                    "repository": "cbusillo/launchplane",
+                    "actions": ["product_environment.read"],
+                },
+            }
+        )
+        instance_envelope = AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+            {
+                "schema_version": 2,
+                "product": "launchplane",
+                "mode": "dry_run",
+                "grant": {
+                    "repository": "cbusillo/launchplane",
+                    "instances": ["testing"],
+                    "actions": ["product_environment.read"],
+                },
+            }
+        )
+
+        self.assertEqual(context_envelope.grant.instances, ())
+        self.assertEqual(instance_envelope.grant.instances, ("testing",))
+
+    def test_schema_v2_rejects_instance_selectors_for_context_only_actions(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "can only declare instances for instance-scoped actions",
+        ):
+            AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+                {
+                    "schema_version": 2,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "grant": {
+                        "repository": "cbusillo/launchplane",
+                        "instances": ["testing"],
+                        "actions": ["product_profile.read"],
+                    },
+                }
+            )
+
+    def test_unknown_grant_schema_version_fails_closed(self) -> None:
+        with self.assertRaises(ValidationError):
+            AuthzPolicyGitHubActionsGrantEnvelope.model_validate(
+                {
+                    "schema_version": 3,
+                    "product": "launchplane",
+                    "mode": "dry_run",
+                    "grant": {
+                        "repository": "cbusillo/launchplane",
+                        "actions": ["product_profile.read"],
+                    },
+                }
+            )
+
     def test_grant_normalizes_tuple_values(self) -> None:
         grant = AuthzPolicyGitHubActionsGrant.model_validate(
             {
@@ -234,14 +439,12 @@ class AuthzGrantServiceTests(unittest.TestCase):
         self.assertEqual(diff["new_github_actions_rule_count"], 1)
         self.assertEqual(diff["new_github_humans_rule_count"], 1)
 
-        updated_policy, record, changed, write_diff, audit = (
-            write_github_human_authz_policy_grant(
-                record_store=store,
-                request=request,
-                identity=_identity(),
-                trace_id="trace-human",
-                now_timestamp=lambda: "2026-05-07T16:00:00Z",
-            )
+        updated_policy, record, changed, write_diff, audit = write_github_human_authz_policy_grant(
+            record_store=store,
+            request=request,
+            identity=_identity(),
+            trace_id="trace-human",
+            now_timestamp=lambda: "2026-05-07T16:00:00Z",
         )
 
         self.assertTrue(changed)
@@ -410,14 +613,12 @@ class AuthzGrantServiceTests(unittest.TestCase):
         store = _AuthzPolicyStore((duplicate_record,))
         request = _removal_request()
 
-        updated_policy, _record, changed, diff, _audit = (
-            write_github_actions_authz_policy_removal(
-                record_store=store,
-                request=request,
-                identity=_identity(),
-                trace_id="trace-remove-duplicates",
-                now_timestamp=lambda: "2026-05-07T16:00:00Z",
-            )
+        updated_policy, _record, changed, diff, _audit = write_github_actions_authz_policy_removal(
+            record_store=store,
+            request=request,
+            identity=_identity(),
+            trace_id="trace-remove-duplicates",
+            now_timestamp=lambda: "2026-05-07T16:00:00Z",
         )
 
         self.assertTrue(changed)
@@ -439,9 +640,9 @@ class AuthzGrantServiceTests(unittest.TestCase):
 
     def test_response_audit_summarizes_human_grant_without_logins(self) -> None:
         audit: dict[str, object] = {
-            "requested_grant": _human_grant_request().grant.to_policy_rule().model_dump(
-                mode="json"
-            ),
+            "requested_grant": _human_grant_request()
+            .grant.to_policy_rule()
+            .model_dump(mode="json"),
             "mode": "dry_run",
         }
 

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -1,4 +1,7 @@
+import ast
+import inspect
 import json
+import textwrap
 import unittest
 from dataclasses import replace
 from pathlib import Path
@@ -439,6 +442,14 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             ("ingress_route.plan",),
         )
         self.assertEqual(route_actions[INGRESS_ROUTE_APPLY_ROUTE].method, "POST")
+        self.assertEqual(
+            route_actions["/v1/drivers/odoo/target-replacement-apply"].scope,
+            "instance",
+        )
+        self.assertEqual(
+            route_actions["/v1/drivers/generic-web/prod-promotion-workflow"].scope,
+            "instance",
+        )
         self.assertFalse(
             route_actions["/v1/drivers/verireel/testing-verification"].operator_visible
         )
@@ -745,6 +756,40 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
             native_routes._native_driver_route_alternate_authz_action(ingress_endpoint),
             "ingress_route.plan",
         )
+
+    def test_instance_scoped_native_handlers_pass_resolved_instances(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=LaunchplaneAuthzPolicy(),
+                record_store_factory=lambda: FilesystemRecordStore(root / "state"),
+                control_plane_root_path=root,
+                state_dir=root / "state",
+            )
+
+        routes_by_path = {
+            getattr(route, "path", ""): getattr(route, "endpoint", None) for route in app.routes
+        }
+        route_metadata = native_routes._driver_route_metadata_from_descriptors()
+        for route_path, metadata in route_metadata.items():
+            if metadata.scope != "instance":
+                continue
+            with self.subTest(route_path=route_path):
+                endpoint = routes_by_path[route_path]
+                assert endpoint is not None
+                source = textwrap.dedent(inspect.getsource(endpoint))
+                syntax_tree = ast.parse(source)
+                authorization_calls = [
+                    node
+                    for node in ast.walk(syntax_tree)
+                    if isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "_native_driver_route_authorization_allows"
+                ]
+                self.assertEqual(len(authorization_calls), 1)
+                keyword_names = {keyword.arg for keyword in authorization_calls[0].keywords}
+                self.assertIn("instances", keyword_names)
 
     def test_native_fastapi_driver_route_validation_fails_closed(self) -> None:
         class _Route:

--- a/tests/test_every_code_reconciliation.py
+++ b/tests/test_every_code_reconciliation.py
@@ -42,6 +42,8 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
                     "grant-workflow",
                     "--service-url",
                     "https://launchplane.example",
+                    "--schema-version",
+                    "2",
                     "--repository",
                     "cbusillo/launchplane",
                     "--workflow-ref",
@@ -52,8 +54,10 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
                     "sellyouroutboard",
                     "--context",
                     "launchplane",
+                    "--instance",
+                    "testing",
                     "--action",
-                    "product_profile.read",
+                    "deployment.write",
                     "--reason",
                     "Inspect grant before apply.",
                     "--related-issue",
@@ -68,12 +72,14 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
         self.assertEqual(captured_request["path"], "/v1/authz-policies/github-actions/grants")
         payload = captured_request["payload"]
         assert isinstance(payload, dict)
+        self.assertEqual(payload["schema_version"], 2)
         self.assertEqual(payload["mode"], "dry_run")
         self.assertEqual(payload["reason"], "Inspect grant before apply.")
         grant = payload["grant"]
         assert isinstance(grant, dict)
         self.assertEqual(grant["repository"], "cbusillo/launchplane")
-        self.assertEqual(grant["actions"], ["product_profile.read"])
+        self.assertEqual(grant["instances"], ["testing"])
+        self.assertEqual(grant["actions"], ["deployment.write"])
         response_payload = json.loads(result.output)
         self.assertEqual(response_payload["result"]["mode"], "dry_run")
 
@@ -143,11 +149,13 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
         self.assertEqual(captured_request["path"], "/v1/authz-policies/github-actions/removals")
         payload = captured_request["payload"]
         assert isinstance(payload, dict)
+        self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["mode"], "dry_run")
         self.assertEqual(payload["reason"], "Inspect broad deploy authority removal.")
         removal = payload["removal"]
         assert isinstance(removal, dict)
         self.assertEqual(removal["repository"], "cbusillo/launchplane")
+        self.assertEqual(removal["instances"], [])
         self.assertEqual(removal["actions"], ["launchplane_service_deploy.execute"])
         response_payload = json.loads(result.output)
         self.assertEqual(response_payload["result"]["mode"], "dry_run")
@@ -200,11 +208,13 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
         self.assertEqual(captured_request["idempotency_key"], "authz-human-grant:syo-dispatch")
         payload = captured_request["payload"]
         assert isinstance(payload, dict)
+        self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["mode"], "apply")
         grant = payload["grant"]
         assert isinstance(grant, dict)
         self.assertEqual(grant["logins"], ["cbusillo"])
         self.assertEqual(grant["roles"], ["admin"])
+        self.assertEqual(grant["instances"], [])
         self.assertEqual(grant["actions"], ["generic_web_prod_promotion.dispatch"])
 
     def test_cli_authz_grant_terminal_agent_posts_service_request(self) -> None:
@@ -255,11 +265,13 @@ class EveryCodeIssueReconciliationTests(unittest.TestCase):
         self.assertEqual(captured_request["idempotency_key"], "authz-terminal-agent-grant:syo-read")
         payload = captured_request["payload"]
         assert isinstance(payload, dict)
+        self.assertEqual(payload["schema_version"], 1)
         self.assertEqual(payload["mode"], "apply")
         grant = payload["grant"]
         assert isinstance(grant, dict)
         self.assertEqual(grant["subjects"], ["local-owner-agent"])
         self.assertEqual(grant["token_labels"], ["local-owner-read"])
+        self.assertEqual(grant["instances"], [])
         self.assertEqual(grant["actions"], ["product_environment.read"])
 
     def test_creates_queued_request_when_trigger_label_is_present(self) -> None:

--- a/tests/test_http_app_core.py
+++ b/tests/test_http_app_core.py
@@ -1793,6 +1793,33 @@ class FastApiOdooOperationStatusReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 403)
         self.assertEqual(response.json()["error"]["code"], "authorization_denied")
 
+    async def test_operation_status_authorizes_against_stored_operation_instance(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record_store.write_odoo_stable_bootstrap_operation_record(
+                _running_odoo_stable_bootstrap_record()
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_odoo_operation_status_identity()),
+                authz_policy=_odoo_operation_status_policy(
+                    action="odoo_stable_bootstrap.execute",
+                    instances=("prod",),
+                    schema_version=2,
+                ),
+                record_store_factory=lambda: record_store,
+            )
+
+            response = await _asgi_get(
+                app,
+                "/v1/drivers/odoo/stable-bootstrap/operations/operation-cm-testing",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
     async def test_operation_status_missing_record_returns_not_found(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             record_store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")

--- a/tests/test_http_app_driver_dokploy.py
+++ b/tests/test_http_app_driver_dokploy.py
@@ -389,6 +389,27 @@ class FastApiDriverContextViewTests(unittest.IsolatedAsyncioTestCase):
             "deployment-example-site-testing",
         )
 
+    async def test_driver_instance_view_denies_ungranted_instance_in_shared_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            record_store = _driver_context_store(Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_driver_read_policy(
+                    context="example-site",
+                    instances=("testing",),
+                    schema_version=2,
+                ),
+                record_store_factory=lambda: record_store,
+                bearer_identity_config=_local_operator_bearer_config(),
+            )
+
+            testing_response = await _get_driver_instance_view(app, "example-site", "testing")
+            prod_response = await _get_driver_instance_view(app, "example-site", "prod")
+
+        self.assertEqual(testing_response.status_code, 200)
+        self.assertEqual(prod_response.status_code, 403)
+        self.assertEqual(prod_response.json()["error"]["code"], "authorization_denied")
+
     async def test_driver_context_view_returns_context_summary(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             record_store = _driver_context_store(Path(temporary_directory_name) / "state")
@@ -1178,6 +1199,27 @@ class FastApiDokployTargetSetupTests(unittest.IsolatedAsyncioTestCase):
 
 
 class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_tracked_target_logs_deny_ungranted_instance_in_shared_context(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_identity()),
+            authz_policy=_record_read_policy(
+                action="target_logs.read",
+                context="sellyouroutboard-testing",
+                instances=("testing",),
+                schema_version=2,
+            ),
+            record_store_factory=lambda: _MissingProductReadStore(),
+        )
+
+        response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "prod",
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
     async def test_tracked_target_logs_returns_redacted_application_logs(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -4325,8 +4325,10 @@ class FastApiOdooTargetReplacementApplyTests(unittest.IsolatedAsyncioTestCase):
     def _policy(
         self,
         *,
+        schema_version: int = 1,
         product: str = "odoo-tenant-cm",
         context: str = "cm",
+        instances: tuple[str, ...] = (),
         action: str = "odoo_target_replacement_apply.execute",
         repository: str = "cbusillo/launchplane",
         workflow_refs: tuple[str, ...] = (
@@ -4335,6 +4337,7 @@ class FastApiOdooTargetReplacementApplyTests(unittest.IsolatedAsyncioTestCase):
     ) -> LaunchplaneAuthzPolicy:
         return LaunchplaneAuthzPolicy.model_validate(
             {
+                "schema_version": schema_version,
                 "github_actions": [
                     {
                         "repository": repository,
@@ -4342,9 +4345,10 @@ class FastApiOdooTargetReplacementApplyTests(unittest.IsolatedAsyncioTestCase):
                         "event_names": ["workflow_dispatch"],
                         "products": [product],
                         "contexts": [context],
+                        "instances": list(instances),
                         "actions": [action],
                     }
-                ]
+                ],
             }
         )
 
@@ -4446,6 +4450,35 @@ class FastApiOdooTargetReplacementApplyTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(stored_operation.finished_at, "")
             self.assertEqual(stored_operation.deployment_record_id, "")
             self.assertIsNone(stored_operation.result)
+
+    async def test_testing_instance_grant_denies_prod_in_shared_context(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._store_with_tenant_profile(root / "state", include_prod_lane=True)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(self._identity()),
+                authz_policy=self._policy(
+                    schema_version=2,
+                    instances=("testing",),
+                ),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+
+            testing_response = await _post_odoo_target_replacement_apply(
+                app,
+                self._payload(instance="testing"),
+                idempotency_key="apply-cm-testing",
+            )
+            prod_response = await _post_odoo_target_replacement_apply(
+                app,
+                self._payload(instance="prod"),
+                idempotency_key="apply-cm-prod",
+            )
+
+        self.assertEqual(testing_response.status_code, 202)
+        self.assertEqual(prod_response.status_code, 403)
+        self.assertEqual(prod_response.json()["error"]["code"], "authorization_denied")
 
     async def test_odoo_target_replacement_apply_replays_existing_operation(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_http_app_evidence.py
+++ b/tests/test_http_app_evidence.py
@@ -47,6 +47,23 @@ from tests.support.auth import _StubVerifier
 
 
 class FastApiDeploymentEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_deployment_evidence_denies_ungranted_instance(self) -> None:
+        store = _DeploymentEvidenceOnlyStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_deployment_write_identity()),
+            authz_policy=_deployment_write_policy(
+                context="example-site",
+                instances=("testing",),
+                schema_version=2,
+            ),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_deployment_evidence(app, _deployment_evidence_payload())
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
     async def test_deployment_evidence_accepts_store_without_promotion_methods(self) -> None:
         store = _DeploymentEvidenceOnlyStore()
         app = create_launchplane_fastapi_app(
@@ -105,6 +122,23 @@ class FastApiDeploymentEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
 
 
 class FastApiBackupGateEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_backup_gate_evidence_denies_ungranted_instance(self) -> None:
+        store = _BackupGateEvidenceOnlyStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_backup_gate_write_identity()),
+            authz_policy=_backup_gate_write_policy(
+                context="example-site",
+                instances=("testing",),
+                schema_version=2,
+            ),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_backup_gate_evidence(app, _backup_gate_evidence_payload())
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
     async def test_backup_gate_evidence_accepts_store_with_only_backup_gate_method(self) -> None:
         store = _BackupGateEvidenceOnlyStore()
         app = create_launchplane_fastapi_app(
@@ -173,6 +207,26 @@ class FastApiBackupGateEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
 
 
 class FastApiPromotionEvidenceStoreGateTests(unittest.IsolatedAsyncioTestCase):
+    async def test_promotion_evidence_requires_every_affected_instance(self) -> None:
+        store = _PromotionEvidenceOnlyStore()
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_promotion_write_identity()),
+            authz_policy=_promotion_write_policy(
+                context="example-site",
+                instances=("testing",),
+                schema_version=2,
+            ),
+            record_store_factory=lambda: store,
+        )
+
+        response = await _post_promotion_evidence(
+            app,
+            _promotion_evidence_payload(link_deployment=False),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
     async def test_promotion_evidence_accepts_record_only_store_without_deployment_methods(
         self,
     ) -> None:

--- a/tests/test_http_app_policy_apply.py
+++ b/tests/test_http_app_policy_apply.py
@@ -2236,6 +2236,50 @@ class FastApiProductConfigApplyTests(unittest.IsolatedAsyncioTestCase):
             unknown_response.json()["error"]["message"],
         )
 
+    async def test_product_environment_config_denies_ungranted_shared_context_lane(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_url = _sqlite_database_url(
+                Path(temporary_directory_name) / "launchplane.sqlite3"
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            app_store.ensure_schema()
+            app_store.write_product_profile_record(
+                LaunchplaneProductProfileRecord.model_validate(_generic_site_profile_payload())
+            )
+            session_manager = HumanSessionManager(
+                config=_github_oauth_config(),
+                session_store=InMemoryHumanSessionStore(),
+            )
+            human_session = session_manager.issue(_github_human_identity())
+            app = create_launchplane_fastapi_app(
+                verifier=_RejectingVerifier(),
+                authz_policy=_github_human_product_config_policy(
+                    action="product_config.plan",
+                    product="example-site",
+                    context="example-site",
+                    instances=("testing",),
+                    schema_version=2,
+                ),
+                record_store_factory=lambda: app_store,
+                human_session_manager=session_manager,
+            )
+
+            response = await _post_product_environment_config_apply(
+                app,
+                {
+                    "mode": "dry-run",
+                    "reason": "Attempt an ungranted shared-context lane.",
+                    "runtime_settings": {"INTERNAL_CALLBACK_URL": "https://example.invalid"},
+                },
+                environment="prod",
+                authorization="",
+                headers=_browser_mutation_headers(session_manager, human_session),
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
     async def test_product_environment_config_path_rejects_dry_run_mismatch(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             root = Path(temporary_directory_name)

--- a/tests/test_product_environment_read_model.py
+++ b/tests/test_product_environment_read_model.py
@@ -596,7 +596,7 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             build_product_site_overview(
                 record_store=store,
                 product="unknown-site",
-                action_allowed=lambda _action, _product, _context: True,
+                action_allowed=lambda _action, _product, _context, _instances: True,
             )
 
     def test_product_environment_detail_raises_for_unknown_environment(self) -> None:
@@ -608,7 +608,7 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
                 record_store=store,
                 product="example-site",
                 environment="staging",
-                action_allowed=lambda _action, _product, _context: True,
+                action_allowed=lambda _action, _product, _context, _instances: True,
             )
 
     def test_product_site_overview_filters_preview_summaries_by_repository_and_state(self) -> None:
@@ -659,7 +659,12 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             )
         )
 
-        def action_allowed(action: str, product: str, context: str) -> bool:
+        def action_allowed(
+            action: str,
+            product: str,
+            context: str,
+            _instances: tuple[str, ...],
+        ) -> bool:
             return (
                 action
                 in {
@@ -690,7 +695,12 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
         profile = LaunchplaneProductProfileRecord.model_validate(_odoo_profile_payload())
         seen_contexts: list[tuple[str, str]] = []
 
-        def action_allowed(action: str, _product: str, context: str) -> bool:
+        def action_allowed(
+            action: str,
+            _product: str,
+            context: str,
+            _instances: tuple[str, ...],
+        ) -> bool:
             if action == "generic_web_prod_rollback.plan":
                 seen_contexts.append((action, context))
                 return context == "cm"
@@ -732,7 +742,12 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             _site_profile_payload(preview_enabled=False)
         )
 
-        def action_allowed(action: str, product: str, context: str) -> bool:
+        def action_allowed(
+            action: str,
+            product: str,
+            context: str,
+            _instances: tuple[str, ...],
+        ) -> bool:
             return action == "generic_web_deploy.execute" and context == "example-site-testing"
 
         overview = build_product_site_overview(
@@ -773,7 +788,12 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             _site_profile_payload(preview_enabled=False)
         )
 
-        def action_allowed(action: str, product: str, context: str) -> bool:
+        def action_allowed(
+            action: str,
+            product: str,
+            context: str,
+            _instances: tuple[str, ...],
+        ) -> bool:
             return (
                 action == "generic_web_prod_promotion.dispatch"
                 and context == "example-site-testing"
@@ -795,7 +815,12 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             _site_profile_payload(preview_enabled=False)
         )
 
-        def action_allowed(action: str, product: str, context: str) -> bool:
+        def action_allowed(
+            action: str,
+            product: str,
+            context: str,
+            _instances: tuple[str, ...],
+        ) -> bool:
             return (
                 action == "generic_web_prod_promotion.dispatch" and context == "example-site-prod"
             )
@@ -834,7 +859,12 @@ class ProductEnvironmentReadModelTest(unittest.TestCase):
             _site_profile_payload(preview_enabled=False)
         )
 
-        def action_allowed(action: str, product: str, context: str) -> bool:
+        def action_allowed(
+            action: str,
+            product: str,
+            context: str,
+            _instances: tuple[str, ...],
+        ) -> bool:
             return context == "example-site-testing" and action in {
                 "generic_web_prod_promotion.dispatch",
                 "generic_web_prod_promotion.execute",

--- a/tests/test_product_promotion_http.py
+++ b/tests/test_product_promotion_http.py
@@ -224,7 +224,7 @@ def _status(
         record_store=store,
         product="atlas-commerce",
         destination_environment="prod",
-        action_allowed=lambda _action, _product, _context: True,
+        action_allowed=lambda _action, _product, _context, _instances: True,
         workflow_credentials_ready=lambda _context: True,
         now=NOW,
     )
@@ -517,7 +517,7 @@ class ProductPromotionStatusTests(unittest.TestCase):
             record_store=store,
             product="atlas-commerce",
             destination_environment="prod",
-            action_allowed=lambda _action, _product, _context: False,
+            action_allowed=lambda _action, _product, _context, _instances: False,
             workflow_credentials_ready=lambda _context: True,
             now=NOW,
         )
@@ -536,6 +536,35 @@ class ProductPromotionStatusTests(unittest.TestCase):
         self.assertIn(
             "Caller is not authorized to dispatch the promotion workflow.",
             status.workflow_live.disabled_reasons,
+        )
+
+    def test_status_authorizes_both_lanes_for_direct_and_workflow_promotion(self) -> None:
+        authorization_targets: dict[str, tuple[str, ...]] = {}
+
+        def action_allowed(
+            action: str,
+            _product: str,
+            _context: str,
+            instances: tuple[str, ...],
+        ) -> bool:
+            authorization_targets[action] = instances
+            return True
+
+        build_product_promotion_status(
+            record_store=_store(),
+            product="atlas-commerce",
+            destination_environment="prod",
+            action_allowed=action_allowed,
+            workflow_credentials_ready=lambda _context: True,
+            now=NOW,
+        )
+
+        self.assertEqual(
+            authorization_targets,
+            {
+                "generic_web_prod_promotion.execute": ("testing", "prod"),
+                "generic_web_prod_promotion.dispatch": ("testing", "prod"),
+            },
         )
 
 
@@ -1070,7 +1099,7 @@ class FastApiProductPromotionTests(unittest.IsolatedAsyncioTestCase):
                 record_store=store,
                 product="atlas-commerce",
                 destination_environment="prod",
-                action_allowed=lambda _action, _product, _context: True,
+                action_allowed=lambda _action, _product, _context, _instances: True,
                 workflow_credentials_ready=lambda _context: True,
             )
             workflow_request = ProductPromotionWorkflowDispatchEnvelope(

--- a/tests/test_product_read_service.py
+++ b/tests/test_product_read_service.py
@@ -240,7 +240,7 @@ class ProductReadServiceTests(unittest.TestCase):
         result = build_product_environment_read_service_result(
             record_store=self.store,
             params={"product": "example-site", "environment": "prod"},
-            action_allowed=lambda _action, _product, _context: True,
+            action_allowed=lambda _action, _product, _context, _instances: True,
         )
 
         self.assertEqual(result.authorization_product, "example-site")
@@ -256,7 +256,7 @@ class ProductReadServiceTests(unittest.TestCase):
             build_product_environment_read_service_result(
                 record_store=self.store,
                 params={},
-                action_allowed=lambda _action, _product, _context: True,
+                action_allowed=lambda _action, _product, _context, _instances: True,
             )
 
     def test_product_environment_results_identify_branch_authorization_targets(
@@ -309,7 +309,7 @@ class ProductReadServiceTests(unittest.TestCase):
                 result = build_product_environment_read_service_result(
                     record_store=self.store,
                     params=params,
-                    action_allowed=lambda _action, _product, _context: True,
+                    action_allowed=lambda _action, _product, _context, _instances: True,
                 )
 
                 self.assertEqual(result.authorization_product, product)
@@ -320,7 +320,7 @@ class ProductReadServiceTests(unittest.TestCase):
     def test_product_environment_list_payload_serializes_overviews(self) -> None:
         payload = build_product_environment_list_service_payload(
             record_store=self.store,
-            action_allowed=lambda _action, _product, _context: True,
+            action_allowed=lambda _action, _product, _context, _instances: True,
         )
 
         products = cast(list[dict[str, object]], payload["products"])

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -7,7 +7,10 @@ from types import SimpleNamespace
 import unittest
 from unittest.mock import Mock, patch
 
+from pydantic import ValidationError
+
 from control_plane.service_auth import (
+    AuthorizationTarget,
     GitHubActionsIdentity,
     GitHubActionsPolicyRule,
     GitHubHumanIdentity,
@@ -24,6 +27,7 @@ from control_plane.service_auth import (
     agent_authz_audit,
     agent_consumer_subject,
     limited_remote_user_action_allowed,
+    migrate_authz_policy_to_schema_v2,
     parse_authz_policy_toml,
 )
 from control_plane.contracts.authz_policy_record import authz_policy_sha256
@@ -1044,6 +1048,8 @@ class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
             )
         )
         legacy_payload = policy.model_dump(mode="json", exclude_none=True)
+        for rule in legacy_payload["github_actions"]:
+            rule.pop("instances", None)
         legacy_payload.pop("terminal_agents", None)
         legacy_payload.pop("local_operators", None)
         legacy_payload.pop("local_admins", None)
@@ -1052,6 +1058,378 @@ class LaunchplaneAuthzPolicyCompatibilityTests(unittest.TestCase):
         ).hexdigest()
 
         self.assertEqual(authz_policy_sha256(policy), legacy_sha256)
+
+    def test_unknown_policy_schema_version_fails_closed(self) -> None:
+        with self.assertRaises(ValidationError):
+            LaunchplaneAuthzPolicy.model_validate({"schema_version": 3})
+
+    def test_schema_v1_preserves_implicit_instance_wildcard(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    repository="cbusillo/verireel",
+                    products=("verireel",),
+                    contexts=("verireel",),
+                    actions=("deployment.write", "product_profile.read"),
+                ),
+            )
+        )
+
+        self.assertTrue(
+            policy.allows(
+                identity=_actions_identity(),
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+                target=AuthorizationTarget(scope="instance", instances=("testing",)),
+            )
+        )
+        self.assertTrue(
+            policy.allows(
+                identity=_actions_identity(),
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+                target=AuthorizationTarget(scope="instance", instances=("prod",)),
+            )
+        )
+
+    def test_policy_schema_rejects_ambiguous_instance_rule_shapes(self) -> None:
+        with self.assertRaisesRegex(
+            ValidationError,
+            "Schema-v1 authz policy rules cannot declare instances",
+        ):
+            LaunchplaneAuthzPolicy(
+                github_actions=(
+                    GitHubActionsPolicyRule(
+                        repository="cbusillo/verireel",
+                        instances=("testing",),
+                        actions=("deployment.write",),
+                    ),
+                ),
+            )
+        with self.assertRaisesRegex(
+            ValidationError,
+            "instance-scoped authz policy rules require instances",
+        ):
+            LaunchplaneAuthzPolicy(
+                schema_version=2,
+                github_actions=(
+                    GitHubActionsPolicyRule(
+                        repository="cbusillo/verireel",
+                        actions=("deployment.write",),
+                    ),
+                ),
+            )
+        with self.assertRaisesRegex(
+            ValidationError,
+            "can only declare instances for instance-scoped actions",
+        ):
+            LaunchplaneAuthzPolicy(
+                schema_version=2,
+                github_actions=(
+                    GitHubActionsPolicyRule(
+                        repository="cbusillo/verireel",
+                        instances=("testing",),
+                        actions=("product_profile.read",),
+                    ),
+                ),
+            )
+
+    def test_schema_v2_requires_matching_instance_selector(self) -> None:
+        identity = _actions_identity()
+        policy = LaunchplaneAuthzPolicy(
+            schema_version=2,
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    repository="cbusillo/verireel",
+                    products=("verireel",),
+                    contexts=("verireel",),
+                    instances=("testing",),
+                    actions=("deployment.write",),
+                ),
+            ),
+        )
+
+        self.assertTrue(
+            policy.allows(
+                identity=identity,
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+                target=AuthorizationTarget(scope="instance", instances=("testing",)),
+            ),
+        )
+        self.assertFalse(
+            policy.allows(
+                identity=identity,
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+                target=AuthorizationTarget(scope="instance", instances=("prod",)),
+            )
+        )
+        self.assertFalse(
+            policy.allows(
+                identity=identity,
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+                target=AuthorizationTarget(
+                    scope="instance",
+                    instances=("testing", "prod"),
+                ),
+            )
+        )
+
+    def test_instance_scope_requires_a_resolved_target(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            schema_version=2,
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    repository="cbusillo/verireel",
+                    products=("verireel",),
+                    contexts=("verireel",),
+                    instances=("*",),
+                    actions=("deployment.write",),
+                ),
+            ),
+        )
+
+        self.assertFalse(
+            policy.allows(
+                identity=_actions_identity(),
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+            )
+        )
+        with self.assertRaises(ValidationError):
+            AuthorizationTarget(scope="instance")
+        with self.assertRaises(ValidationError):
+            AuthorizationTarget(scope="context", instances=("testing",))
+
+    def test_instance_selectors_are_exact_or_a_lone_wildcard(self) -> None:
+        with self.assertRaises(ValidationError):
+            GitHubActionsPolicyRule(
+                repository="cbusillo/verireel",
+                instances=("test*",),
+            )
+        with self.assertRaises(ValidationError):
+            GitHubActionsPolicyRule(
+                repository="cbusillo/verireel",
+                instances=("*", "testing"),
+            )
+
+    def test_schema_v2_exact_instances_apply_to_all_principal_types(self) -> None:
+        target = AuthorizationTarget(scope="instance", instances=("testing",))
+        wrong_target = AuthorizationTarget(scope="instance", instances=("prod",))
+        cases = (
+            (
+                _actions_identity(),
+                LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    github_actions=(
+                        GitHubActionsPolicyRule(
+                            repository="cbusillo/verireel",
+                            instances=("testing",),
+                            actions=("deployment.write",),
+                        ),
+                    ),
+                ),
+            ),
+            (
+                _human_identity(role="admin"),
+                LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    github_humans=(
+                        GitHubHumanPolicyRule(
+                            logins=("alice",),
+                            roles=("admin",),
+                            instances=("testing",),
+                            actions=("deployment.write",),
+                        ),
+                    ),
+                ),
+            ),
+            (
+                _terminal_agent_identity(),
+                LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    terminal_agents=(
+                        TerminalAgentPolicyRule(
+                            subjects=("local-owner-agent",),
+                            token_labels=("local-owner-read",),
+                            instances=("testing",),
+                            actions=("deployment.write",),
+                        ),
+                    ),
+                ),
+            ),
+            (
+                _local_operator_identity(),
+                LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    local_operators=(
+                        LocalOperatorPolicyRule(
+                            subjects=("local-owner-agent",),
+                            token_labels=("local-owner-write",),
+                            instances=("testing",),
+                            actions=("deployment.write",),
+                        ),
+                    ),
+                ),
+            ),
+            (
+                _local_admin_identity(),
+                LaunchplaneAuthzPolicy(
+                    schema_version=2,
+                    local_admins=(
+                        LocalAdminPolicyRule(
+                            subjects=("local-owner-admin",),
+                            token_labels=("local-owner-admin",),
+                            instances=("testing",),
+                            actions=("deployment.write",),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        for identity, policy in cases:
+            with self.subTest(identity_type=type(identity).__name__):
+                self.assertTrue(
+                    policy.allows(
+                        identity=identity,
+                        action="deployment.write",
+                        product="verireel",
+                        context="verireel",
+                        target=target,
+                    )
+                )
+                self.assertFalse(
+                    policy.allows(
+                        identity=identity,
+                        action="deployment.write",
+                        product="verireel",
+                        context="verireel",
+                        target=wrong_target,
+                    )
+                )
+
+    def test_schema_v2_migration_materializes_legacy_instance_wildcards(self) -> None:
+        legacy_policy = LaunchplaneAuthzPolicy(
+            github_actions=(
+                GitHubActionsPolicyRule(
+                    repository="cbusillo/verireel",
+                    products=("verireel",),
+                    contexts=("verireel",),
+                    actions=("deployment.write", "product_profile.read"),
+                ),
+            ),
+            github_humans=(
+                GitHubHumanPolicyRule(
+                    logins=("alice",),
+                    roles=("admin",),
+                    actions=("deployment.write",),
+                ),
+            ),
+            terminal_agents=(
+                TerminalAgentPolicyRule(
+                    subjects=("local-owner-agent",),
+                    token_labels=("local-owner-read",),
+                    actions=("deployment.write",),
+                ),
+            ),
+            local_operators=(
+                LocalOperatorPolicyRule(
+                    subjects=("local-owner-agent",),
+                    token_labels=("local-owner-write",),
+                    actions=("deployment.write",),
+                ),
+            ),
+            local_admins=(
+                LocalAdminPolicyRule(
+                    subjects=("local-owner-admin",),
+                    token_labels=("local-owner-admin",),
+                    actions=("deployment.write",),
+                ),
+            ),
+        )
+
+        migrated_policy = migrate_authz_policy_to_schema_v2(legacy_policy)
+
+        self.assertEqual(migrated_policy.schema_version, 2)
+        self.assertEqual(len(migrated_policy.github_actions), 2)
+        self.assertEqual(
+            migrated_policy.github_actions[0].actions,
+            ("product_profile.read",),
+        )
+        self.assertEqual(migrated_policy.github_actions[0].instances, ())
+        self.assertEqual(
+            migrated_policy.github_actions[1].actions,
+            ("deployment.write",),
+        )
+        self.assertEqual(migrated_policy.github_actions[1].instances, ("*",))
+        for rule_collection in (
+            migrated_policy.github_humans,
+            migrated_policy.terminal_agents,
+            migrated_policy.local_operators,
+            migrated_policy.local_admins,
+        ):
+            self.assertEqual(rule_collection[0].instances, ("*",))
+        self.assertTrue(
+            migrated_policy.allows(
+                identity=_actions_identity(),
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+                target=AuthorizationTarget(scope="instance", instances=("prod",)),
+            )
+        )
+        self.assertTrue(
+            migrated_policy.allows(
+                identity=_actions_identity(),
+                action="product_profile.read",
+                product="verireel",
+                context="verireel",
+            )
+        )
+
+    def test_schema_v2_migration_splits_actionless_legacy_rules_by_scope(self) -> None:
+        migrated_policy = migrate_authz_policy_to_schema_v2(
+            LaunchplaneAuthzPolicy(
+                github_actions=(GitHubActionsPolicyRule(repository="cbusillo/verireel"),),
+            )
+        )
+
+        self.assertEqual(len(migrated_policy.github_actions), 2)
+        self.assertEqual(migrated_policy.github_actions[0].instances, ())
+        self.assertEqual(migrated_policy.github_actions[1].instances, ("*",))
+        self.assertTrue(
+            migrated_policy.allows(
+                identity=_actions_identity(),
+                action="product_profile.read",
+                product="verireel",
+                context="verireel",
+            )
+        )
+        self.assertFalse(
+            migrated_policy.allows(
+                identity=_actions_identity(),
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+            )
+        )
+        self.assertTrue(
+            migrated_policy.allows(
+                identity=_actions_identity(),
+                action="deployment.write",
+                product="verireel",
+                context="verireel",
+                target=AuthorizationTarget(scope="instance", instances=("prod",)),
+            )
+        )
 
     def test_policy_sha256_includes_terminal_agent_rules_when_present(self) -> None:
         base_policy = LaunchplaneAuthzPolicy(

--- a/tests/test_work_graph_service.py
+++ b/tests/test_work_graph_service.py
@@ -153,7 +153,7 @@ class WorkGraphServiceTests(unittest.TestCase):
             generated_at="2026-05-06T02:05:00Z",
             product_store=_EmptyProductStore(),
             work_request_store=work_request_store,
-            action_allowed=lambda _action, _product, _context: True,
+            action_allowed=lambda _action, _product, _context, _instances: True,
             planning_facts_provider=lambda: (
                 WorkGraphPlanningIssueFacts.model_validate(
                     {
@@ -238,7 +238,7 @@ class WorkGraphServiceTests(unittest.TestCase):
             generated_at="2026-05-06T02:05:00Z",
             product_store=_EmptyProductStore((product,)),
             work_request_store=_WorkRequestStore((_work_request(repository="every/example-site"),)),
-            action_allowed=lambda _action, _product, _context: False,
+            action_allowed=lambda _action, _product, _context, _instances: False,
             planning_facts_provider=None,
         )
 
@@ -254,7 +254,7 @@ class WorkGraphServiceTests(unittest.TestCase):
             generated_at="2026-05-06T02:05:00Z",
             product_store=_EmptyProductStore(),
             work_request_store=_WorkRequestStore((_work_request(),)),
-            action_allowed=lambda _action, _product, _context: True,
+            action_allowed=lambda _action, _product, _context, _instances: True,
             planning_facts_provider=None,
         )
         rank_request = WorkGraphRankEnvelope.model_validate(


### PR DESCRIPTION
## Summary
- add schema-v2 exact instance selectors for every authz principal while preserving schema-v1 hashes and breadth through an explicit migration split
- enforce descriptor scope centrally, including both source and destination lanes for promotion, and carry exact targets through evidence, records, driver views/logs, operation status, product reads, and product config
- add same-context cross-lane denial coverage, generated OpenAPI updates, and operator migration documentation

## Migration Safety
- active policy and grant/removal request schema versions must match
- CLI grant commands remain schema v1 by default; v2 requires explicit `--schema-version 2`
- v2 empty selectors are non-instance only; `*` is an explicit all-instance selector
- mixed and actionless v1 rules migrate into separate context and instance representations

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` — 2,123 targets passed across 12 shards
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check .`
- changed-file `uv run --extra dev ruff format --check ...`
- `pnpm --dir frontend validate`
- `uv run launchplane service audit-config-authority --control-plane-root .`
- `docker build -t launchplane-ci:test .`
- `uv run --with pip-audit pip-audit --ignore-vuln PYSEC-2025-183`
- Trivy HIGH/CRITICAL image scan

Repository-wide `ruff format --check .` still reports 30 pre-existing untouched files; all Python files changed by this PR pass the format check.

Closes #1772