### PR TITLE
Allow Odoo target replacement to repair failed lanes

### DIFF
--- a/control_plane/drivers/registry.py
+++ b/control_plane/drivers/registry.py
@@ -696,8 +696,6 @@ ODOO_DRIVER = DriverDescriptor(
                 "runtime_environment",
                 "managed_secrets",
                 "artifact",
-                "deployment",
-                "topology",
             ),
         ),
         _action(
@@ -715,8 +713,6 @@ ODOO_DRIVER = DriverDescriptor(
                 "runtime_environment",
                 "managed_secrets",
                 "artifact",
-                "deployment",
-                "topology",
             ),
         ),
     ),

--- a/docs/driver-descriptors.md
+++ b/docs/driver-descriptors.md
@@ -248,6 +248,14 @@ mint a release tuple. Missing, malformed, mismatched, or unreachable identity
 evidence writes a failed deployment record instead. Lanes that explicitly do
 not require runtime identity keep the existing health-verification behavior.
 
+Odoo target-replacement plan and apply are repair-path actions. Their
+operational-readiness requirements intentionally stop at recorded provider
+target, route binding, runtime environment, managed secrets, and artifact
+authority; they do not require the current deployment or observed topology to
+already pass. The replacement plan still fences the current inventory artifact,
+and apply must pass the normal post-deploy health, canonical, logo, and runtime
+identity checks before inventory can advance.
+
 The `stable_verification` action routes to
 `POST /v1/drivers/generic-web/stable-verification`. Product workflows submit the
 deployment record, optional promotion record, checked URLs, and pass/fail status;

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1605,6 +1605,14 @@ entrypoints and pin those reviewed reusable workers to a full commit SHA. When
 worker behavior changes, land and validate the reusable contracts first, then
 advance the wrapper pin in a separate reviewed change.
 
+Target-replacement plan and apply readiness intentionally permits a degraded
+current deployment or failed public observation because replacement is the
+repair path for those states. Provider-target authority, route binding, runtime
+environment, managed secrets, and the exact persisted artifact remain required.
+The plan and apply paths independently fence the current inventory artifact,
+and apply still requires passing post-deploy verification before inventory or
+release evidence advances.
+
 The operator UI can inspect that same readiness contract from the environment
 `Actions` route without dispatching a workflow or invoking a descriptor route.
 It derives exact lane and artifact selectors from the product-environment read

--- a/tests/test_driver_descriptors.py
+++ b/tests/test_driver_descriptors.py
@@ -441,6 +441,13 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
     def test_odoo_descriptor_marks_prod_rollback_as_destructive(self) -> None:
         descriptor = read_driver_descriptor("odoo")
         actions = {action.action_id: action for action in descriptor.actions}
+        target_replacement_requirements = (
+            "provider_target",
+            "route_binding",
+            "runtime_environment",
+            "managed_secrets",
+            "artifact",
+        )
 
         self.assertEqual(descriptor.base_driver_id, "generic-web")
         self.assertEqual(actions["prod_backup_gate"].safety, "safe_write")
@@ -454,6 +461,14 @@ class DriverDescriptorRegistryTests(unittest.TestCase):
         self.assertEqual(
             actions["stable_bootstrap"].route_path,
             "/v1/drivers/odoo/stable-bootstrap",
+        )
+        self.assertEqual(
+            actions["target_replacement_plan"].readiness_requirements,
+            target_replacement_requirements,
+        )
+        self.assertEqual(
+            actions["target_replacement_apply"].readiness_requirements,
+            target_replacement_requirements,
         )
         setting_groups = {group.group_id: group for group in descriptor.setting_groups}
         self.assertIn("preview_domain_tls", setting_groups)

--- a/tests/test_http_app_product_operational_readiness.py
+++ b/tests/test_http_app_product_operational_readiness.py
@@ -239,7 +239,8 @@ class FastApiProductOperationalReadinessTests(unittest.IsolatedAsyncioTestCase):
             dimension["dimension"]: dimension["state"] for dimension in readiness["dimensions"]
         }
         self.assertEqual(states["provider_target"], "ready")
