### PR TITLE
fix: probe retained source database directly

### DIFF
--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -3460,9 +3460,9 @@ if [ "${{ready}}" != "1" ]; then
     exit 1
 fi
 database_exists=$(docker exec -u postgres "${{clone_container}}" \
-    psql --host /var/run/postgresql --username "${{database_user}}" --dbname postgres \
-    --no-psqlrc --tuples-only --no-align --set=source_database="${{source_database_name}}" \
-    --command "SELECT 1 FROM pg_database WHERE datname = :'source_database';")
+    psql --host /var/run/postgresql --username "${{database_user}}" \
+    --dbname "${{source_database_name}}" --no-psqlrc --tuples-only --no-align \
+    --command "SELECT 1;")
 if [ "${{database_exists}}" != "1" ]; then
     echo "Requested retained source database does not exist in the staging clone." >&2
     exit 1

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1727,12 +1727,14 @@ It never starts PostgreSQL on, or writes to, either retained source volume. It
 copies the source database volume read-only into the fresh staging volume while
 preserving ownership, verifies the copied `pg_control` fingerprint, and starts
 PostgreSQL 17 only from that clone in an isolated named container and network.
-After proving the requested source database exists, it writes a custom-format
-dump and source-filestore archive into the active data volume's standard
-Launchplane backup directory. Artifact names and the schema-v1 manifest use the
-destination database identity; the archived filestore has that identity as its
-top-level directory. Launchplane verifies sizes and SHA-256 values and accepts
-only nonce-, request-, and exact schedule-deployment-bound completion evidence.
+It proves the requested source database exists by connecting to that exact
+validated database name instead of interpolating the name into SQL. It then
+writes a custom-format dump and source-filestore archive into the active data
+volume's standard Launchplane backup directory. Artifact names and the schema-v1
+manifest use the destination database identity; the archived filestore has that
+identity as its top-level directory. Launchplane verifies sizes and SHA-256
+values and accepts only nonce-, request-, and exact schedule-deployment-bound
+completion evidence.
 
 The clone container and network are removed on exit, while the staging clone
 volume remains labeled for explicit recovery inspection. A passing import writes

--- a/tests/test_odoo_prod_retained_volume_backup_import.py
+++ b/tests/test_odoo_prod_retained_volume_backup_import.py
@@ -1281,6 +1281,8 @@ class OdooProdRetainedVolumeBackupImportTests(unittest.TestCase):
         self.assertEqual(combined.count("docker ps -aq"), 2)
         self.assertIn("created_staging_clone_volume", apply_script)
         self.assertIn('mkdir -m 700 "$backup_dir"', apply_script)
+        self.assertIn('--dbname "${source_database_name}"', apply_script)
+        self.assertNotIn("--set=source_database", apply_script)
         self.assertIn("pg_dump --host /var/run/postgresql", apply_script)
         self.assertIn("tarfile.open", apply_script)
         self.assertIn("schema_version", apply_script)


### PR DESCRIPTION
## Summary
- connect directly to the validated retained source database for the existence probe
- avoid unsupported `psql` variable interpolation in the generated apply script
- document and test the fail-closed probe behavior before backup effects

## Validation
- full repository gate: 2381 targets passed
- retained-volume import module: 30 tests passed
- mypy: 570 files passed
- ruff lint and format checks passed
- two independent blockers-only reviews: no blockers