### PR TITLE
Add dedicated Product Health authz set

### DIFF
--- a/.github/workflows/authz-policy-reconcile.yml
+++ b/.github/workflows/authz-policy-reconcile.yml
@@ -19,6 +19,7 @@ name: Manage Launchplane Authorization
         type: choice
         options:
           - primary
+          - product-health-monitoring
           - odoo-route-binding
           - odoo-external-route-binding
           - odoo-testing-ingress-route
@@ -57,6 +58,17 @@ jobs:
       related_issue: ${{ inputs.related_issue }}
     secrets:
       managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON }}
+
+  reconcile-product-health-monitoring:
+    if: ${{ inputs.managed_set == 'product-health-monitoring' }}
+    uses: cbusillo/launchplane/.github/workflows/reusable-authz-policy-reconcile.yml@4dbef2945b0a297a6edaa949a42d8c7d4cbc01cd # main
+    with:
+      mode: ${{ inputs.mode }}
+      reviewed_plan_sha256: ${{ inputs.reviewed_plan_sha256 }}
+      reason: ${{ inputs.reason }}
+      related_issue: ${{ inputs.related_issue }}
+    secrets:
+      managed_set_json: ${{ secrets.LAUNCHPLANE_AUTHZ_PRODUCT_HEALTH_MONITORING_MANAGED_SET_JSON }}
 
   reconcile-odoo-route-binding:
     if: ${{ inputs.managed_set == 'odoo-route-binding' }}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -391,6 +391,8 @@ Operators mutate shared or production authz through the deployed service, not
 through direct DB commands or a local CLI from an arbitrary checkout. Store the
 complete desired rules for one `managed_set_id` in a protected repository
 secret. `LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON` owns the primary operator set;
+`LAUNCHPLANE_AUTHZ_PRODUCT_HEALTH_MONITORING_MANAGED_SET_JSON` owns the generic
+Product Health Monitoring wrapper's exact immutable worker grant;
 `LAUNCHPLANE_AUTHZ_ODOO_ROUTE_BINDING_MANAGED_SET_JSON` owns the independent
 Odoo stable managed route-binding set; and
 `LAUNCHPLANE_AUTHZ_ODOO_EXTERNAL_ROUTE_BINDING_MANAGED_SET_JSON` owns the
@@ -841,7 +843,10 @@ reviewed digest, a unique idempotency key, and confirmation
 `APPLY PRODUCT HEALTH MONITORING`. The service re-reads the complete profile and
 atomically rejects stale or concurrent edits. Authority uses separate exact-
 instance `product_profile.health_monitoring.plan` and `.apply` actions supplied
-through managed authz reconciliation.
+through the dedicated `product-health-monitoring` managed authz set. That set
+owns only the generic wrapper's exact immutable reusable-worker grant; real
+product, context, instance, check, and endpoint values remain explicit operator
+input and DB-backed Launchplane records.
 
 The manual Product Context Cutover workflow plans or applies the same
 current-authority record move through the Launchplane service. The workflow

--- a/tests/test_authz_operator_workflow.py
+++ b/tests/test_authz_operator_workflow.py
@@ -31,6 +31,7 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             managed_set_input["options"],
             [
                 "primary",
+                "product-health-monitoring",
                 "odoo-route-binding",
                 "odoo-external-route-binding",
                 "odoo-testing-ingress-route",
@@ -47,6 +48,10 @@ class AuthzOperatorWorkflowTests(unittest.TestCase):
             "reconcile-primary": (
                 "${{ inputs.managed_set == 'primary' }}",
                 "${{ secrets.LAUNCHPLANE_AUTHZ_MANAGED_SET_JSON }}",
+            ),
+            "reconcile-product-health-monitoring": (
+                "${{ inputs.managed_set == 'product-health-monitoring' }}",
+                "${{ secrets.LAUNCHPLANE_AUTHZ_PRODUCT_HEALTH_MONITORING_MANAGED_SET_JSON }}",
             ),
             "reconcile-odoo-route-binding": (
                 "${{ inputs.managed_set == 'odoo-route-binding' }}",


### PR DESCRIPTION
## Summary
- add a dedicated protected managed-set selector for Product Health Monitoring workflow authority
- preserve the unreadable primary managed set instead of replacing it with a partial policy
- document the ownership boundary and cover the wrapper/secret mapping

## Validation
- `uv run --extra dev python -m unittest tests.test_authz_operator_workflow tests.test_github_actions_security`
- `uv run --extra dev ruff check tests/test_authz_operator_workflow.py`
- `uv run --extra dev ruff format --check tests/test_authz_operator_workflow.py`
- JetBrains changed-file inspection: clean

## Context
Follow-up to #1880 and #1884. The deployed Product Health Monitoring wrapper is correctly pinned to the new immutable worker, but live dry-run `30295754923` failed closed because active managed authz still names the prior worker revision. This PR exposes a separate protected managed set so the exact new worker grant can be reviewed and reconciled without touching the unreadable primary set.
