### PR TITLE
Harden runner host hygiene audits and telemetry

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -128,6 +128,7 @@
     "Reusable Odoo Target Replacement Apply",
     "Preview Lifecycle",
     "Public Ingress Monitor",
+    "Runner Host Hygiene",
     "External Route Binding Reconcile",
     "Reusable External Route Binding Reconcile",
     "Route Binding Reconcile",

--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -44,6 +44,12 @@ name: Runner Host Hygiene
         required: false
         default: "300"
         type: string
+      resolve_action_started:
+        description: >-
+          Finalize a prior action_started audit as failed without repeating the action
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -68,6 +74,8 @@ jobs:
       RUNNER_REPOSITORY_SCOPE: ${{ github.repository }}
       RUNNER_RETAINED_WARM_BUILDERS: >-
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_RETAINED_WARM_BUILDERS }}
+      RUNNER_WORKDIR_ROOTS: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_RUNNER_WORKDIR_ROOTS }}
       RUNNER_ALLOWED_BUILDKIT_STATE_VOLUMES: >-
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_ALLOWED_BUILDKIT_STATE_VOLUMES
         }}
@@ -94,6 +102,7 @@ jobs:
           require_env RUNNER_EXECUTION_LANE
           require_env RUNNER_SERVICE_USER
           require_env RUNNER_RETAINED_WARM_BUILDERS
+          require_env RUNNER_WORKDIR_ROOTS
           if [ "$(id -un)" != "$RUNNER_SERVICE_USER" ]; then
             echo "Runner must execute as ${RUNNER_SERVICE_USER}." >&2
             exit 1
@@ -145,6 +154,20 @@ jobs:
             exit 1
           fi
 
+          runner_root_args=()
+          IFS=',' read -r -a runner_roots <<< "$RUNNER_WORKDIR_ROOTS"
+          for runner_root in "${runner_roots[@]}"; do
+            trimmed="${runner_root#"${runner_root%%[![:space:]]*}"}"
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+            if [ -n "$trimmed" ]; then
+              runner_root_args+=(--runner-workdir-root "$trimmed")
+            fi
+          done
+          if [ "${#runner_root_args[@]}" -eq 0 ]; then
+            echo "At least one runner workdir root is required." >&2
+            exit 1
+          fi
+
           volume_args=()
           target_volumes="${{ inputs.target_buildkit_state_volumes }}"
           IFS=',' read -r -a volumes <<< "$target_volumes"
@@ -174,6 +197,16 @@ jobs:
             mutate_flag="--mutate"
           fi
 
+          resolve_flag="--no-resolve-action-started"
+          if [ "${{ github.event_name }}" != "schedule" ] &&
+            [ "${{ inputs.resolve_action_started }}" = "true" ]; then
+            resolve_flag="--resolve-action-started"
+          fi
+
+          audit_spool_root="${XDG_STATE_HOME:-$HOME/.local/state}/"
+          audit_spool_root+="launchplane/runner-host-hygiene-audits"
+          audit_artifact_file="$RUNNER_TEMP/runner-host-hygiene-audit-evidence.json"
+
           uv run launchplane work-graph runner-host-hygiene-executor \
             --action "$apply_action" \
             --host-name "$RUNNER_HOST_NAME" \
@@ -182,17 +215,24 @@ jobs:
             --repository-scope "$RUNNER_REPOSITORY_SCOPE" \
             --audit-record-key "$audit_record_key" \
             "${builder_args[@]}" \
+            "${runner_root_args[@]}" \
             "${volume_args[@]}" \
             "$mutate_flag" \
+            "$resolve_flag" \
             --minimum-free-disk-bytes "$minimum_free_disk_bytes" \
             --prune-until "$prune_until" \
             --timeout-seconds "$timeout_seconds" \
             --service-url "$LAUNCHPLANE_SERVICE_URL" \
+            --audit-spool-root "$audit_spool_root" \
+            --audit-artifact-file "$audit_artifact_file" \
             | tee runner-host-hygiene-result.json
 
       - name: Upload executor result
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: runner-host-hygiene-result
-          path: runner-host-hygiene-result.json
+          path: |
+            runner-host-hygiene-result.json
+            ${{ runner.temp }}/runner-host-hygiene-audit-evidence.json
           if-no-files-found: error

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -64,6 +64,7 @@ from control_plane.workflows.runner_lane_registration_executor import (
     validate_local_executor_environment as validate_runner_registration_environment,
 )
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import RunnerWorkdirRoot
 from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandRunner
 from control_plane.workflows.runner_host_hygiene_executor import build_local_command_runner
@@ -75,6 +76,9 @@ from control_plane.workflows.runner_host_hygiene_executor import (
 )
 from control_plane.workflows.runner_host_hygiene_executor import (
     validate_local_executor_environment as validate_runner_host_hygiene_environment,
+)
+from control_plane.workflows.runner_host_hygiene_audit_spool import (
+    RunnerHostHygieneAuditSpool,
 )
 from control_plane.workflows.ship import utc_now_timestamp
 
