### PR TITLE
Use canonical runtime identity for placement corroboration

### DIFF
--- a/control_plane/contracts/product_topology_read_model.py
+++ b/control_plane/contracts/product_topology_read_model.py
@@ -36,7 +36,11 @@ from control_plane.contracts.route_binding_record import (
     RouteBindingTerminationKind,
     RouteBindingTlsOwner,
 )
-from control_plane.contracts.runtime_identity import RuntimeIdentity, RuntimeIdentityStatus
+from control_plane.contracts.runtime_identity import (
+    RuntimeIdentity,
+    RuntimeIdentityStatus,
+    compare_runtime_identity,
+)
 
 
 ProductTopologyAuthorityStatus = Literal["active", "disabled", "missing"]
@@ -740,9 +744,21 @@ def _strict_public_ingress_confirms_placement(
         and observed_identity is not None
         and ingress_expected is not None
         and ingress_observed is not None
-        and expected_identity == observed_identity
-        and ingress_expected == ingress_observed
-        and expected_identity == ingress_expected
+        and compare_runtime_identity(
+            expected=expected_identity,
+            observed=observed_identity,
+        )[0]
+        == "match"
+        and compare_runtime_identity(
+            expected=ingress_expected,
+            observed=ingress_observed,
+        )[0]
+        == "match"
+        and compare_runtime_identity(
+            expected=expected_identity,
+            observed=ingress_expected,
+        )[0]
+        == "match"
     )
 
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -844,8 +844,9 @@ The product topology read model may use the newest fresh strict public health
 probe to corroborate observed placement between deployments. This applies only
 to a public-monitoring lane whose exact enabled check requires runtime identity,
 when the health target passes and its expected and observed identities match
-each other and the recorded placement identity, whose recorded health is also
-verified and passing. The placement projection then
+each other and the recorded placement identity under the canonical runtime
+identity comparison, whose recorded health is also verified and passing. The
+placement projection then
 uses the public observation as its current provenance; the environment inventory
 record, its timestamp, and the environment-level provenance remain unchanged.
 Legacy, non-strict, base-page-only, older-than-latest, stale, failing, missing,

--- a/docs/records.md
+++ b/docs/records.md
@@ -870,8 +870,8 @@ route-binding or TLS evidence is called out separately.
 Observed placement can remain current between real deploy or promotion events
 when the newest public HTTP observation is a fresh passing strict health probe
 for the exact configured check and its expected and observed runtime identities
-exactly match the recorded placement identity, whose recorded health is verified
-and passing. In that bounded case,
+match the recorded placement identity under the canonical runtime identity
+comparison, whose recorded health is verified and passing. In that bounded case,
 `observed.placement` uses the public observation as provenance and reports
 verified placement trust. The environment inventory record and the environment
 read model's inventory provenance remain unchanged and may still show their true

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -2234,8 +2234,9 @@ payloads are not exposed.
 For a public-monitoring lane, the read-only topology projection may corroborate
 observed placement from the newest fresh passing strict health probe only when
 the exact configured check requires runtime identity and the probe's expected
-and observed identities both equal the recorded placement identity, whose
-recorded health is verified and passing. The
+and observed identities both match the recorded placement identity under the
+canonical runtime identity comparison, whose recorded health is verified and
+passing. The
 placement provenance then names that public observation. Environment inventory,
 deployment evidence, and their environment-level provenance are neither updated
 nor re-timestamped. Non-strict, legacy, base-page-only, superseded, stale,

