### PR TITLE
Isolate retained import apply plan-read authorization

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -27,6 +27,7 @@ name: Manage Launchplane Authorization
           - odoo-opw-preview-feedback
           - odoo-opw-production-enrollment
           - odoo-production-enrollment
+          - odoo-production-operation-read
       reviewed_plan_sha256:
         description: Plan SHA-256 returned by the reviewed dry run; required for apply.
         required: false
@@ -143,3 +144,14 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON }}
+
+  reconcile-odoo-production-operation-read:
+    if: ${{ inputs.managed_set == 'odoo-production-operation-read' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    with:
+      mode: ${{ inputs.mode }}
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_OPERATION_READ_MANAGED_SET_JSON }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -411,7 +411,10 @@ operator can reconcile that lane without replacing another unreadable managed
 set. `LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON` owns
 additional exact-instance Odoo production inspection and enrollment grants
 without expanding the OPW-specific set or replacing another unreadable managed
-set. The
+set. `LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_OPERATION_READ_MANAGED_SET_JSON` owns
+separate exact-instance cross-operation read grants, such as allowing an
+immutable production apply worker to read its reviewed plan operation without
+replacing the broader production-enrollment set. The
 `Manage Launchplane Authorization` wrapper selects one of those explicit
 secrets and forwards it into the reusable worker, whose OIDC-minting job remains
 gated by the `launchplane-authz-admin` environment. Never replace the unreadable

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -39,6 +39,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
                 "odoo-opw-preview-feedback",
                 "odoo-opw-production-enrollment",
                 "odoo-production-enrollment",
+                "odoo-production-operation-read",
             ],
         )
         expected_jobs = {
@@ -77,6 +78,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-odoo-production-enrollment": (
                 "${{ inputs.managed_set == 'odoo-production-enrollment' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_ENROLLMENT_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-odoo-production-operation-read": (
+                "${{ inputs.managed_set == 'odoo-production-operation-read' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_ODOO_PRODUCTION_OPERATION_READ_MANAGED_SET_JSON }}",
             ),
         }
         self.assertEqual(set(self.dispatch_workflow.jobs), set(expected_jobs))


### PR DESCRIPTION
## Summary

- add a separate protected managed authz set for exact Odoo production cross-operation reads
- route it through the existing immutable authz reconciliation worker and a dedicated repository secret
- keep the broader unreadable production-enrollment desired set untouched

## Intended grant

The dedicated secret contains one exact-instance GitHub Actions rule for the immutable retained-volume import apply workflow. It grants only `odoo_prod_retained_volume_backup_import_plan.execute`, which the operation-status route requires to read the reviewed plan operation before enqueueing apply.

## Validation

- `uv run --extra dev python -m unittest tests.test_authz_operator_workflow`
- `uv run --extra dev launchplane ci unittest-shard local` (2,379 targets)
- `uv run --extra dev ruff check tests/test_authz_operator_workflow.py`
- `uv run --extra dev ruff format --check tests/test_authz_operator_workflow.py`
- independent blockers-only review: no blockers
