### PR TITLE
Surface retained import failures from completed schedules

### DIFF
--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -1351,9 +1351,12 @@ def _run_compose_odoo_retained_volume_backup_import_schedule(
                 inspection_deployment_id=failed_deployment_id,
             ) from None
         try:
-            failure_evidence = _extract_retained_volume_inspection_failure(
-                {"logs": list(failure_log_lines)},
-                marker=failure_marker,
+            failure_evidence = _validate_retained_volume_inspection_failure_identity(
+                _extract_retained_volume_inspection_failure(
+                    {"logs": list(failure_log_lines)},
+                    marker=failure_marker,
+                ),
+                failure_identity=failure_identity,
             )
         except Exception:
             raise _retained_volume_inspection_failure(
@@ -1404,6 +1407,30 @@ def _run_compose_odoo_retained_volume_backup_import_schedule(
         inspection_schedule_id=schedule_id,
         inspection_deployment_id=deployment_id,
     )
+    if failure_marker and failure_identity is not None:
+        try:
+            completed_failure_evidence = _find_retained_volume_inspection_failure(
+                {"logs": list(log_lines)},
+                marker=failure_marker,
+            )
+            if completed_failure_evidence is not None:
+                completed_failure_evidence = _validate_retained_volume_inspection_failure_identity(
+                    completed_failure_evidence,
+                    failure_identity=failure_identity,
+                )
+        except Exception:
+            raise _retained_volume_inspection_failure(
+                failure_identity=failure_identity,
+                failure_code="provider_result_invalid",
+                inspection_schedule_id=schedule_id,
+                inspection_deployment_id=deployment_id,
+            ) from None
+        if completed_failure_evidence is not None:
+            completed_failure_evidence["inspection_schedule_id"] = schedule_id
+            completed_failure_evidence["inspection_deployment_id"] = deployment_id
+            raise OdooRetainedVolumeBackupImportInspectionFailure(
+                evidence=completed_failure_evidence
+            ) from None
     result = _run_retained_volume_inspection_provider_call(
         callback=lambda: _extract_bounded_schedule_result(
             {"logs": list(log_lines)},
@@ -1434,12 +1461,30 @@ def _extract_retained_volume_inspection_failure(
     *,
     marker: str,
 ) -> api.JsonObject:
+    failure_evidence = _find_retained_volume_inspection_failure(
+        payload,
+        marker=marker,
+    )
+    if failure_evidence is None:
+        raise click.ClickException(
+            "Dokploy Odoo retained-volume backup import inspection returned no unique bounded failure evidence."
+        )
+    return failure_evidence
+
+
+def _find_retained_volume_inspection_failure(
+    payload: api.JsonValue,
+    *,
+    marker: str,
+) -> api.JsonObject | None:
     bounded_values: list[str] = []
     marker_prefix = f"{marker}="
     for line in api.normalize_dokploy_log_payload(payload):
         normalized_line = line.strip()
         if normalized_line.startswith(marker_prefix):
             bounded_values.append(normalized_line.removeprefix(marker_prefix).strip())
+    if not bounded_values:
+        return None
     if len(bounded_values) != 1:
         raise click.ClickException(
             "Dokploy Odoo retained-volume backup import inspection returned no unique bounded failure evidence."
@@ -1467,6 +1512,22 @@ def _extract_retained_volume_inspection_failure(
         "failure_stage": failure_stage,
         "failure_code": failure_code,
     }
+
+
+def _validate_retained_volume_inspection_failure_identity(
+    failure_evidence: api.JsonObject,
+    *,
+    failure_identity: tuple[str, str],
+) -> api.JsonObject:
+    inspection_nonce, backup_record_id = failure_identity
+    if (
+        failure_evidence.get("inspection_nonce") != inspection_nonce
+        or failure_evidence.get("backup_record_id") != backup_record_id
+    ):
+        raise click.ClickException(
+            "Dokploy Odoo retained-volume backup import inspection returned invalid bounded failure evidence."
+        )
+    return failure_evidence
 
 
 def _extract_bounded_schedule_result(

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1685,11 +1685,13 @@ execute inside that container or mount its corrupt database volume. The
 script-runner remains running-only because it emits the bounded result and
 writes the imported logical backup into the active data volume.
 
-If the provider inspection schedule terminates before it can emit that result,
-the service reads only the exact failed schedule deployment and accepts one
-nonce- and backup-record-bound failure marker. The operation checkpoint records
-only the request nonce, backup-record id, inspection deployment id, and a
-bounded failure stage/code pair; raw provider logs and command output are not
+If the provider inspection schedule emits a failure instead of its result, the
+service reads only that exact schedule deployment and accepts one nonce- and
+backup-record-bound failure marker. The marker is honored whether Dokploy marks
+the deployment failed or records it as done, because provider terminal status
+does not reliably preserve the script exit status. The operation checkpoint
+records only the request nonce, backup-record id, inspection deployment id, and
+a bounded failure stage/code pair; raw provider logs and command output are not
 copied into the plan, operation error, or API response. An unreadable exact log
 is recorded as `result/provider_result_log_read_failed`; a missing, duplicate,
 or invalid marker is recorded as `result/provider_result_invalid`. This

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -1406,6 +1406,69 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
             line_count=dokploy_api.MAX_DOKPLOY_LOG_LINE_COUNT,
         )
 
+    def test_provider_inspection_returns_bounded_failure_from_done_deployment(self) -> None:
+        target = DokployTargetDefinition(
+            context=CONTEXT,
+            instance="prod",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        )
+        failure_line = (
+            f"{dokploy_post_deploy.ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER}="
+            f"{'e' * 64}|{BACKUP_RECORD_ID}|source_database|"
+            "source_postgres_metadata_read_failed"
+        )
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": ACTIVE_COMPOSE_PROJECT, "serverId": "server-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.latest_deployment_for_schedule",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.dokploy_request",
+                return_value={"ok": True},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.wait_for_dokploy_schedule_deployment",
+                return_value="deployment=done-deployment status=done",
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_deployment_logs",
+                return_value=("private provider output", failure_line),
+            ) as logs_mock,
+        ):
+            with self.assertRaises(
+                dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure
+            ) as raised:
+                _run_provider_inspection(target)
+
+        self.assertEqual(
+            raised.exception.evidence,
+            {
+                "schema_version": 1,
+                "inspection_nonce": "e" * 64,
+                "backup_record_id": BACKUP_RECORD_ID,
+                "failure_stage": "source_database",
+                "failure_code": "source_postgres_metadata_read_failed",
+                "inspection_schedule_id": "schedule-1",
+                "inspection_deployment_id": "done-deployment",
+            },
+        )
+        self.assertNotIn("private provider output", str(raised.exception))
+        logs_mock.assert_called_once_with(
+            host="https://dokploy.example.test",
+            token="token",
+            deployment_id="done-deployment",
+            line_count=dokploy_api.MAX_DOKPLOY_LOG_LINE_COUNT,
+        )
+
     def test_provider_inspection_bounds_control_failures(self) -> None:
         target = DokployTargetDefinition(
             context=CONTEXT,
@@ -1607,6 +1670,62 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
         )
         self.assertNotIn("private provider output", str(raised.exception))
 
+    def test_provider_inspection_rejects_mismatched_done_failure_marker(self) -> None:
+        target = DokployTargetDefinition(
+            context=CONTEXT,
+            instance="prod",
+            target_id="compose-example-prod",
+            target_name="example-prod",
+        )
+        mismatched_failure_line = (
+            f"{dokploy_post_deploy.ODOO_RETAINED_VOLUME_BACKUP_IMPORT_INSPECT_FAILURE_MARKER}="
+            f"{'f' * 64}|other-backup|source_database|"
+            "source_postgres_metadata_read_failed"
+        )
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": ACTIVE_COMPOSE_PROJECT, "serverId": "server-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.upsert_dokploy_schedule",
+                return_value={"scheduleId": "schedule-1"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.latest_deployment_for_schedule",
+                return_value={"deploymentId": "before"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.dokploy_request",
+                return_value={"ok": True},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.wait_for_dokploy_schedule_deployment",
+                return_value="deployment=done-deployment status=done",
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_deployment_logs",
+                return_value=(mismatched_failure_line,),
+            ),
+        ):
+            with self.assertRaises(
+                dokploy_post_deploy.OdooRetainedVolumeBackupImportInspectionFailure
+            ) as raised:
+                _run_provider_inspection(target)
+
+        self.assertEqual(
+            raised.exception.evidence,
+            {
+                "schema_version": 1,
+                "inspection_nonce": "e" * 64,
+                "backup_record_id": BACKUP_RECORD_ID,
+                "failure_stage": "result",
+                "failure_code": "provider_result_invalid",
+                "inspection_schedule_id": "schedule-1",
+                "inspection_deployment_id": "done-deployment",
+            },
+        )
+
     def test_provider_inspection_bounds_unavailable_failure_logs(self) -> None:
         target = DokployTargetDefinition(
             context=CONTEXT,
@@ -1678,6 +1797,12 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
                 {"logs": [valid, valid]},
                 marker=marker,
             )
+        self.assertIsNone(
+            dokploy_post_deploy._find_retained_volume_inspection_failure(
+                {"logs": ["provider output without a failure marker"]},
+                marker=marker,
+            )
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- inspect exact retained-import deployment logs for a bounded failure marker even when Dokploy reports the schedule as done
- bind failure evidence to the current nonce and backup record before surfacing it
- document the provider terminal-status mismatch and cover completed, malformed, and mismatched marker paths

## Validation

- `uv run --extra dev python -m unittest tests.test_odoo_prod_retained_volume_backup_import`
- `uv run --extra dev launchplane ci unittest-shard local` (2,379 targets)
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check control_plane/dokploy/post_deploy.py tests/test_odoo_prod_retained_volume_backup_import.py`
- `uv run --extra dev ruff format --check control_plane/dokploy/post_deploy.py tests/test_odoo_prod_retained_volume_backup_import.py`
