### PR TITLE
feat: add durable runner-host cache telemetry reads

### DIFF
--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -8,6 +8,32 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 RunnerHostHygieneStatus = Literal["healthy", "attention"]
+RunnerHostHygieneEvidenceAvailability = Literal[
+    "available",
+    "partial",
+    "unavailable",
+    "stale",
+]
+RunnerHostHygieneMeasurementStatus = Literal[
+    "complete",
+    "partial",
+    "unavailable",
+    "stale",
+]
+RunnerHostHygieneCacheClass = Literal[
+    "runner_workdir",
+    "generated_filesystem",
+    "docker_images",
+    "docker_containers",
+    "docker_volumes",
+    "docker_build_cache",
+]
+RunnerHostHygieneCacheScope = Literal["host", "runner_root", "generated_cache"]
+RunnerHostHygieneMeasurementBasis = Literal[
+    "filesystem_apparent_allocated",
+    "docker_engine",
+]
+RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS = 128
 RunnerHostHygieneApplyAction = Literal[
     "prune_docker_cache",
     "prune_dangling_images",
@@ -163,7 +189,8 @@ class RunnerHostHygieneRunnerWorkdirUsage(BaseModel):
     root_key: str
     apparent_bytes: int = Field(default=0, ge=0)
     allocated_bytes: int = Field(default=0, ge=0)
-    measurement_status: Literal["complete", "partial"] = "complete"
+    measurement_status: RunnerHostHygieneMeasurementStatus = "complete"
+    reason_code: str = ""
 
     @model_validator(mode="after")
     def _normalize_usage(self) -> "RunnerHostHygieneRunnerWorkdirUsage":
@@ -171,6 +198,15 @@ class RunnerHostHygieneRunnerWorkdirUsage(BaseModel):
             _normalized_token(self.root_key),
             "runner host hygiene workdir usage requires root_key",
         )
+        self.reason_code = _normalized_public_token(self.reason_code)
+        if self.measurement_status == "complete" and self.reason_code:
+            raise ValueError("complete runner workdir measurement cannot include reason_code")
+        if self.measurement_status != "complete" and not self.reason_code:
+            self.reason_code = "legacy_incomplete"
+        if self.measurement_status in {"unavailable", "stale"} and (
+            self.apparent_bytes or self.allocated_bytes
+        ):
+            raise ValueError("unavailable runner workdir measurement cannot include bytes")
         return self
 
 
@@ -207,7 +243,8 @@ class RunnerHostHygieneGeneratedCacheUsage(BaseModel):
     apparent_bytes: int = Field(default=0, ge=0)
     allocated_bytes: int = Field(default=0, ge=0)
     entry_count: int = Field(default=0, ge=0)
-    measurement_status: Literal["complete", "partial"] = "complete"
+    measurement_status: RunnerHostHygieneMeasurementStatus = "complete"
+    reason_code: str = ""
     owner_valid: bool = False
     mode_valid: bool = False
     symlink_safe: bool = False
@@ -228,15 +265,103 @@ class RunnerHostHygieneGeneratedCacheUsage(BaseModel):
             self.cache_key,
             "runner host hygiene generated cache usage requires cache_key",
         )
+        self.reason_code = _normalized_public_token(self.reason_code)
+        if self.measurement_status == "complete" and self.reason_code:
+            raise ValueError("complete generated cache measurement cannot include reason_code")
+        if self.measurement_status != "complete" and not self.reason_code:
+            self.reason_code = "legacy_incomplete"
+        if self.measurement_status in {"unavailable", "stale"} and (
+            self.apparent_bytes
+            or self.allocated_bytes
+            or self.entry_count
+            or self.age_buckets
+            or self.entries
+        ):
+            raise ValueError("unavailable generated cache measurement cannot include usage")
         if any(value < 0 for value in self.owner_worker_observations):
             raise ValueError("generated cache worker observations cannot be negative")
-        self.age_buckets = tuple(sorted(self.age_buckets, key=lambda item: item.bucket))
+        self.age_buckets = tuple(sorted(self.age_buckets, key=_cache_age_bucket_sort_key))
         self.entries = tuple(sorted(self.entries, key=lambda item: item.run_id))
         self.last_removed_run_ids = tuple(sorted(set(self.last_removed_run_ids)))
         if any(run_id <= 0 for run_id in self.last_removed_run_ids):
             raise ValueError("generated cache cleanup history run ids must be positive")
         if self.entry_count < len(self.entries):
             raise ValueError("generated cache entry_count cannot be smaller than entries")
+        return self
+
+
+class RunnerHostHygieneCacheClassTelemetry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    cache_key: str
+    cache_class: RunnerHostHygieneCacheClass
+    scope: RunnerHostHygieneCacheScope
+    availability: RunnerHostHygieneEvidenceAvailability
+    measurement_basis: RunnerHostHygieneMeasurementBasis
+    source: str
+    observed_at: str
+    unavailable_reason: str = ""
+    apparent_bytes: int | None = Field(default=None, ge=0)
+    allocated_bytes: int | None = Field(default=None, ge=0)
+    logical_bytes: int | None = Field(default=None, ge=0)
+    reclaimable_bytes: int | None = Field(default=None, ge=0)
+    entry_count: int | None = Field(default=None, ge=0)
+    age_buckets: tuple[RunnerHostHygieneGeneratedCacheAgeBucket, ...] = ()
+    estimated_daily_growth_bytes: int | None = Field(default=None, ge=0)
+    last_cleanup_epoch_seconds: int | None = Field(default=None, ge=0)
+    last_reclaimed_bytes: int | None = Field(default=None, ge=0)
+
+    @model_validator(mode="after")
+    def _normalize_telemetry(self) -> "RunnerHostHygieneCacheClassTelemetry":
+        self.cache_key = _required_public_token(
+            self.cache_key,
+            "runner host hygiene cache-class telemetry requires cache_key",
+        )
+        self.source = _required_public_token(
+            self.source,
+            "runner host hygiene cache-class telemetry requires source",
+        )
+        self.observed_at = _required_text(
+            self.observed_at,
+            "runner host hygiene cache-class telemetry requires observed_at",
+        )
+        self.unavailable_reason = self.unavailable_reason.strip()
+        self.age_buckets = tuple(sorted(self.age_buckets, key=_cache_age_bucket_sort_key))
+        filesystem_measurements = (self.apparent_bytes, self.allocated_bytes)
+        docker_measurements = (self.logical_bytes, self.reclaimable_bytes)
+        if self.measurement_basis == "filesystem_apparent_allocated" and any(
+            value is not None for value in docker_measurements
+        ):
+            raise ValueError("filesystem cache telemetry cannot include Docker byte measurements")
+        if self.measurement_basis == "docker_engine" and any(
+            value is not None for value in filesystem_measurements
+        ):
+            raise ValueError("Docker cache telemetry cannot include filesystem byte measurements")
+        if self.cache_class in {"runner_workdir", "generated_filesystem"}:
+            if self.measurement_basis != "filesystem_apparent_allocated":
+                raise ValueError("filesystem cache classes require filesystem measurement basis")
+        elif self.measurement_basis != "docker_engine":
+            raise ValueError("Docker cache classes require Docker measurement basis")
+        measurements = (
+            *filesystem_measurements,
+            *docker_measurements,
+            self.entry_count,
+            self.estimated_daily_growth_bytes,
+            self.last_cleanup_epoch_seconds,
+            self.last_reclaimed_bytes,
+        )
+        if self.availability in {"unavailable", "stale"}:
+            if any(value is not None for value in measurements) or self.age_buckets:
+                raise ValueError("unavailable cache telemetry cannot include measurements")
+            if not self.unavailable_reason:
+                raise ValueError("unavailable cache telemetry requires unavailable_reason")
+        else:
+            if not any(value is not None for value in measurements) and not self.age_buckets:
+                raise ValueError("available cache telemetry requires measurement evidence")
+            if self.availability == "partial" and not self.unavailable_reason:
+                raise ValueError("partial cache telemetry requires unavailable_reason")
+            if self.availability == "available" and self.unavailable_reason:
+                raise ValueError("available cache telemetry cannot include unavailable_reason")
         return self
 
 
@@ -256,10 +381,15 @@ class RunnerHostHygieneObservation(BaseModel):
     generated_cache_apparent_bytes: int = Field(default=0, ge=0)
     generated_cache_allocated_bytes: int = Field(default=0, ge=0)
     generated_cache_usage: tuple[RunnerHostHygieneGeneratedCacheUsage, ...] = ()
+    cache_class_telemetry: tuple[RunnerHostHygieneCacheClassTelemetry, ...] = ()
     docker_toolchain: "RunnerHostDockerToolchainObservation | None" = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple["RunnerHostHygieneImageInventoryItem", ...] = ()
+    image_inventory_total_count: int = Field(default=0, ge=0)
+    image_inventory_truncated: bool = False
     volume_inventory: tuple["RunnerHostHygieneVolumeInventoryItem", ...] = ()
+    volume_inventory_total_count: int = Field(default=0, ge=0)
+    volume_inventory_truncated: bool = False
     orphan_buildkit_containers: int = Field(default=0, ge=0)
     orphan_buildkit_volumes: int = Field(default=0, ge=0)
     notes: tuple[str, ...] = ()
@@ -279,8 +409,25 @@ class RunnerHostHygieneObservation(BaseModel):
         self.generated_cache_usage = tuple(
             sorted(self.generated_cache_usage, key=lambda item: item.cache_key)
         )
+        self.cache_class_telemetry = _sorted_cache_class_telemetry(self.cache_class_telemetry)
         self.image_inventory = _sorted_image_inventory(self.image_inventory)
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
+        if not self.image_inventory_total_count:
+            self.image_inventory_total_count = len(self.image_inventory)
+        if not self.volume_inventory_total_count:
+            self.volume_inventory_total_count = len(self.volume_inventory)
+        if self.image_inventory_total_count < len(self.image_inventory):
+            raise ValueError("image inventory total count cannot be smaller than retained rows")
+        if self.volume_inventory_total_count < len(self.volume_inventory):
+            raise ValueError("volume inventory total count cannot be smaller than retained rows")
+        if self.image_inventory_truncated != (
+            self.image_inventory_total_count > len(self.image_inventory)
+        ):
+            raise ValueError("image inventory truncation must match total count")
+        if self.volume_inventory_truncated != (
+            self.volume_inventory_total_count > len(self.volume_inventory)
+        ):
+            raise ValueError("volume inventory truncation must match total count")
         self.notes = tuple(note.strip() for note in self.notes if note.strip())
         return self
 
@@ -327,7 +474,7 @@ class RunnerHostHygieneImageInventoryItem(BaseModel):
     image_id: str
     repository: str
     tag: str
-    size_bytes: int = Field(default=0, ge=0)
+    size_bytes: int | None = Field(default=None, ge=0)
     created_at: str = ""
     dangling: bool = False
     in_use: bool = False
@@ -351,8 +498,8 @@ class RunnerHostHygieneVolumeInventoryItem(BaseModel):
     driver: str
     mountpoint: str = ""
     labels: tuple[str, ...] = ()
-    size_bytes: int = Field(default=0, ge=0)
-    referenced_by_containers: int = Field(default=0, ge=0)
+    size_bytes: int | None = Field(default=None, ge=0)
+    referenced_by_containers: int | None = Field(default=None, ge=0)
     dangling: bool = False
 
     @model_validator(mode="after")
@@ -386,6 +533,7 @@ class RunnerHostHygieneReport(BaseModel):
     schema_version: int = Field(default=1, ge=1)
     status: RunnerHostHygieneStatus
     host_name: str
