### PR TITLE
Fix bundled GitHub CLI gRPC vulnerability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,20 @@ RUN pnpm build
 
 FROM mirror.gcr.io/library/golang:1.26.5-bookworm AS github-cli-build
 
+ARG GITHUB_CLI_VERSION=v2.96.0
+ARG GITHUB_CLI_GRPC_VERSION=v1.82.1
+
 ENV CGO_ENABLED=0 \
     GOTOOLCHAIN=local
 
-RUN go install github.com/cli/cli/v2/cmd/gh@v2.95.0
+RUN mkdir -p /tmp/github-cli-build \
+    && cd /tmp/github-cli-build \
+    && go mod init launchplane.local/github-cli-build \
+    && go get "github.com/cli/cli/v2/cmd/gh@${GITHUB_CLI_VERSION}" \
+    && go get "google.golang.org/grpc@${GITHUB_CLI_GRPC_VERSION}" \
+    && go build -trimpath -o /go/bin/gh github.com/cli/cli/v2/cmd/gh \
+    && go version -m /go/bin/gh | grep -F "github.com/cli/cli/v2" | grep -F "${GITHUB_CLI_VERSION}" \
+    && go version -m /go/bin/gh | grep -F "google.golang.org/grpc" | grep -F "${GITHUB_CLI_GRPC_VERSION}"
 
 FROM mirror.gcr.io/library/python:3.13-slim
 

--- a/tests/test_service_image_contract.py
+++ b/tests/test_service_image_contract.py
@@ -5,6 +5,24 @@ from pathlib import Path
 
 
 class ServiceImageContractTests(unittest.TestCase):
+    def test_service_image_pins_fixed_github_cli_grpc_dependency(self) -> None:
+        dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"
+
+        dockerfile_text = dockerfile.read_text(encoding="utf-8")
+
+        self.assertIn("GITHUB_CLI_VERSION=v2.96.0", dockerfile_text)
+        self.assertIn("GITHUB_CLI_GRPC_VERSION=v1.82.1", dockerfile_text)
+        self.assertIn(
+            'go get "github.com/cli/cli/v2/cmd/gh@${GITHUB_CLI_VERSION}"',
+            dockerfile_text,
+        )
+        self.assertIn(
+            'go get "google.golang.org/grpc@${GITHUB_CLI_GRPC_VERSION}"',
+            dockerfile_text,
+        )
+        self.assertIn("go version -m /go/bin/gh", dockerfile_text)
+        self.assertNotIn("go install github.com/cli/cli/v2/cmd/gh@v2.95.0", dockerfile_text)
+
     def test_service_image_installs_ssh_client_for_rollback_worker(self) -> None:
         dockerfile = Path(__file__).resolve().parents[1] / "Dockerfile"
 


### PR DESCRIPTION
## Summary
- build the bundled GitHub CLI from pinned `v2.96.0`
- explicitly upgrade its embedded gRPC dependency to fixed `v1.82.1`
- assert the resolved module versions during the image build and in the service image contract test

## Verification
- `uv run --extra dev python -m unittest tests.test_service_image_contract`
- `uv run --extra dev ruff check --fix --diff tests/test_service_image_contract.py`
- `uv run --extra dev ruff format --check tests/test_service_image_contract.py`
- `docker build -t launchplane-ci:1793 .`
- `docker run --rm launchplane-ci:1793 gh version`
- CI-equivalent Trivy image scan: no HIGH/CRITICAL findings

Fixes #1793
Unblocks #1791