### PR TITLE
Resolve pg_controldata from PostgreSQL image bindir

### DIFF
--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -2970,7 +2970,8 @@ source_pg_control_size=$(docker run --rm --read-only --network none --user 0:0 \
 pg_controldata_output=$(docker run --rm --read-only --network none --user 0:0 \
     --mount "type=volume,src=${{source_db_volume}},dst=/source,readonly" \
     --entrypoint /bin/bash "${{postgres_image_id}}" \
-    -lc 'LC_ALL=C pg_controldata /source')
+    -lc 'export PATH="/usr/lib/postgresql/${{PG_MAJOR:-17}}/bin:$PATH"; \
+        LC_ALL=C pg_controldata /source')
 source_pg_system_identifier=$(printf '%s\n' "${{pg_controldata_output}}" | \
     sed -n 's/^Database system identifier:[[:space:]]*//p' | head -n 1)
 source_pg_cluster_state=$(printf '%s\n' "${{pg_controldata_output}}" | \

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1666,7 +1666,9 @@ source volumes read-only, verifies their compose project and `odoo_db` /
 `PG_VERSION`, `pg_control` SHA-256 and checkpoint metadata, requires the source
 cluster state to be exactly `shut down`, counts and sizes the source filestore,
 proves the staging and destination paths absent, checks active data-volume free
-space, and binds all evidence into a SHA-256 plan fingerprint.
+space, and binds all evidence into a SHA-256 plan fingerprint. PostgreSQL
+control tools are resolved from the image's versioned bindir rather than
+assuming an overridden shell entrypoint preserves the image's tool `PATH`.
 
 A failed target replacement can update the live target's runtime identity before
 post-deploy verification fails while production inventory correctly remains on

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -1208,6 +1208,10 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
         self.assertIn("container_mounts_volume", combined)
         self.assertIn("active_destination_database_name", combined)
         self.assertIn('"postgres (PostgreSQL) 17."*', combined)
+        self.assertIn(
+            'export PATH="/usr/lib/postgresql/${PG_MAJOR:-17}/bin:$PATH"',
+            inspection_script,
+        )
         self.assertEqual(
             combined.count("resolve_single_container_any_state database"),
             2,


### PR DESCRIPTION
## Summary

- prepend the PostgreSQL image's versioned bindir before retained-volume `pg_controldata` inspection
- preserve existing Alpine-compatible PATH entries while fixing Debian PostgreSQL 17 images whose overridden shell entrypoint omits the bindir
- document and test the exact generated command

## Production evidence

- retained `PG_VERSION` reads as `17`
- retained `global/pg_control` hashes and stats successfully
- bare `pg_controldata` exits `127`; `/usr/lib/postgresql/17/bin/pg_controldata` reports cluster state `shut down`

## Validation

- `uv run --extra dev python -m unittest tests.test_odoo_prod_retained_volume_backup_import`
- `uv run --extra dev launchplane ci unittest-shard local` (2,379 targets)
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check control_plane/dokploy/post_deploy.py tests/test_odoo_prod_retained_volume_backup_import.py`
- `uv run --extra dev ruff format --check control_plane/dokploy/post_deploy.py tests/test_odoo_prod_retained_volume_backup_import.py`
