### PR TITLE
Allow retained import after failed target replacement

### DIFF
--- a/control_plane/workflows/odoo_prod_retained_volume_backup_import.py
+++ b/control_plane/workflows/odoo_prod_retained_volume_backup_import.py
@@ -15,6 +15,7 @@ from control_plane.contracts.artifact_identity import (
     artifact_manifest_matches_image_repository,
 )
 from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
@@ -65,6 +66,8 @@ class OdooProdRetainedVolumeBackupImportStore(Protocol):
     def read_environment_inventory(
         self, *, context_name: str, instance_name: str
     ) -> EnvironmentInventory: ...
+
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord: ...
 
     def read_artifact_manifest(self, artifact_id: str) -> ArtifactIdentityManifest: ...
 
@@ -241,6 +244,13 @@ def build_odoo_prod_retained_volume_backup_import_plan(
         token = ""
         blockers.append("Exact live target evidence could not be read.")
     live_env = dokploy_api.parse_dokploy_env_text(str(target_payload.get("env") or ""))
+    live_target_name = str(target_payload.get("name") or "").strip()
+    target_name = target_record.target_name.strip() or live_target_name
+    if target_record.target_name.strip() and live_target_name != target_record.target_name.strip():
+        blockers.append("Live target name drifted from the DB-backed target record.")
+    target_compose_project = str(target_payload.get("appName") or "").strip()
+    if not target_name or not target_compose_project:
+        blockers.append("Exact live target name and compose project are required.")
     for key, expected_value in (
         ("ODOO_DB_NAME", destination_database_name),
         ("ODOO_DB_USER", database_user),
@@ -250,22 +260,36 @@ def build_odoo_prod_retained_volume_backup_import_plan(
     ):
         if expected_value and live_env.get(key, "").strip() != expected_value:
             blockers.append(f"Live {key} drifted from DB-backed runtime authority.")
+    accepted_runtime_identity = runtime_identity
     if runtime_identity is not None:
         live_runtime_identity = parse_runtime_identity_payload(
             live_env.get("LAUNCHPLANE_RUNTIME_IDENTITY_JSON", "")
         )
-        if live_runtime_identity != runtime_identity:
+        if live_runtime_identity is None or not _live_runtime_identity_env_matches(
+            live_env=live_env,
+            live_runtime_identity=live_runtime_identity,
+        ):
             blockers.append(
                 "Live target runtime identity drifted from production inventory authority."
             )
-
-    live_target_name = str(target_payload.get("name") or "").strip()
-    target_name = target_record.target_name.strip() or live_target_name
-    if target_record.target_name.strip() and live_target_name != target_record.target_name.strip():
-        blockers.append("Live target name drifted from the DB-backed target record.")
-    target_compose_project = str(target_payload.get("appName") or "").strip()
-    if not target_name or not target_compose_project:
-        blockers.append("Exact live target name and compose project are required.")
+        elif live_runtime_identity == runtime_identity:
+            accepted_runtime_identity = live_runtime_identity
+        elif _recorded_failed_deployment_matches_live_identity(
+            record_store=record_store,
+            live_runtime_identity=live_runtime_identity,
+            inventory_runtime_identity=runtime_identity,
+            target_id=target_id_record.target_id,
+            target_name=target_name,
+        ):
+            accepted_runtime_identity = live_runtime_identity
+            warnings.append(
+                "Live runtime identity belongs to a recorded failed deployment; "
+                "the import plan is bound to that exact repair state."
+            )
+        else:
+            blockers.append(
+                "Live target runtime identity drifted from production inventory authority."
+            )
 
     inspection_evidence: OdooProdRetainedVolumeBackupImportInspectionEvidence | None = None
     if not blockers:
@@ -352,7 +376,7 @@ def build_odoo_prod_retained_volume_backup_import_plan(
         "backup_record_id": request.backup_record_id,
         "expected_current_artifact_id": request.expected_current_artifact_id,
         "inventory_updated_at": inventory.updated_at,
-        "runtime_identity": runtime_identity,
+        "runtime_identity": accepted_runtime_identity,
         "active_db_volume": request.expected_active_db_volume,
         "active_data_volume": request.expected_active_data_volume,
         "active_log_volume": request.expected_active_log_volume,
@@ -822,6 +846,70 @@ def _validate_runtime_identity(
         or runtime_identity.source_git_ref != inventory.source_git_ref
     ):
         blockers.append("Current production runtime identity is internally inconsistent.")
+
+
+def _live_runtime_identity_env_matches(
+    *,
+    live_env: dict[str, str],
+    live_runtime_identity: RuntimeIdentity,
+) -> bool:
+    return all(
+        live_env.get(key, "").strip() == expected_value
+        for key, expected_value in (
+            (
+                "LAUNCHPLANE_DEPLOYMENT_RECORD_ID",
+                live_runtime_identity.deployment_record_id,
+            ),
+            ("LAUNCHPLANE_ARTIFACT_ID", live_runtime_identity.artifact_id),
+            ("LAUNCHPLANE_SOURCE_GIT_REF", live_runtime_identity.source_git_ref),
+        )
+    )
+
+
+def _recorded_failed_deployment_matches_live_identity(
+    *,
+    record_store: OdooProdRetainedVolumeBackupImportStore,
+    live_runtime_identity: RuntimeIdentity,
+    inventory_runtime_identity: RuntimeIdentity,
+    target_id: str,
+    target_name: str,
+) -> bool:
+    if (
+        live_runtime_identity.deployment_record_id
+        == inventory_runtime_identity.deployment_record_id
+        or live_runtime_identity.deployed_at.strip()
+        or live_runtime_identity.model_dump(
+            mode="json",
+            exclude={"deployment_record_id", "deployed_at"},
+        )
+        != inventory_runtime_identity.model_dump(
+            mode="json",
+            exclude={"deployment_record_id", "deployed_at"},
+        )
+    ):
+        return False
+    try:
+        deployment_record = record_store.read_deployment_record(
+            live_runtime_identity.deployment_record_id
+        )
+    except FileNotFoundError:
+        return False
+    resolved_target = deployment_record.resolved_target
+    artifact_identity = deployment_record.artifact_identity
+    return (
+        deployment_record.record_id == live_runtime_identity.deployment_record_id
+        and deployment_record.context == live_runtime_identity.context
+        and deployment_record.instance == live_runtime_identity.instance
+        and deployment_record.source_git_ref == live_runtime_identity.source_git_ref
+        and artifact_identity is not None
+        and artifact_identity.artifact_id == live_runtime_identity.artifact_id
+        and deployment_record.runtime_identity == live_runtime_identity
+        and deployment_record.deploy.status == "fail"
+        and resolved_target is not None
+        and resolved_target.target_type == "compose"
+        and resolved_target.target_id == target_id
+        and resolved_target.target_name == target_name
+    )
 
 
 def _artifact_image_reference(manifest: ArtifactIdentityManifest) -> str:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1668,6 +1668,16 @@ cluster state to be exactly `shut down`, counts and sizes the source filestore,
 proves the staging and destination paths absent, checks active data-volume free
 space, and binds all evidence into a SHA-256 plan fingerprint.
 
+A failed target replacement can update the live target's runtime identity before
+post-deploy verification fails while production inventory correctly remains on
+the last successful deployment. Retained-volume import accepts that repair state
+only when every identity field except `deployment_record_id` and `deployed_at`
+still matches inventory, `deployed_at` is empty, and the live deployment id
+resolves to an exact failed deployment record for the same target, artifact, and
+source. The accepted live identity is included in the reviewed plan fingerprint,
+so another replacement attempt invalidates apply. This exception neither marks
+the failed deployment successful nor advances production inventory.
+
 Run `Odoo Prod Retained Volume Backup Import Apply` only with the exact reviewed
 plan operation and fingerprint, a stable idempotency key, and confirmation phrase
 `import-retained-volumes-as-production-backup`. The service queues a dedicated

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -12,6 +12,7 @@ from control_plane.contracts.artifact_identity import (
     ArtifactIdentityManifest,
 )
 from control_plane.contracts.backup_gate_record import BackupGateRecord
+from control_plane.contracts.deployment_record import DeploymentRecord, ResolvedTargetEvidence
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
@@ -229,6 +230,7 @@ class _Store:
             ),
         )
         self.backup_records: dict[str, BackupGateRecord] = {}
+        self.deployment_records: dict[str, DeploymentRecord] = {}
 
     def read_product_profile_record(self, product: str) -> LaunchplaneProductProfileRecord:
         if product != PRODUCT:
@@ -261,6 +263,12 @@ class _Store:
             raise FileNotFoundError(artifact_id)
         return self.artifact
 
+    def read_deployment_record(self, record_id: str) -> DeploymentRecord:
+        try:
+            return self.deployment_records[record_id]
+        except KeyError as error:
+            raise FileNotFoundError(record_id) from error
+
     def read_backup_gate_record(self, record_id: str) -> BackupGateRecord:
         try:
             return self.backup_records[record_id]
@@ -281,14 +289,19 @@ class _Store:
         )
 
 