@@ -1332,6 +1336,33 @@ def runner_host_hygiene_adapter_boundary_plan(
     help="Bounded Docker builder cache prune age filter, passed as until=<value>.",
 )
 @click.option(
+    "--runner-workdir-root",
+    "runner_workdir_roots",
+    multiple=True,
+    required=True,
+    help="Approved runner root formatted as public-key=/absolute/path. Repeat as needed.",
+)
+@click.option(
+    "--idle-observation-count",
+    default=2,
+    show_default=True,
+    type=click.IntRange(min=2, max=10),
+    help="Consecutive local idle samples required before mutation.",
+)
+@click.option(
+    "--idle-observation-interval-seconds",
+    default=5,
+    show_default=True,
+    type=click.IntRange(min=0, max=60),
+    help="Delay between consecutive local idle samples.",
+)
+@click.option(
+    "--resolve-action-started/--no-resolve-action-started",
+    default=False,
+    show_default=True,
+    help="Record terminal failed evidence for a prior action_started state without rerunning it.",
+)
+@click.option(
     "--timeout-seconds",
     default=120,
     show_default=True,
@@ -1349,6 +1380,19 @@ def runner_host_hygiene_adapter_boundary_plan(
     show_default=True,
     help="Environment variable containing a GitHub OIDC bearer token.",
 )
+@click.option(
+    "--audit-spool-root",
+    required=True,
+    type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
+    help="Absolute host-persistent directory for runner hygiene audit delivery state.",
+)
+@click.option(
+    "--audit-artifact-file",
+    default=Path("runner-host-hygiene-audit-evidence.json"),
+    show_default=True,
+    type=click.Path(path_type=Path, file_okay=True, dir_okay=False),
+    help="Current-run redacted audit envelope copied for workflow artifact upload.",
+)
 def runner_host_hygiene_executor(
     apply_action: RunnerHostHygieneApplyAction,
     host_name: str,
@@ -1362,9 +1406,15 @@ def runner_host_hygiene_executor(
     mutate: bool,
     minimum_free_disk_bytes: int,
     prune_until: str,
+    runner_workdir_roots: tuple[str, ...],
+    idle_observation_count: int,
+    idle_observation_interval_seconds: int,
+    resolve_action_started: bool,
     timeout_seconds: int,
     service_url: str,
     bearer_token_env: str,
+    audit_spool_root: Path,
+    audit_artifact_file: Path,
 ) -> None:
     try:
         token_env = bearer_token_env.strip()
@@ -1384,6 +1434,10 @@ def runner_host_hygiene_executor(
             minimum_free_disk_bytes=minimum_free_disk_bytes,
             timeout_seconds=timeout_seconds,
             prune_until=prune_until,
+            runner_workdir_roots=_parse_runner_workdir_roots(runner_workdir_roots),
+            idle_observation_count=idle_observation_count,
+            idle_observation_interval_seconds=idle_observation_interval_seconds,
+            resolve_action_started=resolve_action_started,
         )
         validate_runner_host_hygiene_environment(request=request)
         result = execute_runner_host_hygiene_executor(
@@ -1396,10 +1450,24 @@ def runner_host_hygiene_executor(
                     token_env=token_env,
                 ),
             ),
+            audit_spool=RunnerHostHygieneAuditSpool(
+                root=audit_spool_root,
+                artifact_file=audit_artifact_file,
+            ),
         )
     except (OSError, ValidationError, ValueError) as error:
         raise click.ClickException(str(error)) from error
     click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
+
+
+def _parse_runner_workdir_roots(values: tuple[str, ...]) -> tuple[RunnerWorkdirRoot, ...]:
+    roots: list[RunnerWorkdirRoot] = []
+    for value in values:
+        key, separator, path = value.partition("=")
+        if not separator:
+            raise click.ClickException("runner workdir roots must use public-key=/absolute/path")
+        roots.append(RunnerWorkdirRoot(key=key, path=path))
+    return tuple(roots)
 
 
 def _load_runner_lane_inventory(inventory_file: Path) -> RunnerLaneInventory:

--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -15,6 +15,13 @@ RunnerHostHygieneApplyAction = Literal[
 ]
 RunnerHostHygieneApplyPlanStatus = Literal["ready", "blocked"]
 RunnerHostHygieneApplyAuditStatus = Literal["planned", "completed", "failed"]
+RunnerHostHygieneAuditDeliveryState = Literal["pending", "delivered"]
+RunnerHostHygieneAuditExecutionState = Literal[
+    "planned",
+    "blocked",
+    "action_started",
+    "terminal_recorded",
+]
 RunnerHostHygieneAdapterType = Literal[
     "github_actions_runner",
     "launchplane_worker",
@@ -86,6 +93,40 @@ class RunnerHostHygienePolicy(BaseModel):
         return self
 
 
+class RunnerHostHygieneDockerReclaimableBreakdown(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    images_bytes: int = Field(default=0, ge=0)
+    containers_bytes: int = Field(default=0, ge=0)
+    local_volumes_bytes: int = Field(default=0, ge=0)
+    build_cache_bytes: int = Field(default=0, ge=0)
+
+    @property
+    def total_bytes(self) -> int:
+        return (
+            self.images_bytes
+            + self.containers_bytes
+            + self.local_volumes_bytes
+            + self.build_cache_bytes
+        )
+
+
+class RunnerHostHygieneRunnerWorkdirUsage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    root_key: str
+    apparent_bytes: int = Field(default=0, ge=0)
+    allocated_bytes: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def _normalize_usage(self) -> "RunnerHostHygieneRunnerWorkdirUsage":
+        self.root_key = _required_text(
+            _normalized_token(self.root_key),
+            "runner host hygiene workdir usage requires root_key",
+        )
+        return self
+
+
 class RunnerHostHygieneObservation(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -93,7 +134,12 @@ class RunnerHostHygieneObservation(BaseModel):
     observed_at: str
     free_disk_bytes: int = Field(ge=0)
     docker_reclaimable_bytes: int = Field(default=0, ge=0)
+    docker_reclaimable_breakdown: RunnerHostHygieneDockerReclaimableBreakdown = Field(
+        default_factory=RunnerHostHygieneDockerReclaimableBreakdown
+    )
     runner_workdir_bytes: int = Field(default=0, ge=0)
+    runner_workdir_allocated_bytes: int = Field(default=0, ge=0)
+    runner_workdir_usage: tuple[RunnerHostHygieneRunnerWorkdirUsage, ...] = ()
     docker_toolchain: "RunnerHostDockerToolchainObservation | None" = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple["RunnerHostHygieneImageInventoryItem", ...] = ()
@@ -111,6 +157,9 @@ class RunnerHostHygieneObservation(BaseModel):
             self.observed_at, "runner host hygiene observation requires observed_at"
         )
         self.warm_builders = _normalized_tokens(self.warm_builders)
+        self.runner_workdir_usage = tuple(
+            sorted(self.runner_workdir_usage, key=lambda item: item.root_key)
+        )
         self.image_inventory = _sorted_image_inventory(self.image_inventory)
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
         self.notes = tuple(note.strip() for note in self.notes if note.strip())
@@ -220,7 +269,12 @@ class RunnerHostHygieneReport(BaseModel):
     host_name: str
     free_disk_bytes: int = Field(default=0, ge=0)
     docker_reclaimable_bytes: int = Field(default=0, ge=0)
+    docker_reclaimable_breakdown: RunnerHostHygieneDockerReclaimableBreakdown = Field(
+        default_factory=RunnerHostHygieneDockerReclaimableBreakdown
+    )
     runner_workdir_bytes: int = Field(default=0, ge=0)
+    runner_workdir_allocated_bytes: int = Field(default=0, ge=0)
+    runner_workdir_usage: tuple[RunnerHostHygieneRunnerWorkdirUsage, ...] = ()
     docker_toolchain: RunnerHostDockerToolchainObservation | None = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple[RunnerHostHygieneImageInventoryItem, ...] = ()
@@ -237,6 +291,9 @@ class RunnerHostHygieneReport(BaseModel):
             self.host_name, "runner host hygiene report requires host_name"
         )
         self.warm_builders = _normalized_tokens(self.warm_builders)
+        self.runner_workdir_usage = tuple(
+            sorted(self.runner_workdir_usage, key=lambda item: item.root_key)
+        )
         self.image_inventory = _sorted_image_inventory(self.image_inventory)
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
         self.findings = tuple(sorted(self.findings, key=lambda finding: finding.code))
@@ -394,6 +451,84 @@ class RunnerHostHygieneApplyAuditRecord(BaseModel):
             raise ValueError("terminal runner host hygiene audit record requires post-apply report")
         if self.status in {"completed", "failed"} and self.plan.status != "ready":
             raise ValueError("terminal runner host hygiene audit record requires a ready plan")
+        return self
+
+
+class RunnerHostHygieneAuditDeliveryEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    host_name: str
+    action: RunnerHostHygieneApplyAction
+    audit_record_key: str
+    execution_state: RunnerHostHygieneAuditExecutionState = "planned"
+    planned_audit: RunnerHostHygieneApplyAuditRecord
+    planned_idempotency_key: str
+    planned_delivery_state: RunnerHostHygieneAuditDeliveryState = "pending"
+    terminal_audit: RunnerHostHygieneApplyAuditRecord | None = None
+    terminal_idempotency_key: str = ""
+    terminal_delivery_state: RunnerHostHygieneAuditDeliveryState | None = None
+    created_at: str
+    updated_at: str
+    delivery_attempts: int = Field(default=0, ge=0)
+    last_error: str = ""
+    last_error_retryable: bool | None = None
+
+    @model_validator(mode="after")
+    def _normalize_envelope(self) -> "RunnerHostHygieneAuditDeliveryEnvelope":
+        self.host_name = _required_text(
+            _normalized_host_name(self.host_name),
+            "runner host hygiene audit delivery envelope requires host_name",
+        )
+        self.audit_record_key = _required_text(
+            self.audit_record_key,
+            "runner host hygiene audit delivery envelope requires audit_record_key",
+        )
+        self.planned_idempotency_key = _required_text(
+            self.planned_idempotency_key,
+            "runner host hygiene audit delivery envelope requires planned idempotency key",
+        )
+        self.created_at = _required_text(
+            self.created_at,
+            "runner host hygiene audit delivery envelope requires created_at",
+        )
+        self.updated_at = _required_text(
+            self.updated_at,
+            "runner host hygiene audit delivery envelope requires updated_at",
+        )
+        self.last_error = self.last_error.strip()[:500]
+        if self.audit_record_key != self.planned_audit.audit_record_key:
+            raise ValueError("runner host hygiene audit delivery key must match planned audit")
+        if self.host_name != _normalized_host_name(self.planned_audit.request.host_name):
+            raise ValueError("runner host hygiene audit delivery host must match planned audit")
+        if self.action != self.planned_audit.request.action:
+            raise ValueError("runner host hygiene audit delivery action must match planned audit")
+        if self.planned_audit.status != "planned":
+            raise ValueError("runner host hygiene audit delivery planned audit must be planned")
+        if self.terminal_audit is None:
+            if self.terminal_idempotency_key or self.terminal_delivery_state is not None:
+                raise ValueError(
+                    "runner host hygiene audit delivery terminal metadata requires terminal audit"
+                )
+            if self.execution_state == "terminal_recorded":
+                raise ValueError(
+                    "runner host hygiene terminal-recorded delivery requires terminal audit"
+                )
+        else:
+            if self.terminal_audit.status not in {"completed", "failed"}:
+                raise ValueError("runner host hygiene terminal audit must be completed or failed")
+            if self.terminal_audit.audit_record_key != self.audit_record_key:
+                raise ValueError("runner host hygiene terminal audit key must match envelope")
+            self.terminal_idempotency_key = _required_text(
+                self.terminal_idempotency_key,
+                "runner host hygiene terminal audit requires idempotency key",
+            )
+            if self.terminal_delivery_state is None:
+                raise ValueError("runner host hygiene terminal audit requires delivery state")
+            if self.execution_state != "terminal_recorded":
+                raise ValueError(
+                    "runner host hygiene terminal audit requires terminal-recorded execution state"
+                )
         return self
 
 
@@ -604,7 +739,10 @@ def evaluate_runner_host_hygiene(
         host_name=observation.host_name,
         free_disk_bytes=observation.free_disk_bytes,
         docker_reclaimable_bytes=observation.docker_reclaimable_bytes,
+        docker_reclaimable_breakdown=observation.docker_reclaimable_breakdown,
         runner_workdir_bytes=observation.runner_workdir_bytes,
+        runner_workdir_allocated_bytes=observation.runner_workdir_allocated_bytes,
+        runner_workdir_usage=observation.runner_workdir_usage,
         docker_toolchain=observation.docker_toolchain,
         warm_builders=observation.warm_builders,
         image_inventory=observation.image_inventory,

--- a/control_plane/workflows/runner_host_hygiene_audit_spool.py
+++ b/control_plane/workflows/runner_host_hygiene_audit_spool.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from hashlib import sha256
+import os
+from pathlib import Path
+import tempfile
+
+import click
+from pydantic import ValidationError
+
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAction
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAuditDeliveryEnvelope
+from control_plane.workflows.ship import utc_now_timestamp
+
+
+class RunnerHostHygieneAuditSpool:
+    def __init__(self, *, root: Path, artifact_file: Path | None = None) -> None:
+        if not root.is_absolute():
+            raise click.ClickException("runner host hygiene audit spool root must be absolute")
+        self._root = root
+        self._artifact_file = artifact_file
+        self._ensure_directory(root)
+
+    def create(
+        self,
+        *,
+        planned_audit: RunnerHostHygieneApplyAuditRecord,
+        planned_idempotency_key: str,
+    ) -> RunnerHostHygieneAuditDeliveryEnvelope:
+        existing = self.read(
+            host_name=planned_audit.request.host_name,
+            action=planned_audit.request.action,
+            audit_record_key=planned_audit.audit_record_key,
+        )
+        if existing is not None:
+            if (
+                existing.planned_audit != planned_audit
+                or existing.planned_idempotency_key != planned_idempotency_key
+            ):
+                raise click.ClickException(
+                    "runner host hygiene audit spool key already exists with different intent"
+                )
+            return existing
+        timestamp = utc_now_timestamp()
+        envelope = RunnerHostHygieneAuditDeliveryEnvelope(
+            host_name=planned_audit.request.host_name,
+            action=planned_audit.request.action,
+            audit_record_key=planned_audit.audit_record_key,
+            planned_audit=planned_audit,
+            planned_idempotency_key=planned_idempotency_key,
+            created_at=timestamp,
+            updated_at=timestamp,
+        )
+        self.write(envelope)
+        return envelope
+
+    def read(
+        self,
+        *,
+        host_name: str,
+        action: RunnerHostHygieneApplyAction,
+        audit_record_key: str,
+    ) -> RunnerHostHygieneAuditDeliveryEnvelope | None:
+        path = self._record_path(
+            host_name=host_name,
+            action=action,
+            audit_record_key=audit_record_key,
+        )
+        if not path.exists():
+            return None
+        return self._read_path(path)
+
+    def list_for(
+        self, *, host_name: str, action: RunnerHostHygieneApplyAction
+    ) -> tuple[RunnerHostHygieneAuditDeliveryEnvelope, ...]:
+        directory = self._record_directory(host_name=host_name, action=action)
+        if not directory.exists():
+            return ()
+        return tuple(self._read_path(path) for path in sorted(directory.glob("*.json")))
+
+    def write(
+        self, envelope: RunnerHostHygieneAuditDeliveryEnvelope
+    ) -> RunnerHostHygieneAuditDeliveryEnvelope:
+        updated = envelope.model_copy(update={"updated_at": utc_now_timestamp()})
+        path = self._record_path(
+            host_name=updated.host_name,
+            action=updated.action,
+            audit_record_key=updated.audit_record_key,
+        )
+        self._ensure_directory(path.parent)
+        self._write_model(path, updated)
+        if self._artifact_file is not None:
+            self._write_model(self._artifact_file, updated)
+        return updated
+
+    @staticmethod
+    def is_unresolved(envelope: RunnerHostHygieneAuditDeliveryEnvelope) -> bool:
+        if envelope.execution_state in {"planned", "action_started"}:
+            return True
+        return (
+            envelope.execution_state == "terminal_recorded"
+            and envelope.terminal_delivery_state != "delivered"
+        )
+
+    @staticmethod
+    def pending_delivery_phases(
+        envelope: RunnerHostHygieneAuditDeliveryEnvelope,
+    ) -> tuple[tuple[RunnerHostHygieneApplyAuditRecord, str, str], ...]:
+        pending: list[tuple[RunnerHostHygieneApplyAuditRecord, str, str]] = []
+        if envelope.planned_delivery_state == "pending":
+            pending.append(
+                (
+                    envelope.planned_audit,
+                    envelope.planned_idempotency_key,
+                    "planned",
+                )
+            )
+        if envelope.terminal_audit is not None and envelope.terminal_delivery_state == "pending":
+            pending.append(
+                (
+                    envelope.terminal_audit,
+                    envelope.terminal_idempotency_key,
+                    "terminal",
+                )
+            )
+        return tuple(pending)
+
+    def _record_path(
+        self,
+        *,
+        host_name: str,
+        action: RunnerHostHygieneApplyAction,
+        audit_record_key: str,
+    ) -> Path:
+        digest = sha256(audit_record_key.encode()).hexdigest()
+        return self._record_directory(host_name=host_name, action=action) / f"{digest}.json"
+
+    def _record_directory(self, *, host_name: str, action: RunnerHostHygieneApplyAction) -> Path:
+        return self._root / _safe_segment(host_name) / _safe_segment(action)
+
+    @staticmethod
+    def _ensure_directory(path: Path) -> None:
+        path.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if path.is_symlink() or not path.is_dir():
+            raise click.ClickException(
+                "runner host hygiene audit spool directory must be a real directory"
+            )
+        path.chmod(0o700)
+
+    @staticmethod
+    def _read_path(path: Path) -> RunnerHostHygieneAuditDeliveryEnvelope:
+        if path.is_symlink() or not path.is_file():
+            raise click.ClickException(
+                "runner host hygiene audit spool record must be a regular file"
+            )
+        try:
+            return RunnerHostHygieneAuditDeliveryEnvelope.model_validate_json(
+                path.read_text(encoding="utf-8")
+            )
+        except (OSError, ValidationError, ValueError) as error:
+            raise click.ClickException(
+                "runner host hygiene audit spool contains an unreadable record"
+            ) from error
+
+    @staticmethod
+    def _write_model(path: Path, model: RunnerHostHygieneAuditDeliveryEnvelope) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+        )
+        temporary_path = Path(temporary_name)
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                stream.write(model.model_dump_json(indent=2))
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            temporary_path.replace(path)
+            directory_descriptor = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(directory_descriptor)
+            finally:
+                os.close(directory_descriptor)
+        except Exception:
+            temporary_path.unlink(missing_ok=True)
+            raise
+
+
+def unresolved_audit_keys(
+    envelopes: Iterable[RunnerHostHygieneAuditDeliveryEnvelope],
+) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            envelope.audit_record_key
+            for envelope in envelopes
+            if RunnerHostHygieneAuditSpool.is_unresolved(envelope)
+        )
+    )
+
+
+def _safe_segment(value: str) -> str:
+    normalized = "".join(
+        character if character.isalnum() or character in {"-", "_", "."} else "-"
+        for character in value.strip().lower()
+    ).strip("-.")
+    if not normalized:
+        raise click.ClickException("runner host hygiene audit spool segment was empty")
+    return normalized[:128]

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -7,8 +7,13 @@ from decimal import InvalidOperation
 import json
 import os
 import pwd
