### PR TITLE
Add generic Odoo production enrollment authz set

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -26,6 +26,7 @@ name: Manage Launchplane Authorization
           - odoo-testing-target-replacement
           - odoo-opw-preview-feedback
           - odoo-opw-production-enrollment
+          - odoo-production-enrollment
       reviewed_plan_sha256:
         description: Plan SHA-256 returned by the reviewed dry run; required for apply.
         required: false
@@ -131,3 +132,14 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_OPW_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON }}
+
+  reconcile-odoo-production-enrollment:
+    if: ${{ inputs.managed_set == 'odoo-production-enrollment' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    with:
+      mode: ${{ inputs.mode }}
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -408,6 +408,9 @@ the primary managed-set secret. The
 `LAUNCHPLANE_AUTHZ_ODOO_OPW_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON` owns the
 separate exact-instance OPW production inspection and enrollment grants so the
 operator can reconcile that lane without replacing another unreadable managed
+set. `LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON` owns
+additional exact-instance Odoo production inspection and enrollment grants
+without expanding the OPW-specific set or replacing another unreadable managed
 set. The
 `Manage Launchplane Authorization` wrapper selects one of those explicit
 secrets and forwards it into the reusable worker, whose OIDC-minting job remains

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -38,6 +38,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "odoo-testing-target-replacement",
                 "odoo-opw-preview-feedback",
                 "odoo-opw-production-enrollment",
+                "odoo-production-enrollment",
             ],
         )
         expected_jobs = {
@@ -72,6 +73,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-odoo-opw-production-enrollment": (
                 "${{ inputs.managed_set == 'odoo-opw-production-enrollment' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_OPW_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-odoo-production-enrollment": (
+                "${{ inputs.managed_set == 'odoo-production-enrollment' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON }}",
             ),
         }
         self.assertEqual(set(self.dispatch_workflow.jobs), set(expected_jobs))


### PR DESCRIPTION
## Summary
- add a generic `odoo-production-enrollment` managed-set dispatch path
- isolate its protected secret from the OPW-specific and existing unreadable sets
- preserve the immutable authz worker, OIDC permissions, and environment gate
- document and test the new wrapper wiring

## Validation
- `uv run --extra dev python -m unittest tests.test_authz_operator_workflow`
- `git diff --check`
- two independent security/correctness reviews found no actionable issues

## Operations
The protected repository secret is provisioned with schema-v2 exact-instance CM
Website production dry-run rules only. No apply authority is included.

Related to #1801
