### PR TITLE
Add exact Compose service log selection

### DIFF
--- a/.github/workflows/tracked-target-logs.yml
+++ b/.github/workflows/tracked-target-logs.yml
@@ -35,6 +35,11 @@ name: Tracked Target Logs
         required: false
         default: ""
         type: string
+      service:
+        description: Optional exact Dokploy Compose service for runtime logs.
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -54,6 +59,7 @@ jobs:
       SOURCE: ${{ inputs.source }}
       SINCE: ${{ inputs.since }}
       SEARCH: ${{ inputs.search }}
+      SERVICE: ${{ inputs.service }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -83,8 +89,16 @@ jobs:
             echo "deployment logs do not support search." >&2
             exit 1
           fi
+          if [ "$SOURCE" = "deployment" ] && [ -n "$SERVICE" ]; then
+            echo "deployment logs do not support compose service selection." >&2
+            exit 1
+          fi
           if ! [[ "$SEARCH" =~ ^[a-zA-Z0-9\ ._-]{0,500}$ ]]; then
             echo 'search may contain only safe plain-text characters.' >&2
+            exit 1
+          fi
+          if ! [[ "$SERVICE" =~ ^$|^[a-z0-9][a-z0-9._-]{0,127}$ ]]; then
+            echo 'service must be an exact lowercase Compose service name.' >&2
             exit 1
           fi
 
@@ -104,13 +118,15 @@ jobs:
             --arg source "$SOURCE" \
             --arg since "$effective_since" \
             --arg search "$SEARCH" \
+            --arg service "$SERVICE" \
             '{
               context: $context,
               instance: $instance,
               lines: $lines,
               source: $source,
               since: $since,
-              search: $search
+              search: $search,
+              service: $service
             }' \
             > tracked-target-logs-request.json
           route_path="$({
@@ -119,7 +135,8 @@ jobs:
                "/instances/\(.instance | @uri)/logs" +
                "?lines=\(.lines | @uri)&source=\(.source | @uri)" +
                "&since=\(.since | @uri)" +
-               "&search=\(.search | @uri)"' \
+               "&search=\(.search | @uri)" +
+               "&service=\(.service | @uri)"' \
               tracked-target-logs-request.json
           })"
           echo "route_path=${route_path}" >>"$GITHUB_OUTPUT"