-def _target_payload(store: _Store) -> dict[str, object]:
+def _target_payload(
+    store: _Store,
+    *,
+    runtime_identity: RuntimeIdentity | None = None,
+) -> dict[str, object]:
+    resolved_runtime_identity = runtime_identity or store.runtime_identity
     live_env = {
         "ODOO_DB_NAME": DESTINATION_DATABASE_NAME,
         "ODOO_DB_USER": DATABASE_USER,
         "ODOO_DB_VOLUME": ACTIVE_DB_VOLUME,
         "ODOO_DATA_VOLUME": ACTIVE_DATA_VOLUME,
         "ODOO_LOG_VOLUME": ACTIVE_LOG_VOLUME,
-        **runtime_identity_env(store.runtime_identity),
+        **runtime_identity_env(resolved_runtime_identity),
     }
     return {
         "name": "example-prod",
@@ -296,6 +309,28 @@ def _target_payload(store: _Store) -> dict[str, object]:
         "serverId": "server-example",
         "env": "\n".join(f"{key}={value}" for key, value in live_env.items()),
     }
+
+
+def _failed_deployment_record(runtime_identity: RuntimeIdentity) -> DeploymentRecord:
+    return DeploymentRecord(
+        record_id=runtime_identity.deployment_record_id,
+        artifact_identity=ArtifactIdentityReference(artifact_id=runtime_identity.artifact_id),
+        context=runtime_identity.context,
+        instance=runtime_identity.instance,
+        source_git_ref=runtime_identity.source_git_ref,
+        resolved_target=ResolvedTargetEvidence(
+            target_type="compose",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        ),
+        runtime_identity=runtime_identity,
+        deploy=DeploymentEvidence(
+            target_name="example-prod",
+            target_type="compose",
+            deploy_mode="dokploy-compose-api",
+            status="fail",
+        ),
+    )
 
 
 def _build_plan(store: _Store) -> OdooProdRetainedVolumeBackupImportPlan:
