### PR TITLE
Allow retained import with crash-looping database

### DIFF
--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -2465,6 +2465,19 @@ resolve_single_container() {{
     printf '%s' "${{container_ids}}"
 }}
 
+resolve_single_container_any_state() {{
+    local service_name="$1"
+    local container_ids
+    container_ids=$(docker ps -aq \
+        --filter "label=com.docker.compose.project=${{compose_project}}" \
+        --filter "label=com.docker.compose.service=${{service_name}}")
+    if [ "$(printf '%s\n' "${{container_ids}}" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ]; then
+        echo "Expected exactly one ${{service_name}} container for ${{compose_project}}." >&2
+        exit 1
+    fi
+    printf '%s' "${{container_ids}}"
+}}
+
 require_volume() {{
     docker volume inspect "$1" >/dev/null
 }}
@@ -2497,7 +2510,7 @@ if [ -n "$(docker ps -q --filter "volume=${{source_data_volume}}")" ]; then
     exit 1
 fi
 
-database_container_id=$(resolve_single_container database)
+database_container_id=$(resolve_single_container_any_state database)
 script_runner_container_id=$(resolve_single_container script-runner)
 postgres_image_id=$(docker inspect -f '{{{{.Image}}}}' "${{database_container_id}}")
 script_runner_image_id=$(docker inspect -f '{{{{.Image}}}}' "${{script_runner_container_id}}")
@@ -2807,6 +2820,19 @@ resolve_single_container() {{
     printf '%s' "${{container_ids}}"
 }}
 
+resolve_single_container_any_state() {{
+    local service_name="$1"
+    local container_ids
+    container_ids=$(docker ps -aq \
+        --filter "label=com.docker.compose.project=${{compose_project}}" \
+        --filter "label=com.docker.compose.service=${{service_name}}")
+    if [ "$(printf '%s\n' "${{container_ids}}" | sed '/^$/d' | wc -l | tr -d ' ')" != "1" ]; then
+        echo "Expected exactly one ${{service_name}} container for ${{compose_project}}." >&2
+        exit 1
+    fi
+    printf '%s' "${{container_ids}}"
+}}
+
 volume_label() {{
     local volume_name="$1"
     local label_name="$2"
@@ -2844,7 +2870,7 @@ if [ "$(volume_label "${{source_db_volume}}" com.docker.compose.project)" != \
     exit 1
 fi
 
-database_container_id=$(resolve_single_container database)
+database_container_id=$(resolve_single_container_any_state database)
 script_runner_container_id=$(resolve_single_container script-runner)
 postgres_image_id=$(docker inspect -f '{{{{.Image}}}}' "${{database_container_id}}")
 script_runner_image_id=$(docker inspect -f '{{{{.Image}}}}' "${{script_runner_container_id}}")

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1678,6 +1678,13 @@ source. The accepted live identity is included in the reviewed plan fingerprint,
 so another replacement attempt invalidates apply. This exception neither marks
 the failed deployment successful nor advances production inventory.
 
+The active database container may be stopped or restarting during this repair.
+Plan and apply therefore resolve exactly one database container across all
+states and use only `docker inspect` evidence from it; they never start or
+execute inside that container or mount its corrupt database volume. The
+script-runner remains running-only because it emits the bounded result and
+writes the imported logical backup into the active data volume.
+
 Run `Odoo Prod Retained Volume Backup Import Apply` only with the exact reviewed
 plan operation and fingerprint, a stable idempotency key, and confirmation phrase
 `import-retained-volumes-as-production-backup`. The service queues a dedicated

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -1016,6 +1016,13 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
         self.assertIn("container_mounts_volume", combined)
         self.assertIn("active_destination_database_name", combined)
         self.assertIn('"postgres (PostgreSQL) 17."*', combined)
+        self.assertEqual(
+            combined.count("resolve_single_container_any_state database"),
+            2,
+        )
+        self.assertEqual(combined.count("resolve_single_container script-runner"), 2)
+        self.assertNotIn("resolve_single_container_any_state script-runner", combined)
+        self.assertEqual(combined.count("docker ps -aq"), 2)
         self.assertIn("created_staging_clone_volume", apply_script)
         self.assertIn('mkdir -m 700 "$backup_dir"', apply_script)
         self.assertIn("pg_dump --host /var/run/postgresql", apply_script)


### PR DESCRIPTION
## Summary
- resolve the active Odoo database container across all Docker states during retained-volume inspection and apply
- keep script-runner running-only and preserve exact-one, read-only, no-active-DB-exec safeguards
- document the stopped/restarting database recovery contract

## Validation
- `uv run --extra dev python -m unittest tests.test_odoo_prod_retained_volume_backup_import tests.test_dokploy` (113 tests)
- `uv run --extra dev launchplane ci unittest-shard local` (2,351 targets)
- `uv run --extra dev mypy control_plane tests`
- changed-file Ruff lint and format checks
- independent blockers-only review: no blockers
