### PR TITLE
Fix Odoo runtime addon path repair

### DIFF
--- a/control_plane/contracts/odoo_runtime_environment.py
+++ b/control_plane/contracts/odoo_runtime_environment.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+LAUNCHPLANE_REQUIRED_ODOO_ADDON_PATHS = (
+    "/opt/launchplane/addons",
+    "/opt/enterprise",
+)
+
+
+def _merge_odoo_addons_path(*path_groups: str | Iterable[str]) -> str:
+    merged_paths: list[str] = []
+    for path_group in path_groups:
+        if isinstance(path_group, str):
+            raw_paths: Iterable[str] = path_group.split(",")
+        else:
+            raw_paths = path_group
+        for path in raw_paths:
+            normalized_path = str(path).strip()
+            if not normalized_path or normalized_path in merged_paths:
+                continue
+            merged_paths.append(normalized_path)
+    return ",".join(merged_paths)
+
+
+def merge_required_odoo_addons_path(raw_path: str) -> str:
+    normalized_path = _merge_odoo_addons_path(raw_path)
+    if not normalized_path:
+        return ""
+    return _merge_odoo_addons_path(normalized_path, LAUNCHPLANE_REQUIRED_ODOO_ADDON_PATHS)

--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -13,6 +13,9 @@ from control_plane.contracts.odoo_prod_retained_volume_backup_import import (
     ODOO_PROD_RETAINED_VOLUME_BACKUP_IMPORT_FAILURE_STAGE_BY_CODE,
     OdooProdRetainedVolumeBackupImportInspectionEvidence,
 )