@@ -490,6 +525,147 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
         self.assertEqual(plan.plan_status, "blocked")
         self.assertEqual(plan.plan_fingerprint, "")
         self.assertTrue(any("ODOO_DB_VOLUME" in blocker for blocker in plan.blockers))
+        inspect_mock.assert_not_called()
+
+    def test_plan_accepts_recorded_failed_deployment_identity_for_repair(self) -> None:
+        store = _Store()
+        live_runtime_identity = store.runtime_identity.model_copy(
+            update={"deployment_record_id": "deployment-failed-replacement"}
+        )
+        store.deployment_records[live_runtime_identity.deployment_record_id] = (
+            _failed_deployment_record(live_runtime_identity)
+        )
+
+        def inspect(**kwargs: object) -> dict[str, object]:
+            return _inspection_payload(inspection_nonce=str(kwargs["inspection_nonce"]))
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.test", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_api.fetch_dokploy_target_payload",
+                return_value=_target_payload(
+                    store,
+                    runtime_identity=live_runtime_identity,
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_inspection",
+                side_effect=inspect,
+            ),
+        ):
+            plan = build_odoo_prod_retained_volume_backup_import_plan(
+                control_plane_root=Path("."),
+                record_store=store,
+                operation_id="plan-operation-1",
+                request=_request(),
+                phase_checkpoint=lambda _phase, _evidence: None,
+                provider_effect_checkpoint=lambda _phase, _effect: None,
+            )
+
+        self.assertEqual(plan.plan_status, "ready", plan.blockers)
+        self.assertEqual(plan.runtime_identity, live_runtime_identity)
+        self.assertTrue(any("recorded failed deployment" in warning for warning in plan.warnings))
+
+    def test_plan_rejects_unrecorded_or_changed_failed_deployment_identity(self) -> None:
+        authority_changes: tuple[dict[str, object] | None, ...] = (
+            None,
+            {"schema_version": 2},
+            {"product": "product-drifted"},
+            {"context": "context-drifted"},
+            {"instance": "testing"},
+            {"environment_kind": "preview"},
+            {"artifact_id": "artifact-drifted"},
+            {"source_git_ref": "source-drifted"},
+            {"image_reference": "ghcr.io/example/odoo@sha256:" + "9" * 64},
+            {"release_tuple_id": "release-drifted"},
+            {"preview_id": "preview-drifted"},
+            {"preview_generation_id": "generation-drifted"},
+            {"deployed_at": "2026-07-26T07:00:00Z"},
+        )
+        for authority_change in authority_changes:
+            with self.subTest(authority_change=authority_change):
+                store = _Store()
+                live_runtime_identity = store.runtime_identity.model_copy(
+                    update={
+                        "deployment_record_id": "deployment-failed-replacement",
+                        **(authority_change or {}),
+                    }
+                )
+                if authority_change is not None:
+                    store.deployment_records[live_runtime_identity.deployment_record_id] = (
+                        _failed_deployment_record(live_runtime_identity)
+                    )
+                with (
+                    patch(
+                        "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_source.read_dokploy_config",
+                        return_value=("https://dokploy.example.test", "token"),
+                    ),
+                    patch(
+                        "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_api.fetch_dokploy_target_payload",
+                        return_value=_target_payload(
+                            store,
+                            runtime_identity=live_runtime_identity,
+                        ),
+                    ),
+                    patch(
+                        "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_inspection"
+                    ) as inspect_mock,
+                ):
+                    plan = build_odoo_prod_retained_volume_backup_import_plan(
+                        control_plane_root=Path("."),
+                        record_store=store,
+                        operation_id="plan-operation-1",
+                        request=_request(),
+                        phase_checkpoint=lambda _phase, _evidence: None,
+                        provider_effect_checkpoint=lambda _phase, _effect: None,
+                    )
+
+                self.assertEqual(plan.plan_status, "blocked")
+                self.assertTrue(
+                    any("runtime identity drifted" in blocker for blocker in plan.blockers)
+                )
+                inspect_mock.assert_not_called()
+
+    def test_plan_rejects_nonfailed_deployment_identity_provenance(self) -> None:
+        store = _Store()
+        live_runtime_identity = store.runtime_identity.model_copy(
+            update={"deployment_record_id": "deployment-not-failed"}
+        )
+        deployment_record = _failed_deployment_record(live_runtime_identity)
+        store.deployment_records[live_runtime_identity.deployment_record_id] = (
+            deployment_record.model_copy(
+                update={"deploy": deployment_record.deploy.model_copy(update={"status": "pass"})}
+            )
+        )
+        with (
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.test", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_api.fetch_dokploy_target_payload",
+                return_value=_target_payload(
+                    store,
+                    runtime_identity=live_runtime_identity,
+                ),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_inspection"
+            ) as inspect_mock,
+        ):
+            plan = build_odoo_prod_retained_volume_backup_import_plan(
+                control_plane_root=Path("."),
+                record_store=store,
+                operation_id="plan-operation-1",
+                request=_request(),
+                phase_checkpoint=lambda _phase, _evidence: None,
+                provider_effect_checkpoint=lambda _phase, _effect: None,
+            )
+
+        self.assertEqual(plan.plan_status, "blocked")
         inspect_mock.assert_not_called()
 
     def test_plan_rejects_unbound_inspection_nonce(self) -> None:
