### PR TITLE
Fix production restore filestore stage result

### DIFF
--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -1871,33 +1871,45 @@ def extract_odoo_backup_restore_result(
         normalized_line = line.strip()
         if normalized_line.startswith(marker_prefix):
             encoded_results.append(normalized_line.removeprefix(marker_prefix).strip())
+    if not encoded_results:
+        raise click.ClickException(
+            f"Dokploy Odoo backup restore {phase} failed (provider_result_missing)."
+        )
     if len(encoded_results) != 1:
-        raise click.ClickException("Dokploy Odoo backup restore returned no unique bounded result.")
+        raise click.ClickException(
+            f"Dokploy Odoo backup restore {phase} failed (provider_result_duplicate)."
+        )
     try:
         decoded_payload = base64.b64decode(encoded_results[0], validate=True)
         parsed_payload = json.loads(decoded_payload.decode("utf-8"))
     except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as error:
         raise click.ClickException(
-            "Dokploy Odoo backup restore returned an invalid bounded result."
+            f"Dokploy Odoo backup restore {phase} failed (provider_result_invalid)."
         ) from error
     result = api.as_json_object(parsed_payload)
     if result is None or set(result) != ODOO_BACKUP_RESTORE_RESULT_FIELDS:
         raise click.ClickException(
-            "Dokploy Odoo backup restore returned an unexpected bounded result shape."
+            f"Dokploy Odoo backup restore {phase} failed (provider_result_shape_invalid)."
         )
     if result.get("schema_version") != 1:
-        raise click.ClickException("Dokploy Odoo backup restore returned an unsupported result.")
+        raise click.ClickException(
+            f"Dokploy Odoo backup restore {phase} failed (provider_result_schema_unsupported)."
+        )
     if result.get("operation_id") != operation_id or result.get("phase") != phase:
         raise click.ClickException(
-            "Dokploy Odoo backup restore result did not match the exact operation phase."
+            f"Dokploy Odoo backup restore {phase} failed (provider_result_identity_mismatch)."
         )
     evidence = api.as_json_object(result.get("evidence"))
     if evidence is None or len(evidence) > 32:
-        raise click.ClickException("Dokploy Odoo backup restore evidence was not bounded.")
+        raise click.ClickException(
+            f"Dokploy Odoo backup restore {phase} failed (provider_evidence_unbounded)."
+        )
     normalized_evidence: dict[str, str] = {}
     for key, value in evidence.items():
         if not isinstance(value, str) or len(key) > 100 or len(value) > 4096:
-            raise click.ClickException("Dokploy Odoo backup restore evidence was not bounded.")
+            raise click.ClickException(
+                f"Dokploy Odoo backup restore {phase} failed (provider_evidence_unbounded)."
+            )
         normalized_evidence[key] = value
     return normalized_evidence
 
@@ -4030,7 +4042,7 @@ with tarfile.open(archive_path, mode="r:gz") as archive:
         raise
 PY
 
-python3 - "${result_marker}" "${operation_id}" "${filestore_staging_path}" "${filestore_archive_sha256}" "${filestore_member_count}" "${filestore_unpacked_size}" <<'PY'
+python3 - "${result_marker}" "${operation_id}" "${filestore_staging_path}" "${expected_filestore_archive_sha256}" "${expected_filestore_member_count}" "${expected_filestore_unpacked_size}" <<'PY'
 import base64
 import json
 import sys

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1809,7 +1809,10 @@ Deployment, inventory, release-tuple, phase checkpoint, authorization, provider
 result, and final verification evidence remain durable in Launchplane. A failed
 or interrupted operation must be inspected from its operation record before any
 new restore is planned; do not rerun a provider schedule or use target
-replacement as a recovery shortcut.
+replacement as a recovery shortcut. Missing, duplicate, malformed, mismatched,
+or unbounded provider phase results fail closed with the exact restore phase and
+an allowlisted `provider_result_*` or `provider_evidence_unbounded` code; raw
+provider log text is not persisted in the operation error.
 
 Legacy backup-gate manifests created before manifest schema and hash fields were
 introduced remain verifiable: Launchplane validates their recorded identity,

--- a/tests/test_odoo_prod_backup_restore.py
+++ b/tests/test_odoo_prod_backup_restore.py
@@ -3,6 +3,8 @@ from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import patch
 
+import click
+
 from control_plane.contracts.artifact_identity import (
     ArtifactImageReference,
     ArtifactIdentityManifest,
@@ -630,10 +632,31 @@ class OdooProdBackupRestoreScriptTests(unittest.TestCase):
         self.assertIn("volume_label", database_script)
         self.assertIn("not member.isfile() and not member.isdir()", filestore_script)
         self.assertIn("member_path.parts[0] != database_name", filestore_script)
+        self.assertIn(
+            '"${expected_filestore_archive_sha256}" '
+            '"${expected_filestore_member_count}" '
+            '"${expected_filestore_unpacked_size}"',
+            filestore_script,
+        )
+        self.assertNotIn('"${filestore_archive_sha256}"', filestore_script)
+        self.assertNotIn('"${filestore_member_count}"', filestore_script)
+        self.assertNotIn('"${filestore_unpacked_size}"', filestore_script)
         self.assertIn("filestore_quarantine_path", activation_script)
         self.assertIn("docker exec -u root -i", activation_script)
         self.assertIn("live_path.rename(quarantine_path)", activation_script)
         self.assertNotIn('mv "${current_filestore_path}"', activation_script)
+
+    def test_restore_result_failure_identifies_exact_phase_with_bounded_code(self) -> None:
+        with self.assertRaises(click.ClickException) as raised:
+            dokploy_post_deploy.extract_odoo_backup_restore_result(
+                {"logs": ["untrusted provider error text"]},
+                operation_id="restore-operation-1",
+                phase="filestore_stage",
+            )
+        self.assertEqual(
+            str(raised.exception),
+            "Dokploy Odoo backup restore filestore_stage failed (provider_result_missing).",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix the generated filestore-stage result emitter to use the defined reviewed digest/count/size variables
- report missing, duplicate, malformed, mismatched, or unbounded restore phase results with exact allowlisted phase/code diagnostics
- document the bounded provider-result failure contract

## Root cause
The live filestore-stage script completed extraction but aborted under `set -u` while emitting its bounded result because it referenced undefined `filestore_*` shell variables instead of the header's `expected_filestore_*` variables. The durable operation therefore recorded the old generic no-result error before quiesce, activation, deployment, or cutover.

## Validation
- `uv run --extra dev python -m unittest tests.test_dokploy tests.test_odoo_prod_backup_restore` (105 tests)
- `uv run --extra dev launchplane ci unittest-shard local` (2,382 targets, 12/12 shards)
- `uv run --extra dev mypy control_plane tests` (572 files)
- `uv run --extra dev ruff check --no-fix control_plane/dokploy/post_deploy.py tests/test_odoo_prod_backup_restore.py`
- `uv run --extra dev ruff format --check control_plane/dokploy/post_deploy.py tests/test_odoo_prod_backup_restore.py`
- independent Claude review: no blockers
- independent GPT review: no blockers (review completed before transport disconnect)
