### PR TITLE
fix: bound retained import control failures

### DIFF
--- a/control_plane/contracts/odoo_prod_retained_volume_backup_import.py
+++ b/control_plane/contracts/odoo_prod_retained_volume_backup_import.py
@@ -19,6 +19,7 @@ ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_CONFIRMATION = (
     "import-retained-volumes-as-production-backup"
 )
 OdooProdRetainedVolumeBackupImportInspectionFailureStage = Literal[
+    "provider_control",
     "active_runtime",
     "source_safety",
     "source_database",
@@ -27,6 +28,17 @@ OdooProdRetainedVolumeBackupImportInspectionFailureStage = Literal[
     "result",
 ]
 OdooProdRetainedVolumeBackupImportInspectionFailureCode = Literal[
+    "provider_target_read_failed",
+    "provider_target_identity_mismatch",
+    "provider_schedule_runtime_resolution_failed",
+    "provider_schedule_upsert_failed",
+    "provider_schedule_identity_missing",
+    "provider_schedule_baseline_read_failed",
+    "provider_schedule_trigger_failed",
+    "provider_schedule_wait_failed",
+    "provider_deployment_identity_missing",
+    "provider_result_log_read_failed",
+    "provider_result_invalid",
     "active_volume_missing",
     "source_volume_missing",
     "source_volume_usage_read_failed",
@@ -45,9 +57,19 @@ OdooProdRetainedVolumeBackupImportInspectionFailureCode = Literal[
     "active_data_space_read_failed",
     "destination_check_failed",
     "result_emit_failed",
-    "provider_schedule_failed_without_evidence",
 ]
 ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE: dict[str, str] = {
+    "provider_target_read_failed": "provider_control",
+    "provider_target_identity_mismatch": "provider_control",
+    "provider_schedule_runtime_resolution_failed": "provider_control",
+    "provider_schedule_upsert_failed": "provider_control",
+    "provider_schedule_identity_missing": "provider_control",
+    "provider_schedule_baseline_read_failed": "provider_control",
+    "provider_schedule_trigger_failed": "provider_control",
+    "provider_schedule_wait_failed": "provider_control",
+    "provider_deployment_identity_missing": "provider_control",
+    "provider_result_log_read_failed": "result",
+    "provider_result_invalid": "result",
     "active_volume_missing": "active_runtime",
     "source_volume_missing": "source_safety",
     "source_volume_usage_read_failed": "source_safety",
@@ -66,7 +88,6 @@ ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE: dict[str, str] = 
     "active_data_space_read_failed": "destination",
     "destination_check_failed": "destination",
     "result_emit_failed": "result",
-    "provider_schedule_failed_without_evidence": "result",
 }
 
 
@@ -253,7 +274,16 @@ class OdooProdRetainedVolumeBackupImportInspectionFailureEvidence(BaseModel):
     backup_record_id: str = Field(min_length=1)
     failure_stage: OdooProdRetainedVolumeBackupImportInspectionFailureStage
     failure_code: OdooProdRetainedVolumeBackupImportInspectionFailureCode
-    inspection_deployment_id: str = Field(min_length=1)
+    inspection_schedule_id: str = Field(
+        default="",
+        max_length=200,
+        pattern=r"^$|^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$",
+    )
+    inspection_deployment_id: str = Field(
+        default="",
+        max_length=200,
+        pattern=r"^$|^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$",
+    )
 
     @model_validator(mode="after")
     def _validate_failure_stage_code_pair(
@@ -265,6 +295,10 @@ class OdooProdRetainedVolumeBackupImportInspectionFailureEvidence(BaseModel):
         ):
             raise ValueError(
                 "Odoo retained-volume backup import inspection failure stage/code mismatch."
+            )
+        if self.failure_stage != "provider_control" and not self.inspection_deployment_id:
+            raise ValueError(
+                "Odoo retained-volume backup import inspection runtime failure requires deployment evidence."
             )
         return self
 

--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -1,15 +1,17 @@
 import base64
 import json
+import re
 import shlex
 
 from collections.abc import Callable, Mapping
 from pathlib import Path
-from typing import Literal
+from typing import Literal, TypeVar
 
 import click
 
 from control_plane.contracts.odoo_prod_retained_volume_backup_import import (
     ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE,
+    OdooProdRetainedVolumeBackupImportInspectionEvidence,
 )
 from control_plane.dokploy import api
 from control_plane.dokploy.source import (
@@ -206,6 +208,71 @@ class OdooRetainedVolumeBackupImportInspectionFailure(click.ClickException):
         super().__init__(
             "Dokploy Odoo retained-volume backup import inspection returned bounded failure evidence."
         )
+
+
+_RetainedInspectionCallResult = TypeVar("_RetainedInspectionCallResult")
+_DOKPLOY_EVIDENCE_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,199}")
+
+
+def _bounded_dokploy_evidence_id(value: str) -> str:
+    normalized_value = value.strip()
+    if not _DOKPLOY_EVIDENCE_ID_PATTERN.fullmatch(normalized_value):
+        return ""
+    return normalized_value
+
+
+def _retained_volume_inspection_provider_id(
+    value: str,
+    *,
+    failure_identity: tuple[str, str] | None,
+) -> str:
+    if failure_identity is None:
+        return value
+    return _bounded_dokploy_evidence_id(value)
+
+
+def _retained_volume_inspection_failure(
+    *,
+    failure_identity: tuple[str, str],
+    failure_code: str,
+    inspection_schedule_id: str = "",
+    inspection_deployment_id: str = "",
+) -> OdooRetainedVolumeBackupImportInspectionFailure:
+    failure_stage = ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE[failure_code]
+    return OdooRetainedVolumeBackupImportInspectionFailure(
+        evidence={
+            "schema_version": 1,
+            "inspection_nonce": failure_identity[0],
+            "backup_record_id": failure_identity[1],
+            "failure_stage": failure_stage,
+            "failure_code": failure_code,
+            "inspection_schedule_id": _bounded_dokploy_evidence_id(inspection_schedule_id),
+            "inspection_deployment_id": _bounded_dokploy_evidence_id(inspection_deployment_id),
+        }
+    )
+
+
+def _run_retained_volume_inspection_provider_call(
+    *,
+    callback: Callable[[], _RetainedInspectionCallResult],
+    failure_identity: tuple[str, str] | None,
+    failure_code: str,
+    inspection_schedule_id: str = "",
+    inspection_deployment_id: str = "",
+) -> _RetainedInspectionCallResult:
+    try:
+        return callback()
+    except OdooRetainedVolumeBackupImportInspectionFailure:
+        raise
+    except Exception:
+        if failure_identity is None:
+            raise
+        raise _retained_volume_inspection_failure(
+            failure_identity=failure_identity,
+            failure_code=failure_code,
+            inspection_schedule_id=inspection_schedule_id,
+            inspection_deployment_id=inspection_deployment_id,
+        ) from None
 
 
 OdooBackupRestorePhase = Literal[
@@ -947,14 +1014,42 @@ def run_compose_odoo_retained_volume_backup_import_inspection(
     timeout_seconds: int | None = None,
     before_provider_mutation: Callable[[str], None] | None = None,
 ) -> api.JsonObject:
-    compose_app_name = _compose_app_name_for_restore(
-        host=host,
-        token=token,
-        target_definition=target_definition,
+    failure_identity = (inspection_nonce, backup_record_id)
+    compose_id = target_definition.target_id.strip()
+    compose_name = (
+        target_definition.target_name.strip()
+        or f"{target_definition.context}-{target_definition.instance}"
+    )
+    if not compose_id:
+        raise _retained_volume_inspection_failure(
+            failure_identity=failure_identity,
+            failure_code="provider_target_identity_mismatch",
+        )
+    target_payload = _run_retained_volume_inspection_provider_call(
+        callback=lambda: api.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=compose_id,
+        ),
+        failure_identity=failure_identity,
+        failure_code="provider_target_read_failed",
+    )
+    _, _, compose_app_name, _ = _run_retained_volume_inspection_provider_call(
+        callback=lambda: _resolve_dokploy_schedule_runtime(
+            host=host,
+            token=token,
+            compose_id=compose_id,
+            compose_name=compose_name,
+            target_payload=target_payload,
+        ),
+        failure_identity=failure_identity,
+        failure_code="provider_schedule_runtime_resolution_failed",
     )
     if compose_app_name != expected_compose_app_name.strip():
-        raise click.ClickException(
-            "Odoo retained-volume backup import compose project drifted before inspection."
+        raise _retained_volume_inspection_failure(
+            failure_identity=failure_identity,
+            failure_code="provider_target_identity_mismatch",
         )
     result, deployment_id = _run_compose_odoo_retained_volume_backup_import_schedule(
         host=host,
@@ -982,7 +1077,7 @@ def run_compose_odoo_retained_volume_backup_import_inspection(
         marker=ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_RESULT_MARKER,
         expected_fields=ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_RESULT_FIELDS,
         failure_marker=ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER,
-        failure_identity=(inspection_nonce, backup_record_id),
+        failure_identity=failure_identity,
         timeout_seconds=timeout_seconds,
         before_provider_mutation=before_provider_mutation,
     )
@@ -1102,23 +1197,33 @@ def _run_compose_odoo_retained_volume_backup_import_schedule(
         raise click.ClickException(
             "Odoo retained-volume backup import requires an exact compose target id."
         )
-    target_payload = api.fetch_dokploy_target_payload(
-        host=host,
-        token=token,
-        target_type="compose",
-        target_id=compose_id,
+    target_payload = _run_retained_volume_inspection_provider_call(
+        callback=lambda: api.fetch_dokploy_target_payload(
+            host=host,
+            token=token,
+            target_type="compose",
+            target_id=compose_id,
+        ),
+        failure_identity=failure_identity,
+        failure_code="provider_target_read_failed",
     )
     schedule_timeout_seconds = (
         timeout_seconds
         or target_definition.deploy_timeout_seconds
         or DEFAULT_DOKPLOY_DEPLOY_TIMEOUT_SECONDS
     )
-    schedule_type, schedule_lookup_id, _, schedule_server_id = _resolve_dokploy_schedule_runtime(
-        host=host,
-        token=token,
-        compose_id=compose_id,
-        compose_name=compose_name,
-        target_payload=target_payload,
+    schedule_type, schedule_lookup_id, _, schedule_server_id = (
+        _run_retained_volume_inspection_provider_call(
+            callback=lambda: _resolve_dokploy_schedule_runtime(
+                host=host,
+                token=token,
+                compose_id=compose_id,
+                compose_name=compose_name,
+                target_payload=target_payload,
+            ),
+            failure_identity=failure_identity,
+            failure_code="provider_schedule_runtime_resolution_failed",
+        )
     )
     schedule_payload: api.JsonObject = {
         "name": schedule_name,
@@ -1138,87 +1243,190 @@ def _run_compose_odoo_retained_volume_backup_import_schedule(
     }
     if before_provider_mutation is not None:
         before_provider_mutation("schedule_upsert")
-    schedule = api.upsert_dokploy_schedule(
-        host=host,
-        token=token,
-        target_id=schedule_lookup_id,
-        schedule_type=schedule_type,
-        schedule_name=schedule_name,
-        app_name=str(schedule_payload["appName"]),
-        schedule_payload=schedule_payload,
+    schedule = _run_retained_volume_inspection_provider_call(
+        callback=lambda: api.upsert_dokploy_schedule(
+            host=host,
+            token=token,
+            target_id=schedule_lookup_id,
+            schedule_type=schedule_type,
+            schedule_name=schedule_name,
+            app_name=str(schedule_payload["appName"]),
+            schedule_payload=schedule_payload,
+        ),
+        failure_identity=failure_identity,
+        failure_code="provider_schedule_upsert_failed",
     )
-    schedule_id = api.schedule_key(schedule)
+    schedule_id = _retained_volume_inspection_provider_id(
+        _run_retained_volume_inspection_provider_call(
+            callback=lambda: api.schedule_key(schedule),
+            failure_identity=failure_identity,
+            failure_code="provider_schedule_identity_missing",
+        ),
+        failure_identity=failure_identity,
+    )
     if not schedule_id:
+        if failure_identity is not None:
+            raise _retained_volume_inspection_failure(
+                failure_identity=failure_identity,
+                failure_code="provider_schedule_identity_missing",
+            )
         raise click.ClickException(
             "Dokploy Odoo retained-volume backup import schedule has no schedule id."
         )
-    latest_schedule_deployment = api.latest_deployment_for_schedule(
-        host=host,
-        token=token,
-        schedule_id=schedule_id,
+    latest_schedule_deployment = _run_retained_volume_inspection_provider_call(
+        callback=lambda: api.latest_deployment_for_schedule(
+            host=host,
+            token=token,
+            schedule_id=schedule_id,
+        ),
+        failure_identity=failure_identity,
+        failure_code="provider_schedule_baseline_read_failed",
+        inspection_schedule_id=schedule_id,
     )
+    raw_before_deployment_id = _run_retained_volume_inspection_provider_call(
+        callback=lambda: api.deployment_key(latest_schedule_deployment),
+        failure_identity=failure_identity,
+        failure_code="provider_schedule_baseline_read_failed",
+        inspection_schedule_id=schedule_id,
+    )
+    before_deployment_id = _retained_volume_inspection_provider_id(
+        raw_before_deployment_id,
+        failure_identity=failure_identity,
+    )
+    if (
+        failure_identity is not None
+        and latest_schedule_deployment is not None
+        and not before_deployment_id
+    ):
+        raise _retained_volume_inspection_failure(
+            failure_identity=failure_identity,
+            failure_code="provider_schedule_baseline_read_failed",
+            inspection_schedule_id=schedule_id,
+        )
     if before_provider_mutation is not None:
         before_provider_mutation("schedule_trigger")
-    api.dokploy_request(
-        host=host,
-        token=token,
-        path="/api/schedule.runManually",
-        method="POST",
-        payload={"scheduleId": schedule_id},
-        timeout_seconds=schedule_timeout_seconds,
+    _run_retained_volume_inspection_provider_call(
+        callback=lambda: api.dokploy_request(
+            host=host,
+            token=token,
+            path="/api/schedule.runManually",
+            method="POST",
+            payload={"scheduleId": schedule_id},
+            timeout_seconds=schedule_timeout_seconds,
+        ),
+        failure_identity=failure_identity,
+        failure_code="provider_schedule_trigger_failed",
+        inspection_schedule_id=schedule_id,
     )
     try:
         wait_result = api.wait_for_dokploy_schedule_deployment(
             host=host,
             token=token,
             schedule_id=schedule_id,
-            before_key=api.deployment_key(latest_schedule_deployment),
+            before_key=before_deployment_id,
             timeout_seconds=schedule_timeout_seconds,
         )
     except api.DokployDeploymentFailed as error:
         if not failure_marker or failure_identity is None:
             raise
+        failed_deployment_id = _bounded_dokploy_evidence_id(error.deployment_id)
+        if not failed_deployment_id:
+            raise _retained_volume_inspection_failure(
+                failure_identity=failure_identity,
+                failure_code="provider_deployment_identity_missing",
+                inspection_schedule_id=schedule_id,
+            ) from None
         try:
             failure_log_lines = api.fetch_dokploy_deployment_logs(
                 host=host,
                 token=token,
-                deployment_id=error.deployment_id,
+                deployment_id=failed_deployment_id,
                 line_count=api.MAX_DOKPLOY_LOG_LINE_COUNT,
             )
+        except Exception:
+            raise _retained_volume_inspection_failure(
+                failure_identity=failure_identity,
+                failure_code="provider_result_log_read_failed",
+                inspection_schedule_id=schedule_id,
+                inspection_deployment_id=failed_deployment_id,
+            ) from None
+        try:
             failure_evidence = _extract_retained_volume_inspection_failure(
                 {"logs": list(failure_log_lines)},
                 marker=failure_marker,
             )
-        except (click.ClickException, OSError):
-            failure_evidence = {
-                "schema_version": 1,
-                "inspection_nonce": failure_identity[0],
-                "backup_record_id": failure_identity[1],
-                "failure_stage": "result",
-                "failure_code": "provider_schedule_failed_without_evidence",
-            }
-        failure_evidence["inspection_deployment_id"] = error.deployment_id
-        raise OdooRetainedVolumeBackupImportInspectionFailure(evidence=failure_evidence) from error
-    deployment_id = api.deployment_key_from_wait_result(wait_result)
+        except Exception:
+            raise _retained_volume_inspection_failure(
+                failure_identity=failure_identity,
+                failure_code="provider_result_invalid",
+                inspection_schedule_id=schedule_id,
+                inspection_deployment_id=failed_deployment_id,
+            ) from None
+        failure_evidence["inspection_schedule_id"] = schedule_id
+        failure_evidence["inspection_deployment_id"] = failed_deployment_id
+        raise OdooRetainedVolumeBackupImportInspectionFailure(evidence=failure_evidence) from None
+    except Exception:
+        if failure_identity is None:
+            raise
+        raise _retained_volume_inspection_failure(
+            failure_identity=failure_identity,
+            failure_code="provider_schedule_wait_failed",
+            inspection_schedule_id=schedule_id,
+        ) from None
+    deployment_id = _retained_volume_inspection_provider_id(
+        _run_retained_volume_inspection_provider_call(
+            callback=lambda: api.deployment_key_from_wait_result(wait_result),
+            failure_identity=failure_identity,
+            failure_code="provider_deployment_identity_missing",
+            inspection_schedule_id=schedule_id,
+        ),
+        failure_identity=failure_identity,
+    )
     if not deployment_id:
+        if failure_identity is not None:
+            raise _retained_volume_inspection_failure(
+                failure_identity=failure_identity,
+                failure_code="provider_deployment_identity_missing",
+                inspection_schedule_id=schedule_id,
+            )
         raise click.ClickException(
             "Dokploy Odoo retained-volume backup import did not return an exact deployment id."
         )
-    log_lines = api.fetch_dokploy_deployment_logs(
-        host=host,
-        token=token,
-        deployment_id=deployment_id,
-        line_count=api.MAX_DOKPLOY_LOG_LINE_COUNT,
+    log_lines = _run_retained_volume_inspection_provider_call(
+        callback=lambda: api.fetch_dokploy_deployment_logs(
+            host=host,
+            token=token,
+            deployment_id=deployment_id,
+            line_count=api.MAX_DOKPLOY_LOG_LINE_COUNT,
+        ),
+        failure_identity=failure_identity,
+        failure_code="provider_result_log_read_failed",
+        inspection_schedule_id=schedule_id,
+        inspection_deployment_id=deployment_id,
     )
-    return (
-        _extract_bounded_schedule_result(
+    result = _run_retained_volume_inspection_provider_call(
+        callback=lambda: _extract_bounded_schedule_result(
             {"logs": list(log_lines)},
             marker=marker,
             expected_fields=expected_fields,
             label="Odoo retained-volume backup import",
         ),
-        deployment_id,
+        failure_identity=failure_identity,
+        failure_code="provider_result_invalid",
+        inspection_schedule_id=schedule_id,
+        inspection_deployment_id=deployment_id,
     )
+    if failure_identity is not None:
+        _run_retained_volume_inspection_provider_call(
+            callback=lambda: OdooProdRetainedVolumeBackupImportInspectionEvidence.model_validate(
+                {**result, "inspection_deployment_id": deployment_id}
+            ),
+            failure_identity=failure_identity,
+            failure_code="provider_result_invalid",
+            inspection_schedule_id=schedule_id,
+            inspection_deployment_id=deployment_id,
+        )
+    return result, deployment_id
 
 
 def _extract_retained_volume_inspection_failure(

--- a/control_plane/workflows/odoo_prod_retained_volume_backup_import.py
+++ b/control_plane/workflows/odoo_prod_retained_volume_backup_import.py
@@ -346,15 +346,23 @@ def build_odoo_prod_retained_volume_backup_import_plan(
                 ):
                     blockers.append("Retained-volume provider inspection did not complete.")
                 else:
+                    checkpoint_evidence = {
+                        "inspection_nonce": failure_evidence.inspection_nonce,
+                        "backup_record_id": failure_evidence.backup_record_id,
+                        "failure_stage": failure_evidence.failure_stage,
+                        "failure_code": failure_evidence.failure_code,
+                    }
+                    if failure_evidence.inspection_schedule_id:
+                        checkpoint_evidence["inspection_schedule_id"] = (
+                            failure_evidence.inspection_schedule_id
+                        )
+                    if failure_evidence.inspection_deployment_id:
+                        checkpoint_evidence["inspection_deployment_id"] = (
+                            failure_evidence.inspection_deployment_id
+                        )
                     phase_checkpoint(
                         "inspection_started",
-                        {
-                            "inspection_deployment_id": (failure_evidence.inspection_deployment_id),
-                            "inspection_nonce": failure_evidence.inspection_nonce,
-                            "backup_record_id": failure_evidence.backup_record_id,
-                            "failure_stage": failure_evidence.failure_stage,
-                            "failure_code": failure_evidence.failure_code,
-                        },
+                        checkpoint_evidence,
                     )
                     blockers.append(
                         "Retained-volume provider inspection failed at "

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1690,11 +1690,18 @@ the service reads only the exact failed schedule deployment and accepts one
 nonce- and backup-record-bound failure marker. The operation checkpoint records
 only the request nonce, backup-record id, inspection deployment id, and a
 bounded failure stage/code pair; raw provider logs and command output are not
-copied into the plan, operation error, or API response. If the exact marker or
-its logs are unavailable, the same request and deployment are recorded with the
-generic bounded `result/provider_schedule_failed_without_evidence` pair. This
+copied into the plan, operation error, or API response. An unreadable exact log
+is recorded as `result/provider_result_log_read_failed`; a missing, duplicate,
+or invalid marker is recorded as `result/provider_result_invalid`. This
 distinguishes a provider inspection failure from a GitHub environment approval
 wait without weakening the fail-closed plan boundary.
+
+Failures before a script result are also bounded. Target lookup, schedule
+runtime resolution, upsert, baseline read, trigger, wait,
+deployment-id extraction, result-log read, and result parsing each have a
+distinct allowlisted code. Their checkpoint records the exact schedule and
+deployment ids when those identities are available, but never persists the
+underlying provider exception text.
 
 Run `Odoo Prod Retained Volume Backup Import Apply` only with the exact reviewed
 plan operation and fingerprint, a stable idempotency key, and confirmation phrase

--- a/docs/records.md
+++ b/docs/records.md
@@ -1222,9 +1222,12 @@ state/
   provider-effect checkpoint; later expiry preserves a reconciliation-required
   lane fence for explicit operator inspection. When the read-only provider
   inspection terminates unsuccessfully, its checkpoint may contain the exact
-  inspection deployment id, request nonce, backup-record id, and one allowlisted
-  failure stage/code pair. Provider log text is not persisted in the operation
-  record.
+  inspection schedule/deployment ids when known, request nonce, backup-record
+  id, and one allowlisted failure stage/code pair. Provider log or exception
+  text is not persisted in the operation record. Pre-result failures use a
+  `provider_control` stage with distinct target, schedule, trigger, wait, and
+  identity codes; result-read and result-parse failures use bounded `result`
+  codes.
 - Bootstrap, target replacement, production backup restore, and retained-volume
   backup import creation and worker claim also share one storage-level
   stable-lane reservation.

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -22,6 +22,7 @@ from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.odoo_prod_retained_volume_backup_import import (
     ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_CONFIRMATION,
     OdooProdRetainedVolumeBackupImportApplyRequest,
+    OdooProdRetainedVolumeBackupImportInspectionFailureEvidence,
     OdooProdRetainedVolumeBackupImportPlan,
     OdooProdRetainedVolumeBackupImportRequest,
     build_odoo_prod_retained_volume_backup_import_plan_fingerprint,
@@ -359,6 +360,41 @@ def _run_provider_inspection(target: DokployTargetDefinition) -> dokploy_api.Jso
     )
 
 
+def _run_provider_apply(target: DokployTargetDefinition) -> dokploy_api.JsonObject:
+    return dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_apply(
+        host="https://dokploy.example.test",
+        token="token",
+        target_definition=target,
+        expected_compose_app_name=ACTIVE_COMPOSE_PROJECT,
+        import_nonce="6" * 64,
+        operation_id="retained-import-apply-1",
+        plan_fingerprint="7" * 64,
+        backup_record_id=BACKUP_RECORD_ID,
+        active_db_volume=ACTIVE_DB_VOLUME,
+        active_data_volume=ACTIVE_DATA_VOLUME,
+        active_log_volume=ACTIVE_LOG_VOLUME,
+        source_db_volume=SOURCE_DB_VOLUME,
+        source_data_volume=SOURCE_DATA_VOLUME,
+        staging_clone_volume=STAGING_CLONE_VOLUME,
+        source_database_name=SOURCE_DATABASE_NAME,
+        destination_database_name=DESTINATION_DATABASE_NAME,
+        database_user=DATABASE_USER,
+        expected_source_compose_project=SOURCE_COMPOSE_PROJECT,
+        expected_source_pg_control_sha256=PG_CONTROL_SHA256,
+        expected_source_pg_version="17",
+        expected_postgres_image_id=POSTGRES_IMAGE_ID,
+        expected_script_runner_image_id=SCRIPT_RUNNER_IMAGE_ID,
+        expected_source_filestore_file_count=42,
+        expected_source_filestore_size_bytes=100_000_000,
+        expected_active_data_required_bytes=2_300_000_000,
+        filestore_relative_path="filestore",
+        backup_dir_relative_path="backups/example",
+        database_dump_relative_path="backups/example/example.dump",
+        filestore_archive_relative_path="backups/example/example-filestore.tar.gz",
+        manifest_relative_path="backups/example/manifest.json",
+    )
+
+
 def _build_plan(store: _Store) -> OdooProdRetainedVolumeBackupImportPlan:
     def inspect(**kwargs: object) -> dict[str, object]:
         callback = kwargs.get("before_provider_mutation")
@@ -440,6 +476,22 @@ def _operation(
 
 
 class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
+    def test_inspection_failure_evidence_rejects_unsafe_provider_ids(self) -> None:
+        base_payload = {
+            "schema_version": 1,
+            "inspection_nonce": "e" * 64,
+            "backup_record_id": BACKUP_RECORD_ID,
+            "failure_stage": "provider_control",
+            "failure_code": "provider_schedule_wait_failed",
+            "inspection_schedule_id": "schedule-1",
+            "inspection_deployment_id": "",
+        }
+        for field_name in ("inspection_schedule_id", "inspection_deployment_id"):
+            with self.subTest(field_name=field_name), self.assertRaises(ValueError):
+                OdooProdRetainedVolumeBackupImportInspectionFailureEvidence.model_validate(
+                    {**base_payload, field_name: "unsafe/provider/id"}
+                )
+
     def test_request_rejects_source_or_staging_volume_aliases(self) -> None:
         payload = _request().model_dump()
         payload["source_db_volume"] = ACTIVE_DB_VOLUME
@@ -565,9 +617,10 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
                     "schema_version": 1,
                     "inspection_nonce": inspection_nonces[-1],
                     "backup_record_id": BACKUP_RECORD_ID,
-                    "failure_stage": "source_database",
-                    "failure_code": "source_postgres_metadata_read_failed",
-                    "inspection_deployment_id": "deployment-inspection-failed",
+                    "failure_stage": "provider_control",
+                    "failure_code": "provider_schedule_wait_failed",
+                    "inspection_schedule_id": "schedule-inspection-failed",
+                    "inspection_deployment_id": "",
                 }
             )
 
@@ -596,19 +649,19 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
 
         self.assertEqual(plan.plan_status, "blocked")
         self.assertIn(
-            "Retained-volume provider inspection failed at source_database "
-            "(source_postgres_metadata_read_failed).",
+            "Retained-volume provider inspection failed at provider_control "
+            "(provider_schedule_wait_failed).",
             plan.blockers,
         )
         self.assertIn(
             (
                 "inspection_started",
                 {
-                    "inspection_deployment_id": "deployment-inspection-failed",
                     "inspection_nonce": inspection_nonces[0],
                     "backup_record_id": BACKUP_RECORD_ID,
-                    "failure_stage": "source_database",
-                    "failure_code": "source_postgres_metadata_read_failed",
+                    "failure_stage": "provider_control",
+                    "failure_code": "provider_schedule_wait_failed",
+                    "inspection_schedule_id": "schedule-inspection-failed",
                 },
             ),
             checkpoints,
@@ -1326,6 +1379,7 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
                 "backup_record_id": BACKUP_RECORD_ID,
                 "failure_stage": "source_database",
                 "failure_code": "source_postgres_metadata_read_failed",
+                "inspection_schedule_id": "schedule-1",
                 "inspection_deployment_id": "failed-deployment",
             },
         )
@@ -1336,6 +1390,207 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
             deployment_id="failed-deployment",
             line_count=dokploy_api.MAX_DOKPLOY_LOG_LINE_COUNT,
         )
+
+    def test_provider_inspection_bounds_control_failures(self) -> None:
+        target = DokployTargetDefinition(
+            context=CONTEXT,
+            instance="prod",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        )
+        for failure_point, expected_code, schedule_id in (
+            ("target", "provider_target_read_failed", ""),
+            ("runtime", "provider_schedule_runtime_resolution_failed", ""),
+            ("upsert", "provider_schedule_upsert_failed", ""),
+            ("baseline", "provider_schedule_baseline_read_failed", "schedule-1"),
+            ("trigger", "provider_schedule_trigger_failed", "schedule-1"),
+            ("wait", "provider_schedule_wait_failed", "schedule-1"),
+        ):
+            with self.subTest(failure_point=failure_point):
+                provider_error = click.ClickException(f"private-{failure_point}-provider-error")
+                with (
+                    patch(
+                        "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                        side_effect=provider_error if failure_point == "target" else None,
+                        return_value={
+                            "appName": ACTIVE_COMPOSE_PROJECT,
+                            "serverId": "server-1",
+                        },
+                    ),
+                    patch(
+                        "control_plane.dokploy.post_deploy._resolve_dokploy_schedule_runtime",
+                        side_effect=provider_error if failure_point == "runtime" else None,
+                        return_value=(
+                            "server",
+                            "server-1",
+                            ACTIVE_COMPOSE_PROJECT,
+                            "server-1",
+                        ),
+                    ),
+                    patch(
+                        "control_plane.dokploy.post_deploy.api.upsert_dokploy_schedule",
+                        side_effect=provider_error if failure_point == "upsert" else None,
+                        return_value={"scheduleId": "schedule-1"},
+                    ),
+                    patch(
+                        "control_plane.dokploy.post_deploy.api.latest_deployment_for_schedule",
+                        side_effect=provider_error if failure_point == "baseline" else None,
+                        return_value={"deploymentId": "before"},
+                    ),
+                    patch(
+                        "control_plane.dokploy.post_deploy.api.dokploy_request",
+                        side_effect=provider_error if failure_point == "trigger" else None,
+                        return_value={"ok": True},
+                    ),
+                    patch(
+                        "control_plane.dokploy.post_deploy.api.wait_for_dokploy_schedule_deployment",
+                        side_effect=provider_error if failure_point == "wait" else None,
+                        return_value="deployment=unused status=done",
+                    ),
+                ):
+                    with self.assertRaises(
+                        dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure
+                    ) as raised:
+                        _run_provider_inspection(target)
+
+                self.assertEqual(
+                    raised.exception.evidence,
+                    {
+                        "schema_version": 1,
+                        "inspection_nonce": "e" * 64,
+                        "backup_record_id": BACKUP_RECORD_ID,
+                        "failure_stage": "provider_control",
+                        "failure_code": expected_code,
+                        "inspection_schedule_id": schedule_id,
+                        "inspection_deployment_id": "",
+                    },
+                )
+                self.assertNotIn("private-", str(raised.exception))
+
+    def test_provider_inspection_rejects_unbounded_baseline_identity(self) -> None:
+        target = DokployTargetDefinition(
+            context=CONTEXT,
+            instance="prod",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        )
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": ACTIVE_COMPOSE_PROJECT, "serverId": "server-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.latest_deployment_for_schedule",
+                return_value={"deploymentId": "unsafe/deployment/id"},
+            ),
+            patch("control_plane.dokploy.post_deploy.api.dokploy_request") as trigger_mock,
+        ):
+            with self.assertRaises(
+                dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure
+            ) as raised:
+                _run_provider_inspection(target)
+
+        self.assertEqual(
+            raised.exception.evidence["failure_code"],
+            "provider_schedule_baseline_read_failed",
+        )
+        self.assertEqual(raised.exception.evidence["inspection_schedule_id"], "schedule-1")
+        self.assertEqual(raised.exception.evidence["inspection_deployment_id"], "")
+        trigger_mock.assert_not_called()
+
+    def test_inspection_provider_adapter_preserves_apply_exception(self) -> None:
+        provider_error = click.ClickException("original apply provider failure")
+
+        def fail() -> None:
+            raise provider_error
+
+        with self.assertRaises(click.ClickException) as raised:
+            dokploy_post_deploy._run_retained_volume_inspection_provider_call(
+                callback=fail,
+                failure_identity=None,
+                failure_code="provider_schedule_wait_failed",
+            )
+
+        self.assertIs(raised.exception, provider_error)
+
+    def test_provider_apply_preserves_original_schedule_exception(self) -> None:
+        target = DokployTargetDefinition(
+            context=CONTEXT,
+            instance="prod",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        )
+        provider_error = click.ClickException("original apply schedule failure")
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": ACTIVE_COMPOSE_PROJECT, "serverId": "server-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.upsert_dokploy_schedule",
+                side_effect=provider_error,
+            ),
+        ):
+            with self.assertRaises(click.ClickException) as raised:
+                _run_provider_apply(target)
+
+        self.assertIs(raised.exception, provider_error)
+
+    def test_provider_inspection_bounds_invalid_success_result(self) -> None:
+        target = DokployTargetDefinition(
+            context=CONTEXT,
+            instance="prod",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        )
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": ACTIVE_COMPOSE_PROJECT, "serverId": "server-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.latest_deployment_for_schedule",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.dokploy_request",
+                return_value={"ok": True},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.wait_for_dokploy_schedule_deployment",
+                return_value="deployment=exact-deployment status=done",
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_deployment_logs",
+                return_value=("private provider output without a marker",),
+            ),
+        ):
+            with self.assertRaises(
+                dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure
+            ) as raised:
+                _run_provider_inspection(target)
+
+        self.assertEqual(
+            raised.exception.evidence,
+            {
+                "schema_version": 1,
+                "inspection_nonce": "e" * 64,
+                "backup_record_id": BACKUP_RECORD_ID,
+                "failure_stage": "result",
+                "failure_code": "provider_result_invalid",
+                "inspection_schedule_id": "schedule-1",
+                "inspection_deployment_id": "exact-deployment",
+            },
+        )
+        self.assertNotIn("private provider output", str(raised.exception))
 
     def test_provider_inspection_bounds_unavailable_failure_logs(self) -> None:
         target = DokployTargetDefinition(
@@ -1386,7 +1641,8 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
                 "inspection_nonce": "e" * 64,
                 "backup_record_id": BACKUP_RECORD_ID,
                 "failure_stage": "result",
-                "failure_code": "provider_schedule_failed_without_evidence",
+                "failure_code": "provider_result_log_read_failed",
+                "inspection_schedule_id": "schedule-1",
                 "inspection_deployment_id": "failed-deployment",
             },
         )


### PR DESCRIPTION
## Summary
- classify retained-import inspection failures across target lookup, schedule setup, trigger, wait, deployment identity, log read, and result validation
- persist only nonce-bound allowlisted evidence with bounded provider IDs and no raw exception or log text
- preserve the public apply path's original provider exception behavior and document the expanded operation diagnostics

## Validation
- `uv run --extra dev python -m unittest tests.test_odoo_prod_retained_volume_backup_import tests.test_odoo_prod_retained_volume_backup_import_storage tests.test_odoo_stable_operation_worker`
- `uv run --extra dev launchplane ci unittest-shard local --jobs 1` (2,377 tests)
- `uv run --extra dev ruff check` on changed Python files
- `uv run --extra dev ruff format --check` on changed Python files
- `uv run --extra dev mypy control_plane tests`
- two independent safety reviews: no blockers