--- a/tests/test_product_topology_read_model.py
+++ b/tests/test_product_topology_read_model.py
@@ -47,6 +47,7 @@ def _runtime_identity(
     product: str = "example-site",
     artifact_id: str = "artifact-1",
     image_reference: str = "",
+    deployed_at: str = "",
 ) -> RuntimeIdentity:
     return RuntimeIdentity(
         product=product,
@@ -56,6 +57,7 @@ def _runtime_identity(
         artifact_id=artifact_id,
         source_git_ref="refs/heads/main",
         image_reference=image_reference,
+        deployed_at=deployed_at,
     )
 
 
@@ -284,10 +286,17 @@ def _http_observation(
     observed_at: str = "2026-07-14T11:30:00Z",
     runtime_identity_status: RuntimeIdentityStatus = "match",
     expected_runtime_identity: RuntimeIdentity | None = None,
+    observed_deployed_at: str | None = None,
     monitoring_intent: ProductLaneMonitoringIntent | Literal["legacy"] = "legacy",
 ) -> PublicIngressObservationRecord:
     expected_identity = expected_runtime_identity or _runtime_identity(product=product)
-    observed_identity = expected_identity if runtime_identity_status == "match" else None
+    observed_identity = (
+        expected_identity.model_copy(update={"deployed_at": observed_deployed_at})
+        if runtime_identity_status == "match" and observed_deployed_at is not None
+        else expected_identity
+        if runtime_identity_status == "match"
+        else None
+    )
     status: PublicIngressObservationStatus = (
         "pass" if runtime_identity_status in {"match", "unchecked"} else "fail"
     )
@@ -340,9 +349,16 @@ def _lane_summary(
     runtime_identity_status: RuntimeIdentityStatus = "match",
     health_verified: bool = True,
     health_status: str = "pass",
+    observed_deployed_at: str | None = None,
 ) -> LaunchplaneLaneSummary:
     current_identity = identity or _runtime_identity()
-    observed_identity = current_identity if runtime_identity_status == "match" else None
+    observed_identity = (
+        current_identity.model_copy(update={"deployed_at": observed_deployed_at})
+        if runtime_identity_status == "match" and observed_deployed_at is not None
+        else current_identity
+        if runtime_identity_status == "match"
+        else None
+    )
     return LaunchplaneLaneSummary.model_validate(
         {
             "context": "example-context",
@@ -824,28 +840,34 @@ class ProductTopologyReadModelTests(unittest.TestCase):
         self.assertEqual(topology.observed.ingress.runtime_identity_status, "match")
         self.assertEqual(topology.observed.placement.trust_state, "stale")
 
-    def test_optional_runtime_identity_divergence_does_not_corroborate_placement(self) -> None:
+    def test_optional_runtime_identity_difference_preserves_canonical_match(self) -> None:
         profile = _strict_public_profile()
-        topology = build_product_environment_topology(
-            record_store=_TopologyStore(
-                route_binding=_route_binding(),
-                observations=(
-                    _http_observation(monitoring_intent="public"),
-                    _tls_observation(status="valid"),
-                ),
-            ),
-            profile=profile,
-            lane=profile.lanes[0],
-            lane_summary=_lane_summary(
-                identity=_runtime_identity(
-                    image_reference="ghcr.io/example/example-site@sha256:abc123"
+        identity = _runtime_identity(deployed_at="2026-07-14T10:00:00Z")
+        for observed_deployed_at in ("", "2026-07-14T10:01:00Z"):
+            with self.subTest(observed_deployed_at=observed_deployed_at):
+                topology = build_product_environment_topology(
+                    record_store=_TopologyStore(
+                        route_binding=_route_binding(),
+                        observations=(
+                            _http_observation(
+                                expected_runtime_identity=identity,
+                                observed_deployed_at=observed_deployed_at,
+                                monitoring_intent="public",
+                            ),
+                            _tls_observation(status="valid"),
+                        ),
+                    ),
+                    profile=profile,
+                    lane=profile.lanes[0],
+                    lane_summary=_lane_summary(
+                        identity=identity,
+                        observed_deployed_at=observed_deployed_at,
+                    ),
+                    now=_NOW,
                 )
-            ),
-            now=_NOW,
-        )
 
-        self.assertEqual(topology.observed.ingress.runtime_identity_status, "match")
-        self.assertEqual(topology.observed.placement.trust_state, "stale")
+                self.assertEqual(topology.observed.ingress.runtime_identity_status, "match")
+                self.assertEqual(topology.observed.placement.trust_state, "verified")
 
     def test_prelaunch_or_legacy_runtime_proof_does_not_corroborate_placement(self) -> None:
         strict_profile = _strict_public_profile()


### PR DESCRIPTION
## Summary

- replace full Pydantic runtime-identity equality with Launchplane's authoritative `compare_runtime_identity` contract for stale-placement corroboration
- preserve all existing stale-only, newest-observation, strict-check, passing-health, and route/TLS fail-closed guards
- add regression coverage for the live case where canonical identity fields match but optional `deployed_at` is empty or differs
- align operations, records, and service-boundary docs with canonical comparison semantics

## Live evidence

PR #1887 merged and deployed successfully, but the post-deploy topology read remained stale. Redacted diagnosis showed:

- every canonical runtime-identity field matched across recorded placement and fresh public ingress evidence
- the only full-model difference was optional `deployed_at`
- final route dry-run was unchanged with zero findings
- fresh HTTP, runtime identity, and TLS checks passed with no incidents or deliveries

This PR removes that false negative without writing or refreshing inventory/deployment records.

## Validation

- 2,415 unit-test targets across 12 shards
- 60 PostgreSQL integration tests on isolated PostgreSQL 17
- full mypy (`575` source files)
- full Ruff lint; changed Python files pass Ruff format
- focused topology/environment/readiness tests: 75 passing
- JetBrains PyCharm changed-files inspection: zero findings
- independent review: no blockers or high-severity findings; suggested optional-field subcase added

Refs #1882