+    observed_at: str = ""
     free_disk_bytes: int = Field(default=0, ge=0)
     docker_reclaimable_bytes: int = Field(default=0, ge=0)
     docker_reclaimable_breakdown: RunnerHostHygieneDockerReclaimableBreakdown = Field(
@@ -397,10 +545,15 @@ class RunnerHostHygieneReport(BaseModel):
     generated_cache_apparent_bytes: int = Field(default=0, ge=0)
     generated_cache_allocated_bytes: int = Field(default=0, ge=0)
     generated_cache_usage: tuple[RunnerHostHygieneGeneratedCacheUsage, ...] = ()
+    cache_class_telemetry: tuple[RunnerHostHygieneCacheClassTelemetry, ...] = ()
     docker_toolchain: RunnerHostDockerToolchainObservation | None = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple[RunnerHostHygieneImageInventoryItem, ...] = ()
+    image_inventory_total_count: int = Field(default=0, ge=0)
+    image_inventory_truncated: bool = False
     volume_inventory: tuple[RunnerHostHygieneVolumeInventoryItem, ...] = ()
+    volume_inventory_total_count: int = Field(default=0, ge=0)
+    volume_inventory_truncated: bool = False
     orphan_buildkit_containers: int = Field(default=0, ge=0)
     orphan_buildkit_volumes: int = Field(default=0, ge=0)
     findings: tuple[RunnerHostHygieneFinding, ...] = ()
@@ -412,6 +565,7 @@ class RunnerHostHygieneReport(BaseModel):
         self.host_name = _required_text(
             self.host_name, "runner host hygiene report requires host_name"
         )
+        self.observed_at = self.observed_at.strip()
         self.warm_builders = _normalized_tokens(self.warm_builders)
         self.runner_workdir_usage = tuple(
             sorted(self.runner_workdir_usage, key=lambda item: item.root_key)
@@ -419,8 +573,25 @@ class RunnerHostHygieneReport(BaseModel):
         self.generated_cache_usage = tuple(
             sorted(self.generated_cache_usage, key=lambda item: item.cache_key)
         )
+        self.cache_class_telemetry = _sorted_cache_class_telemetry(self.cache_class_telemetry)
         self.image_inventory = _sorted_image_inventory(self.image_inventory)
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
+        if not self.image_inventory_total_count:
+            self.image_inventory_total_count = len(self.image_inventory)
+        if not self.volume_inventory_total_count:
+            self.volume_inventory_total_count = len(self.volume_inventory)
+        if self.image_inventory_total_count < len(self.image_inventory):
+            raise ValueError("image inventory total count cannot be smaller than retained rows")
+        if self.volume_inventory_total_count < len(self.volume_inventory):
+            raise ValueError("volume inventory total count cannot be smaller than retained rows")
+        if self.image_inventory_truncated != (
+            self.image_inventory_total_count > len(self.image_inventory)
+        ):
+            raise ValueError("image inventory truncation must match total count")
+        if self.volume_inventory_truncated != (
+            self.volume_inventory_total_count > len(self.volume_inventory)
+        ):
+            raise ValueError("volume inventory truncation must match total count")
         self.findings = tuple(sorted(self.findings, key=lambda finding: finding.code))
         self.summary = _required_text(self.summary, "runner host hygiene report requires summary")
         self.next_steps = tuple(step.strip() for step in self.next_steps if step.strip())
@@ -618,6 +789,73 @@ class RunnerHostHygieneApplyAuditRecord(BaseModel):
         if self.status in {"completed", "failed"} and self.plan.status != "ready":
             raise ValueError("terminal runner host hygiene audit record requires a ready plan")
         return self
+
+
+def sanitize_runner_host_hygiene_audit_record_for_persistence(
+    audit: RunnerHostHygieneApplyAuditRecord,
+) -> RunnerHostHygieneApplyAuditRecord:
+    return RunnerHostHygieneApplyAuditRecord.model_validate(
+        {
+            **audit.model_dump(mode="python"),
+            "pre_apply_report": _sanitize_runner_host_hygiene_report_for_persistence(
+                audit.pre_apply_report
+            ).model_dump(mode="python"),
+            "post_apply_report": (
+                _sanitize_runner_host_hygiene_report_for_persistence(
+                    audit.post_apply_report
+                ).model_dump(mode="python")
+                if audit.post_apply_report is not None
+                else None
+            ),
+        }
+    )
+
+
+def _sanitize_runner_host_hygiene_report_for_persistence(
+    report: RunnerHostHygieneReport,
+) -> RunnerHostHygieneReport:
+    image_inventory = tuple(
+        item.model_copy(
+            update={
+                "repository": "",
+                "tag": "",
+                "created_at": "",
+            }
+        )
+        for item in report.image_inventory[:RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS]
+    )
+    volume_inventory = tuple(
+        item.model_copy(update={"mountpoint": "", "labels": ()})
+        for item in report.volume_inventory[:RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS]
+    )
+    image_inventory_total_count = max(
+        report.image_inventory_total_count,
+        len(report.image_inventory),
+    )
+    volume_inventory_total_count = max(
+        report.volume_inventory_total_count,
+        len(report.volume_inventory),
+    )
+    cache_class_telemetry = tuple(
+        item.model_copy(
+            update={"unavailable_reason": _sanitized_unavailable_reason(item.unavailable_reason)}
+        )
+        for item in report.cache_class_telemetry
+    )
+    return RunnerHostHygieneReport.model_validate(
+        {
+            **report.model_dump(mode="python"),
+            "cache_class_telemetry": tuple(
+                item.model_dump(mode="python") for item in cache_class_telemetry
+            ),
+            "image_inventory": tuple(item.model_dump(mode="python") for item in image_inventory),
+            "image_inventory_total_count": image_inventory_total_count,
+            "image_inventory_truncated": image_inventory_total_count > len(image_inventory),
+            "volume_inventory": tuple(item.model_dump(mode="python") for item in volume_inventory),
+            "volume_inventory_total_count": volume_inventory_total_count,
+            "volume_inventory_truncated": volume_inventory_total_count > len(volume_inventory),
+        }
+    )
 
 
 class RunnerHostHygieneAuditDeliveryEnvelope(BaseModel):
@@ -876,7 +1114,7 @@ def evaluate_runner_host_hygiene(
     partial_workdir_roots = tuple(
         item.root_key
         for item in observation.runner_workdir_usage
-        if item.measurement_status == "partial"
+        if item.measurement_status != "complete"
     )
     if partial_workdir_roots:
         findings.append(
@@ -908,7 +1146,7 @@ def evaluate_runner_host_hygiene(
     partial_generated_caches = tuple(
         item.cache_key
         for item in observation.generated_cache_usage
-        if item.measurement_status == "partial"
+        if item.measurement_status != "complete"
     )
     if partial_generated_caches:
         findings.append(
@@ -958,9 +1196,14 @@ def evaluate_runner_host_hygiene(
         )
 
     status: RunnerHostHygieneStatus = "attention" if findings else "healthy"
+    cache_class_telemetry = _merged_cache_class_telemetry(
+        _cache_class_telemetry_from_observation(observation),
+        observation.cache_class_telemetry,
+    )
     return RunnerHostHygieneReport(
         status=status,
         host_name=observation.host_name,
+        observed_at=observation.observed_at,
         free_disk_bytes=observation.free_disk_bytes,
         docker_reclaimable_bytes=observation.docker_reclaimable_bytes,
         docker_reclaimable_breakdown=observation.docker_reclaimable_breakdown,
@@ -970,10 +1213,15 @@ def evaluate_runner_host_hygiene(
         generated_cache_apparent_bytes=observation.generated_cache_apparent_bytes,
         generated_cache_allocated_bytes=observation.generated_cache_allocated_bytes,
         generated_cache_usage=observation.generated_cache_usage,
+        cache_class_telemetry=cache_class_telemetry,
         docker_toolchain=observation.docker_toolchain,
         warm_builders=observation.warm_builders,
         image_inventory=observation.image_inventory,
+        image_inventory_total_count=observation.image_inventory_total_count,
+        image_inventory_truncated=observation.image_inventory_truncated,
         volume_inventory=observation.volume_inventory,
+        volume_inventory_total_count=observation.volume_inventory_total_count,
+        volume_inventory_truncated=observation.volume_inventory_truncated,
         orphan_buildkit_containers=observation.orphan_buildkit_containers,
         orphan_buildkit_volumes=observation.orphan_buildkit_volumes,
         findings=tuple(findings),
@@ -984,6 +1232,177 @@ def evaluate_runner_host_hygiene(
         ),
         next_steps=_next_steps(status),
     )
+
+
+def _cache_class_telemetry_from_observation(
+    observation: RunnerHostHygieneObservation,
+) -> tuple[RunnerHostHygieneCacheClassTelemetry, ...]:
+    telemetry: list[RunnerHostHygieneCacheClassTelemetry] = []
+    for workdir_usage in observation.runner_workdir_usage:
+        availability = _telemetry_availability(workdir_usage.measurement_status)
+        unavailable_reason = workdir_usage.reason_code if availability != "available" else ""
+        telemetry.append(
+            RunnerHostHygieneCacheClassTelemetry(
+                cache_key=workdir_usage.root_key,
+                cache_class="runner_workdir",
+                scope="runner_root",
+                availability=availability,
+                measurement_basis="filesystem_apparent_allocated",
+                source="runner_workdir_probe",
+                observed_at=observation.observed_at,
+                unavailable_reason=unavailable_reason,
+                apparent_bytes=(
+                    workdir_usage.apparent_bytes
+                    if availability in {"available", "partial"}
+                    else None
+                ),
+                allocated_bytes=(
+                    workdir_usage.allocated_bytes
+                    if availability in {"available", "partial"}
+                    else None
+                ),
+            )
+        )
+    for generated_usage in observation.generated_cache_usage:
+        unavailable_reasons: list[str] = []
+        availability = _telemetry_availability(generated_usage.measurement_status)
+        if availability != "available":
+            unavailable_reasons.append(generated_usage.reason_code)
+        if generated_usage.entries_truncated:
+            unavailable_reasons.append("entry_history_truncated")
+            if availability == "available":
+                availability = "partial"
+        has_cleanup_history = generated_usage.last_cleanup_epoch_seconds > 0
+        has_measurement = availability in {"available", "partial"}
+        telemetry.append(
+            RunnerHostHygieneCacheClassTelemetry(
+                cache_key=generated_usage.cache_key,
+                cache_class="generated_filesystem",
+                scope="generated_cache",
+                availability=availability,
+                measurement_basis="filesystem_apparent_allocated",
+                source="generated_cache_probe",
+                observed_at=observation.observed_at,
+                unavailable_reason=",".join(unavailable_reasons),
+                apparent_bytes=generated_usage.apparent_bytes if has_measurement else None,
+                allocated_bytes=generated_usage.allocated_bytes if has_measurement else None,
+                entry_count=generated_usage.entry_count if has_measurement else None,
+                age_buckets=generated_usage.age_buckets if has_measurement else (),
+                estimated_daily_growth_bytes=(
+                    generated_usage.estimated_daily_growth_bytes
+                    if has_measurement and has_cleanup_history
+                    else None
+                ),
+                last_cleanup_epoch_seconds=(
+                    generated_usage.last_cleanup_epoch_seconds
+                    if has_measurement and has_cleanup_history
+                    else None
+                ),
+                last_reclaimed_bytes=(
+                    generated_usage.last_reclaimed_bytes
+                    if has_measurement and has_cleanup_history
+                    else None
+                ),
+            )
+        )
+    image_logical_bytes = _inventory_size_total(
+        observation.image_inventory,
+        truncated=observation.image_inventory_truncated,
+    )
+    image_unavailable_reasons = _inventory_unavailable_reasons(
+        observation.image_inventory,
+        truncated=observation.image_inventory_truncated,
+    )
+    telemetry.append(
+        RunnerHostHygieneCacheClassTelemetry(
+            cache_key="images",
+            cache_class="docker_images",
+            scope="host",
+            availability="partial" if image_unavailable_reasons else "available",
+            measurement_basis="docker_engine",
+            source="docker_engine",
+            observed_at=observation.observed_at,
+            unavailable_reason=",".join(image_unavailable_reasons),
+            logical_bytes=image_logical_bytes,
+            reclaimable_bytes=observation.docker_reclaimable_breakdown.images_bytes,
+            entry_count=observation.image_inventory_total_count,
+        )
+    )
+    telemetry.append(
+        RunnerHostHygieneCacheClassTelemetry(
+            cache_key="containers",
+            cache_class="docker_containers",
+            scope="host",
+            availability="available",
+            measurement_basis="docker_engine",
+            source="docker_engine",
+            observed_at=observation.observed_at,
+            reclaimable_bytes=observation.docker_reclaimable_breakdown.containers_bytes,
+        )
+    )
+    volume_logical_bytes = _inventory_size_total(
+        observation.volume_inventory,
+        truncated=observation.volume_inventory_truncated,
+    )
+    volume_unavailable_reasons = _inventory_unavailable_reasons(
+        observation.volume_inventory,
+        truncated=observation.volume_inventory_truncated,
+    )
+    telemetry.append(
+        RunnerHostHygieneCacheClassTelemetry(
+            cache_key="volumes",
+            cache_class="docker_volumes",
+            scope="host",
+            availability="partial" if volume_unavailable_reasons else "available",
+            measurement_basis="docker_engine",
+            source="docker_engine",
+            observed_at=observation.observed_at,
+            unavailable_reason=",".join(volume_unavailable_reasons),
+            logical_bytes=volume_logical_bytes,
+            reclaimable_bytes=observation.docker_reclaimable_breakdown.local_volumes_bytes,
+            entry_count=observation.volume_inventory_total_count,
+        )
+    )
+    telemetry.append(
+        RunnerHostHygieneCacheClassTelemetry(
+            cache_key="build-cache",
+            cache_class="docker_build_cache",
+            scope="host",
+            availability="available",
+            measurement_basis="docker_engine",
+            source="docker_engine",
+            observed_at=observation.observed_at,
+            reclaimable_bytes=observation.docker_reclaimable_breakdown.build_cache_bytes,
+        )
+    )
+    return _sorted_cache_class_telemetry(tuple(telemetry))
+
+
+def _inventory_size_total(
+    inventory: tuple[
+        RunnerHostHygieneImageInventoryItem | RunnerHostHygieneVolumeInventoryItem, ...
+    ],
+    *,
+    truncated: bool,
+) -> int | None:
+    if truncated or any(item.size_bytes is None for item in inventory):
+        return None
+    return sum(cast(int, item.size_bytes) for item in inventory)
+
+
+def _inventory_unavailable_reasons(
+    inventory: tuple[
+        RunnerHostHygieneImageInventoryItem | RunnerHostHygieneVolumeInventoryItem, ...
+    ],
+    *,
+    truncated: bool,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if truncated:
+        reasons.append("inventory_truncated")
+    if any(item.size_bytes is None for item in inventory):
+        reasons.append("inventory_size_unavailable")
+    return tuple(reasons)
 
 
 def plan_runner_host_hygiene_apply(
@@ -1500,13 +1919,22 @@ def _target_volume_blockers(
                 )
             )
             continue
-        if not volume.dangling or volume.referenced_by_containers > 0:
+        if (
+            volume.referenced_by_containers is None
+            or not volume.dangling
+            or volume.referenced_by_containers > 0
+        ):
+            reference_summary = (
+                str(volume.referenced_by_containers)
+                if volume.referenced_by_containers is not None
+                else "unknown"
+            )
             blockers.append(
                 _apply_blocker(
                     "target_volume_active",
                     (
                         "runner host hygiene target volume is still referenced: "
-                        f"{volume_name} links={volume.referenced_by_containers}"
+                        f"{volume_name} links={reference_summary}"
                     ),
                 )
             )
@@ -1651,12 +2079,53 @@ def _sorted_volume_inventory(
     return tuple(sorted(values, key=lambda item: (item.name, item.driver)))
 
 
+def _sorted_cache_class_telemetry(
+    values: tuple[RunnerHostHygieneCacheClassTelemetry, ...],
+) -> tuple[RunnerHostHygieneCacheClassTelemetry, ...]:
+    sorted_values = tuple(sorted(values, key=lambda item: (item.cache_class, item.cache_key)))
+    keys = tuple((item.cache_class, item.cache_key) for item in sorted_values)
+    if len(set(keys)) != len(keys):
+        raise ValueError("runner host hygiene cache-class telemetry must be unique")
+    return sorted_values
+
+
+def _merged_cache_class_telemetry(
+    derived: tuple[RunnerHostHygieneCacheClassTelemetry, ...],
+    explicit: tuple[RunnerHostHygieneCacheClassTelemetry, ...],
+) -> tuple[RunnerHostHygieneCacheClassTelemetry, ...]:
+    telemetry_by_key = {(item.cache_class, item.cache_key): item for item in derived}
+    telemetry_by_key.update({(item.cache_class, item.cache_key): item for item in explicit})
+    return _sorted_cache_class_telemetry(tuple(telemetry_by_key.values()))
+
+
+def _telemetry_availability(
+    measurement_status: RunnerHostHygieneMeasurementStatus,
+) -> RunnerHostHygieneEvidenceAvailability:
+    if measurement_status == "complete":
+        return "available"
+    if measurement_status == "partial":
+        return "partial"
+    if measurement_status == "unavailable":
+        return "unavailable"
+    return "stale"
+
+
 def _normalized_values(values: tuple[str, ...], normalize: Callable[[str], str]) -> tuple[str, ...]:
     return tuple(sorted({normalized for value in values if (normalized := normalize(value))}))
 
 
 def _normalized_token(value: str) -> str:
     return value.strip().lower()
+
+
+def _cache_age_bucket_sort_key(item: RunnerHostHygieneGeneratedCacheAgeBucket) -> int:
+    return {
+        "under_1h": 0,
+        "1h_to_24h": 1,
+        "1d_to_7d": 2,
+        "7d_to_30d": 3,
+        "30d_or_more": 4,
+    }[item.bucket]
 
 
 def _normalized_public_token(value: str) -> str:
@@ -1668,6 +2137,23 @@ def _normalized_public_token(value: str) -> str:
 
 def _required_public_token(value: str, message: str) -> str:
     return _required_text(_normalized_public_token(value), message)
+
+
+def _sanitized_unavailable_reason(value: str) -> str:
+    if not value.strip():
+        return ""
+    try:
+        normalized_reasons = tuple(
+            _required_public_token(
+                reason,
+                "runner host hygiene unavailable reason must be public-safe",
+            )
+            for reason in value.split(",")
+        )
+    except ValueError:
+        return "redacted_reason"
+    summary = ",".join(normalized_reasons)
+    return summary if len(summary) <= 64 else "redacted_reason"
 
 
 def _normalized_volume_name(value: str) -> str:

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -93,6 +93,7 @@ from control_plane.http_routes import (
     register_product_promotion_status_read_routes,
     register_product_profile_read_routes,
     register_protected_artifact_read_routes,
+    register_runner_host_hygiene_read_routes,
     register_topology_read_routes,
     register_tracked_target_log_read_routes,
     register_work_graph_issue_inbox_read_routes,
@@ -19165,6 +19166,7 @@ def create_launchplane_fastapi_app(
 
     register_topology_read_routes(app, dependencies=read_route_dependencies)
     register_ingress_read_routes(app, dependencies=read_route_dependencies)
+    register_runner_host_hygiene_read_routes(app, dependencies=read_route_dependencies)
     register_deployment_promotion_read_routes(app, dependencies=read_route_dependencies)
 
     every_code_work_request_write_error_responses: dict[int | str, dict[str, object]] = {

--- a/control_plane/http_routes/__init__.py
+++ b/control_plane/http_routes/__init__.py
@@ -47,6 +47,9 @@ from control_plane.http_routes.preview import (
     register_preview_readiness_read_routes,
     register_preview_record_read_routes,
 )
+from control_plane.http_routes.runner_host_hygiene import (
+    register_runner_host_hygiene_read_routes,
+)
 from control_plane.http_routes.products import (
     ProductReadRouteDependencies,
     product_profile_context_cutover_contexts_allowed,
@@ -111,6 +114,7 @@ __all__ = (
     "register_product_promotion_status_read_routes",
     "register_product_profile_read_routes",
     "register_protected_artifact_read_routes",
+    "register_runner_host_hygiene_read_routes",
     "register_topology_read_routes",
     "register_tracked_target_log_read_routes",
     "register_work_graph_issue_inbox_read_routes",

--- a/control_plane/http_routes/evidence.py
+++ b/control_plane/http_routes/evidence.py
@@ -19,6 +19,9 @@ from control_plane.contracts.preview_evidence import (
 )
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import (
+    sanitize_runner_host_hygiene_audit_record_for_persistence,
+)
 from control_plane.contracts.runner_host_hygiene_evidence import (
     RunnerHostHygieneAuditEvidenceEnvelope,
 )
@@ -846,20 +849,19 @@ def register_evidence_write_routes(
                 message=str(error),
             ) from error
 
-        evidence_store.write_runner_host_hygiene_audit_record(runner_host_hygiene_request.audit)
+        persisted_audit = sanitize_runner_host_hygiene_audit_record_for_persistence(
+            runner_host_hygiene_request.audit
+        )
+        evidence_store.write_runner_host_hygiene_audit_record(persisted_audit)
         records = {
-            "runner_host_hygiene_audit_record_key": (
-                runner_host_hygiene_request.audit.audit_record_key
-            ),
+            "runner_host_hygiene_audit_record_key": persisted_audit.audit_record_key,
         }
         result: dict[str, object] = {
-            "runner_host_hygiene_audit_record_key": (
-                runner_host_hygiene_request.audit.audit_record_key
-            ),
-            "host_name": runner_host_hygiene_request.audit.request.host_name,
-            "audit_status": runner_host_hygiene_request.audit.status,
-            "mutate": runner_host_hygiene_request.audit.request.mutate,
-            "audit": runner_host_hygiene_request.audit.model_dump(mode="json"),
+            "runner_host_hygiene_audit_record_key": persisted_audit.audit_record_key,
+            "host_name": persisted_audit.request.host_name,
+            "audit_status": persisted_audit.status,
+            "mutate": persisted_audit.request.mutate,
+            "audit": persisted_audit.model_dump(mode="json"),
         }
         response = accepted_evidence_response(
             trace_id=trace_id,

--- a/control_plane/http_routes/runner_host_hygiene.py
+++ b/control_plane/http_routes/runner_host_hygiene.py
@@ -214,17 +214,20 @@ def _read_observed_at(
 
 
 def _audit_summary(record: RunnerHostHygieneApplyAuditRecord) -> RunnerHostHygieneAuditSummary:
+    pre_apply_observed_at = _read_observed_at(record.pre_apply_report.observed_at)[0]
+    post_apply_observed_at = (
+        _read_observed_at(record.post_apply_report.observed_at)[0]
+        if record.post_apply_report is not None
+        else None
+    )
     return RunnerHostHygieneAuditSummary(
         audit_record_key=record.audit_record_key,
         audit_status=record.status,
         action=record.request.action,
         host_name=record.request.host_name,
         mutate=record.request.mutate,
-        pre_apply_observed_at=record.pre_apply_report.observed_at or None,
-        post_apply_observed_at=(
-            record.post_apply_report.observed_at if record.post_apply_report else None
-        )
-        or None,
+        pre_apply_observed_at=pre_apply_observed_at,
+        post_apply_observed_at=post_apply_observed_at,
         pre_apply_status=record.pre_apply_report.status,
         post_apply_status=(record.post_apply_report.status if record.post_apply_report else None),
     )

--- a/control_plane/http_routes/runner_host_hygiene.py
+++ b/control_plane/http_routes/runner_host_hygiene.py
@@ -1,0 +1,501 @@
+from datetime import datetime, timezone
+from typing import Annotated, Literal, Protocol, cast
+
+from fastapi import Depends, Query
+from pydantic import BaseModel, ConfigDict
+
+from control_plane import service_status as control_plane_service_status
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAction
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditStatus
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneCacheClassTelemetry
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
+from control_plane.http_routes.support import (
+    LAUNCHPLANE_SERVICE_CONTEXT,
+    ApiRouteRegistrar,
+    ReadRouteDependencies,
+)
+from control_plane.service_auth import LaunchplaneIdentity
+
+
+RUNNER_HOST_HYGIENE_AUDIT_READ_ROUTE = "/v1/evidence/runner-host-hygiene/audits"
+RUNNER_HOST_HYGIENE_HISTORY_READ_ROUTE = "/v1/evidence/runner-host-hygiene/history"
+RUNNER_HOST_HYGIENE_AUDIT_RECORD_READ_ROUTE = "/v1/evidence/runner-host-hygiene/audits/record"
+
+
+class RunnerHostHygieneReportReadModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["healthy", "attention"]
+    host_name: str
+    observed_at: str | None
+    chronology_state: Literal["timestamped", "legacy_missing", "invalid"]
+    free_disk_bytes: int
+    docker_reclaimable_bytes: int
+    runner_workdir_apparent_bytes: int
+    runner_workdir_allocated_bytes: int
+    generated_cache_apparent_bytes: int
+    generated_cache_allocated_bytes: int
+    cache_class_telemetry: tuple[RunnerHostHygieneCacheClassTelemetry, ...]
+    image_inventory_total_count: int
+    image_inventory_truncated: bool
+    volume_inventory_total_count: int
+    volume_inventory_truncated: bool
+    finding_codes: tuple[str, ...]
+    summary: str
+
+
+class RunnerHostHygieneAuditSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    audit_record_key: str
+    audit_status: RunnerHostHygieneApplyAuditStatus
+    action: RunnerHostHygieneApplyAction
+    host_name: str
+    mutate: bool
+    pre_apply_observed_at: str | None
+    post_apply_observed_at: str | None
+    pre_apply_status: Literal["healthy", "attention"]
+    post_apply_status: Literal["healthy", "attention"] | None
+
+
+class RunnerHostHygieneAuditReadRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    summary: RunnerHostHygieneAuditSummary
+    pre_apply_report: RunnerHostHygieneReportReadModel
+    post_apply_report: RunnerHostHygieneReportReadModel | None
+
+
+class RunnerHostHygieneHistoryPoint(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    audit_record_key: str
+    phase: Literal["pre_apply", "post_apply"]
+    audit_status: RunnerHostHygieneApplyAuditStatus
+    action: RunnerHostHygieneApplyAction
+    mutate: bool
+    report: RunnerHostHygieneReportReadModel
+
+
+class RunnerHostHygieneAuditRecordResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    record: RunnerHostHygieneAuditReadRecord
+
+
+class RunnerHostHygieneAuditRecordsResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    host_name: str
+    action: RunnerHostHygieneApplyAction | None
+    audit_status: RunnerHostHygieneApplyAuditStatus | None
+    limit: int
+    count: int
+    truncated: bool
+    records: tuple[RunnerHostHygieneAuditSummary, ...]
+
+
+class RunnerHostHygieneHistoryResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    status: Literal["ok"] = "ok"
+    trace_id: str
+    host_name: str
+    cache_key: str
+    limit: int
+    scan_limit: int
+    count: int
+    scan_truncated: bool
+    result_truncated: bool
+    truncated: bool
+    points: tuple[RunnerHostHygieneHistoryPoint, ...]
+
+
+class RunnerHostHygieneAuditReadStore(Protocol):
+    def read_runner_host_hygiene_audit_record(
+        self, audit_record_key: str
+    ) -> RunnerHostHygieneApplyAuditRecord: ...
+
+    def list_runner_host_hygiene_audit_records(
+        self,
+        *,
+        host_name: str = "",
+        action: str = "",
+        status: str = "",
+        limit: int | None = None,
+    ) -> tuple[RunnerHostHygieneApplyAuditRecord, ...]: ...
+
+
+def require_runner_host_hygiene_audit_read_store(
+    record_store: object,
+) -> RunnerHostHygieneAuditReadStore:
+    required_methods = (
+        "read_runner_host_hygiene_audit_record",
+        "list_runner_host_hygiene_audit_records",
+    )
+    missing_methods = [
+        method_name
+        for method_name in required_methods
+        if not callable(getattr(record_store, method_name, None))
+    ]
+    if missing_methods:
+        missing_summary = ", ".join(missing_methods)
+        raise TypeError(
+            "Launchplane record store does not support runner host hygiene audit reads: "
+            f"{missing_summary}"
+        )
+    return cast(RunnerHostHygieneAuditReadStore, record_store)
+
+
+def _ensure_runner_host_hygiene_audit_read_allowed(
+    *,
+    dependencies: ReadRouteDependencies,
+    identity: LaunchplaneIdentity,
+    trace_id: str,
+) -> None:
+    if not dependencies.authorization_allows(
+        identity=identity,
+        action="runner_host_hygiene_audit.read",
+        product="launchplane",
+        context=LAUNCHPLANE_SERVICE_CONTEXT,
+    ):
+        raise dependencies.http_error(
+            status_code=403,
+            trace_id=trace_id,
+            code="authorization_denied",
+            message="Workflow cannot read runner host hygiene audit evidence.",
+        )
+
+
+def _report_read_model(report: RunnerHostHygieneReport) -> RunnerHostHygieneReportReadModel:
+    observed_at, chronology_state = _read_observed_at(report.observed_at)
+    return RunnerHostHygieneReportReadModel(
+        status=report.status,
+        host_name=report.host_name,
+        observed_at=observed_at,
+        chronology_state=chronology_state,
+        free_disk_bytes=report.free_disk_bytes,
+        docker_reclaimable_bytes=report.docker_reclaimable_bytes,
+        runner_workdir_apparent_bytes=report.runner_workdir_bytes,
+        runner_workdir_allocated_bytes=report.runner_workdir_allocated_bytes,
+        generated_cache_apparent_bytes=report.generated_cache_apparent_bytes,
+        generated_cache_allocated_bytes=report.generated_cache_allocated_bytes,
+        cache_class_telemetry=report.cache_class_telemetry,
+        image_inventory_total_count=report.image_inventory_total_count,
+        image_inventory_truncated=report.image_inventory_truncated,
+        volume_inventory_total_count=report.volume_inventory_total_count,
+        volume_inventory_truncated=report.volume_inventory_truncated,
+        finding_codes=tuple(finding.code for finding in report.findings),
+        summary=report.summary,
+    )
+
+
+def _read_observed_at(
+    value: str,
+) -> tuple[str | None, Literal["timestamped", "legacy_missing", "invalid"]]:
+    normalized_value = value.strip()
+    if not normalized_value:
+        return None, "legacy_missing"
+    try:
+        parsed = datetime.fromisoformat(normalized_value.replace("Z", "+00:00"))
+    except ValueError:
+        return None, "invalid"
+    if parsed.tzinfo is None:
+        return None, "invalid"
+    normalized_timestamp = (
+        parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+    return normalized_timestamp, "timestamped"
+
+
+def _audit_summary(record: RunnerHostHygieneApplyAuditRecord) -> RunnerHostHygieneAuditSummary:
+    return RunnerHostHygieneAuditSummary(
+        audit_record_key=record.audit_record_key,
+        audit_status=record.status,
+        action=record.request.action,
+        host_name=record.request.host_name,
+        mutate=record.request.mutate,
+        pre_apply_observed_at=record.pre_apply_report.observed_at or None,
+        post_apply_observed_at=(
+            record.post_apply_report.observed_at if record.post_apply_report else None
+        )
+        or None,
+        pre_apply_status=record.pre_apply_report.status,
+        post_apply_status=(record.post_apply_report.status if record.post_apply_report else None),
+    )
+
+
+def _audit_read_record(
+    record: RunnerHostHygieneApplyAuditRecord,
+) -> RunnerHostHygieneAuditReadRecord:
+    return RunnerHostHygieneAuditReadRecord(
+        summary=_audit_summary(record),
+        pre_apply_report=_report_read_model(record.pre_apply_report),
+        post_apply_report=(
+            _report_read_model(record.post_apply_report) if record.post_apply_report else None
+        ),
+    )
+
+
+def _history_points(
+    records: tuple[RunnerHostHygieneApplyAuditRecord, ...],
+    *,
+    cache_key: str,
+) -> tuple[RunnerHostHygieneHistoryPoint, ...]:
+    points: list[RunnerHostHygieneHistoryPoint] = []
+    for record in records:
+        reports: tuple[tuple[Literal["pre_apply", "post_apply"], RunnerHostHygieneReport], ...] = (
+            ("pre_apply", record.pre_apply_report),
+        )
+        if record.post_apply_report is not None:
+            reports += (("post_apply", record.post_apply_report),)
+        for phase, report in reports:
+            read_report = _report_read_model(report)
+            if cache_key:
+                matching_telemetry = tuple(
+                    item
+                    for item in read_report.cache_class_telemetry
+                    if item.cache_key == cache_key
+                )
+                if not matching_telemetry:
+                    continue
+                read_report = read_report.model_copy(
+                    update={"cache_class_telemetry": matching_telemetry}
+                )
+            points.append(
+                RunnerHostHygieneHistoryPoint(
+                    audit_record_key=record.audit_record_key,
+                    phase=phase,
+                    audit_status=record.status,
+                    action=record.request.action,
+                    mutate=record.request.mutate,
+                    report=read_report,
+                )
+            )
+    return tuple(
+        sorted(
+            points,
+            key=lambda point: (
+                point.report.chronology_state == "timestamped",
+                _history_timestamp(point.report.observed_at),
+                point.audit_record_key,
+                point.phase == "post_apply",
+            ),
+            reverse=True,
+        )
+    )
+
+
+def _history_timestamp(value: str | None) -> float:
+    if value is None:
+        return 0.0
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+
+
+def register_runner_host_hygiene_read_routes(
+    app: ApiRouteRegistrar,
+    *,
+    dependencies: ReadRouteDependencies,
+) -> None:
+    def list_runner_host_hygiene_audit_records(
+        identity: Annotated[LaunchplaneIdentity, Depends(dependencies.read_identity)],
+        record_store: Annotated[object, Depends(dependencies.get_record_store)],
+        host_name: Annotated[str, Query()] = "",
+        action: Annotated[RunnerHostHygieneApplyAction | None, Query()] = None,
+        audit_status: Annotated[RunnerHostHygieneApplyAuditStatus | None, Query()] = None,
+        limit: Annotated[str, Query()] = "25",
+    ) -> RunnerHostHygieneAuditRecordsResponse:
+        trace_id = dependencies.next_trace_id()
+        _ensure_runner_host_hygiene_audit_read_allowed(
+            dependencies=dependencies,
+            identity=identity,
+            trace_id=trace_id,
+        )
+        try:
+            normalized_limit = control_plane_service_status.query_int_value(
+                limit,
+                "limit",
+                default=25,
+                minimum=1,
+                maximum=100,
+            )
+            assert normalized_limit is not None
+            audit_store = require_runner_host_hygiene_audit_read_store(record_store)
+            records = audit_store.list_runner_host_hygiene_audit_records(
+                host_name=host_name.strip().lower(),
+                action=action or "",
+                status=audit_status or "",
+                limit=normalized_limit + 1,
+            )
+        except ValueError as error:
+            raise dependencies.http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        except TypeError as error:
+            raise dependencies.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        limited_records = records[:normalized_limit]
+        return RunnerHostHygieneAuditRecordsResponse(
+            trace_id=trace_id,
+            host_name=host_name.strip().lower(),
+            action=action,
+            audit_status=audit_status,
+            limit=normalized_limit,
+            count=len(limited_records),
+            truncated=len(records) > normalized_limit,
+            records=tuple(_audit_summary(record) for record in limited_records),
+        )
+
+    def read_runner_host_hygiene_history(
+        identity: Annotated[LaunchplaneIdentity, Depends(dependencies.read_identity)],
+        record_store: Annotated[object, Depends(dependencies.get_record_store)],
+        host_name: Annotated[str, Query(min_length=1)],
+        cache_key: Annotated[str, Query()] = "",
+        limit: Annotated[str, Query()] = "25",
+    ) -> RunnerHostHygieneHistoryResponse:
+        trace_id = dependencies.next_trace_id()
+        _ensure_runner_host_hygiene_audit_read_allowed(
+            dependencies=dependencies,
+            identity=identity,
+            trace_id=trace_id,
+        )
+        normalized_host_name = host_name.strip().lower()
+        normalized_cache_key = cache_key.strip().lower()
+        try:
+            if not normalized_host_name:
+                raise ValueError("host_name must not be blank")
+            normalized_limit = control_plane_service_status.query_int_value(
+                limit,
+                "limit",
+                default=25,
+                minimum=1,
+                maximum=100,
+            )
+            assert normalized_limit is not None
+            audit_store = require_runner_host_hygiene_audit_read_store(record_store)
+            candidate_records = audit_store.list_runner_host_hygiene_audit_records(
+                host_name=normalized_host_name,
+                limit=101,
+            )
+        except ValueError as error:
+            raise dependencies.http_error(
+                status_code=400,
+                trace_id=trace_id,
+                code="invalid_query",
+                message=str(error),
+            ) from error
+        except TypeError as error:
+            raise dependencies.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        scan_truncated = len(candidate_records) > 100
+        points = _history_points(
+            candidate_records[:100],
+            cache_key=normalized_cache_key,
+        )
+        limited_points = points[:normalized_limit]
+        result_truncated = len(points) > normalized_limit
+        return RunnerHostHygieneHistoryResponse(
+            trace_id=trace_id,
+            host_name=normalized_host_name,
+            cache_key=normalized_cache_key,
+            limit=normalized_limit,
+            scan_limit=100,
+            count=len(limited_points),
+            scan_truncated=scan_truncated,
+            result_truncated=result_truncated,
+            truncated=scan_truncated or result_truncated,
+            points=limited_points,
+        )
+
+    def read_runner_host_hygiene_audit_record(
+        identity: Annotated[LaunchplaneIdentity, Depends(dependencies.read_identity)],
+        record_store: Annotated[object, Depends(dependencies.get_record_store)],
+        audit_record_key: Annotated[str, Query(min_length=1)],
+    ) -> RunnerHostHygieneAuditRecordResponse:
+        trace_id = dependencies.next_trace_id()
+        _ensure_runner_host_hygiene_audit_read_allowed(
+            dependencies=dependencies,
+            identity=identity,
+            trace_id=trace_id,
+        )
+        normalized_record_key = audit_record_key.strip()
+        try:
+            audit_store = require_runner_host_hygiene_audit_read_store(record_store)
+            record = audit_store.read_runner_host_hygiene_audit_record(normalized_record_key)
+        except TypeError as error:
+            raise dependencies.http_error(
+                status_code=503,
+                trace_id=trace_id,
+                code="database_storage_required",
+                message=str(error),
+            ) from error
+        except FileNotFoundError as error:
+            raise dependencies.http_error(
+                status_code=404,
+                trace_id=trace_id,
+                code="not_found",
+                message=str(error),
+            ) from error
+        return RunnerHostHygieneAuditRecordResponse(
+            trace_id=trace_id,
+            record=_audit_read_record(record),
+        )
+
+    app.add_api_route(
+        RUNNER_HOST_HYGIENE_AUDIT_READ_ROUTE,
+        list_runner_host_hygiene_audit_records,
+        methods=["GET"],
+        response_model=RunnerHostHygieneAuditRecordsResponse,
+        operation_id="list_runner_host_hygiene_audit_records",
+        summary="List runner host hygiene audit records",
+        responses={
+            400: {"model": dependencies.error_response_model},
+            401: {"model": dependencies.error_response_model},
+            403: {"model": dependencies.error_response_model},
+            503: {"model": dependencies.error_response_model},
+        },
+    )
+    app.add_api_route(
+        RUNNER_HOST_HYGIENE_HISTORY_READ_ROUTE,
+        read_runner_host_hygiene_history,
+        methods=["GET"],
+        response_model=RunnerHostHygieneHistoryResponse,
+        operation_id="read_runner_host_hygiene_history",
+        summary="Read runner host hygiene observation history",
+        responses={
+            400: {"model": dependencies.error_response_model},
+            401: {"model": dependencies.error_response_model},
+            403: {"model": dependencies.error_response_model},
+            503: {"model": dependencies.error_response_model},
+        },
+    )
+    app.add_api_route(
+        RUNNER_HOST_HYGIENE_AUDIT_RECORD_READ_ROUTE,
+        read_runner_host_hygiene_audit_record,
+        methods=["GET"],
+        response_model=RunnerHostHygieneAuditRecordResponse,
+        operation_id="read_runner_host_hygiene_audit_record",
+        summary="Read one runner host hygiene audit record",
+        responses={
+            401: {"model": dependencies.error_response_model},
+            403: {"model": dependencies.error_response_model},
+            404: {"model": dependencies.error_response_model},
+            503: {"model": dependencies.error_response_model},
+        },
+    )

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -4668,7 +4668,12 @@ def _odoo_stable_bootstrap_lane_reservation_id(
 
 def _runner_host_hygiene_audit_record_id(audit_record_key: str) -> str:
     digest = hashlib.sha256(audit_record_key.encode()).hexdigest()[:16]
-    return audit_record_key.strip().replace("/", "-") + f"-{digest}"
+    normalized_key = audit_record_key.strip()
+    filename_prefix = "".join(
+        character if character.isascii() and (character.isalnum() or character in "._-") else "-"
+        for character in normalized_key
+    )[:200]
+    return f"{filename_prefix or 'audit'}-{digest}"
 
 
 def _runner_lane_registration_audit_record_id(audit_record_key: str) -> str:

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -143,6 +143,9 @@ from control_plane.contracts.secret_record import (
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import (
+    sanitize_runner_host_hygiene_audit_record_for_persistence,
+)
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
 from control_plane.contracts.verireel_prod_backup_gate_operation import (
     VeriReelProdBackupGateOperationRecord,
@@ -753,10 +756,11 @@ class FilesystemRecordStore:
     def write_runner_host_hygiene_audit_record(
         self, record: RunnerHostHygieneApplyAuditRecord
     ) -> Path:
+        persisted_record = sanitize_runner_host_hygiene_audit_record_for_persistence(record)
         return self._write_model(
             "launchplane_runner_host_hygiene_audits",
-            _runner_host_hygiene_audit_record_id(record.audit_record_key),
-            record,
+            _runner_host_hygiene_audit_record_id(persisted_record.audit_record_key),
+            persisted_record,
         )
 
     def write_runner_lane_registration_audit_record(
@@ -1198,6 +1202,7 @@ class FilesystemRecordStore:
         self,
         *,
         host_name: str = "",
+        action: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[RunnerHostHygieneApplyAuditRecord, ...]:
@@ -1212,12 +1217,22 @@ class FilesystemRecordStore:
                 not normalized_host_name
                 or record.request.host_name.strip().lower() == normalized_host_name
             )
+            and (not action or record.request.action == action)
             and (not status or record.status == status)
         ]
         records.sort(key=lambda record: record.audit_record_key, reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)
+
+    def read_runner_host_hygiene_audit_record(
+        self, audit_record_key: str
+    ) -> RunnerHostHygieneApplyAuditRecord:
+        return self._read_model(
+            RunnerHostHygieneApplyAuditRecord,
+            "launchplane_runner_host_hygiene_audits",
+            _runner_host_hygiene_audit_record_id(audit_record_key),
+        )
 
     def list_runner_lane_registration_audit_records(
         self,

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -171,6 +171,9 @@ from control_plane.contracts.runtime_environment_record import (
 )
 from control_plane.contracts.runtime_key_safety_policy import RuntimeKeySafetyPolicyRecord
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene import (
+    sanitize_runner_host_hygiene_audit_record_for_persistence,
+)
 from control_plane.contracts.runner_lane_registration import RunnerLaneRegistrationAuditRecord
 from control_plane.contracts.secret_record import (
     SecretAuditEvent,
@@ -8230,14 +8233,15 @@ class PostgresRecordStore(HumanSessionStore):
     def write_runner_host_hygiene_audit_record(
         self, record: RunnerHostHygieneApplyAuditRecord
     ) -> None:
+        persisted_record = sanitize_runner_host_hygiene_audit_record_for_persistence(record)
         self._write_row(
             LaunchplaneRunnerHostHygieneAuditRow(
-                audit_record_key=record.audit_record_key,
-                host_name=record.request.host_name,
-                action=record.request.action,
-                status=record.status,
-                mutate=int(record.request.mutate),
-                payload=self._payload_dict(record),
+                audit_record_key=persisted_record.audit_record_key,
+                host_name=persisted_record.request.host_name,
+                action=persisted_record.request.action,
+                status=persisted_record.status,
+                mutate=int(persisted_record.request.mutate),
+                payload=self._payload_dict(persisted_record),
             )
         )
 
@@ -8245,6 +8249,7 @@ class PostgresRecordStore(HumanSessionStore):
         self,
         *,
         host_name: str = "",
+        action: str = "",
         status: str = "",
         limit: int | None = None,
     ) -> tuple[RunnerHostHygieneApplyAuditRecord, ...]:
@@ -8252,6 +8257,8 @@ class PostgresRecordStore(HumanSessionStore):
         normalized_host_name = host_name.strip().lower()
         if normalized_host_name:
             filters.append(LaunchplaneRunnerHostHygieneAuditRow.host_name == normalized_host_name)
+        if action:
+            filters.append(LaunchplaneRunnerHostHygieneAuditRow.action == action)
         if status:
             filters.append(LaunchplaneRunnerHostHygieneAuditRow.status == status)
         return self._list_models(
@@ -8260,6 +8267,15 @@ class PostgresRecordStore(HumanSessionStore):
             filters=filters,
             order_by=(LaunchplaneRunnerHostHygieneAuditRow.audit_record_key.desc(),),
             limit=limit,
+        )
+
+    def read_runner_host_hygiene_audit_record(
+        self, audit_record_key: str
+    ) -> RunnerHostHygieneApplyAuditRecord:
+        return self._read_model(
+            model_type=RunnerHostHygieneApplyAuditRecord,
+            orm_model=LaunchplaneRunnerHostHygieneAuditRow,
+            filters=(LaunchplaneRunnerHostHygieneAuditRow.audit_record_key == audit_record_key,),
         )
 
     def write_runner_lane_registration_audit_record(

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -1640,13 +1640,23 @@ def _mark_docker_cache_class_measurement_partial(
             cache_key=measurement.cache_key,
             cache_class=measurement.cache_class,
             availability="partial",
-            reason_code=reason_code,
+            reason_code=_merge_reason_codes(measurement.reason_code, reason_code),
             logical_bytes=measurement.logical_bytes,
             reclaimable_bytes=measurement.reclaimable_bytes,
             entry_count=measurement.entry_count,
         )
         for measurement in measurements
     )
+
+
+def _merge_reason_codes(*values: str) -> str:
+    reasons: list[str] = []
+    for value in values:
+        for reason in value.split(","):
+            normalized_reason = reason.strip()
+            if normalized_reason and normalized_reason not in reasons:
+                reasons.append(normalized_reason)
+    return ",".join(reasons)
 
 
 def _collect_container_inventory(
@@ -2225,7 +2235,7 @@ def _parse_docker_disk_usage(output: str) -> _DockerDiskUsageSnapshot:
     image_rows = _docker_disk_usage_rows(payload, "Images")
     images_present = "Images" in payload
     image_partial = False
-    image_used = 0
+    image_reclaimable_total = 0
     image_reclaimable_known = True
     for row in image_rows:
         containers = _optional_non_negative_int(row.get("Containers"))
@@ -2235,17 +2245,12 @@ def _parse_docker_disk_usage(output: str) -> _DockerDiskUsageSnapshot:
             image_partial = True
             image_reclaimable_known = False
             continue
-        if containers != 0:
-            image_used += max(size - shared_size, 0)
+        if containers == 0:
+            image_reclaimable_total += max(size - shared_size, 0)
     image_logical = _optional_non_negative_int(payload.get("LayersSize"))
     if images_present and image_logical is None:
         image_partial = True
-        image_reclaimable_known = False
-    image_reclaimable = (
-        max(image_logical - image_used, 0)
-        if image_logical is not None and image_reclaimable_known
-        else None
-    )
+    image_reclaimable = image_reclaimable_total if image_reclaimable_known else None
 
     container_rows = _docker_disk_usage_rows(payload, "Containers")
     containers_present = "Containers" in payload
@@ -2311,21 +2316,21 @@ def _parse_docker_disk_usage(output: str) -> _DockerDiskUsageSnapshot:
     build_cache_rows = _docker_disk_usage_rows(payload, "BuildCache")
     build_cache_present = "BuildCache" in payload
     build_cache_partial = False
-    build_cache_total = _optional_non_negative_int(payload.get("BuilderSize"))
-    build_cache_reclaimable_known = build_cache_total is not None
-    if build_cache_present and build_cache_total is None:
-        build_cache_partial = True
+    build_cache_total = 0
     build_cache_used = 0
+    build_cache_measurements_known = True
     for row in build_cache_rows:
         in_use = row.get("InUse")
         shared = row.get("Shared")
         raw_size = _optional_non_negative_int(row.get("Size"))
         if not isinstance(in_use, bool) or not isinstance(shared, bool) or raw_size is None:
             build_cache_partial = True
-            build_cache_reclaimable_known = False
+            build_cache_measurements_known = False
             continue
-        if in_use and not shared:
-            build_cache_used += raw_size
+        if not shared:
+            build_cache_total += raw_size
+            if in_use:
+                build_cache_used += raw_size
 
     container_logical = container_total if container_logical_known else None
     container_reclaimable = (
@@ -2333,10 +2338,9 @@ def _parse_docker_disk_usage(output: str) -> _DockerDiskUsageSnapshot:
     )
     volume_logical = volume_total if volume_logical_known else None
     volume_reclaimable = max(volume_total - volume_used, 0) if volume_reclaimable_known else None
+    build_cache_logical = build_cache_total if build_cache_measurements_known else None
     build_cache_reclaimable = (
-        max(build_cache_total - build_cache_used, 0)
-        if build_cache_total is not None and build_cache_reclaimable_known
-        else None
+        max(build_cache_total - build_cache_used, 0) if build_cache_measurements_known else None
     )
 
     return _DockerDiskUsageSnapshot(
@@ -2380,7 +2384,7 @@ def _parse_docker_disk_usage(output: str) -> _DockerDiskUsageSnapshot:
                 cache_class="docker_build_cache",
                 present=build_cache_present,
                 partial=build_cache_partial,
-                logical_bytes=build_cache_total,
+                logical_bytes=build_cache_logical,
                 reclaimable_bytes=build_cache_reclaimable,
                 entry_count=len(build_cache_rows),
             ),

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -27,7 +27,11 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAu
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPlan
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneCacheClassTelemetry
 from control_plane.contracts.runner_host_hygiene import RunnerHostDockerToolchainObservation
+from control_plane.contracts.runner_host_hygiene import (
+    RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS,
+)
 from control_plane.contracts.runner_host_hygiene import (
     RunnerHostHygieneAuditDeliveryEnvelope,
 )
@@ -46,6 +50,9 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneRunnerW
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneVolumeInventoryItem
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
+from control_plane.contracts.runner_host_hygiene import (
+    sanitize_runner_host_hygiene_audit_record_for_persistence,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.workflows.runner_host_hygiene_audit_spool import (
     RunnerHostHygieneAuditSpool,
@@ -56,6 +63,8 @@ AUDIT_ROUTE_PATH = "/v1/evidence/runner-host-hygiene/audits"
 DEFAULT_PRUNE_UNTIL = "168h"
 MINIMUM_PRUNE_UNTIL_HOURS = 168
 MINIMUM_DEFAULT_CACHE_KEEP_STORAGE_BYTES = 8 * 1024**3
+MAX_DOCKER_IMAGE_INVENTORY_ITEMS = RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS
+MAX_DOCKER_VOLUME_INVENTORY_ITEMS = RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS
 HOST_LOCK_PATH = "/tmp/launchplane-runner-host-hygiene.lock"
 _BUILDCTL_STORAGE_MB_BYTES = 1_000_000
 _RUNNER_WORKDIR_USAGE_HELPER = "/usr/local/sbin/launchplane-runner-workdir-usage"
@@ -120,6 +129,26 @@ class RemoteCommandResult:
 class _DockerDiskUsageSnapshot:
     reclaimable_breakdown: RunnerHostHygieneDockerReclaimableBreakdown
     volume_inventory: tuple[RunnerHostHygieneVolumeInventoryItem, ...]
+    cache_class_measurements: tuple[_DockerCacheClassMeasurement, ...]
+
+
+_DockerCacheClass = Literal[
+    "docker_images",
+    "docker_containers",
+    "docker_volumes",
+    "docker_build_cache",
+]
+
+
+@dataclass(frozen=True)
+class _DockerCacheClassMeasurement:
+    cache_key: str
+    cache_class: _DockerCacheClass
+    availability: Literal["available", "partial", "unavailable"]
+    reason_code: str
+    logical_bytes: int | None
+    reclaimable_bytes: int | None
+    entry_count: int | None
 
 
 RemoteCommandRunner = Callable[[Sequence[str], int], RemoteCommandResult]
@@ -443,6 +472,8 @@ def execute_runner_host_hygiene_executor(
         remote_runner=remote_runner,
         github_run_state_reader=github_run_state_reader,
     )
+    if request.mutate:
+        _assert_required_docker_telemetry_available(request=request, report=pre_report)
     selected_generated_run_ids = _select_generated_cache_run_ids(
         request=request,
         report=pre_report,
@@ -495,13 +526,15 @@ def execute_runner_host_hygiene_executor(
         request=apply_request,
         report=pre_report,
     )
-    planned_audit = RunnerHostHygieneApplyAuditRecord(
-        audit_record_key=request.audit_record_key,
-        status="planned",
-        request=apply_request,
-        plan=apply_plan,
-        pre_apply_report=pre_report,
-        message="planned runner host hygiene apply; no host mutation was executed yet",
+    planned_audit = sanitize_runner_host_hygiene_audit_record_for_persistence(
+        RunnerHostHygieneApplyAuditRecord(
+            audit_record_key=request.audit_record_key,
+            status="planned",
+            request=apply_request,
+            plan=apply_plan,
+            pre_apply_report=pre_report,
+            message="planned runner host hygiene apply; no host mutation was executed yet",
+        )
     )
     _assert_generated_cache_audit_redacted(audit=planned_audit, request=action_request)
     planned_idempotency_key = f"runner-host-hygiene:{request.audit_record_key}:planned"
@@ -1029,6 +1062,7 @@ def collect_runner_host_hygiene_report(
     remote_runner: RemoteCommandRunner,
     github_run_state_reader: GitHubRunStateReader | None = None,
 ) -> RunnerHostHygieneReport:
+    observed_at = utc_now_timestamp()
     df_result = _require_remote_success(
         remote_runner(("df", "-B1", "-P", "/"), request.timeout_seconds),
         evidence_name="df",
@@ -1045,15 +1079,35 @@ def collect_runner_host_hygiene_report(
         ).returncode
         == 0
     )
-    image_inventory = _collect_image_inventory(
-        request=request,
-        remote_runner=remote_runner,
+    try:
+        collected_image_inventory = _collect_image_inventory(
+            request=request,
+            remote_runner=remote_runner,
+        )
+        image_inventory_available = True
+    except click.ClickException:
+        if request.mutate:
+            raise
+        collected_image_inventory = ()
+        image_inventory_available = False
+    full_image_inventory = _ordered_image_inventory(collected_image_inventory)
+    try:
+        container_inventory = _collect_container_inventory(
+            request=request,
+            remote_runner=remote_runner,
+        )
+        container_inventory_available = True
+    except click.ClickException:
+        if request.mutate:
+            raise
+        container_inventory = ()
+        container_inventory_available = False
+    full_volume_inventory = _ordered_volume_inventory(
+        docker_disk_usage.volume_inventory,
+        allowed_volume_names=set(request.allowed_buildkit_state_volumes),
     )
-    container_inventory = _collect_container_inventory(
-        request=request,
-        remote_runner=remote_runner,
-    )
-    volume_inventory = docker_disk_usage.volume_inventory
+    image_inventory = full_image_inventory[:MAX_DOCKER_IMAGE_INVENTORY_ITEMS]
+    volume_inventory = full_volume_inventory[:MAX_DOCKER_VOLUME_INVENTORY_ITEMS]
     docker_reclaimable_breakdown = docker_disk_usage.reclaimable_breakdown
     runner_workdir_usage = _collect_runner_workdir_usage(
         request=request,
@@ -1064,9 +1118,22 @@ def collect_runner_host_hygiene_report(
         remote_runner=remote_runner,
         github_run_state_reader=github_run_state_reader,
     )
+    docker_cache_class_measurements = docker_disk_usage.cache_class_measurements
+    if not image_inventory_available:
+        docker_cache_class_measurements = _mark_docker_cache_class_measurement_partial(
+            docker_cache_class_measurements,
+            cache_class="docker_images",
+            reason_code="inventory_probe_failed",
+        )
+    if not container_inventory_available:
+        docker_cache_class_measurements = _mark_docker_cache_class_measurement_partial(
+            docker_cache_class_measurements,
+            cache_class="docker_containers",
+            reason_code="inventory_probe_failed",
+        )
     observation = RunnerHostHygieneObservation(
         host_name=request.host_name,
-        observed_at=utc_now_timestamp(),
+        observed_at=observed_at,
         free_disk_bytes=_parse_df_available_bytes(df_result.stdout),
         docker_reclaimable_bytes=docker_reclaimable_breakdown.total_bytes,
         docker_reclaimable_breakdown=docker_reclaimable_breakdown,
@@ -1076,15 +1143,23 @@ def collect_runner_host_hygiene_report(
         generated_cache_apparent_bytes=sum(item.apparent_bytes for item in generated_cache_usage),
         generated_cache_allocated_bytes=sum(item.allocated_bytes for item in generated_cache_usage),
         generated_cache_usage=generated_cache_usage,
+        cache_class_telemetry=_docker_cache_class_telemetry(
+            docker_cache_class_measurements,
+            observed_at=observed_at,
+        ),
         docker_toolchain=_collect_docker_toolchain(
             request=request,
             remote_runner=remote_runner,
         ),
         warm_builders=warm_builders,
         image_inventory=image_inventory,
+        image_inventory_total_count=len(full_image_inventory),
+        image_inventory_truncated=len(full_image_inventory) > len(image_inventory),
         volume_inventory=volume_inventory,
+        volume_inventory_total_count=len(full_volume_inventory),
+        volume_inventory_truncated=len(full_volume_inventory) > len(volume_inventory),
         orphan_buildkit_containers=_count_orphan_buildkit_containers(container_inventory),
-        orphan_buildkit_volumes=_count_orphan_buildkit_volumes(volume_inventory),
+        orphan_buildkit_volumes=_count_orphan_buildkit_volumes(full_volume_inventory),
         notes=(
             f"execution_lane={request.execution_lane}",
             f"service_user={request.service_user}",
@@ -1472,6 +1547,108 @@ def _collect_image_inventory(
     return tuple(inventory)
 
 
+def _ordered_image_inventory(
+    inventory: tuple[RunnerHostHygieneImageInventoryItem, ...],
+) -> tuple[RunnerHostHygieneImageInventoryItem, ...]:
+    return tuple(
+        sorted(
+            inventory,
+            key=lambda item: (
+                not item.is_warm_builder,
+                not item.dangling,
+                not item.in_use,
+                -(item.size_bytes if item.size_bytes is not None else -1),
+                item.image_id,
+            ),
+        )
+    )
+
+
+def _ordered_volume_inventory(
+    inventory: tuple[RunnerHostHygieneVolumeInventoryItem, ...],
+    *,
+    allowed_volume_names: set[str],
+) -> tuple[RunnerHostHygieneVolumeInventoryItem, ...]:
+    return tuple(
+        sorted(
+            inventory,
+            key=lambda item: (
+                item.name not in allowed_volume_names,
+                item.referenced_by_containers != 0,
+                -(item.size_bytes if item.size_bytes is not None else -1),
+                item.name,
+            ),
+        )
+    )
+
+
+def _docker_cache_class_telemetry(
+    measurements: tuple[_DockerCacheClassMeasurement, ...],
+    *,
+    observed_at: str,
+) -> tuple[RunnerHostHygieneCacheClassTelemetry, ...]:
+    return tuple(
+        RunnerHostHygieneCacheClassTelemetry(
+            cache_key=measurement.cache_key,
+            cache_class=measurement.cache_class,
+            scope="host",
+            availability=measurement.availability,
+            measurement_basis="docker_engine",
+            source="docker_engine",
+            observed_at=observed_at,
+            unavailable_reason=measurement.reason_code,
+            logical_bytes=measurement.logical_bytes,
+            reclaimable_bytes=measurement.reclaimable_bytes,
+            entry_count=measurement.entry_count,
+        )
+        for measurement in measurements
+    )
+
+
+def _assert_required_docker_telemetry_available(
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    report: RunnerHostHygieneReport,
+) -> None:
+    required_cache_class = {
+        "prune_docker_cache": "docker_build_cache",
+        "prune_dangling_images": "docker_images",
+        "remove_buildkit_state_volumes": "docker_volumes",
+    }.get(request.action)
+    if required_cache_class is None:
+        return
+    telemetry = next(
+        (item for item in report.cache_class_telemetry if item.cache_class == required_cache_class),
+        None,
+    )
+    if telemetry is None or telemetry.availability != "available":
+        raise click.ClickException(
+            "runner host hygiene required Docker telemetry was unavailable or partial"
+        )
+
+
+def _mark_docker_cache_class_measurement_partial(
+    measurements: tuple[_DockerCacheClassMeasurement, ...],
+    *,
+    cache_class: _DockerCacheClass,
+    reason_code: str,
+) -> tuple[_DockerCacheClassMeasurement, ...]:
+    return tuple(
+        measurement
+        if measurement.cache_class != cache_class or measurement.availability == "unavailable"
+        else _DockerCacheClassMeasurement(
+            cache_key=measurement.cache_key,
+            cache_class=measurement.cache_class,
+            availability="partial",
+            reason_code=reason_code,
+            logical_bytes=measurement.logical_bytes,
+            reclaimable_bytes=measurement.reclaimable_bytes,
+            entry_count=measurement.entry_count,
+        )
+        for measurement in measurements
+    )
+
+
 def _collect_container_inventory(
     *,
     request: RunnerHostHygieneExecutorRequest,
@@ -1561,12 +1738,32 @@ def _collect_runner_workdir_usage(
             request.timeout_seconds,
         )
         if result.returncode != 0:
-            raise click.ClickException(
-                f"runner host hygiene runner_workdir_bytes:{root.key} evidence failed"
+            if request.mutate:
+                raise click.ClickException(
+                    f"runner host hygiene runner_workdir_bytes:{root.key} evidence failed"
+                )
+            usage.append(
+                RunnerHostHygieneRunnerWorkdirUsage(
+                    root_key=root.key,
+                    measurement_status="unavailable",
+                    reason_code="probe_failed",
+                )
             )
+            continue
         lines = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
         if len(lines) not in {2, 3}:
-            raise click.ClickException("runner host hygiene runner workdir evidence was incomplete")
+            if request.mutate:
+                raise click.ClickException(
+                    "runner host hygiene runner workdir evidence was incomplete"
+                )
+            usage.append(
+                RunnerHostHygieneRunnerWorkdirUsage(
+                    root_key=root.key,
+                    measurement_status="unavailable",
+                    reason_code="invalid_evidence",
+                )
+            )
+            continue
         raw_measurement_status = lines[2] if len(lines) == 3 else "complete"
         measurement_status: Literal["complete", "partial"]
         if raw_measurement_status == "complete":
@@ -1574,9 +1771,18 @@ def _collect_runner_workdir_usage(
         elif raw_measurement_status == "partial":
             measurement_status = "partial"
         else:
-            raise click.ClickException(
-                "runner host hygiene runner workdir evidence had an invalid status"
+            if request.mutate:
+                raise click.ClickException(
+                    "runner host hygiene runner workdir evidence had an invalid status"
+                )
+            usage.append(
+                RunnerHostHygieneRunnerWorkdirUsage(
+                    root_key=root.key,
+                    measurement_status="unavailable",
+                    reason_code="invalid_evidence",
+                )
             )
+            continue
         usage.append(
             RunnerHostHygieneRunnerWorkdirUsage(
                 root_key=root.key,
@@ -1587,6 +1793,7 @@ def _collect_runner_workdir_usage(
                     lines[1], evidence_name=f"runner_workdir_allocated_bytes:{root.key}"
                 ),
                 measurement_status=measurement_status,
+                reason_code=("probe_reported_partial" if measurement_status == "partial" else ""),
             )
         )
     return tuple(usage)
@@ -1621,7 +1828,8 @@ def _collect_generated_run_cache_usage(
             usage.append(
                 RunnerHostHygieneGeneratedCacheUsage(
                     cache_key=root.key,
-                    measurement_status="partial",
+                    measurement_status="unavailable",
+                    reason_code="probe_failed",
                 )
             )
             continue
@@ -1637,7 +1845,8 @@ def _collect_generated_run_cache_usage(
             usage.append(
                 RunnerHostHygieneGeneratedCacheUsage(
                     cache_key=root.key,
-                    measurement_status="partial",
+                    measurement_status="unavailable",
+                    reason_code="invalid_evidence",
                 )
             )
     return tuple(usage)
@@ -1740,6 +1949,7 @@ def _parse_generated_run_cache_usage(
         estimated_daily_growth_bytes = (
             (allocated_bytes - last_post_cleanup_allocated_bytes) * 86_400 // elapsed_since_cleanup
         )
+    measurement_status = _generated_cache_measurement_status(summary.get("measurement_status"))
     return RunnerHostHygieneGeneratedCacheUsage(
         cache_key=root.key,
         apparent_bytes=_strict_non_negative_int(
@@ -1750,7 +1960,8 @@ def _parse_generated_run_cache_usage(
         entry_count=_strict_non_negative_int(
             summary.get("entry_count"), evidence_name="generated cache entry count"
         ),
-        measurement_status=_generated_cache_measurement_status(summary.get("measurement_status")),
+        measurement_status=measurement_status,
+        reason_code=("probe_reported_partial" if measurement_status == "partial" else ""),
         owner_valid=_strict_bool(summary.get("owner_valid"), evidence_name="owner_valid"),
         mode_valid=_strict_bool(summary.get("mode_valid"), evidence_name="mode_valid"),
         symlink_safe=_strict_bool(summary.get("symlink_safe"), evidence_name="symlink_safe"),
@@ -1961,11 +2172,42 @@ def _collect_docker_disk_usage(
     request: RunnerHostHygieneExecutorRequest,
     remote_runner: RemoteCommandRunner,
 ) -> _DockerDiskUsageSnapshot:
-    result = _require_remote_success(
-        remote_runner(_DOCKER_DISK_USAGE_COMMAND, request.timeout_seconds),
-        evidence_name="docker_summary",
+    try:
+        result = _require_remote_success(
+            remote_runner(_DOCKER_DISK_USAGE_COMMAND, request.timeout_seconds),
+            evidence_name="docker_summary",
+        )
+        return _parse_docker_disk_usage(result.stdout)
+    except click.ClickException:
+        if request.mutate:
+            raise
+        return _unavailable_docker_disk_usage_snapshot()
+
+
+def _unavailable_docker_disk_usage_snapshot() -> _DockerDiskUsageSnapshot:
+    cache_classes: tuple[tuple[str, _DockerCacheClass], ...] = (
+        ("images", "docker_images"),
+        ("containers", "docker_containers"),
+        ("volumes", "docker_volumes"),
+        ("build-cache", "docker_build_cache"),
     )
-    return _parse_docker_disk_usage(result.stdout)
+    measurements = tuple(
+        _DockerCacheClassMeasurement(
+            cache_key=cache_key,
+            cache_class=cache_class,
+            availability="unavailable",
+            reason_code="probe_failed",
+            logical_bytes=None,
+            reclaimable_bytes=None,
+            entry_count=None,
+        )
+        for cache_key, cache_class in cache_classes
+    )
+    return _DockerDiskUsageSnapshot(
+        reclaimable_breakdown=RunnerHostHygieneDockerReclaimableBreakdown(),
+        volume_inventory=(),
+        cache_class_measurements=measurements,
+    )
 
 
 def _parse_docker_disk_usage(output: str) -> _DockerDiskUsageSnapshot:
@@ -1980,34 +2222,79 @@ def _parse_docker_disk_usage(output: str) -> _DockerDiskUsageSnapshot:
             "runner host hygiene Docker disk usage evidence was not a JSON object"
         )
 
-    image_reclaimable = 0
-    for row in _docker_disk_usage_rows(payload, "Images"):
-        containers = _optional_int(row.get("Containers"))
-        size = _optional_int(row.get("Size"))
-        shared_size = _optional_int(row.get("SharedSize"))
-        if containers == 0 and size is not None and shared_size is not None:
-            image_reclaimable += max(size - shared_size, 0)
+    image_rows = _docker_disk_usage_rows(payload, "Images")
+    images_present = "Images" in payload
+    image_partial = False
+    image_used = 0
+    image_reclaimable_known = True
+    for row in image_rows:
+        containers = _optional_non_negative_int(row.get("Containers"))
+        size = _optional_non_negative_int(row.get("Size"))
+        shared_size = _optional_non_negative_int(row.get("SharedSize"))
+        if containers is None or size is None or shared_size is None:
+            image_partial = True
+            image_reclaimable_known = False
+            continue
+        if containers != 0:
+            image_used += max(size - shared_size, 0)
+    image_logical = _optional_non_negative_int(payload.get("LayersSize"))
+    if images_present and image_logical is None:
+        image_partial = True
+        image_reclaimable_known = False
+    image_reclaimable = (
+        max(image_logical - image_used, 0)
+        if image_logical is not None and image_reclaimable_known
+        else None
+    )
 
+    container_rows = _docker_disk_usage_rows(payload, "Containers")
+    containers_present = "Containers" in payload
+    container_partial = False
     container_total = 0
     container_used = 0
-    for row in _docker_disk_usage_rows(payload, "Containers"):
-        size = max(_optional_int(row.get("SizeRw")) or 0, 0)
-        container_total += size
-        if _docker_json_text(row, "State").lower() in {"running", "paused", "restarting"}:
-            container_used += size
+    container_logical_known = True
+    container_reclaimable_known = True
+    for row in container_rows:
+        raw_size = _optional_non_negative_int(row.get("SizeRw"))
+        if raw_size is None:
+            container_partial = True
+            container_logical_known = False
+            container_reclaimable_known = False
+            continue
+        container_total += raw_size
+        state = _docker_json_text(row, "State").lower()
+        if not state:
+            container_partial = True
+            container_reclaimable_known = False
+        elif state in {"running", "paused", "restarting"}:
+            container_used += raw_size
 
+    volume_rows = _docker_disk_usage_rows(payload, "Volumes")
+    volumes_present = "Volumes" in payload
+    volume_partial = False
     volume_total = 0
     volume_used = 0
+    volume_logical_known = True
+    volume_reclaimable_known = True
     volume_inventory: list[RunnerHostHygieneVolumeInventoryItem] = []
-    for row in _docker_disk_usage_rows(payload, "Volumes"):
+    for row in volume_rows:
         usage_data = row.get("UsageData")
         if not isinstance(usage_data, dict):
             usage_data = {}
-        ref_count = _non_negative_int(usage_data.get("RefCount"))
-        size = _non_negative_int(usage_data.get("Size"))
-        if size > 0:
+            volume_partial = True
+        raw_ref_count = _optional_non_negative_int(usage_data.get("RefCount"))
+        raw_size = _optional_non_negative_int(usage_data.get("Size"))
+        if raw_size is None:
+            volume_logical_known = False
+            volume_reclaimable_known = False
+        if raw_ref_count is None:
+            volume_reclaimable_known = False
+        if raw_ref_count is None or raw_size is None:
+            volume_partial = True
+        size = raw_size
+        if size is not None and size > 0:
             volume_total += size
-            if ref_count > 0:
+            if raw_ref_count is not None and raw_ref_count > 0:
                 volume_used += size
         volume_inventory.append(
             RunnerHostHygieneVolumeInventoryItem(
@@ -2016,29 +2303,119 @@ def _parse_docker_disk_usage(output: str) -> _DockerDiskUsageSnapshot:
                 mountpoint=_docker_json_text(row, "Mountpoint"),
                 labels=_docker_labels(row.get("Labels")),
                 size_bytes=size,
-                referenced_by_containers=ref_count,
-                dangling=ref_count == 0,
+                referenced_by_containers=raw_ref_count,
+                dangling=raw_ref_count == 0,
             )
         )
 
-    build_cache_total = 0
+    build_cache_rows = _docker_disk_usage_rows(payload, "BuildCache")
+    build_cache_present = "BuildCache" in payload
+    build_cache_partial = False
+    build_cache_total = _optional_non_negative_int(payload.get("BuilderSize"))
+    build_cache_reclaimable_known = build_cache_total is not None
+    if build_cache_present and build_cache_total is None:
+        build_cache_partial = True
     build_cache_used = 0
-    for row in _docker_disk_usage_rows(payload, "BuildCache"):
-        if row.get("Shared") is True:
+    for row in build_cache_rows:
+        in_use = row.get("InUse")
+        shared = row.get("Shared")
+        raw_size = _optional_non_negative_int(row.get("Size"))
+        if not isinstance(in_use, bool) or not isinstance(shared, bool) or raw_size is None:
+            build_cache_partial = True
+            build_cache_reclaimable_known = False
             continue
-        size = max(_optional_int(row.get("Size")) or 0, 0)
-        build_cache_total += size
-        if row.get("InUse") is True:
-            build_cache_used += size
+        if in_use and not shared:
+            build_cache_used += raw_size
+
+    container_logical = container_total if container_logical_known else None
+    container_reclaimable = (
+        max(container_total - container_used, 0) if container_reclaimable_known else None
+    )
+    volume_logical = volume_total if volume_logical_known else None
+    volume_reclaimable = max(volume_total - volume_used, 0) if volume_reclaimable_known else None
+    build_cache_reclaimable = (
+        max(build_cache_total - build_cache_used, 0)
+        if build_cache_total is not None and build_cache_reclaimable_known
+        else None
+    )
 
     return _DockerDiskUsageSnapshot(
         reclaimable_breakdown=RunnerHostHygieneDockerReclaimableBreakdown(
-            images_bytes=image_reclaimable,
-            containers_bytes=max(container_total - container_used, 0),
-            local_volumes_bytes=max(volume_total - volume_used, 0),
-            build_cache_bytes=max(build_cache_total - build_cache_used, 0),
+            images_bytes=image_reclaimable or 0,
+            containers_bytes=container_reclaimable or 0,
+            local_volumes_bytes=volume_reclaimable or 0,
+            build_cache_bytes=build_cache_reclaimable or 0,
         ),
         volume_inventory=tuple(volume_inventory),
+        cache_class_measurements=(
+            _docker_cache_class_measurement(
+                cache_key="images",
+                cache_class="docker_images",
+                present=images_present,
+                partial=image_partial,
+                logical_bytes=image_logical,
+                reclaimable_bytes=image_reclaimable,
+                entry_count=len(image_rows),
+            ),
+            _docker_cache_class_measurement(
+                cache_key="containers",
+                cache_class="docker_containers",
+                present=containers_present,
+                partial=container_partial,
+                logical_bytes=container_logical,
+                reclaimable_bytes=container_reclaimable,
+                entry_count=len(container_rows),
+            ),
+            _docker_cache_class_measurement(
+                cache_key="volumes",
+                cache_class="docker_volumes",
+                present=volumes_present,
+                partial=volume_partial,
+                logical_bytes=volume_logical,
+                reclaimable_bytes=volume_reclaimable,
+                entry_count=len(volume_rows),
+            ),
+            _docker_cache_class_measurement(
+                cache_key="build-cache",
+                cache_class="docker_build_cache",
+                present=build_cache_present,
+                partial=build_cache_partial,
+                logical_bytes=build_cache_total,
+                reclaimable_bytes=build_cache_reclaimable,
+                entry_count=len(build_cache_rows),
+            ),
+        ),
+    )
+
+
+def _docker_cache_class_measurement(
+    *,
+    cache_key: str,
+    cache_class: _DockerCacheClass,
+    present: bool,
+    partial: bool,
+    logical_bytes: int | None,
+    reclaimable_bytes: int | None,
+    entry_count: int,
+) -> _DockerCacheClassMeasurement:
+    if not present:
+        return _DockerCacheClassMeasurement(
+            cache_key=cache_key,
+            cache_class=cache_class,
+            availability="unavailable",
+            reason_code="class_unavailable",
+            logical_bytes=None,
+            reclaimable_bytes=None,
+            entry_count=None,
+        )
+    return _DockerCacheClassMeasurement(
+        cache_key=cache_key,
+        cache_class=cache_class,
+        availability="partial" if partial else "available",
+        reason_code="measurement_partial" if partial else "",
+        logical_bytes=logical_bytes,
+        reclaimable_bytes=reclaimable_bytes,
+        entry_count=entry_count,
     )
 
 
@@ -2059,6 +2436,13 @@ def _optional_int(value: object) -> int | None:
     if isinstance(value, bool) or not isinstance(value, int):
         return None
     return value
+
+
+def _optional_non_negative_int(value: object) -> int | None:
+    parsed_value = _optional_int(value)
+    if parsed_value is None or parsed_value < 0:
+        return None
+    return parsed_value
 
 
 def _parse_json_lines(output: str, *, evidence_name: str) -> tuple[dict[str, object], ...]:
@@ -2120,9 +2504,9 @@ def _optional_scalar_text(value: object) -> str:
     return ""
 
 
-def _parse_optional_docker_size_bytes(value: str) -> int:
+def _parse_optional_docker_size_bytes(value: str) -> int | None:
     if not value.strip() or value.strip() in {"N/A", "-"}:
-        return 0
+        return None
     return _parse_docker_size_bytes(value)
 
 
@@ -2211,14 +2595,16 @@ def _terminal_audit(
     status: RunnerHostHygieneApplyAuditStatus,
     message: str,
 ) -> RunnerHostHygieneApplyAuditRecord:
-    return RunnerHostHygieneApplyAuditRecord(
-        audit_record_key=request.audit_record_key,
-        status=status,
-        request=request,
-        plan=apply_plan,
-        pre_apply_report=pre_report,
-        post_apply_report=post_report,
-        message=message,
+    return sanitize_runner_host_hygiene_audit_record_for_persistence(
+        RunnerHostHygieneApplyAuditRecord(
+            audit_record_key=request.audit_record_key,
+            status=status,
+            request=request,
+            plan=apply_plan,
+            pre_apply_report=pre_report,
+            post_apply_report=post_report,
+            message=message,
+        )
     )
 
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -525,13 +525,19 @@ an ORM column/table or remains only in the evidence payload.
 - Runner host hygiene audit: modeled fields are `audit_record_key`,
   `host_name`, `action`, `status`, and `mutate`. The payload carries the typed
   request, plan, pre/post hygiene reports, retained warm-builder evidence, and
-  operator message. Generated-cache public keys, apparent and allocated bytes,
+  operator message. Observation timestamps, generic cache-class availability,
+  source and measurement-basis metadata, filesystem apparent/allocated bytes,
+  Docker logical/reclaimable bytes, bounded inventory counts and truncation,
   age buckets, numeric run ids, GitHub completion state, bounded worker and
   open-handle observations, cleanup history, and hysteresis/cooldown evidence
   also stay payload-only. Absolute cache paths and source repository identity
   are executor-local runtime authority and are not persisted in the audit.
   Docker toolchain evidence, host-command output, Docker summaries, and rollout
-  notes stay payload-only until they need queryable operational views. The host-local audit-delivery envelope is a separate
+  notes stay payload-only until they need queryable operational views. Bounded
+  list, sanitized detail, and observation-history reads use the existing JSON
+  payload and promoted host/action/status columns; no separate history table or
+  inferred timestamp is required. Legacy reports without `observed_at` sort
+  after timestamped evidence. The host-local audit-delivery envelope is a separate
   recovery record: it stores planned and optional terminal audit payloads,
   execution phase, delivery state, idempotency keys, bounded redacted errors,
   and attempt counts. It is written atomically under an explicit state

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -39,6 +39,24 @@ policy from observation:
 - `evaluate_runner_host_hygiene(...)` returns a structured report with
   `healthy` or `attention` status, findings, and non-mutating next steps.
 
+Reports preserve the observation timestamp and expose a generic
+`cache_class_telemetry` read surface alongside the existing action-planning
+fields. Each cache-class row carries a public key, class, scope, source,
+measurement basis, availability, and the measurements that the source can
+honestly provide:
+
+- filesystem roots use apparent and allocated bytes
+- Docker Engine classes use logical and reclaimable bytes
+- measured zero is distinct from unavailable, partial, or stale evidence
+- unavailable or partial evidence carries a bounded reason instead of silently
+  becoming zero
+- generated-cache rows may also carry bounded age buckets, estimated growth,
+  and the latest cleanup snapshot
+
+The generic rows do not grant cleanup authority. Existing action-specific
+fields and apply-plan gates remain authoritative for the already approved
+mutation lanes; new cache classes stay report-only.
+
 The report is intentionally conservative. Missing required warm builders, low
 free disk, Docker reclaimable bytes over budget, runner work-directory bytes over
 budget, and orphan BuildKit artifacts all produce `attention` unless policy
@@ -47,14 +65,13 @@ Reports also carry the typed observation counters used for evaluation, so audit
 records preserve free disk, Docker reclaimable bytes, runner work-directory
 bytes, Docker toolchain evidence, warm builders, and orphan BuildKit counts
 instead of relying only on raw operator notes. Executor-written reports also
-include read-only resource
-inventory for Docker images and volumes. Image rows preserve repository, tag,
-image ID, size, creation timestamp, dangling status, in-use hints, and whether
-the image is one of the retained warm builders. Volume rows preserve name,
-driver, mountpoint, labels, size when Docker exposes it, reference count when
-Docker exposes it, and dangling status. These inventory fields are evidence for
-operator review only; aggregate reclaimable totals are not enough to approve
-destructive volume or image pruning.
+include read-only resource inventory for Docker images and volumes. The
+executor sorts each inventory deterministically, retains at most 128 rows, and
+records the total count plus a truncation flag. Image and volume sizes are
+nullable when Docker does not expose them; absence is not converted into
+measured zero. These inventory fields are evidence for operator review only;
+aggregate reclaimable totals are not enough to approve destructive volume or
+image pruning.
 
 Docker toolchain evidence is preserved for operator review and runner-readiness
 follow-up. The hygiene report records Docker Engine version, Docker CLI version,
@@ -141,6 +158,25 @@ failure may proceed only because the planned intent is already durable locally.
 Generated run-cache mutation is stricter: it requires both the durable host
 spool and accepted service delivery of the planned audit before the privileged
 helper can run. A pending or rejected planned record leaves that action blocked.
+
+Authorized operators and workflows can read the durable evidence through:
+
+- `GET /v1/evidence/runner-host-hygiene/audits` for a bounded summary list,
+  filtered by optional host, action, and audit status
+- `GET /v1/evidence/runner-host-hygiene/audits/record` with an
+  `audit_record_key` query parameter for one sanitized detail projection
+- `GET /v1/evidence/runner-host-hygiene/history` with a required `host_name`
+  and optional `cache_key` for bounded pre/post observation chronology
+
+The read routes require `runner_host_hygiene_audit.read` for
+`launchplane/launchplane`. List and history limits default to 25 and cannot
+exceed 100. Detail and history projections omit raw image and volume inventory
+rows; they expose bounded counts, truncation state, finding codes, and generic
+cache-class telemetry. Legacy audit reports that predate timestamp persistence
+remain readable with `chronology_state: legacy_missing`; Launchplane does not
+infer observation time from the audit key. History responses expose separate
+`scan_truncated` and `result_truncated` flags so callers can distinguish the
+fixed 100-audit scan ceiling from the requested result limit.
 
 ## Approved Ops-Lane Executor
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -253,6 +253,12 @@ cleanup scope so the store is always closed.
   - `POST /v1/evidence/runner-host-hygiene/audits` (native FastAPI for
     bearer-token callers, with Pydantic/OpenAPI contract coverage, idempotency
     replay preservation, and runner-host hygiene audit storage)
+  - `GET /v1/evidence/runner-host-hygiene/audits` (bounded runner-host hygiene
+    audit summaries for authorized bearer-token callers)
+  - `GET /v1/evidence/runner-host-hygiene/audits/record` (one sanitized audit
+    projection selected by `audit_record_key`)
+  - `GET /v1/evidence/runner-host-hygiene/history` (bounded timestamped
+    pre/post cache telemetry history for one runner host)
   - `POST /v1/evidence/runner-lane-registration/audits` (native FastAPI for
     bearer-token callers, with Pydantic/OpenAPI contract coverage, idempotency
     replay preservation, and runner-lane registration audit storage)
@@ -3004,6 +3010,27 @@ accepted records and result details. It is native FastAPI evidence ingress for
 bearer-token callers with OpenAPI contract coverage and idempotency replay
 preservation. It records planned, completed, or failed audit facts supplied by a
 future approved executor, but it does not mutate runner hosts itself.
+
+The corresponding read routes require the separate
+`runner_host_hygiene_audit.read` action for product/context
+`launchplane/launchplane`:
+
+- `GET /v1/evidence/runner-host-hygiene/audits` accepts optional `host_name`,
+  `action`, and `audit_status` filters plus a bounded `limit`.
+- `GET /v1/evidence/runner-host-hygiene/audits/record` requires an
+  `audit_record_key` query parameter because audit keys contain `/` characters.
+- `GET /v1/evidence/runner-host-hygiene/history` requires `host_name`, accepts
+  optional `cache_key`, and returns timestamped pre/post report points.
+
+List responses contain summaries rather than inventory-bearing audit payloads.
+Detail and history responses omit raw image and volume rows and expose bounded
+counts, truncation state, finding codes, and availability-aware cache telemetry.
+Limits default to 25 and cannot exceed 100. Reports written after this contract
+preserve `observed_at`; older reports remain readable as `legacy_missing`
+without inferring time from an audit key. Read access does not authorize writes,
+host mutation, or any new cleanup class. History responses report the fixed
+100-audit `scan_limit` and distinguish `scan_truncated` from
+`result_truncated`; neither condition implies that older evidence was deleted.
 
 ### Runner lane lifecycle audit evidence
 

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -18753,6 +18753,415 @@
         "title": "RunnerHostHygieneAuditEvidenceEnvelope",
         "type": "object"
       },
+      "RunnerHostHygieneAuditReadRecord": {
+        "additionalProperties": false,
+        "properties": {
+          "post_apply_report": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RunnerHostHygieneReportReadModel"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "pre_apply_report": {
+            "$ref": "#/components/schemas/RunnerHostHygieneReportReadModel"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/RunnerHostHygieneAuditSummary"
+          }
+        },
+        "required": [
+          "summary",
+          "pre_apply_report",
+          "post_apply_report"
+        ],
+        "title": "RunnerHostHygieneAuditReadRecord",
+        "type": "object"
+      },
+      "RunnerHostHygieneAuditRecordResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "record": {
+            "$ref": "#/components/schemas/RunnerHostHygieneAuditReadRecord"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "trace_id",
+          "record"
+        ],
+        "title": "RunnerHostHygieneAuditRecordResponse",
+        "type": "object"
+      },
+      "RunnerHostHygieneAuditRecordsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "anyOf": [
+              {
+                "enum": [
+                  "prune_docker_cache",
+                  "prune_dangling_images",
+                  "prune_generated_run_cache",
+                  "remove_buildkit_state_volumes",
+                  "prune_runner_workdir",
+                  "restart_runner_service"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Action"
+          },
+          "audit_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "planned",
+                  "completed",
+                  "failed"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Audit Status"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "host_name": {
+            "title": "Host Name",
+            "type": "string"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "records": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneAuditSummary"
+            },
+            "title": "Records",
+            "type": "array"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "trace_id",
+          "host_name",
+          "action",
+          "audit_status",
+          "limit",
+          "count",
+          "truncated",
+          "records"
+        ],
+        "title": "RunnerHostHygieneAuditRecordsResponse",
+        "type": "object"
+      },
+      "RunnerHostHygieneAuditSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "enum": [
+              "prune_docker_cache",
+              "prune_dangling_images",
+              "prune_generated_run_cache",
+              "remove_buildkit_state_volumes",
+              "prune_runner_workdir",
+              "restart_runner_service"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
+          "audit_record_key": {
+            "title": "Audit Record Key",
+            "type": "string"
+          },
+          "audit_status": {
+            "enum": [
+              "planned",
+              "completed",
+              "failed"
+            ],
+            "title": "Audit Status",
+            "type": "string"
+          },
+          "host_name": {
+            "title": "Host Name",
+            "type": "string"
+          },
+          "mutate": {
+            "title": "Mutate",
+            "type": "boolean"
+          },
+          "post_apply_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Post Apply Observed At"
+          },
+          "post_apply_status": {
+            "anyOf": [
+              {
+                "enum": [
+                  "healthy",
+                  "attention"
+                ],
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Post Apply Status"
+          },
+          "pre_apply_observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pre Apply Observed At"
+          },
+          "pre_apply_status": {
+            "enum": [
+              "healthy",
+              "attention"
+            ],
+            "title": "Pre Apply Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "audit_record_key",
+          "audit_status",
+          "action",
+          "host_name",
+          "mutate",
+          "pre_apply_observed_at",
+          "post_apply_observed_at",
+          "pre_apply_status",
+          "post_apply_status"
+        ],
+        "title": "RunnerHostHygieneAuditSummary",
+        "type": "object"
+      },
+      "RunnerHostHygieneCacheClassTelemetry": {
+        "additionalProperties": false,
+        "properties": {
+          "age_buckets": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneGeneratedCacheAgeBucket"
+            },
+            "title": "Age Buckets",
+            "type": "array"
+          },
+          "allocated_bytes": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allocated Bytes"
+          },
+          "apparent_bytes": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Apparent Bytes"
+          },
+          "availability": {
+            "enum": [
+              "available",
+              "partial",
+              "unavailable",
+              "stale"
+            ],
+            "title": "Availability",
+            "type": "string"
+          },
+          "cache_class": {
+            "enum": [
+              "runner_workdir",
+              "generated_filesystem",
+              "docker_images",
+              "docker_containers",
+              "docker_volumes",
+              "docker_build_cache"
+            ],
+            "title": "Cache Class",
+            "type": "string"
+          },
+          "cache_key": {
+            "title": "Cache Key",
+            "type": "string"
+          },
+          "entry_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Entry Count"
+          },
+          "estimated_daily_growth_bytes": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Estimated Daily Growth Bytes"
+          },
+          "last_cleanup_epoch_seconds": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Cleanup Epoch Seconds"
+          },
+          "last_reclaimed_bytes": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Reclaimed Bytes"
+          },
+          "logical_bytes": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Logical Bytes"
+          },
+          "measurement_basis": {
+            "enum": [
+              "filesystem_apparent_allocated",
+              "docker_engine"
+            ],
+            "title": "Measurement Basis",
+            "type": "string"
+          },
+          "observed_at": {
+            "title": "Observed At",
+            "type": "string"
+          },
+          "reclaimable_bytes": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reclaimable Bytes"
+          },
+          "scope": {
+            "enum": [
+              "host",
+              "runner_root",
+              "generated_cache"
+            ],
+            "title": "Scope",
+            "type": "string"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "unavailable_reason": {
+            "default": "",
+            "title": "Unavailable Reason",
+            "type": "string"
+          }
+        },
+        "required": [
+          "cache_key",
+          "cache_class",
+          "scope",
+          "availability",
+          "measurement_basis",
+          "source",
+          "observed_at"
+        ],
+        "title": "RunnerHostHygieneCacheClassTelemetry",
+        "type": "object"
+      },
       "RunnerHostHygieneDockerReclaimableBreakdown": {
         "additionalProperties": false,
         "properties": {
@@ -18992,7 +19401,9 @@
             "default": "complete",
             "enum": [
               "complete",
-              "partial"
+              "partial",
+              "unavailable",
+              "stale"
             ],
             "title": "Measurement Status",
             "type": "string"
@@ -19015,6 +19426,11 @@
             "title": "Owner Worker Observations",
             "type": "array"
           },
+          "reason_code": {
+            "default": "",
+            "title": "Reason Code",
+            "type": "string"
+          },
           "symlink_safe": {
             "default": false,
             "title": "Symlink Safe",
@@ -19025,6 +19441,129 @@
           "cache_key"
         ],
         "title": "RunnerHostHygieneGeneratedCacheUsage",
+        "type": "object"
+      },
+      "RunnerHostHygieneHistoryPoint": {
+        "additionalProperties": false,
+        "properties": {
+          "action": {
+            "enum": [
+              "prune_docker_cache",
+              "prune_dangling_images",
+              "prune_generated_run_cache",
+              "remove_buildkit_state_volumes",
+              "prune_runner_workdir",
+              "restart_runner_service"
+            ],
+            "title": "Action",
+            "type": "string"
+          },
+          "audit_record_key": {
+            "title": "Audit Record Key",
+            "type": "string"
+          },
+          "audit_status": {
+            "enum": [
+              "planned",
+              "completed",
+              "failed"
+            ],
+            "title": "Audit Status",
+            "type": "string"
+          },
+          "mutate": {
+            "title": "Mutate",
+            "type": "boolean"
+          },
+          "phase": {
+            "enum": [
+              "pre_apply",
+              "post_apply"
+            ],
+            "title": "Phase",
+            "type": "string"
+          },
+          "report": {
+            "$ref": "#/components/schemas/RunnerHostHygieneReportReadModel"
+          }
+        },
+        "required": [
+          "audit_record_key",
+          "phase",
+          "audit_status",
+          "action",
+          "mutate",
+          "report"
+        ],
+        "title": "RunnerHostHygieneHistoryPoint",
+        "type": "object"
+      },
+      "RunnerHostHygieneHistoryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "cache_key": {
+            "title": "Cache Key",
+            "type": "string"
+          },
+          "count": {
+            "title": "Count",
+            "type": "integer"
+          },
+          "host_name": {
+            "title": "Host Name",
+            "type": "string"
+          },
+          "limit": {
+            "title": "Limit",
+            "type": "integer"
+          },
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneHistoryPoint"
+            },
+            "title": "Points",
+            "type": "array"
+          },
+          "result_truncated": {
+            "title": "Result Truncated",
+            "type": "boolean"
+          },
+          "scan_limit": {
+            "title": "Scan Limit",
+            "type": "integer"
+          },
+          "scan_truncated": {
+            "title": "Scan Truncated",
+            "type": "boolean"
+          },
+          "status": {
+            "const": "ok",
+            "default": "ok",
+            "title": "Status",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          },
+          "truncated": {
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "trace_id",
+          "host_name",
+          "cache_key",
+          "limit",
+          "scan_limit",
+          "count",
+          "scan_truncated",
+          "result_truncated",
+          "truncated",
+          "points"
+        ],
+        "title": "RunnerHostHygieneHistoryResponse",
         "type": "object"
       },
       "RunnerHostHygieneImageInventoryItem": {
@@ -19059,10 +19598,16 @@
             "type": "string"
           },
           "size_bytes": {
-            "default": 0,
-            "minimum": 0.0,
-            "title": "Size Bytes",
-            "type": "integer"
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Bytes"
           },
           "tag": {
             "title": "Tag",
@@ -19080,6 +19625,14 @@
       "RunnerHostHygieneReport": {
         "additionalProperties": false,
         "properties": {
+          "cache_class_telemetry": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneCacheClassTelemetry"
+            },
+            "title": "Cache Class Telemetry",
+            "type": "array"
+          },
           "docker_reclaimable_breakdown": {
             "$ref": "#/components/schemas/RunnerHostHygieneDockerReclaimableBreakdown"
           },
@@ -19145,6 +19698,17 @@
             "title": "Image Inventory",
             "type": "array"
           },
+          "image_inventory_total_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Image Inventory Total Count",
+            "type": "integer"
+          },
+          "image_inventory_truncated": {
+            "default": false,
+            "title": "Image Inventory Truncated",
+            "type": "boolean"
+          },
           "next_steps": {
             "default": [],
             "items": {
@@ -19152,6 +19716,11 @@
             },
             "title": "Next Steps",
             "type": "array"
+          },
+          "observed_at": {
+            "default": "",
+            "title": "Observed At",
+            "type": "string"
           },
           "orphan_buildkit_containers": {
             "default": 0,
@@ -19211,6 +19780,17 @@
             "title": "Volume Inventory",
             "type": "array"
           },
+          "volume_inventory_total_count": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Volume Inventory Total Count",
+            "type": "integer"
+          },
+          "volume_inventory_truncated": {
+            "default": false,
+            "title": "Volume Inventory Truncated",
+            "type": "boolean"
+          },
           "warm_builders": {
             "default": [],
             "items": {
@@ -19226,6 +19806,122 @@
           "summary"
         ],
         "title": "RunnerHostHygieneReport",
+        "type": "object"
+      },
+      "RunnerHostHygieneReportReadModel": {
+        "additionalProperties": false,
+        "properties": {
+          "cache_class_telemetry": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneCacheClassTelemetry"
+            },
+            "title": "Cache Class Telemetry",
+            "type": "array"
+          },
+          "chronology_state": {
+            "enum": [
+              "timestamped",
+              "legacy_missing",
+              "invalid"
+            ],
+            "title": "Chronology State",
+            "type": "string"
+          },
+          "docker_reclaimable_bytes": {
+            "title": "Docker Reclaimable Bytes",
+            "type": "integer"
+          },
+          "finding_codes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Finding Codes",
+            "type": "array"
+          },
+          "free_disk_bytes": {
+            "title": "Free Disk Bytes",
+            "type": "integer"
+          },
+          "generated_cache_allocated_bytes": {
+            "title": "Generated Cache Allocated Bytes",
+            "type": "integer"
+          },
+          "generated_cache_apparent_bytes": {
+            "title": "Generated Cache Apparent Bytes",
+            "type": "integer"
+          },
+          "host_name": {
+            "title": "Host Name",
+            "type": "string"
+          },
+          "image_inventory_total_count": {
+            "title": "Image Inventory Total Count",
+            "type": "integer"
+          },
+          "image_inventory_truncated": {
+            "title": "Image Inventory Truncated",
+            "type": "boolean"
+          },
+          "observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observed At"
+          },
+          "runner_workdir_allocated_bytes": {
+            "title": "Runner Workdir Allocated Bytes",
+            "type": "integer"
+          },
+          "runner_workdir_apparent_bytes": {
+            "title": "Runner Workdir Apparent Bytes",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "healthy",
+              "attention"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "summary": {
+            "title": "Summary",
+            "type": "string"
+          },
+          "volume_inventory_total_count": {
+            "title": "Volume Inventory Total Count",
+            "type": "integer"
+          },
+          "volume_inventory_truncated": {
+            "title": "Volume Inventory Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "status",
+          "host_name",
+          "observed_at",
+          "chronology_state",
+          "free_disk_bytes",
+          "docker_reclaimable_bytes",
+          "runner_workdir_apparent_bytes",
+          "runner_workdir_allocated_bytes",
+          "generated_cache_apparent_bytes",
+          "generated_cache_allocated_bytes",
+          "cache_class_telemetry",
+          "image_inventory_total_count",
+          "image_inventory_truncated",
+          "volume_inventory_total_count",
+          "volume_inventory_truncated",
+          "finding_codes",
+          "summary"
+        ],
+        "title": "RunnerHostHygieneReportReadModel",
         "type": "object"
       },
       "RunnerHostHygieneRunnerWorkdirUsage": {
@@ -19247,9 +19943,16 @@
             "default": "complete",
             "enum": [
               "complete",
-              "partial"
+              "partial",
+              "unavailable",
+              "stale"
             ],
             "title": "Measurement Status",
+            "type": "string"
+          },
+          "reason_code": {
+            "default": "",
+            "title": "Reason Code",
             "type": "string"
           },
           "root_key": {
@@ -19293,16 +19996,28 @@
             "type": "string"
           },
           "referenced_by_containers": {
-            "default": 0,
-            "minimum": 0.0,
-            "title": "Referenced By Containers",
-            "type": "integer"
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Referenced By Containers"
           },
           "size_bytes": {
-            "default": 0,
-            "minimum": 0.0,
-            "title": "Size Bytes",
-            "type": "integer"
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Bytes"
           }
         },
         "required": [
@@ -39890,6 +40605,159 @@
       }
     },
     "/v1/evidence/runner-host-hygiene/audits": {
+      "get": {
+        "operationId": "list_runner_host_hygiene_audit_records",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "host_name",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Host Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "action",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "prune_docker_cache",
+                    "prune_dangling_images",
+                    "prune_generated_run_cache",
+                    "remove_buildkit_state_volumes",
+                    "prune_runner_workdir",
+                    "restart_runner_service"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Action"
+            }
+          },
+          {
+            "in": "query",
+            "name": "audit_status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "enum": [
+                    "planned",
+                    "completed",
+                    "failed"
+                  ],
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Audit Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": "25",
+              "title": "Limit",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunnerHostHygieneAuditRecordsResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "List runner host hygiene audit records"
+      },
       "post": {
         "operationId": "write_runner_host_hygiene_audit_evidence",
         "parameters": [
@@ -39997,6 +40865,226 @@
           }
         },
         "summary": "Write runner host hygiene audit evidence"
+      }
+    },
+    "/v1/evidence/runner-host-hygiene/audits/record": {
+      "get": {
+        "operationId": "read_runner_host_hygiene_audit_record",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "audit_record_key",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Audit Record Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunnerHostHygieneAuditRecordResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Read one runner host hygiene audit record"
+      }
+    },
+    "/v1/evidence/runner-host-hygiene/history": {
+      "get": {
+        "operationId": "read_runner_host_hygiene_history",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "host_name",
+            "required": true,
+            "schema": {
+              "minLength": 1,
+              "title": "Host Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cache_key",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cache Key",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": "25",
+              "title": "Limit",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Authorization",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Authorization",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "Cookie",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Cookie",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RunnerHostHygieneHistoryResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LaunchplaneErrorResponse"
+                }
+              }
+            },
+            "description": "Service Unavailable"
+          }
+        },
+        "summary": "Read runner host hygiene observation history"
       }
     },
     "/v1/evidence/runner-lane-registration/audits": {

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -1105,6 +1105,25 @@ def _runner_host_hygiene_audit_write_policy() -> LaunchplaneAuthzPolicy:
     )
 
 
+def _runner_host_hygiene_audit_read_policy() -> LaunchplaneAuthzPolicy:
+    return LaunchplaneAuthzPolicy.model_validate(
+        {
+            "github_actions": [
+                {
+                    "repository": "cbusillo/launchplane",
+                    "workflow_refs": [
+                        "cbusillo/launchplane/.github/workflows/runner-host-hygiene.yml@refs/heads/main"
+                    ],
+                    "event_names": ["workflow_dispatch"],
+                    "products": ["launchplane"],
+                    "contexts": ["launchplane"],
+                    "actions": ["runner_host_hygiene_audit.read"],
+                }
+            ]
+        }
+    )
+
+
 def _github_human_runner_host_hygiene_audit_write_policy() -> LaunchplaneAuthzPolicy:
     return LaunchplaneAuthzPolicy.model_validate(
         {

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -672,9 +672,14 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             store.write_runner_host_hygiene_audit_record(failed_record)
             planned_records = store.list_runner_host_hygiene_audit_records(
                 host_name="Chris-Testing",
+                action="prune_docker_cache",
                 status="planned",
             )
+            nonmatching_action_records = store.list_runner_host_hygiene_audit_records(
+                action="prune_dangling_images"
+            )
             limited_records = store.list_runner_host_hygiene_audit_records(limit=1)
+            read_record = store.read_runner_host_hygiene_audit_record(newer_record.audit_record_key)
 
         self.assertEqual(
             written_path.parent.relative_to(state_dir).as_posix(),
@@ -689,6 +694,8 @@ class FilesystemRecordStoreTests(unittest.TestCase):
             [record.audit_record_key for record in limited_records],
             [failed_record.audit_record_key],
         )
+        self.assertEqual(nonmatching_action_records, ())
+        self.assertEqual(read_record, newer_record)
 
     def test_write_and_list_runner_lane_registration_audit_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_filesystem_store.py
+++ b/tests/test_filesystem_store.py
@@ -697,6 +697,18 @@ class FilesystemRecordStoreTests(unittest.TestCase):
         self.assertEqual(nonmatching_action_records, ())
         self.assertEqual(read_record, newer_record)
 
+    def test_runner_host_hygiene_audit_record_with_overlong_key_round_trips(self) -> None:
+        audit_record_key = "runner-host-hygiene/" + ("a" * 300)
+        record = _runner_host_hygiene_audit_record(audit_record_key=audit_record_key)
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+
+            written_path = store.write_runner_host_hygiene_audit_record(record)
+            read_record = store.read_runner_host_hygiene_audit_record(audit_record_key)
+
+        self.assertLessEqual(len(written_path.name.encode("utf-8")), 255)
+        self.assertEqual(read_record, record)
+
     def test_write_and_list_runner_lane_registration_audit_records(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             state_dir = Path(temporary_directory_name)

--- a/tests/test_http_app_ingress.py
+++ b/tests/test_http_app_ingress.py
@@ -219,7 +219,11 @@ class FastApiIngressTopologyRegistrarTests(unittest.TestCase):
 
         self.assertEqual(
             route_paths[preceding_route_index : preceding_route_index + len(expected_paths) + 2],
-            ["/v1/ingress/canary-routes/apply", *expected_paths, "/v1/deployments/{record_id}"],
+            [
+                "/v1/ingress/canary-routes/apply",
+                *expected_paths,
+                "/v1/evidence/runner-host-hygiene/audits",
+            ],
         )
         routes_by_path = {route.path: route for route in api_routes}
         for path, name, module_name in expected_routes:

--- a/tests/test_http_app_records.py
+++ b/tests/test_http_app_records.py
@@ -2567,6 +2567,29 @@ class FastApiRunnerHostHygieneAuditReadTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(response.status_code, 404)
         self.assertEqual(response.json()["error"]["code"], "not_found")
 
+    async def test_runner_host_hygiene_audit_detail_handles_overlong_missing_key(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_read_policy(),
+                record_store_factory=lambda: store,
+            )
+            audit_record_key = "runner-host-hygiene/" + ("a" * 300)
+
+            response = await http_request(
+                app,
+                "GET",
+                (
+                    "/v1/evidence/runner-host-hygiene/audits/record?audit_record_key="
+                    + quote(audit_record_key, safe="")
+                ),
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
     async def test_runner_host_hygiene_audit_list_rejects_invalid_limit(self) -> None:
         app = create_launchplane_fastapi_app(
             verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),

--- a/tests/test_http_app_records.py
+++ b/tests/test_http_app_records.py
@@ -2285,6 +2285,40 @@ class FastApiPreviewDestroyedEvidenceTests(unittest.IsolatedAsyncioTestCase):
 
 
 class FastApiRunnerHostHygieneAuditReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runner_host_hygiene_audit_list_normalizes_invalid_observed_at(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            record = RunnerHostHygieneApplyAuditRecord.model_validate(
+                _runner_host_hygiene_audit_payload(
+                    audit_record_key="runner-host-hygiene/2026-07-30/invalid-timestamp"
+                )["audit"]
+            )
+            record = record.model_copy(
+                update={
+                    "pre_apply_report": record.pre_apply_report.model_copy(
+                        update={"observed_at": "not-a-timestamp"}
+                    )
+                }
+            )
+            store.write_runner_host_hygiene_audit_record(record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await http_request(
+                app,
+                "GET",
+                "/v1/evidence/runner-host-hygiene/audits?host_name=chris-testing",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNone(response.json()["records"][0]["pre_apply_observed_at"])
+
     async def test_runner_host_hygiene_audit_list_and_detail_return_durable_history(
         self,
     ) -> None:

--- a/tests/test_http_app_records.py
+++ b/tests/test_http_app_records.py
@@ -4,8 +4,10 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 from unittest.mock import patch
+from urllib.parse import quote
 
 from control_plane import secrets as control_plane_secrets
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
 from control_plane.http_app import create_launchplane_fastapi_app
 from control_plane.service_auth import (
     BearerIdentityConfig,
@@ -70,6 +72,7 @@ from tests.http_app_test_support import (
     _record_read_policy,
     _RejectingVerifier,
     _runner_host_hygiene_audit_payload,
+    _runner_host_hygiene_audit_read_policy,
     _runner_host_hygiene_audit_write_identity,
     _runner_host_hygiene_audit_write_policy,
     _runner_lane_registration_audit_payload,
@@ -2279,6 +2282,293 @@ class FastApiPreviewDestroyedEvidenceTests(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(error_schema["$ref"], "#/components/schemas/LaunchplaneErrorResponse")
         envelope_schema = openapi["components"]["schemas"]["PreviewDestroyedEvidenceEnvelope"]
         self.assertFalse(envelope_schema["additionalProperties"])
+
+
+class FastApiRunnerHostHygieneAuditReadTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runner_host_hygiene_audit_list_and_detail_return_durable_history(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            older_record = RunnerHostHygieneApplyAuditRecord.model_validate(
+                _runner_host_hygiene_audit_payload(
+                    audit_record_key="runner-host-hygiene/2026-07-29/runner-host-report"
+                )["audit"]
+            )
+            newer_record = RunnerHostHygieneApplyAuditRecord.model_validate(
+                _runner_host_hygiene_audit_payload(
+                    audit_record_key="runner-host-hygiene/2026-07-30/runner-host-report"
+                )["audit"]
+            )
+            store.write_runner_host_hygiene_audit_record(older_record)
+            store.write_runner_host_hygiene_audit_record(newer_record)
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            list_response = await http_request(
+                app,
+                "GET",
+                (
+                    "/v1/evidence/runner-host-hygiene/audits"
+                    "?host_name=Chris-Testing&action=prune_docker_cache"
+                    "&audit_status=planned&limit=1"
+                ),
+                headers={"Authorization": "Bearer valid-token"},
+            )
+            detail_response = await http_request(
+                app,
+                "GET",
+                (
+                    "/v1/evidence/runner-host-hygiene/audits/record?audit_record_key="
+                    + quote(newer_record.audit_record_key, safe="")
+                ),
+                headers={"Authorization": "Bearer valid-token"},
+            )
+            history_response = await http_request(
+                app,
+                "GET",
+                (
+                    "/v1/evidence/runner-host-hygiene/history"
+                    "?host_name=Chris-Testing&cache_key=images&limit=2"
+                ),
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(list_response.status_code, 200)
+        list_payload = list_response.json()
+        self.assertEqual(list_payload["status"], "ok")
+        self.assertEqual(list_payload["host_name"], "chris-testing")
+        self.assertEqual(list_payload["action"], "prune_docker_cache")
+        self.assertEqual(list_payload["audit_status"], "planned")
+        self.assertEqual(list_payload["count"], 1)
+        self.assertTrue(list_payload["truncated"])
+        self.assertEqual(
+            list_payload["records"][0]["audit_record_key"],
+            newer_record.audit_record_key,
+        )
+        self.assertEqual(
+            list_payload["records"][0]["pre_apply_observed_at"],
+            "2026-05-23T13:00:00Z",
+        )
+        self.assertEqual(detail_response.status_code, 200)
+        self.assertEqual(
+            detail_response.json()["record"]["summary"]["audit_record_key"],
+            newer_record.audit_record_key,
+        )
+        self.assertNotIn("image_inventory", detail_response.json()["record"]["pre_apply_report"])
+        self.assertEqual(history_response.status_code, 200)
+        history_payload = history_response.json()
+        self.assertEqual(history_payload["host_name"], "chris-testing")
+        self.assertEqual(history_payload["cache_key"], "images")
+        self.assertEqual(history_payload["count"], 2)
+        self.assertEqual(history_payload["scan_limit"], 100)
+        self.assertFalse(history_payload["scan_truncated"])
+        self.assertFalse(history_payload["result_truncated"])
+        self.assertTrue(
+            all(
+                point["report"]["cache_class_telemetry"][0]["cache_key"] == "images"
+                for point in history_payload["points"]
+            )
+        )
+        self.assertTrue(
+            all(
+                point["report"]["chronology_state"] == "timestamped"
+                for point in history_payload["points"]
+            )
+        )
+
+    async def test_runner_host_hygiene_history_sorts_legacy_reports_last(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            timestamped_record = RunnerHostHygieneApplyAuditRecord.model_validate(
+                _runner_host_hygiene_audit_payload(
+                    audit_record_key="runner-host-hygiene/2026-07-30/timestamped"
+                )["audit"]
+            )
+            legacy_record = RunnerHostHygieneApplyAuditRecord.model_validate(
+                _runner_host_hygiene_audit_payload(
+                    audit_record_key="runner-host-hygiene/2099-01-01/legacy"
+                )["audit"]
+            )
+            store.write_runner_host_hygiene_audit_record(timestamped_record)
+            legacy_record_path = store.write_runner_host_hygiene_audit_record(legacy_record)
+            legacy_payload = cast(
+                dict[str, object],
+                _runner_host_hygiene_audit_payload(audit_record_key=legacy_record.audit_record_key)[
+                    "audit"
+                ],
+            )
+            legacy_report = cast(dict[str, object], legacy_payload["pre_apply_report"])
+            for field_name in (
+                "observed_at",
+                "cache_class_telemetry",
+                "image_inventory_total_count",
+                "image_inventory_truncated",
+                "volume_inventory_total_count",
+                "volume_inventory_truncated",
+            ):
+                legacy_report.pop(field_name, None)
+            legacy_report["runner_workdir_usage"] = [
+                {
+                    "root_key": "legacy",
+                    "measurement_status": "partial",
+                }
+            ]
+            legacy_report["image_inventory"] = [
+                {
+                    "image_id": "legacy-image",
+                    "repository": "legacy/image",
+                    "tag": "latest",
+                }
+            ]
+            legacy_report["volume_inventory"] = [
+                {
+                    "name": "legacy-volume",
+                    "driver": "local",
+                }
+            ]
+            legacy_record_path.write_text(
+                json.dumps(legacy_payload, indent=2, sort_keys=True),
+                encoding="utf-8",
+            )
+            reloaded_legacy = store.read_runner_host_hygiene_audit_record(
+                legacy_record.audit_record_key
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await http_request(
+                app,
+                "GET",
+                "/v1/evidence/runner-host-hygiene/history?host_name=chris-testing",
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 200)
+        points = response.json()["points"]
+        self.assertEqual(points[0]["audit_record_key"], timestamped_record.audit_record_key)
+        self.assertEqual(points[0]["report"]["chronology_state"], "timestamped")
+        self.assertEqual(points[-1]["audit_record_key"], legacy_record.audit_record_key)
+        self.assertEqual(points[-1]["report"]["chronology_state"], "legacy_missing")
+        self.assertEqual(
+            reloaded_legacy.pre_apply_report.runner_workdir_usage[0].reason_code,
+            "legacy_incomplete",
+        )
+        self.assertIsNone(reloaded_legacy.pre_apply_report.image_inventory[0].size_bytes)
+        self.assertIsNone(
+            reloaded_legacy.pre_apply_report.volume_inventory[0].referenced_by_containers
+        )
+
+    async def test_runner_host_hygiene_history_rejects_blank_host_name(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+            authz_policy=_runner_host_hygiene_audit_read_policy(),
+            record_store_factory=object,
+        )
+
+        response = await http_request(
+            app,
+            "GET",
+            "/v1/evidence/runner-host-hygiene/history?host_name=%20%20%20",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_query")
+
+    async def test_runner_host_hygiene_audit_reads_require_read_authorization(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+            authz_policy=_runner_host_hygiene_audit_write_policy(),
+            record_store_factory=object,
+        )
+
+        response = await http_request(
+            app,
+            "GET",
+            "/v1/evidence/runner-host-hygiene/audits",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_runner_host_hygiene_read_grant_cannot_write_audit(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+            authz_policy=_runner_host_hygiene_audit_read_policy(),
+            record_store_factory=object,
+        )
+
+        response = await _post_runner_host_hygiene_audit_evidence(
+            app,
+            _runner_host_hygiene_audit_payload(),
+        )
+
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.json()["error"]["code"], "authorization_denied")
+
+    async def test_runner_host_hygiene_audit_detail_returns_not_found(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name) / "state")
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+                authz_policy=_runner_host_hygiene_audit_read_policy(),
+                record_store_factory=lambda: store,
+            )
+
+            response = await http_request(
+                app,
+                "GET",
+                ("/v1/evidence/runner-host-hygiene/audits/record?audit_record_key=missing"),
+                headers={"Authorization": "Bearer valid-token"},
+            )
+
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.json()["error"]["code"], "not_found")
+
+    async def test_runner_host_hygiene_audit_list_rejects_invalid_limit(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+            authz_policy=_runner_host_hygiene_audit_read_policy(),
+            record_store_factory=object,
+        )
+
+        response = await http_request(
+            app,
+            "GET",
+            "/v1/evidence/runner-host-hygiene/audits?limit=101",
+            headers={"Authorization": "Bearer valid-token"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"]["code"], "invalid_query")
+
+    def test_openapi_includes_runner_host_hygiene_audit_read_contracts(self) -> None:
+        app = create_launchplane_fastapi_app(
+            verifier=_StubVerifier(_runner_host_hygiene_audit_write_identity()),
+            authz_policy=_runner_host_hygiene_audit_read_policy(),
+            record_store_factory=object,
+        )
+
+        openapi = app.openapi()
+
+        list_route = openapi["paths"]["/v1/evidence/runner-host-hygiene/audits"]["get"]
+        self.assertEqual(list_route["operationId"], "list_runner_host_hygiene_audit_records")
+        detail_route = openapi["paths"]["/v1/evidence/runner-host-hygiene/audits/record"]["get"]
+        self.assertEqual(detail_route["operationId"], "read_runner_host_hygiene_audit_record")
+        history_route = openapi["paths"]["/v1/evidence/runner-host-hygiene/history"]["get"]
+        self.assertEqual(history_route["operationId"], "read_runner_host_hygiene_history")
+        self.assertIn(
+            "RunnerHostHygieneCacheClassTelemetry",
+            openapi["components"]["schemas"],
+        )
 
 
 class FastApiRunnerHostHygieneAuditEvidenceTests(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_http_read_route_registrars.py
+++ b/tests/test_http_read_route_registrars.py
@@ -85,6 +85,27 @@ class FastApiReadRouteRegistrarTests(unittest.TestCase):
                 "control_plane.http_routes.drivers",
             ),
             (
+                "/v1/evidence/runner-host-hygiene/audits",
+                "list_runner_host_hygiene_audit_records",
+                "list_runner_host_hygiene_audit_records",
+                "RunnerHostHygieneAuditRecordsResponse",
+                "control_plane.http_routes.runner_host_hygiene",
+            ),
+            (
+                "/v1/evidence/runner-host-hygiene/history",
+                "read_runner_host_hygiene_history",
+                "read_runner_host_hygiene_history",
+                "RunnerHostHygieneHistoryResponse",
+                "control_plane.http_routes.runner_host_hygiene",
+            ),
+            (
+                "/v1/evidence/runner-host-hygiene/audits/record",
+                "read_runner_host_hygiene_audit_record",
+                "read_runner_host_hygiene_audit_record",
+                "RunnerHostHygieneAuditRecordResponse",
+                "control_plane.http_routes.runner_host_hygiene",
+            ),
+            (
                 "/v1/deployments/{record_id}",
                 "read_deployment_record",
                 "read_deployment_record",
@@ -381,6 +402,9 @@ class FastApiReadRouteRegistrarTests(unittest.TestCase):
             ("GET", "/v1/ingress/route-audits/records/{record_id}"),
             [
                 ("GET", "/v1/ingress/route-audits/records/{record_id}"),
+                ("GET", "/v1/evidence/runner-host-hygiene/audits"),
+                ("GET", "/v1/evidence/runner-host-hygiene/history"),
+                ("GET", "/v1/evidence/runner-host-hygiene/audits/record"),
                 ("GET", "/v1/deployments/{record_id}"),
                 ("GET", "/v1/promotions/{record_id}"),
                 ("POST", "/v1/every-code/github-webhook"),

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -4903,9 +4903,14 @@ env_var = "GH_TOKEN"
             store.write_runner_host_hygiene_audit_record(failed_record)
             planned_records = store.list_runner_host_hygiene_audit_records(
                 host_name="Chris-Testing",
+                action="prune_docker_cache",
                 status="planned",
             )
+            nonmatching_action_records = store.list_runner_host_hygiene_audit_records(
+                action="prune_dangling_images"
+            )
             limited_records = store.list_runner_host_hygiene_audit_records(limit=1)
+            read_record = store.read_runner_host_hygiene_audit_record(newer_record.audit_record_key)
             store.close()
 
         self.assertEqual(
@@ -4916,6 +4921,8 @@ env_var = "GH_TOKEN"
             [record.audit_record_key for record in limited_records],
             [failed_record.audit_record_key],
         )
+        self.assertEqual(nonmatching_action_records, ())
+        self.assertEqual(read_record, newer_record)
         self.assertEqual(limited_records[0].message, "post-apply evidence reported low disk")
 
     def test_runner_lane_registration_audit_records_round_trip(self) -> None:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -4925,6 +4925,23 @@ env_var = "GH_TOKEN"
         self.assertEqual(read_record, newer_record)
         self.assertEqual(limited_records[0].message, "post-apply evidence reported low disk")
 
+    def test_runner_host_hygiene_audit_record_with_overlong_key_round_trips(self) -> None:
+        audit_record_key = "runner-host-hygiene/" + ("a" * 300)
+        record = _runner_host_hygiene_audit_record(audit_record_key=audit_record_key)
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+
+            store.write_runner_host_hygiene_audit_record(record)
+            read_record = store.read_runner_host_hygiene_audit_record(audit_record_key)
+            store.close()
+
+        self.assertEqual(read_record, record)
+
     def test_runner_lane_registration_audit_records_round_trip(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -20,8 +20,13 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPl
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterPolicy
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneAdapterProposal
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneCacheClassTelemetry
+from control_plane.contracts.runner_host_hygiene import (
+    RunnerHostHygieneDockerReclaimableBreakdown,
+)
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneImageInventoryItem
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheBudget
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheAgeBucket
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheEntry
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneGeneratedCacheUsage
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygienePolicy
@@ -31,6 +36,9 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneVolumeI
 from control_plane.contracts.runner_host_hygiene import evaluate_runner_host_hygiene
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
 from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_adapter_boundary
+from control_plane.contracts.runner_host_hygiene import (
+    sanitize_runner_host_hygiene_audit_record_for_persistence,
+)
 from control_plane.cli_runner_lanes import _runner_host_hygiene_bearer_token
 from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
@@ -65,9 +73,98 @@ class RunnerHostHygieneTests(unittest.TestCase):
 
         self.assertEqual(report.status, "healthy")
         self.assertEqual(report.host_name, "chris-testing")
+        self.assertEqual(report.observed_at, "2026-05-23T13:00:00Z")
         self.assertEqual(report.warm_builders, ("odoo-docker-chris-testing",))
         self.assertEqual(report.findings, ())
         self.assertIn("report-only", report.summary)
+
+    def test_report_exposes_honest_cache_class_measurement_semantics(self) -> None:
+        report = evaluate_runner_host_hygiene(
+            policy=RunnerHostHygienePolicy(),
+            observation=RunnerHostHygieneObservation(
+                host_name="runner-host",
+                observed_at="2026-07-30T02:00:00Z",
+                free_disk_bytes=200,
+                docker_reclaimable_bytes=40,
+                docker_reclaimable_breakdown=RunnerHostHygieneDockerReclaimableBreakdown(
+                    images_bytes=10,
+                    containers_bytes=5,
+                    local_volumes_bytes=15,
+                    build_cache_bytes=10,
+                ),
+                runner_workdir_usage=(
+                    RunnerHostHygieneRunnerWorkdirUsage(
+                        root_key="primary",
+                        apparent_bytes=100,
+                        allocated_bytes=80,
+                    ),
+                ),
+                generated_cache_usage=(
+                    RunnerHostHygieneGeneratedCacheUsage(
+                        cache_key="run-cache",
+                        apparent_bytes=60,
+                        allocated_bytes=50,
+                        entry_count=1,
+                        owner_valid=True,
+                        mode_valid=True,
+                        symlink_safe=True,
+                        entries_truncated=True,
+                    ),
+                ),
+                image_inventory=(
+                    RunnerHostHygieneImageInventoryItem(
+                        image_id="abc123",
+                        repository="example/image",
+                        tag="latest",
+                        size_bytes=None,
+                    ),
+                ),
+                volume_inventory=(
+                    RunnerHostHygieneVolumeInventoryItem(
+                        name="cache-volume",
+                        driver="local",
+                        size_bytes=30,
+                    ),
+                ),
+            ),
+        )
+
+        telemetry = {
+            (item.cache_class, item.cache_key): item for item in report.cache_class_telemetry
+        }
+        workdir = telemetry[("runner_workdir", "primary")]
+        self.assertEqual(workdir.measurement_basis, "filesystem_apparent_allocated")
+        self.assertEqual(workdir.apparent_bytes, 100)
+        self.assertEqual(workdir.allocated_bytes, 80)
+        generated = telemetry[("generated_filesystem", "run-cache")]
+        self.assertEqual(generated.availability, "partial")
+        self.assertEqual(generated.unavailable_reason, "entry_history_truncated")
+        self.assertIsNone(generated.estimated_daily_growth_bytes)
+        images = telemetry[("docker_images", "images")]
+        self.assertEqual(images.measurement_basis, "docker_engine")
+        self.assertEqual(images.availability, "partial")
+        self.assertIsNone(images.logical_bytes)
+        self.assertEqual(images.reclaimable_bytes, 10)
+        volumes = telemetry[("docker_volumes", "volumes")]
+        self.assertEqual(volumes.availability, "available")
+        self.assertEqual(volumes.logical_bytes, 30)
+        self.assertEqual(volumes.reclaimable_bytes, 15)
+
+    def test_unavailable_cache_class_telemetry_requires_reason_without_measurements(
+        self,
+    ) -> None:
+        telemetry = RunnerHostHygieneCacheClassTelemetry(
+            cache_key="package-cache",
+            cache_class="generated_filesystem",
+            scope="generated_cache",
+            availability="unavailable",
+            measurement_basis="filesystem_apparent_allocated",
+            source="filesystem_probe",
+            observed_at="2026-07-30T02:00:00Z",
+            unavailable_reason="not_configured",
+        )
+
+        self.assertEqual(telemetry.unavailable_reason, "not_configured")
 
     def test_report_marks_partial_runner_workdir_measurement_for_attention(self) -> None:
         report = evaluate_runner_host_hygiene(
@@ -166,6 +263,26 @@ class RunnerHostHygieneTests(unittest.TestCase):
         self.assertTrue(report.image_inventory[0].in_use)
         self.assertEqual([item.name for item in report.volume_inventory], ["a-volume", "z-volume"])
         self.assertEqual(report.volume_inventory[0].labels, ("role=cache",))
+
+    def test_generated_cache_age_buckets_are_chronological(self) -> None:
+        usage = RunnerHostHygieneGeneratedCacheUsage(
+            cache_key="run-cache",
+            owner_valid=True,
+            mode_valid=True,
+            symlink_safe=True,
+            age_buckets=(
+                RunnerHostHygieneGeneratedCacheAgeBucket(bucket="30d_or_more"),
+                RunnerHostHygieneGeneratedCacheAgeBucket(bucket="under_1h"),
+                RunnerHostHygieneGeneratedCacheAgeBucket(bucket="7d_to_30d"),
+                RunnerHostHygieneGeneratedCacheAgeBucket(bucket="1h_to_24h"),
+                RunnerHostHygieneGeneratedCacheAgeBucket(bucket="1d_to_7d"),
+            ),
+        )
+
+        self.assertEqual(
+            [item.bucket for item in usage.age_buckets],
+            ["under_1h", "1h_to_24h", "1d_to_7d", "7d_to_30d", "30d_or_more"],
+        )
 
     def test_report_finds_missing_builder_and_low_free_disk(self) -> None:
         report = evaluate_runner_host_hygiene(
@@ -927,6 +1044,7 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
                     name=target_volume,
                     driver="local",
                     size_bytes=50_490_000_000,
+                    referenced_by_containers=0,
                     dangling=True,
                 )
             ),
@@ -1349,6 +1467,101 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
         )
 
         self.assertIsNone(audit.post_apply_report)
+
+    def test_audit_persistence_sanitizer_bounds_and_redacts_docker_inventory(self) -> None:
+        audit_record_key = "runner-host-hygiene/2026-07-30/chris-testing"
+        request = RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            audit_record_key=audit_record_key,
+        )
+        report = _healthy_report().model_copy(
+            update={
+                "cache_class_telemetry": (
+                    RunnerHostHygieneCacheClassTelemetry(
+                        cache_key="images",
+                        cache_class="docker_images",
+                        scope="host",
+                        availability="partial",
+                        measurement_basis="docker_engine",
+                        source="docker_engine",
+                        observed_at="2026-07-30T00:00:00Z",
+                        unavailable_reason="private path: /var/lib/docker",
+                        logical_bytes=1,
+                    ),
+                    RunnerHostHygieneCacheClassTelemetry(
+                        cache_key="volumes",
+                        cache_class="docker_volumes",
+                        scope="host",
+                        availability="partial",
+                        measurement_basis="docker_engine",
+                        source="docker_engine",
+                        observed_at="2026-07-30T00:00:00Z",
+                        unavailable_reason=("inventory_truncated,inventory_size_unavailable"),
+                        reclaimable_bytes=1,
+                    ),
+                ),
+                "image_inventory": tuple(
+                    RunnerHostHygieneImageInventoryItem(
+                        image_id=f"image-{index:03d}",
+                        repository="private.example/product/image",
+                        tag="private-tag",
+                        created_at="2026-07-30T00:00:00Z",
+                    )
+                    for index in range(130)
+                ),
+                "image_inventory_total_count": 130,
+                "image_inventory_truncated": False,
+                "volume_inventory": tuple(
+                    RunnerHostHygieneVolumeInventoryItem(
+                        name=f"volume-{index:03d}",
+                        driver="local",
+                        mountpoint=f"/var/lib/docker/volumes/volume-{index:03d}/_data",
+                        labels=("private.repository=example/product",),
+                        referenced_by_containers=0,
+                        dangling=True,
+                    )
+                    for index in range(130)
+                ),
+                "volume_inventory_total_count": 130,
+                "volume_inventory_truncated": False,
+            }
+        )
+        plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(
+                approved_hosts=("chris-testing",),
+                allow_docker_cache_prune=True,
+            ),
+            request=request,
+            report=report,
+        )
+        persisted = sanitize_runner_host_hygiene_audit_record_for_persistence(
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=audit_record_key,
+                status="planned",
+                request=request,
+                plan=plan,
+                pre_apply_report=report,
+            )
+        )
+
+        persisted_report = persisted.pre_apply_report
+        self.assertEqual(len(persisted_report.image_inventory), 128)
+        self.assertEqual(len(persisted_report.volume_inventory), 128)
+        self.assertTrue(persisted_report.image_inventory_truncated)
+        self.assertTrue(persisted_report.volume_inventory_truncated)
+        self.assertEqual(persisted_report.image_inventory[0].repository, "")
+        self.assertEqual(persisted_report.image_inventory[0].tag, "")
+        self.assertEqual(persisted_report.image_inventory[0].created_at, "")
+        self.assertEqual(persisted_report.volume_inventory[0].mountpoint, "")
+        self.assertEqual(persisted_report.volume_inventory[0].labels, ())
+        telemetry_by_key = {item.cache_key: item for item in persisted_report.cache_class_telemetry}
+        self.assertEqual(telemetry_by_key["images"].unavailable_reason, "redacted_reason")
+        self.assertEqual(
+            telemetry_by_key["volumes"].unavailable_reason,
+            "inventory_truncated,inventory_size_unavailable",
+        )
 
     def test_apply_audit_record_requires_terminal_ready_plan(self) -> None:
         request = RunnerHostHygieneApplyRequest(

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -1366,20 +1366,26 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertEqual(snapshot.volume_inventory[0].size_bytes, 45_500_000_000)
         self.assertEqual(snapshot.reclaimable_breakdown.local_volumes_bytes, 45_500_000_000)
 
-    def test_docker_disk_usage_uses_engine_class_totals(self) -> None:
+    def test_docker_disk_usage_uses_legacy_api_class_semantics(self) -> None:
         snapshot = _parse_docker_disk_usage(
             _docker_disk_usage_json(
-                images=[{"Containers": 0, "SharedSize": 100, "Size": 100}],
-                build_cache=[{"InUse": False, "Shared": True, "Size": 100}],
-                layers_size=100,
-                builder_size=100,
+                images=[
+                    {"Containers": 0, "SharedSize": 90, "Size": 100},
+                    {"Containers": 1, "SharedSize": 90, "Size": 100},
+                ],
+                build_cache=[
+                    {"InUse": False, "Shared": False, "Size": 100},
+                    {"InUse": False, "Shared": True, "Size": 200},
+                    {"InUse": True, "Shared": False, "Size": 40},
+                ],
+                layers_size=110,
             )
         )
         measurements = {item.cache_class: item for item in snapshot.cache_class_measurements}
 
-        self.assertEqual(measurements["docker_images"].logical_bytes, 100)
-        self.assertEqual(measurements["docker_images"].reclaimable_bytes, 100)
-        self.assertEqual(measurements["docker_build_cache"].logical_bytes, 100)
+        self.assertEqual(measurements["docker_images"].logical_bytes, 110)
+        self.assertEqual(measurements["docker_images"].reclaimable_bytes, 10)
+        self.assertEqual(measurements["docker_build_cache"].logical_bytes, 140)
         self.assertEqual(measurements["docker_build_cache"].reclaimable_bytes, 100)
 
     def test_docker_disk_usage_marks_unknown_values_partial(self) -> None:
@@ -1399,7 +1405,6 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                         }
                     ],
                     "BuildCache": [{"Size": 100}],
-                    "BuilderSize": 100,
                 }
             )
         )
@@ -1498,6 +1503,43 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
 
         self.assertEqual(image_telemetry.availability, "partial")
         self.assertEqual(image_telemetry.unavailable_reason, "inventory_probe_failed")
+
+    def test_report_merges_partial_image_and_inventory_reasons(self) -> None:
+        command_runner = _CommandRunner(
+            docker_disk_usage=_docker_disk_usage_json(
+                images=[{"Containers": 0, "SharedSize": -1, "Size": 100}],
+                layers_size=100,
+            )
+        )
+
+        def fail_image_inventory(
+            command: Sequence[str], timeout_seconds: int
+        ) -> RemoteCommandResult:
+            if tuple(command) == (
+                "docker",
+                "image",
+                "ls",
+                "--all",
+                "--no-trunc",
+                "--format",
+                "{{json .}}",
+            ):
+                return RemoteCommandResult(returncode=1, stderr="inventory unavailable")
+            return command_runner(command, timeout_seconds)
+
+        report = collect_runner_host_hygiene_report(
+            request=_request(mutate=False),
+            remote_runner=fail_image_inventory,
+        )
+        image_telemetry = next(
+            item for item in report.cache_class_telemetry if item.cache_class == "docker_images"
+        )
+
+        self.assertEqual(image_telemetry.availability, "partial")
+        self.assertEqual(
+            image_telemetry.unavailable_reason,
+            "measurement_partial,inventory_probe_failed",
+        )
 
     def test_executor_blocks_before_prune_without_mutate_intent(self) -> None:
         command_runner = _CommandRunner()
@@ -2279,19 +2321,11 @@ def _docker_disk_usage_json(
     volumes: list[dict[str, object]] | None = None,
     build_cache: list[dict[str, object]] | None = None,
     layers_size: int | None = None,
-    builder_size: int | None = None,
 ) -> str:
     image_rows = images or []
     build_cache_rows = build_cache or []
     return json.dumps(
         {
-            "BuilderSize": (
-                builder_size
-                if builder_size is not None
-                else sum(
-                    size for row in build_cache_rows if isinstance((size := row.get("Size")), int)
-                )
-            ),
             "BuildCache": build_cache_rows,
             "Containers": containers or [],
             "Images": image_rows,

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -32,8 +32,15 @@ from control_plane.workflows.runner_host_hygiene_executor import (
 )
 from control_plane.workflows.runner_host_hygiene_executor import _DOCKER_DISK_USAGE_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import _GENERATED_RUN_CACHE_HELPER
+from control_plane.workflows.runner_host_hygiene_executor import (
+    MAX_DOCKER_IMAGE_INVENTORY_ITEMS,
+)
+from control_plane.workflows.runner_host_hygiene_executor import (
+    MAX_DOCKER_VOLUME_INVENTORY_ITEMS,
+)
 from control_plane.workflows.runner_host_hygiene_executor import _parse_docker_disk_usage
 from control_plane.workflows.runner_host_hygiene_executor import _RUNNER_WORKDIR_USAGE_HELPER
+from control_plane.workflows.runner_host_hygiene_executor import collect_runner_host_hygiene_report
 from control_plane.workflows.runner_host_hygiene_executor import validate_local_executor_environment
 from control_plane.workflows.runner_host_hygiene_audit_spool import (
     RunnerHostHygieneAuditSpool,
@@ -705,11 +712,11 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertIsNotNone(post_apply_report)
         assert post_apply_report is not None
         warm_image = next(
-            image
-            for image in post_apply_report.image_inventory
-            if image.repository == "odoo-docker-chris-testing"
+            image for image in post_apply_report.image_inventory if image.is_warm_builder
         )
-        self.assertEqual(warm_image.tag, "latest")
+        self.assertEqual(warm_image.repository, "")
+        self.assertEqual(warm_image.tag, "")
+        self.assertEqual(warm_image.created_at, "")
         self.assertEqual(warm_image.size_bytes, 1_200_000_000)
         self.assertTrue(warm_image.in_use)
         self.assertFalse(warm_image.dangling)
@@ -723,8 +730,79 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertEqual(volume.size_bytes, 45_500_000_000)
         self.assertEqual(volume.referenced_by_containers, 0)
         self.assertTrue(volume.dangling)
-        self.assertEqual(volume.labels, ("launchplane.scope=test",))
+        self.assertEqual(volume.mountpoint, "")
+        self.assertEqual(volume.labels, ())
         self.assertEqual(command_runner.commands.count(_DOCKER_DISK_USAGE_COMMAND), 2)
+
+    def test_report_bounds_docker_inventories_and_marks_telemetry_partial(self) -> None:
+        image_rows: list[dict[str, object]] = [
+            {
+                "CreatedAt": "2026-07-30 01:00:00 +0000 UTC",
+                "ID": f"sha256:image-{index}",
+                "Repository": f"example/image-{index}",
+                "Size": "1MB",
+                "Tag": "latest",
+            }
+            for index in range(MAX_DOCKER_IMAGE_INVENTORY_ITEMS + 2)
+        ]
+        image_inventory = _json_lines(*image_rows)
+        volume_inventory = [
+            {
+                "Driver": "local",
+                "Labels": {},
+                "Mountpoint": f"/var/lib/docker/volumes/cache-{index}/_data",
+                "Name": f"cache-{index}",
+                "UsageData": {"RefCount": 0, "Size": 1_000_000},
+            }
+            for index in range(MAX_DOCKER_VOLUME_INVENTORY_ITEMS + 2)
+        ]
+        command_runner = _CommandRunner(
+            image_inventory=image_inventory,
+            volume_inventory=json.dumps(volume_inventory),
+        )
+
+        report = collect_runner_host_hygiene_report(
+            request=_request(mutate=False),
+            remote_runner=command_runner,
+        )
+
+        self.assertEqual(len(report.image_inventory), MAX_DOCKER_IMAGE_INVENTORY_ITEMS)
+        self.assertTrue(report.image_inventory_truncated)
+        self.assertEqual(len(report.volume_inventory), MAX_DOCKER_VOLUME_INVENTORY_ITEMS)
+        self.assertTrue(report.volume_inventory_truncated)
+        telemetry = {item.cache_class: item for item in report.cache_class_telemetry}
+        self.assertEqual(telemetry["docker_images"].availability, "available")
+        self.assertEqual(telemetry["docker_volumes"].availability, "available")
+        self.assertEqual(telemetry["docker_images"].entry_count, 1)
+        self.assertEqual(
+            telemetry["docker_volumes"].entry_count,
+            MAX_DOCKER_VOLUME_INVENTORY_ITEMS + 2,
+        )
+
+    def test_report_preserves_unavailable_docker_image_size(self) -> None:
+        command_runner = _CommandRunner(
+            image_inventory=_json_lines(
+                {
+                    "CreatedAt": "2026-07-30 01:00:00 +0000 UTC",
+                    "ID": "sha256:image-without-size",
+                    "Repository": "example/image",
+                    "Size": "N/A",
+                    "Tag": "latest",
+                }
+            )
+        )
+
+        report = collect_runner_host_hygiene_report(
+            request=_request(mutate=False),
+            remote_runner=command_runner,
+        )
+
+        self.assertIsNone(report.image_inventory[0].size_bytes)
+        image_telemetry = next(
+            item for item in report.cache_class_telemetry if item.cache_class == "docker_images"
+        )
+        self.assertEqual(image_telemetry.availability, "available")
+        self.assertEqual(image_telemetry.logical_bytes, 500_000_000)
 
     def test_executor_records_runner_workdir_bytes(self) -> None:
         command_runner = _CommandRunner(runner_workdir_bytes=12_345_678)
@@ -1113,7 +1191,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 ),
             )
 
-    def test_executor_hides_workdir_helper_failure_detail(self) -> None:
+    def test_report_records_workdir_helper_failure_as_unavailable_without_detail(self) -> None:
         command_runner = _CommandRunner()
 
         def failing_runner(command: Sequence[str], timeout_seconds: int) -> RemoteCommandResult:
@@ -1128,14 +1206,20 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 )
             return command_runner(command, timeout_seconds)
 
-        with self.assertRaises(click.ClickException) as raised:
-            execute_runner_host_hygiene_executor(
-                request=_request(mutate=False),
-                remote_runner=failing_runner,
-                audit_poster=_AuditPoster(),
-            )
+        report = collect_runner_host_hygiene_report(
+            request=_request(mutate=False),
+            remote_runner=failing_runner,
+        )
 
-        self.assertNotIn("/private/runner/root", str(raised.exception))
+        self.assertEqual(report.status, "attention")
+        self.assertEqual(report.runner_workdir_usage[0].measurement_status, "unavailable")
+        self.assertEqual(report.runner_workdir_usage[0].reason_code, "probe_failed")
+        telemetry = next(
+            item for item in report.cache_class_telemetry if item.cache_class == "runner_workdir"
+        )
+        self.assertEqual(telemetry.availability, "unavailable")
+        self.assertEqual(telemetry.unavailable_reason, "probe_failed")
+        self.assertNotIn("/private/runner/root", report.model_dump_json())
 
     def test_executor_records_failed_terminal_audit_when_post_report_fails(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1282,6 +1366,82 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertEqual(snapshot.volume_inventory[0].size_bytes, 45_500_000_000)
         self.assertEqual(snapshot.reclaimable_breakdown.local_volumes_bytes, 45_500_000_000)
 
+    def test_docker_disk_usage_uses_engine_class_totals(self) -> None:
+        snapshot = _parse_docker_disk_usage(
+            _docker_disk_usage_json(
+                images=[{"Containers": 0, "SharedSize": 100, "Size": 100}],
+                build_cache=[{"InUse": False, "Shared": True, "Size": 100}],
+                layers_size=100,
+                builder_size=100,
+            )
+        )
+        measurements = {item.cache_class: item for item in snapshot.cache_class_measurements}
+
+        self.assertEqual(measurements["docker_images"].logical_bytes, 100)
+        self.assertEqual(measurements["docker_images"].reclaimable_bytes, 100)
+        self.assertEqual(measurements["docker_build_cache"].logical_bytes, 100)
+        self.assertEqual(measurements["docker_build_cache"].reclaimable_bytes, 100)
+
+    def test_docker_disk_usage_marks_unknown_values_partial(self) -> None:
+        snapshot = _parse_docker_disk_usage(
+            json.dumps(
+                {
+                    "Images": [{"Containers": 0, "SharedSize": -1, "Size": -1}],
+                    "LayersSize": 100,
+                    "Containers": [{"SizeRw": -1}],
+                    "Volumes": [
+                        {
+                            "Driver": "local",
+                            "Labels": {},
+                            "Mountpoint": "/private/docker/volume",
+                            "Name": "unknown-volume",
+                            "UsageData": {"RefCount": -1, "Size": -1},
+                        }
+                    ],
+                    "BuildCache": [{"Size": 100}],
+                    "BuilderSize": 100,
+                }
+            )
+        )
+        measurements = {item.cache_class: item for item in snapshot.cache_class_measurements}
+
+        self.assertTrue(all(item.availability == "partial" for item in measurements.values()))
+        self.assertIsNone(measurements["docker_images"].reclaimable_bytes)
+        self.assertIsNone(measurements["docker_containers"].logical_bytes)
+        self.assertIsNone(measurements["docker_volumes"].logical_bytes)
+        self.assertIsNone(measurements["docker_build_cache"].reclaimable_bytes)
+        self.assertIsNone(snapshot.volume_inventory[0].referenced_by_containers)
+
+    def test_docker_disk_usage_distinguishes_empty_and_unavailable_classes(self) -> None:
+        empty_snapshot = _parse_docker_disk_usage(_docker_disk_usage_json())
+        empty_measurements = {
+            item.cache_class: item for item in empty_snapshot.cache_class_measurements
+        }
+
+        self.assertTrue(
+            all(item.availability == "available" for item in empty_measurements.values())
+        )
+        self.assertTrue(all(item.logical_bytes == 0 for item in empty_measurements.values()))
+        self.assertTrue(all(item.reclaimable_bytes == 0 for item in empty_measurements.values()))
+
+        missing_snapshot = _parse_docker_disk_usage(json.dumps({"Images": [], "LayersSize": 0}))
+        missing_measurements = {
+            item.cache_class: item for item in missing_snapshot.cache_class_measurements
+        }
+
+        self.assertEqual(missing_measurements["docker_images"].availability, "available")
+        for cache_class in (
+            "docker_containers",
+            "docker_volumes",
+            "docker_build_cache",
+        ):
+            with self.subTest(cache_class=cache_class):
+                measurement = missing_measurements[cache_class]
+                self.assertEqual(measurement.availability, "unavailable")
+                self.assertEqual(measurement.reason_code, "class_unavailable")
+                self.assertIsNone(measurement.logical_bytes)
+                self.assertIsNone(measurement.reclaimable_bytes)
+
     def test_executor_fails_closed_when_docker_summary_is_unparseable(self) -> None:
         command_runner = _CommandRunner(docker_disk_usage="not-json")
         audit_poster = _AuditPoster()
@@ -1294,6 +1454,50 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             )
 
         self.assertEqual(audit_poster.records, [])
+
+    def test_report_records_unavailable_docker_summary_without_aborting(self) -> None:
+        report = collect_runner_host_hygiene_report(
+            request=_request(mutate=False),
+            remote_runner=_CommandRunner(docker_disk_usage="not-json"),
+        )
+
+        docker_telemetry = tuple(
+            item
+            for item in report.cache_class_telemetry
+            if item.measurement_basis == "docker_engine"
+        )
+        self.assertEqual(len(docker_telemetry), 4)
+        self.assertTrue(all(item.availability == "unavailable" for item in docker_telemetry))
+        self.assertTrue(all(item.unavailable_reason == "probe_failed" for item in docker_telemetry))
+
+    def test_report_marks_failed_image_inventory_partial(self) -> None:
+        command_runner = _CommandRunner()
+
+        def fail_image_inventory(
+            command: Sequence[str], timeout_seconds: int
+        ) -> RemoteCommandResult:
+            if tuple(command) == (
+                "docker",
+                "image",
+                "ls",
+                "--all",
+                "--no-trunc",
+                "--format",
+                "{{json .}}",
+            ):
+                return RemoteCommandResult(returncode=1, stderr="inventory unavailable")
+            return command_runner(command, timeout_seconds)
+
+        report = collect_runner_host_hygiene_report(
+            request=_request(mutate=False),
+            remote_runner=fail_image_inventory,
+        )
+        image_telemetry = next(
+            item for item in report.cache_class_telemetry if item.cache_class == "docker_images"
+        )
+
+        self.assertEqual(image_telemetry.availability, "partial")
+        self.assertEqual(image_telemetry.unavailable_reason, "inventory_probe_failed")
 
     def test_executor_blocks_before_prune_without_mutate_intent(self) -> None:
         command_runner = _CommandRunner()
@@ -2074,13 +2278,28 @@ def _docker_disk_usage_json(
     containers: list[dict[str, object]] | None = None,
     volumes: list[dict[str, object]] | None = None,
     build_cache: list[dict[str, object]] | None = None,
+    layers_size: int | None = None,
+    builder_size: int | None = None,
 ) -> str:
+    image_rows = images or []
+    build_cache_rows = build_cache or []
     return json.dumps(
         {
-            "BuildCache": build_cache or [],
+            "BuilderSize": (
+                builder_size
+                if builder_size is not None
+                else sum(
+                    size for row in build_cache_rows if isinstance((size := row.get("Size")), int)
+                )
+            ),
+            "BuildCache": build_cache_rows,
             "Containers": containers or [],
-            "Images": images or [],
-            "LayersSize": 0,
+            "Images": image_rows,
+            "LayersSize": (
+                layers_size
+                if layers_size is not None
+                else sum(size for row in image_rows if isinstance((size := row.get("Size")), int))
+            ),
             "Volumes": volumes or [],
         }
     )


### PR DESCRIPTION
## Summary
- add typed, source-attributed cache-class telemetry with explicit available/partial/unavailable/stale semantics
- persist bounded and redacted runner-host hygiene evidence across filesystem and PostgreSQL stores
- add authorized audit list/detail/history reads, chronology handling, OpenAPI contracts, and ownership documentation
- preserve existing mutation lanes while treating unknown Docker v1.45 measurements conservatively and fail-closed
- bound filesystem audit identifiers so overlong keys retain backend/API parity

## Validation
- `uv run --extra dev python -m unittest tests.test_runner_host_hygiene_executor tests.test_runner_host_hygiene tests.test_http_app_records tests.test_http_read_route_registrars tests.test_filesystem_store tests.test_postgres_store` (424 passed)
- `LAUNCHPLANE_TEST_POSTGRES_URL=... uv run --extra dev launchplane ci postgres-integration` (60 passed against PostgreSQL 17)
- `uv run --extra dev mypy control_plane tests`
- `uv run --extra dev ruff check ...` and `ruff format --check ...` for changed files
- `pnpm --dir frontend validate`
- `pnpm --dir frontend check:openapi-drift`
- `docker build -t launchplane-ci:test .`
- config-authority audit and JetBrains changed-files inspection (0 findings)
- independent post-fix agent reviews: SHIP

Closes #1900
Parent: #1842