### PR TITLE
fix: allow safe internal generated-cache symlinks

### DIFF
--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -384,14 +384,21 @@ Cmnd_Alias LAUNCHPLANE_GENERATED_CACHE_PRUNE = /usr/local/sbin/launchplane-gener
 Validate the candidate and complete sudoers policy with `visudo -cf`. The
 helper independently revalidates the root-owned config and fixed retention
 policy, canonical root,
-owner/group/mode, top-level name shape, same-filesystem traversal, absence of
-symlinks, age floor, owner idle samples, and exact target open handles. It emits
+owner/group/mode, top-level name shape, same-filesystem traversal,
+non-dereferencing handling of internal symlinks, fail-closed nested-mount
+detection, age floor, owner idle samples, and exact target open handles. It emits
 only public keys, numeric run ids, counts, sizes, ages, and booleans. Deleting
 completed run-scoped generated data has no byte-for-byte rollback; recovery is
 regeneration in a later run, while the durable `action_started` envelope
 prevents an uncertain action from being repeated automatically.
 
-The helper fails closed when mount discovery is unavailable or incomplete. A
+The helper never follows internal symlinks during measurement, quarantine, or
+removal; only an exact canonical top-level directory can become a target. It
+fails closed when mount discovery is unavailable or incomplete. A
+post-quarantine owner-worker and open-handle check restores the exact entries
+before aborting when work starts during the final race window; an ambiguous
+restore leaves the root-owned quarantine visible as partial evidence instead of
+deleting it. A
 cleanup attempt that removes data but cannot reach the configured low-water
 target persists its reclaimed-byte and target receipt without advancing the
 successful-cleanup cooldown, so a corrected follow-up can run immediately.