--- a/control_plane/cli_runtime_environments.py
+++ b/control_plane/cli_runtime_environments.py
@@ -415,6 +415,12 @@ def environments_show_live_target(context_name: str, instance_name: str) -> None
 @click.option("--since", default="all", show_default=True)
 @click.option("--search", default="", show_default=False)
 @click.option(
+    "--service",
+    default="",
+    show_default=False,
+    help="Optional exact Dokploy Compose service whose runtime logs should be read.",
+)
+@click.option(
     "--control-plane-root",
     type=click.Path(path_type=Path),
     default=None,
@@ -427,6 +433,7 @@ def environments_logs(
     line_count: int,
     since: str,
     search: str,
+    service: str,
     control_plane_root: Path | None,
 ) -> None:
     callbacks = _runtime_environment_callbacks()
@@ -441,6 +448,7 @@ def environments_logs(
                 line_count=line_count,
                 since=since,
                 search=search,
+                service=service,
             )
         except ValueError as error:
             raise click.ClickException(str(error)) from error

--- a/control_plane/dokploy/api.py
+++ b/control_plane/dokploy/api.py
@@ -27,6 +27,7 @@ _DATABASE_URI_CREDENTIAL_PATTERN = re.compile(
 )
 _DOKPLOY_LOG_SINCE_PATTERN = re.compile(r"^(all|\d+[smhd])$")
 _DOKPLOY_LOG_SEARCH_PATTERN = re.compile(r"^[a-zA-Z0-9 ._-]{0,500}$")
+_DOKPLOY_COMPOSE_SERVICE_PATTERN = re.compile(r"^$|^[a-z0-9][a-z0-9._-]{0,127}$")
 type JsonPrimitive = str | int | float | bool | None
 type JsonValue = JsonPrimitive | dict[str, "JsonValue"] | list["JsonValue"]
 type JsonObject = dict[str, JsonValue]
@@ -184,6 +185,16 @@ def normalize_dokploy_log_search(raw_search: str) -> str:
     return search
 
 
+def normalize_dokploy_compose_service_name(raw_service_name: str) -> str:
+    service_name = raw_service_name.strip().lower()
+    if not _DOKPLOY_COMPOSE_SERVICE_PATTERN.fullmatch(service_name):
+        raise click.ClickException(
+            "Dokploy compose log service must contain only lowercase letters, numbers, dots, "
+            "underscores, and dashes."
+        )
+    return service_name
+
+
 def redact_dokploy_log_line(raw_line: str) -> str:
     redacted_line = _DOUBLE_QUOTED_SECRET_LOG_VALUE_PATTERN.sub(r'\1"[redacted]"', raw_line)
     redacted_line = _SINGLE_QUOTED_SECRET_LOG_VALUE_PATTERN.sub(r"\1'[redacted]'", redacted_line)
@@ -262,6 +273,7 @@ def fetch_dokploy_compose_logs(
     compose_id: str,
     app_name: str = "",
     server_id: str = "",
+    service_name: str = "",
     line_count: int = DEFAULT_DOKPLOY_LOG_LINE_COUNT,
     since: str = "all",
     search: str = "",
@@ -274,6 +286,11 @@ def fetch_dokploy_compose_logs(
     normalized_search = normalize_dokploy_log_search(search)
     normalized_app_name = app_name.strip()
     normalized_server_id = server_id.strip()
+    normalized_service_name = normalize_dokploy_compose_service_name(service_name)
+    if normalized_service_name and not normalized_app_name:
+        raise click.ClickException(
+            "Dokploy compose service log selection requires tracked application metadata."
+        )
     query: dict[str, str | int] = {
         "composeId": normalized_compose_id,
         "tail": normalized_line_count,
@@ -297,8 +314,16 @@ def fetch_dokploy_compose_logs(
             if isinstance(containers_payload, list)
             else []
         )
-        web_container = _select_compose_log_container(containers)
-        container_id = str(web_container.get("containerId") or "").strip()
+        selected_container = _select_compose_log_container(
+            containers,
+            app_name=normalized_app_name,
+            service_name=normalized_service_name,
+        )
+        container_id = str(selected_container.get("containerId") or "").strip()
+        if normalized_service_name and not container_id:
+            raise click.ClickException(
+                f"Dokploy compose log service {normalized_service_name!r} has no container id."
+            )
         if container_id:
             query["containerId"] = container_id
     if normalized_search:
@@ -334,7 +359,29 @@ def fetch_dokploy_deployment_logs(
     return lines[-normalized_line_count:]
 
 
-def _select_compose_log_container(containers: list[JsonObject]) -> JsonObject:
+def _select_compose_log_container(
+    containers: list[JsonObject],
+    *,
+    app_name: str = "",
+    service_name: str = "",
+) -> JsonObject:
+    normalized_service_name = normalize_dokploy_compose_service_name(service_name)
+    if normalized_service_name:
+        service_matches = [
+            container
+            for container in containers
+            if _compose_log_container_matches_service(
+                container,
+                app_name=app_name,
+                service_name=normalized_service_name,
+            )
+        ]
+        if len(service_matches) != 1:
+            qualifier = "not found" if not service_matches else "ambiguous"
+            raise click.ClickException(
+                f"Dokploy compose log service {normalized_service_name!r} is {qualifier}."
+            )
+        return service_matches[0]
     for container in containers:
         if _compose_log_container_has_web_service(container):
             return container
@@ -345,6 +392,31 @@ def _select_compose_log_container(containers: list[JsonObject]) -> JsonObject:
         if str(container.get("containerId") or "").strip():
             return container
     return {}
+
+
+def _compose_log_container_matches_service(
+    container: JsonObject,
+    *,
+    app_name: str,
+    service_name: str,
+) -> bool:
+    service_names = _compose_log_container_service_names(container)
+    if service_names:
+        return service_name in service_names
+    normalized_app_name = app_name.strip().lower()
+    if not normalized_app_name:
+        return False
+    for container_name in _compose_log_container_names(container):
+        normalized_name = container_name.strip().lower().strip("/")
+        for separator in ("-", "_", "."):
+            prefix = f"{normalized_app_name}{separator}"
+            replica_match = re.search(rf"{re.escape(separator)}\d+$", normalized_name)
+            if not normalized_name.startswith(prefix) or replica_match is None:
+                continue
+            matched_service_name = normalized_name[len(prefix) : replica_match.start()]
+            if matched_service_name == service_name:
+                return True
+    return False
 
 
 def _compose_log_container_is_web(container: JsonObject) -> bool:

--- a/control_plane/http_routes/drivers.py
+++ b/control_plane/http_routes/drivers.py
@@ -126,6 +126,7 @@ class TrackedTargetLogRequestResponse(BaseModel):
     line_count: int
     since: str
     search: str
+    service: str
 
 
 class TrackedTargetLogLinesResponse(BaseModel):
@@ -661,6 +662,7 @@ def register_tracked_target_log_read_routes(
         lines: Annotated[str, Query()] = str(dokploy_api.DEFAULT_DOKPLOY_LOG_LINE_COUNT),
         since: Annotated[str, Query()] = "all",
         search: Annotated[str, Query()] = "",
+        service: Annotated[str, Query()] = "",
         source: Annotated[str, Query()] = "runtime",
     ) -> TrackedTargetLogsResponse:
         trace_id = common.next_trace_id()
@@ -696,6 +698,7 @@ def register_tracked_target_log_read_routes(
         try:
             normalized_since = dokploy_api.normalize_dokploy_log_since(since)
             normalized_search = dokploy_api.normalize_dokploy_log_search(search)
+            normalized_service = dokploy_api.normalize_dokploy_compose_service_name(service)
             normalized_source = (
                 control_plane_tracked_target_logs.normalize_tracked_target_log_source(source)
             )
@@ -703,6 +706,10 @@ def register_tracked_target_log_read_routes(
                 raise ValueError("Tracked deployment logs require since='all'.")
             if normalized_source == "deployment" and normalized_search:
                 raise ValueError("Tracked deployment logs do not support search.")
+            if normalized_source == "deployment" and normalized_service:
+                raise ValueError(
+                    "Tracked deployment logs do not support compose service selection."
+                )
         except (ValueError, click.ClickException) as error:
             raise common.http_error(
                 status_code=400,
@@ -720,6 +727,7 @@ def register_tracked_target_log_read_routes(
                 line_count=line_count,
                 since=normalized_since,
                 search=normalized_search,
+                service=normalized_service,
                 source=normalized_source,
             )
         except TypeError as error:

--- a/control_plane/tracked_target_logs.py
+++ b/control_plane/tracked_target_logs.py
@@ -53,6 +53,7 @@ def build_tracked_target_logs_payload(
     line_count: int,
     since: str = "all",
     search: str = "",
+    service: str = "",
     source: str = "runtime",
 ) -> dict[str, object]:
     normalized_context = context_name.strip().lower()
@@ -81,11 +82,16 @@ def build_tracked_target_logs_payload(
     normalized_line_count = dokploy_api.normalize_dokploy_log_line_count(line_count)
     normalized_since = dokploy_api.normalize_dokploy_log_since(since)
     normalized_search = dokploy_api.normalize_dokploy_log_search(search)
+    normalized_service = dokploy_api.normalize_dokploy_compose_service_name(service)
     normalized_source = normalize_tracked_target_log_source(source)
     if normalized_source == "deployment" and normalized_since != "all":
         raise ValueError("Tracked deployment logs require since='all'.")
     if normalized_source == "deployment" and normalized_search:
         raise ValueError("Tracked deployment logs do not support search.")
+    if normalized_source == "deployment" and normalized_service:
+        raise ValueError("Tracked deployment logs do not support compose service selection.")
+    if target_record.target_type == "application" and normalized_service:
+        raise ValueError("Tracked application logs do not support compose service selection.")
     try:
         host, token = dokploy_source.read_dokploy_config(control_plane_root=control_plane_root)
     except click.ClickException as error:
@@ -158,6 +164,7 @@ def build_tracked_target_logs_payload(
                 compose_id=target_id_record.target_id,
                 app_name=app_name,
                 server_id=server_id,
+                service_name=normalized_service,
                 line_count=normalized_line_count,
                 since=normalized_since,
                 search=normalized_search,
@@ -183,6 +190,7 @@ def build_tracked_target_logs_payload(
             "line_count": normalized_line_count,
             "since": normalized_since,
             "search": normalized_search,
+            "service": normalized_service,
         },
         "logs": {
             "line_count": len(logs),

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1177,7 +1177,10 @@ Current derived-state behavior:
   resolves the DB-backed tracked Dokploy target and target id before fetching
   bounded logs. It supports Dokploy `application` and `compose` targets,
   includes route/target/app/server metadata, accepts optional `--since` and
-  `--search`, and redacts likely secret values from returned log lines.
+  `--search`, and redacts likely secret values from returned log lines. Compose
+  runtime reads may also pass `--service <exact-compose-service>` to select one
+  exact service container. Launchplane fails closed when that service is absent
+  or ambiguous; application and deployment log reads reject service selection.
 - `GET /v1/contexts/{context}/instances/{instance}/logs?lines=200` exposes the
   same tracked-target log reader through a native FastAPI service route using
   action `target_logs.read`. The default `source=runtime` reads current

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -18490,6 +18490,10 @@
             "title": "Search",
             "type": "string"
           },
+          "service": {
+            "title": "Service",
+            "type": "string"
+          },
           "since": {
             "title": "Since",
             "type": "string"
@@ -18507,7 +18511,8 @@
           "source",
           "line_count",
           "since",
-          "search"
+          "search",
+          "service"
         ],
         "title": "TrackedTargetLogRequestResponse",
         "type": "object"
@@ -21936,6 +21941,16 @@
             "schema": {
               "default": "",
               "title": "Search",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "service",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Service",
               "type": "string"
             }
           },

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -4058,6 +4058,7 @@ async def _get_tracked_target_logs(
     source: str = "",
     since: str = "",
     search: str = "",
+    service: str = "",
     authorization: str = "Bearer valid-token",
     headers: dict[str, str] | None = None,
 ) -> _AsgiResponse:
@@ -4073,6 +4074,8 @@ async def _get_tracked_target_logs(
         params["since"] = since
     if search:
         params["search"] = search
+    if service:
+        params["service"] = service
     suffix = f"?{urlencode(params)}" if params else ""
     return await _asgi_get(
         app,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -352,6 +352,126 @@ class DokployConfigTests(unittest.TestCase):
         )
         self.assertEqual(lines, ("two", "THREE_TOKEN=[redacted]"))
 
+    def test_fetch_compose_logs_selects_exact_service(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "database", "serviceName": "database"},
+                    {"containerId": "web", "serviceName": "web"},
+                ]
+            return {"logs": "database ready"}
+
+        with patch(
+            "control_plane.dokploy.api.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                service_name="database",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("database ready",))
+        query = cast(dict[str, object], requests[1]["query"])
+        self.assertEqual(query["containerId"], "database")
+
+    def test_fetch_compose_logs_selects_exact_service_from_container_name(self) -> None:
+        requests: list[dict[str, object]] = []
+
+        def capture_request(**kwargs: object) -> object:
+            requests.append(kwargs)
+            if kwargs["path"] == "/api/docker.getContainersByAppNameMatch":
+                return [
+                    {"containerId": "database", "Name": "/tenant_database_1"},
+                    {"containerId": "web", "Name": "/tenant_web_1"},
+                ]
+            return {"logs": "database ready"}
+
+        with patch(
+            "control_plane.dokploy.api.dokploy_request",
+            side_effect=capture_request,
+        ):
+            lines = control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                service_name="database",
+                line_count=10,
+            )
+
+        self.assertEqual(lines, ("database ready",))
+        query = cast(dict[str, object], requests[1]["query"])
+        self.assertEqual(query["containerId"], "database")
+
+    def test_fetch_compose_logs_rejects_missing_exact_service(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.api.dokploy_request",
+                return_value=[{"containerId": "web", "serviceName": "web"}],
+            ),
+            self.assertRaises(click.ClickException) as error_context,
+        ):
+            control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                service_name="database",
+            )
+
+        self.assertIn("not found", str(error_context.exception))
+
+    def test_fetch_compose_logs_does_not_match_longer_service_name_suffix(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.api.dokploy_request",
+                return_value=[
+                    {
+                        "containerId": "primary-database",
+                        "name": "tenant_primary-database_1",
+                    }
+                ],
+            ),
+            self.assertRaises(click.ClickException) as error_context,
+        ):
+            control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                service_name="database",
+            )
+
+        self.assertIn("not found", str(error_context.exception))
+
+    def test_fetch_compose_logs_rejects_ambiguous_exact_service(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.api.dokploy_request",
+                return_value=[
+                    {"containerId": "database-1", "serviceName": "database"},
+                    {"containerId": "database-2", "serviceName": "database"},
+                ],
+            ),
+            self.assertRaises(click.ClickException) as error_context,
+        ):
+            control_plane_dokploy.fetch_dokploy_compose_logs(
+                host="https://dokploy.example.com",
+                token="secret-token",
+                compose_id="compose-123",
+                app_name="tenant",
+                service_name="database",
+            )
+
+        self.assertIn("ambiguous", str(error_context.exception))
+
     def test_fetch_deployment_logs_calls_dokploy_read_logs_endpoint(self) -> None:
         requests: list[dict[str, object]] = []
 
@@ -781,6 +901,8 @@ target_name = "opw-testing"
                         "2",
                         "--since",
                         "5m",
+                        "--service",
+                        "database",
                     ],
                 )
 
@@ -791,6 +913,7 @@ target_name = "opw-testing"
             compose_id="compose-123",
             app_name="opw-testing-iul0ql",
             server_id="server-1",
+            service_name="database",
             line_count=2,
             since="5m",
             search="",
@@ -800,6 +923,7 @@ target_name = "opw-testing"
         self.assertEqual(payload["target"]["target_id"], "compose-123")
         self.assertEqual(payload["target"]["target_type"], "compose")
         self.assertEqual(payload["target"]["app_name"], "opw-testing-iul0ql")
+        self.assertEqual(payload["request"]["service"], "database")
         self.assertEqual(payload["logs"]["lines"], ["started", "ODOO_DB_PASSWORD=[redacted]"])
         self.assertNotIn("secret-token", result.output)
 

--- a/tests/test_http_app_driver_dokploy.py
+++ b/tests/test_http_app_driver_dokploy.py
@@ -1283,7 +1283,13 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["target"]["app_name"], "syo-testing-gfbiqh")
         self.assertEqual(
             payload["request"],
-            {"source": "runtime", "line_count": 2, "since": "5m", "search": "contact"},
+            {
+                "source": "runtime",
+                "line_count": 2,
+                "since": "5m",
+                "search": "contact",
+                "service": "",
+            },
         )
         self.assertEqual(payload["logs"]["lines"], ["contact form submitted"])
         self.assertTrue(payload["logs"]["redacted"])
@@ -1603,6 +1609,7 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
             compose_id="compose-123",
             app_name="cm-website-testing-iul0ql",
             server_id="server-1",
+            service_name="",
             line_count=2,
             since="5m",
             search="",
@@ -1613,6 +1620,102 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["target"]["app_name"], "cm-website-testing-iul0ql")
         self.assertEqual(payload["logs"]["lines"], ["booting", "ODOO_ADMIN_PASSWORD=[redacted]"])
         self.assertNotIn("secret-token", json.dumps(payload))