@@ -692,6 +868,21 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
     def test_plan_fingerprint_changes_when_pg_control_changes(self) -> None:
         plan = _build_plan(_Store())
         changed = plan.model_copy(update={"source_pg_control_sha256": "9" * 64})
+        self.assertNotEqual(
+            build_odoo_prod_retained_volume_backup_import_plan_fingerprint(plan),
+            build_odoo_prod_retained_volume_backup_import_plan_fingerprint(changed),
+        )
+
+    def test_plan_fingerprint_binds_live_failed_deployment_identity(self) -> None:
+        plan = _build_plan(_Store())
+        assert plan.runtime_identity is not None
+        changed = plan.model_copy(
+            update={
+                "runtime_identity": plan.runtime_identity.model_copy(
+                    update={"deployment_record_id": "deployment-changed-after-review"}
+                )
+            }
+        )
         self.assertNotEqual(
             build_odoo_prod_retained_volume_backup_import_plan_fingerprint(plan),
             build_odoo_prod_retained_volume_backup_import_plan_fingerprint(changed),


### PR DESCRIPTION
## Summary
- permit retained-volume backup import when the live runtime identity belongs to an exact DB-recorded failed replacement
- keep schema, lane, artifact, source, image, release, preview, target, and scalar env authority fail-closed
- bind the accepted live failed identity into the reviewed plan fingerprint and document the repair boundary

## Validation
- `uv run --extra dev python -m unittest tests.test_odoo_prod_retained_volume_backup_import`
- `uv run --extra dev launchplane ci unittest-shard local` (2,351 targets)
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff lint and format checks
- independent blockers-only review: no blockers