--- a/scripts/runner-host-hygiene-generated-run-cache.sh
+++ b/scripts/runner-host-hygiene-generated-run-cache.sh
@@ -281,8 +281,7 @@ collect_inventory() {
     if (( (8#$entry_mode & 0022) != 0 )); then
       mode_valid=false
     fi
-    symlink_path="$(/usr/bin/find "$entry_path" -xdev -type l -print -quit)"
-    if [[ -n "$symlink_path" ]] || entry_has_mount_escape "$entry_path"; then
+    if entry_has_mount_escape "$entry_path"; then
       symlink_safe=false
     fi
     measure_directory "$entry_path" apparent
@@ -488,6 +487,52 @@ quarantine_directory="$(
 )"
 /usr/bin/chown root:root "$quarantine_directory"
 /usr/bin/chmod 0700 "$quarantine_directory"
+quarantine_identity="$(/usr/bin/stat -c '%d:%i' "$quarantine_directory")"
+[[ "$quarantine_identity" =~ ^[0-9]+:[0-9]+$ ]]
+quarantined_entry_names=()
+
+validate_quarantine_directory() {
+  [[ -d "$quarantine_directory" && ! -L "$quarantine_directory" ]]
+  [[ "$(/usr/bin/realpath -e -- "$quarantine_directory")" == "$quarantine_directory" ]]
+  [[ "$(/usr/bin/stat -c '%d:%i' "$quarantine_directory")" == "$quarantine_identity" ]]
+  read -r quarantine_owner quarantine_group quarantine_mode < <(
+    /usr/bin/stat -c '%U %G %a' "$quarantine_directory"
+  )
+  [[ "$quarantine_owner" == "root" ]]
+  [[ "$quarantine_group" == "root" ]]
+  [[ "$quarantine_mode" == "700" ]]
+}
+
+quarantine_open_handle_count() {
+  local fd target
+  quarantined_open_handles=0
+  for fd in /proc/[0-9]*/fd/*; do
+    target="$(/usr/bin/readlink -- "$fd" 2>/dev/null || true)"
+    target="${target% (deleted)}"
+    if [[ "$target" == "$quarantine_directory" || "$target" == "$quarantine_directory/"* ]]; then
+      quarantined_open_handles=$((quarantined_open_handles + 1))
+    fi
+  done
+}
+
+restore_quarantined_entries() {
+  local entry_name quarantined_path original_path restore_failed=false
+  for entry_name in "${quarantined_entry_names[@]}"; do
+    quarantined_path="$quarantine_directory/$entry_name"
+    original_path="$root_path/$entry_name"
+    [[ -e "$quarantined_path" ]] || continue
+    if [[ -e "$original_path" || -L "$original_path" ]]; then
+      restore_failed=true
+      continue
+    fi
+    /usr/bin/mv -T -- "$quarantined_path" "$original_path" || restore_failed=true
+  done
+  if [[ "$restore_failed" == "false" ]]; then
+    /usr/bin/rmdir -- "$quarantine_directory"
+  fi
+}
+
+validate_quarantine_directory
 removed_entries=0
 for run_id in "${requested_run_ids[@]}"; do
   matched_entries=0
@@ -504,21 +549,33 @@ for run_id in "${requested_run_ids[@]}"; do
     [[ "$entry_owner" == "$expected_owner" ]]
     [[ "$entry_group" == "$expected_group" ]]
     (( (8#$entry_mode & 0022) == 0 ))
-    symlink_path="$(/usr/bin/find "$entry_path" -xdev -type l -print -quit)"
-    [[ -z "$symlink_path" ]]
     if entry_has_mount_escape "$entry_path"; then
       exit 1
     fi
     current_age_seconds=$(( $(/usr/bin/date +%s) - $(/usr/bin/stat -c '%Y' "$entry_path") ))
     ((current_age_seconds >= minimum_age_hours * 3600))
     quarantined_path="$quarantine_directory/$entry_name"
+    validate_quarantine_directory
     /usr/bin/mv -T -- "$entry_path" "$quarantined_path"
     [[ "$(/usr/bin/stat -c '%d:%i' "$quarantined_path")" == "${entry_identity_by_name["$entry_name"]}" ]]
+    quarantined_entry_names+=("$entry_name")
     matched_entries=$((matched_entries + 1))
     removed_entries=$((removed_entries + 1))
   done
   ((matched_entries > 0))
 done
+validate_quarantine_directory
+worker_count="$(
+  /usr/bin/ps -u "$expected_uid" -o args= \
+    | /usr/bin/grep -c '[R]unner.Worker' || true
+)"
+[[ "$worker_count" =~ ^[0-9]+$ ]]
+quarantine_open_handle_count
+if ((worker_count != 0 || quarantined_open_handles != 0)); then
+  restore_quarantined_entries
+  exit 1
+fi
+validate_quarantine_directory
 /usr/bin/rm -rf --one-file-system -- "$quarantine_directory"
 [[ ! -e "$quarantine_directory" ]]
 

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -1080,7 +1080,11 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertIn("entry_version_by_name", helper_text)
         self.assertIn("last_attempt_epoch_seconds", helper_text)
         self.assertNotIn('findmnt -rn -R -o TARGET --target "$entry_path" || true', helper_text)
+        self.assertNotIn('find "$entry_path" -xdev -type l', helper_text)
         self.assertIn(".launchplane-generated-run-cache-prune.", helper_text)
+        self.assertIn("validate_quarantine_directory", helper_text)
+        self.assertIn("quarantine_open_handle_count", helper_text)
+        self.assertIn("restore_quarantined_entries", helper_text)
         self.assertIn("last_removed_run_ids", helper_text)
         self.assertIn('/usr/bin/sync -f "$state_file"', helper_text)
         subprocess.run(


### PR DESCRIPTION
## Summary
- permit legitimate internal Bazel cache symlinks because all measurement and removal operations remain non-dereferencing
- retain exact canonical top-level, nested-mount, owner/mode, age, inode/ctime, and open-handle checks
- close the final race window by validating a root-owned quarantine identity, rechecking owner workers and open descriptors after atomic rename, and restoring entries before aborting when work starts

## Live rehearsal
The merged observe-only helper correctly blocked on `symlink_safe=false` against the target cache. GNU behavior was then verified directly on `chris-testing`: default `du` did not count an external symlink target and `rm -rf --one-file-system` removed the symlink without deleting the target.

## Validation
- `uv run --extra dev python -m unittest tests.test_runner_host_hygiene_executor` (57 passed)
- `shellcheck scripts/runner-host-hygiene-generated-run-cache.sh`
- changed-file Ruff check and format check
- `git diff --check`

Follow-up to #1875; advances #1842 and #1838.