+import re
+import shlex
+import socket
 import subprocess
+import time
 from urllib.error import HTTPError
+from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 import click
@@ -21,14 +26,24 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPo
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPlan
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
 from control_plane.contracts.runner_host_hygiene import RunnerHostDockerToolchainObservation
+from control_plane.contracts.runner_host_hygiene import (
+    RunnerHostHygieneAuditDeliveryEnvelope,
+)
+from control_plane.contracts.runner_host_hygiene import (
+    RunnerHostHygieneDockerReclaimableBreakdown,
+)
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneImageInventoryItem
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneRunnerWorkdirUsage
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneVolumeInventoryItem
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
 from control_plane.workflows.ship import utc_now_timestamp
+from control_plane.workflows.runner_host_hygiene_audit_spool import (
+    RunnerHostHygieneAuditSpool,
+)
 
 
 AUDIT_ROUTE_PATH = "/v1/evidence/runner-host-hygiene/audits"
@@ -39,10 +54,18 @@ _DOCKER_LOCAL_VOLUME_USAGE_HEADERS = (
     "local volumes space usage:",
     "local volumes:",
 )
-_RUNNER_WORKDIR_BYTES_COMMAND = (
-    "find /opt/actions-runners -mindepth 2 -maxdepth 2 -type d -name _work "
-    "-exec du -sb {} + 2>/dev/null | "
-    "awk '{ total += $1 } END { print total + 0 }'"
+_ACTIVE_WORK_COMMAND = (
+    "command -v pgrep >/dev/null 2>&1 || exit 127; "
+    "command -v ps >/dev/null 2>&1 || exit 127; "
+    "ancestor_pids=''; pid=$PPID; "
+    'while [ -n "$pid" ] && [ "$pid" -gt 1 ]; do '
+    'ancestor_pids="$ancestor_pids $pid"; '
+    "pid=$(ps -o ppid= -p \"$pid\" | tr -d ' '); "
+    "done; printf 'ancestor_pids=%s\\n' \"$ancestor_pids\"; "
+    "status=0; output=$(pgrep -af "
+    "'[d]ocker buildx|[d]ocker build|[b]uildctl|[R]unner.Worker') || status=$?; "
+    'if [ "$status" -gt 1 ]; then exit "$status"; fi; '
+    "printf '%s\\n' \"$output\""
 )
 _DOCKER_SIZE_UNITS = {
     "b": Decimal(1),
@@ -81,6 +104,19 @@ class RemoteCommandResult:
 RemoteCommandRunner = Callable[[Sequence[str], int], RemoteCommandResult]
 AuditPoster = Callable[[RunnerHostHygieneApplyAuditRecord, str], dict[str, object]]
 BearerTokenProvider = Callable[[], str]
+AuditDeliverySleeper = Callable[[float], None]
+
+
+@dataclass(frozen=True)
+class RunnerWorkdirRoot:
+    key: str
+    path: str
+
+
+class AuditDeliveryError(click.ClickException):
+    def __init__(self, message: str, *, retryable: bool) -> None:
+        super().__init__(message)
+        self.retryable = retryable
 
 
 class RunnerHostHygieneExecutorRequest(BaseModel):
@@ -98,6 +134,10 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
     minimum_free_disk_bytes: int = Field(default=0, ge=0)
     timeout_seconds: int = Field(default=120, ge=1)
     prune_until: str = DEFAULT_PRUNE_UNTIL
+    runner_workdir_roots: tuple[RunnerWorkdirRoot, ...] = ()
+    idle_observation_count: int = Field(default=2, ge=2, le=10)
+    idle_observation_interval_seconds: int = Field(default=5, ge=0, le=60)
+    resolve_action_started: bool = False
     target_buildkit_state_volumes: tuple[str, ...] = ()
     allowed_buildkit_state_volumes: tuple[str, ...] = ()
 
@@ -126,6 +166,22 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
         self.retained_warm_builders = tuple(
             token.strip().lower() for token in self.retained_warm_builders if token.strip()
         )
+        normalized_roots: list[RunnerWorkdirRoot] = []
+        seen_root_keys: set[str] = set()
+        seen_root_paths: set[str] = set()
+        for root in self.runner_workdir_roots:
+            key = root.key.strip().lower()
+            path = root.path.strip()
+            if not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", key):
+                raise ValueError("runner workdir root key must be a public-safe token")
+            if not path.startswith("/") or path == "/" or "/../" in f"{path}/":
+                raise ValueError("runner workdir root path must be a scoped absolute path")
+            if key in seen_root_keys or path in seen_root_paths:
+                raise ValueError("runner workdir roots must be unique")
+            seen_root_keys.add(key)
+            seen_root_paths.add(path)
+            normalized_roots.append(RunnerWorkdirRoot(key=key, path=path.rstrip("/") or "/"))
+        self.runner_workdir_roots = tuple(sorted(normalized_roots, key=lambda item: item.key))
         self.target_buildkit_state_volumes = tuple(
             sorted(
                 {
@@ -162,6 +218,8 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
             raise ValueError("runner host hygiene executor requires retained_warm_builders")
         if not self.prune_until:
             raise ValueError("runner host hygiene executor requires prune_until")
+        if not self.runner_workdir_roots:
+            raise ValueError("runner host hygiene executor requires runner_workdir_roots")
         return self
 
 
@@ -172,6 +230,8 @@ class RunnerHostHygieneExecutorResult(BaseModel):
     audit_record_key: str
     planned_response: dict[str, object]
     terminal_response: dict[str, object] | None = None
+    audit_delivery_pending: bool = False
+    reconciled: bool = False
     message: str
 
 
@@ -184,7 +244,20 @@ def execute_runner_host_hygiene_executor(
     request: RunnerHostHygieneExecutorRequest,
     remote_runner: RemoteCommandRunner,
     audit_poster: AuditPoster,
+    audit_spool: RunnerHostHygieneAuditSpool | None = None,
+    audit_delivery_sleeper: AuditDeliverySleeper = time.sleep,
 ) -> RunnerHostHygieneExecutorResult:
+    if audit_spool is not None:
+        reconciliation_result = _reconcile_audit_spool(
+            request=request,
+            remote_runner=remote_runner,
+            audit_spool=audit_spool,
+            audit_poster=audit_poster,
+            audit_delivery_sleeper=audit_delivery_sleeper,
+        )
+        if reconciliation_result is not None:
+            return reconciliation_result
+
     pre_report = collect_runner_host_hygiene_report(
         request=request,
         remote_runner=remote_runner,
@@ -217,11 +290,45 @@ def execute_runner_host_hygiene_executor(
         pre_apply_report=pre_report,
         message="planned runner host hygiene apply; no host mutation was executed yet",
     )
-    planned_response = audit_poster(
-        planned_audit,
-        f"runner-host-hygiene:{request.audit_record_key}:planned",
-    )
+    planned_idempotency_key = f"runner-host-hygiene:{request.audit_record_key}:planned"
+    audit_envelope: RunnerHostHygieneAuditDeliveryEnvelope | None = None
+    if audit_spool is None:
+        planned_response = audit_poster(planned_audit, planned_idempotency_key)
+    else:
+        audit_envelope = audit_spool.create(
+            planned_audit=planned_audit,
+            planned_idempotency_key=planned_idempotency_key,
+        )
+        audit_envelope, delivery_responses = _deliver_audit_envelope(
+            envelope=audit_envelope,
+            audit_spool=audit_spool,
+            audit_poster=audit_poster,
+            audit_delivery_sleeper=audit_delivery_sleeper,
+        )
+        planned_response = delivery_responses.get("planned", {})
+        if (
+            apply_plan.status == "ready"
+            and audit_envelope.planned_delivery_state == "pending"
+            and audit_envelope.last_error_retryable is False
+        ):
+            audit_envelope = audit_spool.write(
+                audit_envelope.model_copy(update={"execution_state": "blocked"})
+            )
+            return RunnerHostHygieneExecutorResult(
+                status="blocked",
+                audit_record_key=request.audit_record_key,
+                planned_response=planned_response,
+                audit_delivery_pending=True,
+                message=(
+                    "runner host hygiene planned audit was permanently rejected; "
+                    "host mutation was not executed"
+                ),
+            )
     if apply_plan.status != "ready":
+        if audit_envelope is not None and audit_spool is not None:
+            audit_envelope = audit_spool.write(
+                audit_envelope.model_copy(update={"execution_state": "blocked"})
+            )
         return RunnerHostHygieneExecutorResult(
             status="blocked",
             audit_record_key=request.audit_record_key,
@@ -229,17 +336,20 @@ def execute_runner_host_hygiene_executor(
             message=apply_plan.summary,
         )
 
-    idle_result = _check_host_idle(request=request, remote_runner=remote_runner)
+    idle_result = _check_host_idle(
+        request=request,
+        remote_runner=remote_runner,
+        sleeper=audit_delivery_sleeper,
+    )
     if idle_result is not None:
         post_report = collect_runner_host_hygiene_report(
             request=request,
             remote_runner=remote_runner,
         )
         terminal_message = (
-            f"runner host hygiene apply blocked by active build processes: {idle_result}"
+            f"runner host hygiene apply blocked by active runner or build processes: {idle_result}"
         )
-        terminal_response = _post_terminal_audit(
-            audit_poster=audit_poster,
+        terminal_audit = _terminal_audit(
             request=apply_request,
             apply_plan=apply_plan,
             pre_report=pre_report,
@@ -247,14 +357,26 @@ def execute_runner_host_hygiene_executor(
             status="failed",
             message=terminal_message,
         )
+        terminal_response, audit_delivery_pending = _deliver_terminal_audit(
+            terminal_audit=terminal_audit,
+            audit_envelope=audit_envelope,
+            audit_spool=audit_spool,
+            audit_poster=audit_poster,
+            audit_delivery_sleeper=audit_delivery_sleeper,
+        )
         return RunnerHostHygieneExecutorResult(
-            status="failed",
+            status="audit_delivery_pending" if audit_delivery_pending else "failed",
             audit_record_key=request.audit_record_key,
             planned_response=planned_response,
             terminal_response=terminal_response,
+            audit_delivery_pending=audit_delivery_pending,
             message=terminal_message,
         )
 
+    if audit_envelope is not None and audit_spool is not None:
+        audit_envelope = audit_spool.write(
+            audit_envelope.model_copy(update={"execution_state": "action_started"})
+        )
     action_result = _execute_apply_action(request=request, remote_runner=remote_runner)
     post_report = collect_runner_host_hygiene_report(
         request=request,
@@ -270,8 +392,7 @@ def execute_runner_host_hygiene_executor(
         action_result=action_result,
         post_report=post_report,
     )
-    terminal_response = _post_terminal_audit(
-        audit_poster=audit_poster,
+    terminal_audit = _terminal_audit(
         request=apply_request,
         apply_plan=apply_plan,
         pre_report=pre_report,
@@ -279,12 +400,209 @@ def execute_runner_host_hygiene_executor(
         status=terminal_status,
         message=terminal_message,
     )
+    terminal_response, audit_delivery_pending = _deliver_terminal_audit(
+        terminal_audit=terminal_audit,
+        audit_envelope=audit_envelope,
+        audit_spool=audit_spool,
+        audit_poster=audit_poster,
+        audit_delivery_sleeper=audit_delivery_sleeper,
+    )
     return RunnerHostHygieneExecutorResult(
-        status=terminal_status,
+        status="audit_delivery_pending" if audit_delivery_pending else terminal_status,
         audit_record_key=request.audit_record_key,
         planned_response=planned_response,
         terminal_response=terminal_response,
+        audit_delivery_pending=audit_delivery_pending,
         message=terminal_message,
+    )
+
+
+def _reconcile_audit_spool(
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+    audit_spool: RunnerHostHygieneAuditSpool,
+    audit_poster: AuditPoster,
+    audit_delivery_sleeper: AuditDeliverySleeper,
+) -> RunnerHostHygieneExecutorResult | None:
+    for original_envelope in audit_spool.list_for(
+        host_name=request.host_name,
+        action=request.action,
+    ):
+        envelope, delivery_responses = _deliver_audit_envelope(
+            envelope=original_envelope,
+            audit_spool=audit_spool,
+            audit_poster=audit_poster,
+            audit_delivery_sleeper=audit_delivery_sleeper,
+        )
+        is_current_request = envelope.audit_record_key == request.audit_record_key
+        if is_current_request and envelope.execution_state == "terminal_recorded":
+            terminal_audit = envelope.terminal_audit
+            assert terminal_audit is not None
+            delivery_pending = envelope.terminal_delivery_state != "delivered"
+            return RunnerHostHygieneExecutorResult(
+                status=("audit_delivery_pending" if delivery_pending else terminal_audit.status),
+                audit_record_key=request.audit_record_key,
+                planned_response=delivery_responses.get("planned", {}),
+                terminal_response=delivery_responses.get("terminal"),
+                audit_delivery_pending=delivery_pending,
+                reconciled=not delivery_pending,
+                message=(
+                    "runner host hygiene terminal audit delivery remains pending"
+                    if delivery_pending
+                    else "runner host hygiene terminal audit delivery reconciled; action not repeated"
+                ),
+            )
+        if (
+            is_current_request
+            and envelope.execution_state == "action_started"
+            and request.resolve_action_started
+        ):
+            post_report = collect_runner_host_hygiene_report(
+                request=request,
+                remote_runner=remote_runner,
+            )
+            terminal_message = (
+                "runner host hygiene previous execution stopped after action_started; "
+                "current post evidence was captured and the action was not repeated"
+            )
+            terminal_audit = _terminal_audit(
+                request=envelope.planned_audit.request,
+                apply_plan=envelope.planned_audit.plan,
+                pre_report=envelope.planned_audit.pre_apply_report,
+                post_report=post_report,
+                status="failed",
+                message=terminal_message,
+            )
+            terminal_response, delivery_pending = _deliver_terminal_audit(
+                terminal_audit=terminal_audit,
+                audit_envelope=envelope,
+                audit_spool=audit_spool,
+                audit_poster=audit_poster,
+                audit_delivery_sleeper=audit_delivery_sleeper,
+            )
+            return RunnerHostHygieneExecutorResult(
+                status="audit_delivery_pending" if delivery_pending else "failed",
+                audit_record_key=request.audit_record_key,
+                planned_response=delivery_responses.get("planned", {}),
+                terminal_response=terminal_response,
+                audit_delivery_pending=delivery_pending,
+                reconciled=not delivery_pending,
+                message=terminal_message,
+            )
+        if RunnerHostHygieneAuditSpool.is_unresolved(envelope):
+            return RunnerHostHygieneExecutorResult(
+                status="blocked",
+                audit_record_key=request.audit_record_key,
+                planned_response=delivery_responses.get("planned", {}),
+                terminal_response=delivery_responses.get("terminal"),
+                audit_delivery_pending=True,
+                message=(
+                    "runner host hygiene blocked by unresolved audit delivery or "
+                    f"execution evidence for {envelope.audit_record_key}"
+                ),
+            )
+        if is_current_request and envelope.execution_state == "blocked":
+            return RunnerHostHygieneExecutorResult(
+                status="blocked",
+                audit_record_key=request.audit_record_key,
+                planned_response=delivery_responses.get("planned", {}),
+                message="runner host hygiene request was already recorded as blocked",
+            )
+    return None
+
+
+def _deliver_terminal_audit(
+    *,
+    terminal_audit: RunnerHostHygieneApplyAuditRecord,
+    audit_envelope: RunnerHostHygieneAuditDeliveryEnvelope | None,
+    audit_spool: RunnerHostHygieneAuditSpool | None,
+    audit_poster: AuditPoster,
+    audit_delivery_sleeper: AuditDeliverySleeper,
+) -> tuple[dict[str, object] | None, bool]:
+    idempotency_key = (
+        f"runner-host-hygiene:{terminal_audit.audit_record_key}:{terminal_audit.status}"
+    )
+    if audit_envelope is None or audit_spool is None:
+        return audit_poster(terminal_audit, idempotency_key), False
+    audit_envelope = audit_spool.write(
+        audit_envelope.model_copy(
+            update={
+                "execution_state": "terminal_recorded",
+                "terminal_audit": terminal_audit,
+                "terminal_idempotency_key": idempotency_key,
+                "terminal_delivery_state": "pending",
+            }
+        )
+    )
+    audit_envelope, delivery_responses = _deliver_audit_envelope(
+        envelope=audit_envelope,
+        audit_spool=audit_spool,
+        audit_poster=audit_poster,
+        audit_delivery_sleeper=audit_delivery_sleeper,
+    )
+    return (
+        delivery_responses.get("terminal"),
+        audit_envelope.terminal_delivery_state != "delivered",
+    )
+
+
+def _deliver_audit_envelope(
+    *,
+    envelope: RunnerHostHygieneAuditDeliveryEnvelope,
+    audit_spool: RunnerHostHygieneAuditSpool,
+    audit_poster: AuditPoster,
+    audit_delivery_sleeper: AuditDeliverySleeper,
+) -> tuple[RunnerHostHygieneAuditDeliveryEnvelope, dict[str, dict[str, object]]]:
+    responses: dict[str, dict[str, object]] = {}
+    for audit, idempotency_key, phase in audit_spool.pending_delivery_phases(envelope):
+        response, error_message, attempts, retryable_error = _post_audit_with_retry(
+            audit=audit,
+            idempotency_key=idempotency_key,
+            audit_poster=audit_poster,
+            sleeper=audit_delivery_sleeper,
+        )
+        updates: dict[str, object] = {
+            "delivery_attempts": envelope.delivery_attempts + attempts,
+            "last_error": error_message,
+            "last_error_retryable": retryable_error,
+        }
+        if response is not None:
+            responses[phase] = response
+            updates[f"{phase}_delivery_state"] = "delivered"
+        envelope = audit_spool.write(envelope.model_copy(update=updates))
+        if response is None:
+            break
+    return envelope, responses
+
+
+def _post_audit_with_retry(
+    *,
+    audit: RunnerHostHygieneApplyAuditRecord,
+    idempotency_key: str,
+    audit_poster: AuditPoster,
+    sleeper: AuditDeliverySleeper,
+    max_attempts: int = 3,
+) -> tuple[dict[str, object] | None, str, int, bool | None]:
+    last_error = ""
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return audit_poster(audit, idempotency_key), "", attempt, None
+        except AuditDeliveryError as error:
+            last_error = _redact_sensitive_text(error.message)
+            if not error.retryable:
+                return None, last_error, attempt, False
+        except click.ClickException as error:
+            return None, _redact_sensitive_text(error.message), attempt, False
+        except OSError as error:
+            last_error = _redact_sensitive_text(str(error))
+        if attempt < max_attempts:
+            sleeper(float(2 ** (attempt - 1)))
+    return (
+        None,
+        last_error or "runner host hygiene audit delivery failed",
+        max_attempts,
+        True,
     )
 
 
@@ -363,15 +681,22 @@ def collect_runner_host_hygiene_report(
         request=request,
         remote_runner=remote_runner,
     )
+    docker_reclaimable_breakdown = _parse_docker_system_df_reclaimable_breakdown(
+        docker_summary.stdout
+    )
+    runner_workdir_usage = _collect_runner_workdir_usage(
+        request=request,
+        remote_runner=remote_runner,
+    )
     observation = RunnerHostHygieneObservation(
         host_name=request.host_name,
         observed_at=utc_now_timestamp(),
         free_disk_bytes=_parse_df_available_bytes(df_result.stdout),
-        docker_reclaimable_bytes=_parse_docker_system_df_reclaimable_bytes(docker_summary.stdout),
-        runner_workdir_bytes=_collect_runner_workdir_bytes(
-            request=request,
-            remote_runner=remote_runner,
-        ),
+        docker_reclaimable_bytes=docker_reclaimable_breakdown.total_bytes,
+        docker_reclaimable_breakdown=docker_reclaimable_breakdown,
+        runner_workdir_bytes=sum(item.apparent_bytes for item in runner_workdir_usage),
+        runner_workdir_allocated_bytes=sum(item.allocated_bytes for item in runner_workdir_usage),
+        runner_workdir_usage=runner_workdir_usage,
         docker_toolchain=_collect_docker_toolchain(
             request=request,
             remote_runner=remote_runner,
@@ -490,11 +815,23 @@ def build_refreshing_service_audit_poster(
                 response_payload = json.loads(response.read().decode("utf-8"))
         except HTTPError as error:
             response_text = error.read().decode(errors="replace")
-            raise click.ClickException(
+            message = _redact_sensitive_text(
                 response_text.strip() or f"Launchplane service returned HTTP {error.code}."
+            )
+            raise AuditDeliveryError(
+                message,
+                retryable=error.code in {429, 500, 502, 503, 504},
+            ) from error
+        except (URLError, TimeoutError, socket.timeout) as error:
+            raise AuditDeliveryError(
+                _redact_sensitive_text(str(error) or "Launchplane service request failed"),
+                retryable=True,
             ) from error
         if not isinstance(response_payload, dict):
-            raise click.ClickException("Launchplane service returned a non-object response.")
+            raise AuditDeliveryError(
+                "Launchplane service returned a non-object response.",
+                retryable=False,
+            )
         return response_payload
 
     return post
@@ -764,21 +1101,53 @@ def _count_orphan_buildkit_volumes(
     )
 
 
-def _collect_runner_workdir_bytes(
+def _collect_runner_workdir_usage(
     *,
     request: RunnerHostHygieneExecutorRequest,
     remote_runner: RemoteCommandRunner,
-) -> int:
-    result = _require_remote_success(
-        remote_runner(
-            ("bash", "-lc", _RUNNER_WORKDIR_BYTES_COMMAND),
-            request.timeout_seconds,
-        ),
-        evidence_name="runner_workdir_bytes",
+) -> tuple[RunnerHostHygieneRunnerWorkdirUsage, ...]:
+    usage: list[RunnerHostHygieneRunnerWorkdirUsage] = []
+    for root in request.runner_workdir_roots:
+        result = _require_remote_success(
+            remote_runner(
+                ("bash", "-lc", _runner_workdir_usage_command(root.path)),
+                request.timeout_seconds,
+            ),
+            evidence_name=f"runner_workdir_bytes:{root.key}",
+        )
+        lines = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+        if len(lines) != 2:
+            raise click.ClickException("runner host hygiene runner workdir evidence was incomplete")
+        usage.append(
+            RunnerHostHygieneRunnerWorkdirUsage(
+                root_key=root.key,
+                apparent_bytes=_parse_non_negative_int_evidence(
+                    lines[0], evidence_name=f"runner_workdir_apparent_bytes:{root.key}"
+                ),
+                allocated_bytes=_parse_non_negative_int_evidence(
+                    lines[1], evidence_name=f"runner_workdir_allocated_bytes:{root.key}"
+                ),
+            )
+        )
+    return tuple(usage)
+
+
+def _runner_workdir_usage_command(root_path: str) -> str:
+    quoted_root = shlex.quote(root_path)
+    apparent_command = (
+        f"find {quoted_root} -mindepth 2 -maxdepth 2 -type d -name _work "
+        "-exec du -sb {} + 2>/dev/null | "
+        "awk '{ total += $1 } END { print total + 0 }'"
     )
-    return _parse_non_negative_int_evidence(
-        result.stdout,
-        evidence_name="runner_workdir_bytes",
+    allocated_command = (
+        f"find {quoted_root} -mindepth 2 -maxdepth 2 -type d -name _work "
+        "-exec du -s -B1 {} + 2>/dev/null | "
+        "awk '{ total += $1 } END { print total + 0 }'"
+    )
+    return (
+        "set -euo pipefail; "
+        f"test -d {quoted_root}; test ! -L {quoted_root}; "
+        f"{apparent_command}; {allocated_command}"
     )
 
 
@@ -885,7 +1254,13 @@ def _collect_volume_usage(
 
 
 def _parse_docker_system_df_reclaimable_bytes(output: str) -> int:
-    total = 0
+    return _parse_docker_system_df_reclaimable_breakdown(output).total_bytes
+
+
+def _parse_docker_system_df_reclaimable_breakdown(
+    output: str,
+) -> RunnerHostHygieneDockerReclaimableBreakdown:
+    values: dict[str, int] = {row_type: 0 for row_type in _DOCKER_SYSTEM_DF_TYPES}
     parsed_rows = 0
     for line in output.splitlines():
         stripped_line = line.strip()
@@ -899,14 +1274,19 @@ def _parse_docker_system_df_reclaimable_bytes(output: str) -> int:
                     raise click.ClickException(
                         "runner host hygiene docker summary evidence was incomplete"
                     )
-                total += _parse_docker_size_bytes(columns[2])
+                values[row_type] = _parse_docker_size_bytes(columns[2])
                 parsed_rows += 1
                 break
     if parsed_rows == 0:
         raise click.ClickException(
             "runner host hygiene docker summary evidence did not include reclaimable bytes"
         )
-    return total
+    return RunnerHostHygieneDockerReclaimableBreakdown(
+        images_bytes=values["Images"],
+        containers_bytes=values["Containers"],
+        local_volumes_bytes=values["Local Volumes"],
+        build_cache_bytes=values["Build Cache"],
+    )
 
 
 def _parse_volume_usage(output: str) -> dict[str, _VolumeUsage]:
@@ -1059,40 +1439,50 @@ def _compact_evidence(output: str) -> str:
 
 
 def _check_host_idle(
-    *, request: RunnerHostHygieneExecutorRequest, remote_runner: RemoteCommandRunner
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+    sleeper: AuditDeliverySleeper,
 ) -> str | None:
-    active_processes = _require_remote_success(
-        remote_runner(
-            (
-                "bash",
-                "-lc",
-                "pgrep -af '[d]ocker buildx|[d]ocker build|[b]uildctl' || true",
+    for sample_index in range(request.idle_observation_count):
+        active_processes = _require_remote_success(
+            remote_runner(
+                ("bash", "-lc", _ACTIVE_WORK_COMMAND),
+                request.timeout_seconds,
             ),
-            request.timeout_seconds,
-        ),
-        evidence_name="active_build_processes",
-    )
-    lines = tuple(
-        line.strip()
-        for line in active_processes.stdout.splitlines()
-        if line.strip() and "runner-host-hygiene" not in line
-    )
-    if lines:
-        return _compact_evidence("\n".join(lines))
+            evidence_name="active_runner_or_build_processes",
+        )
+        raw_lines = tuple(
+            line.strip() for line in active_processes.stdout.splitlines() if line.strip()
+        )
+        ancestor_pids: set[str] = set()
+        lines: list[str] = []
+        for line in raw_lines:
+            if line.startswith("ancestor_pids="):
+                ancestor_pids.update(line.partition("=")[2].split())
+                continue
+            process_id = line.split(maxsplit=1)[0]
+            if "Runner.Worker" in line and process_id in ancestor_pids:
+                continue
+            if "runner-host-hygiene" not in line:
+                lines.append(line)
+        if lines:
+            return _compact_evidence(_redact_sensitive_text("\n".join(lines)))
+        if sample_index + 1 < request.idle_observation_count:
+            sleeper(float(request.idle_observation_interval_seconds))
     return None
 
 
-def _post_terminal_audit(
+def _terminal_audit(
     *,
-    audit_poster: AuditPoster,
     request: RunnerHostHygieneApplyRequest,
     apply_plan: RunnerHostHygieneApplyPlan,
     pre_report: RunnerHostHygieneReport,
     post_report: RunnerHostHygieneReport,
     status: RunnerHostHygieneApplyAuditStatus,
     message: str,
-) -> dict[str, object]:
-    terminal_audit = RunnerHostHygieneApplyAuditRecord(
+) -> RunnerHostHygieneApplyAuditRecord:
+    return RunnerHostHygieneApplyAuditRecord(
         audit_record_key=request.audit_record_key,
         status=status,
         request=request,
@@ -1101,10 +1491,22 @@ def _post_terminal_audit(
         post_apply_report=post_report,
         message=message,
     )
-    return audit_poster(
-        terminal_audit,
-        f"runner-host-hygiene:{request.audit_record_key}:{status}",
+
+
+def _redact_sensitive_text(value: str) -> str:
+    redacted = re.sub(
+        r"\b(?:ghp_|ghs_|github_pat_|sk-)[A-Za-z0-9_-]{12,}\b",
+        "[REDACTED]",
+        value,
     )
+    redacted = re.sub(r"(?i)\bbearer\s+\S+", "Bearer [REDACTED]", redacted)
+    redacted = re.sub(
+        r"(?i)\b(token|secret|password|authorization)\s*([=:]|\s)\s*[^\s,;]+",
+        r"\1\2[REDACTED]",
+        redacted,
+    )
+    redacted = re.sub(r"(?i)(https?://)[^/@\s]+@", r"\1[REDACTED]@", redacted)
+    return redacted.strip()[:500]
 
 
 def _terminal_message(
@@ -1120,7 +1522,7 @@ def _terminal_message(
     )
     if action_result.returncode != 0:
         detail = action_result.stderr.strip() or action_result.stdout.strip() or "unknown error"
-        return f"runner host {action_label} failed: {detail}"
+        return f"runner host {action_label} failed: {_redact_sensitive_text(detail)}"
     if post_report.status != "healthy":
         return (
             f"runner host {action_label} completed but post evidence is not healthy: "

--- a/docs/records.md
+++ b/docs/records.md
@@ -513,7 +513,11 @@ an ORM column/table or remains only in the evidence payload.
   request, plan, pre/post hygiene reports, retained warm-builder evidence, and
   operator message. Docker toolchain evidence, host-command output, Docker
   summaries, and rollout notes stay payload-only until they need queryable
-  operational views.
+  operational views. The host-local audit-delivery envelope is a separate
+  recovery record: it stores planned and optional terminal audit payloads,
+  execution phase, delivery state, idempotency keys, bounded redacted errors,
+  and attempt counts. It is written atomically under an explicit state
+  directory and is not a substitute for the service-owned audit row.
 - Runner lane registration audit: modeled fields are `audit_record_key`,
   `repository`, `host_name`, `lane_name`, `status`, and `mutate`. The payload
   carries the typed request, registration plan, pre/post runner inventory, and

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -128,6 +128,16 @@ under `runner_host_hygiene_audit.write`, preserves the `Idempotency-Key`
 replay/conflict contract, and returns the accepted record key plus audit result
 details. The local planner only prints the planned record; the approved executor
 calls the service route after it captures the required pre/post host evidence.
+The executor also keeps a host-persistent delivery envelope outside the Actions
+workspace. It atomically records planned intent before mutation, records
+`action_started` immediately before the privileged command, and records terminal
+evidence before remote delivery. Transient delivery failures retain the exact
+idempotency key and block another mutation for the same host/action until the
+pending envelope is reconciled. The current-run envelope is copied to a redacted
+workflow artifact; bearer tokens and raw authorization headers are never part of
+the envelope. A permanently rejected planned audit (for example, authorization,
+route, or idempotency conflict) blocks mutation; a retryable transport/service
+failure may proceed only because the planned intent is already durable locally.
 
 ## Approved Ops-Lane Executor
 
@@ -168,6 +178,9 @@ The workflow requires these repository variables:
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_EXECUTION_LANE`
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_SERVICE_USER`
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_RETAINED_WARM_BUILDERS`
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_RUNNER_WORKDIR_ROOTS`, as comma-separated
+  public-key/absolute-path pairs such as `legacy=/srv/runners`. The keys appear
+  in evidence; absolute paths remain executor-local runtime input.
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_ALLOWED_BUILDKIT_STATE_VOLUMES` for any
   approved BuildKit state-volume retirement target. Leave it empty when no
   named volume cleanup has been reviewed.
@@ -175,7 +188,8 @@ The workflow requires these repository variables:
 The executor fails closed unless the process user matches the requested service
 user, the GitHub repository matches the requested repository scope, retained
 warm builders are present in pre-apply evidence, the apply plan is ready, no
-active Docker build client process is observed, and
+active Docker build client or another Actions `Runner.Worker` process is observed
+in two consecutive local samples, and
 `mutate=true` is explicitly supplied to a manual workflow dispatch. Scheduled
 runs write a planned audit and stop at the `mutate_not_requested` blocker, which
 keeps the cadence report-only while preserving typed pre-apply evidence. Manual
@@ -186,6 +200,16 @@ writes `failed`. It does not run `docker system prune`, `docker image prune -a`,
 generic `docker volume prune`, runner work-directory deletion, runner service
 restart, builder deletion, or automatic rollback. Operators should use the
 captured image and volume inventory to decide any later phase-two cleanup lane.
+Runner work-directory evidence covers every operator-supplied root and records
+both apparent and allocated bytes per public root key; Docker reclaimable bytes
+are also split into images, containers, local volumes, and build cache while the
+existing aggregate remains backward-compatible.
+
+The executor excludes only its own ancestor `Runner.Worker` from the idle gate;
+any sibling worker still blocks a shared-host mutation. If a prior run stopped
+after the durable `action_started` marker, an operator may manually dispatch with
+`resolve_action_started=true`. That path captures current post evidence and
+writes a terminal failed audit without repeating the privileged action.
 
 Runner lane registration uses a separate manual ops-lane workflow,
 `.github/workflows/runner-lane-registration.yml`. It shares the same approved

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -17069,6 +17069,37 @@
         "title": "RunnerHostHygieneAuditEvidenceEnvelope",
         "type": "object"
       },
+      "RunnerHostHygieneDockerReclaimableBreakdown": {
+        "additionalProperties": false,
+        "properties": {
+          "build_cache_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Build Cache Bytes",
+            "type": "integer"
+          },
+          "containers_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Containers Bytes",
+            "type": "integer"
+          },
+          "images_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Images Bytes",
+            "type": "integer"
+          },
+          "local_volumes_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Local Volumes Bytes",
+            "type": "integer"
+          }
+        },
+        "title": "RunnerHostHygieneDockerReclaimableBreakdown",
+        "type": "object"
+      },
       "RunnerHostHygieneFinding": {
         "additionalProperties": false,
         "properties": {
@@ -17148,6 +17179,9 @@
       "RunnerHostHygieneReport": {
         "additionalProperties": false,
         "properties": {
+          "docker_reclaimable_breakdown": {
+            "$ref": "#/components/schemas/RunnerHostHygieneDockerReclaimableBreakdown"
+          },
           "docker_reclaimable_bytes": {
             "default": 0,
             "minimum": 0.0,
@@ -17210,11 +17244,25 @@
             "title": "Orphan Buildkit Volumes",
             "type": "integer"
           },
+          "runner_workdir_allocated_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Runner Workdir Allocated Bytes",
+            "type": "integer"
+          },
           "runner_workdir_bytes": {
             "default": 0,
             "minimum": 0.0,
             "title": "Runner Workdir Bytes",
             "type": "integer"
+          },
+          "runner_workdir_usage": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneRunnerWorkdirUsage"
+            },
+            "title": "Runner Workdir Usage",
+            "type": "array"
           },
           "schema_version": {
             "default": 1,
@@ -17257,6 +17305,32 @@
           "summary"
         ],
         "title": "RunnerHostHygieneReport",
+        "type": "object"
+      },
+      "RunnerHostHygieneRunnerWorkdirUsage": {
+        "additionalProperties": false,
+        "properties": {
+          "allocated_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Allocated Bytes",
+            "type": "integer"
+          },
+          "apparent_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Apparent Bytes",
+            "type": "integer"
+          },
+          "root_key": {
+            "title": "Root Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "root_key"
+        ],
+        "title": "RunnerHostHygieneRunnerWorkdirUsage",
         "type": "object"
       },
       "RunnerHostHygieneVolumeInventoryItem": {

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -31,6 +31,7 @@ from control_plane.cli_runner_lanes import _runner_host_hygiene_bearer_token
 from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import RunnerWorkdirRoot
 from control_plane.workflows.runner_host_hygiene_executor import collect_runner_host_hygiene_report
 
 
@@ -207,6 +208,8 @@ class RunnerHostHygieneTests(unittest.TestCase):
             command_tuple = tuple(command)
             if command_tuple[:3] == ("docker", "volume", "inspect"):
                 return RemoteCommandResult(returncode=1)
+            if command_tuple[:2] == ("bash", "-lc") and "-name _work" in command_tuple[2]:
+                return RemoteCommandResult(returncode=0, stdout="0\n0\n")
             return RemoteCommandResult(returncode=0, stdout=outputs.get(command_tuple, ""))
 
         report = collect_runner_host_hygiene_report(
@@ -218,6 +221,9 @@ class RunnerHostHygieneTests(unittest.TestCase):
                 repository_scope="cbusillo/launchplane",
                 audit_record_key="runner-host-hygiene/2026-06-04/chris-testing",
                 retained_warm_builders=("odoo-docker-chris-testing",),
+                runner_workdir_roots=(
+                    RunnerWorkdirRoot(key="legacy", path="/opt/actions-runners"),
+                ),
             ),
             remote_runner=runner,
         )
@@ -295,6 +301,8 @@ class RunnerHostHygieneTests(unittest.TestCase):
             command_tuple = tuple(command)
             if command_tuple[:3] == ("docker", "volume", "inspect"):
                 return RemoteCommandResult(returncode=1)
+            if command_tuple[:2] == ("bash", "-lc") and "-name _work" in command_tuple[2]:
+                return RemoteCommandResult(returncode=0, stdout="0\n0\n")
             return RemoteCommandResult(returncode=0, stdout=outputs.get(command_tuple, ""))
 
         report = collect_runner_host_hygiene_report(
@@ -306,6 +314,9 @@ class RunnerHostHygieneTests(unittest.TestCase):
                 repository_scope="cbusillo/launchplane",
                 audit_record_key="runner-host-hygiene/2026-06-04/chris-testing",
                 retained_warm_builders=("odoo-docker-chris-testing",),
+                runner_workdir_roots=(
+                    RunnerWorkdirRoot(key="legacy", path="/opt/actions-runners"),
+                ),
             ),
             remote_runner=runner,
         )
@@ -401,6 +412,8 @@ class RunnerHostHygieneTests(unittest.TestCase):
             command_tuple = tuple(command)
             if command_tuple[:3] == ("docker", "volume", "inspect"):
                 return RemoteCommandResult(returncode=1)
+            if command_tuple[:2] == ("bash", "-lc") and "-name _work" in command_tuple[2]:
+                return RemoteCommandResult(returncode=0, stdout="0\n0\n")
             if command_tuple in outputs:
                 return RemoteCommandResult(returncode=0, stdout=outputs[command_tuple])
             return RemoteCommandResult(returncode=1, stderr="not installed")
@@ -414,6 +427,9 @@ class RunnerHostHygieneTests(unittest.TestCase):
                 repository_scope="cbusillo/launchplane",
                 audit_record_key="runner-host-hygiene/2026-06-04/chris-testing",
                 retained_warm_builders=("odoo-docker-chris-testing",),
+                runner_workdir_roots=(
+                    RunnerWorkdirRoot(key="legacy", path="/opt/actions-runners"),
+                ),
             ),
             remote_runner=runner,
         )

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -928,7 +928,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             )
 
     def test_executor_redacts_action_failure_before_audit_and_artifact(self) -> None:
-        secret = "ghp_1234567890abcdefghijklmnop"
+        secret = "ghp_aaaaaaaaaaaa"
         with tempfile.TemporaryDirectory() as temporary_directory:
             temporary_path = Path(temporary_directory)
             spool = RunnerHostHygieneAuditSpool(

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+from email.message import Message
+from io import BytesIO
+import tempfile
 import unittest
 
 from collections.abc import Sequence
@@ -9,11 +12,14 @@ import subprocess
 from pathlib import Path
 from typing import Literal
 from unittest.mock import patch
+from urllib.error import HTTPError
 from urllib.request import Request
 
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import RunnerWorkdirRoot
+from control_plane.workflows.runner_host_hygiene_executor import AuditDeliveryError
 from control_plane.workflows.runner_host_hygiene_executor import (
     build_refreshing_service_audit_poster,
 )
@@ -22,6 +28,9 @@ from control_plane.workflows.runner_host_hygiene_executor import (
 )
 from control_plane.workflows.runner_host_hygiene_executor import _parse_volume_usage
 from control_plane.workflows.runner_host_hygiene_executor import validate_local_executor_environment
+from control_plane.workflows.runner_host_hygiene_audit_spool import (
+    RunnerHostHygieneAuditSpool,
+)
 
 
 _VOLUME_RM_PREFIX = (
@@ -39,6 +48,7 @@ class _CommandRunner:
         self,
         *,
         prune_returncode: int = 0,
+        prune_stderr: str = "prune failed",
         image_present_after: bool = True,
         active_build_processes: str = "",
         volume_remove_returncode: int = 0,
@@ -49,9 +59,11 @@ class _CommandRunner:
         container_inventory: str | None = None,
         volume_inventory: str | None = None,
         runner_workdir_bytes: int = 0,
+        runner_workdir_usage: Mapping[str, tuple[int, int]] | None = None,
     ) -> None:
         self.commands: list[tuple[str, ...]] = []
         self._prune_returncode = prune_returncode
+        self._prune_stderr = prune_stderr
         self._volume_remove_returncode = volume_remove_returncode
         self._volume_remove_partial_failure = volume_remove_partial_failure
         self._image_present_after = image_present_after
@@ -98,6 +110,7 @@ class _CommandRunner:
             ]
         )
         self._runner_workdir_bytes = runner_workdir_bytes
+        self._runner_workdir_usage = dict(runner_workdir_usage or {})
         self._pruned = False
         self.removed_volumes: list[str] = []
 
@@ -158,23 +171,26 @@ class _CommandRunner:
                     self.removed_volumes,
                 ),
             )
-        if command_tuple == (
-            "bash",
-            "-lc",
-            "find /opt/actions-runners -mindepth 2 -maxdepth 2 -type d -name _work "
-            "-exec du -sb {} + 2>/dev/null | "
-            "awk '{ total += $1 } END { print total + 0 }'",
+        if (
+            command_tuple[:2] == ("bash", "-lc")
+            and "-name _work" in command_tuple[2]
+            and "du -sb" in command_tuple[2]
         ):
-            return RemoteCommandResult(returncode=0, stdout=f"{self._runner_workdir_bytes}\n")
+            apparent_bytes = self._runner_workdir_bytes
+            allocated_bytes = self._runner_workdir_bytes
+            for root_path, root_usage in self._runner_workdir_usage.items():
+                if root_path in command_tuple[2]:
+                    apparent_bytes, allocated_bytes = root_usage
+                    break
+            return RemoteCommandResult(
+                returncode=0,
+                stdout=f"{apparent_bytes}\n{allocated_bytes}\n",
+            )
         if command_tuple[:3] == ("docker", "image", "inspect"):
             if not self._pruned or self._image_present_after:
                 return RemoteCommandResult(returncode=0, stdout="[]\n")
             return RemoteCommandResult(returncode=1, stderr="image missing")
-        if command_tuple == (
-            "bash",
-            "-lc",
-            "pgrep -af '[d]ocker buildx|[d]ocker build|[b]uildctl' || true",
-        ):
+        if command_tuple[:2] == ("bash", "-lc") and "pgrep -af" in command_tuple[2]:
             return RemoteCommandResult(returncode=0, stdout=self._active_build_processes)
         if command_tuple == (
             "flock",
@@ -188,7 +204,10 @@ class _CommandRunner:
             "until=168h",
         ):
             self._pruned = True
-            return RemoteCommandResult(returncode=self._prune_returncode, stderr="prune failed")
+            return RemoteCommandResult(
+                returncode=self._prune_returncode,
+                stderr=self._prune_stderr,
+            )
         if command_tuple[:6] == _VOLUME_RM_PREFIX:
             if self._volume_remove_partial_failure and len(command_tuple[6:]) > 1:
                 self.removed_volumes.append(command_tuple[6])
@@ -234,6 +253,89 @@ class _AuditPoster:
         }
 
 
+class _TerminalFailingAuditPoster(_AuditPoster):
+    def __call__(
+        self, audit: RunnerHostHygieneApplyAuditRecord, idempotency_key: str
+    ) -> dict[str, object]:
+        if audit.status == "planned":
+            return super().__call__(audit, idempotency_key)
+        self.records.append((audit.status, idempotency_key))
+        self.audits.append(audit)
+        raise AuditDeliveryError("temporary audit service failure", retryable=True)
+
+
+class _PermanentlyFailingAuditPoster(_AuditPoster):
+    def __call__(
+        self, audit: RunnerHostHygieneApplyAuditRecord, idempotency_key: str
+    ) -> dict[str, object]:
+        self.records.append((audit.status, idempotency_key))
+        self.audits.append(audit)
+        raise AuditDeliveryError("audit route rejected request", retryable=False)
+
+
+class _FlakyTerminalAuditPoster(_AuditPoster):
+    def __init__(self, *, failures: int) -> None:
+        super().__init__()
+        self._failures = failures
+
+    def __call__(
+        self, audit: RunnerHostHygieneApplyAuditRecord, idempotency_key: str
+    ) -> dict[str, object]:
+        if audit.status != "planned" and self._failures > 0:
+            self._failures -= 1
+            self.records.append((audit.status, idempotency_key))
+            self.audits.append(audit)
+            raise AuditDeliveryError("temporary audit service failure", retryable=True)
+        return super().__call__(audit, idempotency_key)
+
+
+class _SpoolAwareCommandRunner(_CommandRunner):
+    def __init__(
+        self,
+        *,
+        spool: RunnerHostHygieneAuditSpool,
+        request: RunnerHostHygieneExecutorRequest,
+    ) -> None:
+        super().__init__()
+        self._spool = spool
+        self._request = request
+
+    def __call__(self, command: Sequence[str], timeout_seconds: int) -> RemoteCommandResult:
+        command_tuple = tuple(command)
+        if command_tuple[:5] == (
+            "flock",
+            "-n",
+            "/tmp/launchplane-runner-host-hygiene.lock",
+            "docker",
+            "builder",
+        ):
+            envelope = self._spool.read(
+                host_name=self._request.host_name,
+                action=self._request.action,
+                audit_record_key=self._request.audit_record_key,
+            )
+            if envelope is None or envelope.execution_state != "action_started":
+                return RemoteCommandResult(
+                    returncode=99,
+                    stderr="audit intent was not durable before mutation",
+                )
+        return super().__call__(command_tuple, timeout_seconds)
+
+
+class _CrashingCommandRunner(_CommandRunner):
+    def __call__(self, command: Sequence[str], timeout_seconds: int) -> RemoteCommandResult:
+        command_tuple = tuple(command)
+        if command_tuple[:5] == (
+            "flock",
+            "-n",
+            "/tmp/launchplane-runner-host-hygiene.lock",
+            "docker",
+            "builder",
+        ):
+            raise RuntimeError("simulated runner termination")
+        return super().__call__(command_tuple, timeout_seconds)
+
+
 class RunnerHostHygieneWorkflowTests(unittest.TestCase):
     def test_workflow_runs_on_ops_lane_without_xargs_dependency(self) -> None:
         workflow_text = Path(".github/workflows/runner-host-hygiene.yml").read_text(
@@ -249,6 +351,11 @@ class RunnerHostHygieneWorkflowTests(unittest.TestCase):
         self.assertNotIn("${{ vars.LAUNCHPLANE_RUNNER_LABEL }}", workflow_text)
         self.assertNotIn("xargs <<<", workflow_text)
         self.assertIn('trimmed="${builder#', workflow_text)
+        self.assertIn("LAUNCHPLANE_RUNNER_HOST_HYGIENE_RUNNER_WORKDIR_ROOTS", workflow_text)
+        self.assertIn("--runner-workdir-root", workflow_text)
+        self.assertIn("--audit-spool-root", workflow_text)
+        self.assertIn("--audit-artifact-file", workflow_text)
+        self.assertIn("      - name: Upload executor result\n        if: always()\n", workflow_text)
 
 
 class RunnerHostHygieneExecutorTests(unittest.TestCase):
@@ -325,6 +432,18 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             post_apply_report.docker_reclaimable_bytes,
             reclaimable_bytes,
         )
+        self.assertEqual(
+            post_apply_report.docker_reclaimable_breakdown.images_bytes,
+            23_120_000_000,
+        )
+        self.assertEqual(
+            post_apply_report.docker_reclaimable_breakdown.local_volumes_bytes,
+            97_470_000_000,
+        )
+        self.assertEqual(
+            post_apply_report.docker_reclaimable_breakdown.build_cache_bytes,
+            27_880_000_000,
+        )
 
     def test_executor_records_read_only_resource_inventory(self) -> None:
         command_runner = _CommandRunner()
@@ -387,6 +506,41 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertIsNotNone(post_apply_report)
         assert post_apply_report is not None
         self.assertEqual(post_apply_report.runner_workdir_bytes, 12_345_678)
+
+    def test_executor_records_all_approved_runner_roots(self) -> None:
+        command_runner = _CommandRunner(
+            runner_workdir_usage={
+                "/opt/actions-runners": (12_000, 8_000),
+                "/home/runner/actions-runners": (7_000, 5_000),
+            }
+        )
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_host_hygiene_executor(
+            request=_request(
+                mutate=True,
+                runner_workdir_roots=(
+                    RunnerWorkdirRoot(key="legacy", path="/opt/actions-runners"),
+                    RunnerWorkdirRoot(key="managed", path="/home/runner/actions-runners"),
+                ),
+            ),
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "completed")
+        post_apply_report = audit_poster.audits[-1].post_apply_report
+        assert post_apply_report is not None
+        self.assertEqual(post_apply_report.runner_workdir_bytes, 19_000)
+        self.assertEqual(post_apply_report.runner_workdir_allocated_bytes, 13_000)
+        self.assertEqual(
+            [item.root_key for item in post_apply_report.runner_workdir_usage],
+            ["legacy", "managed"],
+        )
+        self.assertEqual(
+            [item.apparent_bytes for item in post_apply_report.runner_workdir_usage],
+            [12_000, 7_000],
+        )
 
     def test_executor_flags_orphan_buildkit_artifacts_from_live_evidence(self) -> None:
         command_runner = _CommandRunner(
@@ -490,7 +644,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         )
 
         self.assertEqual(result.status, "failed")
-        self.assertIn("active build processes", result.message)
+        self.assertIn("active runner or build processes", result.message)
         self.assertIn(
             ("failed", "runner-host-hygiene:runner-host-hygiene/2026-05-23/chris-testing:failed"),
             audit_poster.records,
@@ -498,6 +652,310 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertNotIn(
             ("docker", "builder", "prune", "--all", "--force"), command_runner.commands
         )
+
+    def test_executor_blocks_when_runner_worker_is_active(self) -> None:
+        command_runner = _CommandRunner(
+            active_build_processes="456 /opt/actions-runner/bin/Runner.Worker spawnclient 123\n"
+        )
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_host_hygiene_executor(
+            request=_request(mutate=True),
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("Runner.Worker", result.message)
+        self.assertFalse(
+            any(
+                command[:5]
+                == ("flock", "-n", "/tmp/launchplane-runner-host-hygiene.lock", "docker", "builder")
+                for command in command_runner.commands
+            )
+        )
+
+    def test_executor_excludes_current_job_runner_worker_ancestor(self) -> None:
+        command_runner = _CommandRunner(
+            active_build_processes=(
+                "ancestor_pids=456 123 1\n"
+                "456 /opt/actions-runner/bin/Runner.Worker spawnclient 123\n"
+            )
+        )
+
+        result = execute_runner_host_hygiene_executor(
+            request=_request(mutate=True),
+            remote_runner=command_runner,
+            audit_poster=_AuditPoster(),
+            audit_delivery_sleeper=lambda _seconds: None,
+        )
+
+        self.assertEqual(result.status, "completed")
+
+    def test_executor_blocks_other_runner_worker_beside_current_job(self) -> None:
+        command_runner = _CommandRunner(
+            active_build_processes=(
+                "ancestor_pids=456 123 1\n"
+                "456 /opt/actions-runner/bin/Runner.Worker spawnclient 123\n"
+                "789 /opt/actions-runner/bin/Runner.Worker spawnclient 456\n"
+            )
+        )
+
+        result = execute_runner_host_hygiene_executor(
+            request=_request(mutate=True),
+            remote_runner=command_runner,
+            audit_poster=_AuditPoster(),
+            audit_delivery_sleeper=lambda _seconds: None,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("789", result.message)
+
+    def test_executor_requires_two_consecutive_idle_samples(self) -> None:
+        command_runner = _CommandRunner()
+
+        result = execute_runner_host_hygiene_executor(
+            request=_request(mutate=True),
+            remote_runner=command_runner,
+            audit_poster=_AuditPoster(),
+            audit_delivery_sleeper=lambda _seconds: None,
+        )
+
+        self.assertEqual(result.status, "completed")
+        idle_commands = [
+            command
+            for command in command_runner.commands
+            if command[:2] == ("bash", "-lc") and "pgrep -af" in command[2]
+        ]
+        self.assertEqual(len(idle_commands), 2)
+
+    def test_executor_spools_terminal_audit_before_failed_delivery(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            spool = RunnerHostHygieneAuditSpool(
+                root=temporary_path / "spool",
+                artifact_file=temporary_path / "artifact.json",
+            )
+            request = _request(mutate=True)
+
+            result = execute_runner_host_hygiene_executor(
+                request=request,
+                remote_runner=_CommandRunner(),
+                audit_poster=_TerminalFailingAuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(result.status, "audit_delivery_pending")
+            self.assertTrue(result.audit_delivery_pending)
+            envelope = spool.read(
+                host_name=request.host_name,
+                action=request.action,
+                audit_record_key=request.audit_record_key,
+            )
+            assert envelope is not None
+            self.assertEqual(envelope.execution_state, "terminal_recorded")
+            self.assertEqual(envelope.planned_delivery_state, "delivered")
+            self.assertEqual(envelope.terminal_delivery_state, "pending")
+            terminal_audit = envelope.terminal_audit
+            assert terminal_audit is not None
+            self.assertEqual(terminal_audit.status, "completed")
+            artifact_text = (temporary_path / "artifact.json").read_text(encoding="utf-8")
+            self.assertNotIn("Bearer", artifact_text)
+            self.assertNotIn("temporary-token", artifact_text)
+
+            reconciliation_runner = _CommandRunner()
+            reconciled = execute_runner_host_hygiene_executor(
+                request=request,
+                remote_runner=reconciliation_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(reconciled.status, "completed")
+            self.assertTrue(reconciled.reconciled)
+            self.assertEqual(reconciliation_runner.commands, [])
+
+    def test_executor_persists_action_started_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
+            request = _request(mutate=True)
+
+            result = execute_runner_host_hygiene_executor(
+                request=request,
+                remote_runner=_SpoolAwareCommandRunner(spool=spool, request=request),
+                audit_poster=_AuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(result.status, "completed")
+            envelope = spool.read(
+                host_name=request.host_name,
+                action=request.action,
+                audit_record_key=request.audit_record_key,
+            )
+            assert envelope is not None
+            self.assertEqual(envelope.execution_state, "terminal_recorded")
+            self.assertEqual(envelope.terminal_delivery_state, "delivered")
+
+    def test_executor_retries_terminal_audit_delivery(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
+            request = _request(mutate=True)
+            poster = _FlakyTerminalAuditPoster(failures=2)
+
+            result = execute_runner_host_hygiene_executor(
+                request=request,
+                remote_runner=_CommandRunner(),
+                audit_poster=poster,
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(result.status, "completed")
+            self.assertFalse(result.audit_delivery_pending)
+            envelope = spool.read(
+                host_name=request.host_name,
+                action=request.action,
+                audit_record_key=request.audit_record_key,
+            )
+            assert envelope is not None
+            self.assertEqual(envelope.terminal_delivery_state, "delivered")
+            self.assertEqual(envelope.delivery_attempts, 4)
+
+    def test_executor_blocks_new_action_while_terminal_delivery_is_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
+            first_request = _request(mutate=True)
+            execute_runner_host_hygiene_executor(
+                request=first_request,
+                remote_runner=_CommandRunner(),
+                audit_poster=_TerminalFailingAuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+            second_runner = _CommandRunner()
+
+            blocked = execute_runner_host_hygiene_executor(
+                request=_request(
+                    mutate=True,
+                    audit_record_key="runner-host-hygiene/2026-05-24/chris-testing",
+                ),
+                remote_runner=second_runner,
+                audit_poster=_TerminalFailingAuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(blocked.status, "blocked")
+            self.assertTrue(blocked.audit_delivery_pending)
+            self.assertEqual(second_runner.commands, [])
+
+    def test_executor_blocks_permanently_rejected_planned_audit_before_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
+            command_runner = _CommandRunner()
+
+            result = execute_runner_host_hygiene_executor(
+                request=_request(mutate=True),
+                remote_runner=command_runner,
+                audit_poster=_PermanentlyFailingAuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(result.status, "blocked")
+            self.assertTrue(result.audit_delivery_pending)
+            self.assertFalse(
+                any(
+                    command[:5]
+                    == (
+                        "flock",
+                        "-n",
+                        "/tmp/launchplane-runner-host-hygiene.lock",
+                        "docker",
+                        "builder",
+                    )
+                    for command in command_runner.commands
+                )
+            )
+
+    def test_executor_resolves_action_started_without_repeating_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
+            request = _request(mutate=True)
+            with self.assertRaisesRegex(RuntimeError, "simulated runner termination"):
+                execute_runner_host_hygiene_executor(
+                    request=request,
+                    remote_runner=_CrashingCommandRunner(),
+                    audit_poster=_AuditPoster(),
+                    audit_spool=spool,
+                    audit_delivery_sleeper=lambda _seconds: None,
+                )
+            envelope = spool.read(
+                host_name=request.host_name,
+                action=request.action,
+                audit_record_key=request.audit_record_key,
+            )
+            assert envelope is not None
+            self.assertEqual(envelope.execution_state, "action_started")
+            resolution_runner = _CommandRunner()
+
+            resolved = execute_runner_host_hygiene_executor(
+                request=_request(mutate=True, resolve_action_started=True),
+                remote_runner=resolution_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(resolved.status, "failed")
+            self.assertTrue(resolved.reconciled)
+            self.assertFalse(
+                any(
+                    command[:5]
+                    == (
+                        "flock",
+                        "-n",
+                        "/tmp/launchplane-runner-host-hygiene.lock",
+                        "docker",
+                        "builder",
+                    )
+                    for command in resolution_runner.commands
+                )
+            )
+
+    def test_executor_redacts_action_failure_before_audit_and_artifact(self) -> None:
+        secret = "ghp_1234567890abcdefghijklmnop"
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            temporary_path = Path(temporary_directory)
+            spool = RunnerHostHygieneAuditSpool(
+                root=temporary_path / "spool",
+                artifact_file=temporary_path / "artifact.json",
+            )
+            poster = _AuditPoster()
+
+            result = execute_runner_host_hygiene_executor(
+                request=_request(mutate=True),
+                remote_runner=_CommandRunner(
+                    prune_returncode=1,
+                    prune_stderr=f"token={secret} Bearer raw-jwt-value",
+                ),
+                audit_poster=poster,
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(result.status, "failed")
+            self.assertNotIn(secret, result.message)
+            self.assertNotIn("raw-jwt-value", result.message)
+            terminal_audit = poster.audits[-1]
+            self.assertNotIn(secret, terminal_audit.message)
+            artifact_text = (temporary_path / "artifact.json").read_text(encoding="utf-8")
+            self.assertNotIn(secret, artifact_text)
+            self.assertNotIn("raw-jwt-value", artifact_text)
 
     def test_executor_removes_allowlisted_zero_link_buildkit_state_volume(
         self,
@@ -769,6 +1227,29 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             ["Bearer first-token", "Bearer second-token"],
         )
 
+    def test_service_audit_poster_marks_route_not_found_non_retryable(self) -> None:
+        poster = build_refreshing_service_audit_poster(
+            service_url="https://launchplane.example",
+            bearer_token_provider=lambda: "token",
+        )
+        error = HTTPError(
+            url="https://launchplane.example/v1/evidence/runner-host-hygiene/audits",
+            code=404,
+            msg="not found",
+            hdrs=Message(),
+            fp=BytesIO(b"404 page not found"),
+        )
+
+        with patch(
+            "control_plane.workflows.runner_host_hygiene_executor.urlopen",
+            side_effect=error,
+        ):
+            with self.assertRaises(AuditDeliveryError) as raised:
+                poster(_planned_audit(), "idempotency-key")
+
+        self.assertFalse(raised.exception.retryable)
+        self.assertIn("404 page not found", raised.exception.message)
+
 
 def _request(
     *,
@@ -781,6 +1262,11 @@ def _request(
     ] = "prune_docker_cache",
     target_buildkit_state_volumes: tuple[str, ...] = (),
     allowed_buildkit_state_volumes: tuple[str, ...] = (),
+    audit_record_key: str = "runner-host-hygiene/2026-05-23/chris-testing",
+    runner_workdir_roots: tuple[RunnerWorkdirRoot, ...] = (
+        RunnerWorkdirRoot(key="legacy", path="/opt/actions-runners"),
+    ),
+    resolve_action_started: bool = False,
 ) -> RunnerHostHygieneExecutorRequest:
     return RunnerHostHygieneExecutorRequest(
         action=action,
@@ -788,11 +1274,14 @@ def _request(
         execution_lane="chris-testing-ops-gate",
         service_user="launchplane-runner-hygiene",
         repository_scope="cbusillo/launchplane",
-        audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        audit_record_key=audit_record_key,
         retained_warm_builders=("odoo-docker-chris-testing",),
         target_buildkit_state_volumes=target_buildkit_state_volumes,
         allowed_buildkit_state_volumes=allowed_buildkit_state_volumes,
         mutate=mutate,
+        runner_workdir_roots=runner_workdir_roots,
+        idle_observation_interval_seconds=0,
+        resolve_action_started=resolve_action_started,
     )
 
 


### PR DESCRIPTION
## Summary

- add a host-persistent, atomic audit-delivery envelope for planned, action-started, and terminal runner-hygiene evidence
- retry retryable audit delivery, fail closed on permanent planned-audit rejection, fence unresolved host/action state, and reconcile without repeating privileged actions
- add explicit recovery for an outcome-unknown `action_started` state and broaden secret/error redaction before service or artifact persistence
- replace single-root runner accounting with runtime-supplied roots and per-root apparent/allocated bytes
- split Docker reclaimable evidence by image, container, volume, and build-cache class
- require two consecutive local idle samples, excluding only the current hygiene job's ancestor worker while blocking sibling workers and build clients
- preserve the current audit envelope as an always-uploaded workflow artifact and refresh docs/OpenAPI metadata

## Safety Notes

- no new destructive action is enabled; executor scope remains bounded to the existing Docker cache and exact BuildKit state-volume lanes
- retryable remote audit failure may rely on already-durable local intent, but authorization/route/idempotency rejection blocks mutation
- `action_started` recovery captures current post evidence and records failure without rerunning the action
- runner root paths remain runtime/operator input; service evidence contains only public root keys and byte counts

## Validation

- `uv run --extra dev python -m unittest tests.test_runner_host_hygiene_executor tests.test_runner_host_hygiene tests.test_config_authority_audit tests.test_http_read_route_registrars.FastApiReadRouteRegistrarTests.test_canonical_openapi_bytes_match_checked_contract` — 166 tests passed
- `uv run --extra dev launchplane ci unittest-shard local` — 12/12 shards, 2,288 targets passed after merging current `main`
- `uv run --extra dev mypy control_plane tests` — 550 source files passed
- changed-file Ruff format/lint passed
- `pnpm --dir frontend check:openapi-drift` passed
- PyCharm changed-file inspection passed with zero findings

## Rollout

1. Deploy the service/model-compatible change before exercising the updated executor workflow.
2. Configure `LAUNCHPLANE_RUNNER_HOST_HYGIENE_RUNNER_WORKDIR_ROOTS` through operator-managed runtime configuration.
3. Run report-only audit delivery/reconciliation soak evidence.
4. Enable a supervised mutation only after the soak is clean.

Refs #1837
Refs #1841
Refs #1842
