### PR TITLE
Keep volatile free space out of retained import fingerprint

### DIFF
--- a/control_plane/contracts/odoo_prod_retained_volume_backup_import.py
+++ b/control_plane/contracts/odoo_prod_retained_volume_backup_import.py
@@ -523,6 +523,7 @@ def build_odoo_prod_retained_volume_backup_import_plan_fingerprint(
             "plan_fingerprint",
             "inspection_nonce",
             "inspection_deployment_id",
+            "active_data_free_bytes",
             "blockers",
             "warnings",
             "steps",

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1672,6 +1672,11 @@ proves the staging and destination paths absent, checks active data-volume free
 space, and binds all evidence into a SHA-256 plan fingerprint. PostgreSQL
 control tools are resolved from the image's versioned bindir rather than
 assuming an overridden shell entrypoint preserves the image's tool `PATH`.
+The fingerprint binds the conservative required-capacity calculation but not
+the volatile observed free-byte count. Apply remeasures live free space and
+blocks before backup-record or provider-import effects when it falls below the
+reviewed requirement, while harmless filesystem churn does not invalidate an
+otherwise identical plan.
 
 A failed target replacement can update the live target's runtime identity before
 post-deploy verification fails while production inventory correctly remains on

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -983,7 +983,11 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
             callback = cast(Callable[[str], None], kwargs["before_provider_mutation"])
             callback("schedule_upsert")
             callback("schedule_trigger")
-            return _inspection_payload(inspection_nonce=str(kwargs["inspection_nonce"]))
+            payload = _inspection_payload(inspection_nonce=str(kwargs["inspection_nonce"]))
+            payload["active_data_free_bytes"] = (
+                cast(int, payload["active_data_free_bytes"]) - 1_048_576
+            )
+            return payload
 
         def apply_provider(**kwargs: object) -> dict[str, object]:
             callback = cast(Callable[[str], None], kwargs["before_provider_mutation"])
@@ -1057,10 +1061,66 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
             ["schedule_upsert", "schedule_trigger", "schedule_upsert", "schedule_trigger"],
         )
 
+    def test_apply_blocks_insufficient_reinspection_space_before_import(self) -> None:
+        store = _Store()
+        reviewed_plan = _build_plan(store)
+        apply_request = OdooProdRetainedVolumeBackupImportApplyRequest(
+            **_request().model_dump(),
+            plan_operation_id="retained-import-plan-operation-1",
+            plan_fingerprint=reviewed_plan.plan_fingerprint,
+            confirmation=ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_CONFIRMATION,
+        )
+
+        def inspect(**kwargs: object) -> dict[str, object]:
+            payload = _inspection_payload(inspection_nonce=str(kwargs["inspection_nonce"]))
+            payload["active_data_free_bytes"] = 1
+            return payload
+
+        with (
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example.test", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_api.fetch_dokploy_target_payload",
+                return_value=_target_payload(store),
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_inspection",
+                side_effect=inspect,
+            ),
+            patch(
+                "control_plane.workflows.odoo_prod_retained_volume_backup_import.dokploy_post_deploy.run_compose_odoo_retained_volume_backup_import_apply"
+            ) as apply_provider_mock,
+        ):
+            with self.assertRaisesRegex(click.ClickException, "lacks conservative space"):
+                execute_odoo_prod_retained_volume_backup_import_apply(
+                    control_plane_root=Path("."),
+                    record_store=store,
+                    operation_id="retained-import-apply-1",
+                    reviewed_plan=reviewed_plan,
+                    request=apply_request,
+                    phase_checkpoint=lambda _phase, _evidence: None,
+                    provider_effect_checkpoint=lambda _phase, _effect: None,
+                )
+
+        self.assertNotIn(BACKUP_RECORD_ID, store.backup_records)
+        apply_provider_mock.assert_not_called()
+
     def test_plan_fingerprint_changes_when_pg_control_changes(self) -> None:
         plan = _build_plan(_Store())
         changed = plan.model_copy(update={"source_pg_control_sha256": "9" * 64})
         self.assertNotEqual(
+            build_odoo_prod_retained_volume_backup_import_plan_fingerprint(plan),
+            build_odoo_prod_retained_volume_backup_import_plan_fingerprint(changed),
+        )
+
+    def test_plan_fingerprint_ignores_volatile_active_data_free_bytes(self) -> None:
+        plan = _build_plan(_Store())
+        changed = plan.model_copy(
+            update={"active_data_free_bytes": plan.active_data_free_bytes - 1_048_576}
+        )
+        self.assertEqual(
             build_odoo_prod_retained_volume_backup_import_plan_fingerprint(plan),
             build_odoo_prod_retained_volume_backup_import_plan_fingerprint(changed),
         )


### PR DESCRIPTION
## Summary

- exclude the live observed free-byte count from retained-volume import plan fingerprints
- continue binding the conservative required-capacity calculation
- remeasure free space during apply and fail before backup-record/provider-import effects if capacity is insufficient

## Production evidence

Two applies rebuilt identical source/runtime plans but produced different fingerprints within minutes solely because active data free bytes changed. Both failed before clone or backup creation.

## Validation

- `uv run --extra dev python -m unittest tests.test_odoo_prod_retained_volume_backup_import` (30 tests)
- `uv run --extra dev launchplane ci unittest-shard local` (2,380 targets before final test-only addition)
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check control_plane/contracts/odoo_prod_retained_volume_backup_import.py tests/test_odoo_prod_retained_volume_backup_import.py`
- `uv run --extra dev ruff format --check control_plane/contracts/odoo_prod_retained_volume_backup_import.py tests/test_odoo_prod_retained_volume_backup_import.py`
- independent reviews: no remaining blockers; requested fail-closed capacity test added