+from control_plane.contracts.odoo_runtime_environment import (
+    merge_required_odoo_addons_path,
+)
 from control_plane.dokploy import api
 from control_plane.dokploy.source import (
     DEFAULT_DOKPLOY_DEPLOY_TIMEOUT_SECONDS,
@@ -324,6 +327,11 @@ def run_compose_post_deploy_update(
         current_env_map=current_env_map,
         env_file=env_file,
     )
+    addons_path = merge_required_odoo_addons_path(desired_env_map.get("ODOO_ADDONS_PATH", ""))
+    if addons_path:
+        desired_env_map["ODOO_ADDONS_PATH"] = addons_path
+    else:
+        desired_env_map.pop("ODOO_ADDONS_PATH", None)
     resolved_workflow_environment_overrides = dict(workflow_environment_overrides or {})
     resolved_required_workflow_environment_keys = tuple(required_workflow_environment_keys)
     runtime_override_target_environment = {
@@ -590,6 +598,11 @@ def run_compose_odoo_stable_bootstrap(
         current_env_map=current_env_map,
         env_file=env_file,
     )
+    addons_path = merge_required_odoo_addons_path(desired_env_map.get("ODOO_ADDONS_PATH", ""))
+    if addons_path:
+        desired_env_map["ODOO_ADDONS_PATH"] = addons_path
+    else:
+        desired_env_map.pop("ODOO_ADDONS_PATH", None)
     resolved_workflow_environment_overrides = dict(workflow_environment_overrides or {})
     resolved_required_workflow_environment_keys = tuple(required_workflow_environment_keys)
     required_update_modules = desired_env_map.get("ODOO_INSTALL_MODULES", "").strip()
@@ -2311,8 +2324,9 @@ docker exec \
     "${{script_runner_container_id}}" \
     python3 -u /volumes/scripts/run_odoo_data_workflows.py "${{workflow_arguments[@]}}" \
     2>&1 | tee "$workflow_output_file"
-workflow_exit_status=${{PIPESTATUS[0]}}
-workflow_output_status=${{PIPESTATUS[1]}}
+workflow_pipeline_status=("${{PIPESTATUS[@]}}")
+workflow_exit_status=${{workflow_pipeline_status[0]}}
+workflow_output_status=${{workflow_pipeline_status[1]}}
 set -e
 
 echo "Odoo {workflow_label} readback markers:"

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -28,6 +28,9 @@ from control_plane.contracts.odoo_preview_runtime_plan import (
     OdooPreviewRuntimePlanStatus,
     plan_odoo_preview_runtime,
 )
+from control_plane.contracts.odoo_runtime_environment import (
+    merge_required_odoo_addons_path,
+)
 from control_plane.contracts.odoo_stable_target_replacement import (
     LAUNCHPLANE_REQUIRED_ODOO_MODULES,
     merge_odoo_install_modules,
@@ -1409,6 +1412,11 @@ def _preview_refresh_environment_values(
     *, request: OdooPreviewDokployApplyRequest
 ) -> dict[str, str]:
     environment_values = dict(request.environment_values)
+    addons_path = merge_required_odoo_addons_path(environment_values.get("ODOO_ADDONS_PATH", ""))
+    if addons_path:
+        environment_values["ODOO_ADDONS_PATH"] = addons_path
+    else:
+        environment_values.pop("ODOO_ADDONS_PATH", None)
     manifest_modules = request.manifest.odoo_install_modules if request.manifest is not None else ()
     update_modules = merge_odoo_install_modules(
         LAUNCHPLANE_REQUIRED_ODOO_MODULES,

--- a/control_plane/workflows/odoo_stable_target_replacement.py
+++ b/control_plane/workflows/odoo_stable_target_replacement.py
@@ -22,6 +22,10 @@ from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.environment_inventory import EnvironmentInventory
 from control_plane.contracts.odoo_instance_override_record import OdooInstanceOverrideRecord
 from control_plane.contracts.odoo_instance_override_record import OdooOverrideApplyPhase
+from control_plane.contracts.odoo_runtime_environment import (
+    LAUNCHPLANE_REQUIRED_ODOO_ADDON_PATHS,
+    merge_required_odoo_addons_path,
+)
 from control_plane.contracts.product_profile_record import (
     LaunchplaneProductProfileRecord,
     ProductLaneProfile,
@@ -102,6 +106,7 @@ class OdooStableTargetReplacementStore(RuntimeKeySafetyPolicyReadStore, Protocol
 DokployRequest = Callable[..., JsonValue]
 DokployConfigReader = Callable[..., tuple[str, str]]
 ODOO_STABLE_TARGET_REPLACEMENT_VERIFY_RETRY_INTERVAL_SECONDS = 5
+ODOO_ADDONS_PATH_ENV_KEY = "ODOO_ADDONS_PATH"
 ODOO_INSTALL_MODULES_ENV_KEY = "ODOO_INSTALL_MODULES"
 ODOO_REQUIRED_VOLUME_ENV_KEYS = ("ODOO_DATA_VOLUME", "ODOO_LOG_VOLUME", "ODOO_DB_VOLUME")
 
@@ -1484,6 +1489,13 @@ def execute_odoo_stable_target_replacement_apply(
         desired_env_map.pop(ODOO_INSTALL_MODULES_ENV_KEY, None)
         desired_env_map.update(runtime_environment_values)
         desired_env_map.update(runtime_override_environment)
+        addons_path = merge_required_odoo_addons_path(
+            desired_env_map.get(ODOO_ADDONS_PATH_ENV_KEY, "")
+        )
+        if addons_path:
+            desired_env_map[ODOO_ADDONS_PATH_ENV_KEY] = addons_path
+        else:
+            desired_env_map.pop(ODOO_ADDONS_PATH_ENV_KEY, None)
         explicit_odoo_install_modules = desired_env_map.get(ODOO_INSTALL_MODULES_ENV_KEY, "")
         manifest_odoo_install_modules = artifact_manifest.odoo_install_modules
         fallback_odoo_install_modules = (
@@ -1496,6 +1508,10 @@ def execute_odoo_stable_target_replacement_apply(
             explicit_odoo_install_modules,
         )
         runtime_source["required_odoo_modules"] = ",".join(LAUNCHPLANE_REQUIRED_ODOO_MODULES)
+        runtime_source["required_odoo_addon_paths"] = ",".join(
+            LAUNCHPLANE_REQUIRED_ODOO_ADDON_PATHS
+        )
+        runtime_source["odoo_addons_path"] = desired_env_map.get(ODOO_ADDONS_PATH_ENV_KEY, "")
         runtime_source["artifact_odoo_install_modules"] = ",".join(
             artifact_manifest.odoo_install_modules
         )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1609,7 +1609,12 @@ context only, and `context_instance` has both context and instance.
   container. Artifact inputs or base images make addon files available, but the
   target env install list is what activates modules such as
   `launchplane_settings` and `disable_odoo_online` in already-initialized
-  databases.
+  databases. Preview refresh, stable replacement, post-deploy update, and stable
+  bootstrap also preserve the recorded addon path while adding the managed
+  `/opt/launchplane/addons` and `/opt/enterprise` roots when missing. This
+  prevents a stale explicit `ODOO_ADDONS_PATH` record from overriding the
+  compose default and making a required module dependency unavailable during
+  fresh database initialization or maintenance.
 - When a deploy-phase payload is expected, Launchplane also persists generic
   runtime assertion flags that tell the Odoo runtime to fail closed if managed
   instance overrides or website bootstrap data are missing. Launchplane re-reads

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -247,14 +247,17 @@ workflows should treat the Odoo refresh route's `refresh_status="pass"` as the
 ready-to-comment signal instead of independently deciding readiness from raw
 health checks. Refresh merges the artifact manifest's declared Odoo modules
 with Launchplane-required modules into both `ODOO_INSTALL_MODULES` and the
-explicit maintenance-only `ODOO_UPDATE_MODULES` input, deploys the compose, and
-then runs the managed Odoo post-deploy maintenance schedule before any smoke
-check can pass. The schedule must prove that exactly one current web container
-and script-runner container use the same artifact image, that an explicit module
-list was configured, and that the install/update workflow completed. Missing,
-false, or unavailable schedule-log evidence fails the refresh. A terminal
-provider deployment alone remains an unknown recovery outcome because it does
-not prove that database-backed views were upgraded.
+explicit maintenance-only `ODOO_UPDATE_MODULES` input. It also merges the
+managed Launchplane and Enterprise addon roots into `ODOO_ADDONS_PATH` so a
+stale explicit runtime-environment value cannot override the compose default
+and make required module dependencies unavailable. Refresh then deploys the
+compose and runs the managed Odoo post-deploy maintenance schedule before any
+smoke check can pass. The schedule must prove that exactly one current web
+container and script-runner container use the same artifact image, that an
+explicit module list was configured, and that the install/update workflow
+completed. Missing, false, or unavailable schedule-log evidence fails the
+refresh. A terminal provider deployment alone remains an unknown recovery
+outcome because it does not prove that database-backed views were upgraded.
 
 Ready Odoo apply-inputs responses also include the normalized `plan_request`
 and `plan_provenance`: a service-derived plan id, canonical SHA-256 fingerprint,

--- a/docs/records.md
+++ b/docs/records.md
@@ -1502,13 +1502,15 @@ run` is the foreground loop intended for an external process supervisor, and
   Launchplane-required modules such as `launchplane_settings` and
   `disable_odoo_online`; deployment fails closed before provider mutation when
   that evidence is absent. Post-deploy maintenance forces the deployed artifact
-  module list through `ODOO_UPDATE_MODULES` and only records pass after provider
-  schedule logs prove a matching web/script-runner artifact image, an explicit
-  module list, and successful install/update completion. Missing or unavailable
-  readback evidence fails the deployment instead of allowing health-only
-  readiness against stale database-backed Odoo views. Stable bootstrap uses the
-  same explicit artifact module list and provider-log evidence gate before it
-  can report completion.
+  module list through `ODOO_UPDATE_MODULES`, restores the managed Launchplane
+  and Enterprise addon roots when an older runtime-environment record omitted
+  them, and only records pass after provider schedule logs prove a matching
+  web/script-runner artifact image, an explicit module list, and successful
+  install/update completion. Missing or unavailable readback evidence fails the
+  deployment instead of allowing health-only readiness against stale
+  database-backed Odoo views. Stable bootstrap uses the same explicit artifact
+  module list, addon-path normalization, and provider-log evidence gate before
+  it can report completion.
 - Artifact manifests may carry `build_provenance` metadata for Odoo runtime and
   devtools base images plus build tools such as `odoo-devkit`. That provenance
   is artifact evidence, not addon ownership: `odoo-docker`, `odoo-devkit`,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2343,6 +2343,7 @@ domains = ["cm-testing.shinycomputers.com"]
                     else (
                         "ODOO_DB_NAME=old_db\n"
                         "ODOO_FILESTORE_PATH=/volumes/data/filestore\n"
+                        "ODOO_ADDONS_PATH=/opt/project/addons,/opt/launchplane/addons,/odoo/addons\n"
                         "ODOO_INSTALL_MODULES=opw_custom\n"
                     ),
                     "appName": "opw-prod-app",
@@ -2412,6 +2413,10 @@ domains = ["cm-testing.shinycomputers.com"]
         self.assertIn("ODOO_DB_NAME=opw_prod", updated_env_payloads[0])
         self.assertIn("ODOO_FILESTORE_PATH=/volumes/data/custom-filestore", updated_env_payloads[0])
         self.assertIn(
+            "ODOO_ADDONS_PATH=/opt/project/addons,/opt/launchplane/addons,/odoo/addons,/opt/enterprise",
+            updated_env_payloads[0],
+        )
+        self.assertIn(
             f"{ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY}={override_payload_b64}",
             updated_env_payloads[0],
         )
@@ -2434,7 +2439,9 @@ domains = ["cm-testing.shinycomputers.com"]
         self.assertIn('echo "odoo_module_update_image_match=true"', schedule_script)
         self.assertIn('echo "odoo_module_update_modules_configured=true"', schedule_script)
         self.assertIn('echo "odoo_module_update_completed=true"', schedule_script)
-        self.assertIn("workflow_output_status=${PIPESTATUS[1]}", schedule_script)
+        self.assertIn('workflow_pipeline_status=("${PIPESTATUS[@]}")', schedule_script)
+        self.assertIn("workflow_exit_status=${workflow_pipeline_status[0]}", schedule_script)
+        self.assertIn("workflow_output_status=${workflow_pipeline_status[1]}", schedule_script)
         self.assertIn("/api/compose.deploy", request_paths)
         self.assertIn("/api/schedule.runManually", request_paths)
         self.assertEqual(
@@ -3558,6 +3565,7 @@ domains = ["cm-testing.shinycomputers.com"]
             target_name="cm-testing",
         )
         schedule_payloads: list[dict[str, object]] = []
+        updated_env_payloads: list[str] = []
         request_paths: list[str] = []
 
         def capture_schedule_payload(**kwargs: object) -> dict[str, str]:
@@ -3576,6 +3584,7 @@ domains = ["cm-testing.shinycomputers.com"]
                     "env": (
                         "ODOO_DB_NAME=cm_testing\n"
                         "ODOO_FILESTORE_PATH=/volumes/data/filestore\n"
+                        "ODOO_ADDONS_PATH=/opt/project/addons,/opt/launchplane/addons,/odoo/addons\n"
                         "ODOO_INSTALL_MODULES=launchplane_settings,disable_odoo_online,cm_website\n"
                     ),
                     "appName": "cm-testing-app",
@@ -3586,6 +3595,16 @@ domains = ["cm-testing.shinycomputers.com"]
                 "control_plane.dokploy.api.find_matching_dokploy_schedule",
                 return_value=None,
             ),
+            patch(
+                "control_plane.dokploy.api.update_dokploy_target_env",
+                side_effect=lambda **kwargs: updated_env_payloads.append(str(kwargs["env_text"])),
+            ),
+            patch(
+                "control_plane.dokploy.api.latest_deployment_for_target",
+                return_value={"deploymentId": "deployment-before"},
+            ),
+            patch("control_plane.dokploy.api.trigger_deployment"),
+            patch("control_plane.dokploy.api.wait_for_target_deployment"),
             patch(
                 "control_plane.dokploy.api.upsert_dokploy_schedule",
                 side_effect=capture_schedule_payload,
@@ -3620,6 +3639,11 @@ domains = ["cm-testing.shinycomputers.com"]
                 env_file=None,
             )
 
+        self.assertEqual(len(updated_env_payloads), 1)
+        self.assertIn(
+            "ODOO_ADDONS_PATH=/opt/project/addons,/opt/launchplane/addons,/odoo/addons,/opt/enterprise",
+            updated_env_payloads[0],
+        )
         self.assertEqual(len(schedule_payloads), 1)
         self.assertEqual(
             schedule_payloads[0]["name"],
@@ -4211,7 +4235,9 @@ actions = ["launchplane_service_deploy.execute"]
         self.assertIn('if [ "${web_was_running}" != "1" ]; then', script)
         self.assertIn('docker start "${web_container_id}" >/dev/null || true', script)
         self.assertIn("workflow_output_file=$(mktemp)", script)
-        self.assertIn("workflow_exit_status=${PIPESTATUS[0]}", script)
+        self.assertIn('workflow_pipeline_status=("${PIPESTATUS[@]}")', script)
+        self.assertIn("workflow_exit_status=${workflow_pipeline_status[0]}", script)
+        self.assertIn("workflow_output_status=${workflow_pipeline_status[1]}", script)
         self.assertIn("Odoo post-deploy maintenance readback markers:", script)
         self.assertIn("grep -E '^(", script)
         self.assertIn("odoo_instance_overrides_payload_present", script)

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -1713,7 +1713,12 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
                 request=OdooPreviewDokployApplyRequest(
                     dry_run_plan=dry_run,
                     manifest=manifest,
-                    environment_values=_environment_values(),
+                    environment_values={
+                        **_environment_values(),
+                        "ODOO_ADDONS_PATH": (
+                            "/opt/project/addons,/opt/launchplane/addons,/odoo/addons"
+                        ),
+                    },
                 ),
             )
 
@@ -1746,6 +1751,10 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(
             env_map["ODOO_UPDATE_MODULES"],
             "launchplane_settings,disable_odoo_online,cm_website",
+        )
+        self.assertEqual(
+            env_map["ODOO_ADDONS_PATH"],
+            "/opt/project/addons,/opt/launchplane/addons,/odoo/addons,/opt/enterprise",
         )
         trigger_deployment.assert_called_once_with(
             host="https://dokploy.example",

--- a/tests/test_odoo_runtime_environment.py
+++ b/tests/test_odoo_runtime_environment.py
@@ -1,0 +1,26 @@
+import unittest
+
+from control_plane.contracts.odoo_runtime_environment import (
+    merge_required_odoo_addons_path,
+)
+
+
+class OdooRuntimeEnvironmentTests(unittest.TestCase):
+    def test_merge_required_addons_preserves_compose_default_when_not_explicit(self) -> None:
+        self.assertEqual(merge_required_odoo_addons_path(""), "")
+
+    def test_merge_required_addons_preserves_order_and_adds_missing_paths(self) -> None:
+        self.assertEqual(
+            merge_required_odoo_addons_path(
+                "/opt/project/addons,/opt/launchplane/addons,/odoo/addons"
+            ),
+            "/opt/project/addons,/opt/launchplane/addons,/odoo/addons,/opt/enterprise",
+        )
+
+    def test_merge_required_addons_deduplicates_existing_paths(self) -> None:
+        self.assertEqual(
+            merge_required_odoo_addons_path(
+                "/opt/project/addons,/opt/enterprise,/opt/launchplane/addons,/opt/enterprise"
+            ),
+            "/opt/project/addons,/opt/enterprise,/opt/launchplane/addons",
+        )

--- a/tests/test_odoo_stable_target_replacement.py
+++ b/tests/test_odoo_stable_target_replacement.py
@@ -1265,6 +1265,7 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
                             "ODOO_DATA_VOLUME=cm_testing_odoo_data",
                             "ODOO_LOG_VOLUME=cm_testing_odoo_logs",
                             "ODOO_DB_VOLUME=cm_testing_odoo_db",
+                            "ODOO_ADDONS_PATH=/opt/project/addons,/opt/launchplane/addons,/odoo/addons",
                             "ODOO_INSTALL_MODULES=stale_module,disable_odoo_online",
                             f"{ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY}={stale_payload_b64}",
                             f"{LAUNCHPLANE_INSTANCE_OVERRIDES_REQUIRED_ENV_KEY}=true",
@@ -1517,6 +1518,10 @@ class OdooStableTargetReplacementTests(unittest.TestCase):
         self.assertEqual(
             persisted_env_map["ODOO_INSTALL_MODULES"],
             "launchplane_settings,disable_odoo_online,cm_website",
+        )
+        self.assertEqual(
+            persisted_env_map["ODOO_ADDONS_PATH"],
+            "/opt/project/addons,/opt/launchplane/addons,/odoo/addons,/opt/enterprise",
         )
         self.assertEqual(persisted_env_map[LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY], "true")
         self.assertNotIn(


### PR DESCRIPTION
## Summary

- preserve the compose default when `ODOO_ADDONS_PATH` is absent or blank;
- repair stale explicit Odoo addon paths before preview refresh, stable replacement, post-deploy update, and stable bootstrap provider effects;
- snapshot the full Bash `PIPESTATUS` array before reading pipeline exit codes under `set -u`;
- document the runtime-path repair contract and add regression coverage.

## Live canary evidence

On July 30, 2026, `odoo-tenant-cm-website` PR #63 proved that the current preview artifact contained `/opt/enterprise/mail_enterprise`, while the authoritative preview environment omitted `/opt/enterprise`. Fresh database initialization therefore restart-looped when `disable_odoo_online` could not resolve `mail_enterprise`. The same review reproduced the sequential `PIPESTATUS` assignment failure locally.

This keeps the fix in Launchplane's remote lifecycle/runtime boundary; no tenant or `odoo-devkit` change is included.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 2,444 targets across 12 shards passed
- 206 focused Odoo preview/Dokploy/stable replacement tests passed
- `uv run --extra dev ruff check .` passed
- changed Python files pass `ruff format --check`
- `uv run --extra dev mypy control_plane tests` passed
- JetBrains changed-files inspection passed with zero findings
- independent production-risk review found no actionable findings

The repository-wide formatter currently reports 25 pre-existing files outside this branch; none of the changed Python files are among them.

Related to #1898. Keep #1898 open until the merged service is deployed and a real two-revision tenant preview plus testing post-deploy/browser validation pass.
