### PR TITLE
fix: read retained volume labels safely

### DIFF
--- a/control_plane/contracts/odoo_prod_retained_volume_backup_import.py
+++ b/control_plane/contracts/odoo_prod_retained_volume_backup_import.py
@@ -277,12 +277,12 @@ class OdooProdRetainedVolumeBackupImportInspectionFailureEvidence(BaseModel):
     inspection_schedule_id: str = Field(
         default="",
         max_length=200,
-        pattern=r"^$|^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$",
+        pattern=r"^$|^[A-Za-z0-9_-][A-Za-z0-9._:-]{0,199}$",
     )
     inspection_deployment_id: str = Field(
         default="",
         max_length=200,
-        pattern=r"^$|^[A-Za-z0-9][A-Za-z0-9._:-]{0,199}$",
+        pattern=r"^$|^[A-Za-z0-9_-][A-Za-z0-9._:-]{0,199}$",
     )
 
     @model_validator(mode="after")

--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -211,7 +211,7 @@ class OdooRetainedVolumeBackupImportInspectionFailure(click.ClickException):
 
 
 _RetainedInspectionCallResult = TypeVar("_RetainedInspectionCallResult")
-_DOKPLOY_EVIDENCE_ID_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,199}")
+_DOKPLOY_EVIDENCE_ID_PATTERN = re.compile(r"[A-Za-z0-9_-][A-Za-z0-9._:-]{0,199}")
 
 
 def _bounded_dokploy_evidence_id(value: str) -> str:
@@ -2799,7 +2799,7 @@ require_volume() {{
 volume_label() {{
     local volume_name="$1"
     local label_name="$2"
-    docker volume inspect -f "{{{{ index .Labels \"${{label_name}}\" }}}}" "${{volume_name}}"
+    docker volume inspect -f "{{{{ index .Labels \\"${{label_name}}\\" }}}}" "${{volume_name}}"
 }}
 
 container_mounts_volume() {{
@@ -3189,7 +3189,7 @@ resolve_single_container_any_state() {{
 volume_label() {{
     local volume_name="$1"
     local label_name="$2"
-    docker volume inspect -f "{{{{ index .Labels \"${{label_name}}\" }}}}" "${{volume_name}}"
+    docker volume inspect -f "{{{{ index .Labels \\"${{label_name}}\\" }}}}" "${{volume_name}}"
 }}
 
 container_mounts_volume() {{

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -492,6 +492,16 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
                     {**base_payload, field_name: "unsafe/provider/id"}
                 )
 
+        accepted = OdooProdRetainedVolumeBackupImportInspectionFailureEvidence.model_validate(
+            {
+                **base_payload,
+                "inspection_schedule_id": "_schedule-id",
+                "inspection_deployment_id": "-deployment-id",
+            }
+        )
+        self.assertEqual(accepted.inspection_schedule_id, "_schedule-id")
+        self.assertEqual(accepted.inspection_deployment_id, "-deployment-id")
+
     def test_request_rejects_source_or_staging_volume_aliases(self) -> None:
         payload = _request().model_dump()
         payload["source_db_volume"] = ACTIVE_DB_VOLUME
@@ -1210,6 +1220,11 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
         self.assertIn("pg_dump --host /var/run/postgresql", apply_script)
         self.assertIn("tarfile.open", apply_script)
         self.assertIn("schema_version", apply_script)
+        volume_label_command = (
+            'docker volume inspect -f "{{ index .Labels \\"${label_name}\\" }}" "${volume_name}"'
+        )
+        self.assertIn(volume_label_command, inspection_script)
+        self.assertIn(volume_label_command, apply_script)
         self.assertIn("set -Eeuo pipefail", inspection_script)
         self.assertIn("trap 'emit_inspection_failure \"$?\"' EXIT", inspection_script)
         self.assertIn("trap 'exit 143' TERM", inspection_script)


### PR DESCRIPTION
## Summary
- accept Dokploy NanoIDs that validly begin with `-` or `_`
- preserve quoted Docker label keys in generated retained-volume inspection and apply Bash
- add regression coverage for both provider IDs and rendered label commands

## Validation
- `uv run --extra dev python -m unittest tests.test_odoo_prod_retained_volume_backup_import`
- focused rendered-script and provider-ID tests
- changed-file Ruff lint/format and mypy
- independent review: no blockers
- exact production read-only reproduction confirmed the corrected Docker label command