+
+    async def test_tracked_target_logs_selects_exact_compose_service(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="cm_website",
+                instance="testing",
+                target_id="compose-123",
+                target_type="compose",
+                target_name="cm-website-testing",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            with (
+                patch(
+                    "control_plane.tracked_target_logs.dokploy_source.read_dokploy_config",
+                    return_value=("https://dokploy.example.com", "secret-token"),
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.dokploy_api.fetch_dokploy_target_payload",
+                    return_value={"appName": "cm-website-testing-iul0ql", "serverId": "server-1"},
+                ),
+                patch(
+                    "control_plane.tracked_target_logs.dokploy_api.fetch_dokploy_compose_logs",
+                    return_value=("database system is ready",),
+                ) as logs_mock,
+            ):
+                app = create_launchplane_fastapi_app(
+                    verifier=_StubVerifier(_identity()),
+                    authz_policy=_record_read_policy(
+                        action="target_logs.read",
+                        context="cm_website",
+                    ),
+                    record_store_factory=lambda: app_store,
+                    control_plane_root_path=root,
+                )
+                response = await _get_tracked_target_logs(
+                    app,
+                    "cm_website",
+                    "testing",
+                    lines="20",
+                    since="30m",
+                    service="database",
+                )
+                app_store.close()
+
+        self.assertEqual(response.status_code, 200)
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.com",
+            token="secret-token",
+            compose_id="compose-123",
+            app_name="cm-website-testing-iul0ql",
+            server_id="server-1",
+            service_name="database",
+            line_count=20,
+            since="30m",
+            search="",
+        )
+        payload = response.json()
+        self.assertEqual(payload["request"]["service"], "database")
+        self.assertEqual(payload["logs"]["lines"], ["database system is ready"])
+
+    async def test_tracked_target_logs_rejects_service_for_application_target(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            database_url = _sqlite_database_url(root / "launchplane.sqlite3")
+            _seed_tracked_target_records(
+                database_url=database_url,
+                context="sellyouroutboard-testing",
+                instance="testing",
+                target_id="app-123",
+                target_type="application",
+                target_name="syo-testing-app",
+            )
+            app_store = PostgresRecordStore(database_url=database_url)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_identity()),
+                authz_policy=_record_read_policy(
+                    action="target_logs.read",
+                    context="sellyouroutboard-testing",
+                ),
+                record_store_factory=lambda: app_store,
+                control_plane_root_path=root,
+            )
+            response = await _get_tracked_target_logs(
+                app,
+                "sellyouroutboard-testing",
+                "testing",
+                service="database",
+            )
+            app_store.close()
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_request")
+        self.assertIn("application logs", response.json()["error"]["message"])
 
     async def test_tracked_target_logs_delegates_compose_log_search_to_provider(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
@@ -1667,6 +1770,7 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
             compose_id="compose-123",
             app_name="cm-website-testing-iul0ql",
             server_id="server-1",
+            service_name="",
             line_count=2,
             since="2h",
             search="website_bootstrap_applied",
@@ -1679,6 +1783,7 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
                 "line_count": 2,
                 "since": "2h",
                 "search": "website_bootstrap_applied",
+                "service": "",
             },
         )
         self.assertEqual(payload["logs"]["lines"], ["website_bootstrap_applied name=Cell Mechanic"])
