### PR TITLE
Fix Odoo workflow filestore environment

### DIFF
--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -2103,18 +2103,16 @@ def _build_dokploy_data_workflow_script(
     quoted_database_name = shlex.quote(database_name)
     quoted_filestore_path = shlex.quote(normalized_filestore_path)
     quoted_lock_path = shlex.quote(data_workflow_lock_path)
+    resolved_workflow_environment_overrides = dict(workflow_environment_overrides or {})
+    resolved_workflow_environment_overrides["ODOO_FILESTORE_PATH"] = normalized_filestore_path
     workflow_environment_lines = _render_docker_exec_environment_lines(
-        workflow_environment_overrides or {}
+        resolved_workflow_environment_overrides
     )
     effective_required_workflow_environment_keys = tuple(
         sorted(
             {
                 *required_workflow_environment_keys,
-                *(
-                    tuple(workflow_environment_overrides or {})
-                    if workflow_environment_overrides
-                    else ()
-                ),
+                *resolved_workflow_environment_overrides,
             }
         )
     )

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1614,7 +1614,10 @@ context only, and `context_instance` has both context and instance.
   `/opt/launchplane/addons` and `/opt/enterprise` roots when missing. This
   prevents a stale explicit `ODOO_ADDONS_PATH` record from overriding the
   compose default and making a required module dependency unavailable during
-  fresh database initialization or maintenance.
+  fresh database initialization or maintenance. Managed data-workflow schedules
+  also pass their resolved `ODOO_FILESTORE_PATH` explicitly so a target that
+  relies on the compose default still satisfies the workflow's typed runtime
+  configuration.
 - When a deploy-phase payload is expected, Launchplane also persists generic
   runtime assertion flags that tell the Odoo runtime to fail closed if managed
   instance overrides or website bootstrap data are missing. Launchplane re-reads

--- a/docs/preview-workflow-contract.md
+++ b/docs/preview-workflow-contract.md
@@ -255,9 +255,11 @@ compose and runs the managed Odoo post-deploy maintenance schedule before any
 smoke check can pass. The schedule must prove that exactly one current web
 container and script-runner container use the same artifact image, that an
 explicit module list was configured, and that the install/update workflow
-completed. Missing, false, or unavailable schedule-log evidence fails the
-refresh. A terminal provider deployment alone remains an unknown recovery
-outcome because it does not prove that database-backed views were upgraded.
+completed. Launchplane passes the resolved filestore path explicitly to the
+workflow even when the live target relies on the compose default. Missing,
+false, or unavailable schedule-log evidence fails the refresh. A terminal
+provider deployment alone remains an unknown recovery outcome because it does
+not prove that database-backed views were upgraded.
 
 Ready Odoo apply-inputs responses also include the normalized `plan_request`
 and `plan_provenance`: a service-derived plan id, canonical SHA-256 fingerprint,

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -2434,6 +2434,10 @@ domains = ["cm-testing.shinycomputers.com"]
         self.assertIn("--post-deploy-maintenance", schedule_script)
         self.assertNotIn("--update-only", schedule_script)
         self.assertIn("ONE_OFF_WORKFLOW_ONLY", schedule_script)
+        self.assertIn(
+            "workflow_environment+=(-e ODOO_FILESTORE_PATH=/volumes/data/custom-filestore)",
+            schedule_script,
+        )
         self.assertIn("workflow_environment+=(-e ODOO_UPDATE_MODULES=opw_custom)", schedule_script)
         self.assertIn("resolve_single_running_container", schedule_script)
         self.assertIn('echo "odoo_module_update_image_match=true"', schedule_script)
@@ -3655,6 +3659,10 @@ domains = ["cm-testing.shinycomputers.com"]
         self.assertNotIn("workflow_arguments=(--update-only)", script)
         self.assertIn(
             "workflow_environment+=(-e ODOO_UPDATE_MODULES=launchplane_settings,disable_odoo_online,cm_website)",
+            script,
+        )
+        self.assertIn(
+            "workflow_environment+=(-e ODOO_FILESTORE_PATH=/volumes/data/filestore)",
             script,
         )
         self.assertIn("/api/schedule.runManually", request_paths)


### PR DESCRIPTION
## Summary

- pass the already-resolved `ODOO_FILESTORE_PATH` into every managed Odoo data workflow;
- require that value in the generated `docker exec` environment for maintenance, bootstrap, and restore modes;
- document the explicit remote runtime handoff and add maintenance/bootstrap regressions.

## Live canary evidence

On July 30, 2026, `odoo-tenant-cm-website` PR #64 proved the previous addon-path repair: its preview web, database, and script-runner containers all became healthy. The post-deploy schedule then failed typed runtime validation because `LocalServerSettings` required `ODOO_FILESTORE_PATH` while the target relied on the compose default.

Launchplane already resolved `/volumes/data/filestore` for ownership normalization and schedule rendering; this change passes that same authoritative value to the inner Odoo workflow instead of changing `odoo-devkit`.

## Validation

- `uv run --extra dev launchplane ci unittest-shard local` — 2,444 targets across 12 shards passed
- `uv run python -m unittest tests.test_dokploy` — 102 tests passed
- focused maintenance/bootstrap regressions passed
- changed Python files pass Ruff and `ruff format --check`
- `uv run --extra dev mypy control_plane tests` passed
- JetBrains changed-files inspection passed with zero findings

Related to #1898. Keep #1898 open until Launchplane is deployed and tenant PR #64 passes revision A and revision B browser validation.
