### PR TITLE
chore: pin restore poll worker

### DIFF
--- a/.github/workflows/odoo-prod-backup-restore-apply.yml
+++ b/.github/workflows/odoo-prod-backup-restore-apply.yml
@@ -69,7 +69,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: cbusillo/launchplane/.github/workflows/reusable-odoo-prod-backup-restore-apply.yml@75c632d645f29775c5f2b1ab91f5318e1468000b # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-odoo-prod-backup-restore-apply.yml@2e3168626bd90cc0839eed455b9b206a9a19231e # main
     with:
       product: ${{ inputs.product }}
       context: ${{ inputs.context }}

--- a/tests/test_odoo_prod_backup_restore_workflow.py
+++ b/tests/test_odoo_prod_backup_restore_workflow.py
@@ -14,7 +14,8 @@ PLAN_WRAPPER_PATH = Path(".github/workflows/odoo-prod-backup-restore-plan.yml")
 PLAN_WORKER_PATH = Path(".github/workflows/reusable-odoo-prod-backup-restore-plan.yml")
 APPLY_WRAPPER_PATH = Path(".github/workflows/odoo-prod-backup-restore-apply.yml")
 APPLY_WORKER_PATH = Path(".github/workflows/reusable-odoo-prod-backup-restore-apply.yml")
-PINNED_WORKFLOW_SHA = "75c632d645f29775c5f2b1ab91f5318e1468000b"
+PLAN_PINNED_WORKFLOW_SHA = "75c632d645f29775c5f2b1ab91f5318e1468000b"
+APPLY_PINNED_WORKFLOW_SHA = "2e3168626bd90cc0839eed455b9b206a9a19231e"
 
 RESTORE_IDENTITY_INPUTS = {
     "product",
@@ -53,7 +54,7 @@ class OdooProdBackupRestoreWorkflowTests(unittest.TestCase):
         self.assertEqual(
             self.plan_wrapper.job_uses("plan"),
             "cbusillo/launchplane/.github/workflows/"
-            f"reusable-odoo-prod-backup-restore-plan.yml@{PINNED_WORKFLOW_SHA}",
+            f"reusable-odoo-prod-backup-restore-plan.yml@{PLAN_PINNED_WORKFLOW_SHA}",
         )
         self.assertEqual(self.plan_wrapper.steps("plan"), ())
         concurrency = cast(YamlMapping, self.plan_wrapper.data["concurrency"])
@@ -85,7 +86,7 @@ class OdooProdBackupRestoreWorkflowTests(unittest.TestCase):
         self.assertEqual(
             self.apply_wrapper.job_uses("apply"),
             "cbusillo/launchplane/.github/workflows/"
-            f"reusable-odoo-prod-backup-restore-apply.yml@{PINNED_WORKFLOW_SHA}",
+            f"reusable-odoo-prod-backup-restore-apply.yml@{APPLY_PINNED_WORKFLOW_SHA}",
         )
         self.assertEqual(self.apply_wrapper.steps("apply"), ())
         concurrency = cast(YamlMapping, self.apply_wrapper.data["concurrency"])


### PR DESCRIPTION
## Summary
- advance only the production restore-apply wrapper to the reviewed reusable worker merged in `2e316862`
- keep the restore-plan worker on its existing immutable pin
- split focused test constants so each wrapper pin is asserted independently

## Safety
Authz policy revision `303` temporarily authorizes both the old and new immutable restore-apply worker SHAs. The overlap will be narrowed after the new pin is proven.

## Validation
- focused restore workflow and GitHub Actions security tests: 10 passed
- ruff check and format check passed
- `git diff --check` passed