### PR TITLE
Corroborate stale placement from strict ingress proof

### DIFF
--- a/control_plane/contracts/product_topology_read_model.py
+++ b/control_plane/contracts/product_topology_read_model.py
@@ -15,6 +15,9 @@ from control_plane.contracts.product_profile_record import (
     ProductLaneProfile,
     product_lane_monitoring_incident_eligible,
 )
+from control_plane.contracts.product_health_monitoring_migration import (
+    canonical_health_check_record_token,
+)
 from control_plane.contracts.public_ingress_monitoring import (
     PUBLIC_HTTP_STALE_AFTER_SECONDS,
     PublicIngressIncidentEventKind,
@@ -300,6 +303,14 @@ class _ObservedTlsEvidence:
     tls: PublicIngressTlsObservation
 
 
+@dataclass(frozen=True)
+class _ObservedIngressEvidence:
+    projection: ProductObservedIngress
+    runtime_target_observation: PublicIngressObservationRecord | None = None
+    absolute_newest_observation: PublicIngressObservationRecord | None = None
+    runtime_target: PublicIngressTargetObservation | None = None
+
+
 def build_product_environment_topology(
     *,
     record_store: object,
@@ -546,12 +557,17 @@ def _observed_topology(
     provider_recorded: ProductProviderRecordedTopology,
     now: datetime,
 ) -> tuple[ProductObservedTopology, tuple[_ObservedTlsEvidence, ...]]:
-    placement = _observed_placement(lane_summary)
-    ingress = _observed_ingress(
+    ingress_evidence = _observed_ingress(
         record_store=record_store,
         profile=profile,
         lane=lane,
         now=now,
+    )
+    ingress = ingress_evidence.projection
+    placement = _observed_placement(
+        lane_summary,
+        lane=lane,
+        ingress_evidence=ingress_evidence,
     )
     domain_roles: dict[str, ProductTopologyDomainRole] = {
         domain.domain_name: domain.role for domain in desired.domains
@@ -606,6 +622,9 @@ def _observed_topology(
 
 def _observed_placement(
     lane_summary: LaunchplaneLaneSummary | None,
+    *,
+    lane: ProductLaneProfile,
+    ingress_evidence: _ObservedIngressEvidence,
 ) -> ProductObservedPlacement:
     if lane_summary is None:
         return ProductObservedPlacement()
@@ -613,11 +632,16 @@ def _observed_placement(
     observed_identity: RuntimeIdentity | None = None
     status: RuntimeIdentityStatus = "unchecked"
     detail = ""
+    health_verified = False
+    health_status = "skipped"
+    provenance = lane_summary.provenance
     if lane_summary.inventory is not None:
         expected_identity = lane_summary.inventory.runtime_identity
         observed_identity = lane_summary.inventory.destination_health.observed_runtime_identity
         status = lane_summary.inventory.destination_health.runtime_identity_status
         detail = lane_summary.inventory.destination_health.runtime_identity_detail
+        health_verified = lane_summary.inventory.destination_health.verified
+        health_status = lane_summary.inventory.destination_health.status
     elif lane_summary.latest_deployment is not None:
         expected_identity = lane_summary.latest_deployment.runtime_identity
         observed_identity = (
@@ -625,19 +649,100 @@ def _observed_placement(
         )
         status = lane_summary.latest_deployment.destination_health.runtime_identity_status
         detail = lane_summary.latest_deployment.destination_health.runtime_identity_detail
+        health_verified = lane_summary.latest_deployment.destination_health.verified
+        health_status = lane_summary.latest_deployment.destination_health.status
     if status == "unchecked":
         trust_state: FreshnessStatus = "missing"
     else:
         trust_state = lane_summary.provenance.freshness_status
         if trust_state in {"recorded", "verified"}:
             trust_state = "verified"
+        elif trust_state == "stale" and _strict_public_ingress_confirms_placement(
+            lane=lane,
+            ingress_evidence=ingress_evidence,
+            expected_identity=expected_identity,
+            observed_identity=observed_identity,
+            runtime_identity_status=status,
+            health_verified=health_verified,
+            health_status=health_status,
+        ):
+            ingress = ingress_evidence.projection
+            expected_identity = ingress.expected_runtime_identity
+            observed_identity = ingress.observed_runtime_identity
+            status = ingress.runtime_identity_status
+            detail = ingress.runtime_identity_detail
+            trust_state = "verified"
+            provenance = ingress.provenance.model_copy(
+                update={
+                    "detail": (
+                        "Fresh strict public ingress runtime identity evidence "
+                        "corroborates the recorded placement."
+                    )
+                }
+            )
     return ProductObservedPlacement(
         expected_runtime_identity=expected_identity,
         observed_runtime_identity=observed_identity,
         runtime_identity_status=status,
         runtime_identity_detail=detail,
         trust_state=trust_state,
-        provenance=lane_summary.provenance,
+        provenance=provenance,
+    )
+
+
+def _strict_public_ingress_confirms_placement(
+    *,
+    lane: ProductLaneProfile,
+    ingress_evidence: _ObservedIngressEvidence,
+    expected_identity: RuntimeIdentity | None,
+    observed_identity: RuntimeIdentity | None,
+    runtime_identity_status: RuntimeIdentityStatus,
+    health_verified: bool,
+    health_status: str,
+) -> bool:
+    ingress = ingress_evidence.projection
+    observation = ingress_evidence.runtime_target_observation
+    absolute_newest_observation = ingress_evidence.absolute_newest_observation
+    runtime_target = ingress_evidence.runtime_target
+    if (
+        lane.health_monitoring.monitoring_intent != "public"
+        or ingress.monitoring_intent != "public"
+        or not ingress.incident_eligible
+        or ingress.status != "pass"
+        or ingress.trust_state != "verified"
+        or ingress.runtime_identity_status != "match"
+        or runtime_identity_status != "match"
+        or not health_verified
+        or health_status != "pass"
+        or observation is None
+        or absolute_newest_observation is None
+        or observation.record_id != absolute_newest_observation.record_id
+        or observation.monitoring_intent != "public"
+        or observation.status != "pass"
+        or runtime_target is None
+        or runtime_target.target != "health_url"
+        or runtime_target.status != "pass"
+    ):
+        return False
+    check_token = canonical_health_check_record_token(observation.check_name)
+    if not any(
+        check.enabled
+        and check.kind == "public_http"
+        and check.require_runtime_identity
+        and canonical_health_check_record_token(check.name) == check_token
+        for check in lane.health_monitoring.checks
+    ):
+        return False
+    ingress_expected = ingress.expected_runtime_identity
+    ingress_observed = ingress.observed_runtime_identity
+    return (
+        expected_identity is not None
+        and observed_identity is not None
+        and ingress_expected is not None
+        and ingress_observed is not None
+        and expected_identity == observed_identity
+        and ingress_expected == ingress_observed
+        and expected_identity == ingress_expected
     )
 
 
@@ -647,14 +752,14 @@ def _observed_ingress(
     profile: LaunchplaneProductProfileRecord,
     lane: ProductLaneProfile,
     now: datetime,
-) -> ProductObservedIngress:
+) -> _ObservedIngressEvidence:
     monitoring_intent = lane.health_monitoring.monitoring_intent
     incident_eligible = product_lane_monitoring_incident_eligible(
         monitoring_intent=monitoring_intent,
         check_kind="public_http",
     )
     if monitoring_intent == "private":
-        return ProductObservedIngress(
+        projection = ProductObservedIngress(
             monitoring_intent=monitoring_intent,
             incident_eligible=False,
             status="not_expected",
@@ -669,6 +774,7 @@ def _observed_ingress(
                 detail="Launchplane product-profile private monitoring intent.",
             ),
         )
+        return _ObservedIngressEvidence(projection=projection)
     records = _optional_records(
         record_store,
         "list_public_ingress_observation_records",
@@ -683,15 +789,17 @@ def _observed_ingress(
         for record in records
         if isinstance(record, PublicIngressObservationRecord) and record.purpose == "probe"
     )
+    newest_observation = observations[0] if observations else None
     latest = next(
         (record for record in observations if _public_runtime_identity_target(record) is not None),
-        observations[0] if observations else None,
+        newest_observation,
     )
     if latest is None:
-        return ProductObservedIngress(
+        projection = ProductObservedIngress(
             monitoring_intent=monitoring_intent,
             incident_eligible=incident_eligible,
         )
+        return _ObservedIngressEvidence(projection=projection)
     incident = _latest_open_incident(
         record_store=record_store,
         product=profile.product,
@@ -738,7 +846,7 @@ def _observed_ingress(
         record_store=record_store,
         incident_id=incident.incident_id if incident is not None else "",
     )
-    return ProductObservedIngress(
+    projection = ProductObservedIngress(
         monitoring_intent=monitoring_intent,
         incident_eligible=incident_eligible,
         status=latest.status,
@@ -772,6 +880,12 @@ def _observed_ingress(
         stale_after=stale_after_value,
         trust_state=trust_state,
         provenance=provenance,
+    )
+    return _ObservedIngressEvidence(
+        projection=projection,
+        runtime_target_observation=latest,
+        absolute_newest_observation=newest_observation,
+        runtime_target=runtime_target,
     )
 
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -840,6 +840,19 @@ passes without treating old evidence as current for an entire workday, while the
 14-day expiry window gives operators enough time to review ownership and
 rotation before a certificate crosses into an outage condition.
 
+The product topology read model may use the newest fresh strict public health
+probe to corroborate observed placement between deployments. This applies only
+to a public-monitoring lane whose exact enabled check requires runtime identity,
+when the health target passes and its expected and observed identities match
+each other and the recorded placement identity, whose recorded health is also
+verified and passing. The placement projection then
+uses the public observation as its current provenance; the environment inventory
+record, its timestamp, and the environment-level provenance remain unchanged.
+Legacy, non-strict, base-page-only, older-than-latest, stale, failing, missing,
+unchecked, unverifiable, or mismatched evidence never refreshes placement trust.
+This is a read-only corroboration rule, not an inventory heartbeat or a substitute
+for deployment, promotion, route, provider-target, or TLS authority.
+
 Notification routing is a separate service-backed policy and delivery concern,
 not lane-owned text config. The initial notification destinations are GitHub
 issues, email, and Discord; each is selected by DB-backed policy and evidenced

--- a/docs/records.md
+++ b/docs/records.md
@@ -867,6 +867,19 @@ from Dokploy records, provider target ids, or other provider payloads. Fresh
 failing probes remain verified observations with a failing status, while stale
 route-binding or TLS evidence is called out separately.
 
+Observed placement can remain current between real deploy or promotion events
+when the newest public HTTP observation is a fresh passing strict health probe
+for the exact configured check and its expected and observed runtime identities
+exactly match the recorded placement identity, whose recorded health is verified
+and passing. In that bounded case,
+`observed.placement` uses the public observation as provenance and reports
+verified placement trust. The environment inventory record and the environment
+read model's inventory provenance remain unchanged and may still show their true
+age. Legacy, non-strict, base-page-only, superseded, stale, failing, missing,
+unchecked, unverifiable, or identity-divergent evidence leaves placement trust
+fail closed. No observation writes or re-timestamps deployment or inventory
+records.
+
 Typed topology warnings identify missing or disabled authority, desired versus
 recorded domain divergence, placement disagreement, ingress or TLS ownership
 divergence, stale evidence, missing TLS observations, certificate mismatch,

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2230,6 +2230,19 @@ context. Raw context names remain evidence metadata, while provider target ids,
 host ids, certificate ids, edge addresses, provider evidence maps, runtime
 values, secret plaintext, secret ciphertext, and product-specific driver
 payloads are not exposed.
+
+For a public-monitoring lane, the read-only topology projection may corroborate
+observed placement from the newest fresh passing strict health probe only when
+the exact configured check requires runtime identity and the probe's expected
+and observed identities both equal the recorded placement identity, whose
+recorded health is verified and passing. The
+placement provenance then names that public observation. Environment inventory,
+deployment evidence, and their environment-level provenance are neither updated
+nor re-timestamped. Non-strict, legacy, base-page-only, superseded, stale,
+failing, missing, unchecked, unverifiable, or mismatched observations remain
+fail closed, and route, provider-target, TLS, and authorization readiness are
+still evaluated independently.
+
 `/v1/repo-product-mapping` and `/v1/agent/context` are also native FastAPI routes.
 
 `GET /v1/products/{product}/environments` returns the product's stable

--- a/tests/test_product_topology_read_model.py
+++ b/tests/test_product_topology_read_model.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Literal
 import unittest
 
 from control_plane.contracts.data_provenance import FreshnessStatus
 from control_plane.contracts.deploy_target import ProviderTargetRecord
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
-from control_plane.contracts.product_profile_record import LaunchplaneProductProfileRecord
+from control_plane.contracts.product_profile_record import (
+    LaunchplaneProductProfileRecord,
+    ProductLaneMonitoringIntent,
+)
 from control_plane.contracts.product_topology_read_model import (
     build_product_environment_topology,
 )
@@ -38,6 +42,23 @@ from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIde
 _NOW = datetime(2026, 7, 14, 12, 0, tzinfo=timezone.utc)
 
 
+def _runtime_identity(
+    *,
+    product: str = "example-site",
+    artifact_id: str = "artifact-1",
+    image_reference: str = "",
+) -> RuntimeIdentity:
+    return RuntimeIdentity(
+        product=product,
+        context="example-context",
+        instance="prod",
+        deployment_record_id="deployment-1",
+        artifact_id=artifact_id,
+        source_git_ref="refs/heads/main",
+        image_reference=image_reference,
+    )
+
+
 def _profile(
     *,
     product: str = "example-site",
@@ -65,6 +86,25 @@ def _profile(
             "source": "test",
         }
     )
+
+
+def _strict_public_profile(
+    *,
+    product: str = "example-site",
+    domain_name: str = "example.test",
+) -> LaunchplaneProductProfileRecord:
+    payload = _profile(product=product, domain_name=domain_name).model_dump(mode="json")
+    payload["lanes"][0]["health_monitoring"] = {
+        "monitoring_intent": "public",
+        "checks": [
+            {
+                "name": "public-ingress",
+                "kind": "public_http",
+                "require_runtime_identity": True,
+            }
+        ],
+    }
+    return LaunchplaneProductProfileRecord.model_validate(payload)
 
 
 def _route_binding(
@@ -243,15 +283,10 @@ def _http_observation(
     domain_name: str = "example.test",
     observed_at: str = "2026-07-14T11:30:00Z",
     runtime_identity_status: RuntimeIdentityStatus = "match",
+    expected_runtime_identity: RuntimeIdentity | None = None,
+    monitoring_intent: ProductLaneMonitoringIntent | Literal["legacy"] = "legacy",
 ) -> PublicIngressObservationRecord:
-    expected_identity = RuntimeIdentity(
-        product=product,
-        context="example-context",
-        instance="prod",
-        deployment_record_id="deployment-1",
-        artifact_id="artifact-1",
-        source_git_ref="refs/heads/main",
-    )
+    expected_identity = expected_runtime_identity or _runtime_identity(product=product)
     observed_identity = expected_identity if runtime_identity_status == "match" else None
     status: PublicIngressObservationStatus = (
         "pass" if runtime_identity_status in {"match", "unchecked"} else "fail"
@@ -286,6 +321,7 @@ def _http_observation(
         instance="prod",
         check_name="public-ingress",
         check_kind="public_http",
+        monitoring_intent=monitoring_intent,
         observed_at=observed_at,
         status=status,
         failure_code=failure_code,
@@ -294,6 +330,69 @@ def _http_observation(
         expected_runtime_identity=expected_identity,
         targets=(target,),
         summary=target.summary,
+    )
+
+
+def _lane_summary(
+    *,
+    identity: RuntimeIdentity | None = None,
+    freshness_status: FreshnessStatus = "stale",
+    runtime_identity_status: RuntimeIdentityStatus = "match",
+    health_verified: bool = True,
+    health_status: str = "pass",
+) -> LaunchplaneLaneSummary:
+    current_identity = identity or _runtime_identity()
+    observed_identity = current_identity if runtime_identity_status == "match" else None
+    return LaunchplaneLaneSummary.model_validate(
+        {
+            "context": "example-context",
+            "instance": "prod",
+            "inventory": {
+                "context": "example-context",
+                "instance": "prod",
+                "artifact_identity": {"artifact_id": current_identity.artifact_id},
+                "source_git_ref": current_identity.source_git_ref,
+                "deploy": {
+                    "target_name": "example-site-prod",
+                    "target_type": "application",
+                    "deploy_mode": "test",
+                    "deployment_id": current_identity.deployment_record_id,
+                    "status": "pass",
+                    "started_at": "2026-07-14T09:55:00Z",
+                    "finished_at": "2026-07-14T10:00:00Z",
+                },
+                "runtime_identity": current_identity.model_dump(mode="json"),
+                "destination_health": {
+                    "verified": health_verified,
+                    "urls": ("https://example.test/healthz",),
+                    "timeout_seconds": 30,
+                    "status": health_status,
+                    "runtime_identity_status": runtime_identity_status,
+                    "runtime_identity_detail": "Recorded deployment runtime identity evidence.",
+                    "observed_runtime_identity": (
+                        observed_identity.model_dump(mode="json")
+                        if observed_identity is not None
+                        else None
+                    ),
+                },
+                "updated_at": "2026-07-14T10:00:00Z",
+                "deployment_record_id": current_identity.deployment_record_id,
+            },
+            "provider_target": _provider_target().model_dump(mode="json"),
+            "provenance": {
+                "source_kind": "record",
+                "source_record_id": "environment-inventory-prod",
+                "recorded_at": "2026-07-14T10:00:00Z",
+                "refreshed_at": "2026-07-14T10:00:00Z",
+                "freshness_status": freshness_status,
+                "stale_after": (
+                    "2026-07-14T10:30:00Z"
+                    if freshness_status == "stale"
+                    else "2099-01-01T00:00:00Z"
+                ),
+                "detail": "Launchplane environment inventory evidence.",
+            },
+        }
     )
 
 
@@ -594,6 +693,255 @@ class ProductTopologyReadModelTests(unittest.TestCase):
             "public_runtime_identity_unverified",
             {warning.code for warning in unverified.warnings},
         )
+
+    def test_fresh_strict_public_runtime_proof_corroborates_stale_placement(self) -> None:
+        profile = _strict_public_profile()
+        identity = _runtime_identity()
+        lane_summary = _lane_summary(identity=identity)
+        topology = build_product_environment_topology(
+            record_store=_TopologyStore(
+                route_binding=_route_binding(),
+                observations=(
+                    _http_observation(
+                        expected_runtime_identity=identity,
+                        monitoring_intent="public",
+                    ),
+                    _tls_observation(status="valid"),
+                ),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            lane_summary=lane_summary,
+            now=_NOW,
+        )
+
+        self.assertEqual(lane_summary.provenance.freshness_status, "stale")
+        self.assertEqual(topology.observed.placement.trust_state, "verified")
+        self.assertEqual(topology.observed.placement.runtime_identity_status, "match")
+        self.assertEqual(
+            topology.observed.placement.expected_runtime_identity,
+            topology.observed.placement.observed_runtime_identity,
+        )
+        self.assertEqual(topology.observed.placement.provenance.source_kind, "provider")
+        self.assertEqual(
+            topology.observed.placement.provenance.source_record_id,
+            "http-observation-example-site-match",
+        )
+        self.assertEqual(topology.observed.trust_state, "verified")
+        self.assertEqual(topology.trust_state, "recorded")
+
+    def test_stale_public_runtime_proof_does_not_corroborate_placement(self) -> None:
+        profile = _strict_public_profile()
+        topology = build_product_environment_topology(
+            record_store=_TopologyStore(
+                route_binding=_route_binding(),
+                observations=(
+                    _http_observation(
+                        observed_at="2026-07-14T09:30:00Z",
+                        monitoring_intent="public",
+                    ),
+                    _tls_observation(status="valid"),
+                ),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            lane_summary=_lane_summary(),
+            now=_NOW,
+        )
+
+        self.assertEqual(topology.observed.ingress.trust_state, "stale")
+        self.assertEqual(topology.observed.placement.trust_state, "stale")
+        self.assertEqual(topology.observed.placement.provenance.source_kind, "record")
+
+    def test_runtime_proof_does_not_replace_missing_or_unsupported_placement_trust(
+        self,
+    ) -> None:
+        profile = _strict_public_profile()
+        for freshness_status in ("missing", "unsupported"):
+            with self.subTest(freshness_status=freshness_status):
+                topology = build_product_environment_topology(
+                    record_store=_TopologyStore(
+                        route_binding=_route_binding(),
+                        observations=(
+                            _http_observation(monitoring_intent="public"),
+                            _tls_observation(status="valid"),
+                        ),
+                    ),
+                    profile=profile,
+                    lane=profile.lanes[0],
+                    lane_summary=_lane_summary(freshness_status=freshness_status),
+                    now=_NOW,
+                )
+
+                self.assertEqual(
+                    topology.observed.placement.trust_state,
+                    freshness_status,
+                )
+                self.assertEqual(topology.observed.placement.provenance.source_kind, "record")
+
+    def test_non_strict_public_runtime_proof_does_not_corroborate_placement(self) -> None:
+        profile_payload = _strict_public_profile().model_dump(mode="json")
+        profile_payload["lanes"][0]["health_monitoring"]["checks"][0][
+            "require_runtime_identity"
+        ] = False
+        profile = LaunchplaneProductProfileRecord.model_validate(profile_payload)
+        topology = build_product_environment_topology(
+            record_store=_TopologyStore(
+                route_binding=_route_binding(),
+                observations=(
+                    _http_observation(monitoring_intent="public"),
+                    _tls_observation(status="valid"),
+                ),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            lane_summary=_lane_summary(),
+            now=_NOW,
+        )
+
+        self.assertEqual(topology.observed.ingress.runtime_identity_status, "match")
+        self.assertEqual(topology.observed.placement.trust_state, "stale")
+
+    def test_different_public_runtime_identity_does_not_corroborate_placement(self) -> None:
+        profile = _strict_public_profile()
+        topology = build_product_environment_topology(
+            record_store=_TopologyStore(
+                route_binding=_route_binding(),
+                observations=(
+                    _http_observation(
+                        expected_runtime_identity=_runtime_identity(artifact_id="artifact-2"),
+                        monitoring_intent="public",
+                    ),
+                    _tls_observation(status="valid"),
+                ),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            lane_summary=_lane_summary(),
+            now=_NOW,
+        )
+
+        self.assertEqual(topology.observed.ingress.runtime_identity_status, "match")
+        self.assertEqual(topology.observed.placement.trust_state, "stale")
+
+    def test_optional_runtime_identity_divergence_does_not_corroborate_placement(self) -> None:
+        profile = _strict_public_profile()
+        topology = build_product_environment_topology(
+            record_store=_TopologyStore(
+                route_binding=_route_binding(),
+                observations=(
+                    _http_observation(monitoring_intent="public"),
+                    _tls_observation(status="valid"),
+                ),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            lane_summary=_lane_summary(
+                identity=_runtime_identity(
+                    image_reference="ghcr.io/example/example-site@sha256:abc123"
+                )
+            ),
+            now=_NOW,
+        )
+
+        self.assertEqual(topology.observed.ingress.runtime_identity_status, "match")
+        self.assertEqual(topology.observed.placement.trust_state, "stale")
+
+    def test_prelaunch_or_legacy_runtime_proof_does_not_corroborate_placement(self) -> None:
+        strict_profile = _strict_public_profile()
+        prelaunch_payload = strict_profile.model_dump(mode="json")
+        prelaunch_payload["lanes"][0]["health_monitoring"]["monitoring_intent"] = "prelaunch"
+        cases = (
+            (
+                "prelaunch_lane",
+                LaunchplaneProductProfileRecord.model_validate(prelaunch_payload),
+                _http_observation(monitoring_intent="public"),
+            ),
+            ("legacy_observation", strict_profile, _http_observation()),
+        )
+        for label, profile, observation in cases:
+            with self.subTest(case=label):
+                topology = build_product_environment_topology(
+                    record_store=_TopologyStore(
+                        route_binding=_route_binding(),
+                        observations=(observation, _tls_observation(status="valid")),
+                    ),
+                    profile=profile,
+                    lane=profile.lanes[0],
+                    lane_summary=_lane_summary(),
+                    now=_NOW,
+                )
+
+                self.assertEqual(topology.observed.placement.trust_state, "stale")
+
+    def test_failing_public_runtime_proof_does_not_corroborate_placement(self) -> None:
+        profile = _strict_public_profile()
+        topology = build_product_environment_topology(
+            record_store=_TopologyStore(
+                route_binding=_route_binding(),
+                observations=(
+                    _http_observation(
+                        runtime_identity_status="unverifiable",
+                        monitoring_intent="public",
+                    ),
+                    _tls_observation(status="valid"),
+                ),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            lane_summary=_lane_summary(),
+            now=_NOW,
+        )
+
+        self.assertEqual(topology.observed.ingress.status, "fail")
+        self.assertEqual(topology.observed.placement.trust_state, "stale")
+
+    def test_failed_recorded_health_does_not_corroborate_placement(self) -> None:
+        profile = _strict_public_profile()
+        topology = build_product_environment_topology(
+            record_store=_TopologyStore(
+                route_binding=_route_binding(),
+                observations=(
+                    _http_observation(monitoring_intent="public"),
+                    _tls_observation(status="valid"),
+                ),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            lane_summary=_lane_summary(health_status="fail"),
+            now=_NOW,
+        )
+
+        self.assertEqual(topology.observed.ingress.status, "pass")
+        self.assertEqual(topology.observed.placement.runtime_identity_status, "match")
+        self.assertEqual(topology.observed.placement.trust_state, "stale")
+
+    def test_newer_equivalent_public_evidence_fences_older_strict_proof(self) -> None:
+        profile = _strict_public_profile()
+        topology = build_product_environment_topology(
+            record_store=_TopologyStore(
+                route_binding=_route_binding(),
+                observations=(
+                    _http_observation(
+                        observed_at="2026-07-14T11:30:00Z",
+                        monitoring_intent="public",
+                    ),
+                    _http_observation(
+                        observed_at="2026-07-14T11:45:00Z",
+                        runtime_identity_status="unchecked",
+                        monitoring_intent="public",
+                    ),
+                    _tls_observation(status="valid"),
+                ),
+            ),
+            profile=profile,
+            lane=profile.lanes[0],
+            lane_summary=_lane_summary(),
+            now=_NOW,
+        )
+
+        self.assertEqual(topology.observed.ingress.runtime_identity_status, "match")
+        self.assertEqual(topology.observed.placement.trust_state, "stale")
 
     def test_projection_diagnoses_cm_website_tls_hostname_mismatch(self) -> None:
         profile = _profile(


### PR DESCRIPTION
## Summary

- allow a stale observed placement projection to be corroborated by the absolute newest fresh, passing, strict public health runtime-identity observation
- require the exact configured public check, verified/passing recorded health, and full typed identity equality while preserving fail-closed behavior for every weaker evidence state
- keep inventory and deployment records unchanged while using the public observation as the derived placement provenance
- document the projection boundary and add focused positive and negative topology/readiness coverage

## Safety

- no provider, route, deployment, inventory, incident, notification, or database mutation path changes
- no runtime identities, products, tenants, domains, endpoints, lanes, or operator identities are hard-coded
- route, TLS, provider-target, deployment, and authorization readiness remain independently fail closed
- `#1883` remains blocked until this code is deployed and the sanctioned live evidence sequence passes

## Validation

- 2,415 unit-test targets across 12 shards
- 60 PostgreSQL integration tests on isolated PostgreSQL 17
- full mypy (`575` source files)
- full Ruff lint; changed Python files pass Ruff format
- config-authority audit
- Odoo ownership boundary across 7 repositories / 806 files
- frontend validate, OpenAPI drift, and production build
- 30 Playwright browser smoke journeys / screenshots
- pip-audit: no known vulnerabilities in auditable dependencies
- JetBrains PyCharm changed-files inspection: zero findings
- independent code review: no blockers after review findings were addressed

Refs #1882
