### PR TITLE
Pin recovery dispatch workers to landed authority

### DIFF
--- a/.github/github.json
+++ b/.github/github.json
@@ -98,6 +98,7 @@
     "Manage Launchplane Authorization",
     "Merge Train Runner",
     "Odoo Config Parameter Override",
+    "Odoo Artifact Publish",
     "Odoo Driver Route Smoke",
     "Odoo Prod Backup Verification",
     "Odoo Prod Backup Restore Plan",

--- a/.github/workflows/odoo-artifact-publish.yml
+++ b/.github/workflows/odoo-artifact-publish.yml
@@ -1,0 +1,55 @@
+---
+name: Odoo Artifact Publish
+
+"on":
+  workflow_dispatch:
+    inputs:
+      product:
+        description: Launchplane product profile key.
+        required: true
+        type: string
+      context:
+        description: Launchplane Odoo context.
+        required: true
+        type: string
+      instance:
+        description: Odoo instance whose artifact should be published.
+        required: true
+        type: string
+      source_git_ref:
+        description: Source ref or commit SHA attached to the artifact.
+        required: true
+        type: string
+      confirmation:
+        description: Type PUBLISH LAUNCHPLANE ODOO ARTIFACT to confirm.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+concurrency:
+  group: >-
+    odoo-artifact-publish-${{ inputs.product }}-${{ inputs.instance }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    uses: cbusillo/launchplane/.github/workflows/reusable-odoo-artifact-publish.yml@e605d8ab9ec26950247233c4237d65ea8b44a6d6 # main
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    with:
+      product: ${{ inputs.product }}
+      context: ${{ inputs.context }}
+      instance: ${{ inputs.instance }}
+      source_git_ref: ${{ inputs.source_git_ref }}
+      confirmation: ${{ inputs.confirmation }}
+      launchplane_url: ${{ vars.LAUNCHPLANE_PUBLIC_URL }}
+      launchplane_audience: ${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}
+    secrets:
+      ODOO_GHCR_PUBLISH_TOKEN: ${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}
+      ODOO_SOURCE_GITHUB_TOKEN: ${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}

--- a/.github/workflows/odoo-target-replacement-plan.yml
+++ b/.github/workflows/odoo-target-replacement-plan.yml
@@ -19,6 +19,16 @@ name: Odoo Target Replacement Plan
         options:
           - recreate-in-place
           - replace-and-cutover
+      artifact_id:
+        description: Optional stored artifact ID to plan instead of the current inventory artifact.
+        required: false
+        default: ""
+        type: string
+      source_git_ref:
+        description: Required when artifact_id is set; must match the stored artifact manifest.
+        required: false
+        default: ""
+        type: string
       allow_empty_data:
         description: Allow missing Odoo volume env keys.
         required: true
@@ -49,7 +59,7 @@ concurrency:
 
 jobs:
   plan:
-    uses: cbusillo/launchplane/.github/workflows/reusable-odoo-target-replacement-plan.yml@480c9280b1ae3610f05547192783da2230dc7ff5 # main
+    uses: cbusillo/launchplane/.github/workflows/reusable-odoo-target-replacement-plan.yml@e605d8ab9ec26950247233c4237d65ea8b44a6d6 # main
     permissions:
       contents: read
       id-token: write
@@ -57,6 +67,8 @@ jobs:
       product: ${{ inputs.product }}
       instance: ${{ inputs.instance }}
       strategy: ${{ inputs.strategy }}
+      artifact_id: ${{ inputs.artifact_id }}
+      source_git_ref: ${{ inputs.source_git_ref }}
       allow_empty_data: ${{ inputs.allow_empty_data }}
       data_source_mode: ${{ inputs.data_source_mode }}
       confirmation: ${{ inputs.confirmation }}

--- a/docs/github-actions-security.md
+++ b/docs/github-actions-security.md
@@ -53,8 +53,8 @@ remote code or move workflow data across trust boundaries.
   whose full-SHA `job_workflow_ref` is itself part of the active policy trust
   boundary. The approved set is limited to managed authz administration,
   route-binding reconciliation, exact-instance product health-policy mutation,
-  and exact-instance Odoo target-replacement plan/apply workers whose actions
-  are separately authorized.
+  exact-instance immutable Odoo artifact publication, and exact-instance Odoo
+  target-replacement plan/apply workers whose actions are separately authorized.
 - Changes to an approved privileged worker's `workflow_call` interface require
   two landings. First land the worker contract without changing caller pins,
   then pin each caller to that landed commit and start passing the new input or

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1758,9 +1758,8 @@ gate check. Plan payload generation and apply operation creation occur only
 after an exact `ready` result. Apply uses a
 complete explicit `artifact_id`/`source_git_ref` pair when supplied; otherwise it
 pins both values from the current environment record before enqueue. The plan
-request and reusable plan worker accept the same pair so a newly published
-immutable recovery artifact can be reviewed before apply once a caller advances
-to the landed worker contract. Plan and apply both read the selected manifest,
+workflow accepts the same pair so a newly published immutable recovery artifact
+can be reviewed before apply. Plan and apply both read the selected manifest,
 require its source commit and image repository to match, and reject artifacts
 whose `odoo_install_modules` omit Launchplane's required safety modules. Apply
 repeats those checks before creating a durable operation. Both

--- a/tests/test_github_actions_security.py
+++ b/tests/test_github_actions_security.py
@@ -56,6 +56,9 @@ PINNED_SELF_REUSABLE_WORKFLOWS: Mapping[Path, frozenset[str]] = {
     Path(".github/workflows/product-prelaunch-rebuild-policy.yml"): frozenset(
         {"cbusillo/launchplane/.github/workflows/reusable-product-prelaunch-rebuild-policy.yml"}
     ),
+    Path(".github/workflows/odoo-artifact-publish.yml"): frozenset(
+        {"cbusillo/launchplane/.github/workflows/reusable-odoo-artifact-publish.yml"}
+    ),
     Path(".github/workflows/odoo-testing-route-binding-refresh.yml"): frozenset(
         {"cbusillo/launchplane/.github/workflows/reusable-odoo-testing-route-binding-refresh.yml"}
     ),
@@ -215,6 +218,12 @@ APPROVED_REMOTE_ACTIONS: Mapping[str, ActionClassification] = {
         ActionClassification(
             "First-party same-repository",
             "exact-instance product prelaunch rebuild policy mutation",
+        )
+    ),
+    "cbusillo/launchplane/.github/workflows/reusable-odoo-artifact-publish.yml": (
+        ActionClassification(
+            "First-party same-repository",
+            "exact-instance immutable Odoo artifact publication",
         )
     ),
     "docker/build-push-action": ActionClassification(

--- a/tests/test_odoo_artifact_publish_workflows.py
+++ b/tests/test_odoo_artifact_publish_workflows.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+from tests.support.workflows import load_workflow
+
+
+_PUBLISH_WORKER = (
+    "cbusillo/launchplane/.github/workflows/reusable-odoo-artifact-publish.yml@"
+    "e605d8ab9ec26950247233c4237d65ea8b44a6d6"
+)
+
+
+class OdooArtifactPublishWorkflowTests(unittest.TestCase):
+    def test_dispatch_wrapper_pins_landed_authoritative_worker(self) -> None:
+        workflow = load_workflow(".github/workflows/odoo-artifact-publish.yml")
+
+        trigger = workflow.data["on"]
+        self.assertIsInstance(trigger, dict)
+        assert isinstance(trigger, dict)
+        self.assertEqual(set(trigger), {"workflow_dispatch"})
+        dispatch = trigger["workflow_dispatch"]
+        self.assertIsInstance(dispatch, dict)
+        assert isinstance(dispatch, dict)
+        inputs = dispatch["inputs"]
+        self.assertIsInstance(inputs, dict)
+        assert isinstance(inputs, dict)
+        self.assertEqual(
+            set(inputs),
+            {"product", "context", "instance", "source_git_ref", "confirmation"},
+        )
+        self.assertNotIn("product_repository", inputs)
+        self.assertEqual(set(workflow.jobs), {"publish"})
+        self.assertEqual(workflow.job_uses("publish"), _PUBLISH_WORKER)
+        self.assertEqual(
+            workflow.job_permissions("publish"),
+            {"contents": "read", "id-token": "write", "packages": "write"},
+        )
+        self.assertEqual(workflow.steps("publish"), ())
+        self.assertEqual(
+            workflow.job("publish")["with"],
+            {
+                "product": "${{ inputs.product }}",
+                "context": "${{ inputs.context }}",
+                "instance": "${{ inputs.instance }}",
+                "source_git_ref": "${{ inputs.source_git_ref }}",
+                "confirmation": "${{ inputs.confirmation }}",
+                "launchplane_url": "${{ vars.LAUNCHPLANE_PUBLIC_URL }}",
+                "launchplane_audience": "${{ vars.LAUNCHPLANE_SERVICE_AUDIENCE }}",
+            },
+        )
+        self.assertEqual(
+            workflow.job("publish")["secrets"],
+            {
+                "ODOO_GHCR_PUBLISH_TOKEN": "${{ secrets.ODOO_GHCR_PUBLISH_TOKEN }}",
+                "ODOO_SOURCE_GITHUB_TOKEN": "${{ secrets.ODOO_SOURCE_GITHUB_TOKEN }}",
+            },
+        )
+        text = Path(workflow.path).read_text(encoding="utf-8")
+        self.assertNotIn("launchplane-request@", text)
+        self.assertNotIn("runs-on:", text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_odoo_target_replacement_workflows.py
+++ b/tests/test_odoo_target_replacement_workflows.py
@@ -10,7 +10,8 @@ _LAUNCHPLANE_REQUEST = (
     "cbusillo/launchplane/.github/actions/launchplane-request@"
     "adcf937c6aef14e02478724040852d1d2a82a850"
 )
-_WORKER_SHA = "480c9280b1ae3610f05547192783da2230dc7ff5"
+_PLAN_WORKER_SHA = "e605d8ab9ec26950247233c4237d65ea8b44a6d6"
+_APPLY_WORKER_SHA = "480c9280b1ae3610f05547192783da2230dc7ff5"
 
 
 class OdooTargetReplacementWorkflowTests(unittest.TestCase):
@@ -29,6 +30,8 @@ class OdooTargetReplacementWorkflowTests(unittest.TestCase):
                 "type": "choice",
                 "options": ["recreate-in-place", "replace-and-cutover"],
             },
+            "artifact_id": {"required": False, "default": "", "type": "string"},
+            "source_git_ref": {"required": False, "default": "", "type": "string"},
             "allow_empty_data": {"required": True, "default": False, "type": "boolean"},
             "data_source_mode": {
                 "required": True,
@@ -70,16 +73,18 @@ class OdooTargetReplacementWorkflowTests(unittest.TestCase):
                 self.plan_wrapper,
                 "plan",
                 "reusable-odoo-target-replacement-plan.yml",
+                _PLAN_WORKER_SHA,
                 plan_contract,
             ),
             (
                 self.apply_wrapper,
                 "apply",
                 "reusable-odoo-target-replacement-apply.yml",
+                _APPLY_WORKER_SHA,
                 apply_contract,
             ),
         )
-        for workflow, job_id, worker_name, dispatch_contract in expected:
+        for workflow, job_id, worker_name, worker_sha, dispatch_contract in expected:
             with self.subTest(workflow=workflow.label):
                 trigger = workflow.data["on"]
                 self.assertIsInstance(trigger, dict)
@@ -104,7 +109,7 @@ class OdooTargetReplacementWorkflowTests(unittest.TestCase):
                 self.assertEqual(set(workflow.jobs), {job_id})
                 self.assertEqual(
                     workflow.job_uses(job_id),
-                    f"cbusillo/launchplane/.github/workflows/{worker_name}@{_WORKER_SHA}",
+                    f"cbusillo/launchplane/.github/workflows/{worker_name}@{worker_sha}",
                 )
                 self.assertEqual(
                     workflow.job_permissions(job_id),


### PR DESCRIPTION
## Summary
- add the bounded Odoo artifact-publish dispatch wrapper pinned to landed main commit `e605d8ab9ec26950247233c4237d65ea8b44a6d6`
- expose explicit immutable artifact/source selection through the target-replacement plan wrapper pinned to the same landed worker contract
- resolve the product repository only through Launchplane authority and pass exactly the two required publication secrets
- update privileged-workflow security classification, operator workflow inventory, docs, and focused tests

## Two-Stage Evidence
Foundation PR #1892 merged as `e605d8ab9ec26950247233c4237d65ea8b44a6d6`. Main CI `30407180981`, Security `30407180967`, CodeQL `30407180940`, and supported Deploy Launchplane `30407662865` passed before this caller-pin change.

## Validation
- `uv run --extra dev launchplane ci unittest-shard local --jobs 2` (12/12, 2435 targets)
- focused wrapper, workflow-security, config-authority, workflow-invariant, docs, and onboarding tests
- actionlint on both affected dispatch workflows
- changed-file Ruff checks
- JetBrains changed-files inspection: clean, 0 findings
- independent review found one medium least-secret issue; fixed by replacing `secrets: inherit` with an explicit two-secret mapping

Refs #1890
Refs #1801