### PR TITLE
fix: expose retained import inspection failures

### DIFF
--- a/control_plane/contracts/odoo_prod_retained_volume_backup_import.py
+++ b/control_plane/contracts/odoo_prod_retained_volume_backup_import.py
@@ -18,6 +18,56 @@ _DOCKER_IMAGE_ID_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
 ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_CONFIRMATION = (
     "import-retained-volumes-as-production-backup"
 )
+OdooProdRetainedVolumeBackupImportInspectionFailureStage = Literal[
+    "active_runtime",
+    "source_safety",
+    "source_database",
+    "source_filestore",
+    "destination",
+    "result",
+]
+OdooProdRetainedVolumeBackupImportInspectionFailureCode = Literal[
+    "active_volume_missing",
+    "source_volume_missing",
+    "source_volume_usage_read_failed",
+    "source_volume_in_use",
+    "active_database_container_unavailable",
+    "script_runner_container_unavailable",
+    "active_runtime_inspection_failed",
+    "active_runtime_identity_mismatch",
+    "active_volume_mount_mismatch",
+    "active_image_invalid",
+    "active_postgres_version_mismatch",
+    "source_volume_label_read_failed",
+    "source_postgres_metadata_read_failed",
+    "source_db_measurement_failed",
+    "source_filestore_measurement_failed",
+    "active_data_space_read_failed",
+    "destination_check_failed",
+    "result_emit_failed",
+    "provider_schedule_failed_without_evidence",
+]
+ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE: dict[str, str] = {
+    "active_volume_missing": "active_runtime",
+    "source_volume_missing": "source_safety",
+    "source_volume_usage_read_failed": "source_safety",
+    "source_volume_in_use": "source_safety",
+    "active_database_container_unavailable": "active_runtime",
+    "script_runner_container_unavailable": "active_runtime",
+    "active_runtime_inspection_failed": "active_runtime",
+    "active_runtime_identity_mismatch": "active_runtime",
+    "active_volume_mount_mismatch": "active_runtime",
+    "active_image_invalid": "active_runtime",
+    "active_postgres_version_mismatch": "active_runtime",
+    "source_volume_label_read_failed": "source_safety",
+    "source_postgres_metadata_read_failed": "source_database",
+    "source_db_measurement_failed": "source_database",
+    "source_filestore_measurement_failed": "source_filestore",
+    "active_data_space_read_failed": "destination",
+    "destination_check_failed": "destination",
+    "result_emit_failed": "result",
+    "provider_schedule_failed_without_evidence": "result",
+}
 
 
 class OdooProdRetainedVolumeBackupImportRequest(BaseModel):
@@ -193,6 +243,30 @@ class OdooProdRetainedVolumeBackupImportInspectionEvidence(BaseModel):
     postgres_image_id: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
     script_runner_image_id: str = Field(pattern=r"^sha256:[0-9a-f]{64}$")
     inspection_deployment_id: str = Field(min_length=1)
+
+
+class OdooProdRetainedVolumeBackupImportInspectionFailureEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    schema_version: Literal[1] = 1
+    inspection_nonce: str = Field(pattern=r"^[0-9a-f]{64}$")
+    backup_record_id: str = Field(min_length=1)
+    failure_stage: OdooProdRetainedVolumeBackupImportInspectionFailureStage
+    failure_code: OdooProdRetainedVolumeBackupImportInspectionFailureCode
+    inspection_deployment_id: str = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def _validate_failure_stage_code_pair(
+        self,
+    ) -> "OdooProdRetainedVolumeBackupImportInspectionFailureEvidence":
+        if (
+            ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE.get(self.failure_code)
+            != self.failure_stage
+        ):
+            raise ValueError(
+                "Odoo retained-volume backup import inspection failure stage/code mismatch."
+            )
+        return self
 
 
 class OdooProdRetainedVolumeBackupImportPlan(BaseModel):

--- a/control_plane/dokploy/api.py
+++ b/control_plane/dokploy/api.py
@@ -33,6 +33,19 @@ type JsonValue = JsonPrimitive | dict[str, "JsonValue"] | list["JsonValue"]
 type JsonObject = dict[str, JsonValue]
 
 