-        self.assertEqual(states["deployment"], "ready")
+        self.assertNotIn("deployment", states)
+        self.assertNotIn("topology", states)
 
     async def test_readiness_reports_exact_authorization_and_missing_records_without_mutation(
         self,
@@ -282,7 +283,7 @@ class FastApiProductOperationalReadinessTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 200)
         readiness = response.json()["readiness"]
         self.assertFalse(readiness["ready"])
-        self.assertEqual(readiness["state"], "blocked")
+        self.assertEqual(readiness["state"], "missing")
         states = {
             dimension["dimension"]: dimension["state"] for dimension in readiness["dimensions"]
         }

--- a/tests/test_product_operational_readiness.py
+++ b/tests/test_product_operational_readiness.py
@@ -37,6 +37,7 @@ from control_plane.contracts.promotion_record import (
     DeploymentEvidence,
     HealthcheckEvidence,
 )
+from control_plane.drivers.registry import read_driver_descriptor
 from control_plane.service_auth import GitHubActionsIdentity, LaunchplaneAuthzPolicy
 from tests.support.artifact_manifests import artifact_manifest_v2
 
@@ -350,6 +351,57 @@ class ProductOperationalReadinessTests(unittest.TestCase):
         )
         self.assertEqual(provider_target.state, "ready")
         self.assertEqual(provider_target.evidence[0].freshness_status, "recorded")
+
+    def test_target_replacement_remains_ready_for_broken_live_deployment(self) -> None:
+        inputs = _inputs()
+        lane_summary = inputs.lane_summary
+        assert lane_summary is not None
+        deployment = lane_summary.latest_deployment
+        assert deployment is not None
+        failed_health = deployment.destination_health.model_copy(
+            update={
+                "verified": False,
+                "status": "fail",
+                "runtime_identity_status": "unchecked",
+            }
+        )
+        topology = inputs.topology.model_copy(
+            update={
+                "warnings": (
+                    ProductTopologyWarning(
+                        code="public_ingress_failure",
+                        scope="observation",
+                        severity="error",
+                        detail="The current public ingress observation failed.",
+                    ),
+                )
+            }
+        )
+        descriptor = read_driver_descriptor("odoo")
+        action = next(
+            action for action in descriptor.actions if action.action_id == "target_replacement_plan"
+        )
+
+        readiness = build_product_operational_readiness(
+            replace(
+                inputs,
+                action=action,
+                lane_summary=lane_summary.model_copy(
+                    update={
+                        "latest_deployment": deployment.model_copy(
+                            update={"destination_health": failed_health}
+                        )
+                    }
+                ),
+                topology=topology,
+            )
+        )
+
+        self.assertTrue(readiness.ready)
+        dimensions = {dimension.dimension: dimension for dimension in readiness.dimensions}
+        self.assertEqual(dimensions["route_binding"].state, "ready")
+        self.assertNotIn("deployment", dimensions)
+        self.assertNotIn("topology", dimensions)
 
     def test_warning_severity_controls_route_and_topology_readiness(self) -> None:
         cases = (


### PR DESCRIPTION
## Summary
- treat Odoo target replacement plan/apply as repair actions by requiring structural authority, not already-passing deployment/topology evidence
- retain provider-target, route-binding, runtime-environment, managed-secret, and artifact gates
- add descriptor/readiness regression coverage and document the repair boundary

## Validation
- `uv run --extra dev ruff check --no-fix control_plane/drivers/registry.py tests/test_driver_descriptors.py tests/test_product_operational_readiness.py tests/test_http_app_product_operational_readiness.py`
- `uv run --extra dev ruff format --check control_plane/drivers/registry.py tests/test_driver_descriptors.py tests/test_product_operational_readiness.py tests/test_http_app_product_operational_readiness.py`
- `uv run --extra dev python -m unittest tests.test_driver_descriptors tests.test_product_operational_readiness tests.test_http_app_product_operational_readiness`
- `uv run --extra dev launchplane ci unittest-shard local`

Related #1801