### PR TITLE
fix: derive restore operation poll path

### DIFF
--- a/.github/workflows/reusable-odoo-prod-backup-restore-apply.yml
+++ b/.github/workflows/reusable-odoo-prod-backup-restore-apply.yml
@@ -245,39 +245,30 @@ jobs:
           route-path: /v1/drivers/odoo/prod-backup-restore-apply
           payload-file: .launchplane/restore-apply-payload.json
           idempotency-key: ${{ inputs.idempotency_key }}
-          output-paths: >-
-            poll_url=result.poll_url,operation_id=result.operation_id
+          output-paths: operation_id=result.operation_id
           fail-result-paths: ""
           log-response-body: "false"
           response-output-file: odoo-prod-backup-restore-create.json
 
       - name: Validate restore operation metadata
+        id: restore_metadata
         env:
           CREATE_STATUS_CODE: ${{ steps.create_restore.outputs.status-code }}
-          POLL_URL: ${{ steps.create_restore.outputs.poll_url }}
           OPERATION_ID: ${{ steps.create_restore.outputs.operation_id }}
         shell: bash
         run: |
           set -euo pipefail
           if [ "$CREATE_STATUS_CODE" != "202" ] || \
-            [ -z "$POLL_URL" ] || \
             [ -z "$OPERATION_ID" ]; then
-            echo 'Restore operation was not accepted with poll metadata.' >&2
+            echo 'Restore operation was not accepted with operation metadata.' >&2
             exit 1
           fi
-          case "$POLL_URL" in
-            /v1/drivers/odoo/prod-backup-restore/operations/*) ;;
-            *)
-              echo 'Restore operation returned an unexpected poll path.' >&2
-              exit 1
-              ;;
-          esac
-          case "$POLL_URL" in
-            *$'\n'* | *$'\r'* | *://* | *'?'* | *'#'* | *'%'*)
-              echo 'Restore poll URL must be a bounded local path.' >&2
-              exit 1
-              ;;
-          esac
+          if ! [[ "$OPERATION_ID" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*$ ]]; then
+            echo 'Restore operation ID must be path-safe.' >&2
+            exit 1
+          fi
+          poll_url="/v1/drivers/odoo/prod-backup-restore/operations/${OPERATION_ID}"
+          echo "poll_url=${poll_url}" >> "$GITHUB_OUTPUT"
 
       - name: Poll destructive restore operation
         id: poll_restore
@@ -291,7 +282,7 @@ jobs:
               vars.LAUNCHPLANE_SERVICE_AUDIENCE
             }}
           method: GET
-          route-path: ${{ steps.create_restore.outputs.poll_url }}
+          route-path: ${{ steps.restore_metadata.outputs.poll_url }}
           poll-result-path: operation.status
           poll-result-statuses: pending,running
           poll-interval-ms: 15000

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1783,13 +1783,15 @@ Run `Odoo Prod Backup Restore Apply` only with that exact fingerprint, a stable
 idempotency key, and confirmation phrase
 `restore-verified-production-backup`. The service creates a dedicated durable
 restore operation; routine existing-data target replacement cannot exercise
-this authority. The worker rechecks authorization after claim and immediately
-before the first provider effect, then records before/after checkpoints for fresh
-database restore, filestore staging, web quiesce, filestore activation,
-runtime-environment update, deploy, post-deploy work, and verification. Once any
-provider effect starts, an expired lease moves to `reconciliation_required`,
-keeps the shared lane fenced, and requires exact provider inspection rather than
-automatic retry.
+this authority. The workflow derives the canonical bounded operation-status
+route from the accepted path-safe operation id instead of requiring a redundant
+service-supplied poll URL. The worker rechecks authorization after claim and
+immediately before the first provider effect, then records before/after
+checkpoints for fresh database restore, filestore staging, web quiesce,
+filestore activation, runtime-environment update, deploy, post-deploy work, and
+verification. Once any provider effect starts, an expired lease moves to
+`reconciliation_required`, keeps the shared lane fenced, and requires exact
+provider inspection rather than automatic retry.
 
 The database phase creates the exact fresh volume and restores the complete
 archive with `pg_restore --exit-on-error`; it never runs `pg_resetwal` and never

--- a/tests/test_odoo_prod_backup_restore_workflow.py
+++ b/tests/test_odoo_prod_backup_restore_workflow.py
@@ -144,7 +144,7 @@ class OdooProdBackupRestoreWorkflowTests(unittest.TestCase):
             [
                 "/v1/drivers/odoo/prod-backup-restore-plan",
                 "/v1/drivers/odoo/prod-backup-restore-apply",
-                "${{ steps.create_restore.outputs.poll_url }}",
+                "${{ steps.restore_metadata.outputs.poll_url }}",
             ],
         )
         for request_step in request_steps:
@@ -162,6 +162,20 @@ class OdooProdBackupRestoreWorkflowTests(unittest.TestCase):
             request_steps[2].with_values["poll-result-statuses"],
             "pending,running",
         )
+        self.assertEqual(
+            request_steps[1].with_values["output-paths"],
+            "operation_id=result.operation_id",
+        )
+
+        metadata_step = self.apply_worker.step_named("apply", "Validate restore operation metadata")
+        assert metadata_step is not None
+        self.assertEqual(metadata_step.data["id"], "restore_metadata")
+        self.assertIn("Restore operation ID must be path-safe", metadata_step.run)
+        self.assertIn(
+            "/v1/drivers/odoo/prod-backup-restore/operations/${OPERATION_ID}",
+            metadata_step.run,
+        )
+        self.assertIn('echo "poll_url=${poll_url}" >> "$GITHUB_OUTPUT"', metadata_step.run)
 
         validate_step = self.apply_worker.step_named("apply", "Validate destructive restore inputs")
         assert validate_step is not None


### PR DESCRIPTION
## Summary
- treat the durable restore operation ID as the sole create-response polling authority
- validate the ID as a single path-safe segment and derive the canonical local status route
- update focused workflow tests and operations documentation

## Incident
Restore apply run `30224074449` created durable operation `odoo-prod-backup-restore-2026-07-26T225419Z-5299c735df9dd7bb`, but the pinned worker stopped before polling because the accepted service response did not include redundant `result.poll_url` metadata.

## Validation
- full repository unittest gate: 2382 targets passed
- focused workflow/security tests: 10 passed
- mypy: 572 files passed
- ruff check and format check passed for the changed Python test
- independent blockers-only review: no blockers