### PR TITLE
feat: add bounded generated run-cache maintenance

### DIFF
--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -19,6 +19,7 @@ name: Runner Host Hygiene
         options:
           - prune_docker_cache
           - prune_dangling_images
+          - prune_generated_run_cache
           - remove_buildkit_state_volumes
       mutate:
         description: Execute the approved hygiene action
@@ -33,6 +34,11 @@ name: Runner Host Hygiene
         type: string
       target_buildkit_builder:
         description: Exact allowlisted Buildx builder whose cache should be bounded
+        required: false
+        default: ""
+        type: string
+      target_generated_cache_key:
+        description: Exact public generated run-cache key for bounded cleanup
         required: false
         default: ""
         type: string
@@ -59,6 +65,7 @@ name: Runner Host Hygiene
         type: boolean
 
 permissions:
+  actions: read
   contents: read
   id-token: write
 
@@ -84,6 +91,8 @@ jobs:
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_RETAINED_WARM_BUILDERS }}
       RUNNER_WORKDIR_ROOTS: >-
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_RUNNER_WORKDIR_ROOTS }}
+      RUNNER_GENERATED_RUN_CACHE_ROOTS: >-
+        ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_GENERATED_RUN_CACHE_ROOTS }}
       RUNNER_ALLOWED_BUILDKIT_STATE_VOLUMES: >-
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_ALLOWED_BUILDKIT_STATE_VOLUMES
         }}
@@ -115,6 +124,7 @@ jobs:
           require_env RUNNER_SERVICE_USER
           require_env RUNNER_RETAINED_WARM_BUILDERS
           require_env RUNNER_WORKDIR_ROOTS
+          require_env RUNNER_GENERATED_RUN_CACHE_ROOTS
           require_env RUNNER_BUILDKIT_CACHE_BUDGETS
           require_env RUNNER_DEFAULT_CACHE_BUDGET_BYTES
           if [[ ! "$RUNNER_DEFAULT_CACHE_BUDGET_BYTES" =~ ^[1-9][0-9]*$ ]]; then
@@ -139,9 +149,13 @@ jobs:
           INPUT_PRUNE_UNTIL: ${{ inputs.prune_until }}
           INPUT_RESOLVE_ACTION_STARTED: ${{ inputs.resolve_action_started }}
           INPUT_TARGET_BUILDKIT_BUILDER: ${{ inputs.target_buildkit_builder }}
+          INPUT_TARGET_GENERATED_CACHE_KEY: >-
+            ${{ inputs.target_generated_cache_key }}
           INPUT_TARGET_BUILDKIT_STATE_VOLUMES: >-
             ${{ inputs.target_buildkit_state_volumes }}
           INPUT_TIMEOUT_SECONDS: ${{ inputs.timeout_seconds }}
