### PR TITLE
Add isolated OPW production enrollment authz set

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -25,6 +25,7 @@ name: Manage Launchplane Authorization
           - odoo-testing-route-binding-refresh
           - odoo-testing-target-replacement
           - odoo-opw-preview-feedback
+          - odoo-opw-production-enrollment
       reviewed_plan_sha256:
         description: Plan SHA-256 returned by the reviewed dry run; required for apply.
         required: false
@@ -119,3 +120,14 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_OPW_PREVIEW_FEEDBACK_MANAGED_SET_JSON }}
+
+  reconcile-odoo-opw-production-enrollment:
+    if: ${{ inputs.managed_set == 'odoo-opw-production-enrollment' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    with:
+      mode: ${{ inputs.mode }}
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_OPW_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -405,6 +405,10 @@ Odoo target-replacement workers. The
 `LAUNCHPLANE_AUTHZ_ODOO_OPW_PREVIEW_FEEDBACK_MANAGED_SET_JSON` owns the isolated
 OPW preview feedback writer grant without requiring operators to read or replace
 the primary managed-set secret. The
+`LAUNCHPLANE_AUTHZ_ODOO_OPW_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON` owns the
+separate exact-instance OPW production inspection and enrollment grants so the
+operator can reconcile that lane without replacing another unreadable managed
+set. The
 `Manage Launchplane Authorization` wrapper selects one of those explicit
 secrets and forwards it into the reusable worker, whose OIDC-minting job remains
 gated by the `launchplane-authz-admin` environment. Never replace the unreadable

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -37,6 +37,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "odoo-testing-route-binding-refresh",
                 "odoo-testing-target-replacement",
                 "odoo-opw-preview-feedback",
+                "odoo-opw-production-enrollment",
             ],
         )
         expected_jobs = {
@@ -67,6 +68,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-odoo-opw-preview-feedback": (
                 "${{ inputs.managed_set == 'odoo-opw-preview-feedback' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_OPW_PREVIEW_FEEDBACK_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-odoo-opw-production-enrollment": (
+                "${{ inputs.managed_set == 'odoo-opw-production-enrollment' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_OPW_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON }}",
             ),
         }
         self.assertEqual(set(self.dispatch_workflow.jobs), set(expected_jobs))


### PR DESCRIPTION
## Summary
- add a dedicated `odoo-opw-production-enrollment` managed-set dispatch path
- keep the protected immutable authz worker and OIDC permissions unchanged
- document the isolated secret boundary and cover the wrapper wiring

## Validation
- `uv run --extra dev python -m unittest tests.test_authz_operator_workflow`
- `git diff --check`
- independent security/correctness reviews found no blocking issues

## Operations
The protected repository secret was provisioned with a schema-v2 exact-instance dry-run set for `odoo-tenant-opw` / `opw` / `prod`. It grants managed route-binding read authority and external route-binding read/plan authority only; no apply action is included.

Related to #1801