### PR TITLE
Fix stale Odoo preview fence recovery

### DIFF
--- a/control_plane/dokploy/post_deploy.py
+++ b/control_plane/dokploy/post_deploy.py
@@ -2085,6 +2085,41 @@ def _resolve_dokploy_schedule_runtime(
     return "dokploy-server", user_id, compose_app_name, None
 
 
+def compose_data_workflow_is_quiescent(
+    *,
+    host: str,
+    token: str,
+    target_definition: DokployTargetDefinition,
+) -> bool:
+    target_payload = api.fetch_dokploy_target_payload(
+        host=host,
+        token=token,
+        target_type="compose",
+        target_id=target_definition.target_id,
+    )
+    schedule_type, schedule_lookup_id, _compose_app_name, _schedule_server_id = (
+        _resolve_dokploy_schedule_runtime(
+            host=host,
+            token=token,
+            compose_id=target_definition.target_id,
+            compose_name=target_definition.target_name,
+            target_payload=target_payload,
+        )
+    )
+    schedule = api.find_matching_dokploy_schedule(
+        host=host,
+        token=token,
+        target_id=schedule_lookup_id,
+        schedule_type=schedule_type,
+        schedule_name=DOKPLOY_DATA_WORKFLOW_SCHEDULE_NAME,
+        app_name=_build_dokploy_data_workflow_schedule_app_name(
+            context_name=target_definition.context,
+            instance_name=target_definition.instance,
+        ),
+    )
+    return not _has_running_schedule_deployment(schedule)
+
+
 def _build_dokploy_data_workflow_script(
     *,
     compose_app_name: str,

--- a/control_plane/http_app.py
+++ b/control_plane/http_app.py
@@ -155,6 +155,7 @@ from control_plane.provider_operations import (
     ProviderObservation,
     ProviderObservationOutcome,
     ProviderOperationLease,
+    ProviderTargetSupersession,
     provider_operation_title,
     run_durable_provider_operation,
 )
@@ -328,6 +329,7 @@ from control_plane.odoo_preview_apply_http import (
     execute_odoo_preview_apply_result,
     issue_odoo_preview_apply_plan,
     observe_odoo_preview_apply_result,
+    odoo_preview_destroy_supersession_is_quiescent,
     resolve_odoo_preview_apply_profile,
     validate_odoo_preview_issued_plan,
 )
@@ -464,7 +466,10 @@ from control_plane.workflows.odoo_prod_backup_restore import (
     OdooProdBackupRestoreStore,
     build_odoo_prod_backup_restore_plan,
 )
-from control_plane.workflows.odoo_preview_runtime import OdooPreviewApplyInputsResult
+from control_plane.workflows.odoo_preview_runtime import (
+    ODOO_PREVIEW_DESTROY_SUPERSESSION_GRACE_SECONDS,
+    OdooPreviewApplyInputsResult,
+)
 from control_plane.contracts.product_environment_read_model import (
     ActionAllowed,
 )
@@ -5562,6 +5567,30 @@ def create_launchplane_fastapi_app(
             database_url=getattr(record_store, "database_url", None),
             trace_id=trace_id,
         )
+        target_supersession = None
+        if service_apply_request.apply.dry_run_plan.operation == "destroy":
+            target_supersession = ProviderTargetSupersession(
+                response_status_code=409,
+                response_payload=_provider_operation_response_payload(
+                    trace_id=trace_id,
+                    records={},
+                    result={
+                        "status": "fail",
+                        "error_message": (
+                            "The earlier Odoo preview apply was superseded by an "
+                            "authoritative destroy after its recovery lease expired."
+                        ),
+                    },
+                ),
+                minimum_expired_seconds=ODOO_PREVIEW_DESTROY_SUPERSESSION_GRACE_SECONDS,
+                quiescence_check=lambda _reservation: (
+                    odoo_preview_destroy_supersession_is_quiescent(
+                        control_plane_root_path=resolved_control_plane_root,
+                        request=service_apply_request,
+                        database_url=getattr(record_store, "database_url", None),
+                    )
+                ),
+            )
         try:
             return await run_provider_mutation(
                 record_store=record_store,
@@ -5576,6 +5605,7 @@ def create_launchplane_fastapi_app(
                     "Retry with the same Idempotency-Key."
                 ),
                 reconcile_message=("The Odoo preview apply requires reconciliation before retry."),
+                target_supersession=target_supersession,
             )
         except OdooPreviewPlanProvenanceError as error:
             raise _launchplane_http_error(
@@ -11629,6 +11659,7 @@ def create_launchplane_fastapi_app(
         in_progress_message: str,
         reconcile_message: str,
         reservation_scope: str = "",
+        target_supersession: ProviderTargetSupersession | None = None,
     ) -> AcceptedEvidenceResponse:
         reservation_store = require_provider_operation_store(
             record_store=record_store,
@@ -11645,6 +11676,7 @@ def create_launchplane_fastapi_app(
                 lease_owner=trace_id,
                 response_trace_id=trace_id,
                 adapter=adapter,
+                target_supersession=target_supersession,
             )
 
         operation_task = asyncio.create_task(

--- a/control_plane/odoo_preview_apply_http.py
+++ b/control_plane/odoo_preview_apply_http.py
@@ -28,6 +28,7 @@ from control_plane.workflows.odoo_preview_runtime import (
     build_odoo_preview_apply_inputs,
     execute_odoo_preview_dokploy_apply,
     observe_odoo_preview_dokploy_apply,
+    odoo_preview_destroy_target_is_quiescent,
     odoo_preview_apply_plan_sha256,
 )
 
@@ -340,6 +341,19 @@ def observe_odoo_preview_apply_result(
     if observation.outcome != "present" or observation.result is None:
         return observation.outcome, None, observation.retry_safe
     return observation.outcome, observation.result.model_dump(mode="json"), False
+
+
+def odoo_preview_destroy_supersession_is_quiescent(
+    *,
+    control_plane_root_path: Path,
+    request: OdooPreviewApplyEnvelope,
+    database_url: str | None,
+) -> bool:
+    return odoo_preview_destroy_target_is_quiescent(
+        control_plane_root=control_plane_root_path,
+        request=request.apply,
+        database_url=database_url,
+    )
 
 
 def driver_result_contains_status(

--- a/control_plane/provider_operations.py
+++ b/control_plane/provider_operations.py
@@ -19,13 +19,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import hashlib
 from threading import Event, Lock, Thread
-from typing import Literal, NamedTuple, Protocol, runtime_checkable
+from typing import Callable, Literal, NamedTuple, Protocol, runtime_checkable
 
 from control_plane.contracts.idempotency_record import (
     LaunchplaneIdempotencyRecord,
     complete_launchplane_mutation_reservation,
 )
 from control_plane.storage.postgres import (
+    MutationReconciliationSupersessionResult,
     MutationReservationAdoptionResult,
     MutationReservationCompletionResult,
     MutationReconciliationRetryResult,
@@ -86,6 +87,16 @@ class ProviderObservation:
     response_status_code: int = 202
     response_payload: dict[str, object] = field(default_factory=dict)
     retry_safe: bool = False
+
+
+@dataclass(frozen=True)
+class ProviderTargetSupersession:
+    response_status_code: int
+    response_payload: dict[str, object] = field(default_factory=dict)
+    minimum_expired_seconds: int = 0
+    quiescence_check: Callable[[LaunchplaneIdempotencyRecord], bool] = field(
+        default=lambda _reservation: False
+    )
 
 
 class ProviderOperationLease(Protocol):
@@ -168,6 +179,24 @@ class DurableProviderOperationStore(Protocol):
         response_trace_id: str,
         response_payload: dict[str, object],
     ) -> MutationReservationAdoptionResult: ...
+
+    def supersede_expired_reconciled_mutation_and_reserve(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        response_status_code: int,
+        response_trace_id: str,
+        response_payload: dict[str, object],
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+        request_fingerprint: str,
+        lease_owner: str,
+        lease_seconds: int,
+        minimum_expired_seconds: int,
+        reconciliation_key: str,
+        provider_target_key: str,
+    ) -> MutationReconciliationSupersessionResult: ...
 
     def release_reserved_mutation(
         self,
@@ -328,6 +357,7 @@ def run_durable_provider_operation(
     adapter: DurableProviderMutationAdapter,
     lease_seconds: int = 300,
     heartbeat_interval_seconds: float | None = None,
+    target_supersession: ProviderTargetSupersession | None = None,
 ) -> DurableProviderOperationResult:
     if lease_seconds < 1:
         raise ValueError("Durable provider operation leases must be positive.")
@@ -338,6 +368,8 @@ def run_durable_provider_operation(
         raise ValueError("Durable provider operation heartbeat intervals must be positive.")
     if resolved_heartbeat_interval >= lease_seconds:
         raise ValueError("Durable provider operation heartbeats must run before lease expiry.")
+    if target_supersession is not None and target_supersession.minimum_expired_seconds < 0:
+        raise ValueError("Provider target supersession delays cannot be negative.")
     provider_target_key = adapter.target_key().strip()
     if not provider_target_key:
         raise ValueError("Durable provider operations require a provider target key.")
@@ -348,18 +380,50 @@ def run_durable_provider_operation(
     if not normalized_response_trace_id:
         raise ValueError("Durable provider operations require a response trace id.")
 
-    reservation_result = store.reserve_mutation(
-        scope=scope,
-        route_path=route_path,
-        idempotency_key=idempotency_key,
-        request_fingerprint=request_fingerprint,
-        lease_owner=lease_owner,
-        lease_seconds=lease_seconds,
-        reconciliation_key=reconciliation_key,
-        provider_target_key=provider_target_key,
-    )
+    def reserve() -> MutationReservationResult:
+        return store.reserve_mutation(
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+            lease_owner=lease_owner,
+            lease_seconds=lease_seconds,
+            reconciliation_key=reconciliation_key,
+            provider_target_key=provider_target_key,
+        )
+
+    reservation_result = reserve()
     decision = reservation_result.status
     reservation = reservation_result.record
+
+    if (
+        decision == "target_busy"
+        and reservation.state == "reconcile_required"
+        and target_supersession is not None
+        and target_supersession.quiescence_check(reservation)
+    ):
+        supersession = store.supersede_expired_reconciled_mutation_and_reserve(
+            reservation=reservation,
+            response_status_code=target_supersession.response_status_code,
+            response_trace_id=normalized_response_trace_id,
+            response_payload=target_supersession.response_payload,
+            scope=scope,
+            route_path=route_path,
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
+            lease_owner=lease_owner,
+            lease_seconds=lease_seconds,
+            minimum_expired_seconds=target_supersession.minimum_expired_seconds,
+            reconciliation_key=reconciliation_key,
+            provider_target_key=provider_target_key,
+        )
+        if supersession.status == "acquired" and supersession.record is not None:
+            decision = "acquired"
+            reservation = supersession.record
+        elif supersession.status == "retry":
+            reservation_result = reserve()
+            decision = reservation_result.status
+            reservation = reservation_result.record
 
     if decision == "replayed":
         return _replayed_result(reservation)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -284,6 +284,15 @@ MutationReconciliationRetryStatus = Literal[
     "not_reconcile_required",
     "reservation_mismatch",
 ]
+MutationReconciliationSupersessionStatus = Literal[
+    "acquired",
+    "retry",
+    "missing",
+    "not_reconcile_required",
+    "reservation_mismatch",
+    "lease_active",
+    "grace_active",
+]
 
 
 class ProductProfileCompareWriteResult(NamedTuple):
@@ -307,6 +316,11 @@ class MutationReservationUpdateResult(NamedTuple):
 
 class MutationReservationCompletionResult(NamedTuple):
     status: MutationReservationCompletionStatus
+    record: LaunchplaneIdempotencyRecord | None = None
+
+
+class MutationReconciliationSupersessionResult(NamedTuple):
+    status: MutationReconciliationSupersessionStatus
     record: LaunchplaneIdempotencyRecord | None = None
 
 
@@ -4049,6 +4063,128 @@ class PostgresRecordStore(HumanSessionStore):
                 status="adopted",
                 record=adopted_record,
             )
+
+    def supersede_expired_reconciled_mutation_and_reserve(
+        self,
+        *,
+        reservation: LaunchplaneIdempotencyRecord,
+        response_status_code: int,
+        response_trace_id: str,
+        response_payload: dict[str, Any],
+        scope: str,
+        route_path: str,
+        idempotency_key: str,
+        request_fingerprint: str,
+        lease_owner: str,
+        lease_seconds: int,
+        minimum_expired_seconds: int,
+        reconciliation_key: str,
+        provider_target_key: str,
+    ) -> MutationReconciliationSupersessionResult:
+        normalized_response_trace_id = response_trace_id.strip()
+        normalized_reconciliation_key = reconciliation_key.strip()
+        normalized_provider_target_key = provider_target_key.strip()
+        if minimum_expired_seconds < 0:
+            raise ValueError("Reconciled mutation supersession delays cannot be negative.")
+        if reservation.state != "reconcile_required" or not normalized_response_trace_id:
+            raise ValueError(
+                "Reconciled mutation supersession requires reservation evidence and trace."
+            )
+        if (
+            not normalized_reconciliation_key
+            or not normalized_provider_target_key
+            or normalized_reconciliation_key != reservation.reconciliation_key
+            or normalized_provider_target_key != reservation.provider_target_key
+        ):
+            raise ValueError(
+                "Reconciled mutation supersession requires the same provider target identity."
+            )
+        try:
+            with self._session_factory() as session:
+                self._begin_serialized_write(session)
+                row = session.scalar(
+                    self._idempotency_statement(
+                        scope=reservation.scope,
+                        route_path=reservation.route_path,
+                        idempotency_key=reservation.idempotency_key,
+                        for_update=True,
+                    )
+                )
+                if row is None:
+                    return MutationReconciliationSupersessionResult(status="missing")
+                current_record = self._read_payload(
+                    model_type=LaunchplaneIdempotencyRecord,
+                    payload=row.payload,
+                )
+                if current_record.state == "completed":
+                    return MutationReconciliationSupersessionResult(status="retry")
+                if current_record.state != "reconcile_required":
+                    return MutationReconciliationSupersessionResult(
+                        status="not_reconcile_required",
+                        record=current_record,
+                    )
+                if not self._mutation_reservation_matches(current_record, reservation):
+                    return MutationReconciliationSupersessionResult(
+                        status="reservation_mismatch",
+                        record=current_record,
+                    )
+                observed_at = self._database_mutation_timestamp(session)
+                if not current_record.lease_expires_at or parse_launchplane_mutation_timestamp(
+                    current_record.lease_expires_at,
+                    field_name="lease_expires_at",
+                ) > parse_launchplane_mutation_timestamp(
+                    observed_at,
+                    field_name="observed_at",
+                ):
+                    return MutationReconciliationSupersessionResult(
+                        status="lease_active",
+                        record=current_record,
+                    )
+                if parse_launchplane_mutation_timestamp(
+                    current_record.lease_expires_at,
+                    field_name="lease_expires_at",
+                ) + timedelta(
+                    seconds=minimum_expired_seconds
+                ) > parse_launchplane_mutation_timestamp(
+                    observed_at,
+                    field_name="observed_at",
+                ):
+                    return MutationReconciliationSupersessionResult(
+                        status="grace_active",
+                        record=current_record,
+                    )
+                superseded_record = self._updated_idempotency_record(
+                    current_record,
+                    state="completed",
+                    updated_at=observed_at,
+                    response_status_code=response_status_code,
+                    response_trace_id=normalized_response_trace_id,
+                    recorded_at=observed_at,
+                    response_payload=response_payload,
+                )
+                replacement = build_launchplane_mutation_reservation(
+                    scope=scope,
+                    route_path=route_path,
+                    idempotency_key=idempotency_key,
+                    request_fingerprint=request_fingerprint,
+                    lease_owner=lease_owner,
+                    lease_expires_at=self._mutation_lease_expiry(
+                        observed_at=observed_at,
+                        lease_seconds=lease_seconds,
+                    ),
+                    reserved_at=observed_at,
+                    reconciliation_key=normalized_reconciliation_key,
+                    provider_target_key=normalized_provider_target_key,
+                )
+                self._sync_idempotency_row(row, superseded_record)
+                session.add(self._idempotency_row(replacement))
+                session.commit()
+                return MutationReconciliationSupersessionResult(
+                    status="acquired",
+                    record=replacement,
+                )
+        except IntegrityError:
+            return MutationReconciliationSupersessionResult(status="retry")
 
     def release_reserved_mutation(
         self,

--- a/control_plane/workflows/odoo_preview_runtime.py
+++ b/control_plane/workflows/odoo_preview_runtime.py
@@ -103,6 +103,8 @@ ODOO_PREVIEW_GENERATED_ENV_KEYS = (
     "ODOO_LOG_VOLUME",
     "ODOO_DB_VOLUME",
 )
+ODOO_PREVIEW_MAX_APPLY_TIMEOUT_SECONDS = 600
+ODOO_PREVIEW_DESTROY_SUPERSESSION_GRACE_SECONDS = ODOO_PREVIEW_MAX_APPLY_TIMEOUT_SECONDS + 300
 
 
 class OdooPreviewTargetDiscoveryAmbiguousError(click.ClickException):
@@ -1077,7 +1079,11 @@ class OdooPreviewDokployApplyRequest(BaseModel):
     manifest: ArtifactIdentityManifest | None = None
     environment_values: dict[str, str] = Field(default_factory=dict)
     health_path: str = DEFAULT_ODOO_RUNTIME_HEALTH_PATH
-    timeout_seconds: int = Field(default=300, ge=1)
+    timeout_seconds: int = Field(
+        default=300,
+        ge=1,
+        le=ODOO_PREVIEW_MAX_APPLY_TIMEOUT_SECONDS,
+    )
     wait_for_deploy: bool = True
     smoke_check: bool | None = None
 
@@ -1374,6 +1380,51 @@ def observe_odoo_preview_dokploy_apply(
     except click.ClickException:
         return OdooPreviewDokployObservation(outcome="unknown")
     return OdooPreviewDokployObservation(outcome="unknown")
+
+
+def odoo_preview_destroy_target_is_quiescent(
+    *,
+    control_plane_root: Path,
+    request: OdooPreviewDokployApplyRequest,
+    database_url: str | None,
+) -> bool:
+    plan = request.dry_run_plan
+    if plan.operation != "destroy" or not plan.compose_ref:
+        return False
+    try:
+        host, token = dokploy_source.read_dokploy_config(
+            control_plane_root=control_plane_root,
+            database_url=database_url,
+        )
+        if not _compose_exists_by_id(
+            host=host,
+            token=token,
+            compose_id=plan.compose_ref,
+        ):
+            return True
+        if any(
+            dokploy_api.deployment_status(deployment)
+            in dokploy_post_deploy.DOKPLOY_RUNNING_DEPLOYMENT_STATUSES
+            for deployment in dokploy_api.list_deployments_for_target(
+                host=host,
+                token=token,
+                target_type="compose",
+                target_id=plan.compose_ref,
+            )
+        ):
+            return False
+        return dokploy_post_deploy.compose_data_workflow_is_quiescent(
+            host=host,
+            token=token,
+            target_definition=dokploy_source.DokployTargetDefinition(
+                context=plan.product,
+                instance=plan.preview_slug,
+                target_id=plan.compose_ref,
+                target_name=plan.compose_name,
+            ),
+        )
+    except click.ClickException:
+        return False
 
 
 def _missing_endpoint_paths(*, request: OdooPreviewDokployDryRunRequest) -> tuple[str, ...]:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -291,6 +291,18 @@ former replaces the previous process-local apply lock. Both require an
   failure. Incomplete terminal observations remain unknown.
 - Blocked plans and other non-durable results release the reservation instead of
   storing replay evidence, so a corrected retry with the same key can proceed.
+- Odoo preview destroy is the only current lifecycle operation allowed to
+  supersede a different-key target fence. When the blocking preview apply is
+  already `reconcile_required`, Launchplane waits until its recovery lease has
+  been expired for 15 minutes and verifies that Dokploy has no running compose
+  deployment or Odoo data-workflow schedule. It then atomically records that
+  earlier apply as a terminal superseded failure while reserving the destroy.
+  Odoo preview apply timeouts are capped at 10 minutes, so the additional grace
+  outlives a supported in-flight provider request before cleanup can take over.
+  Active leases remain fenced, stale reservation snapshots cannot supersede a
+  newer attempt, and the original request keeps durable replay evidence
+  explaining that cleanup won. Provider read failures remain fail-closed. Do not
+  reproduce this transition with direct SQL or provider-side deletion.
 
 ## Target Launchplane Ingress
 

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -30039,6 +30039,7 @@
                       },
                       "timeout_seconds": {
                         "default": 300,
+                        "maximum": 600,
                         "minimum": 1,
                         "title": "Timeout Seconds",
                         "type": "integer"

--- a/tests/test_dokploy.py
+++ b/tests/test_dokploy.py
@@ -19,6 +19,7 @@ from pydantic import ValidationError
 from control_plane import dokploy as control_plane_dokploy
 from control_plane.dokploy import JsonValue
 from control_plane.dokploy import api as dokploy_api
+from control_plane.dokploy import post_deploy as dokploy_post_deploy
 from control_plane.odoo_instance_overrides import LAUNCHPLANE_INSTANCE_OVERRIDES_REQUIRED_ENV_KEY
 from control_plane.odoo_instance_overrides import LAUNCHPLANE_WEBSITE_BOOTSTRAP_REQUIRED_ENV_KEY
 from control_plane.odoo_instance_overrides import ODOO_INSTANCE_OVERRIDES_PAYLOAD_ENV_KEY
@@ -2298,6 +2299,64 @@ domains = ["cm-testing.shinycomputers.com"]
                     "odoo_module_update_modules_configured": "true",
                 }
             )
+
+    def test_compose_data_workflow_quiescence_rejects_running_schedule(self) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="odoo-tenant-cm",
+            instance="pr-45",
+            target_id="compose-cm-pr-45",
+            target_name="cm-pr-45",
+        )
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": "cm-pr-45", "serverId": "server-one"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.find_matching_dokploy_schedule",
+                return_value={"deployments": [{"status": "running"}]},
+            ) as find_schedule,
+        ):
+            quiescent = dokploy_post_deploy.compose_data_workflow_is_quiescent(
+                host="https://dokploy.example",
+                token="token",
+                target_definition=target_definition,
+            )
+
+        self.assertFalse(quiescent)
+        find_schedule.assert_called_once_with(
+            host="https://dokploy.example",
+            token="token",
+            target_id="server-one",
+            schedule_type="server",
+            schedule_name="platform-data-workflow",
+            app_name="platform-odoo-tenant-cm-pr-45-data-workflow",
+        )
+
+    def test_compose_data_workflow_quiescence_allows_missing_schedule(self) -> None:
+        target_definition = control_plane_dokploy.DokployTargetDefinition(
+            context="odoo-tenant-cm",
+            instance="pr-45",
+            target_id="compose-cm-pr-45",
+            target_name="cm-pr-45",
+        )
+        with (
+            patch(
+                "control_plane.dokploy.post_deploy.api.fetch_dokploy_target_payload",
+                return_value={"appName": "cm-pr-45", "serverId": "server-one"},
+            ),
+            patch(
+                "control_plane.dokploy.post_deploy.api.find_matching_dokploy_schedule",
+                return_value=None,
+            ),
+        ):
+            quiescent = dokploy_post_deploy.compose_data_workflow_is_quiescent(
+                host="https://dokploy.example",
+                token="token",
+                target_definition=target_definition,
+            )
+
+        self.assertTrue(quiescent)
 
     def test_run_compose_post_deploy_update_applies_explicit_env_file_without_control_plane_secrets(
         self,

--- a/tests/test_http_app_driver_odoo.py
+++ b/tests/test_http_app_driver_odoo.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
+import hashlib
 import json
 import unittest
 from pathlib import Path
@@ -2386,6 +2387,111 @@ class FastApiOdooPreviewApplyTests(unittest.IsolatedAsyncioTestCase):
         applied_request = apply_driver.call_args.kwargs["request"]
         self.assertEqual(applied_request.dry_run_plan.operation, "destroy")
         self.assertEqual(applied_request.image_reference, "")
+
+    async def test_odoo_preview_destroy_supersedes_expired_reconciled_refresh(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            root = Path(temporary_directory_name)
+            store = self._reservation_store(root)
+            identity = self._identity(
+                repository="cbusillo/launchplane",
+                workflow_ref=(
+                    "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml@refs/heads/main"
+                ),
+            )
+            app = create_launchplane_fastapi_app(
+                verifier=_StubVerifier(identity),
+                authz_policy=self._policy(
+                    actions=("odoo_preview_apply.execute",),
+                    repository="cbusillo/launchplane",
+                    workflow_ref=(
+                        "cbusillo/launchplane/.github/workflows/odoo-preview-apply.yml"
+                        "@refs/heads/main"
+                    ),
+                ),
+                record_store_factory=lambda: store,
+                control_plane_root_path=root,
+            )
+            destroy_payload = _ready_odoo_preview_destroy_payload()
+            destroy_plan_id = self._store_issued_preview_plan(
+                store=store,
+                identity=identity,
+                payload=destroy_payload,
+                plan_id="odoo-preview-destroy-after-stale-refresh",
+            )
+            reconciliation_key = "dokploy:compose:cm:cm-odoo-preview-pr-42"
+            provider_target_key = (
+                "dokploy-provider-target:"
+                + hashlib.sha256(reconciliation_key.encode("utf-8")).hexdigest()
+            )
+            clock = {"now": "2026-07-30T15:00:00Z"}
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: clock["now"],
+            ):
+                stale_refresh = store.reserve_mutation(
+                    scope=idempotency_scope(identity),
+                    route_path="/v1/drivers/odoo/preview-apply",
+                    idempotency_key="odoo-preview-stale-refresh",
+                    request_fingerprint="odoo-preview-stale-refresh-fingerprint",
+                    lease_owner="stale-refresh-trace",
+                    lease_seconds=60,
+                    reconciliation_key=reconciliation_key,
+                    provider_target_key=provider_target_key,
+                )
+                reconciled_refresh = store.mark_mutation_reconcile_required(
+                    reservation=stale_refresh.record,
+                    reconciliation_key=reconciliation_key,
+                )
+                clock["now"] = "2026-07-30T15:17:00Z"
+                with (
+                    patch(
+                        "control_plane.odoo_preview_apply_http.refresh_odoo_preview_issued_plan",
+                        side_effect=lambda **kwargs: kwargs["request"],
+                    ),
+                    patch(
+                        "control_plane.odoo_preview_apply_http.execute_odoo_preview_dokploy_apply",
+                        return_value=OdooPreviewDokployApplyResult(
+                            status="pass",
+                            operation="destroy",
+                            product="odoo-tenant-cm",
+                            repository="cbusillo/odoo-tenant-cm",
+                            preview_slug="pr-42",
+                            preview_url="https://pr-42.cm-preview.example.test",
+                            domain_host="pr-42.cm-preview.example.test",
+                            compose_id="compose-cm-pr-42",
+                            compose_name="cm-odoo-preview-pr-42",
+                        ),
+                    ) as apply_driver,
+                    patch(
+                        "control_plane.http_app.odoo_preview_destroy_supersession_is_quiescent",
+                        return_value=True,
+                    ),
+                ):
+                    response = await _post_odoo_preview_apply(
+                        app,
+                        destroy_payload,
+                        idempotency_key=destroy_plan_id,
+                    )
+            stored_refresh = store.read_idempotency_record(
+                scope=idempotency_scope(identity),
+                route_path="/v1/drivers/odoo/preview-apply",
+                idempotency_key="odoo-preview-stale-refresh",
+            )
+
+        self.assertEqual(reconciled_refresh.status, "updated")
+        self.assertEqual(response.status_code, 202)
+        self.assertEqual(response.json()["result"]["status"], "pass")
+        apply_driver.assert_called_once()
+        assert stored_refresh is not None
+        self.assertEqual(stored_refresh.state, "completed")
+        self.assertEqual(stored_refresh.response_status_code, 409)
+        self.assertIn(
+            "superseded by an authoritative destroy",
+            str(stored_refresh.response_payload),
+        )
 
     async def test_odoo_preview_apply_does_not_replay_blocked_idempotency(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_odoo_preview_runtime.py
+++ b/tests/test_odoo_preview_runtime.py
@@ -40,6 +40,7 @@ from control_plane.workflows.odoo_preview_runtime import (
     build_odoo_preview_artifact_publish_inputs_workflow_request,
     execute_odoo_preview_dokploy_apply,
     observe_odoo_preview_dokploy_apply,
+    odoo_preview_destroy_target_is_quiescent,
     _preview_runtime_bindings,
     _rollback_created_runtime,
     _wait_for_smoke_check,
@@ -350,6 +351,22 @@ def _patched_apply_inputs_runtime(*, dokploy_side_effect: object) -> Iterator[No
 
 
 class OdooPreviewDokployDryRunTests(unittest.TestCase):
+    def test_apply_rejects_timeout_beyond_destroy_supersession_bound(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+
+        with self.assertRaises(ValueError):
+            OdooPreviewDokployApplyRequest(
+                dry_run_plan=dry_run,
+                image_reference="ghcr.io/cbusillo/odoo-tenant-cm@sha256:abc123",
+                environment_values=_environment_values(),
+                timeout_seconds=601,
+            )
+
     def test_rollback_rechecks_fence_before_each_delete(self) -> None:
         phases: list[str] = []
 
@@ -1990,6 +2007,100 @@ class OdooPreviewDokployDryRunTests(unittest.TestCase):
         self.assertEqual(observation.outcome, "present")
         assert observation.result is not None
         self.assertEqual(observation.result.status, "pass")
+
+    def test_destroy_supersession_requires_quiescent_compose_deployment(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(operation="destroy", target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+        request = OdooPreviewDokployApplyRequest(dry_run_plan=dry_run)
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._compose_exists_by_id",
+                return_value=True,
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.dokploy_api.list_deployments_for_target",
+                return_value=[{"status": "running"}],
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.dokploy_post_deploy.compose_data_workflow_is_quiescent"
+            ) as schedule_quiescence,
+        ):
+            quiescent = odoo_preview_destroy_target_is_quiescent(
+                control_plane_root=Path("."),
+                request=request,
+                database_url=None,
+            )
+
+        self.assertFalse(quiescent)
+        schedule_quiescence.assert_not_called()
+
+    def test_destroy_supersession_requires_quiescent_data_workflow(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(operation="destroy", target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+        request = OdooPreviewDokployApplyRequest(dry_run_plan=dry_run)
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._compose_exists_by_id",
+                return_value=True,
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.dokploy_api.list_deployments_for_target",
+                return_value=[{"status": "completed"}],
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.dokploy_post_deploy.compose_data_workflow_is_quiescent",
+                return_value=False,
+            ),
+        ):
+            quiescent = odoo_preview_destroy_target_is_quiescent(
+                control_plane_root=Path("."),
+                request=request,
+                database_url=None,
+            )
+
+        self.assertFalse(quiescent)
+
+    def test_destroy_supersession_allows_missing_compose(self) -> None:
+        dry_run = build_odoo_preview_dokploy_dry_run(
+            request=OdooPreviewDokployDryRunRequest(
+                runtime_plan=_runtime_plan(operation="destroy", target=_target()),
+                endpoint_spec=_endpoint_spec(),
+            )
+        )
+        request = OdooPreviewDokployApplyRequest(dry_run_plan=dry_run)
+        with (
+            patch(
+                "control_plane.workflows.odoo_preview_runtime.dokploy_source.read_dokploy_config",
+                return_value=("https://dokploy.example", "token"),
+            ),
+            patch(
+                "control_plane.workflows.odoo_preview_runtime._compose_exists_by_id",
+                return_value=False,
+            ),
+        ):
+            quiescent = odoo_preview_destroy_target_is_quiescent(
+                control_plane_root=Path("."),
+                request=request,
+                database_url=None,
+            )
+
+        self.assertTrue(quiescent)
 
     def test_observe_refresh_does_not_retry_missing_marker_after_trigger_checkpoint(
         self,

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -71,6 +71,7 @@ from control_plane.provider_operations import (
     ProviderMutationOutcome,
     ProviderObservation,
     ProviderOperationLease,
+    ProviderTargetSupersession,
     run_durable_provider_operation,
 )
 from control_plane.workflows.public_ingress_monitor import (
@@ -2980,6 +2981,7 @@ def _run_integration_provider_operation(
     heartbeat_interval_seconds: float | None = None,
     idempotency_key: str = _PROVIDER_OPERATION_KEY,
     request_fingerprint: str = _PROVIDER_OPERATION_FINGERPRINT,
+    target_supersession: ProviderTargetSupersession | None = None,
 ) -> DurableProviderOperationResult:
     return run_durable_provider_operation(
         store=store,
@@ -2992,6 +2994,7 @@ def _run_integration_provider_operation(
         adapter=adapter,
         lease_seconds=lease_seconds,
         heartbeat_interval_seconds=heartbeat_interval_seconds,
+        target_supersession=target_supersession,
     )
 
 
@@ -3065,6 +3068,51 @@ class RealPostgresProviderOperationTests(unittest.TestCase):
 
         self.assertEqual(first.status, "acquired")
         self.assertEqual(second.status, "target_busy")
+
+    def test_destroy_supersedes_expired_reconcile_required_target_fence(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            stale = store.reserve_mutation(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key="provider-operation:integration:stale-refresh",
+                request_fingerprint="provider-operation-integration-stale-refresh",
+                lease_owner="instance-a",
+                lease_seconds=1,
+                reconciliation_key=_PROVIDER_OPERATION_RECONCILIATION_KEY,
+                provider_target_key=_PROVIDER_OPERATION_TARGET_KEY,
+            )
+            reconciled = store.mark_mutation_reconcile_required(
+                reservation=stale.record,
+                reconciliation_key=_PROVIDER_OPERATION_RECONCILIATION_KEY,
+            )
+            time.sleep(1.2)
+            destroy_adapter = _IntegrationProviderAdapter()
+            result = _run_integration_provider_operation(
+                store,
+                destroy_adapter,
+                lease_owner="instance-b",
+                response_trace_id="integration-destroy-trace",
+                idempotency_key="provider-operation:integration:destroy",
+                request_fingerprint="provider-operation-integration-destroy",
+                target_supersession=ProviderTargetSupersession(
+                    response_status_code=409,
+                    response_payload={"status": "superseded"},
+                    quiescence_check=lambda _reservation: True,
+                ),
+            )
+            stored_stale = store.read_idempotency_record(
+                scope=_PROVIDER_OPERATION_SCOPE,
+                route_path=_PROVIDER_OPERATION_ROUTE,
+                idempotency_key="provider-operation:integration:stale-refresh",
+            )
+
+        self.assertEqual(reconciled.status, "updated")
+        self.assertEqual(result.status, "completed")
+        self.assertEqual(destroy_adapter.apply_calls, 1)
+        assert stored_stale is not None
+        self.assertEqual(stored_stale.state, "completed")
+        self.assertEqual(stored_stale.response_status_code, 409)
+        self.assertEqual(stored_stale.response_payload, {"status": "superseded"})
 
     def test_heartbeats_hold_target_fence_past_original_lease(self) -> None:
         with _store_for_fresh_head_database() as store:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -2570,6 +2570,178 @@ class PostgresRecordStoreTests(unittest.TestCase):
         self.assertEqual(blocked.status, "target_busy")
         self.assertEqual(blocked.record.state, "reconcile_required")
 
+    def test_expired_reconcile_required_target_can_be_superseded(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            clock = {"now": "2026-07-30T15:00:00Z"}
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: clock["now"],
+            ):
+                first = store.reserve_mutation(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:stale",
+                    request_fingerprint="mutation-fingerprint-a",
+                    lease_owner="worker-a",
+                    lease_seconds=60,
+                    reconciliation_key="dokploy:compose:target-stale",
+                )
+                marked = store.mark_mutation_reconcile_required(
+                    reservation=first.record,
+                    reconciliation_key="dokploy:compose:target-stale",
+                )
+                assert marked.record is not None
+                clock["now"] = "2026-07-30T15:17:00Z"
+                replacement = store.supersede_expired_reconciled_mutation_and_reserve(
+                    reservation=marked.record,
+                    response_status_code=409,
+                    response_trace_id="destroy-trace",
+                    response_payload={"status": "superseded"},
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:replacement",
+                    request_fingerprint="mutation-fingerprint-b",
+                    lease_owner="worker-b",
+                    lease_seconds=300,
+                    minimum_expired_seconds=900,
+                    reconciliation_key="dokploy:compose:target-stale",
+                    provider_target_key="dokploy:compose:target-stale",
+                )
+                replay = store.reserve_mutation(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:stale",
+                    request_fingerprint="mutation-fingerprint-a",
+                    lease_owner="worker-c",
+                    lease_seconds=300,
+                    reconciliation_key="dokploy:compose:target-stale",
+                )
+                stored_stale = store.read_idempotency_record(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:stale",
+                )
+            assert replacement.record is not None
+            assert stored_stale is not None
+            store.close()
+
+        self.assertEqual(marked.status, "updated")
+        self.assertEqual(replacement.status, "acquired")
+        self.assertEqual(replacement.record.state, "running")
+        self.assertEqual(stored_stale.state, "completed")
+        self.assertEqual(stored_stale.response_status_code, 409)
+        self.assertEqual(replacement.status, "acquired")
+        self.assertEqual(replay.status, "replayed")
+        self.assertEqual(replay.record.response_payload, {"status": "superseded"})
+
+    def test_reconcile_required_target_cannot_be_superseded_before_lease_expiry(
+        self,
+    ) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            clock = {"now": "2026-07-30T15:00:00Z"}
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: clock["now"],
+            ):
+                first = store.reserve_mutation(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:settling",
+                    request_fingerprint="mutation-fingerprint-a",
+                    lease_owner="worker-a",
+                    lease_seconds=300,
+                    reconciliation_key="dokploy:compose:target-settling",
+                )
+                marked = store.mark_mutation_reconcile_required(
+                    reservation=first.record,
+                    reconciliation_key="dokploy:compose:target-settling",
+                )
+                assert marked.record is not None
+                superseded = store.supersede_expired_reconciled_mutation_and_reserve(
+                    reservation=marked.record,
+                    response_status_code=409,
+                    response_trace_id="destroy-trace",
+                    response_payload={"status": "superseded"},
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:replacement",
+                    request_fingerprint="mutation-fingerprint-b",
+                    lease_owner="worker-b",
+                    lease_seconds=300,
+                    minimum_expired_seconds=0,
+                    reconciliation_key="dokploy:compose:target-settling",
+                    provider_target_key="dokploy:compose:target-settling",
+                )
+            assert superseded.record is not None
+            store.close()
+
+        self.assertEqual(superseded.status, "lease_active")
+        self.assertEqual(superseded.record.state, "reconcile_required")
+
+    def test_expired_reconcile_required_target_waits_for_supersession_grace(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = PostgresRecordStore(
+                database_url=_sqlite_database_url(
+                    Path(temporary_directory_name) / "launchplane.sqlite3"
+                )
+            )
+            store.ensure_schema()
+            clock = {"now": "2026-07-30T15:00:00Z"}
+            with patch.object(
+                store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: clock["now"],
+            ):
+                first = store.reserve_mutation(
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:grace",
+                    request_fingerprint="mutation-fingerprint-a",
+                    lease_owner="worker-a",
+                    lease_seconds=60,
+                    reconciliation_key="dokploy:compose:target-grace",
+                )
+                marked = store.mark_mutation_reconcile_required(
+                    reservation=first.record,
+                    reconciliation_key="dokploy:compose:target-grace",
+                )
+                assert marked.record is not None
+                clock["now"] = "2026-07-30T15:02:00Z"
+                superseded = store.supersede_expired_reconciled_mutation_and_reserve(
+                    reservation=marked.record,
+                    response_status_code=409,
+                    response_trace_id="destroy-trace",
+                    response_payload={"status": "superseded"},
+                    scope="github-actions:mutation-test",
+                    route_path="/v1/test/mutation",
+                    idempotency_key="mutation:target:replacement",
+                    request_fingerprint="mutation-fingerprint-b",
+                    lease_owner="worker-b",
+                    lease_seconds=300,
+                    minimum_expired_seconds=900,
+                    reconciliation_key="dokploy:compose:target-grace",
+                    provider_target_key="dokploy:compose:target-grace",
+                )
+            assert superseded.record is not None
+            store.close()
+
+        self.assertEqual(superseded.status, "grace_active")
+        self.assertEqual(superseded.record.state, "reconcile_required")
+
     def test_db_only_mutation_preflight_releases_expired_unbound_reservation(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:
             store = PostgresRecordStore(

--- a/tests/test_provider_operations.py
+++ b/tests/test_provider_operations.py
@@ -14,6 +14,7 @@ from control_plane.provider_operations import (
     ProviderMutationUnknownError,
     ProviderObservation,
     ProviderOperationLease,
+    ProviderTargetSupersession,
     run_durable_provider_operation,
 )
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
@@ -115,18 +116,22 @@ class _StoreFixture:
         response_trace_id: str = "provider-op-trace-a",
         lease_seconds: int = 300,
         heartbeat_interval_seconds: float | None = None,
+        idempotency_key: str = _KEY,
+        request_fingerprint: str = _FINGERPRINT,
+        target_supersession: ProviderTargetSupersession | None = None,
     ) -> DurableProviderOperationResult:
         return run_durable_provider_operation(
             store=self.store,
             scope=_SCOPE,
             route_path=_ROUTE,
-            idempotency_key=_KEY,
-            request_fingerprint=_FINGERPRINT,
+            idempotency_key=idempotency_key,
+            request_fingerprint=request_fingerprint,
             lease_owner=lease_owner,
             response_trace_id=response_trace_id,
             adapter=adapter,
             lease_seconds=lease_seconds,
             heartbeat_interval_seconds=heartbeat_interval_seconds,
+            target_supersession=target_supersession,
         )
 
     def maybe_stored(self) -> LaunchplaneIdempotencyRecord | None:
@@ -215,6 +220,141 @@ class DurableProviderOperationRunnerTests(unittest.TestCase):
             )
 
             result = fixture.run(adapter, lease_owner="instance-b")
+
+            self.assertEqual(result.status, "target_busy")
+            self.assertEqual(adapter.apply_calls, 0)
+
+    def test_destroy_supersedes_expired_reconcile_required_target(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter()
+            clock = {"now": "2026-07-30T15:00:00Z"}
+            with patch.object(
+                fixture.store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: clock["now"],
+            ):
+                stale = fixture.store.reserve_mutation(
+                    scope=_SCOPE,
+                    route_path=_ROUTE,
+                    idempotency_key="provider-op:refresh:stale",
+                    request_fingerprint="provider-op-fingerprint-stale",
+                    lease_owner="instance-a",
+                    lease_seconds=60,
+                    reconciliation_key=_RECONCILIATION_KEY,
+                    provider_target_key=adapter.target_key(),
+                )
+                marked = fixture.store.mark_mutation_reconcile_required(
+                    reservation=stale.record,
+                    reconciliation_key=_RECONCILIATION_KEY,
+                )
+                clock["now"] = "2026-07-30T15:17:00Z"
+                result = fixture.run(
+                    adapter,
+                    lease_owner="instance-b",
+                    response_trace_id="destroy-trace",
+                    idempotency_key="provider-op:destroy:new",
+                    request_fingerprint="provider-op-fingerprint-destroy",
+                    target_supersession=ProviderTargetSupersession(
+                        response_status_code=409,
+                        response_payload={"status": "superseded"},
+                        minimum_expired_seconds=900,
+                        quiescence_check=lambda _reservation: True,
+                    ),
+                )
+            stored_stale = fixture.store.read_idempotency_record(
+                scope=_SCOPE,
+                route_path=_ROUTE,
+                idempotency_key="provider-op:refresh:stale",
+            )
+
+            self.assertEqual(marked.status, "updated")
+            self.assertEqual(result.status, "completed")
+            self.assertEqual(adapter.apply_calls, 1)
+            self.assertIsNotNone(stored_stale)
+            assert stored_stale is not None
+            self.assertEqual(stored_stale.state, "completed")
+            self.assertEqual(stored_stale.response_status_code, 409)
+            self.assertEqual(stored_stale.response_payload, {"status": "superseded"})
+
+    def test_destroy_does_not_supersede_reconciled_target_with_active_lease(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter()
+            clock = {"now": "2026-07-30T15:00:00Z"}
+            with patch.object(
+                fixture.store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: clock["now"],
+            ):
+                stale = fixture.store.reserve_mutation(
+                    scope=_SCOPE,
+                    route_path=_ROUTE,
+                    idempotency_key="provider-op:refresh:settling",
+                    request_fingerprint="provider-op-fingerprint-settling",
+                    lease_owner="instance-a",
+                    lease_seconds=300,
+                    reconciliation_key=_RECONCILIATION_KEY,
+                    provider_target_key=adapter.target_key(),
+                )
+                fixture.store.mark_mutation_reconcile_required(
+                    reservation=stale.record,
+                    reconciliation_key=_RECONCILIATION_KEY,
+                )
+                result = fixture.run(
+                    adapter,
+                    lease_owner="instance-b",
+                    response_trace_id="destroy-trace",
+                    idempotency_key="provider-op:destroy:new",
+                    request_fingerprint="provider-op-fingerprint-destroy",
+                    target_supersession=ProviderTargetSupersession(
+                        response_status_code=409,
+                        response_payload={"status": "superseded"},
+                        quiescence_check=lambda _reservation: True,
+                    ),
+                )
+
+            self.assertEqual(result.status, "target_busy")
+            self.assertEqual(adapter.apply_calls, 0)
+
+    def test_destroy_does_not_supersede_without_provider_quiescence(self) -> None:
+        with TemporaryDirectory() as directory:
+            fixture = _StoreFixture(directory)
+            adapter = _FakeAdapter()
+            clock = {"now": "2026-07-30T15:00:00Z"}
+            with patch.object(
+                fixture.store,
+                "_database_mutation_timestamp",
+                side_effect=lambda _session: clock["now"],
+            ):
+                stale = fixture.store.reserve_mutation(
+                    scope=_SCOPE,
+                    route_path=_ROUTE,
+                    idempotency_key="provider-op:refresh:not-quiescent",
+                    request_fingerprint="provider-op-fingerprint-not-quiescent",
+                    lease_owner="instance-a",
+                    lease_seconds=60,
+                    reconciliation_key=_RECONCILIATION_KEY,
+                    provider_target_key=adapter.target_key(),
+                )
+                fixture.store.mark_mutation_reconcile_required(
+                    reservation=stale.record,
+                    reconciliation_key=_RECONCILIATION_KEY,
+                )
+                clock["now"] = "2026-07-30T15:17:00Z"
+                result = fixture.run(
+                    adapter,
+                    lease_owner="instance-b",
+                    response_trace_id="destroy-trace",
+                    idempotency_key="provider-op:destroy:new",
+                    request_fingerprint="provider-op-fingerprint-destroy",
+                    target_supersession=ProviderTargetSupersession(
+                        response_status_code=409,
+                        response_payload={"status": "superseded"},
+                        minimum_expired_seconds=900,
+                        quiescence_check=lambda _reservation: False,
+                    ),
+                )
 
             self.assertEqual(result.status, "target_busy")
             self.assertEqual(adapter.apply_calls, 0)


### PR DESCRIPTION
## Summary

- let an authoritative Odoo preview destroy recover a different-key target fence only when the stale reservation is `reconcile_required`
- atomically complete the stale record and reserve the replacement destroy under one database transaction
- require a 15-minute post-lease grace plus live Dokploy compose-deployment and data-workflow quiescence evidence
- cap supported Odoo preview apply requests at 10 minutes so the grace outlives an in-flight provider request
- preserve terminal replay evidence for the superseded apply and document the recovery contract

## Safety

- destroy-only opt-in; refresh and other provider operations keep the existing fail-closed target fence
- exact reservation CAS under `SELECT FOR UPDATE`
- active leases, newer attempts, mismatched target identity, provider read failures, running deployments, and running data workflows remain blocked
- no direct SQL or out-of-band provider mutation

## Validation

- 4,245 unit/integration tests pass; 61 PostgreSQL-only tests are skipped in the default run
- 61 real PostgreSQL integration tests pass against PostgreSQL 17
- Ruff lint passes; all changed Python files are Ruff-formatted
- mypy passes for `control_plane` and `tests`
- frontend tests, OpenAPI drift check, TypeScript typecheck, and production build pass
- Docker image build passes
- JetBrains changed-file inspection reports zero findings
- independent concurrency reviews found no blocking changed-code risks

Repository-wide `ruff format --check .` still reports 25 unrelated pre-existing files inherited from `origin/main`; none are touched by this PR.

Refs #1905