+          GH_TOKEN: >-
+            ${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_GITHUB_READ_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -193,6 +207,34 @@ jobs:
           done
           if [ "${#runner_root_args[@]}" -eq 0 ]; then
             echo "At least one runner workdir root is required." >&2
+            exit 1
+          fi
+
+          generated_cache_args=()
+          generated_cache_keys=()
+          declare -A seen_generated_cache_keys=()
+          IFS=',' read -r -a generated_cache_roots <<< "$RUNNER_GENERATED_RUN_CACHE_ROOTS"
+          for generated_cache_root in "${generated_cache_roots[@]}"; do
+            trimmed="${generated_cache_root#"${generated_cache_root%%[![:space:]]*}"}"
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+            if [ -z "$trimmed" ]; then
+              continue
+            fi
+            cache_key="${trimmed%%=*}"
+            if [[ ! "$cache_key" =~ ^[a-z0-9][a-z0-9._-]{0,63}$ ]]; then
+              echo "Generated cache key must be public-safe." >&2
+              exit 1
+            fi
+            if [ -n "${seen_generated_cache_keys[$cache_key]:-}" ]; then
+              echo "Generated cache keys must be unique." >&2
+              exit 1
+            fi
+            seen_generated_cache_keys[$cache_key]=1
+            generated_cache_keys+=("$cache_key")
+            generated_cache_args+=(--generated-run-cache-root "$trimmed")
+          done
+          if [ "${#generated_cache_args[@]}" -eq 0 ]; then
+            echo "At least one generated run cache root is required." >&2
             exit 1
           fi
 
@@ -286,6 +328,7 @@ jobs:
               --audit-record-key "$audit_key" \
               "${builder_args[@]}" \
               "${runner_root_args[@]}" \
+              "${generated_cache_args[@]}" \
               "$@" \
               "$mutation_flag" \
               "$resolve_flag" \
@@ -335,6 +378,17 @@ jobs:
                   maintenance_failures=$((maintenance_failures + 1))
                 fi
               done
+              for generated_cache_key in "${generated_cache_keys[@]}"; do
+                if ! run_hygiene \
+                  prune_generated_run_cache \
+                  "${audit_prefix}-scheduled-generated-${generated_cache_key}-${GITHUB_RUN_ID}" \
+                  168h \
+                  --mutate \
+                  "generated-${generated_cache_key}" \
+                  --target-generated-cache-key "$generated_cache_key"; then
+                  maintenance_failures=$((maintenance_failures + 1))
+                fi
+              done
               if ((maintenance_failures > 0)); then
                 echo "${maintenance_failures} scheduled hygiene action(s) failed." >&2
                 exit 1
@@ -358,6 +412,24 @@ jobs:
           fi
 
           target_builder_args=()
+          target_generated_cache_args=()
+          target_generated_cache_key="$INPUT_TARGET_GENERATED_CACHE_KEY"
+          target_generated_cache_key="${target_generated_cache_key#"${target_generated_cache_key%%[![:space:]]*}"}"
+          target_generated_cache_key="${target_generated_cache_key%"${target_generated_cache_key##*[![:space:]]}"}"
+          target_generated_cache_key="${target_generated_cache_key,,}"
+          if [ "$apply_action" = "prune_generated_run_cache" ]; then
+            if [ -z "$target_generated_cache_key" ] ||
+              [ -z "${seen_generated_cache_keys[$target_generated_cache_key]:-}" ]; then
+              echo "Target generated cache key is not configured." >&2
+              exit 1
+            fi
+            target_generated_cache_args=(
+              --target-generated-cache-key "$target_generated_cache_key"
+            )
+          elif [ -n "$target_generated_cache_key" ]; then
+            echo "Target generated cache key requires prune_generated_run_cache." >&2
+            exit 1
+          fi
           target_builder="$INPUT_TARGET_BUILDKIT_BUILDER"
           target_builder="${target_builder#"${target_builder%%[![:space:]]*}"}"
           target_builder="${target_builder%"${target_builder##*[![:space:]]}"}"
@@ -392,7 +464,8 @@ jobs:
             "$mutate_flag" \
             manual \
             "${volume_args[@]}" \
-            "${target_builder_args[@]}"
+            "${target_builder_args[@]}" \
+            "${target_generated_cache_args[@]}"
 
       - name: Upload executor result
         if: always() && steps.executor.outcome != 'skipped'

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -75,10 +75,12 @@ from control_plane.workflows.runner_lane_retirement_executor import (
     validate_local_executor_environment as validate_runner_retirement_environment,
 )
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import GeneratedRunCacheRoot
 from control_plane.workflows.runner_host_hygiene_executor import RunnerWorkdirRoot
 from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandRunner
 from control_plane.workflows.runner_host_hygiene_executor import build_local_command_runner
+from control_plane.workflows.runner_host_hygiene_executor import build_github_run_state_reader
 from control_plane.workflows.runner_host_hygiene_executor import (
     build_refreshing_service_audit_poster,
 )
@@ -1108,6 +1110,7 @@ def runner_host_hygiene_report(
         (
             "prune_docker_cache",
             "prune_dangling_images",
+            "prune_generated_run_cache",
             "remove_buildkit_state_volumes",
             "prune_runner_workdir",
             "restart_runner_service",
@@ -1176,6 +1179,48 @@ def runner_host_hygiene_report(
     help="Retained cache bytes for the default daemon cache or a target builder.",
 )
 @click.option(
+    "--target-generated-cache-key",
+    default="",
+    help="Public generated-cache key the request targets.",
+)
+@click.option(
+    "--target-generated-cache-run-id",
+    "target_generated_cache_run_ids",
+    multiple=True,
+    type=click.IntRange(min=1),
+    help="Completed generated-cache run id targeted for removal. Repeat as needed.",
+)
+@click.option(
+    "--allowed-generated-cache-key",
+    "allowed_generated_cache_keys",
+    multiple=True,
+    help="Generated-cache key allowed by local policy. Repeat as needed.",
+)
+@click.option(
+    "--generated-cache-minimum-age-hours",
+    default=0,
+    show_default=True,
+    type=click.IntRange(min=0),
+)
+@click.option(
+    "--generated-cache-high-water-bytes",
+    default=0,
+    show_default=True,
+    type=click.IntRange(min=0),
+)
+@click.option(
+    "--generated-cache-low-water-bytes",
+    default=0,
+    show_default=True,
+    type=click.IntRange(min=0),
+)
+@click.option(
+    "--generated-cache-cooldown-hours",
+    default=0,
+    show_default=True,
+    type=click.IntRange(min=0),
+)
+@click.option(
     "--allow-docker-cache-prune/--disallow-docker-cache-prune",
     default=False,
     show_default=True,
@@ -1186,6 +1231,12 @@ def runner_host_hygiene_report(
     default=False,
     show_default=True,
     help="Enable dangling-only Docker image prune planning in the local policy.",
+)
+@click.option(
+    "--allow-generated-run-cache-prune/--disallow-generated-run-cache-prune",
+    default=False,
+    show_default=True,
+    help="Enable completed-run generated cache prune planning in the local policy.",
 )
 @click.option(
     "--allow-buildkit-state-volume-remove/--disallow-buildkit-state-volume-remove",
@@ -1236,8 +1287,16 @@ def runner_host_hygiene_apply_plan(
     target_buildkit_builder: str,
     allowed_buildkit_builders: tuple[str, ...],
     max_used_space_bytes: int,
+    target_generated_cache_key: str,
+    target_generated_cache_run_ids: tuple[int, ...],
+    allowed_generated_cache_keys: tuple[str, ...],
+    generated_cache_minimum_age_hours: int,
+    generated_cache_high_water_bytes: int,
+    generated_cache_low_water_bytes: int,
+    generated_cache_cooldown_hours: int,
     allow_docker_cache_prune: bool,
     allow_dangling_image_prune: bool,
+    allow_generated_run_cache_prune: bool,
     allow_buildkit_state_volume_remove: bool,
     allow_runner_workdir_prune: bool,
     allow_runner_service_restart: bool,
@@ -1254,6 +1313,8 @@ def runner_host_hygiene_apply_plan(
             require_audit_record=require_audit_record,
             allow_docker_cache_prune=allow_docker_cache_prune,
             allow_dangling_image_prune=allow_dangling_image_prune,
+            allow_generated_run_cache_prune=allow_generated_run_cache_prune,
+            allowed_generated_cache_keys=allowed_generated_cache_keys,
             allowed_buildkit_builders=allowed_buildkit_builders,
             allow_buildkit_state_volume_remove=allow_buildkit_state_volume_remove,
             allowed_buildkit_state_volumes=allowed_buildkit_state_volumes,
@@ -1268,6 +1329,12 @@ def runner_host_hygiene_apply_plan(
             target_buildkit_builder=target_buildkit_builder,
             max_used_space_bytes=max_used_space_bytes,
             target_buildkit_state_volumes=target_buildkit_state_volumes,
+            target_generated_cache_key=target_generated_cache_key,
+            target_generated_cache_run_ids=target_generated_cache_run_ids,
+            generated_cache_minimum_age_hours=generated_cache_minimum_age_hours,
+            generated_cache_high_water_bytes=generated_cache_high_water_bytes,
+            generated_cache_low_water_bytes=generated_cache_low_water_bytes,
+            generated_cache_cooldown_hours=generated_cache_cooldown_hours,
             audit_record_key=audit_record_key,
         )
         plan = plan_runner_host_hygiene_apply(
@@ -1325,7 +1392,9 @@ def runner_host_hygiene_apply_plan(
     "--privileged-scope",
     "privileged_scopes",
     multiple=True,
-    type=click.Choice(("docker_cache", "docker_volume", "runner_service", "runner_workdir")),
+    type=click.Choice(
+        ("docker_cache", "docker_volume", "generated_cache", "runner_service", "runner_workdir")
+    ),
     help="Privileged host capability requested by the adapter. Repeat for each scope.",
 )
 @click.option(
@@ -1385,7 +1454,9 @@ def runner_host_hygiene_apply_plan(
     "--allowed-privileged-scope",
     "allowed_privileged_scopes",
     multiple=True,
-    type=click.Choice(("docker_cache", "docker_volume", "runner_service", "runner_workdir")),
+    type=click.Choice(
+        ("docker_cache", "docker_volume", "generated_cache", "runner_service", "runner_workdir")
+    ),
     help="Privileged host scope allowed by local policy. Repeat for each scope.",
 )
 @click.option(
@@ -1496,7 +1567,12 @@ def runner_host_hygiene_adapter_boundary_plan(
     default="prune_docker_cache",
     show_default=True,
     type=click.Choice(
-        ("prune_docker_cache", "prune_dangling_images", "remove_buildkit_state_volumes")
+        (
+            "prune_docker_cache",
+            "prune_dangling_images",
+            "prune_generated_run_cache",
+            "remove_buildkit_state_volumes",
+        )
     ),
     help="Approved runner host hygiene executor action.",
 )
@@ -1589,6 +1665,20 @@ def runner_host_hygiene_adapter_boundary_plan(
     help="Approved runner root formatted as public-key=/absolute/path. Repeat as needed.",
 )
 @click.option(
+    "--generated-run-cache-root",
+    "generated_run_cache_roots",
+    multiple=True,
+    help=(
+        "Approved generated run cache formatted as "
+        "public-key=/absolute/path|owner/repo|high|low|min-age-hours|cooldown-hours."
+    ),
+)
+@click.option(
+    "--target-generated-cache-key",
+    default="",
+    help="Exact public generated-cache key selected for bounded completed-run cleanup.",
+)
+@click.option(
     "--idle-observation-count",
     default=2,
     show_default=True,
@@ -1627,6 +1717,12 @@ def runner_host_hygiene_adapter_boundary_plan(
     help="Environment variable containing a GitHub OIDC bearer token.",
 )
 @click.option(
+    "--github-token-env",
+    default="GH_TOKEN",
+    show_default=True,
+    help="Environment variable containing the GitHub token used for run-state evidence.",
+)
+@click.option(
     "--audit-spool-root",
     required=True,
     type=click.Path(path_type=Path, file_okay=False, dir_okay=True),
@@ -1656,12 +1752,15 @@ def runner_host_hygiene_executor(
     minimum_free_disk_bytes: int,
     prune_until: str,
     runner_workdir_roots: tuple[str, ...],
+    generated_run_cache_roots: tuple[str, ...],
+    target_generated_cache_key: str,
     idle_observation_count: int,
     idle_observation_interval_seconds: int,
     resolve_action_started: bool,
     timeout_seconds: int,
     service_url: str,
     bearer_token_env: str,
+    github_token_env: str,
     audit_spool_root: Path,
     audit_artifact_file: Path,
 ) -> None:
@@ -1669,6 +1768,19 @@ def runner_host_hygiene_executor(
         token_env = bearer_token_env.strip()
         if not token_env:
             raise click.ClickException("runner host hygiene executor requires --bearer-token-env.")
+        parsed_generated_run_cache_roots = _parse_generated_run_cache_roots(
+            generated_run_cache_roots
+        )
+        github_token_env_name = github_token_env.strip()
+        if parsed_generated_run_cache_roots and not github_token_env_name:
+            raise click.ClickException(
+                "runner host hygiene generated cache evidence requires --github-token-env."
+            )
+        github_token = (
+            os.environ.get(github_token_env_name, "").strip()
+            if parsed_generated_run_cache_roots
+            else ""
+        )
         request = RunnerHostHygieneExecutorRequest(
             action=apply_action,
             host_name=host_name,
@@ -1687,6 +1799,8 @@ def runner_host_hygiene_executor(
             timeout_seconds=timeout_seconds,
             prune_until=prune_until,
             runner_workdir_roots=_parse_runner_workdir_roots(runner_workdir_roots),
+            generated_run_cache_roots=parsed_generated_run_cache_roots,
+            target_generated_cache_key=target_generated_cache_key,
             idle_observation_count=idle_observation_count,
             idle_observation_interval_seconds=idle_observation_interval_seconds,
             resolve_action_started=resolve_action_started,
@@ -1706,13 +1820,18 @@ def runner_host_hygiene_executor(
                 root=audit_spool_root,
                 artifact_file=audit_artifact_file,
             ),
+            github_run_state_reader=(
+                build_github_run_state_reader(bearer_token=github_token)
+                if parsed_generated_run_cache_roots
+                else None
+            ),
         )
     except (OSError, ValidationError, ValueError) as error:
         raise click.ClickException(str(error)) from error
     click.echo(json.dumps(result.model_dump(mode="json"), indent=2, sort_keys=True))
     if result.audit_delivery_pending:
         raise click.ClickException("runner host hygiene audit delivery remains pending")
-    if mutate and result.status != "completed":
+    if mutate and result.status not in {"completed", "not_needed"}:
         raise click.ClickException(
             f"runner host hygiene mutation did not complete: {result.status}"
         )
@@ -1725,6 +1844,42 @@ def _parse_runner_workdir_roots(values: tuple[str, ...]) -> tuple[RunnerWorkdirR
         if not separator:
             raise click.ClickException("runner workdir roots must use public-key=/absolute/path")
         roots.append(RunnerWorkdirRoot(key=key, path=path))
+    return tuple(roots)
+
+
+def _parse_generated_run_cache_roots(
+    values: tuple[str, ...],
+) -> tuple[GeneratedRunCacheRoot, ...]:
+    roots: list[GeneratedRunCacheRoot] = []
+    for value in values:
+        parts = value.split("|")
+        if len(parts) != 6:
+            raise click.ClickException(
+                "generated run cache roots must use "
+                "public-key=/absolute/path|owner/repo|high|low|min-age-hours|cooldown-hours"
+            )
+        binding, source_repository, high_water, low_water, minimum_age, cooldown = parts
+        key, separator, path = binding.partition("=")
+        if not separator:
+            raise click.ClickException(
+                "generated run cache roots must use public-key=/absolute/path"
+            )
+        try:
+            roots.append(
+                GeneratedRunCacheRoot(
+                    key=key,
+                    path=path,
+                    source_repository=source_repository,
+                    high_water_bytes=int(high_water),
+                    low_water_bytes=int(low_water),
+                    minimum_age_hours=int(minimum_age),
+                    cooldown_hours=int(cooldown),
+                )
+            )
+        except ValueError as error:
+            raise click.ClickException(
+                "generated run cache budget and age fields must be integers"
+            ) from error
     return tuple(roots)
 
 

--- a/control_plane/config_authority_audit.py
+++ b/control_plane/config_authority_audit.py
@@ -1250,7 +1250,10 @@ WORKFLOW_THIN_CONNECTOR_PATH_VALUES = {
         )
     },
     ".github/workflows/runner-host-hygiene.yml": {
-        "RUNNER_REPOSITORY_SCOPE": frozenset(("${{ github.repository }}",))
+        "GH_TOKEN": frozenset(
+            ("${{ secrets.LAUNCHPLANE_RUNNER_HOST_HYGIENE_GITHUB_READ_TOKEN }}",)
+        ),
+        "RUNNER_REPOSITORY_SCOPE": frozenset(("${{ github.repository }}",)),
     },
     ".github/workflows/runner-lane-registration.yml": {
         "GH_TOKEN": frozenset(("${{ secrets.LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN }}",))

--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -11,6 +11,7 @@ RunnerHostHygieneStatus = Literal["healthy", "attention"]
 RunnerHostHygieneApplyAction = Literal[
     "prune_docker_cache",
     "prune_dangling_images",
+    "prune_generated_run_cache",
     "remove_buildkit_state_volumes",
     "prune_runner_workdir",
     "restart_runner_service",
@@ -45,12 +46,28 @@ RunnerHostHygieneApplyBlockerCode = Literal[
     "target_volume_not_requested",
     "target_builder_budget_missing",
     "target_builder_not_allowlisted",
+    "target_generated_cache_below_high_water",
+    "target_generated_cache_budget_invalid",
+    "target_generated_cache_cooldown_active",
+    "target_generated_cache_key_missing",
+    "target_generated_cache_missing_from_report",
+    "target_generated_cache_not_allowlisted",
+    "target_generated_cache_owner_busy",
+    "target_generated_cache_run_active",
+    "target_generated_cache_run_missing",
+    "target_generated_cache_run_not_idle",
+    "target_generated_cache_run_too_recent",
+    "target_generated_cache_runs_missing",
+    "target_generated_cache_safety_failed",
     "retained_warm_builder_missing_from_report",
     "warm_builder_not_retained",
 ]
 RunnerHostHygieneFindingCode = Literal[
     "docker_reclaimable_above_limit",
     "free_disk_below_minimum",
+    "generated_cache_above_limit",
+    "generated_cache_measurement_partial",
+    "generated_cache_safety_failed",
     "orphan_buildkit_present",
     "required_warm_builder_missing",
     "runner_workdir_above_limit",
@@ -59,6 +76,7 @@ RunnerHostHygieneFindingCode = Literal[
 RunnerHostHygienePrivilegedScope = Literal[
     "docker_cache",
     "docker_volume",
+    "generated_cache",
     "runner_service",
     "runner_workdir",
 ]
@@ -82,6 +100,21 @@ RunnerHostHygieneAdapterBoundaryBlockerCode = Literal[
 ]
 
 
+class RunnerHostHygieneGeneratedCacheBudget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cache_key: str
+    high_water_bytes: int = Field(ge=1)
+
+    @model_validator(mode="after")
+    def _normalize_budget(self) -> "RunnerHostHygieneGeneratedCacheBudget":
+        self.cache_key = _required_public_token(
+            self.cache_key,
+            "runner host hygiene generated cache budget requires cache_key",
+        )
+        return self
+
+
 class RunnerHostHygienePolicy(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -89,12 +122,20 @@ class RunnerHostHygienePolicy(BaseModel):
     minimum_free_disk_bytes: int = Field(default=0, ge=0)
     maximum_docker_reclaimable_bytes: int | None = Field(default=None, ge=0)
     maximum_runner_workdir_bytes: int | None = Field(default=None, ge=0)
+    generated_cache_budgets: tuple[RunnerHostHygieneGeneratedCacheBudget, ...] = ()
     required_warm_builders: tuple[str, ...] = ()
     allow_orphan_buildkit: bool = False
 
     @model_validator(mode="after")
     def _normalize_policy(self) -> "RunnerHostHygienePolicy":
         self.required_warm_builders = _normalized_tokens(self.required_warm_builders)
+        self.generated_cache_budgets = tuple(
+            sorted(self.generated_cache_budgets, key=lambda item: item.cache_key)
+        )
+        if len({item.cache_key for item in self.generated_cache_budgets}) != len(
+            self.generated_cache_budgets
+        ):
+            raise ValueError("runner host hygiene generated cache budgets must be unique")
         return self
 
 
@@ -133,6 +174,72 @@ class RunnerHostHygieneRunnerWorkdirUsage(BaseModel):
         return self
 
 
+class RunnerHostHygieneGeneratedCacheAgeBucket(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    bucket: Literal["under_1h", "1h_to_24h", "1d_to_7d", "7d_to_30d", "30d_or_more"]
+    entry_count: int = Field(default=0, ge=0)
+    apparent_bytes: int = Field(default=0, ge=0)
+    allocated_bytes: int = Field(default=0, ge=0)
+
+
+class RunnerHostHygieneGeneratedCacheEntry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: int = Field(ge=1)
+    apparent_bytes: int = Field(default=0, ge=0)
+    allocated_bytes: int = Field(default=0, ge=0)
+    age_seconds: int = Field(default=0, ge=0)
+    open_handle_observations: tuple[int, ...] = ()
+    github_run_state: Literal["completed", "active", "unknown"] = "unknown"
+
+    @model_validator(mode="after")
+    def _normalize_entry(self) -> "RunnerHostHygieneGeneratedCacheEntry":
+        if any(value < 0 for value in self.open_handle_observations):
+            raise ValueError("generated cache open-handle observations cannot be negative")
+        return self
+
+
+class RunnerHostHygieneGeneratedCacheUsage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cache_key: str
+    apparent_bytes: int = Field(default=0, ge=0)
+    allocated_bytes: int = Field(default=0, ge=0)
+    entry_count: int = Field(default=0, ge=0)
+    measurement_status: Literal["complete", "partial"] = "complete"
+    owner_valid: bool = False
+    mode_valid: bool = False
+    symlink_safe: bool = False
+    owner_worker_observations: tuple[int, ...] = ()
+    age_buckets: tuple[RunnerHostHygieneGeneratedCacheAgeBucket, ...] = ()
+    entries: tuple[RunnerHostHygieneGeneratedCacheEntry, ...] = ()
+    entries_truncated: bool = False
+    last_cleanup_epoch_seconds: int = Field(default=0, ge=0)
+    last_reclaimed_bytes: int = Field(default=0, ge=0)
+    last_post_cleanup_allocated_bytes: int = Field(default=0, ge=0)
+    last_removed_run_ids: tuple[int, ...] = ()
+    estimated_daily_growth_bytes: int = Field(default=0, ge=0)
+    cooldown_remaining_seconds: int = Field(default=0, ge=0)
+
+    @model_validator(mode="after")
+    def _normalize_usage(self) -> "RunnerHostHygieneGeneratedCacheUsage":
+        self.cache_key = _required_public_token(
+            self.cache_key,
+            "runner host hygiene generated cache usage requires cache_key",
+        )
+        if any(value < 0 for value in self.owner_worker_observations):
+            raise ValueError("generated cache worker observations cannot be negative")
+        self.age_buckets = tuple(sorted(self.age_buckets, key=lambda item: item.bucket))
+        self.entries = tuple(sorted(self.entries, key=lambda item: item.run_id))
+        self.last_removed_run_ids = tuple(sorted(set(self.last_removed_run_ids)))
+        if any(run_id <= 0 for run_id in self.last_removed_run_ids):
+            raise ValueError("generated cache cleanup history run ids must be positive")
+        if self.entry_count < len(self.entries):
+            raise ValueError("generated cache entry_count cannot be smaller than entries")
+        return self
+
+
 class RunnerHostHygieneObservation(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -146,6 +253,9 @@ class RunnerHostHygieneObservation(BaseModel):
     runner_workdir_bytes: int = Field(default=0, ge=0)
     runner_workdir_allocated_bytes: int = Field(default=0, ge=0)
     runner_workdir_usage: tuple[RunnerHostHygieneRunnerWorkdirUsage, ...] = ()
+    generated_cache_apparent_bytes: int = Field(default=0, ge=0)
+    generated_cache_allocated_bytes: int = Field(default=0, ge=0)
+    generated_cache_usage: tuple[RunnerHostHygieneGeneratedCacheUsage, ...] = ()
     docker_toolchain: "RunnerHostDockerToolchainObservation | None" = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple["RunnerHostHygieneImageInventoryItem", ...] = ()
@@ -165,6 +275,9 @@ class RunnerHostHygieneObservation(BaseModel):
         self.warm_builders = _normalized_tokens(self.warm_builders)
         self.runner_workdir_usage = tuple(
             sorted(self.runner_workdir_usage, key=lambda item: item.root_key)
+        )
+        self.generated_cache_usage = tuple(
+            sorted(self.generated_cache_usage, key=lambda item: item.cache_key)
         )
         self.image_inventory = _sorted_image_inventory(self.image_inventory)
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
@@ -281,6 +394,9 @@ class RunnerHostHygieneReport(BaseModel):
     runner_workdir_bytes: int = Field(default=0, ge=0)
     runner_workdir_allocated_bytes: int = Field(default=0, ge=0)
     runner_workdir_usage: tuple[RunnerHostHygieneRunnerWorkdirUsage, ...] = ()
+    generated_cache_apparent_bytes: int = Field(default=0, ge=0)
+    generated_cache_allocated_bytes: int = Field(default=0, ge=0)
+    generated_cache_usage: tuple[RunnerHostHygieneGeneratedCacheUsage, ...] = ()
     docker_toolchain: RunnerHostDockerToolchainObservation | None = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple[RunnerHostHygieneImageInventoryItem, ...] = ()
@@ -299,6 +415,9 @@ class RunnerHostHygieneReport(BaseModel):
         self.warm_builders = _normalized_tokens(self.warm_builders)
         self.runner_workdir_usage = tuple(
             sorted(self.runner_workdir_usage, key=lambda item: item.root_key)
+        )
+        self.generated_cache_usage = tuple(
+            sorted(self.generated_cache_usage, key=lambda item: item.cache_key)
         )
         self.image_inventory = _sorted_image_inventory(self.image_inventory)
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
@@ -322,6 +441,8 @@ class RunnerHostHygieneApplyPolicy(BaseModel):
     require_audit_record: bool = True
     allow_docker_cache_prune: bool = False
     allow_dangling_image_prune: bool = False
+    allow_generated_run_cache_prune: bool = False
+    allowed_generated_cache_keys: tuple[str, ...] = ()
     allowed_buildkit_builders: tuple[str, ...] = ()
     allow_buildkit_state_volume_remove: bool = False
     allowed_buildkit_state_volumes: tuple[str, ...] = ()
@@ -336,6 +457,17 @@ class RunnerHostHygieneApplyPolicy(BaseModel):
         )
         self.allowed_buildkit_builders = _normalized_buildkit_builder_names(
             self.allowed_buildkit_builders
+        )
+        self.allowed_generated_cache_keys = tuple(
+            sorted(
+                {
+                    _required_public_token(
+                        value,
+                        "runner host hygiene allowed generated cache key must be public-safe",
+                    )
+                    for value in self.allowed_generated_cache_keys
+                }
+            )
         )
         self.allowed_buildkit_state_volumes = _normalized_volume_names(
             self.allowed_buildkit_state_volumes
@@ -354,6 +486,12 @@ class RunnerHostHygieneApplyRequest(BaseModel):
     target_buildkit_builder: str = ""
     max_used_space_bytes: int = Field(default=0, ge=0)
     target_buildkit_state_volumes: tuple[str, ...] = ()
+    target_generated_cache_key: str = ""
+    target_generated_cache_run_ids: tuple[int, ...] = ()
+    generated_cache_minimum_age_hours: int = Field(default=0, ge=0)
+    generated_cache_high_water_bytes: int = Field(default=0, ge=0)
+    generated_cache_low_water_bytes: int = Field(default=0, ge=0)
+    generated_cache_cooldown_hours: int = Field(default=0, ge=0)
     audit_record_key: str = ""
 
     @model_validator(mode="after")
@@ -368,6 +506,12 @@ class RunnerHostHygieneApplyRequest(BaseModel):
         self.target_buildkit_state_volumes = _normalized_volume_name_entries(
             self.target_buildkit_state_volumes
         )
+        self.target_generated_cache_key = _normalized_public_token(self.target_generated_cache_key)
+        self.target_generated_cache_run_ids = tuple(
+            sorted(set(self.target_generated_cache_run_ids))
+        )
+        if any(run_id <= 0 for run_id in self.target_generated_cache_run_ids):
+            raise ValueError("generated cache run ids must be positive")
         self.audit_record_key = self.audit_record_key.strip()
         return self
 
@@ -744,6 +888,49 @@ def evaluate_runner_host_hygiene(
                 ),
             )
         )
+    generated_cache_budgets = {
+        item.cache_key: item.high_water_bytes for item in policy.generated_cache_budgets
+    }
+    over_budget_generated_caches = tuple(
+        item.cache_key
+        for item in observation.generated_cache_usage
+        if item.cache_key in generated_cache_budgets
+        and item.allocated_bytes > generated_cache_budgets[item.cache_key]
+    )
+    if over_budget_generated_caches:
+        findings.append(
+            _finding(
+                "generated_cache_above_limit",
+                "runner host generated caches exceed configured high-water limits: "
+                + ", ".join(over_budget_generated_caches),
+            )
+        )
+    partial_generated_caches = tuple(
+        item.cache_key
+        for item in observation.generated_cache_usage
+        if item.measurement_status == "partial"
+    )
+    if partial_generated_caches:
+        findings.append(
+            _finding(
+                "generated_cache_measurement_partial",
+                "runner host generated cache measurement was partial for keys: "
+                + ", ".join(partial_generated_caches),
+            )
+        )
+    unsafe_generated_caches = tuple(
+        item.cache_key
+        for item in observation.generated_cache_usage
+        if not item.owner_valid or not item.mode_valid or not item.symlink_safe
+    )
+    if unsafe_generated_caches:
+        findings.append(
+            _finding(
+                "generated_cache_safety_failed",
+                "runner host generated cache safety checks failed for keys: "
+                + ", ".join(unsafe_generated_caches),
+            )
+        )
     missing_builders = tuple(
         builder
         for builder in policy.required_warm_builders
@@ -780,6 +967,9 @@ def evaluate_runner_host_hygiene(
         runner_workdir_bytes=observation.runner_workdir_bytes,
         runner_workdir_allocated_bytes=observation.runner_workdir_allocated_bytes,
         runner_workdir_usage=observation.runner_workdir_usage,
+        generated_cache_apparent_bytes=observation.generated_cache_apparent_bytes,
+        generated_cache_allocated_bytes=observation.generated_cache_allocated_bytes,
+        generated_cache_usage=observation.generated_cache_usage,
         docker_toolchain=observation.docker_toolchain,
         warm_builders=observation.warm_builders,
         image_inventory=observation.image_inventory,
@@ -878,6 +1068,7 @@ def plan_runner_host_hygiene_apply(
         )
     blockers.extend(_target_volume_blockers(policy=policy, request=request, report=report))
     blockers.extend(_target_builder_blockers(policy=policy, request=request))
+    blockers.extend(_target_generated_cache_blockers(policy=policy, request=request, report=report))
 
     status: RunnerHostHygieneApplyPlanStatus = "blocked" if blockers else "ready"
     return RunnerHostHygieneApplyPlan(
@@ -1083,11 +1274,154 @@ def _apply_action_allowed(
         return policy.allow_docker_cache_prune
     if action == "prune_dangling_images":
         return policy.allow_dangling_image_prune
+    if action == "prune_generated_run_cache":
+        return policy.allow_generated_run_cache_prune
     if action == "remove_buildkit_state_volumes":
         return policy.allow_buildkit_state_volume_remove
     if action == "prune_runner_workdir":
         return policy.allow_runner_workdir_prune
     return policy.allow_runner_service_restart
+
+
+def _target_generated_cache_blockers(
+    *,
+    policy: RunnerHostHygieneApplyPolicy,
+    request: RunnerHostHygieneApplyRequest,
+    report: RunnerHostHygieneReport,
+) -> tuple[RunnerHostHygieneApplyBlocker, ...]:
+    if request.action != "prune_generated_run_cache":
+        return ()
+    blockers: list[RunnerHostHygieneApplyBlocker] = []
+    cache_key = request.target_generated_cache_key
+    if not cache_key:
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_key_missing",
+                "runner host generated cache cleanup requires a target cache key",
+            )
+        )
+        return tuple(blockers)
+    if cache_key not in policy.allowed_generated_cache_keys:
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_not_allowlisted",
+                f"runner host generated cache key is not allowlisted: {cache_key}",
+            )
+        )
+    cache_by_key = {item.cache_key: item for item in report.generated_cache_usage}
+    cache = cache_by_key.get(cache_key)
+    if cache is None:
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_missing_from_report",
+                f"runner host generated cache is missing from report: {cache_key}",
+            )
+        )
+        return tuple(blockers)
+    if (
+        request.generated_cache_high_water_bytes <= 0
+        or request.generated_cache_low_water_bytes >= request.generated_cache_high_water_bytes
+        or request.generated_cache_minimum_age_hours <= 0
+        or request.generated_cache_cooldown_hours <= 0
+    ):
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_budget_invalid",
+                "runner host generated cache cleanup requires positive age/high-water inputs "
+                "and a lower low-water target",
+            )
+        )
+    if cache.allocated_bytes <= request.generated_cache_high_water_bytes:
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_below_high_water",
+                (
+                    "runner host generated cache is not above its high-water limit: "
+                    f"{cache.allocated_bytes} <= {request.generated_cache_high_water_bytes}"
+                ),
+            )
+        )
+    if cache.cooldown_remaining_seconds > 0:
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_cooldown_active",
+                (
+                    "runner host generated cache cleanup cooldown remains active for "
+                    f"{cache.cooldown_remaining_seconds} seconds"
+                ),
+            )
+        )
+    if cache.measurement_status != "complete" or not (
+        cache.owner_valid and cache.mode_valid and cache.symlink_safe
+    ):
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_safety_failed",
+                f"runner host generated cache safety evidence is incomplete: {cache_key}",
+            )
+        )
+    if len(cache.owner_worker_observations) < 2 or any(
+        value > 0 for value in cache.owner_worker_observations
+    ):
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_owner_busy",
+                (
+                    "runner host generated cache owner lacks two idle worker observations: "
+                    f"{cache_key}"
+                ),
+            )
+        )
+    if not request.target_generated_cache_run_ids:
+        blockers.append(
+            _apply_blocker(
+                "target_generated_cache_runs_missing",
+                "runner host generated cache cleanup requires completed run targets",
+            )
+        )
+        return tuple(blockers)
+    entries_by_run_id = {item.run_id: item for item in cache.entries}
+    minimum_age_seconds = request.generated_cache_minimum_age_hours * 3600
+    for run_id in request.target_generated_cache_run_ids:
+        entry = entries_by_run_id.get(run_id)
+        if entry is None:
+            blockers.append(
+                _apply_blocker(
+                    "target_generated_cache_run_missing",
+                    f"runner host generated cache run is missing from report: {run_id}",
+                )
+            )
+            continue
+        if entry.github_run_state != "completed":
+            blockers.append(
+                _apply_blocker(
+                    "target_generated_cache_run_active",
+                    (
+                        "runner host generated cache run is not proven completed: "
+                        f"{run_id} state={entry.github_run_state}"
+                    ),
+                )
+            )
+        if entry.age_seconds < minimum_age_seconds:
+            blockers.append(
+                _apply_blocker(
+                    "target_generated_cache_run_too_recent",
+                    (
+                        "runner host generated cache run is newer than the configured age: "
+                        f"{run_id} age_seconds={entry.age_seconds}"
+                    ),
+                )
+            )
+        if len(entry.open_handle_observations) < 2 or any(
+            value > 0 for value in entry.open_handle_observations
+        ):
+            blockers.append(
+                _apply_blocker(
+                    "target_generated_cache_run_not_idle",
+                    f"runner host generated cache run lacks two zero-handle observations: {run_id}",
+                )
+            )
+    return tuple(blockers)
 
 
 def _target_builder_blockers(
@@ -1208,6 +1542,12 @@ def _apply_next_steps(
             "prune only dangling Docker images older than the approved age",
             "capture post-apply host hygiene evidence and write the audit record",
         )
+    if action == "prune_generated_run_cache":
+        return (
+            "capture completed-run, ownership, symlink, and open-handle evidence",
+            "remove only exact allowlisted completed-run cache directories above high water",
+            "capture post-apply generated cache evidence and write the audit record",
+        )
     return (
         "capture pre-apply host hygiene evidence",
         "prune Docker cache without removing retained warm builders",
@@ -1247,6 +1587,8 @@ def _required_privileged_scope(
         return "docker_cache"
     if action == "remove_buildkit_state_volumes":
         return "docker_volume"
+    if action == "prune_generated_run_cache":
+        return "generated_cache"
     if action == "prune_runner_workdir":
         return "runner_workdir"
     return "runner_service"
@@ -1315,6 +1657,17 @@ def _normalized_values(values: tuple[str, ...], normalize: Callable[[str], str])
 
 def _normalized_token(value: str) -> str:
     return value.strip().lower()
+
+
+def _normalized_public_token(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized and not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", normalized):
+        raise ValueError("value must be a public-safe token")
+    return normalized
+
+
+def _required_public_token(value: str, message: str) -> str:
+    return _required_text(_normalized_public_token(value), message)
 
 
 def _normalized_volume_name(value: str) -> str:

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -12,7 +12,7 @@ import re
 import socket
 import subprocess
 import time
-from typing import Literal
+from typing import Literal, cast
 from urllib.error import HTTPError
 from urllib.error import URLError
 from urllib.parse import quote
@@ -35,6 +35,10 @@ from control_plane.contracts.runner_host_hygiene import (
     RunnerHostHygieneDockerReclaimableBreakdown,
 )
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneImageInventoryItem
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheAgeBucket
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheBudget
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheEntry
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheUsage
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneObservation
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
@@ -55,6 +59,7 @@ MINIMUM_DEFAULT_CACHE_KEEP_STORAGE_BYTES = 8 * 1024**3
 HOST_LOCK_PATH = "/tmp/launchplane-runner-host-hygiene.lock"
 _BUILDCTL_STORAGE_MB_BYTES = 1_000_000
 _RUNNER_WORKDIR_USAGE_HELPER = "/usr/local/sbin/launchplane-runner-workdir-usage"
+_GENERATED_RUN_CACHE_HELPER = "/usr/local/sbin/launchplane-generated-run-cache"
 _DOCKER_DISK_USAGE_COMMAND = (
     "curl",
     "--silent",
@@ -121,12 +126,24 @@ RemoteCommandRunner = Callable[[Sequence[str], int], RemoteCommandResult]
 AuditPoster = Callable[[RunnerHostHygieneApplyAuditRecord, str], dict[str, object]]
 BearerTokenProvider = Callable[[], str]
 AuditDeliverySleeper = Callable[[float], None]
+GitHubRunStateReader = Callable[[str, tuple[int, ...]], Mapping[int, str]]
 
 
 @dataclass(frozen=True)
 class RunnerWorkdirRoot:
     key: str
     path: str
+
+
+@dataclass(frozen=True)
+class GeneratedRunCacheRoot:
+    key: str
+    path: str
+    source_repository: str
+    high_water_bytes: int
+    low_water_bytes: int
+    minimum_age_hours: int
+    cooldown_hours: int
 
 
 class AuditDeliveryError(click.ClickException):
@@ -151,6 +168,9 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
     timeout_seconds: int = Field(default=120, ge=1)
     prune_until: str = DEFAULT_PRUNE_UNTIL
     runner_workdir_roots: tuple[RunnerWorkdirRoot, ...] = ()
+    generated_run_cache_roots: tuple[GeneratedRunCacheRoot, ...] = ()
+    target_generated_cache_key: str = ""
+    target_generated_cache_run_ids: tuple[int, ...] = ()
     idle_observation_count: int = Field(default=2, ge=2, le=10)
     idle_observation_interval_seconds: int = Field(default=5, ge=0, le=60)
     resolve_action_started: bool = False
@@ -165,11 +185,13 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
         if self.action not in {
             "prune_docker_cache",
             "prune_dangling_images",
+            "prune_generated_run_cache",
             "remove_buildkit_state_volumes",
         }:
             raise ValueError(
                 "runner host hygiene executor only supports prune_docker_cache "
-                "prune_dangling_images, and remove_buildkit_state_volumes"
+                "prune_dangling_images, prune_generated_run_cache, and "
+                "remove_buildkit_state_volumes"
             )
         (
             self.host_name,
@@ -211,6 +233,62 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
             seen_root_paths.add(path)
             normalized_roots.append(RunnerWorkdirRoot(key=key, path=path))
         self.runner_workdir_roots = tuple(sorted(normalized_roots, key=lambda item: item.key))
+        normalized_generated_roots: list[GeneratedRunCacheRoot] = []
+        seen_generated_keys: set[str] = set()
+        seen_generated_paths: set[str] = set()
+        for generated_root in self.generated_run_cache_roots:
+            key = generated_root.key.strip().lower()
+            path = generated_root.path.strip().rstrip("/")
+            source_repository = generated_root.source_repository.strip().lower()
+            if not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", key):
+                raise ValueError("generated run cache key must be a public-safe token")
+            if (
+                not path
+                or not path.startswith("/")
+                or "/../" in f"{path}/"
+                or re.search(r"\s", path)
+                or posixpath.normpath(path) != path
+            ):
+                raise ValueError("generated run cache path must be a scoped absolute path")
+            if not re.fullmatch(r"[a-z0-9_.-]+/[a-z0-9_.-]+", source_repository):
+                raise ValueError("generated run cache repository must use owner/name")
+            if (
+                generated_root.high_water_bytes <= 0
+                or generated_root.low_water_bytes >= generated_root.high_water_bytes
+            ):
+                raise ValueError("generated run cache requires positive high water above low water")
+            if generated_root.minimum_age_hours <= 0:
+                raise ValueError("generated run cache minimum age must be positive hours")
+            if generated_root.cooldown_hours <= 0:
+                raise ValueError("generated run cache cooldown must be positive hours")
+            if key in seen_generated_keys or path in seen_generated_paths:
+                raise ValueError("generated run cache roots must be unique")
+            seen_generated_keys.add(key)
+            seen_generated_paths.add(path)
+            normalized_generated_roots.append(
+                GeneratedRunCacheRoot(
+                    key=key,
+                    path=path,
+                    source_repository=source_repository,
+                    high_water_bytes=generated_root.high_water_bytes,
+                    low_water_bytes=generated_root.low_water_bytes,
+                    minimum_age_hours=generated_root.minimum_age_hours,
+                    cooldown_hours=generated_root.cooldown_hours,
+                )
+            )
+        self.generated_run_cache_roots = tuple(
+            sorted(normalized_generated_roots, key=lambda item: item.key)
+        )
+        self.target_generated_cache_key = self.target_generated_cache_key.strip().lower()
+        if self.target_generated_cache_key and not re.fullmatch(
+            r"[a-z0-9][a-z0-9._-]{0,63}", self.target_generated_cache_key
+        ):
+            raise ValueError("target generated cache key must be a public-safe token")
+        self.target_generated_cache_run_ids = tuple(
+            sorted(set(self.target_generated_cache_run_ids))
+        )
+        if any(run_id <= 0 for run_id in self.target_generated_cache_run_ids):
+            raise ValueError("target generated cache run ids must be positive")
         self.target_buildkit_builder = self.target_buildkit_builder.strip().lower()
         if self.target_buildkit_builder and not re.fullmatch(
             r"[a-z0-9][a-z0-9._-]{0,127}", self.target_buildkit_builder
@@ -252,6 +330,10 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
             raise ValueError("Docker cache and image prune requests cannot include target volumes")
         if self.action != "remove_buildkit_state_volumes" and self.allowed_buildkit_state_volumes:
             raise ValueError("Docker cache and image prune requests cannot include allowed volumes")
+        if self.action != "prune_generated_run_cache" and self.target_generated_cache_key:
+            raise ValueError("non-generated-cache requests cannot include a generated cache key")
+        if self.action != "prune_generated_run_cache" and self.target_generated_cache_run_ids:
+            raise ValueError("non-generated-cache requests cannot include generated cache run ids")
         if self.action == "prune_dangling_images" and (
             self.target_buildkit_builder
             or self.allowed_buildkit_builders
@@ -264,6 +346,21 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
             or self.max_used_space_bytes
         ):
             raise ValueError("BuildKit volume removal requests cannot include builder cache inputs")
+        if self.action == "prune_generated_run_cache" and (
+            self.target_buildkit_builder
+            or self.allowed_buildkit_builders
+            or self.max_used_space_bytes
+            or self.target_buildkit_state_volumes
+            or self.allowed_buildkit_state_volumes
+        ):
+            raise ValueError("generated cache requests cannot include Docker mutation targets")
+        if self.action == "prune_generated_run_cache":
+            if not self.target_generated_cache_key:
+                raise ValueError("generated cache requests require a target cache key")
+            if self.target_generated_cache_key not in {
+                root.key for root in self.generated_run_cache_roots
+            }:
+                raise ValueError("target generated cache key is not configured")
         if (
             not self.target_buildkit_builder
             and self.max_used_space_bytes
@@ -323,7 +420,12 @@ def execute_runner_host_hygiene_executor(
     audit_poster: AuditPoster,
     audit_spool: RunnerHostHygieneAuditSpool | None = None,
     audit_delivery_sleeper: AuditDeliverySleeper = time.sleep,
+    github_run_state_reader: GitHubRunStateReader | None = None,
 ) -> RunnerHostHygieneExecutorResult:
+    if request.action == "prune_generated_run_cache" and request.mutate and audit_spool is None:
+        raise click.ClickException(
+            "generated run cache mutation requires durable host-local audit delivery state"
+        )
     if audit_spool is not None:
         reconciliation_result = _reconcile_audit_spool(
             request=request,
@@ -331,6 +433,7 @@ def execute_runner_host_hygiene_executor(
             audit_spool=audit_spool,
             audit_poster=audit_poster,
             audit_delivery_sleeper=audit_delivery_sleeper,
+            github_run_state_reader=github_run_state_reader,
         )
         if reconciliation_result is not None:
             return reconciliation_result
@@ -338,27 +441,56 @@ def execute_runner_host_hygiene_executor(
     pre_report = collect_runner_host_hygiene_report(
         request=request,
         remote_runner=remote_runner,
+        github_run_state_reader=github_run_state_reader,
     )
+    selected_generated_run_ids = _select_generated_cache_run_ids(
+        request=request,
+        report=pre_report,
+    )
+    action_request = request.model_copy(
+        update={"target_generated_cache_run_ids": selected_generated_run_ids}
+    )
+    target_generated_cache = _target_generated_run_cache_root(action_request)
     apply_request = RunnerHostHygieneApplyRequest(
-        action=request.action,
-        host_name=request.host_name,
-        mutate=request.mutate,
-        retained_warm_builders=request.retained_warm_builders,
-        target_buildkit_builder=request.target_buildkit_builder,
-        max_used_space_bytes=request.max_used_space_bytes,
-        target_buildkit_state_volumes=request.target_buildkit_state_volumes,
-        audit_record_key=request.audit_record_key,
+        action=action_request.action,
+        host_name=action_request.host_name,
+        mutate=action_request.mutate,
+        retained_warm_builders=action_request.retained_warm_builders,
+        target_buildkit_builder=action_request.target_buildkit_builder,
+        max_used_space_bytes=action_request.max_used_space_bytes,
+        target_buildkit_state_volumes=action_request.target_buildkit_state_volumes,
+        target_generated_cache_key=action_request.target_generated_cache_key,
+        target_generated_cache_run_ids=action_request.target_generated_cache_run_ids,
+        generated_cache_minimum_age_hours=(
+            target_generated_cache.minimum_age_hours if target_generated_cache else 0
+        ),
+        generated_cache_high_water_bytes=(
+            target_generated_cache.high_water_bytes if target_generated_cache else 0
+        ),
+        generated_cache_low_water_bytes=(
+            target_generated_cache.low_water_bytes if target_generated_cache else 0
+        ),
+        generated_cache_cooldown_hours=(
+            target_generated_cache.cooldown_hours if target_generated_cache else 0
+        ),
+        audit_record_key=action_request.audit_record_key,
     )
     apply_plan = plan_runner_host_hygiene_apply(
         policy=RunnerHostHygieneApplyPolicy(
-            approved_hosts=(request.host_name,),
-            required_retained_warm_builders=request.retained_warm_builders,
+            approved_hosts=(action_request.host_name,),
+            required_retained_warm_builders=action_request.retained_warm_builders,
             require_healthy_report=False,
-            allow_docker_cache_prune=request.action == "prune_docker_cache",
-            allow_dangling_image_prune=request.action == "prune_dangling_images",
-            allowed_buildkit_builders=request.allowed_buildkit_builders,
-            allow_buildkit_state_volume_remove=(request.action == "remove_buildkit_state_volumes"),
-            allowed_buildkit_state_volumes=request.allowed_buildkit_state_volumes,
+            allow_docker_cache_prune=action_request.action == "prune_docker_cache",
+            allow_dangling_image_prune=action_request.action == "prune_dangling_images",
+            allow_generated_run_cache_prune=(action_request.action == "prune_generated_run_cache"),
+            allowed_generated_cache_keys=tuple(
+                root.key for root in action_request.generated_run_cache_roots
+            ),
+            allowed_buildkit_builders=action_request.allowed_buildkit_builders,
+            allow_buildkit_state_volume_remove=(
+                action_request.action == "remove_buildkit_state_volumes"
+            ),
+            allowed_buildkit_state_volumes=action_request.allowed_buildkit_state_volumes,
         ),
         request=apply_request,
         report=pre_report,
@@ -371,6 +503,7 @@ def execute_runner_host_hygiene_executor(
         pre_apply_report=pre_report,
         message="planned runner host hygiene apply; no host mutation was executed yet",
     )
+    _assert_generated_cache_audit_redacted(audit=planned_audit, request=action_request)
     planned_idempotency_key = f"runner-host-hygiene:{request.audit_record_key}:planned"
     audit_envelope: RunnerHostHygieneAuditDeliveryEnvelope | None = None
     if audit_spool is None:
@@ -387,6 +520,24 @@ def execute_runner_host_hygiene_executor(
             audit_delivery_sleeper=audit_delivery_sleeper,
         )
         planned_response = delivery_responses.get("planned", {})
+        if (
+            action_request.action == "prune_generated_run_cache"
+            and apply_plan.status == "ready"
+            and audit_envelope.planned_delivery_state != "delivered"
+        ):
+            audit_envelope = audit_spool.write(
+                audit_envelope.model_copy(update={"execution_state": "blocked"})
+            )
+            return RunnerHostHygieneExecutorResult(
+                status="blocked",
+                audit_record_key=request.audit_record_key,
+                planned_response=planned_response,
+                audit_delivery_pending=True,
+                message=(
+                    "generated run cache mutation requires accepted planned audit delivery; "
+                    "host mutation was not executed"
+                ),
+            )
         if (
             apply_plan.status == "ready"
             and audit_envelope.planned_delivery_state == "pending"
@@ -406,6 +557,7 @@ def execute_runner_host_hygiene_executor(
                 ),
             )
     if apply_plan.status != "ready":
+        generated_cache_not_needed = _generated_cache_apply_not_needed(apply_plan)
         audit_delivery_pending = (
             audit_envelope is not None and audit_envelope.planned_delivery_state != "delivered"
         )
@@ -414,26 +566,33 @@ def execute_runner_host_hygiene_executor(
                 audit_envelope.model_copy(update={"execution_state": "blocked"})
             )
         return RunnerHostHygieneExecutorResult(
-            status="blocked",
+            status="not_needed" if generated_cache_not_needed else "blocked",
             audit_record_key=request.audit_record_key,
             planned_response=planned_response,
             audit_delivery_pending=audit_delivery_pending,
             message=(
                 f"{apply_plan.summary}; planned audit delivery remains pending"
                 if audit_delivery_pending
-                else apply_plan.summary
+                else (
+                    "runner host generated cache cleanup is not needed under current policy"
+                    if generated_cache_not_needed
+                    else apply_plan.summary
+                )
             ),
         )
 
-    idle_result = _check_host_idle(
-        request=request,
-        remote_runner=remote_runner,
-        sleeper=audit_delivery_sleeper,
-    )
+    idle_result = None
+    if action_request.action != "prune_generated_run_cache":
+        idle_result = _check_host_idle(
+            request=action_request,
+            remote_runner=remote_runner,
+            sleeper=audit_delivery_sleeper,
+        )
     if idle_result is not None:
         post_report = _collect_terminal_report(
-            request=request,
+            request=action_request,
             remote_runner=remote_runner,
+            github_run_state_reader=github_run_state_reader,
         )
         terminal_message = (
             f"runner host hygiene apply blocked by active runner or build processes: {idle_result}"
@@ -448,6 +607,7 @@ def execute_runner_host_hygiene_executor(
             status="failed",
             message=terminal_message,
         )
+        _assert_generated_cache_audit_redacted(audit=terminal_audit, request=action_request)
         terminal_response, audit_delivery_pending = _deliver_terminal_audit(
             terminal_audit=terminal_audit,
             audit_envelope=audit_envelope,
@@ -468,28 +628,29 @@ def execute_runner_host_hygiene_executor(
         audit_envelope = audit_spool.write(
             audit_envelope.model_copy(update={"execution_state": "action_started"})
         )
-    action_result = _execute_apply_action(request=request, remote_runner=remote_runner)
+    action_result = _execute_apply_action(request=action_request, remote_runner=remote_runner)
     post_report = _collect_terminal_report(
-        request=request,
+        request=action_request,
         remote_runner=remote_runner,
+        github_run_state_reader=github_run_state_reader,
     )
     if post_report is None:
         terminal_status: RunnerHostHygieneApplyAuditStatus = "failed"
         action_outcome = "succeeded" if action_result.returncode == 0 else "failed"
         terminal_message = (
-            f"runner host hygiene {request.action} {action_outcome}; "
+            f"runner host hygiene {action_request.action} {action_outcome}; "
             "terminal evidence collection failed"
         )
     else:
         post_evidence_failure = _post_apply_evidence_failure(
-            request=request,
+            request=action_request,
             post_report=post_report,
         )
         terminal_status = (
             "completed" if action_result.returncode == 0 and not post_evidence_failure else "failed"
         )
         terminal_message = _terminal_message(
-            action=request.action,
+            action=action_request.action,
             action_result=action_result,
             post_report=post_report,
             post_evidence_failure=post_evidence_failure,
@@ -502,6 +663,7 @@ def execute_runner_host_hygiene_executor(
         status=terminal_status,
         message=terminal_message,
     )
+    _assert_generated_cache_audit_redacted(audit=terminal_audit, request=action_request)
     terminal_response, audit_delivery_pending = _deliver_terminal_audit(
         terminal_audit=terminal_audit,
         audit_envelope=audit_envelope,
@@ -526,6 +688,7 @@ def _reconcile_audit_spool(
     audit_spool: RunnerHostHygieneAuditSpool,
     audit_poster: AuditPoster,
     audit_delivery_sleeper: AuditDeliverySleeper,
+    github_run_state_reader: GitHubRunStateReader | None,
 ) -> RunnerHostHygieneExecutorResult | None:
     for original_envelope in audit_spool.list_for(
         host_name=request.host_name,
@@ -563,6 +726,7 @@ def _reconcile_audit_spool(
             post_report = _collect_terminal_report(
                 request=request,
                 remote_runner=remote_runner,
+                github_run_state_reader=github_run_state_reader,
             )
             if post_report is None:
                 terminal_message = (
@@ -582,6 +746,7 @@ def _reconcile_audit_spool(
                 status="failed",
                 message=terminal_message,
             )
+            _assert_generated_cache_audit_redacted(audit=terminal_audit, request=request)
             terminal_response, delivery_pending = _deliver_terminal_audit(
                 terminal_audit=terminal_audit,
                 audit_envelope=envelope,
@@ -618,6 +783,20 @@ def _reconcile_audit_spool(
                 message="runner host hygiene request was already recorded as blocked",
             )
     return None
+
+
+def _generated_cache_apply_not_needed(apply_plan: RunnerHostHygieneApplyPlan) -> bool:
+    if apply_plan.action != "prune_generated_run_cache" or not apply_plan.mutate:
+        return False
+    blocker_codes = {blocker.code for blocker in apply_plan.blockers}
+    benign_codes = {
+        "target_generated_cache_below_high_water",
+        "target_generated_cache_cooldown_active",
+        "target_generated_cache_runs_missing",
+    }
+    return "target_generated_cache_below_high_water" in blocker_codes and blocker_codes.issubset(
+        benign_codes
+    )
 
 
 def _deliver_terminal_audit(
@@ -717,6 +896,29 @@ def _post_audit_with_retry(
 def _execute_apply_action(
     *, request: RunnerHostHygieneExecutorRequest, remote_runner: RemoteCommandRunner
 ) -> RemoteCommandResult:
+    if request.action == "prune_generated_run_cache":
+        root = _target_generated_run_cache_root(request)
+        if root is None or not request.target_generated_cache_run_ids:
+            return RemoteCommandResult(
+                returncode=1,
+                stderr="generated cache action lacks an exact configured target",
+            )
+        return remote_runner(
+            (
+                "flock",
+                "-n",
+                HOST_LOCK_PATH,
+                "/usr/bin/sudo",
+                "-n",
+                _GENERATED_RUN_CACHE_HELPER,
+                "prune",
+                f"{root.key}={root.path}",
+                str(request.idle_observation_count),
+                str(request.idle_observation_interval_seconds),
+                ",".join(str(run_id) for run_id in request.target_generated_cache_run_ids),
+            ),
+            request.timeout_seconds,
+        )
     if request.action == "remove_buildkit_state_volumes":
         target_volume = request.target_buildkit_state_volumes[0]
         return remote_runner(
@@ -801,10 +1003,7 @@ def _execute_apply_action(
             json.dumps({"until": [request.prune_until]}, separators=(",", ":")),
             safe="",
         )
-        prune_url = (
-            "http://localhost/v1.45/build/prune?all=true&filters="
-            f"{prune_filters}"
-        )
+        prune_url = f"http://localhost/v1.45/build/prune?all=true&filters={prune_filters}"
     return remote_runner(
         (
             "flock",
@@ -828,6 +1027,7 @@ def collect_runner_host_hygiene_report(
     *,
     request: RunnerHostHygieneExecutorRequest,
     remote_runner: RemoteCommandRunner,
+    github_run_state_reader: GitHubRunStateReader | None = None,
 ) -> RunnerHostHygieneReport:
     df_result = _require_remote_success(
         remote_runner(("df", "-B1", "-P", "/"), request.timeout_seconds),
@@ -859,6 +1059,11 @@ def collect_runner_host_hygiene_report(
         request=request,
         remote_runner=remote_runner,
     )
+    generated_cache_usage = _collect_generated_run_cache_usage(
+        request=request,
+        remote_runner=remote_runner,
+        github_run_state_reader=github_run_state_reader,
+    )
     observation = RunnerHostHygieneObservation(
         host_name=request.host_name,
         observed_at=utc_now_timestamp(),
@@ -868,6 +1073,9 @@ def collect_runner_host_hygiene_report(
         runner_workdir_bytes=sum(item.apparent_bytes for item in runner_workdir_usage),
         runner_workdir_allocated_bytes=sum(item.allocated_bytes for item in runner_workdir_usage),
         runner_workdir_usage=runner_workdir_usage,
+        generated_cache_apparent_bytes=sum(item.apparent_bytes for item in generated_cache_usage),
+        generated_cache_allocated_bytes=sum(item.allocated_bytes for item in generated_cache_usage),
+        generated_cache_usage=generated_cache_usage,
         docker_toolchain=_collect_docker_toolchain(
             request=request,
             remote_runner=remote_runner,
@@ -887,6 +1095,13 @@ def collect_runner_host_hygiene_report(
     return evaluate_runner_host_hygiene(
         policy=RunnerHostHygienePolicy(
             minimum_free_disk_bytes=request.minimum_free_disk_bytes,
+            generated_cache_budgets=tuple(
+                RunnerHostHygieneGeneratedCacheBudget(
+                    cache_key=root.key,
+                    high_water_bytes=root.high_water_bytes,
+                )
+                for root in request.generated_run_cache_roots
+            ),
             required_warm_builders=request.retained_warm_builders,
         ),
         observation=observation,
@@ -951,6 +1166,10 @@ def validate_local_executor_environment(
             "Runner host hygiene executor host must match the approved host."
         )
     github_repository = resolved_env.get("GITHUB_REPOSITORY", "").strip()
+    if request.action == "prune_generated_run_cache" and request.mutate and not github_repository:
+        raise click.ClickException(
+            "Generated run cache mutation requires GITHUB_REPOSITORY scope evidence."
+        )
     if github_repository and github_repository != request.repository_scope:
         raise click.ClickException(
             "Runner host hygiene repository scope must match GITHUB_REPOSITORY."
@@ -965,6 +1184,50 @@ def build_service_audit_poster(*, service_url: str, bearer_token: str) -> AuditP
         service_url=service_url,
         bearer_token_provider=lambda: normalized_bearer_token,
     )
+
+
+def build_github_run_state_reader(
+    *,
+    bearer_token: str,
+    api_base_url: str = "https://api.github.com",
+) -> GitHubRunStateReader:
+    normalized_token = bearer_token.strip()
+    normalized_api_base_url = api_base_url.strip().rstrip("/")
+    if not normalized_api_base_url:
+        raise click.ClickException("generated cache GitHub run evidence requires API base URL")
+
+    def read(repository: str, run_ids: tuple[int, ...]) -> Mapping[int, str]:
+        owner, name = repository.split("/", maxsplit=1)
+        states: dict[int, str] = {}
+        for run_id in run_ids:
+            headers = {
+                "Accept": "application/vnd.github+json",
+                "User-Agent": "launchplane-runner-host-hygiene",
+                "X-GitHub-Api-Version": "2022-11-28",
+            }
+            if normalized_token:
+                headers["Authorization"] = f"Bearer {normalized_token}"
+            request = Request(
+                (
+                    f"{normalized_api_base_url}/repos/{quote(owner, safe='')}"
+                    f"/{quote(name, safe='')}/actions/runs/{run_id}"
+                ),
+                headers=headers,
+                method="GET",
+            )
+            try:
+                with urlopen(request, timeout=30) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+            except (HTTPError, URLError, TimeoutError, socket.timeout, json.JSONDecodeError):
+                states[run_id] = "unknown"
+                continue
+            if not isinstance(payload, dict):
+                states[run_id] = "unknown"
+                continue
+            states[run_id] = "completed" if payload.get("status") == "completed" else "active"
+        return states
+
+    return read
 
 
 def build_refreshing_service_audit_poster(
@@ -1329,6 +1592,350 @@ def _collect_runner_workdir_usage(
     return tuple(usage)
 
 
+def _collect_generated_run_cache_usage(
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+    github_run_state_reader: GitHubRunStateReader | None,
+) -> tuple[RunnerHostHygieneGeneratedCacheUsage, ...]:
+    usage: list[RunnerHostHygieneGeneratedCacheUsage] = []
+    effective_github_run_state_reader = (
+        github_run_state_reader
+        if request.action == "prune_generated_run_cache" or not request.mutate
+        else None
+    )
+    for root in request.generated_run_cache_roots:
+        result = remote_runner(
+            (
+                "/usr/bin/sudo",
+                "-n",
+                _GENERATED_RUN_CACHE_HELPER,
+                "observe",
+                f"{root.key}={root.path}",
+                str(request.idle_observation_count),
+                str(request.idle_observation_interval_seconds),
+            ),
+            request.timeout_seconds,
+        )
+        if result.returncode != 0:
+            usage.append(
+                RunnerHostHygieneGeneratedCacheUsage(
+                    cache_key=root.key,
+                    measurement_status="partial",
+                )
+            )
+            continue
+        try:
+            usage.append(
+                _parse_generated_run_cache_usage(
+                    output=result.stdout,
+                    root=root,
+                    github_run_state_reader=effective_github_run_state_reader,
+                )
+            )
+        except (click.ClickException, ValueError):
+            usage.append(
+                RunnerHostHygieneGeneratedCacheUsage(
+                    cache_key=root.key,
+                    measurement_status="partial",
+                )
+            )
+    return tuple(usage)
+
+
+def _parse_generated_run_cache_usage(
+    *,
+    output: str,
+    root: GeneratedRunCacheRoot,
+    github_run_state_reader: GitHubRunStateReader | None,
+) -> RunnerHostHygieneGeneratedCacheUsage:
+    rows = _parse_json_lines(output, evidence_name=f"generated_cache:{root.key}")
+    summary_rows = tuple(row for row in rows if row.get("record_type") == "summary")
+    entry_rows = tuple(row for row in rows if row.get("record_type") == "entry")
+    if len(summary_rows) != 1:
+        raise click.ClickException("runner host generated cache evidence requires one summary")
+    summary = summary_rows[0]
+    if _docker_json_text(summary, "cache_key") != root.key:
+        raise click.ClickException("runner host generated cache evidence key mismatch")
+    configured_policy = (
+        ("minimum_age_hours", root.minimum_age_hours),
+        ("high_water_bytes", root.high_water_bytes),
+        ("low_water_bytes", root.low_water_bytes),
+        ("cooldown_hours", root.cooldown_hours),
+    )
+    for field_name, expected_value in configured_policy:
+        if (
+            _strict_non_negative_int(
+                summary.get(field_name),
+                evidence_name=f"generated cache {field_name}",
+            )
+            != expected_value
+        ):
+            raise click.ClickException(
+                f"runner host generated cache {field_name} does not match root-owned policy"
+            )
+    run_ids = tuple(
+        sorted(
+            {
+                _strict_positive_int(row.get("run_id"), evidence_name="generated cache run id")
+                for row in entry_rows
+            }
+        )
+    )
+    github_states = (
+        github_run_state_reader(root.source_repository, run_ids)
+        if github_run_state_reader is not None and run_ids
+        else {}
+    )
+    entries = tuple(
+        RunnerHostHygieneGeneratedCacheEntry(
+            run_id=_strict_positive_int(row.get("run_id"), evidence_name="generated cache run id"),
+            apparent_bytes=_strict_non_negative_int(
+                row.get("apparent_bytes"), evidence_name="generated cache apparent bytes"
+            ),
+            allocated_bytes=_strict_non_negative_int(
+                row.get("allocated_bytes"), evidence_name="generated cache allocated bytes"
+            ),
+            age_seconds=_strict_non_negative_int(
+                row.get("age_seconds"), evidence_name="generated cache age seconds"
+            ),
+            open_handle_observations=_strict_non_negative_int_tuple(
+                row.get("open_handle_observations"),
+                evidence_name="generated cache open-handle observations",
+            ),
+            github_run_state=_github_run_state(github_states.get(run_id)),
+        )
+        for row in entry_rows
+        for run_id in (
+            _strict_positive_int(row.get("run_id"), evidence_name="generated cache run id"),
+        )
+    )
+    observed_epoch_seconds = _strict_non_negative_int(
+        summary.get("observed_epoch_seconds"),
+        evidence_name="generated cache observed epoch",
+    )
+    last_cleanup_epoch_seconds = _strict_non_negative_int(
+        summary.get("last_cleanup_epoch_seconds", 0),
+        evidence_name="generated cache last cleanup epoch",
+    )
+    last_post_cleanup_allocated_bytes = _strict_non_negative_int(
+        summary.get("last_post_cleanup_allocated_bytes", 0),
+        evidence_name="generated cache last post-cleanup bytes",
+    )
+    allocated_bytes = _strict_non_negative_int(
+        summary.get("allocated_bytes"),
+        evidence_name="generated cache allocated bytes",
+    )
+    cooldown_remaining_seconds = max(
+        last_cleanup_epoch_seconds + root.cooldown_hours * 3600 - observed_epoch_seconds,
+        0,
+    )
+    elapsed_since_cleanup = max(observed_epoch_seconds - last_cleanup_epoch_seconds, 0)
+    estimated_daily_growth_bytes = 0
+    if (
+        last_cleanup_epoch_seconds > 0
+        and elapsed_since_cleanup > 0
+        and allocated_bytes > last_post_cleanup_allocated_bytes
+    ):
+        estimated_daily_growth_bytes = (
+            (allocated_bytes - last_post_cleanup_allocated_bytes) * 86_400 // elapsed_since_cleanup
+        )
+    return RunnerHostHygieneGeneratedCacheUsage(
+        cache_key=root.key,
+        apparent_bytes=_strict_non_negative_int(
+            summary.get("apparent_bytes"),
+            evidence_name="generated cache apparent bytes",
+        ),
+        allocated_bytes=allocated_bytes,
+        entry_count=_strict_non_negative_int(
+            summary.get("entry_count"), evidence_name="generated cache entry count"
+        ),
+        measurement_status=_generated_cache_measurement_status(summary.get("measurement_status")),
+        owner_valid=_strict_bool(summary.get("owner_valid"), evidence_name="owner_valid"),
+        mode_valid=_strict_bool(summary.get("mode_valid"), evidence_name="mode_valid"),
+        symlink_safe=_strict_bool(summary.get("symlink_safe"), evidence_name="symlink_safe"),
+        owner_worker_observations=_strict_non_negative_int_tuple(
+            summary.get("owner_worker_observations"),
+            evidence_name="generated cache owner-worker observations",
+        ),
+        age_buckets=_generated_cache_age_buckets(entries),
+        entries=entries,
+        entries_truncated=_strict_bool(
+            summary.get("entries_truncated"), evidence_name="entries_truncated"
+        ),
+        last_cleanup_epoch_seconds=last_cleanup_epoch_seconds,
+        last_reclaimed_bytes=_strict_non_negative_int(
+            summary.get("last_reclaimed_bytes", 0),
+            evidence_name="generated cache last reclaimed bytes",
+        ),
+        last_post_cleanup_allocated_bytes=last_post_cleanup_allocated_bytes,
+        last_removed_run_ids=_strict_non_negative_int_tuple(
+            summary.get("last_removed_run_ids"),
+            evidence_name="generated cache last removed run ids",
+        ),
+        estimated_daily_growth_bytes=estimated_daily_growth_bytes,
+        cooldown_remaining_seconds=cooldown_remaining_seconds,
+    )
+
+
+def _generated_cache_age_buckets(
+    entries: tuple[RunnerHostHygieneGeneratedCacheEntry, ...],
+) -> tuple[RunnerHostHygieneGeneratedCacheAgeBucket, ...]:
+    bucket_names = (
+        "under_1h",
+        "1h_to_24h",
+        "1d_to_7d",
+        "7d_to_30d",
+        "30d_or_more",
+    )
+    bucket_values: dict[str, list[int]] = {name: [0, 0, 0] for name in bucket_names}
+    for entry in entries:
+        if entry.age_seconds < 3600:
+            bucket = "under_1h"
+        elif entry.age_seconds < 86_400:
+            bucket = "1h_to_24h"
+        elif entry.age_seconds < 7 * 86_400:
+            bucket = "1d_to_7d"
+        elif entry.age_seconds < 30 * 86_400:
+            bucket = "7d_to_30d"
+        else:
+            bucket = "30d_or_more"
+        bucket_values[bucket][0] += 1
+        bucket_values[bucket][1] += entry.apparent_bytes
+        bucket_values[bucket][2] += entry.allocated_bytes
+    return tuple(
+        RunnerHostHygieneGeneratedCacheAgeBucket(
+            bucket=cast(
+                Literal[
+                    "under_1h",
+                    "1h_to_24h",
+                    "1d_to_7d",
+                    "7d_to_30d",
+                    "30d_or_more",
+                ],
+                bucket_name,
+            ),
+            entry_count=bucket_values[bucket_name][0],
+            apparent_bytes=bucket_values[bucket_name][1],
+            allocated_bytes=bucket_values[bucket_name][2],
+        )
+        for bucket_name in bucket_names
+    )
+
+
+def _select_generated_cache_run_ids(
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    report: RunnerHostHygieneReport,
+) -> tuple[int, ...]:
+    if request.action != "prune_generated_run_cache":
+        return ()
+    root = _target_generated_run_cache_root(request)
+    if root is None:
+        return ()
+    usage = next(
+        (
+            item
+            for item in report.generated_cache_usage
+            if item.cache_key == request.target_generated_cache_key
+        ),
+        None,
+    )
+    if (
+        usage is None
+        or usage.allocated_bytes <= root.high_water_bytes
+        or usage.cooldown_remaining_seconds > 0
+        or usage.measurement_status != "complete"
+        or usage.entries_truncated
+        or not (usage.owner_valid and usage.mode_valid and usage.symlink_safe)
+        or len(usage.owner_worker_observations) < request.idle_observation_count
+        or any(value > 0 for value in usage.owner_worker_observations)
+    ):
+        return ()
+    projected_allocated_bytes = usage.allocated_bytes
+    selected: list[int] = []
+    for entry in sorted(usage.entries, key=lambda item: (-item.age_seconds, item.run_id)):
+        if projected_allocated_bytes <= root.low_water_bytes:
+            break
+        if (
+            entry.github_run_state != "completed"
+            or entry.age_seconds < root.minimum_age_hours * 3600
+            or len(entry.open_handle_observations) < request.idle_observation_count
+            or any(value > 0 for value in entry.open_handle_observations)
+        ):
+            continue
+        selected.append(entry.run_id)
+        projected_allocated_bytes = max(
+            projected_allocated_bytes - entry.allocated_bytes,
+            0,
+        )
+    if projected_allocated_bytes > root.low_water_bytes:
+        return ()
+    return tuple(sorted(selected))
+
+
+def _target_generated_run_cache_root(
+    request: RunnerHostHygieneExecutorRequest,
+) -> GeneratedRunCacheRoot | None:
+    if not request.target_generated_cache_key:
+        return None
+    return next(
+        (
+            root
+            for root in request.generated_run_cache_roots
+            if root.key == request.target_generated_cache_key
+        ),
+        None,
+    )
+
+
+def _generated_cache_measurement_status(value: object) -> Literal["complete", "partial"]:
+    if value == "complete":
+        return "complete"
+    if value == "partial":
+        return "partial"
+    raise click.ClickException("runner host generated cache measurement status was invalid")
+
+
+def _github_run_state(value: object) -> Literal["completed", "active", "unknown"]:
+    if value == "completed":
+        return "completed"
+    if value == "active":
+        return "active"
+    return "unknown"
+
+
+def _strict_bool(value: object, *, evidence_name: str) -> bool:
+    if isinstance(value, bool):
+        return value
+    raise click.ClickException(f"runner host hygiene {evidence_name} evidence was not boolean")
+
+
+def _strict_positive_int(value: object, *, evidence_name: str) -> int:
+    parsed = _strict_non_negative_int(value, evidence_name=evidence_name)
+    if parsed <= 0:
+        raise click.ClickException(f"runner host hygiene {evidence_name} was not positive")
+    return parsed
+
+
+def _strict_non_negative_int(value: object, *, evidence_name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise click.ClickException(
+            f"runner host hygiene {evidence_name} evidence was not a non-negative integer"
+        )
+    return value
+
+
+def _strict_non_negative_int_tuple(
+    value: object,
+    *,
+    evidence_name: str,
+) -> tuple[int, ...]:
+    if not isinstance(value, list):
+        raise click.ClickException(f"runner host hygiene {evidence_name} was not a list")
+    return tuple(_strict_non_negative_int(item, evidence_name=evidence_name) for item in value)
+
+
 def _is_buildkit_state_volume_name(value: str) -> bool:
     return value.startswith("buildx_buildkit_") and value.endswith("_state")
 
@@ -1619,11 +2226,13 @@ def _collect_terminal_report(
     *,
     request: RunnerHostHygieneExecutorRequest,
     remote_runner: RemoteCommandRunner,
+    github_run_state_reader: GitHubRunStateReader | None,
 ) -> RunnerHostHygieneReport | None:
     try:
         return collect_runner_host_hygiene_report(
             request=request,
             remote_runner=remote_runner,
+            github_run_state_reader=github_run_state_reader,
         )
     except click.ClickException:
         return None
@@ -1645,6 +2254,25 @@ def _redact_sensitive_text(value: str) -> str:
     return redacted.strip()[:500]
 
 
+def _assert_generated_cache_audit_redacted(
+    *,
+    audit: RunnerHostHygieneApplyAuditRecord,
+    request: RunnerHostHygieneExecutorRequest,
+) -> None:
+    serialized_audit = json.dumps(audit.model_dump(mode="json"), sort_keys=True)
+    forbidden_values = {
+        value
+        for root in request.generated_run_cache_roots
+        for value in (root.path, root.source_repository)
+        if value
+    }
+    leaked_values = tuple(sorted(value for value in forbidden_values if value in serialized_audit))
+    if leaked_values:
+        raise click.ClickException(
+            "runner host generated cache audit contained forbidden runtime topology"
+        )
+
+
 def _terminal_message(
     *,
     action: RunnerHostHygieneApplyAction,
@@ -1655,6 +2283,7 @@ def _terminal_message(
     action_label = {
         "prune_docker_cache": "Docker cache prune",
         "prune_dangling_images": "dangling Docker image prune",
+        "prune_generated_run_cache": "generated completed-run cache prune",
         "remove_buildkit_state_volumes": "BuildKit state volume removal",
         "prune_runner_workdir": "runner workdir prune",
         "restart_runner_service": "runner service restart",
@@ -1693,4 +2322,34 @@ def _post_apply_evidence_failure(
         )
         if remaining_targets:
             return "target BuildKit state volumes remain present: " + ", ".join(remaining_targets)
+    if request.action == "prune_generated_run_cache":
+        root = _target_generated_run_cache_root(request)
+        if root is None:
+            return "target generated cache policy is missing from post evidence"
+        cache = next(
+            (
+                item
+                for item in post_report.generated_cache_usage
+                if item.cache_key == request.target_generated_cache_key
+            ),
+            None,
+        )
+        if cache is None:
+            return "target generated cache is missing from post evidence"
+        remaining_run_ids = {entry.run_id for entry in cache.entries}.intersection(
+            request.target_generated_cache_run_ids
+        )
+        if remaining_run_ids:
+            return "target generated cache runs remain present: " + ", ".join(
+                str(run_id) for run_id in sorted(remaining_run_ids)
+            )
+        if cache.allocated_bytes > root.low_water_bytes:
+            return (
+                "target generated cache remains above its low-water target: "
+                f"{cache.allocated_bytes} > {root.low_water_bytes}"
+            )
+        if cache.measurement_status != "complete" or not (
+            cache.owner_valid and cache.mode_valid and cache.symlink_safe
+        ):
+            return "target generated cache post evidence failed safety checks"
     return ""

--- a/docs/records.md
+++ b/docs/records.md
@@ -513,9 +513,13 @@ an ORM column/table or remains only in the evidence payload.
 - Runner host hygiene audit: modeled fields are `audit_record_key`,
   `host_name`, `action`, `status`, and `mutate`. The payload carries the typed
   request, plan, pre/post hygiene reports, retained warm-builder evidence, and
-  operator message. Docker toolchain evidence, host-command output, Docker
-  summaries, and rollout notes stay payload-only until they need queryable
-  operational views. The host-local audit-delivery envelope is a separate
+  operator message. Generated-cache public keys, apparent and allocated bytes,
+  age buckets, numeric run ids, GitHub completion state, bounded worker and
+  open-handle observations, cleanup history, and hysteresis/cooldown evidence
+  also stay payload-only. Absolute cache paths and source repository identity
+  are executor-local runtime authority and are not persisted in the audit.
+  Docker toolchain evidence, host-command output, Docker summaries, and rollout
+  notes stay payload-only until they need queryable operational views. The host-local audit-delivery envelope is a separate
   recovery record: it stores planned and optional terminal audit payloads,
   execution phase, delivery state, idempotency keys, bounded redacted errors,
   and attempt counts. It is written atomically under an explicit state

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -138,6 +138,9 @@ workflow artifact; bearer tokens and raw authorization headers are never part of
 the envelope. A permanently rejected planned audit (for example, authorization,
 route, or idempotency conflict) blocks mutation; a retryable transport/service
 failure may proceed only because the planned intent is already durable locally.
+Generated run-cache mutation is stricter: it requires both the durable host
+spool and accepted service delivery of the planned audit before the privileged
+helper can run. A pending or rejected planned record leaves that action blocked.
 
 ## Approved Ops-Lane Executor
 
@@ -154,8 +157,9 @@ be hidden by a later action failure.
 
 The report-only schedule generates an audit key under
 `runner-host-hygiene/<date>/<host>-scheduled-report-<run-id>`. Sunday maintenance
-uses separate keys for default cache, dangling images, and each runtime-approved
-Buildx builder. The workflow attempts every scheduled action even when an
+uses separate keys for default cache, dangling images, each runtime-approved
+Buildx builder, and each runtime-approved generated run cache. The workflow
+attempts every scheduled action even when an
 earlier action is blocked or fails, then fails the aggregate job after all
 per-action audits have been recorded. Default Docker cache uses an
 operator-configured LRU retained-space ceiling:
@@ -201,6 +205,19 @@ The separate `prune_dangling_images` action runs `docker image prune --force
 --filter until=168h`. It never supplies `-a` or `--all`, so tagged retained warm
 images remain outside that action.
 
+The `prune_generated_run_cache` action is narrower than runner work-directory
+cleanup. It addresses only top-level directories whose names match a
+root-owned configured run-cache prefix and numeric GitHub Actions run id. Before
+the planned audit becomes mutation authority, Launchplane records apparent and
+allocated bytes, age buckets, last cleanup and growth evidence, two local
+open-handle observations per run, two `Runner.Worker` counts for the configured
+owner, and the source repository's live GitHub run state. Cleanup remains
+blocked unless the exact run is completed, old enough, free of open handles,
+the owning user is idle in both samples, the class is above its high-water
+limit, and its cooldown has expired. The helper deletes only selected
+completed-run directories and records the lower post-cleanup size; it never
+touches sibling Cargo, Bazel disk, package, credential, or configuration roots.
+
 Launchplane's PostgreSQL integration job mounts `/var/lib/postgresql/data` as a
 bounded tmpfs. The official PostgreSQL image declares that path as a volume;
 overriding it keeps ephemeral test data out of durable anonymous Docker volumes
@@ -226,6 +243,12 @@ The workflow requires these repository variables:
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_RUNNER_WORKDIR_ROOTS`, as comma-separated
   public-key/absolute-path pairs such as `legacy=/srv/runners`. The keys appear
   in evidence; absolute paths remain executor-local runtime input.
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_GENERATED_RUN_CACHE_ROOTS`, as comma-separated
+  `key=/absolute/path|owner/repository|high-bytes|low-bytes|min-age-hours|cooldown-hours`
+  entries. Only the public key, run ids, and bounded measurements enter audit
+  evidence; the absolute path and repository identity remain executor-local
+  runtime authority. High water must be positive, low water must be smaller,
+  and minimum age must be at least one hour.
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_ALLOWED_BUILDKIT_STATE_VOLUMES` for any
   approved BuildKit state-volume retirement target. Leave it empty when no
   named volume cleanup has been reviewed.
@@ -240,6 +263,12 @@ The workflow requires these repository variables:
   executor rejects values below 8 GiB. Capacity remains runtime authority;
   production code contains no host-specific cache budget.
 
+Public source repositories need no GitHub credential for generated-cache run
+state. Private source repositories require the optional
+`LAUNCHPLANE_RUNNER_HOST_HYGIENE_GITHUB_READ_TOKEN` secret, scoped only to
+Actions-read access for the exact source repositories. Do not reuse runner
+registration or administration credentials for this evidence path.
+
 The executor fails closed unless the process user matches the requested service
 user, the GitHub repository matches the requested repository scope, retained
 warm builders are present in pre-apply evidence, the apply plan is ready, no
@@ -247,7 +276,11 @@ active Docker build client or another Actions `Runner.Worker` process is observe
 in two consecutive local samples. Manual mutations additionally require
 `mutate=true`. Monday-through-Saturday scheduled runs stop at the
 `mutate_not_requested` blocker, while the Sunday maintenance schedule supplies
-explicit mutation intent only for the bounded cache and dangling-image actions.
+explicit mutation intent for bounded Docker, dangling-image, named-builder, and
+generated completed-run cache actions. Shared Docker actions require full-host
+idle. Generated run-cache actions instead require two idle observations for the
+configured owning user plus two zero-handle observations for every exact target;
+unrelated users and lanes do not block that isolated cache class.
 Cache and image maintenance may proceed when the report has unrelated attention
 findings so cleanup can remediate pressure; host identity, warm-image retention,
 audit durability, exact builder allowlists, and the idle gate remain mandatory.
@@ -318,6 +351,53 @@ as an authoritative total. Do not grant generic passwordless
 errors, and the executor treats any denied or failed privileged measurement as
 incomplete evidence. A service-user-controlled helper, config directory,
 config file, or sudo environment invalidates this security boundary.
+
+Generated run-cache inventory and cleanup use the separate root-owned helper
+`/usr/local/sbin/launchplane-generated-run-cache`, installed only from
+`scripts/runner-host-hygiene-generated-run-cache.sh` in a reviewed merged
+revision. Its mode-`0600` config file is
+`/etc/launchplane/runner-host-hygiene-generated-caches`; each line binds the
+runtime public key and path to the expected owner, group, root mode, exact
+top-level directory prefix, minimum age, high water, low water, and cooldown:
+
+```text
+public-key=/srv/generated-cache|runner-user|runner-group|755|run-cache-|1|21474836480|4294967296|1
+```
+
+Install the helper and prepared binding file as root, then add only the two
+argument-bounded helper forms to the existing hygiene sudoers policy:
+
+```bash
+install -o root -g root -m 0755 \
+  scripts/runner-host-hygiene-generated-run-cache.sh \
+  /usr/local/sbin/launchplane-generated-run-cache
+install -o root -g root -m 0600 <prepared-generated-cache-bindings> \
+  /etc/launchplane/runner-host-hygiene-generated-caches
+```
+
+```sudoers
+Cmnd_Alias LAUNCHPLANE_GENERATED_CACHE_OBSERVE = /usr/local/sbin/launchplane-generated-run-cache ^observe [a-z0-9][a-z0-9._-]{0,63}=/[^[:space:]]+ ([2-9]|10) ([0-9]|[1-5][0-9]|60)$
+Cmnd_Alias LAUNCHPLANE_GENERATED_CACHE_PRUNE = /usr/local/sbin/launchplane-generated-run-cache ^prune [a-z0-9][a-z0-9._-]{0,63}=/[^[:space:]]+ ([2-9]|10) ([0-9]|[1-5][0-9]|60) [1-9][0-9]*(,[1-9][0-9]*)*$
+<service-user> ALL=(root) NOPASSWD: NOSETENV: LAUNCHPLANE_GENERATED_CACHE_OBSERVE, LAUNCHPLANE_GENERATED_CACHE_PRUNE
+```
+
+Validate the candidate and complete sudoers policy with `visudo -cf`. The
+helper independently revalidates the root-owned config and fixed retention
+policy, canonical root,
+owner/group/mode, top-level name shape, same-filesystem traversal, absence of
+symlinks, age floor, owner idle samples, and exact target open handles. It emits
+only public keys, numeric run ids, counts, sizes, ages, and booleans. Deleting
+completed run-scoped generated data has no byte-for-byte rollback; recovery is
+regeneration in a later run, while the durable `action_started` envelope
+prevents an uncertain action from being repeated automatically.
+
+The helper fails closed when mount discovery is unavailable or incomplete. A
+cleanup attempt that removes data but cannot reach the configured low-water
+target persists its reclaimed-byte and target receipt without advancing the
+successful-cleanup cooldown, so a corrected follow-up can run immediately.
+Grant the prune form only to the dedicated hygiene workflow service account;
+direct interactive helper invocation is unsupported because the workflow owns
+the accepted planned and terminal audit sequence.
 
 The executor excludes only its own ancestor `Runner.Worker` from the idle gate;
 any sibling worker still blocks a shared-host mutation. If a prior run stopped

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -17031,6 +17031,19 @@
               "target_volume_not_requested",
               "target_builder_budget_missing",
               "target_builder_not_allowlisted",
+              "target_generated_cache_below_high_water",
+              "target_generated_cache_budget_invalid",
+              "target_generated_cache_cooldown_active",
+              "target_generated_cache_key_missing",
+              "target_generated_cache_missing_from_report",
+              "target_generated_cache_not_allowlisted",
+              "target_generated_cache_owner_busy",
+              "target_generated_cache_run_active",
+              "target_generated_cache_run_missing",
+              "target_generated_cache_run_not_idle",
+              "target_generated_cache_run_too_recent",
+              "target_generated_cache_runs_missing",
+              "target_generated_cache_safety_failed",
               "retained_warm_builder_missing_from_report",
               "warm_builder_not_retained"
             ],
@@ -17056,6 +17069,7 @@
             "enum": [
               "prune_docker_cache",
               "prune_dangling_images",
+              "prune_generated_run_cache",
               "remove_buildkit_state_volumes",
               "prune_runner_workdir",
               "restart_runner_service"
@@ -17128,6 +17142,7 @@
             "enum": [
               "prune_docker_cache",
               "prune_dangling_images",
+              "prune_generated_run_cache",
               "remove_buildkit_state_volumes",
               "prune_runner_workdir",
               "restart_runner_service"
@@ -17139,6 +17154,30 @@
             "default": "",
             "title": "Audit Record Key",
             "type": "string"
+          },
+          "generated_cache_cooldown_hours": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Generated Cache Cooldown Hours",
+            "type": "integer"
+          },
+          "generated_cache_high_water_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Generated Cache High Water Bytes",
+            "type": "integer"
+          },
+          "generated_cache_low_water_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Generated Cache Low Water Bytes",
+            "type": "integer"
+          },
+          "generated_cache_minimum_age_hours": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Generated Cache Minimum Age Hours",
+            "type": "integer"
           },
           "host_name": {
             "title": "Host Name",
@@ -17180,6 +17219,19 @@
               "type": "string"
             },
             "title": "Target Buildkit State Volumes",
+            "type": "array"
+          },
+          "target_generated_cache_key": {
+            "default": "",
+            "title": "Target Generated Cache Key",
+            "type": "string"
+          },
+          "target_generated_cache_run_ids": {
+            "default": [],
+            "items": {
+              "type": "integer"
+            },
+            "title": "Target Generated Cache Run Ids",
             "type": "array"
           }
         },
@@ -17252,6 +17304,9 @@
             "enum": [
               "docker_reclaimable_above_limit",
               "free_disk_below_minimum",
+              "generated_cache_above_limit",
+              "generated_cache_measurement_partial",
+              "generated_cache_safety_failed",
               "orphan_buildkit_present",
               "required_warm_builder_missing",
               "runner_workdir_above_limit",
@@ -17270,6 +17325,219 @@
           "message"
         ],
         "title": "RunnerHostHygieneFinding",
+        "type": "object"
+      },
+      "RunnerHostHygieneGeneratedCacheAgeBucket": {
+        "additionalProperties": false,
+        "properties": {
+          "allocated_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Allocated Bytes",
+            "type": "integer"
+          },
+          "apparent_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Apparent Bytes",
+            "type": "integer"
+          },
+          "bucket": {
+            "enum": [
+              "under_1h",
+              "1h_to_24h",
+              "1d_to_7d",
+              "7d_to_30d",
+              "30d_or_more"
+            ],
+            "title": "Bucket",
+            "type": "string"
+          },
+          "entry_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Entry Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "bucket"
+        ],
+        "title": "RunnerHostHygieneGeneratedCacheAgeBucket",
+        "type": "object"
+      },
+      "RunnerHostHygieneGeneratedCacheEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "age_seconds": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Age Seconds",
+            "type": "integer"
+          },
+          "allocated_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Allocated Bytes",
+            "type": "integer"
+          },
+          "apparent_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Apparent Bytes",
+            "type": "integer"
+          },
+          "github_run_state": {
+            "default": "unknown",
+            "enum": [
+              "completed",
+              "active",
+              "unknown"
+            ],
+            "title": "Github Run State",
+            "type": "string"
+          },
+          "open_handle_observations": {
+            "default": [],
+            "items": {
+              "type": "integer"
+            },
+            "title": "Open Handle Observations",
+            "type": "array"
+          },
+          "run_id": {
+            "minimum": 1.0,
+            "title": "Run Id",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "run_id"
+        ],
+        "title": "RunnerHostHygieneGeneratedCacheEntry",
+        "type": "object"
+      },
+      "RunnerHostHygieneGeneratedCacheUsage": {
+        "additionalProperties": false,
+        "properties": {
+          "age_buckets": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneGeneratedCacheAgeBucket"
+            },
+            "title": "Age Buckets",
+            "type": "array"
+          },
+          "allocated_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Allocated Bytes",
+            "type": "integer"
+          },
+          "apparent_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Apparent Bytes",
+            "type": "integer"
+          },
+          "cache_key": {
+            "title": "Cache Key",
+            "type": "string"
+          },
+          "cooldown_remaining_seconds": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Cooldown Remaining Seconds",
+            "type": "integer"
+          },
+          "entries": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneGeneratedCacheEntry"
+            },
+            "title": "Entries",
+            "type": "array"
+          },
+          "entries_truncated": {
+            "default": false,
+            "title": "Entries Truncated",
+            "type": "boolean"
+          },
+          "entry_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Entry Count",
+            "type": "integer"
+          },
+          "estimated_daily_growth_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Estimated Daily Growth Bytes",
+            "type": "integer"
+          },
+          "last_cleanup_epoch_seconds": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Last Cleanup Epoch Seconds",
+            "type": "integer"
+          },
+          "last_post_cleanup_allocated_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Last Post Cleanup Allocated Bytes",
+            "type": "integer"
+          },
+          "last_reclaimed_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Last Reclaimed Bytes",
+            "type": "integer"
+          },
+          "last_removed_run_ids": {
+            "default": [],
+            "items": {
+              "type": "integer"
+            },
+            "title": "Last Removed Run Ids",
+            "type": "array"
+          },
+          "measurement_status": {
+            "default": "complete",
+            "enum": [
+              "complete",
+              "partial"
+            ],
+            "title": "Measurement Status",
+            "type": "string"
+          },
+          "mode_valid": {
+            "default": false,
+            "title": "Mode Valid",
+            "type": "boolean"
+          },
+          "owner_valid": {
+            "default": false,
+            "title": "Owner Valid",
+            "type": "boolean"
+          },
+          "owner_worker_observations": {
+            "default": [],
+            "items": {
+              "type": "integer"
+            },
+            "title": "Owner Worker Observations",
+            "type": "array"
+          },
+          "symlink_safe": {
+            "default": false,
+            "title": "Symlink Safe",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "cache_key"
+        ],
+        "title": "RunnerHostHygieneGeneratedCacheUsage",
         "type": "object"
       },
       "RunnerHostHygieneImageInventoryItem": {
@@ -17357,6 +17625,26 @@
             "minimum": 0.0,
             "title": "Free Disk Bytes",
             "type": "integer"
+          },
+          "generated_cache_allocated_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Generated Cache Allocated Bytes",
+            "type": "integer"
+          },
+          "generated_cache_apparent_bytes": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Generated Cache Apparent Bytes",
+            "type": "integer"
+          },
+          "generated_cache_usage": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneGeneratedCacheUsage"
+            },
+            "title": "Generated Cache Usage",
+            "type": "array"
           },
           "host_name": {
             "title": "Host Name",

--- a/scripts/runner-host-hygiene-generated-run-cache.sh
+++ b/scripts/runner-host-hygiene-generated-run-cache.sh
@@ -1,0 +1,547 @@
+#!/bin/bash
+set -euo pipefail
+
+export LC_ALL=C
+readonly config_directory="/etc/launchplane"
+readonly config_file="/etc/launchplane/runner-host-hygiene-generated-caches"
+readonly state_directory="/var/lib/launchplane/runner-host-hygiene-generated-cache"
+readonly maximum_reported_entries=128
+temporary_files=()
+
+exec 3>&2
+exec 2>/dev/null
+
+cleanup() {
+  local status=$?
+  local temporary_file
+  for temporary_file in "${temporary_files[@]}"; do
+    /usr/bin/rm -f -- "$temporary_file" >/dev/null 2>&1 || true
+  done
+  if ((status != 0)); then
+    /usr/bin/printf '%s\n' "generated run cache operation failed" >&3
+  fi
+  trap - EXIT
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+[[ $# -ge 2 ]]
+readonly operation="$1"
+readonly binding="$2"
+[[ "$operation" == "observe" || "$operation" == "prune" ]]
+[[ "$binding" =~ ^[a-z0-9][a-z0-9._-]{0,63}=/[^[:space:]]+$ ]]
+if [[ "$operation" == "observe" ]]; then
+  [[ $# -eq 4 ]]
+  readonly observation_count="$3"
+  readonly observation_interval_seconds="$4"
+else
+  [[ $# -eq 5 ]]
+  readonly observation_count="$3"
+  readonly observation_interval_seconds="$4"
+fi
+[[ "$observation_count" =~ ^([2-9]|10)$ ]]
+[[ "$observation_interval_seconds" =~ ^([0-9]|[1-5][0-9]|60)$ ]]
+
+readonly cache_key="${binding%%=*}"
+readonly root_path="${binding#*=}"
+[[ "$root_path" != "/" ]]
+[[ "$root_path" != *"/../"* ]]
+[[ "$root_path" != *"/.." ]]
+[[ -d "$config_directory" && ! -L "$config_directory" ]]
+
+read -r directory_owner directory_group directory_mode < <(
+  /usr/bin/stat -c '%U %G %a' "$config_directory"
+)
+[[ "$directory_owner" == "root" ]]
+[[ "$directory_group" == "root" ]]
+[[ "$directory_mode" == "700" ]]
+
+[[ -f "$config_file" && ! -L "$config_file" ]]
+exec 4<"$config_file"
+read -r config_owner config_group config_mode < <(
+  /usr/bin/stat -Lc '%U %G %a' /proc/self/fd/4
+)
+[[ "$config_owner" == "root" ]]
+[[ "$config_group" == "root" ]]
+[[ "$config_mode" == "600" ]]
+
+configured_binding=""
+expected_owner=""
+expected_group=""
+expected_mode=""
+entry_prefix=""
+minimum_age_hours=""
+high_water_bytes=""
+low_water_bytes=""
+cooldown_hours=""
+while IFS='|' read -r candidate_binding candidate_owner candidate_group candidate_mode candidate_prefix candidate_minimum_age candidate_high_water candidate_low_water candidate_cooldown; do
+  [[ -n "$candidate_binding" ]]
+  [[ "$candidate_binding" =~ ^[a-z0-9][a-z0-9._-]{0,63}=/[^[:space:]|]+$ ]]
+  [[ "$candidate_owner" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]]
+  [[ "$candidate_group" =~ ^[a-z_][a-z0-9_-]{0,31}$ ]]
+  [[ "$candidate_mode" =~ ^[0-7]{3,4}$ ]]
+  [[ "$candidate_prefix" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,95}-$ ]]
+  [[ "$candidate_minimum_age" =~ ^[1-9][0-9]*$ ]]
+  [[ "$candidate_high_water" =~ ^[1-9][0-9]*$ ]]
+  [[ "$candidate_low_water" =~ ^[0-9]+$ ]]
+  [[ "$candidate_cooldown" =~ ^[1-9][0-9]*$ ]]
+  ((candidate_low_water < candidate_high_water))
+  if [[ "$candidate_binding" == "$binding" ]]; then
+    [[ -z "$configured_binding" ]]
+    configured_binding="$candidate_binding"
+    expected_owner="$candidate_owner"
+    expected_group="$candidate_group"
+    expected_mode="$candidate_mode"
+    entry_prefix="$candidate_prefix"
+    minimum_age_hours="$candidate_minimum_age"
+    high_water_bytes="$candidate_high_water"
+    low_water_bytes="$candidate_low_water"
+    cooldown_hours="$candidate_cooldown"
+  fi
+done <&4
+[[ "$configured_binding" == "$binding" ]]
+[[ -d "$root_path" && ! -L "$root_path" ]]
+[[ "$(/usr/bin/realpath -e -- "$root_path")" == "$root_path" ]]
+
+expected_uid="$(/usr/bin/id -u "$expected_owner")"
+readonly expected_uid
+readonly state_file="${state_directory}/${cache_key}.state"
+
+last_cleanup_epoch_seconds=0
+last_reclaimed_bytes=0
+last_post_cleanup_allocated_bytes=0
+last_removed_run_ids=""
+read_state() {
+  if [[ ! -e "$state_file" ]]; then
+    return 0
+  fi
+  [[ -d "$state_directory" && ! -L "$state_directory" ]]
+  read -r state_directory_owner state_directory_group state_directory_mode < <(
+    /usr/bin/stat -c '%U %G %a' "$state_directory"
+  )
+  [[ "$state_directory_owner" == "root" ]]
+  [[ "$state_directory_group" == "root" ]]
+  [[ "$state_directory_mode" == "700" ]]
+  [[ -f "$state_file" && ! -L "$state_file" ]]
+  read -r state_owner state_group state_mode < <(
+    /usr/bin/stat -c '%U %G %a' "$state_file"
+  )
+  [[ "$state_owner" == "root" ]]
+  [[ "$state_group" == "root" ]]
+  [[ "$state_mode" == "600" ]]
+  local key value
+  while IFS='=' read -r key value; do
+    case "$key" in
+      last_cleanup_epoch_seconds)
+        [[ "$value" =~ ^[0-9]+$ ]]
+        last_cleanup_epoch_seconds="$value"
+        ;;
+      last_attempt_epoch_seconds)
+        [[ "$value" =~ ^[0-9]+$ ]]
+        ;;
+      last_reclaimed_bytes)
+        [[ "$value" =~ ^[0-9]+$ ]]
+        last_reclaimed_bytes="$value"
+        ;;
+      last_post_cleanup_allocated_bytes)
+        [[ "$value" =~ ^[0-9]+$ ]]
+        last_post_cleanup_allocated_bytes="$value"
+        ;;
+      last_removed_run_ids)
+        [[ -z "$value" || "$value" =~ ^[1-9][0-9]*(,[1-9][0-9]*)*$ ]]
+        last_removed_run_ids="$value"
+        ;;
+      *) return 1 ;;
+    esac
+  done <"$state_file"
+}
+read_state
+
+declare -A apparent_by_run=()
+declare -A allocated_by_run=()
+declare -A age_by_run=()
+declare -A handle_observations_by_run=()
+declare -A entry_names_by_run=()
+declare -A entry_identity_by_name=()
+declare -A entry_version_by_name=()
+declare -a worker_observations=()
+measurement_status="complete"
+owner_valid=true
+mode_valid=true
+symlink_safe=true
+observed_epoch_seconds=0
+entry_count=0
+total_apparent_bytes=0
+total_allocated_bytes=0
+entries_truncated=false
+
+measure_directory() {
+  local directory_path="$1"
+  local measurement_mode="$2"
+  local output status=0
+  if [[ "$measurement_mode" == "apparent" ]]; then
+    output="$(/usr/bin/du -s -b -x -- "$directory_path")" || status=$?
+  else
+    output="$(/usr/bin/du -s -B1 -x -- "$directory_path")" || status=$?
+  fi
+  if ((status != 0)); then
+    measurement_status="partial"
+    measured_bytes=0
+    return 0
+  fi
+  output="${output%%$'\t'*}"
+  [[ "$output" =~ ^[0-9]+$ ]]
+  measured_bytes="$output"
+}
+
+count_open_handles() {
+  declare -A sample_counts=()
+  local fd target relative top_name run_id
+  for fd in /proc/[0-9]*/fd/*; do
+    target="$(/usr/bin/readlink -- "$fd" 2>/dev/null || true)"
+    target="${target% (deleted)}"
+    [[ "$target" == "$root_path/"* ]] || continue
+    relative="${target#"$root_path/"}"
+    top_name="${relative%%/*}"
+    if [[ "$top_name" =~ ^${entry_prefix}([0-9]+)-[A-Za-z0-9._-]+$ ]]; then
+      run_id="${BASH_REMATCH[1]}"
+      sample_counts["$run_id"]=$(( ${sample_counts["$run_id"]:-0} + 1 ))
+    fi
+  done
+  for run_id in "${!apparent_by_run[@]}"; do
+    if [[ -n "${handle_observations_by_run["$run_id"]:-}" ]]; then
+      handle_observations_by_run["$run_id"]+=","
+    fi
+    handle_observations_by_run["$run_id"]+="${sample_counts["$run_id"]:-0}"
+  done
+}
+
+entry_has_mount_escape() {
+  local entry_path="$1"
+  local mount_output mount_target
+  if ! mount_output="$(/usr/bin/findmnt -rn -R -o TARGET --target "$entry_path")"; then
+    return 0
+  fi
+  while IFS= read -r mount_target; do
+    if [[ "$mount_target" == "$entry_path" || "$mount_target" == "$entry_path/"* ]]; then
+      return 0
+    fi
+  done <<<"$mount_output"
+  return 1
+}
+
+collect_inventory() {
+  local samples="$1"
+  local interval="$2"
+  apparent_by_run=()
+  allocated_by_run=()
+  age_by_run=()
+  handle_observations_by_run=()
+  entry_names_by_run=()
+  entry_identity_by_name=()
+  entry_version_by_name=()
+  worker_observations=()
+  measurement_status="complete"
+  owner_valid=true
+  mode_valid=true
+  symlink_safe=true
+  observed_epoch_seconds="$(/usr/bin/date +%s)"
+  entry_count=0
+  total_apparent_bytes=0
+  total_allocated_bytes=0
+  entries_truncated=false
+
+  read -r root_owner root_group root_mode < <(
+    /usr/bin/stat -c '%U %G %a' "$root_path"
+  )
+  [[ "$root_owner" == "$expected_owner" ]] || owner_valid=false
+  [[ "$root_group" == "$expected_group" ]] || owner_valid=false
+  [[ "$root_mode" == "$expected_mode" ]] || mode_valid=false
+  quarantine_path="$(
+    /usr/bin/find "$root_path" -xdev -mindepth 1 -maxdepth 1 -type d \
+      -name '.launchplane-generated-run-cache-prune-*' -print -quit
+  )"
+  if [[ -n "$quarantine_path" ]]; then
+    measurement_status="partial"
+  fi
+
+  local entry_path entry_name run_id apparent_bytes allocated_bytes modified_epoch age_seconds entry_identity entry_version
+  while IFS= read -r -d '' entry_path; do
+    entry_name="${entry_path##*/}"
+    [[ "$entry_name" =~ ^${entry_prefix}([0-9]+)-[A-Za-z0-9._-]+$ ]] || continue
+    run_id="${BASH_REMATCH[1]}"
+    read -r entry_owner entry_group entry_mode < <(
+      /usr/bin/stat -c '%U %G %a' "$entry_path"
+    )
+    [[ "$entry_owner" == "$expected_owner" ]] || owner_valid=false
+    [[ "$entry_group" == "$expected_group" ]] || owner_valid=false
+    if (( (8#$entry_mode & 0022) != 0 )); then
+      mode_valid=false
+    fi
+    symlink_path="$(/usr/bin/find "$entry_path" -xdev -type l -print -quit)"
+    if [[ -n "$symlink_path" ]] || entry_has_mount_escape "$entry_path"; then
+      symlink_safe=false
+    fi
+    measure_directory "$entry_path" apparent
+    apparent_bytes="$measured_bytes"
+    measure_directory "$entry_path" allocated
+    allocated_bytes="$measured_bytes"
+    modified_epoch="$(/usr/bin/stat -c '%Y' "$entry_path")"
+    [[ "$modified_epoch" =~ ^[0-9]+$ ]]
+    age_seconds=$((observed_epoch_seconds - modified_epoch))
+    if ((age_seconds < 0)); then
+      age_seconds=0
+    fi
+    apparent_by_run["$run_id"]=$(( ${apparent_by_run["$run_id"]:-0} + apparent_bytes ))
+    allocated_by_run["$run_id"]=$(( ${allocated_by_run["$run_id"]:-0} + allocated_bytes ))
+    if [[ -z "${age_by_run["$run_id"]:-}" ]] || ((age_seconds < age_by_run["$run_id"])); then
+      age_by_run["$run_id"]="$age_seconds"
+    fi
+    entry_identity="$(/usr/bin/stat -c '%d:%i' "$entry_path")"
+    entry_version="$(/usr/bin/stat -c '%Z' "$entry_path")"
+    [[ "$entry_identity" =~ ^[0-9]+:[0-9]+$ ]]
+    [[ "$entry_version" =~ ^[0-9]+$ ]]
+    entry_identity_by_name["$entry_name"]="$entry_identity"
+    entry_version_by_name["$entry_name"]="$entry_version"
+    if [[ -n "${entry_names_by_run["$run_id"]:-}" ]]; then
+      entry_names_by_run["$run_id"]+=","
+    fi
+    entry_names_by_run["$run_id"]+="$entry_name"
+    total_apparent_bytes=$((total_apparent_bytes + apparent_bytes))
+    total_allocated_bytes=$((total_allocated_bytes + allocated_bytes))
+  done < <(
+    /usr/bin/find "$root_path" -xdev -mindepth 1 -maxdepth 1 -type d \
+      -name "${entry_prefix}*" -print0
+  )
+  entry_count="${#apparent_by_run[@]}"
+
+  local sample_index worker_count
+  for ((sample_index = 0; sample_index < samples; sample_index += 1)); do
+    worker_count="$(
+      /usr/bin/ps -u "$expected_uid" -o args= \
+        | /usr/bin/grep -c '[R]unner.Worker' || true
+    )"
+    [[ "$worker_count" =~ ^[0-9]+$ ]]
+    worker_observations+=("$worker_count")
+    count_open_handles
+    if ((sample_index + 1 < samples)); then
+      /usr/bin/sleep "$interval"
+    fi
+  done
+}
+
+json_number_array() {
+  local joined="$1"
+  if [[ -z "$joined" ]]; then
+    /usr/bin/printf '[]'
+  else
+    /usr/bin/printf '[%s]' "$joined"
+  fi
+}
+
+emit_inventory() {
+  local sorted_file
+  sorted_file="$(/usr/bin/mktemp /tmp/launchplane-generated-cache.XXXXXX)"
+  temporary_files+=("$sorted_file")
+  local run_id
+  for run_id in "${!apparent_by_run[@]}"; do
+    /usr/bin/printf '%s\t%s\t%s\t%s\n' \
+      "$run_id" \
+      "${apparent_by_run["$run_id"]}" \
+      "${allocated_by_run["$run_id"]}" \
+      "${age_by_run["$run_id"]}" >>"$sorted_file"
+  done
+  /usr/bin/sort -t $'\t' -k4,4nr -k1,1n -o "$sorted_file" "$sorted_file"
+  if ((entry_count > maximum_reported_entries)); then
+    entries_truncated=true
+  fi
+  local worker_joined
+  worker_joined="$(IFS=,; /usr/bin/printf '%s' "${worker_observations[*]}")"
+  /usr/bin/printf '{"record_type":"summary","cache_key":"%s","observed_epoch_seconds":%s,"apparent_bytes":%s,"allocated_bytes":%s,"entry_count":%s,"measurement_status":"%s","owner_valid":%s,"mode_valid":%s,"symlink_safe":%s,"owner_worker_observations":' \
+    "$cache_key" \
+    "$observed_epoch_seconds" \
+    "$total_apparent_bytes" \
+    "$total_allocated_bytes" \
+    "$entry_count" \
+    "$measurement_status" \
+    "$owner_valid" \
+    "$mode_valid" \
+    "$symlink_safe"
+  json_number_array "$worker_joined"
+  /usr/bin/printf ',"entries_truncated":%s,"minimum_age_hours":%s,"high_water_bytes":%s,"low_water_bytes":%s,"cooldown_hours":%s,"last_cleanup_epoch_seconds":%s,"last_reclaimed_bytes":%s,"last_post_cleanup_allocated_bytes":%s,"last_removed_run_ids":' \
+    "$entries_truncated" \
+    "$minimum_age_hours" \
+    "$high_water_bytes" \
+    "$low_water_bytes" \
+    "$cooldown_hours" \
+    "$last_cleanup_epoch_seconds" \
+    "$last_reclaimed_bytes" \
+    "$last_post_cleanup_allocated_bytes"
+  json_number_array "$last_removed_run_ids"
+  /usr/bin/printf '}\n'
+  local emitted=0 apparent_bytes allocated_bytes age_seconds observations
+  while IFS=$'\t' read -r run_id apparent_bytes allocated_bytes age_seconds; do
+    ((emitted < maximum_reported_entries)) || break
+    observations="${handle_observations_by_run["$run_id"]:-}"
+    /usr/bin/printf '{"record_type":"entry","cache_key":"%s","run_id":%s,"apparent_bytes":%s,"allocated_bytes":%s,"age_seconds":%s,"open_handle_observations":' \
+      "$cache_key" \
+      "$run_id" \
+      "$apparent_bytes" \
+      "$allocated_bytes" \
+      "$age_seconds"
+    json_number_array "$observations"
+    /usr/bin/printf '}\n'
+    emitted=$((emitted + 1))
+  done <"$sorted_file"
+}
+
+write_state() {
+  local cleanup_epoch="$1"
+  local attempt_epoch="$2"
+  local reclaimed_bytes="$3"
+  local post_allocated_bytes="$4"
+  local removed_run_ids="$5"
+  /usr/bin/install -d -o root -g root -m 0700 "$state_directory"
+  [[ -d "$state_directory" && ! -L "$state_directory" ]]
+  read -r state_directory_owner state_directory_group state_directory_mode < <(
+    /usr/bin/stat -c '%U %G %a' "$state_directory"
+  )
+  [[ "$state_directory_owner" == "root" ]]
+  [[ "$state_directory_group" == "root" ]]
+  [[ "$state_directory_mode" == "700" ]]
+  local state_temporary
+  state_temporary="$(/usr/bin/mktemp "${state_directory}/.${cache_key}.XXXXXX")"
+  temporary_files+=("$state_temporary")
+  /usr/bin/printf 'last_cleanup_epoch_seconds=%s\nlast_attempt_epoch_seconds=%s\nlast_reclaimed_bytes=%s\nlast_post_cleanup_allocated_bytes=%s\nlast_removed_run_ids=%s\n' \
+    "$cleanup_epoch" \
+    "$attempt_epoch" \
+    "$reclaimed_bytes" \
+    "$post_allocated_bytes" \
+    "$removed_run_ids" >"$state_temporary"
+  /usr/bin/chown root:root "$state_temporary"
+  /usr/bin/chmod 0600 "$state_temporary"
+  /usr/bin/mv -f -- "$state_temporary" "$state_file"
+  /usr/bin/sync -f "$state_file"
+  /usr/bin/sync -f "$state_directory"
+}
+
+if [[ "$operation" == "observe" ]]; then
+  collect_inventory "$observation_count" "$observation_interval_seconds"
+  emit_inventory
+  exit 0
+fi
+
+readonly prune_observation_count="$3"
+readonly prune_observation_interval_seconds="$4"
+readonly requested_run_ids_csv="$5"
+[[ "$prune_observation_count" =~ ^([2-9]|10)$ ]]
+[[ "$prune_observation_interval_seconds" =~ ^([0-9]|[1-5][0-9]|60)$ ]]
+[[ "$requested_run_ids_csv" =~ ^[1-9][0-9]*(,[1-9][0-9]*)*$ ]]
+
+collect_inventory "$prune_observation_count" "$prune_observation_interval_seconds"
+[[ "$measurement_status" == "complete" ]]
+[[ "$owner_valid" == "true" ]]
+[[ "$mode_valid" == "true" ]]
+[[ "$symlink_safe" == "true" ]]
+[[ "$entries_truncated" == "false" ]]
+((total_allocated_bytes > high_water_bytes))
+for worker_count in "${worker_observations[@]}"; do
+  ((worker_count == 0))
+done
+if ((last_cleanup_epoch_seconds > 0)); then
+  ((observed_epoch_seconds >= last_cleanup_epoch_seconds + cooldown_hours * 3600))
+fi
+
+IFS=',' read -r -a requested_run_ids <<<"$requested_run_ids_csv"
+declare -A requested_seen=()
+for run_id in "${requested_run_ids[@]}"; do
+  [[ -z "${requested_seen["$run_id"]:-}" ]]
+  requested_seen["$run_id"]=1
+  [[ -n "${age_by_run["$run_id"]:-}" ]]
+  ((age_by_run["$run_id"] >= minimum_age_hours * 3600))
+  IFS=',' read -r -a handle_observations <<<"${handle_observations_by_run["$run_id"]}"
+  ((${#handle_observations[@]} == prune_observation_count))
+  for handle_count in "${handle_observations[@]}"; do
+    ((handle_count == 0))
+  done
+done
+
+readonly pre_prune_allocated_bytes="$total_allocated_bytes"
+worker_count="$(
+  /usr/bin/ps -u "$expected_uid" -o args= \
+    | /usr/bin/grep -c '[R]unner.Worker' || true
+)"
+[[ "$worker_count" =~ ^[0-9]+$ ]]
+((worker_count == 0))
+count_open_handles
+for run_id in "${requested_run_ids[@]}"; do
+  IFS=',' read -r -a handle_observations <<<"${handle_observations_by_run["$run_id"]}"
+  ((${#handle_observations[@]} == prune_observation_count + 1))
+  ((${handle_observations[-1]} == 0))
+done
+
+quarantine_directory="$(
+  /usr/bin/mktemp -d "${root_path}/.launchplane-generated-run-cache-prune.XXXXXX"
+)"
+/usr/bin/chown root:root "$quarantine_directory"
+/usr/bin/chmod 0700 "$quarantine_directory"
+removed_entries=0
+for run_id in "${requested_run_ids[@]}"; do
+  matched_entries=0
+  IFS=',' read -r -a recorded_entry_names <<<"${entry_names_by_run["$run_id"]}"
+  for entry_name in "${recorded_entry_names[@]}"; do
+    entry_path="$root_path/$entry_name"
+    [[ "$entry_name" =~ ^${entry_prefix}${run_id}-[A-Za-z0-9._-]+$ ]]
+    [[ -d "$entry_path" && ! -L "$entry_path" ]]
+    [[ "$(/usr/bin/realpath -e -- "$entry_path")" == "$root_path/$entry_name" ]]
+    [[ "$(/usr/bin/stat -c '%d:%i:%Z' "$entry_path")" == "${entry_identity_by_name["$entry_name"]}:${entry_version_by_name["$entry_name"]}" ]]
+    read -r entry_owner entry_group entry_mode < <(
+      /usr/bin/stat -c '%U %G %a' "$entry_path"
+    )
+    [[ "$entry_owner" == "$expected_owner" ]]
+    [[ "$entry_group" == "$expected_group" ]]
+    (( (8#$entry_mode & 0022) == 0 ))
+    symlink_path="$(/usr/bin/find "$entry_path" -xdev -type l -print -quit)"
+    [[ -z "$symlink_path" ]]
+    if entry_has_mount_escape "$entry_path"; then
+      exit 1
+    fi
+    current_age_seconds=$(( $(/usr/bin/date +%s) - $(/usr/bin/stat -c '%Y' "$entry_path") ))
+    ((current_age_seconds >= minimum_age_hours * 3600))
+    quarantined_path="$quarantine_directory/$entry_name"
+    /usr/bin/mv -T -- "$entry_path" "$quarantined_path"
+    [[ "$(/usr/bin/stat -c '%d:%i' "$quarantined_path")" == "${entry_identity_by_name["$entry_name"]}" ]]
+    matched_entries=$((matched_entries + 1))
+    removed_entries=$((removed_entries + 1))
+  done
+  ((matched_entries > 0))
+done
+/usr/bin/rm -rf --one-file-system -- "$quarantine_directory"
+[[ ! -e "$quarantine_directory" ]]
+
+collect_inventory 1 0
+post_prune_allocated_bytes="$total_allocated_bytes"
+reclaimed_bytes=$((pre_prune_allocated_bytes - post_prune_allocated_bytes))
+if ((reclaimed_bytes < 0)); then
+  reclaimed_bytes=0
+fi
+cleanup_epoch_seconds="$(/usr/bin/date +%s)"
+successful_cleanup_epoch_seconds="$last_cleanup_epoch_seconds"
+if ((post_prune_allocated_bytes <= low_water_bytes)); then
+  successful_cleanup_epoch_seconds="$cleanup_epoch_seconds"
+fi
+write_state \
+  "$successful_cleanup_epoch_seconds" \
+  "$cleanup_epoch_seconds" \
+  "$reclaimed_bytes" \
+  "$post_prune_allocated_bytes" \
+  "$requested_run_ids_csv"
+((post_prune_allocated_bytes <= low_water_bytes))
+/usr/bin/printf '{"cache_key":"%s","removed_entries":%s,"reclaimed_bytes":%s,"post_allocated_bytes":%s}\n' \
+  "$cache_key" \
+  "$removed_entries" \
+  "$reclaimed_bytes" \
+  "$post_prune_allocated_bytes"

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -21,6 +21,9 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRe
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterPolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterProposal
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneImageInventoryItem
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheBudget
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheEntry
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheUsage
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneRunnerWorkdirUsage
@@ -88,6 +91,44 @@ class RunnerHostHygieneTests(unittest.TestCase):
         self.assertEqual(
             [finding.code for finding in report.findings],
             ["runner_workdir_measurement_partial"],
+        )
+
+    def test_report_marks_generated_cache_budget_and_safety_findings(self) -> None:
+        report = evaluate_runner_host_hygiene(
+            policy=RunnerHostHygienePolicy(
+                generated_cache_budgets=(
+                    RunnerHostHygieneGeneratedCacheBudget(
+                        cache_key="codex-lab-runs",
+                        high_water_bytes=100,
+                    ),
+                )
+            ),
+            observation=RunnerHostHygieneObservation(
+                host_name="chris-testing",
+                observed_at="2026-07-27T00:00:00Z",
+                free_disk_bytes=200,
+                generated_cache_apparent_bytes=120,
+                generated_cache_allocated_bytes=120,
+                generated_cache_usage=(
+                    RunnerHostHygieneGeneratedCacheUsage(
+                        cache_key="codex-lab-runs",
+                        apparent_bytes=120,
+                        allocated_bytes=120,
+                        entry_count=1,
+                        measurement_status="partial",
+                    ),
+                ),
+            ),
+        )
+
+        self.assertEqual(report.status, "attention")
+        self.assertEqual(
+            [finding.code for finding in report.findings],
+            [
+                "generated_cache_above_limit",
+                "generated_cache_measurement_partial",
+                "generated_cache_safety_failed",
+            ],
         )
 
     def test_report_preserves_sorted_resource_inventory(self) -> None:
@@ -706,6 +747,101 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
 
         self.assertEqual(plan.status, "ready")
         self.assertEqual(plan.blockers, ())
+
+    def test_apply_plan_can_prune_completed_idle_generated_run_cache(self) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",),
+                allow_generated_run_cache_prune=True,
+                allowed_generated_cache_keys=("codex-lab-runs",),
+            ),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_generated_run_cache",
+                host_name="chris-testing",
+                mutate=True,
+                target_generated_cache_key="codex-lab-runs",
+                target_generated_cache_run_ids=(101,),
+                generated_cache_minimum_age_hours=1,
+                generated_cache_high_water_bytes=100,
+                generated_cache_low_water_bytes=10,
+                generated_cache_cooldown_hours=1,
+                audit_record_key="runner-host-hygiene/2026-07-27/generated-cache",
+            ),
+            report=_healthy_report_with_generated_cache(
+                RunnerHostHygieneGeneratedCacheUsage(
+                    cache_key="codex-lab-runs",
+                    apparent_bytes=120,
+                    allocated_bytes=120,
+                    entry_count=1,
+                    owner_valid=True,
+                    mode_valid=True,
+                    symlink_safe=True,
+                    owner_worker_observations=(0, 0),
+                    entries=(
+                        RunnerHostHygieneGeneratedCacheEntry(
+                            run_id=101,
+                            apparent_bytes=120,
+                            allocated_bytes=120,
+                            age_seconds=7_200,
+                            open_handle_observations=(0, 0),
+                            github_run_state="completed",
+                        ),
+                    ),
+                )
+            ),
+        )
+
+        self.assertEqual(plan.status, "ready")
+        self.assertEqual(plan.blockers, ())
+
+    def test_apply_plan_blocks_generated_cache_when_owner_is_busy(self) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",),
+                allow_generated_run_cache_prune=True,
+                allowed_generated_cache_keys=("codex-lab-runs",),
+            ),
+            request=RunnerHostHygieneApplyRequest(
+                action="prune_generated_run_cache",
+                host_name="chris-testing",
+                mutate=True,
+                target_generated_cache_key="codex-lab-runs",
+                target_generated_cache_run_ids=(101,),
+                generated_cache_minimum_age_hours=1,
+                generated_cache_high_water_bytes=100,
+                generated_cache_low_water_bytes=10,
+                generated_cache_cooldown_hours=1,
+                audit_record_key="runner-host-hygiene/2026-07-27/generated-cache",
+            ),
+            report=_healthy_report_with_generated_cache(
+                RunnerHostHygieneGeneratedCacheUsage(
+                    cache_key="codex-lab-runs",
+                    apparent_bytes=120,
+                    allocated_bytes=120,
+                    entry_count=1,
+                    owner_valid=True,
+                    mode_valid=True,
+                    symlink_safe=True,
+                    owner_worker_observations=(1, 1),
+                    entries=(
+                        RunnerHostHygieneGeneratedCacheEntry(
+                            run_id=101,
+                            apparent_bytes=120,
+                            allocated_bytes=120,
+                            age_seconds=7_200,
+                            open_handle_observations=(0, 0),
+                            github_run_state="completed",
+                        ),
+                    ),
+                )
+            ),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertEqual(
+            [blocker.code for blocker in plan.blockers],
+            ["target_generated_cache_owner_busy"],
+        )
 
     def test_apply_plan_blocks_unallowlisted_builder_without_budget(self) -> None:
         plan = plan_runner_host_hygiene_apply(
@@ -1431,6 +1567,79 @@ class RunnerHostHygieneApplyPlanCliTests(unittest.TestCase):
         )
         self.assertEqual(payload["request"]["max_used_space_bytes"], 64_424_509_440)
 
+    def test_cli_builds_generated_run_cache_apply_plan(self) -> None:
+        generated_usage = RunnerHostHygieneGeneratedCacheUsage(
+            cache_key="codex-lab-runs",
+            apparent_bytes=120,
+            allocated_bytes=120,
+            entry_count=1,
+            owner_valid=True,
+            mode_valid=True,
+            symlink_safe=True,
+            owner_worker_observations=(0, 0),
+            entries=(
+                RunnerHostHygieneGeneratedCacheEntry(
+                    run_id=101,
+                    apparent_bytes=120,
+                    allocated_bytes=120,
+                    age_seconds=7_200,
+                    open_handle_observations=(0, 0),
+                    github_run_state="completed",
+                ),
+            ),
+        )
+        with TemporaryDirectory() as temp_dir:
+            report_file = Path(temp_dir) / "report.json"
+            report_file.write_text(
+                json.dumps(
+                    {
+                        "report": _healthy_report_with_generated_cache(generated_usage).model_dump(
+                            mode="json"
+                        )
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-host-hygiene-apply-plan",
+                    "--action",
+                    "prune_generated_run_cache",
+                    "--host-name",
+                    "chris-testing",
+                    "--mutate",
+                    "--audit-record-key",
+                    "runner-host-hygiene/2026-07-27/generated-cache",
+                    "--approved-host",
+                    "chris-testing",
+                    "--allow-generated-run-cache-prune",
+                    "--allowed-generated-cache-key",
+                    "codex-lab-runs",
+                    "--target-generated-cache-key",
+                    "codex-lab-runs",
+                    "--target-generated-cache-run-id",
+                    "101",
+                    "--generated-cache-minimum-age-hours",
+                    "1",
+                    "--generated-cache-high-water-bytes",
+                    "100",
+                    "--generated-cache-low-water-bytes",
+                    "10",
+                    "--generated-cache-cooldown-hours",
+                    "1",
+                    "--report-file",
+                    report_file.as_posix(),
+                ],
+            )
+
+        self.assertEqual(result.exit_code, 0, result.output)
+        payload = json.loads(result.output)
+        self.assertEqual(payload["plan"]["status"], "ready")
+        self.assertEqual(payload["request"]["target_generated_cache_run_ids"], [101])
+
     def test_cli_builds_dangling_image_apply_plan(self) -> None:
         with TemporaryDirectory() as temp_dir:
             report_file = Path(temp_dir) / "report.json"
@@ -1559,6 +1768,22 @@ def _healthy_report_with_volumes(
             free_disk_bytes=500,
             warm_builders=("odoo-docker-chris-testing",),
             volume_inventory=volumes,
+        ),
+    )
+
+
+def _healthy_report_with_generated_cache(
+    usage: RunnerHostHygieneGeneratedCacheUsage,
+) -> RunnerHostHygieneReport:
+    return evaluate_runner_host_hygiene(
+        policy=RunnerHostHygienePolicy(),
+        observation=RunnerHostHygieneObservation(
+            host_name="chris-testing",
+            observed_at="2026-07-27T00:00:00Z",
+            free_disk_bytes=500,
+            generated_cache_apparent_bytes=usage.apparent_bytes,
+            generated_cache_allocated_bytes=usage.allocated_bytes,
+            generated_cache_usage=(usage,),
         ),
     )
 

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -20,15 +20,18 @@ import click
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
+from control_plane.workflows.runner_host_hygiene_executor import GeneratedRunCacheRoot
 from control_plane.workflows.runner_host_hygiene_executor import RunnerWorkdirRoot
 from control_plane.workflows.runner_host_hygiene_executor import AuditDeliveryError
 from control_plane.workflows.runner_host_hygiene_executor import (
     build_refreshing_service_audit_poster,
 )
+from control_plane.workflows.runner_host_hygiene_executor import build_github_run_state_reader
 from control_plane.workflows.runner_host_hygiene_executor import (
     execute_runner_host_hygiene_executor,
 )
 from control_plane.workflows.runner_host_hygiene_executor import _DOCKER_DISK_USAGE_COMMAND
+from control_plane.workflows.runner_host_hygiene_executor import _GENERATED_RUN_CACHE_HELPER
 from control_plane.workflows.runner_host_hygiene_executor import _parse_docker_disk_usage
 from control_plane.workflows.runner_host_hygiene_executor import _RUNNER_WORKDIR_USAGE_HELPER
 from control_plane.workflows.runner_host_hygiene_executor import validate_local_executor_environment
@@ -52,6 +55,15 @@ _ENGINE_PRUNE_PREFIX = (
     "curl",
     "--silent",
 )
+_GENERATED_CACHE_PRUNE_PREFIX = (
+    "flock",
+    "-n",
+    "/tmp/launchplane-runner-host-hygiene.lock",
+    "/usr/bin/sudo",
+    "-n",
+    _GENERATED_RUN_CACHE_HELPER,
+    "prune",
+)
 
 
 class _CommandRunner:
@@ -72,6 +84,8 @@ class _CommandRunner:
         runner_workdir_usage: Mapping[str, tuple[int, int]] | None = None,
         buildctl_bounded_prune_supported: bool = True,
         runner_workdir_status: Literal["complete", "partial"] = "complete",
+        generated_cache_before: str = "",
+        generated_cache_after: str = "",
     ) -> None:
         self.commands: list[tuple[str, ...]] = []
         self._prune_returncode = prune_returncode
@@ -123,6 +137,9 @@ class _CommandRunner:
         self._runner_workdir_usage = dict(runner_workdir_usage or {})
         self._buildctl_bounded_prune_supported = buildctl_bounded_prune_supported
         self._runner_workdir_status = runner_workdir_status
+        self._generated_cache_before = generated_cache_before
+        self._generated_cache_after = generated_cache_after
+        self._generated_cache_pruned = False
         self._pruned = False
         self.removed_volumes: list[str] = []
 
@@ -182,6 +199,20 @@ class _CommandRunner:
                     else f"{apparent_bytes}\n{allocated_bytes}\npartial\n"
                 ),
             )
+        if command_tuple[:4] == (
+            "/usr/bin/sudo",
+            "-n",
+            _GENERATED_RUN_CACHE_HELPER,
+            "observe",
+        ):
+            return RemoteCommandResult(
+                returncode=0,
+                stdout=(
+                    self._generated_cache_after
+                    if self._generated_cache_pruned
+                    else self._generated_cache_before
+                ),
+            )
         if command_tuple[:3] == ("docker", "image", "inspect"):
             if not self._pruned or self._image_present_after:
                 return RemoteCommandResult(returncode=0, stdout="[]\n")
@@ -205,6 +236,12 @@ class _CommandRunner:
             )
         if command_tuple[:5] == _ENGINE_PRUNE_PREFIX:
             self._pruned = True
+            return RemoteCommandResult(
+                returncode=self._prune_returncode,
+                stderr=self._prune_stderr,
+            )
+        if command_tuple[:7] == _GENERATED_CACHE_PRUNE_PREFIX:
+            self._generated_cache_pruned = True
             return RemoteCommandResult(
                 returncode=self._prune_returncode,
                 stderr=self._prune_stderr,
@@ -393,6 +430,12 @@ class RunnerHostHygieneWorkflowTests(unittest.TestCase):
         self.assertIn("maintenance_failures=$((maintenance_failures + 1))", workflow_text)
         self.assertIn("scheduled hygiene action(s) failed", workflow_text)
         self.assertIn("BuildKit cache budgets must not repeat a builder.", workflow_text)
+        self.assertIn("LAUNCHPLANE_RUNNER_HOST_HYGIENE_GENERATED_RUN_CACHE_ROOTS", workflow_text)
+        self.assertIn("prune_generated_run_cache", workflow_text)
+        self.assertIn("--generated-run-cache-root", workflow_text)
+        self.assertIn("--target-generated-cache-key", workflow_text)
+        self.assertNotIn("LAUNCHPLANE_RUNNER_REGISTRATION_GITHUB_TOKEN", workflow_text)
+        self.assertIn("LAUNCHPLANE_RUNNER_HOST_HYGIENE_GITHUB_READ_TOKEN", workflow_text)
 
 
 class RunnerHostHygieneExecutorTests(unittest.TestCase):
@@ -490,9 +533,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
 
         self.assertEqual(result.status, "completed")
         prune_command = next(
-            command
-            for command in command_runner.commands
-            if command[:5] == _ENGINE_PRUNE_PREFIX
+            command for command in command_runner.commands if command[:5] == _ENGINE_PRUNE_PREFIX
         )
         self.assertEqual(
             prune_command[-1],
@@ -702,6 +743,255 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         assert post_apply_report is not None
         self.assertEqual(post_apply_report.runner_workdir_bytes, 12_345_678)
 
+    def test_generated_run_cache_prune_uses_completed_idle_targets(self) -> None:
+        root = GeneratedRunCacheRoot(
+            key="codex-lab-runs",
+            path="/home/gha/.cache/codex-ci",
+            source_repository="cbusillo/codex-lab",
+            high_water_bytes=100,
+            low_water_bytes=10,
+            minimum_age_hours=1,
+            cooldown_hours=1,
+        )
+        command_runner = _CommandRunner(
+            generated_cache_before=_generated_cache_evidence(
+                entries=((101, 80, 80, 7_200, (0, 0)), (102, 40, 40, 5_400, (0, 0))),
+                worker_observations=(0, 0),
+            ),
+            generated_cache_after=_generated_cache_evidence(
+                entries=(),
+                worker_observations=(0, 0),
+                last_cleanup_epoch_seconds=1_000,
+                last_reclaimed_bytes=120,
+            ),
+        )
+        audit_poster = _AuditPoster()
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = execute_runner_host_hygiene_executor(
+                request=_request(
+                    mutate=True,
+                    action="prune_generated_run_cache",
+                    generated_run_cache_roots=(root,),
+                    target_generated_cache_key=root.key,
+                ),
+                remote_runner=command_runner,
+                audit_poster=audit_poster,
+                audit_spool=RunnerHostHygieneAuditSpool(
+                    root=Path(temporary_directory),
+                    artifact_file=Path(temporary_directory) / "artifact.json",
+                ),
+                github_run_state_reader=lambda _repository, run_ids: {
+                    run_id: "completed" for run_id in run_ids
+                },
+            )
+
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(
+            audit_poster.audits[0].request.target_generated_cache_run_ids,
+            (101, 102),
+        )
+        prune_command = next(
+            command
+            for command in command_runner.commands
+            if command[:7] == _GENERATED_CACHE_PRUNE_PREFIX
+        )
+        self.assertEqual(prune_command[-1], "101,102")
+        self.assertFalse(any(command[:2] == ("bash", "-lc") for command in command_runner.commands))
+        serialized_audits = json.dumps(
+            [audit.model_dump(mode="json") for audit in audit_poster.audits]
+        )
+        self.assertNotIn(root.path, serialized_audits)
+        self.assertNotIn(root.source_repository, serialized_audits)
+
+    def test_generated_run_cache_prune_blocks_busy_owner(self) -> None:
+        root = GeneratedRunCacheRoot(
+            key="codex-lab-runs",
+            path="/home/gha/.cache/codex-ci",
+            source_repository="cbusillo/codex-lab",
+            high_water_bytes=100,
+            low_water_bytes=10,
+            minimum_age_hours=1,
+            cooldown_hours=1,
+        )
+        command_runner = _CommandRunner(
+            generated_cache_before=_generated_cache_evidence(
+                entries=((101, 120, 120, 7_200, (0, 0)),),
+                worker_observations=(1, 1),
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = execute_runner_host_hygiene_executor(
+                request=_request(
+                    mutate=True,
+                    action="prune_generated_run_cache",
+                    generated_run_cache_roots=(root,),
+                    target_generated_cache_key=root.key,
+                ),
+                remote_runner=command_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=RunnerHostHygieneAuditSpool(
+                    root=Path(temporary_directory),
+                    artifact_file=Path(temporary_directory) / "artifact.json",
+                ),
+                github_run_state_reader=lambda _repository, run_ids: {
+                    run_id: "completed" for run_id in run_ids
+                },
+            )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertFalse(
+            any(command[:7] == _GENERATED_CACHE_PRUNE_PREFIX for command in command_runner.commands)
+        )
+
+    def test_generated_run_cache_prune_blocks_unknown_github_state(self) -> None:
+        root = GeneratedRunCacheRoot(
+            key="codex-lab-runs",
+            path="/home/gha/.cache/codex-ci",
+            source_repository="cbusillo/codex-lab",
+            high_water_bytes=100,
+            low_water_bytes=10,
+            minimum_age_hours=1,
+            cooldown_hours=1,
+        )
+        command_runner = _CommandRunner(
+            generated_cache_before=_generated_cache_evidence(
+                entries=((101, 120, 120, 7_200, (0, 0)),),
+                worker_observations=(0, 0),
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = execute_runner_host_hygiene_executor(
+                request=_request(
+                    mutate=True,
+                    action="prune_generated_run_cache",
+                    generated_run_cache_roots=(root,),
+                    target_generated_cache_key=root.key,
+                ),
+                remote_runner=command_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=RunnerHostHygieneAuditSpool(
+                    root=Path(temporary_directory),
+                    artifact_file=Path(temporary_directory) / "artifact.json",
+                ),
+                github_run_state_reader=lambda _repository, run_ids: {
+                    run_id: "unknown" for run_id in run_ids
+                },
+            )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertFalse(
+            any(command[:7] == _GENERATED_CACHE_PRUNE_PREFIX for command in command_runner.commands)
+        )
+
+    def test_generated_run_cache_mutation_requires_durable_spool(self) -> None:
+        root = GeneratedRunCacheRoot(
+            key="codex-lab-runs",
+            path="/home/gha/.cache/codex-ci",
+            source_repository="cbusillo/codex-lab",
+            high_water_bytes=100,
+            low_water_bytes=10,
+            minimum_age_hours=1,
+            cooldown_hours=1,
+        )
+
+        with self.assertRaisesRegex(click.ClickException, "requires durable"):
+            execute_runner_host_hygiene_executor(
+                request=_request(
+                    mutate=True,
+                    action="prune_generated_run_cache",
+                    generated_run_cache_roots=(root,),
+                    target_generated_cache_key=root.key,
+                ),
+                remote_runner=_CommandRunner(),
+                audit_poster=_AuditPoster(),
+            )
+
+    def test_generated_run_cache_below_high_water_is_not_needed(self) -> None:
+        root = GeneratedRunCacheRoot(
+            key="codex-lab-runs",
+            path="/home/gha/.cache/codex-ci",
+            source_repository="cbusillo/codex-lab",
+            high_water_bytes=100,
+            low_water_bytes=10,
+            minimum_age_hours=1,
+            cooldown_hours=1,
+        )
+        command_runner = _CommandRunner(
+            generated_cache_before=_generated_cache_evidence(
+                entries=((101, 80, 80, 7_200, (0, 0)),),
+                worker_observations=(0, 0),
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = execute_runner_host_hygiene_executor(
+                request=_request(
+                    mutate=True,
+                    action="prune_generated_run_cache",
+                    generated_run_cache_roots=(root,),
+                    target_generated_cache_key=root.key,
+                ),
+                remote_runner=command_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=RunnerHostHygieneAuditSpool(
+                    root=Path(temporary_directory),
+                    artifact_file=Path(temporary_directory) / "artifact.json",
+                ),
+                github_run_state_reader=lambda _repository, run_ids: {
+                    run_id: "completed" for run_id in run_ids
+                },
+            )
+
+        self.assertEqual(result.status, "not_needed")
+        self.assertFalse(
+            any(command[:7] == _GENERATED_CACHE_PRUNE_PREFIX for command in command_runner.commands)
+        )
+
+    def test_generated_run_cache_above_high_water_during_cooldown_is_blocked(self) -> None:
+        root = GeneratedRunCacheRoot(
+            key="codex-lab-runs",
+            path="/home/gha/.cache/codex-ci",
+            source_repository="cbusillo/codex-lab",
+            high_water_bytes=100,
+            low_water_bytes=10,
+            minimum_age_hours=1,
+            cooldown_hours=1,
+        )
+        command_runner = _CommandRunner(
+            generated_cache_before=_generated_cache_evidence(
+                entries=((101, 120, 120, 7_200, (0, 0)),),
+                worker_observations=(0, 0),
+                last_cleanup_epoch_seconds=9_900,
+            )
+        )
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            result = execute_runner_host_hygiene_executor(
+                request=_request(
+                    mutate=True,
+                    action="prune_generated_run_cache",
+                    generated_run_cache_roots=(root,),
+                    target_generated_cache_key=root.key,
+                ),
+                remote_runner=command_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=RunnerHostHygieneAuditSpool(
+                    root=Path(temporary_directory),
+                    artifact_file=Path(temporary_directory) / "artifact.json",
+                ),
+                github_run_state_reader=lambda _repository, run_ids: {
+                    run_id: "completed" for run_id in run_ids
+                },
+            )
+
+        self.assertEqual(result.status, "blocked")
+        self.assertFalse(
+            any(command[:7] == _GENERATED_CACHE_PRUNE_PREFIX for command in command_runner.commands)
+        )
+
     def test_cache_prune_completes_when_unrelated_workdir_evidence_is_partial(self) -> None:
         command_runner = _CommandRunner(runner_workdir_status="partial")
 
@@ -759,6 +1049,40 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertIn("measurement_partial=1", helper_text)
         self.assertIn("((record_count <= expected_count))", helper_text)
         self.assertIn("else\n  /usr/bin/printf '%s\\n%s\\n'", helper_text)
+        subprocess.run(
+            ("/bin/bash", "-n", str(helper_path)),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+
+    def test_generated_run_cache_helper_security_invariants_are_pinned(self) -> None:
+        helper_path = (
+            Path(__file__).resolve().parents[1]
+            / "scripts"
+            / "runner-host-hygiene-generated-run-cache.sh"
+        )
+        helper_text = helper_path.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            _GENERATED_RUN_CACHE_HELPER,
+            "/usr/local/sbin/launchplane-generated-run-cache",
+        )
+        self.assertTrue(helper_path.stat().st_mode & 0o111)
+        self.assertTrue(helper_text.startswith("#!/bin/bash\nset -euo pipefail\n"))
+        self.assertIn('readonly config_directory="/etc/launchplane"', helper_text)
+        self.assertIn("/proc/self/fd/4", helper_text)
+        self.assertIn("owner_worker_observations", helper_text)
+        self.assertIn("open_handle_observations", helper_text)
+        self.assertIn("--one-file-system", helper_text)
+        self.assertIn("candidate_low_water < candidate_high_water", helper_text)
+        self.assertIn("entry_identity_by_name", helper_text)
+        self.assertIn("entry_version_by_name", helper_text)
+        self.assertIn("last_attempt_epoch_seconds", helper_text)
+        self.assertNotIn('findmnt -rn -R -o TARGET --target "$entry_path" || true', helper_text)
+        self.assertIn(".launchplane-generated-run-cache-prune.", helper_text)
+        self.assertIn("last_removed_run_ids", helper_text)
+        self.assertIn('/usr/bin/sync -f "$state_file"', helper_text)
         subprocess.run(
             ("/bin/bash", "-n", str(helper_path)),
             capture_output=True,
@@ -1575,6 +1899,36 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             ["Bearer first-token", "Bearer second-token"],
         )
 
+    def test_github_run_state_reader_supports_public_repository_without_token(self) -> None:
+        class _Response:
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            @staticmethod
+            def read() -> bytes:
+                return b'{"status":"completed"}'
+
+        observed_authorization: list[str | None] = []
+
+        def fake_urlopen(request: Request, timeout: int) -> _Response:
+            self.assertEqual(timeout, 30)
+            observed_authorization.append(request.get_header("Authorization"))
+            self.assertIn("/repos/cbusillo/codex-lab/actions/runs/101", request.full_url)
+            return _Response()
+
+        reader = build_github_run_state_reader(bearer_token="")
+        with patch(
+            "control_plane.workflows.runner_host_hygiene_executor.urlopen",
+            side_effect=fake_urlopen,
+        ):
+            states = reader("cbusillo/codex-lab", (101,))
+
+        self.assertEqual(states, {101: "completed"})
+        self.assertEqual(observed_authorization, [None])
+
     def test_service_audit_poster_marks_route_not_found_non_retryable(self) -> None:
         poster = build_refreshing_service_audit_poster(
             service_url="https://launchplane.example",
@@ -1605,6 +1959,7 @@ def _request(
     action: Literal[
         "prune_docker_cache",
         "prune_dangling_images",
+        "prune_generated_run_cache",
         "remove_buildkit_state_volumes",
         "prune_runner_workdir",
         "restart_runner_service",
@@ -1619,6 +1974,8 @@ def _request(
     runner_workdir_roots: tuple[RunnerWorkdirRoot, ...] = (
         RunnerWorkdirRoot(key="legacy", path="/opt/actions-runners"),
     ),
+    generated_run_cache_roots: tuple[GeneratedRunCacheRoot, ...] = (),
+    target_generated_cache_key: str = "",
     resolve_action_started: bool = False,
 ) -> RunnerHostHygieneExecutorRequest:
     return RunnerHostHygieneExecutorRequest(
@@ -1637,6 +1994,8 @@ def _request(
         mutate=mutate,
         prune_until=prune_until,
         runner_workdir_roots=runner_workdir_roots,
+        generated_run_cache_roots=generated_run_cache_roots,
+        target_generated_cache_key=target_generated_cache_key,
         idle_observation_interval_seconds=0,
         resolve_action_started=resolve_action_started,
     )
@@ -1655,6 +2014,54 @@ def _planned_audit() -> RunnerHostHygieneApplyAuditRecord:
 
 def _json_lines(*rows: dict[str, object]) -> str:
     return "".join(f"{json.dumps(row)}\n" for row in rows)
+
+
+def _generated_cache_evidence(
+    *,
+    entries: tuple[tuple[int, int, int, int, tuple[int, ...]], ...],
+    worker_observations: tuple[int, ...],
+    last_cleanup_epoch_seconds: int = 0,
+    last_reclaimed_bytes: int = 0,
+) -> str:
+    allocated_bytes = sum(entry[2] for entry in entries)
+    apparent_bytes = sum(entry[1] for entry in entries)
+    rows: list[dict[str, object]] = [
+        {
+            "record_type": "summary",
+            "cache_key": "codex-lab-runs",
+            "observed_epoch_seconds": 10_000,
+            "apparent_bytes": apparent_bytes,
+            "allocated_bytes": allocated_bytes,
+            "entry_count": len(entries),
+            "measurement_status": "complete",
+            "owner_valid": True,
+            "mode_valid": True,
+            "symlink_safe": True,
+            "owner_worker_observations": list(worker_observations),
+            "entries_truncated": False,
+            "minimum_age_hours": 1,
+            "high_water_bytes": 100,
+            "low_water_bytes": 10,
+            "cooldown_hours": 1,
+            "last_cleanup_epoch_seconds": last_cleanup_epoch_seconds,
+            "last_reclaimed_bytes": last_reclaimed_bytes,
+            "last_post_cleanup_allocated_bytes": allocated_bytes,
+            "last_removed_run_ids": [],
+        }
+    ]
+    rows.extend(
+        {
+            "record_type": "entry",
+            "cache_key": "codex-lab-runs",
+            "run_id": run_id,
+            "apparent_bytes": apparent,
+            "allocated_bytes": allocated,
+            "age_seconds": age_seconds,
+            "open_handle_observations": list(handle_observations),
+        }
+        for run_id, apparent, allocated, age_seconds, handle_observations in entries
+    )
+    return _json_lines(*rows)
 
 
 def _docker_disk_usage_json(


### PR DESCRIPTION
## Summary
- add typed generated run-cache inventory with allocated/apparent bytes, age buckets, completed-run state, owner worker samples, open-handle samples, and cleanup history
- add a root-owned exact-binding helper with fixed age/high-low-water/cooldown policy, fail-closed mount/symlink/owner checks, inode-bound atomic quarantine, and fsynced cleanup receipts
- add audited `prune_generated_run_cache` planning/execution, host-local delivery recovery, benign no-op semantics, workflow wiring, OpenAPI, docs, and focused tests

## Safety
- mutation requires an accepted planned service audit and durable host-local spool
- only completed GitHub run IDs selected by the configured source repository are eligible
- two owner-idle and zero-open-handle observations are rechecked immediately before quarantine
- exact root-owned binding policy controls path, owner/group/mode, prefix, age, high/low water, and cooldown
- absolute paths and source repository identity are rejected from persisted audit evidence

## Validation
- `uv run --extra dev python -m unittest tests.test_runner_host_hygiene tests.test_runner_host_hygiene_executor` (106 passed)
- broader focused store/API/config suite (511 passed)
- `uv run --extra dev ruff check ...`
- `uv run --extra dev ruff format --check ...`
- `uv run --extra dev mypy control_plane tests`
- `actionlint .github/workflows/runner-host-hygiene.yml`
- `shellcheck scripts/runner-host-hygiene-generated-run-cache.sh`
- `pnpm --dir frontend check:openapi-drift`
- `git diff --check`

Advances #1842 and unblocks the bounded generated-cache portion of #1838.