### PR TITLE
Fix Odoo runtime identity evidence after target replacement

### DIFF
--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Callable, Iterable, Mapping
 from pathlib import Path
 from typing import Literal, Protocol
@@ -41,6 +42,11 @@ from control_plane.workflows.odoo_verification import (
     default_odoo_health_url,
     is_legacy_derived_odoo_health_url,
     verify_odoo_stable_readiness,
+)
+from control_plane.workflows.runtime_identity_health import (
+    RuntimeIdentityHealthcheckError,
+    healthcheck_evidence_with_runtime_identity,
+    wait_for_runtime_identity_healthcheck_with_retry,
 )
 from control_plane.runtime_key_safety import RuntimeKeySafetyPolicyReadStore
 from control_plane.workflows.ship import (
@@ -774,6 +780,57 @@ def _build_runtime_identity(
     )
 
 
+def _verify_required_runtime_identity_evidence(
+    *,
+    health_url: str,
+    timeout_seconds: int,
+    expected_runtime_identity: RuntimeIdentity,
+) -> HealthcheckEvidence:
+    evidence = HealthcheckEvidence(
+        verified=True,
+        urls=(health_url,),
+        timeout_seconds=timeout_seconds,
+        status="fail",
+    )
+    try:
+        healthcheck_pass = wait_for_runtime_identity_healthcheck_with_retry(
+            url=health_url,
+            timeout_seconds=timeout_seconds,
+            expected_runtime_identity=expected_runtime_identity,
+            sleep=time.sleep,
+            monotonic=time.monotonic,
+        )
+    except RuntimeIdentityHealthcheckError as error:
+        if error.healthcheck_pass is not None:
+            return healthcheck_evidence_with_runtime_identity(
+                evidence,
+                expected_runtime_identity=expected_runtime_identity,
+                healthcheck_pass=error.healthcheck_pass,
+            )
+        return evidence.model_copy(
+            update={
+                "runtime_identity_status": "unverifiable",
+                "runtime_identity_detail": str(error),
+            }
+        )
+    except (click.ClickException, TimeoutError, OSError) as error:
+        return evidence.model_copy(
+            update={
+                "runtime_identity_status": "unverifiable",
+                "runtime_identity_detail": str(error),
+            }
+        )
+
+    verified_evidence = healthcheck_evidence_with_runtime_identity(
+        evidence.model_copy(update={"status": "pass"}),
+        expected_runtime_identity=expected_runtime_identity,
+        healthcheck_pass=healthcheck_pass,
+    )
+    if verified_evidence.runtime_identity_status != "match":
+        return verified_evidence.model_copy(update={"status": "fail"})
+    return verified_evidence
+
+
 def _write_failed_deployment(
     *,
     record_store: OdooStableTargetReplacementStore,
@@ -1151,6 +1208,21 @@ def execute_odoo_stable_target_replacement_apply(
         source_git_ref=source_git_ref,
         image_reference=image_reference,
     )
+    base_url = _target_base_url(lane=lane, domains=plan.expected_domain_hosts)
+    health_url = _target_health_url(
+        profile=profile,
+        lane=lane,
+        domains=plan.expected_domain_hosts,
+    )
+    if lane.odoo_data_policy.requires_runtime_identity:
+        if not request.verify_health:
+            raise click.ClickException(
+                "Odoo target replacement requires health verification when the lane requires runtime identity."
+            )
+        if not health_url:
+            raise click.ClickException(
+                "Odoo target replacement runtime identity verification has no health URL."
+            )
 
     record_store.write_deployment_record(
         build_deployment_record(
@@ -1179,7 +1251,6 @@ def execute_odoo_stable_target_replacement_apply(
         image_reference=image_reference,
     )
     runtime_source: dict[str, str] = {}
-    base_url = _target_base_url(lane=lane, domains=plan.expected_domain_hosts)
     odoo_override_record = _read_odoo_instance_override_record(
         record_store=record_store,
         context=plan.context,
@@ -1565,7 +1636,6 @@ def execute_odoo_stable_target_replacement_apply(
             error_message=post_deploy_result.error_message or "Odoo post-deploy failed.",
         )
 
-    health_url = _target_health_url(profile=profile, lane=lane, domains=plan.expected_domain_hosts)
     verification = verify_odoo_stable_readiness(
         base_url=base_url,
         health_url=health_url,
@@ -1614,12 +1684,52 @@ def execute_odoo_stable_target_replacement_apply(
 
     finished_at = utc_now_timestamp()
     final_runtime_identity = runtime_identity.model_copy(update={"deployed_at": finished_at})
-    destination_health = HealthcheckEvidence(
-        verified=request.verify_health,
-        urls=(health_url,) if request.verify_health and health_url else (),
-        timeout_seconds=health_timeout_seconds if request.verify_health and health_url else None,
-        status=health_status,
-    )
+    if lane.odoo_data_policy.requires_runtime_identity:
+        destination_health = _verify_required_runtime_identity_evidence(
+            health_url=health_url,
+            timeout_seconds=health_timeout_seconds,
+            expected_runtime_identity=runtime_identity,
+        )
+        if destination_health.runtime_identity_status != "match":
+            error_message = "Odoo runtime identity verification failed: " + (
+                destination_health.runtime_identity_detail
+                or destination_health.runtime_identity_status
+            )
+            _write_failed_deployment(
+                record_store=record_store,
+                ship_request=ship_request,
+                deployment_record_id=deployment_record_id,
+                started_at=started_at,
+                resolved_target=resolved_target,
+                runtime_source=runtime_source,
+                runtime_identity=runtime_identity,
+                post_deploy_update=post_deploy_evidence,
+                destination_health=destination_health,
+            )
+            return base_result.result(
+                deploy_status="fail",
+                post_deploy_status="pass",
+                post_deploy_result=post_deploy_result,
+                health_status="fail",
+                canonical_status=canonical_status,
+                logo_status=logo_status,
+                health_url=verification.evidence.health_url,
+                canonical_url=verification.evidence.canonical_url,
+                logo_urls=verification.evidence.logo_urls,
+                verification_evidence=verification.evidence,
+                runtime_identity_injected=True,
+                runtime_source=runtime_source,
+                error_message=error_message,
+            )
+    else:
+        destination_health = HealthcheckEvidence(
+            verified=request.verify_health,
+            urls=(health_url,) if request.verify_health and health_url else (),
+            timeout_seconds=health_timeout_seconds
+            if request.verify_health and health_url
+            else None,
+            status=health_status,
+        )
     deployment_record = build_deployment_record(
         request=ship_request,
         record_id=deployment_record_id,

--- a/control_plane/workflows/runtime_identity_health.py
+++ b/control_plane/workflows/runtime_identity_health.py
@@ -90,6 +90,8 @@ def wait_for_runtime_identity_healthcheck_with_retry(
             last_detail = f"http {error.code}"
         except URLError as error:
             last_detail = str(error.reason)
+        except (TimeoutError, OSError) as error:
+            last_detail = str(error)
         else:
             last_healthcheck_pass = healthcheck_pass
             status, detail, _observed = health_payload_runtime_identity_status(

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -240,6 +240,13 @@ Odoo stable target replacement so runtime identity, post-deploy maintenance,
 canonical/logo verification, deployment records, inventory, and release tuples
 stay on the canonical stable executor while the rollback wrapper owns promotion
 rollback provenance.
+When an Odoo lane requires runtime identity, the stable target-replacement
+executor also reads the injected identity back from the lane-owned health URL
+after the Odoo health, canonical, and logo probes pass. Only an exact match of
+the authoritative deployment identity fields can advance current inventory or
+mint a release tuple. Missing, malformed, mismatched, or unreachable identity
+evidence writes a failed deployment record instead. Lanes that explicitly do
+not require runtime identity keep the existing health-verification behavior.
 
 The `stable_verification` action routes to
 `POST /v1/drivers/generic-web/stable-verification`. Product workflows submit the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1610,6 +1610,15 @@ current inventory, live Dokploy target payload, domains, volume env keys, latest
 deployment, and expected runtime identity. It does not create, delete, deploy,
 or change routes.
 
+After a target-replacement apply deploys and the Odoo health, canonical, and
+logo probes pass, lanes whose Odoo data policy requires runtime identity perform
+a separate bounded JSON health readback. This second probe may use the full lane
+health timeout so a stale old container can drain before the new deployment
+identity appears. A missing, malformed, mismatched, or unreachable identity
+marks the deployment failed and leaves current inventory and release tuples
+unchanged. A successful record carries `runtime_identity_status=match` plus the
+bounded observed identity copied into environment inventory.
+
 For an already-tracked Dokploy compose target, use `Dokploy Target Setup` with
 `operation=reconcile-compose-domain` to reconcile the provider domain route
 without creating or adopting the target again. The service reads the

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2550,10 +2550,13 @@ Launchplane. Prod rollback reads DB-backed release tuples, artifact manifests,
 and current promotion/inventory records, then delegates the provider mutation to
 stable target replacement. That shared executor deploys the selected
 artifact-backed image, injects runtime identity, runs post-deploy maintenance,
-verifies health/canonical/logo evidence, and writes deployment/release-tuple
-evidence. The rollback wrapper only adds rollback provenance to inventory and
-the current prod promotion record. Local Odoo runtime commands remain in
-`odoo-devkit`; these drivers are for remote control-plane execution only.
+verifies health/canonical/logo evidence, reads required runtime identity back
+from the lane-owned health endpoint, and writes deployment/release-tuple
+evidence only when that identity matches. Failed required identity evidence does
+not advance current inventory. The rollback wrapper only adds rollback
+provenance to inventory and the current prod promotion record. Local Odoo
+runtime commands remain in `odoo-devkit`; these drivers are for remote
+control-plane execution only.
 
 Privileged product rollback actions should use a narrow delegated-worker runtime
 contract when they require network reach or host authority that does not belong

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -37,7 +37,9 @@ from control_plane.contracts.product_profile_record import (
 from control_plane.contracts.promotion_record import (
     ArtifactIdentityReference,
     DeploymentEvidence,
+    HealthcheckEvidence,
 )
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.contracts.runtime_key_safety_policy import (
     RuntimeKeySafetyPolicyRecord,
     RuntimeSecretSafetyRule,
@@ -56,6 +58,11 @@ from control_plane.workflows.odoo_stable_target_replacement import (
     build_odoo_stable_target_replacement_plan,
     execute_odoo_stable_target_replacement_apply,
     _target_health_url,
+    _verify_required_runtime_identity_evidence,
+)
+from control_plane.workflows.runtime_identity_health import (
+    HealthcheckPass,
+    RuntimeIdentityHealthcheckError,
 )
 from control_plane.workflows.odoo_verification import (
     OdooVerificationEvidence,
@@ -240,6 +247,14 @@ def _verification_result() -> OdooVerificationResult:
     )
 
 
+def _matching_runtime_identity_healthcheck(
+    *, expected_runtime_identity: RuntimeIdentity, **_: object
+) -> HealthcheckPass:
+    return HealthcheckPass(
+        payload={"runtime_identity": expected_runtime_identity.model_dump(mode="json")}
+    )
+
+
 def _opw_profile_with_prelaunch_policy(*, enabled: bool) -> LaunchplaneProductProfileRecord:
     return LaunchplaneProductProfileRecord(
         product="odoo-tenant-opw",
@@ -384,6 +399,143 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             _merge_required_odoo_install_modules("cm_website, disable_odoo_online, website"),
             "launchplane_settings,disable_odoo_online,cm_website,website",
         )
+
+    def test_required_runtime_identity_evidence_records_exact_match(self) -> None:
+        expected_runtime_identity = RuntimeIdentity(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            deployment_record_id="deployment-current",
+            artifact_id="artifact-current",
+            source_git_ref="abc1234",
+        )
+
+        with patch(
+            "control_plane.workflows.odoo_stable_target_replacement.wait_for_runtime_identity_healthcheck_with_retry",
+            side_effect=_matching_runtime_identity_healthcheck,
+        ):
+            evidence = _verify_required_runtime_identity_evidence(
+                health_url="https://cm-testing.example.com/launchplane/health",
+                timeout_seconds=30,
+                expected_runtime_identity=expected_runtime_identity,
+            )
+
+        self.assertEqual(evidence.status, "pass")
+        self.assertEqual(evidence.runtime_identity_status, "match")
+        self.assertEqual(evidence.observed_runtime_identity, expected_runtime_identity)
+
+    def test_required_runtime_identity_evidence_fails_closed_on_mismatch(self) -> None:
+        expected_runtime_identity = RuntimeIdentity(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            deployment_record_id="deployment-current",
+            artifact_id="artifact-current",
+            source_git_ref="abc1234",
+        )
+        observed_runtime_identity = expected_runtime_identity.model_copy(
+            update={"deployment_record_id": "deployment-stale"}
+        )
+
+        with patch(
+            "control_plane.workflows.odoo_stable_target_replacement.wait_for_runtime_identity_healthcheck_with_retry",
+            side_effect=RuntimeIdentityHealthcheckError(
+                "runtime identity mismatch",
+                healthcheck_pass=HealthcheckPass(
+                    payload={"runtime_identity": observed_runtime_identity.model_dump(mode="json")}
+                ),
+            ),
+        ):
+            evidence = _verify_required_runtime_identity_evidence(
+                health_url="https://cm-testing.example.com/launchplane/health",
+                timeout_seconds=30,
+                expected_runtime_identity=expected_runtime_identity,
+            )
+
+        self.assertEqual(evidence.status, "fail")
+        self.assertEqual(evidence.runtime_identity_status, "mismatch")
+        self.assertIn("deployment_record_id", evidence.runtime_identity_detail)
+        self.assertEqual(evidence.observed_runtime_identity, observed_runtime_identity)
+
+    def test_required_runtime_identity_evidence_records_unverifiable_timeout(self) -> None:
+        expected_runtime_identity = RuntimeIdentity(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            deployment_record_id="deployment-current",
+            artifact_id="artifact-current",
+            source_git_ref="abc1234",
+        )
+
+        with patch(
+            "control_plane.workflows.odoo_stable_target_replacement.wait_for_runtime_identity_healthcheck_with_retry",
+            side_effect=RuntimeIdentityHealthcheckError("healthcheck timed out"),
+        ):
+            evidence = _verify_required_runtime_identity_evidence(
+                health_url="https://cm-testing.example.com/launchplane/health",
+                timeout_seconds=30,
+                expected_runtime_identity=expected_runtime_identity,
+            )
+
+        self.assertEqual(evidence.status, "fail")
+        self.assertEqual(evidence.runtime_identity_status, "unverifiable")
+        self.assertIn("healthcheck timed out", evidence.runtime_identity_detail)
+
+    def test_apply_rejects_disabled_health_when_runtime_identity_is_required(self) -> None:
+        store = _Store(
+            target_record=_target_record(),
+            target_id_record=_target_id_record(),
+            inventory=_inventory(),
+        )
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_source.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.fetch_dokploy_target_payload",
+                return_value={
+                    "name": "cm-testing",
+                    "env": "\n".join(
+                        (
+                            "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                            "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                            "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                        )
+                    ),
+                },
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.update_dokploy_target_env"
+            ) as update_env,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.trigger_deployment"
+            ) as trigger_deployment,
+        ):
+            with self.assertRaisesRegex(
+                click.ClickException,
+                "requires health verification when the lane requires runtime identity",
+            ):
+                execute_odoo_stable_target_replacement_apply(
+                    control_plane_root=Path("."),
+                    record_store=store,
+                    request=OdooStableTargetReplacementApplyRequest(
+                        product="odoo-tenant-cm",
+                        instance="testing",
+                        verify_health=False,
+                    ),
+                    dokploy_request=cast(DokployRequest, _request),
+                )
+
+        self.assertEqual(store.deployment_records, [])
+        self.assertEqual(store.environment_inventories, [])
+        update_env.assert_not_called()
+        trigger_deployment.assert_not_called()
 
     def test_build_plan_allows_issue_backed_opw_upstream_restore_policy(self) -> None:
         with (
@@ -1016,6 +1168,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 "control_plane.workflows.odoo_stable_target_replacement.verify_odoo_stable_readiness",
                 return_value=_verification_result(),
             ) as verify_readiness,
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.wait_for_runtime_identity_healthcheck_with_retry",
+                side_effect=_matching_runtime_identity_healthcheck,
+            ) as verify_runtime_identity,
         ):
             ensure_domain.side_effect = _ensure_domain
             wait_deploy.side_effect = _wait_for_deploy
@@ -1232,6 +1388,14 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             final_deployment.runtime_identity.deployment_record_id,
             final_deployment.record_id,
         )
+        self.assertEqual(final_deployment.destination_health.status, "pass")
+        self.assertEqual(final_deployment.destination_health.runtime_identity_status, "match")
+        assert final_deployment.destination_health.observed_runtime_identity is not None
+        self.assertEqual(
+            final_deployment.destination_health.observed_runtime_identity.deployment_record_id,
+            final_deployment.record_id,
+        )
+        verify_runtime_identity.assert_called_once()
         self.assertEqual(len(store.environment_inventories), 1)
         self.assertEqual(
             store.environment_inventories[0].deployment_record_id,
@@ -1253,7 +1417,22 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 "cm_website",
             ),
         )
+        profile = _profile()
+        profile = profile.model_copy(
+            update={
+                "lanes": (
+                    profile.lanes[0].model_copy(
+                        update={
+                            "odoo_data_policy": ProductOdooLaneDataPolicy(
+                                requires_runtime_identity=False
+                            )
+                        }
+                    ),
+                )
+            }
+        )
         store = _Store(
+            profile=profile,
             target_record=_target_record(),
             target_id_record=_target_id_record(),
             inventory=_inventory(),
@@ -1336,6 +1515,9 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                 "control_plane.workflows.odoo_stable_target_replacement.verify_odoo_stable_readiness",
                 return_value=_verification_result(),
             ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.wait_for_runtime_identity_healthcheck_with_retry"
+            ) as verify_runtime_identity,
         ):
             result = execute_odoo_stable_target_replacement_apply(
                 control_plane_root=Path("."),
@@ -1366,7 +1548,158 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         assert final_deployment.runtime_identity is not None
         self.assertEqual(final_deployment.runtime_identity.artifact_id, "artifact-cm-fresh")
         self.assertEqual(final_deployment.runtime_identity.source_git_ref, "feed123")
+        self.assertEqual(final_deployment.destination_health.runtime_identity_status, "unchecked")
+        verify_runtime_identity.assert_not_called()
         self.assertEqual(sync_source.call_args.kwargs["compose_name"], "cm-testing")
+
+    def test_apply_fails_required_runtime_identity_failures_before_inventory(self) -> None:
+        store = _Store(
+            target_record=_target_record(),
+            target_id_record=_target_id_record(),
+            inventory=_inventory(),
+        )
+        persisted_env = ""
+        rendered_compose_file = control_plane_dokploy.render_odoo_raw_compose_file(
+            image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:artifact",
+            domain_hosts=("cm-testing.shinycomputers.com",),
+            runtime_port=8069,
+        )
+        observed_runtime_identity = RuntimeIdentity(
+            product="odoo-tenant-cm",
+            context="cm",
+            instance="testing",
+            deployment_record_id="deployment-stale",
+            artifact_id="artifact-cm-testing",
+            source_git_ref="abc1234",
+        )
+        mismatched_evidence = HealthcheckEvidence(
+            verified=True,
+            urls=("https://cm-testing.shinycomputers.com/launchplane/health",),
+            timeout_seconds=120,
+            status="fail",
+            runtime_identity_status="mismatch",
+            runtime_identity_detail="Runtime identity mismatched fields: deployment_record_id",
+            observed_runtime_identity=observed_runtime_identity,
+        )
+        unverifiable_evidence = HealthcheckEvidence(
+            verified=True,
+            urls=("https://cm-testing.shinycomputers.com/launchplane/health",),
+            timeout_seconds=120,
+            status="fail",
+            runtime_identity_status="unverifiable",
+            runtime_identity_detail="socket timed out",
+        )
+
+        def _fetch_target_payload(**_: object) -> JsonValue:
+            return {
+                "name": "cm-testing",
+                "sourceType": "raw",
+                "composePath": "docker-compose.yml",
+                "composeFile": rendered_compose_file,
+                "env": persisted_env
+                or "\n".join(
+                    (
+                        "ODOO_DATA_VOLUME=cm_testing_odoo_data",
+                        "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
+                        "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                    )
+                ),
+            }
+
+        def _update_env(*, env_text: str, **_: object) -> None:
+            nonlocal persisted_env
+            persisted_env = env_text
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_source.read_dokploy_config",
+                return_value=("host", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.fetch_dokploy_target_payload",
+                side_effect=_fetch_target_payload,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.latest_deployment_for_target",
+                return_value={"deploymentId": "deploy-123", "status": "success"},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.control_plane_runtime_environments.resolve_runtime_environment_values",
+                return_value={},
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_compose.sync_dokploy_compose_raw_source"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_compose.ensure_compose_web_domain_route"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_compose.fetch_dokploy_converted_compose_file",
+                return_value=rendered_compose_file,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.update_dokploy_target_env",
+                side_effect=_update_env,
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.trigger_deployment"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.dokploy_api.wait_for_target_deployment"
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.execute_odoo_post_deploy",
+                return_value=OdooPostDeployResult(
+                    context="cm",
+                    instance="testing",
+                    phase="deploy",
+                    post_deploy_status="pass",
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.verify_odoo_stable_readiness",
+                return_value=_verification_result(),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement._verify_required_runtime_identity_evidence",
+                side_effect=(mismatched_evidence, unverifiable_evidence),
+            ) as verify_runtime_identity,
+        ):
+            results = tuple(
+                execute_odoo_stable_target_replacement_apply(
+                    control_plane_root=Path("."),
+                    record_store=store,
+                    request=OdooStableTargetReplacementApplyRequest(
+                        product="odoo-tenant-cm", instance="testing"
+                    ),
+                    dokploy_request=cast(DokployRequest, _request),
+                )
+                for _ in range(2)
+            )
+
+        self.assertTrue(all(result.deploy_status == "fail" for result in results))
+        self.assertTrue(all(result.health_status == "fail" for result in results))
+        self.assertTrue(
+            all(
+                "runtime identity verification failed" in result.error_message.lower()
+                for result in results
+            )
+        )
+        self.assertEqual(store.environment_inventories, [])
+        self.assertEqual(store.release_tuples, [])
+        failed_deployments = [
+            record for record in store.deployment_records if record.deploy.status == "fail"
+        ]
+        self.assertEqual(
+            [record.destination_health.runtime_identity_status for record in failed_deployments],
+            ["mismatch", "unverifiable"],
+        )
+        self.assertEqual(
+            failed_deployments[0].destination_health.observed_runtime_identity,
+            observed_runtime_identity,
+        )
+        self.assertIsNone(failed_deployments[1].destination_health.observed_runtime_identity)
+        self.assertEqual(verify_runtime_identity.call_count, 2)
 
     def test_apply_persists_post_deploy_failure_evidence(self) -> None:
         store = _Store(
@@ -1797,6 +2130,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                     evidence=OdooVerificationEvidence(),
                 ),
             ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.wait_for_runtime_identity_healthcheck_with_retry",
+                side_effect=_matching_runtime_identity_healthcheck,
+            ),
         ):
             result = execute_odoo_stable_target_replacement_apply(
                 control_plane_root=Path("."),
@@ -2195,6 +2532,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
             patch(
                 "control_plane.workflows.odoo_stable_target_replacement.verify_odoo_stable_readiness",
                 return_value=_verification_result(),
+            ),
+            patch(
+                "control_plane.workflows.odoo_stable_target_replacement.wait_for_runtime_identity_healthcheck_with_retry",
+                side_effect=_matching_runtime_identity_healthcheck,
             ),
         ):
             result = execute_odoo_stable_target_replacement_apply(

--- a/tests/test_runtime_identity_health.py
+++ b/tests/test_runtime_identity_health.py
@@ -114,7 +114,9 @@ class RuntimeIdentityHealthTests(unittest.TestCase):
         attempts = iter(
             (
                 HealthcheckPass(payload={"status": "ok"}),
-                HealthcheckPass(payload={"runtime_identity": {"deployment_record_id": "deployment-123"}}),
+                HealthcheckPass(
+                    payload={"runtime_identity": {"deployment_record_id": "deployment-123"}}
+                ),
                 HealthcheckPass(payload={"runtime_identity": identity.model_dump(mode="json")}),
             )
         )
@@ -171,6 +173,42 @@ class RuntimeIdentityHealthTests(unittest.TestCase):
             result.payload,
             {"runtime_identity": expected_identity.model_dump(mode="json")},
         )
+        self.assertEqual(sleeps, [1])
+
+    def test_wait_for_runtime_identity_healthcheck_retries_raw_timeout(self) -> None:
+        expected_identity = RuntimeIdentity(
+            product="sellyouroutboard",
+            context="sellyouroutboard-prod",
+            instance="production",
+            deployment_record_id="deployment-new",
+            artifact_id="artifact-a",
+            source_git_ref="abc123",
+        )
+        matching_pass = HealthcheckPass(
+            payload={"runtime_identity": expected_identity.model_dump(mode="json")}
+        )
+        attempts: list[BaseException | HealthcheckPass] = [
+            TimeoutError("socket timed out"),
+            matching_pass,
+        ]
+        sleeps: list[float] = []
+
+        def wait_once(**_kwargs: object) -> HealthcheckPass:
+            result = attempts.pop(0)
+            if isinstance(result, BaseException):
+                raise result
+            return result
+
+        result = wait_for_runtime_identity_healthcheck_with_retry(
+            url="https://example.com/health",
+            timeout_seconds=30,
+            expected_runtime_identity=expected_identity,
+            sleep=sleeps.append,
+            monotonic=lambda: 0,
+            wait_once=wait_once,
+        )
+
+        self.assertIs(result, matching_pass)
         self.assertEqual(sleeps, [1])
 
     def test_wait_for_runtime_identity_healthcheck_timeout_keeps_last_mismatch(


### PR DESCRIPTION
## Summary
- require Odoo target replacement to read back the injected runtime identity before advancing current inventory when the lane requires it
- persist bounded match, mismatch, missing, malformed, and unverifiable deployment health evidence; failed identity proof leaves inventory and release tuples unchanged
- retry raw socket timeouts inside the configured health window and preserve opt-out lane behavior
- document the deployment-owned identity boundary

## Validation
- `uv run --extra dev python -m unittest tests.test_odoo_stable_target_replacement tests.test_runtime_identity_health tests.test_product_operational_readiness tests.test_odoo_target_replacement_workflows`
- `uv run --extra dev launchplane ci unittest-shard local --jobs 1` (2,281 targets)
- changed-file Ruff lint/format and mypy
- `uv run launchplane service audit-config-authority --control-plane-root .`
- JetBrains changed-files inspection: zero findings
- independent multi-model reviews: clean after fixes

Closes #1823