+class DokployDeploymentFailed(click.ClickException):
+    def __init__(
+        self,
+        *,
+        deployment_id: str,
+        deployment_status: str,
+        message_prefix: str,
+    ) -> None:
+        self.deployment_id = deployment_id
+        self.deployment_status = deployment_status
+        super().__init__(f"{message_prefix}: deployment={deployment_id} status={deployment_status}")
+
+
 def trigger_deployment(
     *,
     host: str,
@@ -906,8 +919,10 @@ def _wait_for_deployment_status(
             if latest_status in success_statuses:
                 return f"deployment={latest_key} status={latest_status}"
             if latest_status in failure_statuses:
-                raise click.ClickException(
-                    f"{failure_message_prefix}: deployment={latest_key} status={latest_status}"
+                raise DokployDeploymentFailed(
+                    deployment_id=latest_key,
+                    deployment_status=latest_status,
+                    message_prefix=failure_message_prefix,
                 )
         time.sleep(3)
 

--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -8,6 +8,9 @@ from typing import Literal
 
 import click
 
+from control_plane.contracts.odoo_prod_retained_volume_backup_import import (
+    ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE,
+)
 from control_plane.dokploy import api
 from control_plane.dokploy.source import (
     DEFAULT_DOKPLOY_DEPLOY_TIMEOUT_SECONDS,
@@ -129,6 +132,9 @@ ODOO_BACKUP_RESTORE_RESULT_FIELDS = frozenset(
 ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_RESULT_MARKER = (
     "LAUNCHPLANE_ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_RESULT_B64"
 )
+ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER = (
+    "LAUNCHPLANE_ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE"
+)
 ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_RESULT_FIELDS = frozenset(
     {
         "schema_version",
@@ -192,6 +198,16 @@ ODOO_RETAINED_VOLUME_BACKUP_IMPORT_APPLY_RESULT_FIELDS = frozenset(
         "source_filestore_size_bytes",
     }
 )
+
+
+class OdooRetainedVolumeBackupImportInspectionFailure(click.ClickException):
+    def __init__(self, *, evidence: api.JsonObject) -> None:
+        self.evidence = evidence
+        super().__init__(
+            "Dokploy Odoo retained-volume backup import inspection returned bounded failure evidence."
+        )
+
+
 OdooBackupRestorePhase = Literal[
     "database_restore",
     "filestore_stage",
@@ -965,6 +981,8 @@ def run_compose_odoo_retained_volume_backup_import_inspection(
         ),
         marker=ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_RESULT_MARKER,
         expected_fields=ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_RESULT_FIELDS,
+        failure_marker=ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER,
+        failure_identity=(inspection_nonce, backup_record_id),
         timeout_seconds=timeout_seconds,
         before_provider_mutation=before_provider_mutation,
     )
@@ -1072,6 +1090,8 @@ def _run_compose_odoo_retained_volume_backup_import_schedule(
     expected_fields: frozenset[str],
     timeout_seconds: int | None,
     before_provider_mutation: Callable[[str], None] | None,
+    failure_marker: str = "",
+    failure_identity: tuple[str, str] | None = None,
 ) -> tuple[api.JsonObject, str]:
     compose_id = target_definition.target_id.strip()
     compose_name = (
@@ -1147,13 +1167,38 @@ def _run_compose_odoo_retained_volume_backup_import_schedule(
         payload={"scheduleId": schedule_id},
         timeout_seconds=schedule_timeout_seconds,
     )
-    wait_result = api.wait_for_dokploy_schedule_deployment(
-        host=host,
-        token=token,
-        schedule_id=schedule_id,
-        before_key=api.deployment_key(latest_schedule_deployment),
-        timeout_seconds=schedule_timeout_seconds,
-    )
+    try:
+        wait_result = api.wait_for_dokploy_schedule_deployment(
+            host=host,
+            token=token,
+            schedule_id=schedule_id,
+            before_key=api.deployment_key(latest_schedule_deployment),
+            timeout_seconds=schedule_timeout_seconds,
+        )
+    except api.DokployDeploymentFailed as error:
+        if not failure_marker or failure_identity is None:
+            raise
+        try:
+            failure_log_lines = api.fetch_dokploy_deployment_logs(
+                host=host,
+                token=token,
+                deployment_id=error.deployment_id,
+                line_count=api.MAX_DOKPLOY_LOG_LINE_COUNT,
+            )
+            failure_evidence = _extract_retained_volume_inspection_failure(
+                {"logs": list(failure_log_lines)},
+                marker=failure_marker,
+            )
+        except (click.ClickException, OSError):
+            failure_evidence = {
+                "schema_version": 1,
+                "inspection_nonce": failure_identity[0],
+                "backup_record_id": failure_identity[1],
+                "failure_stage": "result",
+                "failure_code": "provider_schedule_failed_without_evidence",
+            }
+        failure_evidence["inspection_deployment_id"] = error.deployment_id
+        raise OdooRetainedVolumeBackupImportInspectionFailure(evidence=failure_evidence) from error
     deployment_id = api.deployment_key_from_wait_result(wait_result)
     if not deployment_id:
         raise click.ClickException(
@@ -1174,6 +1219,46 @@ def _run_compose_odoo_retained_volume_backup_import_schedule(
         ),
         deployment_id,
     )
+
+
+def _extract_retained_volume_inspection_failure(
+    payload: api.JsonValue,
+    *,
+    marker: str,
+) -> api.JsonObject:
+    bounded_values: list[str] = []
+    marker_prefix = f"{marker}="
+    for line in api.normalize_dokploy_log_payload(payload):
+        normalized_line = line.strip()
+        if normalized_line.startswith(marker_prefix):
+            bounded_values.append(normalized_line.removeprefix(marker_prefix).strip())
+    if len(bounded_values) != 1:
+        raise click.ClickException(
+            "Dokploy Odoo retained-volume backup import inspection returned no unique bounded failure evidence."
+        )
+    parts = bounded_values[0].split("|")
+    if len(parts) != 4:
+        raise click.ClickException(
+            "Dokploy Odoo retained-volume backup import inspection returned invalid bounded failure evidence."
+        )
+    inspection_nonce, backup_record_id, failure_stage, failure_code = parts
+    if (
+        len(inspection_nonce) != 64
+        or any(character not in "0123456789abcdef" for character in inspection_nonce)
+        or not backup_record_id
+        or ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE.get(failure_code)
+        != failure_stage
+    ):
+        raise click.ClickException(
+            "Dokploy Odoo retained-volume backup import inspection returned invalid bounded failure evidence."
+        )
+    return {
+        "schema_version": 1,
+        "inspection_nonce": inspection_nonce,
+        "backup_record_id": backup_record_id,
+        "failure_stage": failure_stage,
+        "failure_code": failure_code,
+    }
 
 
 def _extract_bounded_schedule_result(
@@ -2434,11 +2519,14 @@ def _build_dokploy_odoo_retained_volume_backup_import_inspection_script(
     backup_dir_relative_path: str,
 ) -> str:
     return f"""#!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 compose_project={shlex.quote(compose_app_name)}
 inspection_nonce={shlex.quote(inspection_nonce)}
 backup_record_id={shlex.quote(backup_record_id)}
+failure_marker={shlex.quote(ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER)}
+failure_stage=active_runtime
+failure_code=active_runtime_inspection_failed
 active_db_volume={shlex.quote(active_db_volume)}
 active_data_volume={shlex.quote(active_data_volume)}
 active_log_volume={shlex.quote(active_log_volume)}
@@ -2451,6 +2539,24 @@ database_user={shlex.quote(database_user)}
 expected_source_compose_project={shlex.quote(expected_source_compose_project)}
 filestore_relative_path={shlex.quote(filestore_relative_path)}
 backup_dir_relative_path={shlex.quote(backup_dir_relative_path)}
+
+emit_inspection_failure() {{
+    local exit_status="$1"
+    if [ "${{exit_status}}" -ne 0 ]; then
+        printf '%s=%s|%s|%s|%s\n' \
+            "${{failure_marker}}" \
+            "${{inspection_nonce}}" \
+            "${{backup_record_id}}" \
+            "${{failure_stage}}" \
+            "${{failure_code}}"
+    fi
+    return "${{exit_status}}"
+}}
+
+trap 'emit_inspection_failure "$?"' EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 resolve_single_container() {{
     local service_name="$1"
@@ -2495,23 +2601,42 @@ container_mounts_volume() {{
         "${{container_id}}" | grep -Fx -- "${{volume_name}}" >/dev/null
 }}
 
+failure_stage=active_runtime
+failure_code=active_volume_missing
 require_volume "${{active_db_volume}}"
 require_volume "${{active_data_volume}}"
 require_volume "${{active_log_volume}}"
+
+failure_stage=source_safety
+failure_code=source_volume_missing
 require_volume "${{source_db_volume}}"
 require_volume "${{source_data_volume}}"
 
-if [ -n "$(docker ps -q --filter "volume=${{source_db_volume}}")" ]; then
+failure_code=source_volume_usage_read_failed
+source_db_container_ids=
+if ! source_db_container_ids=$(docker ps -q --filter "volume=${{source_db_volume}}"); then
+    exit 1
+fi
+source_data_container_ids=
+if ! source_data_container_ids=$(docker ps -q --filter "volume=${{source_data_volume}}"); then
+    exit 1
+fi
+failure_code=source_volume_in_use
+if [ -n "${{source_db_container_ids}}" ]; then
     echo "Retained source DB volume is mounted by a running container." >&2
     exit 1
 fi
-if [ -n "$(docker ps -q --filter "volume=${{source_data_volume}}")" ]; then
+if [ -n "${{source_data_container_ids}}" ]; then
     echo "Retained source data volume is mounted by a running container." >&2
     exit 1
 fi
 
+failure_stage=active_runtime
+failure_code=active_database_container_unavailable
 database_container_id=$(resolve_single_container_any_state database)
+failure_code=script_runner_container_unavailable
 script_runner_container_id=$(resolve_single_container script-runner)
+failure_code=active_runtime_inspection_failed
 postgres_image_id=$(docker inspect -f '{{{{.Image}}}}' "${{database_container_id}}")
 script_runner_image_id=$(docker inspect -f '{{{{.Image}}}}' "${{script_runner_container_id}}")
 postgres_binary_version=$(docker run --rm --read-only --network none \
@@ -2521,6 +2646,7 @@ active_database_user=$(docker inspect -f '{{{{range .Config.Env}}}}{{{{println .
 active_destination_database_name=$(docker inspect \
     -f '{{{{range .Config.Env}}}}{{{{println .}}}}{{{{end}}}}' \
     "${{script_runner_container_id}}" | sed -n 's/^ODOO_DB_NAME=//p' | tail -n 1)
+failure_code=active_runtime_identity_mismatch
 if [ "${{active_database_user}}" != "${{database_user}}" ]; then
     echo "Active PostgreSQL user does not match runtime authority." >&2
     exit 1
@@ -2529,12 +2655,14 @@ if [ "${{active_destination_database_name}}" != "${{destination_database_name}}"
     echo "Active destination database name does not match runtime authority." >&2
     exit 1
 fi
+failure_code=active_volume_mount_mismatch
 if ! container_mounts_volume "${{database_container_id}}" "${{active_db_volume}}" || \
    ! container_mounts_volume "${{script_runner_container_id}}" "${{active_data_volume}}" || \
    ! container_mounts_volume "${{script_runner_container_id}}" "${{active_log_volume}}"; then
     echo "Active container volume mounts do not match runtime authority." >&2
     exit 1
 fi
+failure_code=active_image_invalid
 case "${{postgres_image_id}}" in
     sha256:[0-9a-f][0-9a-f]*) ;;
     *) echo "Active PostgreSQL container did not expose an immutable image id." >&2; exit 1 ;;
@@ -2543,16 +2671,21 @@ case "${{script_runner_image_id}}" in
     sha256:[0-9a-f][0-9a-f]*) ;;
     *) echo "Active script-runner container did not expose an immutable image id." >&2; exit 1 ;;
 esac
+failure_code=active_postgres_version_mismatch
 case "${{postgres_binary_version}}" in
     "postgres (PostgreSQL) 17" | "postgres (PostgreSQL) 17."*) ;;
     *) echo "Active PostgreSQL image is not major version 17." >&2; exit 1 ;;
 esac
 
+failure_stage=source_safety
+failure_code=source_volume_label_read_failed
 source_db_project_label=$(volume_label "${{source_db_volume}}" com.docker.compose.project)
 source_db_role_label=$(volume_label "${{source_db_volume}}" com.docker.compose.volume)
 source_data_project_label=$(volume_label "${{source_data_volume}}" com.docker.compose.project)
 source_data_role_label=$(volume_label "${{source_data_volume}}" com.docker.compose.volume)
 
+failure_stage=source_database
+failure_code=source_postgres_metadata_read_failed
 source_pg_version=$(docker run --rm --read-only --network none --user 0:0 \
     --mount "type=volume,src=${{source_db_volume}},dst=/source,readonly" \
     --entrypoint /bin/bash "${{postgres_image_id}}" \
@@ -2582,6 +2715,7 @@ source_pg_checkpoint_timeline_id=$(printf '%s\n' "${{pg_controldata_output}}" | 
 source_pg_checkpoint_time=$(printf '%s\n' "${{pg_controldata_output}}" | \
     sed -n 's/^Time of latest checkpoint:[[:space:]]*//p' | head -n 1)
 
+failure_code=source_db_measurement_failed
 source_db_volume_used_bytes=$(docker run --rm --read-only --network none --user 0:0 \
     --mount "type=volume,src=${{source_db_volume}},dst=/source,readonly" \
     --entrypoint python3 "${{script_runner_image_id}}" -c '
@@ -2596,6 +2730,8 @@ for root, directories, files in os.walk("/source", followlinks=False):
 print(total)
 ')
 
+failure_stage=source_filestore
+failure_code=source_filestore_measurement_failed
 filestore_metrics=$(docker run --rm --read-only --network none --user 0:0 \
     --mount "type=volume,src=${{source_data_volume}},dst=/source-data,readonly" \
     --entrypoint python3 "${{script_runner_image_id}}" -c '
@@ -2624,12 +2760,19 @@ print(f"{{count}}:{{size}}")
 source_filestore_file_count=${{filestore_metrics%%:*}}
 source_filestore_size_bytes=${{filestore_metrics#*:}}
 
+failure_stage=destination
+failure_code=active_data_space_read_failed
 active_data_free_bytes=$(docker run --rm --read-only --network none --user 0:0 \
     --mount "type=volume,src=${{active_data_volume}},dst=/active-data,readonly" \
     --entrypoint python3 "${{script_runner_image_id}}" \
     -c 'import shutil; print(shutil.disk_usage("/active-data").free)')
 
-if docker volume inspect "${{staging_clone_volume}}" >/dev/null 2>&1; then
+failure_code=destination_check_failed
+staging_volume_names=
+if ! staging_volume_names=$(docker volume ls -q --filter "name=${{staging_clone_volume}}"); then
+    exit 1
+fi
+if printf '%s\n' "${{staging_volume_names}}" | grep -Fx -- "${{staging_clone_volume}}" >/dev/null; then
     staging_clone_volume_absent=false
 else
     staging_clone_volume_absent=true
@@ -2642,6 +2785,8 @@ import sys
 print("true" if not os.path.lexists(os.path.join("/active-data", sys.argv[1])) else "false")
 ' "${{backup_dir_relative_path}}")
 
+failure_stage=result
+failure_code=result_emit_failed
 docker exec -i \
     -e RESULT_MARKER={shlex.quote(ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_RESULT_MARKER)} \
     -e INSPECTION_NONCE="${{inspection_nonce}}" \

--- a/control_plane/workflows/odoo_prod_retained_volume_backup_import.py
+++ b/control_plane/workflows/odoo_prod_retained_volume_backup_import.py
@@ -23,6 +23,7 @@ from control_plane.contracts.odoo_prod_retained_volume_backup_import import (
     OdooProdRetainedVolumeBackupImportApplyRequest,
     OdooProdRetainedVolumeBackupImportCompletionEvidence,
     OdooProdRetainedVolumeBackupImportInspectionEvidence,
+    OdooProdRetainedVolumeBackupImportInspectionFailureEvidence,
     OdooProdRetainedVolumeBackupImportPlan,
     OdooProdRetainedVolumeBackupImportRequest,
     OdooProdRetainedVolumeBackupImportResult,
@@ -329,6 +330,37 @@ def build_odoo_prod_retained_volume_backup_import_plan(
             inspection_evidence = (
                 OdooProdRetainedVolumeBackupImportInspectionEvidence.model_validate(raw_inspection)
             )
+        except dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure as error:
+            try:
+                failure_evidence = (
+                    OdooProdRetainedVolumeBackupImportInspectionFailureEvidence.model_validate(
+                        error.evidence
+                    )
+                )
+            except ValidationError:
+                blockers.append("Retained-volume provider inspection did not complete.")
+            else:
+                if (
+                    failure_evidence.inspection_nonce != inspection_nonce
+                    or failure_evidence.backup_record_id != request.backup_record_id
+                ):
+                    blockers.append("Retained-volume provider inspection did not complete.")
+                else:
+                    phase_checkpoint(
+                        "inspection_started",
+                        {
+                            "inspection_deployment_id": (failure_evidence.inspection_deployment_id),
+                            "inspection_nonce": failure_evidence.inspection_nonce,
+                            "backup_record_id": failure_evidence.backup_record_id,
+                            "failure_stage": failure_evidence.failure_stage,
+                            "failure_code": failure_evidence.failure_code,
+                        },
+                    )
+                    blockers.append(
+                        "Retained-volume provider inspection failed at "
+                        f"{failure_evidence.failure_stage} "
+                        f"({failure_evidence.failure_code})."
+                    )
         except (click.ClickException, OSError, ValidationError):
             blockers.append("Retained-volume provider inspection did not complete.")
         if inspection_evidence is not None:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1685,6 +1685,17 @@ execute inside that container or mount its corrupt database volume. The
 script-runner remains running-only because it emits the bounded result and
 writes the imported logical backup into the active data volume.
 
+If the provider inspection schedule terminates before it can emit that result,
+the service reads only the exact failed schedule deployment and accepts one
+nonce- and backup-record-bound failure marker. The operation checkpoint records
+only the request nonce, backup-record id, inspection deployment id, and a
+bounded failure stage/code pair; raw provider logs and command output are not
+copied into the plan, operation error, or API response. If the exact marker or
+its logs are unavailable, the same request and deployment are recorded with the
+generic bounded `result/provider_schedule_failed_without_evidence` pair. This
+distinguishes a provider inspection failure from a GitHub environment approval
+wait without weakening the fail-closed plan boundary.
+
 Run `Odoo Prod Retained Volume Backup Import Apply` only with the exact reviewed
 plan operation and fingerprint, a stable idempotency key, and confirmation phrase
 `import-retained-volumes-as-production-backup`. The service queues a dedicated

--- a/docs/records.md
+++ b/docs/records.md
@@ -1220,7 +1220,11 @@ state/
   product/context/instance lane across plan and apply while work is pending,
   running, or reconciliation-required. Expired work is recoverable only before a
   provider-effect checkpoint; later expiry preserves a reconciliation-required
-  lane fence for explicit operator inspection.
+  lane fence for explicit operator inspection. When the read-only provider
+  inspection terminates unsuccessfully, its checkpoint may contain the exact
+  inspection deployment id, request nonce, backup-record id, and one allowlisted
+  failure stage/code pair. Provider log text is not persisted in the operation
+  record.
 - Bootstrap, target replacement, production backup restore, and retained-volume
   backup import creation and worker claim also share one storage-level
   stable-lane reservation.

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.dokploy import JsonValue
+from control_plane.dokploy import api as dokploy_api
 from control_plane.odoo_instance_overrides import LAUNCHPLANE_INSTANCE_OVERRIDES_REQUIRED_ENV_KEY
 from control_plane.odoo_instance_overrides import LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY
 from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
@@ -138,6 +139,33 @@ class _FakeDokployTargetStore:
 
 
 class DokployConfigTests(unittest.TestCase):
+    def test_wait_for_schedule_deployment_exposes_exact_terminal_failure(self) -> None:
+        with (
+            patch(
+                "control_plane.dokploy.api.latest_deployment_for_schedule",
+                return_value={
+                    "deploymentId": "deployment-failed",
+                    "status": "failed",
+                },
+            ),
+            patch("control_plane.dokploy.api.time.sleep"),
+        ):
+            with self.assertRaises(dokploy_api.DokployDeploymentFailed) as raised:
+                control_plane_dokploy.wait_for_dokploy_schedule_deployment(
+                    host="https://dokploy.example",
+                    token="token",
+                    schedule_id="schedule-one",
+                    before_key="deployment-before",
+                    timeout_seconds=30,
+                )
+
+        self.assertEqual(raised.exception.deployment_id, "deployment-failed")
+        self.assertEqual(raised.exception.deployment_status, "failed")
+        self.assertEqual(
+            raised.exception.format_message(),
+            "Dokploy schedule deployment failed: deployment=deployment-failed status=failed",
+        )
+
     def test_wait_for_target_deployment_tracks_exact_operation_title(self) -> None:
         exact_deployment = {
             "deploymentId": "deployment-exact",

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -4,8 +4,11 @@ import subprocess
 import unittest
 from collections.abc import Callable
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
+
+import click
 
 from control_plane.contracts.artifact_identity import (
     ArtifactImageReference,
@@ -333,6 +336,29 @@ def _failed_deployment_record(runtime_identity: RuntimeIdentity) -> DeploymentRe
     )
 
 
+def _run_provider_inspection(target: DokployTargetDefinition) -> dokploy_api.JsonObject:
+    return dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_inspection(
+        host="https://dokploy.example.test",
+        token="token",
+        target_definition=target,
+        expected_compose_app_name=ACTIVE_COMPOSE_PROJECT,
+        inspection_nonce="e" * 64,
+        backup_record_id=BACKUP_RECORD_ID,
+        active_db_volume=ACTIVE_DB_VOLUME,
+        active_data_volume=ACTIVE_DATA_VOLUME,
+        active_log_volume=ACTIVE_LOG_VOLUME,
+        source_db_volume=SOURCE_DB_VOLUME,
+        source_data_volume=SOURCE_DATA_VOLUME,
+        staging_clone_volume=STAGING_CLONE_VOLUME,
+        source_database_name=SOURCE_DATABASE_NAME,
+        destination_database_name=DESTINATION_DATABASE_NAME,
+        database_user=DATABASE_USER,
+        expected_source_compose_project=SOURCE_COMPOSE_PROJECT,
+        filestore_relative_path="filestore",
+        backup_dir_relative_path="backups/example",
+    )
+
+
 def _build_plan(store: _Store) -> OdooProdRetainedVolumeBackupImportPlan:
     def inspect(**kwargs: object) -> dict[str, object]:
         callback = kwargs.get("before_provider_mutation")
@@ -526,6 +552,109 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
         self.assertEqual(plan.plan_fingerprint, "")
         self.assertTrue(any("ODOO_DB_VOLUME" in blocker for blocker in plan.blockers))
         inspect_mock.assert_not_called()
+
+    def test_plan_persists_bounded_provider_inspection_failure(self) -> None:
+        store = _Store()
+        checkpoints: list[tuple[str, dict[str, str]]] = []
+        inspection_nonces: list[str] = []
+
+        def inspect(**kwargs: object) -> dict[str, object]:
+            inspection_nonces.append(str(kwargs["inspection_nonce"]))
+            raise dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure(
+                evidence={
+                    "schema_version": 1,
+                    "inspection_nonce": inspection_nonces[-1],
+                    "backup_record_id": BACKUP_RECORD_ID,
+                    "failure_stage": "source_database",
+                    "failure_code": "source_postgres_metadata_read_failed",
+                    "inspection_deployment_id": "deployment-inspection-failed",
+                }
+            )
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.test", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_api.fetch_dokploy_target_payload",
+                return_value=_target_payload(store),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_inspection",
+                side_effect=inspect,
+            ),
+        ):
+            plan = build_odoo_prod_retained_volume_backup_import_plan(
+                control_plane_root=Path("."),
+                record_store=store,
+                operation_id="plan-operation-1",
+                request=_request(),
+                phase_checkpoint=lambda phase, evidence: checkpoints.append((phase, evidence)),
+                provider_effect_checkpoint=lambda _phase, _effect: None,
+            )
+
+        self.assertEqual(plan.plan_status, "blocked")
+        self.assertIn(
+            "Retained-volume provider inspection failed at source_database "
+            "(source_postgres_metadata_read_failed).",
+            plan.blockers,
+        )
+        self.assertIn(
+            (
+                "inspection_started",
+                {
+                    "inspection_deployment_id": "deployment-inspection-failed",
+                    "inspection_nonce": inspection_nonces[0],
+                    "backup_record_id": BACKUP_RECORD_ID,
+                    "failure_stage": "source_database",
+                    "failure_code": "source_postgres_metadata_read_failed",
+                },
+            ),
+            checkpoints,
+        )
+
+    def test_plan_rejects_unbound_provider_inspection_failure(self) -> None:
+        store = _Store()
+        checkpoints: list[tuple[str, dict[str, str]]] = []
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.test", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_api.fetch_dokploy_target_payload",
+                return_value=_target_payload(store),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_inspection",
+                side_effect=(
+                    dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure(
+                        evidence={
+                            "schema_version": 1,
+                            "inspection_nonce": "0" * 64,
+                            "backup_record_id": BACKUP_RECORD_ID,
+                            "failure_stage": "source_database",
+                            "failure_code": "source_postgres_metadata_read_failed",
+                            "inspection_deployment_id": "deployment-inspection-failed",
+                        }
+                    )
+                ),
+            ),
+        ):
+            plan = build_odoo_prod_retained_volume_backup_import_plan(
+                control_plane_root=Path("."),
+                record_store=store,
+                operation_id="plan-operation-1",
+                request=_request(),
+                phase_checkpoint=lambda phase, evidence: checkpoints.append((phase, evidence)),
+                provider_effect_checkpoint=lambda _phase, _effect: None,
+            )
+
+        self.assertEqual(plan.plan_status, "blocked")
+        self.assertIn("Retained-volume provider inspection did not complete.", plan.blockers)
+        self.assertEqual(checkpoints, [])
 
     def test_plan_accepts_recorded_failed_deployment_identity_for_repair(self) -> None:
         store = _Store()
@@ -1028,6 +1157,34 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
         self.assertIn("pg_dump --host /var/run/postgresql", apply_script)
         self.assertIn("tarfile.open", apply_script)
         self.assertIn("schema_version", apply_script)
+        self.assertIn("set -Eeuo pipefail", inspection_script)
+        self.assertIn("trap 'emit_inspection_failure \"$?\"' EXIT", inspection_script)
+        self.assertIn("trap 'exit 143' TERM", inspection_script)
+        self.assertIn(
+            dokploy_post_deploy.ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER,
+            inspection_script,
+        )
+        for failure_code in (
+            "active_volume_missing",
+            "source_volume_missing",
+            "source_volume_in_use",
+            "active_database_container_unavailable",
+            "script_runner_container_unavailable",
+            "active_runtime_inspection_failed",
+            "active_runtime_identity_mismatch",
+            "active_volume_mount_mismatch",
+            "active_image_invalid",
+            "active_postgres_version_mismatch",
+            "source_volume_label_read_failed",
+            "source_volume_usage_read_failed",
+            "source_postgres_metadata_read_failed",
+            "source_db_measurement_failed",
+            "source_filestore_measurement_failed",
+            "active_data_space_read_failed",
+            "destination_check_failed",
+            "result_emit_failed",
+        ):
+            self.assertIn(f"failure_code={failure_code}", inspection_script)
         self.assertIn("trap cleanup EXIT", apply_script)
         self.assertNotIn('docker volume rm "${staging_clone_volume}"', apply_script)
         for script in (inspection_script, apply_script):
@@ -1039,6 +1196,27 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
                 check=False,
             )
             self.assertEqual(syntax_check.returncode, 0, msg=syntax_check.stderr)
+
+        with TemporaryDirectory() as temp_dir:
+            docker_stub = Path(temp_dir) / "docker"
+            docker_stub.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            docker_stub.chmod(0o700)
+            failed_inspection = subprocess.run(
+                ["bash"],
+                input=inspection_script,
+                capture_output=True,
+                text=True,
+                check=False,
+                env={"PATH": f"{temp_dir}:/usr/bin:/bin"},
+            )
+        self.assertEqual(failed_inspection.returncode, 1)
+        self.assertEqual(
+            failed_inspection.stdout.splitlines(),
+            [
+                f"{dokploy_post_deploy.ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER}="
+                f"{'e' * 64}|{BACKUP_RECORD_ID}|active_runtime|active_volume_missing"
+            ],
+        )
 
     def test_provider_inspection_binds_exact_schedule_deployment(self) -> None:
         target = DokployTargetDefinition(
@@ -1083,26 +1261,7 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
                 ),
             ) as logs_mock,
         ):
-            result = dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_inspection(
-                host="https://dokploy.example.test",
-                token="token",
-                target_definition=target,
-                expected_compose_app_name=ACTIVE_COMPOSE_PROJECT,
-                inspection_nonce="e" * 64,
-                backup_record_id=BACKUP_RECORD_ID,
-                active_db_volume=ACTIVE_DB_VOLUME,
-                active_data_volume=ACTIVE_DATA_VOLUME,
-                active_log_volume=ACTIVE_LOG_VOLUME,
-                source_db_volume=SOURCE_DB_VOLUME,
-                source_data_volume=SOURCE_DATA_VOLUME,
-                staging_clone_volume=STAGING_CLONE_VOLUME,
-                source_database_name=SOURCE_DATABASE_NAME,
-                destination_database_name=DESTINATION_DATABASE_NAME,
-                database_user=DATABASE_USER,
-                expected_source_compose_project=SOURCE_COMPOSE_PROJECT,
-                filestore_relative_path="filestore",
-                backup_dir_relative_path="backups/example",
-            )
+            result = _run_provider_inspection(target)
 
         self.assertEqual(result["inspection_deployment_id"], "exact-deployment")
         logs_mock.assert_called_once_with(
@@ -1111,6 +1270,143 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
             deployment_id="exact-deployment",
             line_count=dokploy_api.MAX_DOKPLOY_LOG_LINE_COUNT,
         )
+
+    def test_provider_inspection_returns_bounded_terminal_failure(self) -> None:
+        target = DokployTargetDefinition(
+            context=CONTEXT,
+            instance="prod",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        )
+        failure_line = (
+            f"{dokploy_post_deploy.ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER}="
+            f"{'e' * 64}|{BACKUP_RECORD_ID}|source_database|"
+            "source_postgres_metadata_read_failed"
+        )
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": ACTIVE_COMPOSE_PROJECT, "serverId": "server-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.latest_deployment_for_schedule",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.dokploy_request",
+                return_value={"ok": True},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.wait_for_dokploy_schedule_deployment",
+                side_effect=dokploy_api.DokployDeploymentFailed(
+                    deployment_id="failed-deployment",
+                    deployment_status="failed",
+                    message_prefix="Dokploy schedule deployment failed",
+                ),
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_deployment_logs",
+                return_value=("private provider output", failure_line),
+            ) as logs_mock,
+        ):
+            with self.assertRaises(
+                dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure
+            ) as raised:
+                _run_provider_inspection(target)
+
+        self.assertEqual(
+            raised.exception.evidence,
+            {
+                "schema_version": 1,
+                "inspection_nonce": "e" * 64,
+                "backup_record_id": BACKUP_RECORD_ID,
+                "failure_stage": "source_database",
+                "failure_code": "source_postgres_metadata_read_failed",
+                "inspection_deployment_id": "failed-deployment",
+            },
+        )
+        self.assertNotIn("private provider output", str(raised.exception))
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.test",
+            token="token",
+            deployment_id="failed-deployment",
+            line_count=dokploy_api.MAX_DOKPLOY_LOG_LINE_COUNT,
+        )
+
+    def test_provider_inspection_bounds_unavailable_failure_logs(self) -> None:
+        target = DokployTargetDefinition(
+            context=CONTEXT,
+            instance="prod",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        )
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": ACTIVE_COMPOSE_PROJECT, "serverId": "server-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.latest_deployment_for_schedule",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.dokploy_request",
+                return_value={"ok": True},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.wait_for_dokploy_schedule_deployment",
+                side_effect=dokploy_api.DokployDeploymentFailed(
+                    deployment_id="failed-deployment",
+                    deployment_status="failed",
+                    message_prefix="Dokploy schedule deployment failed",
+                ),
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_deployment_logs",
+                side_effect=click.ClickException("private-secret-bearing-provider-body"),
+            ),
+        ):
+            with self.assertRaises(
+                dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure
+            ) as raised:
+                _run_provider_inspection(target)
+
+        self.assertEqual(
+            raised.exception.evidence,
+            {
+                "schema_version": 1,
+                "inspection_nonce": "e" * 64,
+                "backup_record_id": BACKUP_RECORD_ID,
+                "failure_stage": "result",
+                "failure_code": "provider_schedule_failed_without_evidence",
+                "inspection_deployment_id": "failed-deployment",
+            },
+        )
+        self.assertNotIn("private-secret-bearing-provider-body", str(raised.exception))
+
+    def test_provider_inspection_rejects_invalid_or_duplicate_failure_markers(self) -> None:
+        marker = dokploy_post_deploy.ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER
+        invalid_pair = f"{marker}={'e' * 64}|{BACKUP_RECORD_ID}|result|source_volume_missing"
+        valid = f"{marker}={'e' * 64}|{BACKUP_RECORD_ID}|source_safety|source_volume_missing"
+
+        with self.assertRaisesRegex(click.ClickException, "invalid bounded failure evidence"):
+            dokploy_post_deploy._extract_retained_volume_inspection_failure(
+                {"logs": [invalid_pair]},
+                marker=marker,
+            )
+        with self.assertRaisesRegex(click.ClickException, "no unique bounded failure evidence"):
+            dokploy_post_deploy._extract_retained_volume_inspection_failure(
+                {"logs": [valid, valid]},
+                marker=marker,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- preserve exact failed Dokploy schedule deployment identity and parse only bounded retained-import failure evidence
- make generated inspection probes fail closed and emit allowlisted stage/code diagnostics, including catchable termination handling
- persist request-bound diagnostics without provider log text and document the operation contract

## Validation
- `uv run --extra dev python -m unittest tests.test_odoo_prod_retained_volume_backup_import tests.test_odoo_prod_retained_volume_backup_import_storage tests.test_odoo_stable_operation_worker`
- `uv run --extra dev launchplane ci unittest-shard local --jobs 1` (2,352 tests)
- `uv run --extra dev ruff check` on changed Python files
- `uv run --extra dev ruff format --check` on changed Python files
- `uv run --extra dev mypy control_plane tests`
- independent safety re-review: no blockers