@@ -1938,6 +2043,20 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
             since="all",
             search="failed",
         )
+        deployment_service_response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            source="deployment",
+            since="all",
+            service="database",
+        )
+        service_response = await _get_tracked_target_logs(
+            app,
+            "sellyouroutboard-testing",
+            "testing",
+            service="database;rm",
+        )
 
         self.assertEqual(line_response.status_code, 400)
         self.assertEqual(since_response.status_code, 400)
@@ -1945,12 +2064,16 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(source_response.status_code, 400)
         self.assertEqual(deployment_since_response.status_code, 400)
         self.assertEqual(deployment_search_response.status_code, 400)
+        self.assertEqual(deployment_service_response.status_code, 400)
+        self.assertEqual(service_response.status_code, 400)
         self.assertEqual(line_response.json()["error"]["code"], "invalid_query")
         self.assertEqual(since_response.json()["error"]["code"], "invalid_query")
         self.assertEqual(max_line_response.json()["error"]["code"], "invalid_query")
         self.assertEqual(source_response.json()["error"]["code"], "invalid_query")
         self.assertEqual(deployment_since_response.json()["error"]["code"], "invalid_query")
         self.assertEqual(deployment_search_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(deployment_service_response.json()["error"]["code"], "invalid_query")
+        self.assertEqual(service_response.json()["error"]["code"], "invalid_query")
 
     async def test_openapi_includes_tracked_target_logs_contract(self) -> None:
         app = create_launchplane_fastapi_app(
@@ -1968,6 +2091,7 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         openapi = response.json()
         route = openapi["paths"]["/v1/contexts/{context}/instances/{instance}/logs"]["get"]
         self.assertEqual(route["operationId"], "read_tracked_target_logs")
+        self.assertIn("service", {parameter["name"] for parameter in route["parameters"]})
         self.assertEqual(
             route["responses"]["200"]["content"]["application/json"]["schema"]["$ref"],
             "#/components/schemas/TrackedTargetLogsResponse",
@@ -1980,4 +2104,8 @@ class FastApiTrackedTargetLogsReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(
             openapi["components"]["schemas"]["TrackedTargetLogsResponse"]["additionalProperties"],
             False,
+        )
+        self.assertIn(
+            "service",
+            openapi["components"]["schemas"]["TrackedTargetLogRequestResponse"]["properties"],
         )

--- a/tests/test_tracked_target_logs_operator_workflow.py
+++ b/tests/test_tracked_target_logs_operator_workflow.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import unittest
+
+from tests.support.workflows import load_workflow
+
+
+class TrackedTargetLogsOperatorWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = load_workflow(".github/workflows/tracked-target-logs.yml")
+
+    def test_dispatch_contract_includes_exact_compose_service_selector(self) -> None:
+        trigger = self.workflow.data["on"]
+        assert isinstance(trigger, dict)
+        workflow_dispatch = trigger["workflow_dispatch"]
+        assert isinstance(workflow_dispatch, dict)
+        inputs = workflow_dispatch["inputs"]
+        assert isinstance(inputs, dict)
+        self.assertEqual(
+            set(inputs),
+            {"context", "instance", "lines", "source", "since", "search", "service"},
+        )
+        service_input = inputs["service"]
+        assert isinstance(service_input, dict)
+        self.assertEqual(service_input["default"], "")
+        self.assertEqual(self.workflow.permissions, {"contents": "read", "id-token": "write"})
+
+    def test_service_selector_is_validated_and_forwarded(self) -> None:
+        validation_step = self.workflow.step_named("read", "Validate inputs")
+        route_step = self.workflow.step_named("read", "Build logs route")
+        self.assertIsNotNone(validation_step)
+        self.assertIsNotNone(route_step)
+        assert validation_step is not None
+        assert route_step is not None
+        self.assertIn("deployment logs do not support compose service", validation_step.run)
+        self.assertIn("exact lowercase Compose service name", validation_step.run)
+        self.assertIn('--arg service "$SERVICE"', route_step.run)
+        self.assertIn('"&service=\\(.service | @uri)"', route_step.run)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an optional exact Compose service selector to tracked runtime log reads across the service API, CLI, and protected GitHub workflow
- resolve the selected container through exact project/service identity and fail closed when it is absent, ambiguous, or lacks a container id
- preserve instance-scoped authorization and log/error redaction, and update operations docs plus the canonical OpenAPI contract

## Validation
- `uv run --extra dev python -m unittest tests.test_dokploy.DokployConfigTests tests.test_http_app_driver_dokploy.FastApiTrackedTargetLogsReadTests tests.test_tracked_target_logs_operator_workflow` (93 tests)
- `uv run --extra dev launchplane ci unittest-shard local --jobs 4` (2,287 tests)
- changed-file Ruff format/lint and mypy checks
- `pnpm --dir frontend check:openapi-drift`
- `actionlint -no-color .github/workflows/tracked-target-logs.yml`
- JetBrains changed-file inspection: clean