### PR TITLE
Add source-attributed runner-host idle evidence

### DIFF
--- a/.github/workflows/runner-host-hygiene.yml
+++ b/.github/workflows/runner-host-hygiene.yml
@@ -26,6 +26,12 @@ name: Runner Host Hygiene
         required: true
         default: false
         type: boolean
+      github_idle_bindings:
+        description: >-
+          Complete comma-separated owner/repo|lane|runner|service-unit host manifest
+        required: false
+        default: ""
+        type: string
       target_buildkit_state_volumes:
         description: >-
           One zero-link BuildKit state volume for removal
@@ -87,6 +93,9 @@ jobs:
       RUNNER_SERVICE_USER: >-
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_SERVICE_USER }}
       RUNNER_REPOSITORY_SCOPE: ${{ github.repository }}
+      RUNNER_GITHUB_IDLE_BINDINGS: >-
+        ${{ inputs.github_idle_bindings ||
+        vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_GITHUB_IDLE_BINDINGS }}
       RUNNER_RETAINED_WARM_BUILDERS: >-
         ${{ vars.LAUNCHPLANE_RUNNER_HOST_HYGIENE_RETAINED_WARM_BUILDERS }}
       RUNNER_WORKDIR_ROOTS: >-
@@ -210,6 +219,16 @@ jobs:
             exit 1
           fi
 
+          github_idle_binding_args=()
+          IFS=',' read -r -a github_idle_bindings <<< "$RUNNER_GITHUB_IDLE_BINDINGS"
+          for github_idle_binding in "${github_idle_bindings[@]}"; do
+            trimmed="${github_idle_binding#"${github_idle_binding%%[![:space:]]*}"}"
+            trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+            if [ -n "$trimmed" ]; then
+              github_idle_binding_args+=(--github-idle-binding "$trimmed")
+            fi
+          done
+
           generated_cache_args=()
           generated_cache_keys=()
           declare -A seen_generated_cache_keys=()
@@ -328,6 +347,7 @@ jobs:
               --audit-record-key "$audit_key" \
               "${builder_args[@]}" \
               "${runner_root_args[@]}" \
+              "${github_idle_binding_args[@]}" \
               "${generated_cache_args[@]}" \
               "$@" \
               "$mutation_flag" \

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -1802,6 +1802,11 @@ def runner_host_hygiene_executor(
                 "runner host hygiene GitHub evidence requires --github-token-env."
             )
         github_token = os.environ.get(github_token_env_name, "").strip()
+        if parsed_github_idle_bindings and not github_token:
+            raise click.ClickException(
+                "runner host hygiene GitHub idle evidence requires a populated token in "
+                f"{github_token_env_name}."
+            )
         request = RunnerHostHygieneExecutorRequest(
             action=apply_action,
             host_name=host_name,

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -76,10 +76,14 @@ from control_plane.workflows.runner_lane_retirement_executor import (
 )
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
 from control_plane.workflows.runner_host_hygiene_executor import GeneratedRunCacheRoot
+from control_plane.workflows.runner_host_hygiene_executor import RunnerHostGitHubBinding
 from control_plane.workflows.runner_host_hygiene_executor import RunnerWorkdirRoot
 from control_plane.workflows.runner_host_hygiene_executor import DOCKER_BUILDX_PLUGIN_PATH_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandRunner
 from control_plane.workflows.runner_host_hygiene_executor import build_local_command_runner
+from control_plane.workflows.runner_host_hygiene_executor import (
+    build_github_idle_evidence_reader,
+)
 from control_plane.workflows.runner_host_hygiene_executor import build_github_run_state_reader
 from control_plane.workflows.runner_host_hygiene_executor import (
     build_refreshing_service_audit_poster,
@@ -1674,6 +1678,15 @@ def runner_host_hygiene_adapter_boundary_plan(
     ),
 )
 @click.option(
+    "--github-idle-binding",
+    "github_idle_bindings",
+    multiple=True,
+    help=(
+        "Complete host runner binding formatted as "
+        "owner/repo|lane|runner-name|systemd-service-unit. Repeat for every host lane."
+    ),
+)
+@click.option(
     "--target-generated-cache-key",
     default="",
     help="Exact public generated-cache key selected for bounded completed-run cleanup.",
@@ -1689,8 +1702,15 @@ def runner_host_hygiene_adapter_boundary_plan(
     "--idle-observation-interval-seconds",
     default=5,
     show_default=True,
-    type=click.IntRange(min=0, max=60),
+    type=click.IntRange(min=1, max=60),
     help="Delay between consecutive local idle samples.",
+)
+@click.option(
+    "--idle-max-age-seconds",
+    default=300,
+    show_default=True,
+    type=click.IntRange(min=1, max=86_400),
+    help="Maximum age for source-attributed idle evidence used by the apply gate.",
 )
 @click.option(
     "--resolve-action-started/--no-resolve-action-started",
@@ -1753,9 +1773,11 @@ def runner_host_hygiene_executor(
     prune_until: str,
     runner_workdir_roots: tuple[str, ...],
     generated_run_cache_roots: tuple[str, ...],
+    github_idle_bindings: tuple[str, ...],
     target_generated_cache_key: str,
     idle_observation_count: int,
     idle_observation_interval_seconds: int,
+    idle_max_age_seconds: int,
     resolve_action_started: bool,
     timeout_seconds: int,
     service_url: str,
@@ -1776,17 +1798,15 @@ def runner_host_hygiene_executor(
             raise click.ClickException(
                 "runner host hygiene generated cache evidence requires --github-token-env."
             )
-        github_token = (
-            os.environ.get(github_token_env_name, "").strip()
-            if parsed_generated_run_cache_roots
-            else ""
-        )
+        github_token = os.environ.get(github_token_env_name, "").strip()
         request = RunnerHostHygieneExecutorRequest(
             action=apply_action,
             host_name=host_name,
             execution_lane=execution_lane,
             service_user=service_user,
             repository_scope=repository_scope,
+            current_runner_name=os.environ.get("RUNNER_NAME", ""),
+            github_idle_bindings=_parse_runner_host_github_bindings(github_idle_bindings),
             audit_record_key=audit_record_key,
             retained_warm_builders=retained_warm_builders,
             target_buildkit_builder=target_buildkit_builder,
@@ -1803,6 +1823,7 @@ def runner_host_hygiene_executor(
             target_generated_cache_key=target_generated_cache_key,
             idle_observation_count=idle_observation_count,
             idle_observation_interval_seconds=idle_observation_interval_seconds,
+            idle_max_age_seconds=idle_max_age_seconds,
             resolve_action_started=resolve_action_started,
         )
         validate_runner_host_hygiene_environment(request=request)
@@ -1825,6 +1846,15 @@ def runner_host_hygiene_executor(
                 if parsed_generated_run_cache_roots
                 else None
             ),
+            github_idle_evidence_reader=build_github_idle_evidence_reader(
+                bearer_token=github_token,
+                current_run_id=(
+                    int(os.environ["GITHUB_RUN_ID"])
+                    if os.environ.get("GITHUB_RUN_ID", "").isdigit()
+                    else None
+                ),
+                current_runner_name=os.environ.get("RUNNER_NAME", ""),
+            ),
         )
     except (OSError, ValidationError, ValueError) as error:
         raise click.ClickException(str(error)) from error
@@ -1845,6 +1875,29 @@ def _parse_runner_workdir_roots(values: tuple[str, ...]) -> tuple[RunnerWorkdirR
             raise click.ClickException("runner workdir roots must use public-key=/absolute/path")
         roots.append(RunnerWorkdirRoot(key=key, path=path))
     return tuple(roots)
+
+
+def _parse_runner_host_github_bindings(
+    values: tuple[str, ...],
+) -> tuple[RunnerHostGitHubBinding, ...]:
+    bindings: list[RunnerHostGitHubBinding] = []
+    for value in values:
+        parts = value.split("|")
+        if len(parts) != 4:
+            raise click.ClickException(
+                "runner host GitHub bindings must use "
+                "owner/repo|lane|runner-name|systemd-service-unit"
+            )
+        repository_scope, execution_lane, runner_name, service_unit = parts
+        bindings.append(
+            RunnerHostGitHubBinding(
+                repository_scope=repository_scope,
+                execution_lane=execution_lane,
+                runner_name=runner_name,
+                service_unit=service_unit,
+            )
+        )
+    return tuple(bindings)
 
 
 def _parse_generated_run_cache_roots(

--- a/control_plane/cli_runner_lanes.py
+++ b/control_plane/cli_runner_lanes.py
@@ -1793,10 +1793,13 @@ def runner_host_hygiene_executor(
         parsed_generated_run_cache_roots = _parse_generated_run_cache_roots(
             generated_run_cache_roots
         )
+        parsed_github_idle_bindings = _parse_runner_host_github_bindings(github_idle_bindings)
         github_token_env_name = github_token_env.strip()
-        if parsed_generated_run_cache_roots and not github_token_env_name:
+        if (
+            parsed_generated_run_cache_roots or parsed_github_idle_bindings
+        ) and not github_token_env_name:
             raise click.ClickException(
-                "runner host hygiene generated cache evidence requires --github-token-env."
+                "runner host hygiene GitHub evidence requires --github-token-env."
             )
         github_token = os.environ.get(github_token_env_name, "").strip()
         request = RunnerHostHygieneExecutorRequest(
@@ -1806,7 +1809,7 @@ def runner_host_hygiene_executor(
             service_user=service_user,
             repository_scope=repository_scope,
             current_runner_name=os.environ.get("RUNNER_NAME", ""),
-            github_idle_bindings=_parse_runner_host_github_bindings(github_idle_bindings),
+            github_idle_bindings=parsed_github_idle_bindings,
             audit_record_key=audit_record_key,
             retained_warm_builders=retained_warm_builders,
             target_buildkit_builder=target_buildkit_builder,

--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -820,8 +820,16 @@ class RunnerHostHygieneApplyAuditRecord(BaseModel):
             raise ValueError(
                 "failed runner host hygiene audit record without post report requires a message"
             )
-        if self.status in {"completed", "failed"} and self.plan.status != "ready":
-            raise ValueError("terminal runner host hygiene audit record requires a ready plan")
+        if self.status == "completed" and self.plan.status != "ready":
+            raise ValueError("completed runner host hygiene audit record requires a ready plan")
+        if (
+            self.status == "failed"
+            and self.post_apply_report is not None
+            and self.plan.status != "ready"
+        ):
+            raise ValueError(
+                "failed runner host hygiene audit record with post report requires a ready plan"
+            )
         return self
 
 

--- a/control_plane/contracts/runner_host_hygiene.py
+++ b/control_plane/contracts/runner_host_hygiene.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.runner_host_hygiene_idle import (
+    RunnerHostHygieneIdleConvergence,
+    RunnerHostHygieneIdleScope,
+    RunnerHostHygieneIdleSource,
+)
 
 
 RunnerHostHygieneStatus = Literal["healthy", "attention"]
@@ -62,6 +69,10 @@ RunnerHostHygieneApplyBlockerCode = Literal[
     "approved_host_mismatch",
     "audit_record_required",
     "host_needs_attention",
+    "idle_evidence_missing",
+    "idle_evidence_not_converged",
+    "idle_evidence_scope_mismatch",
+    "idle_evidence_stale",
     "mutate_not_requested",
     "report_host_mismatch",
     "target_volume_active",
@@ -94,6 +105,9 @@ RunnerHostHygieneFindingCode = Literal[
     "generated_cache_above_limit",
     "generated_cache_measurement_partial",
     "generated_cache_safety_failed",
+    "idle_evidence_active",
+    "idle_evidence_conflicting",
+    "idle_evidence_incomplete",
     "orphan_buildkit_present",
     "required_warm_builder_missing",
     "runner_workdir_above_limit",
@@ -227,7 +241,7 @@ class RunnerHostHygieneGeneratedCacheEntry(BaseModel):
     allocated_bytes: int = Field(default=0, ge=0)
     age_seconds: int = Field(default=0, ge=0)
     open_handle_observations: tuple[int, ...] = ()
-    github_run_state: Literal["completed", "active", "unknown"] = "unknown"
+    github_run_state: Literal["completed", "active", "unknown", "unauthorized"] = "unknown"
 
     @model_validator(mode="after")
     def _normalize_entry(self) -> "RunnerHostHygieneGeneratedCacheEntry":
@@ -258,6 +272,7 @@ class RunnerHostHygieneGeneratedCacheUsage(BaseModel):
     last_removed_run_ids: tuple[int, ...] = ()
     estimated_daily_growth_bytes: int = Field(default=0, ge=0)
     cooldown_remaining_seconds: int = Field(default=0, ge=0)
+    idle_convergence: RunnerHostHygieneIdleConvergence | None = None
 
     @model_validator(mode="after")
     def _normalize_usage(self) -> "RunnerHostHygieneGeneratedCacheUsage":
@@ -287,6 +302,9 @@ class RunnerHostHygieneGeneratedCacheUsage(BaseModel):
             raise ValueError("generated cache cleanup history run ids must be positive")
         if self.entry_count < len(self.entries):
             raise ValueError("generated cache entry_count cannot be smaller than entries")
+        if self.idle_convergence is not None:
+            if self.idle_convergence.scope == "full_host":
+                raise ValueError("generated cache idle convergence must use an isolated scope")
         return self
 
 
@@ -382,6 +400,7 @@ class RunnerHostHygieneObservation(BaseModel):
     generated_cache_allocated_bytes: int = Field(default=0, ge=0)
     generated_cache_usage: tuple[RunnerHostHygieneGeneratedCacheUsage, ...] = ()
     cache_class_telemetry: tuple[RunnerHostHygieneCacheClassTelemetry, ...] = ()
+    idle_convergences: tuple[RunnerHostHygieneIdleConvergence, ...] = ()
     docker_toolchain: "RunnerHostDockerToolchainObservation | None" = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple["RunnerHostHygieneImageInventoryItem", ...] = ()
@@ -410,6 +429,7 @@ class RunnerHostHygieneObservation(BaseModel):
             sorted(self.generated_cache_usage, key=lambda item: item.cache_key)
         )
         self.cache_class_telemetry = _sorted_cache_class_telemetry(self.cache_class_telemetry)
+        self.idle_convergences = _sorted_idle_convergences(self.idle_convergences)
         self.image_inventory = _sorted_image_inventory(self.image_inventory)
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
         if not self.image_inventory_total_count:
@@ -546,6 +566,7 @@ class RunnerHostHygieneReport(BaseModel):
     generated_cache_allocated_bytes: int = Field(default=0, ge=0)
     generated_cache_usage: tuple[RunnerHostHygieneGeneratedCacheUsage, ...] = ()
     cache_class_telemetry: tuple[RunnerHostHygieneCacheClassTelemetry, ...] = ()
+    idle_convergences: tuple[RunnerHostHygieneIdleConvergence, ...] = ()
     docker_toolchain: RunnerHostDockerToolchainObservation | None = None
     warm_builders: tuple[str, ...] = ()
     image_inventory: tuple[RunnerHostHygieneImageInventoryItem, ...] = ()
@@ -574,6 +595,7 @@ class RunnerHostHygieneReport(BaseModel):
             sorted(self.generated_cache_usage, key=lambda item: item.cache_key)
         )
         self.cache_class_telemetry = _sorted_cache_class_telemetry(self.cache_class_telemetry)
+        self.idle_convergences = _sorted_idle_convergences(self.idle_convergences)
         self.image_inventory = _sorted_image_inventory(self.image_inventory)
         self.volume_inventory = _sorted_volume_inventory(self.volume_inventory)
         if not self.image_inventory_total_count:
@@ -610,6 +632,7 @@ class RunnerHostHygieneApplyPolicy(BaseModel):
     required_retained_warm_builders: tuple[str, ...] = ()
     require_healthy_report: bool = True
     require_audit_record: bool = True
+    require_idle_convergence: bool = False
     allow_docker_cache_prune: bool = False
     allow_dangling_image_prune: bool = False
     allow_generated_run_cache_prune: bool = False
@@ -663,6 +686,12 @@ class RunnerHostHygieneApplyRequest(BaseModel):
     generated_cache_high_water_bytes: int = Field(default=0, ge=0)
     generated_cache_low_water_bytes: int = Field(default=0, ge=0)
     generated_cache_cooldown_hours: int = Field(default=0, ge=0)
+    idle_scope: RunnerHostHygieneIdleScope = "full_host"
+    idle_scope_key: str = "host"
+    idle_observation_count: int = Field(default=2, ge=2, le=10)
+    idle_observation_interval_seconds: int = Field(default=5, ge=1, le=3600)
+    idle_max_age_seconds: int = Field(default=300, ge=1, le=86_400)
+    idle_decision_at: str = ""
     audit_record_key: str = ""
 
     @model_validator(mode="after")
@@ -683,6 +712,11 @@ class RunnerHostHygieneApplyRequest(BaseModel):
         )
         if any(run_id <= 0 for run_id in self.target_generated_cache_run_ids):
             raise ValueError("generated cache run ids must be positive")
+        self.idle_scope_key = _required_public_token(
+            self.idle_scope_key,
+            "runner host hygiene apply requires idle_scope_key",
+        )
+        self.idle_decision_at = _normalized_optional_timestamp(self.idle_decision_at)
         self.audit_record_key = self.audit_record_key.strip()
         return self
 
@@ -869,6 +903,8 @@ class RunnerHostHygieneAuditDeliveryEnvelope(BaseModel):
     planned_audit: RunnerHostHygieneApplyAuditRecord
     planned_idempotency_key: str
     planned_delivery_state: RunnerHostHygieneAuditDeliveryState = "pending"
+    executor_intent_sha256: str = ""
+    action_authorization: RunnerHostHygieneApplyAuditRecord | None = None
     terminal_audit: RunnerHostHygieneApplyAuditRecord | None = None
     terminal_idempotency_key: str = ""
     terminal_delivery_state: RunnerHostHygieneAuditDeliveryState | None = None
@@ -892,6 +928,11 @@ class RunnerHostHygieneAuditDeliveryEnvelope(BaseModel):
             self.planned_idempotency_key,
             "runner host hygiene audit delivery envelope requires planned idempotency key",
         )
+        self.executor_intent_sha256 = self.executor_intent_sha256.strip().lower()
+        if self.schema_version >= 2 and not re.fullmatch(
+            r"[0-9a-f]{64}", self.executor_intent_sha256
+        ):
+            raise ValueError("runner host hygiene audit delivery requires executor intent sha256")
         self.created_at = _required_text(
             self.created_at,
             "runner host hygiene audit delivery envelope requires created_at",
@@ -909,6 +950,40 @@ class RunnerHostHygieneAuditDeliveryEnvelope(BaseModel):
             raise ValueError("runner host hygiene audit delivery action must match planned audit")
         if self.planned_audit.status != "planned":
             raise ValueError("runner host hygiene audit delivery planned audit must be planned")
+        if self.action_authorization is not None:
+            if self.action_authorization.status != "planned":
+                raise ValueError("runner host hygiene action authorization audit must be planned")
+            if self.action_authorization.audit_record_key != self.audit_record_key:
+                raise ValueError("runner host hygiene action authorization key must match envelope")
+            if _normalized_host_name(self.action_authorization.request.host_name) != self.host_name:
+                raise ValueError(
+                    "runner host hygiene action authorization host must match envelope"
+                )
+            if self.action_authorization.request.action != self.action:
+                raise ValueError(
+                    "runner host hygiene action authorization action must match envelope"
+                )
+            if (
+                not self.action_authorization.request.mutate
+                or self.action_authorization.plan.status != "ready"
+            ):
+                raise ValueError("runner host hygiene action authorization must be ready to mutate")
+            planned_request = self.planned_audit.request.model_dump(mode="python")
+            authorized_request = self.action_authorization.request.model_dump(mode="python")
+            planned_request.pop("idle_decision_at", None)
+            authorized_request.pop("idle_decision_at", None)
+            if planned_request != authorized_request:
+                raise ValueError(
+                    "runner host hygiene action authorization must match planned targets"
+                )
+        if (
+            self.schema_version >= 2
+            and self.execution_state == "action_started"
+            and self.action_authorization is None
+        ):
+            raise ValueError(
+                "runner host hygiene action_started delivery requires action authorization"
+            )
         if self.terminal_audit is None:
             if self.terminal_idempotency_key or self.terminal_delivery_state is not None:
                 raise ValueError(
@@ -1169,6 +1244,27 @@ def evaluate_runner_host_hygiene(
                 + ", ".join(unsafe_generated_caches),
             )
         )
+    idle_convergence_groups = (
+        ("active", "idle_evidence_active"),
+        ("conflicting", "idle_evidence_conflicting"),
+        ("incomplete", "idle_evidence_incomplete"),
+    )
+    for convergence_status, finding_code in idle_convergence_groups:
+        affected_scopes = tuple(
+            f"{item.scope}/{item.scope_key}"
+            for item in observation.idle_convergences
+            if item.status == convergence_status
+        )
+        if affected_scopes:
+            findings.append(
+                _finding(
+                    cast(RunnerHostHygieneFindingCode, finding_code),
+                    (
+                        "runner host idle evidence did not converge for scopes: "
+                        + ", ".join(affected_scopes)
+                    ),
+                )
+            )
     missing_builders = tuple(
         builder
         for builder in policy.required_warm_builders
@@ -1214,6 +1310,7 @@ def evaluate_runner_host_hygiene(
         generated_cache_allocated_bytes=observation.generated_cache_allocated_bytes,
         generated_cache_usage=observation.generated_cache_usage,
         cache_class_telemetry=cache_class_telemetry,
+        idle_convergences=observation.idle_convergences,
         docker_toolchain=observation.docker_toolchain,
         warm_builders=observation.warm_builders,
         image_inventory=observation.image_inventory,
@@ -1485,6 +1582,7 @@ def plan_runner_host_hygiene_apply(
                 ),
             )
         )
+    blockers.extend(_idle_convergence_blockers(policy=policy, request=request, report=report))
     blockers.extend(_target_volume_blockers(policy=policy, request=request, report=report))
     blockers.extend(_target_builder_blockers(policy=policy, request=request))
     blockers.extend(_target_generated_cache_blockers(policy=policy, request=request, report=report))
@@ -1502,6 +1600,108 @@ def plan_runner_host_hygiene_apply(
             "runner host hygiene apply plan is ready"
             if status == "ready"
             else "runner host hygiene apply plan is blocked"
+        ),
+    )
+
+
+def _idle_convergence_blockers(
+    *,
+    policy: RunnerHostHygieneApplyPolicy,
+    request: RunnerHostHygieneApplyRequest,
+    report: RunnerHostHygieneReport,
+) -> tuple[RunnerHostHygieneApplyBlocker, ...]:
+    if not policy.require_idle_convergence:
+        return ()
+    matching = tuple(
+        convergence
+        for convergence in report.idle_convergences
+        if convergence.scope == request.idle_scope
+        and convergence.scope_key == request.idle_scope_key
+    )
+    if not matching:
+        code: RunnerHostHygieneApplyBlockerCode = (
+            "idle_evidence_scope_mismatch" if report.idle_convergences else "idle_evidence_missing"
+        )
+        return (
+            _apply_blocker(
+                code,
+                (
+                    "runner host hygiene apply lacks idle evidence for scope: "
+                    f"{request.idle_scope}/{request.idle_scope_key}"
+                ),
+            ),
+        )
+    if len(matching) != 1:
+        return (
+            _apply_blocker(
+                "idle_evidence_scope_mismatch",
+                "runner host hygiene apply found duplicate idle evidence for its scope",
+            ),
+        )
+    convergence = matching[0]
+    expected_sources: set[RunnerHostHygieneIdleSource] = (
+        {"github_jobs", "github_runners", "local_processes", "runner_services"}
+        if request.idle_scope == "full_host"
+        else {"github_jobs", "local_user_processes", "open_handles"}
+    )
+    requirements_by_source = {
+        source: tuple(
+            requirement for requirement in convergence.requirements if requirement.source == source
+        )
+        for source in expected_sources
+    }
+    temporal_sources = (
+        expected_sources
+        if request.idle_scope == "full_host"
+        else expected_sources - {"github_jobs", "github_runners"}
+    )
+    if (
+        convergence.minimum_observation_interval_seconds < request.idle_observation_interval_seconds
+        or convergence.maximum_evidence_age_seconds > request.idle_max_age_seconds
+        or any(not requirements_by_source[source] for source in expected_sources)
+        or any(
+            requirement.minimum_observation_count < request.idle_observation_count
+            for source in temporal_sources
+            for requirement in requirements_by_source[source]
+        )
+    ):
+        return (
+            _apply_blocker(
+                "idle_evidence_not_converged",
+                "runner host hygiene idle evidence does not meet the requested policy window",
+            ),
+        )
+    if not request.idle_decision_at:
+        return (
+            _apply_blocker(
+                "idle_evidence_stale",
+                "runner host hygiene apply requires an idle evidence decision timestamp",
+            ),
+        )
+    decision_at = _parse_timestamp(request.idle_decision_at)
+    convergence_evaluated_at = _parse_timestamp(convergence.evaluated_at)
+    evidence_age_seconds = (decision_at - convergence_evaluated_at).total_seconds()
+    if evidence_age_seconds < 0 or evidence_age_seconds > request.idle_max_age_seconds:
+        return (
+            _apply_blocker(
+                "idle_evidence_stale",
+                "runner host hygiene idle evidence is stale at the apply decision",
+            ),
+        )
+    if convergence.status == "idle":
+        return ()
+    blocker_code: RunnerHostHygieneApplyBlockerCode = (
+        "idle_evidence_stale"
+        if "source_stale" in convergence.blocker_codes
+        else "idle_evidence_not_converged"
+    )
+    return (
+        _apply_blocker(
+            blocker_code,
+            (
+                "runner host hygiene idle evidence did not converge: "
+                f"{request.idle_scope}/{request.idle_scope_key} status={convergence.status}"
+            ),
         ),
     )
 
@@ -2079,6 +2279,16 @@ def _sorted_volume_inventory(
     return tuple(sorted(values, key=lambda item: (item.name, item.driver)))
 
 
+def _sorted_idle_convergences(
+    values: tuple[RunnerHostHygieneIdleConvergence, ...],
+) -> tuple[RunnerHostHygieneIdleConvergence, ...]:
+    sorted_values = tuple(sorted(values, key=lambda item: (item.scope, item.scope_key)))
+    keys = tuple((item.scope, item.scope_key) for item in sorted_values)
+    if len(set(keys)) != len(keys):
+        raise ValueError("runner host hygiene idle convergences must be unique")
+    return sorted_values
+
+
 def _sorted_cache_class_telemetry(
     values: tuple[RunnerHostHygieneCacheClassTelemetry, ...],
 ) -> tuple[RunnerHostHygieneCacheClassTelemetry, ...]:
@@ -2137,6 +2347,23 @@ def _normalized_public_token(value: str) -> str:
 
 def _required_public_token(value: str, message: str) -> str:
     return _required_text(_normalized_public_token(value), message)
+
+
+def _normalized_optional_timestamp(value: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        return ""
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError("value must be a timezone-aware timestamp") from error
+    if parsed.tzinfo is None:
+        raise ValueError("value must be a timezone-aware timestamp")
+    return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def _sanitized_unavailable_reason(value: str) -> str:

--- a/control_plane/contracts/runner_host_hygiene_idle.py
+++ b/control_plane/contracts/runner_host_hygiene_idle.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+RunnerHostHygieneEvidenceAvailability = Literal[
+    "available",
+    "partial",
+    "unavailable",
+    "stale",
+]
+RunnerHostHygieneIdleScope = Literal["full_host", "isolated_user", "isolated_lane"]
+RunnerHostHygieneIdleSource = Literal[
+    "github_jobs",
+    "github_runners",
+    "local_processes",
+    "local_user_processes",
+    "runner_services",
+    "open_handles",
+]
+RunnerHostHygieneIdleState = Literal["idle", "active", "unknown"]
+RunnerHostHygieneIdleConvergenceStatus = Literal[
+    "idle",
+    "active",
+    "incomplete",
+    "conflicting",
+]
+RunnerHostHygieneIdleBlockerCode = Literal[
+    "observation_count_insufficient",
+    "observation_time_invalid",
+    "observation_window_too_short",
+    "source_active",
+    "source_conflicting",
+    "source_missing",
+    "source_stale",
+    "source_truncated",
+    "source_unauthorized",
+    "source_unavailable",
+]
+
+
+class RunnerHostHygieneIdleSourceRequirement(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: RunnerHostHygieneIdleSource
+    subject_key: str
+    minimum_observation_count: int = Field(default=2, ge=1, le=10)
+
+    @model_validator(mode="after")
+    def _normalize_requirement(self) -> "RunnerHostHygieneIdleSourceRequirement":
+        self.subject_key = _required_public_token(
+            self.subject_key,
+            "runner host hygiene idle source requirement requires subject_key",
+        )
+        return self
+
+
+class RunnerHostHygieneIdleObservation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: RunnerHostHygieneIdleSource
+    scope: RunnerHostHygieneIdleScope
+    scope_key: str
+    subject_key: str
+    observed_at: str
+    availability: RunnerHostHygieneEvidenceAvailability
+    state: RunnerHostHygieneIdleState
+    sample_count: int = Field(default=1, ge=1, le=10)
+    observation_window_seconds: int = Field(default=0, ge=0, le=36_000)
+    active_count: int | None = Field(default=None, ge=0)
+    total_count: int | None = Field(default=None, ge=0)
+    truncated: bool = False
+    reason_code: str = ""
+
+    @model_validator(mode="after")
+    def _normalize_observation(self) -> "RunnerHostHygieneIdleObservation":
+        self.scope_key = _required_public_token(
+            self.scope_key,
+            "runner host hygiene idle observation requires scope_key",
+        )
+        self.subject_key = _required_public_token(
+            self.subject_key,
+            "runner host hygiene idle observation requires subject_key",
+        )
+        self.observed_at = _normalized_timestamp(
+            self.observed_at,
+            "runner host hygiene idle observation requires timezone-aware observed_at",
+        )
+        self.reason_code = _normalized_public_token(self.reason_code)
+        if (
+            self.active_count is not None
+            and self.total_count is not None
+            and self.active_count > self.total_count
+        ):
+            raise ValueError("runner host hygiene idle active_count cannot exceed total_count")
+        if self.availability == "available":
+            if self.state == "unknown" or self.active_count is None:
+                raise ValueError("available idle observation requires a measured state and count")
+            if self.truncated or self.reason_code:
+                raise ValueError(
+                    "available idle observation cannot be truncated or include reason_code"
+                )
+            if self.state == "idle" and self.active_count != 0:
+                raise ValueError("idle observation requires active_count=0")
+            if self.state == "active" and self.active_count <= 0:
+                raise ValueError("active observation requires a positive active_count")
+        else:
+            if self.state != "unknown" or not self.reason_code:
+                raise ValueError(
+                    "incomplete idle observation requires unknown state and reason_code"
+                )
+            if self.availability in {"unavailable", "stale"} and (
+                self.active_count is not None or self.total_count is not None
+            ):
+                raise ValueError("unavailable idle observation cannot include measured counts")
+            if self.truncated and self.availability != "partial":
+                raise ValueError("truncated idle observation must be partial")
+        if self.sample_count == 1 and self.observation_window_seconds != 0:
+            raise ValueError("single idle observation cannot include an observation window")
+        return self
+
+
+class RunnerHostHygieneIdleConvergence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    scope: RunnerHostHygieneIdleScope
+    scope_key: str
+    evaluated_at: str
+    minimum_observation_interval_seconds: int = Field(ge=1, le=3600)
+    maximum_evidence_age_seconds: int = Field(default=300, ge=1, le=86_400)
+    requirements: tuple[RunnerHostHygieneIdleSourceRequirement, ...]
+    observations: tuple[RunnerHostHygieneIdleObservation, ...]
+    status: RunnerHostHygieneIdleConvergenceStatus = "incomplete"
+    blocker_codes: tuple[RunnerHostHygieneIdleBlockerCode, ...] = ()
+
+    @model_validator(mode="after")
+    def _normalize_convergence(self) -> "RunnerHostHygieneIdleConvergence":
+        self.scope_key = _required_public_token(
+            self.scope_key,
+            "runner host hygiene idle convergence requires scope_key",
+        )
+        self.evaluated_at = _normalized_timestamp(
+            self.evaluated_at,
+            "runner host hygiene idle convergence requires timezone-aware evaluated_at",
+        )
+        if not self.requirements or len(self.requirements) > 256:
+            raise ValueError("runner host hygiene idle convergence requires bounded sources")
+        if not self.observations or len(self.observations) > 512:
+            raise ValueError("runner host hygiene idle convergence requires bounded observations")
+        self.requirements = tuple(
+            sorted(self.requirements, key=lambda item: (item.source, item.subject_key))
+        )
+        requirement_keys = tuple(
+            (requirement.source, requirement.subject_key) for requirement in self.requirements
+        )
+        if len(set(requirement_keys)) != len(requirement_keys):
+            raise ValueError("runner host hygiene idle requirements must be unique")
+        for observation in self.observations:
+            if observation.scope != self.scope or observation.scope_key != self.scope_key:
+                raise ValueError(
+                    "runner host hygiene idle observation scope must match convergence"
+                )
+            if (observation.source, observation.subject_key) not in requirement_keys:
+                raise ValueError("runner host hygiene idle observation requires a matching source")
+        self.observations = tuple(
+            sorted(
+                self.observations,
+                key=lambda item: (item.source, item.subject_key),
+            )
+        )
+        observation_keys = tuple(
+            (observation.source, observation.subject_key) for observation in self.observations
+        )
+        if len(set(observation_keys)) != len(observation_keys):
+            raise ValueError("runner host hygiene idle observations must be unique")
+        self.status, self.blocker_codes = _evaluate_convergence(self)
+        return self
+
+
+def build_runner_host_hygiene_idle_convergence(
+    *,
+    scope: RunnerHostHygieneIdleScope,
+    scope_key: str,
+    evaluated_at: str,
+    minimum_observation_interval_seconds: int,
+    maximum_evidence_age_seconds: int,
+    requirements: tuple[RunnerHostHygieneIdleSourceRequirement, ...],
+    observations: tuple[RunnerHostHygieneIdleObservation, ...],
+) -> RunnerHostHygieneIdleConvergence:
+    return RunnerHostHygieneIdleConvergence(
+        scope=scope,
+        scope_key=scope_key,
+        evaluated_at=evaluated_at,
+        minimum_observation_interval_seconds=minimum_observation_interval_seconds,
+        maximum_evidence_age_seconds=maximum_evidence_age_seconds,
+        requirements=requirements,
+        observations=observations,
+    )
+
+
+def _evaluate_convergence(
+    convergence: RunnerHostHygieneIdleConvergence,
+) -> tuple[
+    RunnerHostHygieneIdleConvergenceStatus,
+    tuple[RunnerHostHygieneIdleBlockerCode, ...],
+]:
+    evaluated_at = _parse_timestamp(convergence.evaluated_at)
+    blockers: set[RunnerHostHygieneIdleBlockerCode] = set()
+    has_active = False
+    has_conflict = False
+    for requirement in convergence.requirements:
+        observations = tuple(
+            observation
+            for observation in convergence.observations
+            if observation.source == requirement.source
+            and observation.subject_key == requirement.subject_key
+        )
+        if not observations:
+            blockers.add("source_missing")
+            continue
+        if len(observations) != 1:
+            blockers.add("source_conflicting")
+            has_conflict = True
+            continue
+        observation = observations[0]
+        if observation.sample_count < requirement.minimum_observation_count:
+            blockers.add("observation_count_insufficient")
+        timestamp = _parse_timestamp(observation.observed_at)
+        if timestamp > evaluated_at:
+            blockers.add("observation_time_invalid")
+        if (evaluated_at - timestamp).total_seconds() > (convergence.maximum_evidence_age_seconds):
+            blockers.add("source_stale")
+        required_window = (
+            requirement.minimum_observation_count - 1
+        ) * convergence.minimum_observation_interval_seconds
+        if observation.observation_window_seconds < required_window:
+            blockers.add("observation_window_too_short")
+        if observation.state == "active":
+            blockers.add("source_active")
+            has_active = True
+        if observation.truncated:
+            blockers.add("source_truncated")
+        if observation.reason_code == "source_contradictory":
+            blockers.add("source_conflicting")
+            has_conflict = True
+        elif observation.reason_code == "source_unauthorized":
+            blockers.add("source_unauthorized")
+        elif observation.reason_code == "source_missing":
+            blockers.add("source_missing")
+        elif observation.reason_code == "source_truncated":
+            blockers.add("source_truncated")
+        elif observation.reason_code == "source_stale":
+            blockers.add("source_stale")
+        elif observation.availability == "stale":
+            blockers.add("source_stale")
+        elif observation.availability == "partial":
+            blockers.add("source_truncated" if observation.truncated else "source_unavailable")
+        elif observation.availability == "unavailable":
+            blockers.add("source_unavailable")
+    if has_conflict:
+        status: RunnerHostHygieneIdleConvergenceStatus = "conflicting"
+    elif has_active:
+        status = "active"
+    elif blockers:
+        status = "incomplete"
+    else:
+        status = "idle"
+    return status, tuple(sorted(blockers))
+
+
+def _normalized_timestamp(value: str, message: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(message)
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(message) from error
+    if parsed.tzinfo is None:
+        raise ValueError(message)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def _normalized_public_token(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized and not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", normalized):
+        raise ValueError("value must be a public-safe token")
+    return normalized
+
+
+def _required_public_token(value: str, message: str) -> str:
+    normalized = _normalized_public_token(value)
+    if not normalized:
+        raise ValueError(message)
+    return normalized

--- a/control_plane/http_routes/runner_host_hygiene.py
+++ b/control_plane/http_routes/runner_host_hygiene.py
@@ -10,6 +10,9 @@ from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAu
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditStatus
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneCacheClassTelemetry
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
+from control_plane.contracts.runner_host_hygiene_idle import (
+    RunnerHostHygieneIdleConvergence,
+)
 from control_plane.http_routes.support import (
     LAUNCHPLANE_SERVICE_CONTEXT,
     ApiRouteRegistrar,
@@ -37,6 +40,7 @@ class RunnerHostHygieneReportReadModel(BaseModel):
     generated_cache_apparent_bytes: int
     generated_cache_allocated_bytes: int
     cache_class_telemetry: tuple[RunnerHostHygieneCacheClassTelemetry, ...]
+    idle_convergences: tuple[RunnerHostHygieneIdleConvergence, ...]
     image_inventory_total_count: int
     image_inventory_truncated: bool
     volume_inventory_total_count: int
@@ -186,6 +190,7 @@ def _report_read_model(report: RunnerHostHygieneReport) -> RunnerHostHygieneRepo
         generated_cache_apparent_bytes=report.generated_cache_apparent_bytes,
         generated_cache_allocated_bytes=report.generated_cache_allocated_bytes,
         cache_class_telemetry=report.cache_class_telemetry,
+        idle_convergences=report.idle_convergences,
         image_inventory_total_count=report.image_inventory_total_count,
         image_inventory_truncated=report.image_inventory_truncated,
         volume_inventory_total_count=report.volume_inventory_total_count,

--- a/control_plane/workflows/runner_host_hygiene_audit_spool.py
+++ b/control_plane/workflows/runner_host_hygiene_audit_spool.py
@@ -28,6 +28,7 @@ class RunnerHostHygieneAuditSpool:
         *,
         planned_audit: RunnerHostHygieneApplyAuditRecord,
         planned_idempotency_key: str,
+        executor_intent_sha256: str = "",
     ) -> RunnerHostHygieneAuditDeliveryEnvelope:
         existing = self.read(
             host_name=planned_audit.request.host_name,
@@ -38,6 +39,7 @@ class RunnerHostHygieneAuditSpool:
             if (
                 existing.planned_audit != planned_audit
                 or existing.planned_idempotency_key != planned_idempotency_key
+                or existing.executor_intent_sha256 != executor_intent_sha256
             ):
                 raise click.ClickException(
                     "runner host hygiene audit spool key already exists with different intent"
@@ -45,11 +47,13 @@ class RunnerHostHygieneAuditSpool:
             return existing
         timestamp = utc_now_timestamp()
         envelope = RunnerHostHygieneAuditDeliveryEnvelope(
+            schema_version=2 if executor_intent_sha256 else 1,
             host_name=planned_audit.request.host_name,
             action=planned_audit.request.action,
             audit_record_key=planned_audit.audit_record_key,
             planned_audit=planned_audit,
             planned_idempotency_key=planned_idempotency_key,
+            executor_intent_sha256=executor_intent_sha256,
             created_at=timestamp,
             updated_at=timestamp,
         )

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -83,6 +83,8 @@ _GITHUB_ACTIVE_WORKFLOW_RUN_STATUSES = (
     "pending",
     "requested",
 )
+_GITHUB_ACTIVE_JOB_STATUSES = frozenset(("queued", "in_progress", "waiting", "pending"))
+_GITHUB_KNOWN_JOB_STATUSES = _GITHUB_ACTIVE_JOB_STATUSES | {"completed"}
 HOST_LOCK_PATH = "/tmp/launchplane-runner-host-hygiene.lock"
 _BUILDCTL_STORAGE_MB_BYTES = 1_000_000
 _RUNNER_WORKDIR_USAGE_HELPER = "/usr/local/sbin/launchplane-runner-workdir-usage"
@@ -1552,10 +1554,9 @@ def _read_github_idle_sample(
     observations: list[RunnerHostHygieneIdleObservation] = []
     for binding in request.github_idle_bindings:
         subject_key = _github_binding_subject_key(binding)
-        is_current_binding = (
+        is_current_repository_lane = (
             binding.repository_scope == request.repository_scope.lower()
             and binding.execution_lane == request.execution_lane.lower()
-            and binding.runner_name == request.current_runner_name
         )
         if github_idle_evidence_reader is None:
             returned: tuple[RunnerHostHygieneIdleObservation, ...] = ()
@@ -1566,7 +1567,7 @@ def _read_github_idle_sample(
                     binding.repository_scope,
                     binding.execution_lane,
                     binding.runner_name,
-                    is_current_binding,
+                    is_current_repository_lane,
                 )
                 unavailable_reason = "source_missing"
             except (OSError, ValueError):
@@ -2068,12 +2069,15 @@ def build_github_idle_evidence_reader(
         repository: str,
         execution_lane: str,
         runner_name: str = "",
-        exclude_current: bool = False,
+        exclude_current_job: bool = False,
     ) -> tuple[RunnerHostHygieneIdleObservation, ...]:
         owner, name = repository.split("/", maxsplit=1)
         observed_at = utc_now_timestamp()
         effective_runner_name = runner_name.strip() or normalized_runner_name
-        effective_exclude_current = exclude_current or not runner_name.strip()
+        effective_exclude_current_job = exclude_current_job or not runner_name.strip()
+        exclude_current_runner = (
+            effective_exclude_current_job and effective_runner_name == normalized_runner_name
+        )
         subject_key = _public_identity_key(
             "runner",
             "|".join(
@@ -2092,7 +2096,8 @@ def build_github_idle_evidence_reader(
             execution_lane=execution_lane,
             bearer_token=normalized_token,
             current_run_id=current_run_id,
-            exclude_current_run=effective_exclude_current,
+            current_runner_name=normalized_runner_name,
+            exclude_current_job=effective_exclude_current_job,
             subject_key=subject_key,
             observed_at=observed_at,
         )
@@ -2101,7 +2106,7 @@ def build_github_idle_evidence_reader(
             execution_lane=execution_lane,
             bearer_token=normalized_token,
             runner_name=effective_runner_name,
-            exclude_current_runner=effective_exclude_current,
+            exclude_current_runner=exclude_current_runner,
             subject_key=subject_key,
             observed_at=observed_at,
         )
@@ -2116,11 +2121,12 @@ def _github_jobs_idle_observation(
     execution_lane: str,
     bearer_token: str,
     current_run_id: int | None,
-    exclude_current_run: bool,
+    current_runner_name: str,
+    exclude_current_job: bool,
     subject_key: str,
     observed_at: str,
 ) -> RunnerHostHygieneIdleObservation:
-    if exclude_current_run and current_run_id is None:
+    if exclude_current_job and (current_run_id is None or not current_runner_name):
         return _unavailable_idle_observation(
             source="github_jobs",
             scope="full_host",
@@ -2178,8 +2184,16 @@ def _github_jobs_idle_observation(
                     reason_code="source_contradictory",
                 )
             run_id = workflow_run.get("id")
-            if isinstance(run_id, int) and (not exclude_current_run or run_id != current_run_id):
-                active_run_ids.add(run_id)
+            if not isinstance(run_id, int) or run_id <= 0:
+                return _unavailable_idle_observation(
+                    source="github_jobs",
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=observed_at,
+                    reason_code="source_contradictory",
+                )
+            active_run_ids.add(run_id)
     if len(active_run_ids) > MAX_GITHUB_IDLE_ACTIVE_RUNS:
         return _partial_idle_observation(
             source="github_jobs",
@@ -2195,6 +2209,7 @@ def _github_jobs_idle_observation(
     normalized_lane = execution_lane.strip().lower()
     active_jobs = 0
     observed_jobs = 0
+    current_job_observed = False
     for run_id in sorted(active_run_ids):
         payload, reason_code = _github_api_object(
             url=f"{repository_url}/actions/runs/{run_id}/jobs?filter=latest&per_page=100",
@@ -2242,6 +2257,33 @@ def _github_jobs_idle_observation(
                     observed_at=observed_at,
                     reason_code="source_contradictory",
                 )
+            job_status = job.get("status")
+            if not isinstance(job_status, str) or job_status not in _GITHUB_KNOWN_JOB_STATUSES:
+                return _unavailable_idle_observation(
+                    source="github_jobs",
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=observed_at,
+                    reason_code="source_contradictory",
+                )
+            job_runner_name = job.get("runner_name")
+            if job_runner_name is not None and not isinstance(job_runner_name, str):
+                return _unavailable_idle_observation(
+                    source="github_jobs",
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=observed_at,
+                    reason_code="source_contradictory",
+                )
+            if (
+                exclude_current_job
+                and run_id == current_run_id
+                and job_runner_name == current_runner_name
+            ):
+                current_job_observed = True
+                continue
             labels = job.get("labels")
             if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
                 return _unavailable_idle_observation(
@@ -2256,8 +2298,17 @@ def _github_jobs_idle_observation(
             if "self-hosted" not in normalized_labels or normalized_lane not in normalized_labels:
                 continue
             observed_jobs += 1
-            if job.get("status") in {"queued", "in_progress", "waiting", "pending"}:
+            if job_status in _GITHUB_ACTIVE_JOB_STATUSES:
                 active_jobs += 1
+    if exclude_current_job and not current_job_observed:
+        return _unavailable_idle_observation(
+            source="github_jobs",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            reason_code="source_missing",
+        )
     return RunnerHostHygieneIdleObservation(
         source="github_jobs",
         scope="full_host",

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -76,6 +76,13 @@ MINIMUM_DEFAULT_CACHE_KEEP_STORAGE_BYTES = 8 * 1024**3
 MAX_DOCKER_IMAGE_INVENTORY_ITEMS = RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS
 MAX_DOCKER_VOLUME_INVENTORY_ITEMS = RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS
 MAX_GITHUB_IDLE_ACTIVE_RUNS = 32
+_GITHUB_ACTIVE_WORKFLOW_RUN_STATUSES = (
+    "queued",
+    "in_progress",
+    "waiting",
+    "pending",
+    "requested",
+)
 HOST_LOCK_PATH = "/tmp/launchplane-runner-host-hygiene.lock"
 _BUILDCTL_STORAGE_MB_BYTES = 1_000_000
 _RUNNER_WORKDIR_USAGE_HELPER = "/usr/local/sbin/launchplane-runner-workdir-usage"
@@ -2123,7 +2130,7 @@ def _github_jobs_idle_observation(
             reason_code="source_missing",
         )
     active_run_ids: set[int] = set()
-    for status in ("queued", "in_progress"):
+    for status in _GITHUB_ACTIVE_WORKFLOW_RUN_STATUSES:
         payload, reason_code = _github_api_object(
             url=f"{repository_url}/actions/runs?status={status}&per_page=100",
             bearer_token=bearer_token,
@@ -2451,14 +2458,43 @@ def build_refreshing_service_audit_poster(
                 _redact_sensitive_text(str(error) or "Launchplane service request failed"),
                 retryable=True,
             ) from error
-        if not isinstance(response_payload, dict):
+        except (UnicodeDecodeError, json.JSONDecodeError) as error:
             raise AuditDeliveryError(
-                "Launchplane service returned a non-object response.",
+                "Launchplane service returned an invalid audit acceptance response.",
                 retryable=False,
-            )
-        return response_payload
+            ) from error
+        return _validated_audit_acceptance_response(response_payload, audit=audit)
 
     return post
+
+
+def _validated_audit_acceptance_response(
+    response_payload: object,
+    *,
+    audit: RunnerHostHygieneApplyAuditRecord,
+) -> dict[str, object]:
+    if not isinstance(response_payload, dict):
+        raise AuditDeliveryError(
+            "Launchplane service returned a non-object audit acceptance response.",
+            retryable=False,
+        )
+    records = response_payload.get("records")
+    result = response_payload.get("result")
+    expected_key = audit.audit_record_key
+    if (
+        response_payload.get("status") != "accepted"
+        or not isinstance(records, dict)
+        or records.get("runner_host_hygiene_audit_record_key") != expected_key
+        or not isinstance(result, dict)
+        or result.get("runner_host_hygiene_audit_record_key") != expected_key
+        or result.get("audit_status") != audit.status
+        or result.get("mutate") is not audit.request.mutate
+    ):
+        raise AuditDeliveryError(
+            "Launchplane service returned a mismatched audit acceptance response.",
+            retryable=False,
+        )
+    return response_payload
 
 
 def _audit_route_payload(audit: RunnerHostHygieneApplyAuditRecord) -> dict[str, object]:

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -2184,7 +2184,8 @@ def _github_jobs_idle_observation(
                     reason_code="source_contradictory",
                 )
             run_id = workflow_run.get("id")
-            if not isinstance(run_id, int) or run_id <= 0:
+            workflow_run_status = workflow_run.get("status")
+            if not isinstance(run_id, int) or run_id <= 0 or workflow_run_status != status:
                 return _unavailable_idle_observation(
                     source="github_jobs",
                     scope="full_host",

--- a/control_plane/workflows/runner_host_hygiene_executor.py
+++ b/control_plane/workflows/runner_host_hygiene_executor.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from decimal import Decimal
 from decimal import InvalidOperation
+import hashlib
 import json
 import os
 import posixpath
@@ -53,6 +55,14 @@ from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene
 from control_plane.contracts.runner_host_hygiene import (
     sanitize_runner_host_hygiene_audit_record_for_persistence,
 )
+from control_plane.contracts.runner_host_hygiene_idle import (
+    RunnerHostHygieneIdleConvergence,
+    RunnerHostHygieneIdleObservation,
+    RunnerHostHygieneIdleScope,
+    RunnerHostHygieneIdleSource,
+    RunnerHostHygieneIdleSourceRequirement,
+    build_runner_host_hygiene_idle_convergence,
+)
 from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.workflows.runner_host_hygiene_audit_spool import (
     RunnerHostHygieneAuditSpool,
@@ -65,6 +75,7 @@ MINIMUM_PRUNE_UNTIL_HOURS = 168
 MINIMUM_DEFAULT_CACHE_KEEP_STORAGE_BYTES = 8 * 1024**3
 MAX_DOCKER_IMAGE_INVENTORY_ITEMS = RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS
 MAX_DOCKER_VOLUME_INVENTORY_ITEMS = RUNNER_HOST_HYGIENE_MAX_DOCKER_INVENTORY_ITEMS
+MAX_GITHUB_IDLE_ACTIVE_RUNS = 32
 HOST_LOCK_PATH = "/tmp/launchplane-runner-host-hygiene.lock"
 _BUILDCTL_STORAGE_MB_BYTES = 1_000_000
 _RUNNER_WORKDIR_USAGE_HELPER = "/usr/local/sbin/launchplane-runner-workdir-usage"
@@ -90,6 +101,12 @@ _ACTIVE_WORK_COMMAND = (
     "'[d]ocker buildx|[d]ocker build|[b]uildctl|[R]unner.Worker') || status=$?; "
     'if [ "$status" -gt 1 ]; then exit "$status"; fi; '
     "printf '%s\\n' \"$output\""
+)
+_RUNNER_SERVICE_STATE_COMMAND = (
+    "command -v systemctl >/dev/null 2>&1 || exit 127; "
+    "systemctl list-units --type=service --all --no-legend --plain "
+    "'launchplane-runner@*.service' 'actions.runner.*.service' | "
+    'awk \'{print $1 " " $3 " " $4}\''
 )
 _DOCKER_SIZE_UNITS = {
     "b": Decimal(1),
@@ -156,12 +173,24 @@ AuditPoster = Callable[[RunnerHostHygieneApplyAuditRecord, str], dict[str, objec
 BearerTokenProvider = Callable[[], str]
 AuditDeliverySleeper = Callable[[float], None]
 GitHubRunStateReader = Callable[[str, tuple[int, ...]], Mapping[int, str]]
+GitHubIdleEvidenceReader = Callable[
+    [str, str, str, bool],
+    tuple[RunnerHostHygieneIdleObservation, ...],
+]
 
 
 @dataclass(frozen=True)
 class RunnerWorkdirRoot:
     key: str
     path: str
+
+
+@dataclass(frozen=True)
+class RunnerHostGitHubBinding:
+    repository_scope: str
+    execution_lane: str
+    runner_name: str
+    service_unit: str
 
 
 @dataclass(frozen=True)
@@ -173,6 +202,8 @@ class GeneratedRunCacheRoot:
     low_water_bytes: int
     minimum_age_hours: int
     cooldown_hours: int
+    idle_scope: RunnerHostHygieneIdleScope = "isolated_user"
+    idle_scope_key: str = ""
 
 
 class AuditDeliveryError(click.ClickException):
@@ -192,6 +223,8 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
     repository_scope: str
     audit_record_key: str
     retained_warm_builders: tuple[str, ...]
+    current_runner_name: str = ""
+    github_idle_bindings: tuple[RunnerHostGitHubBinding, ...] = ()
     mutate: bool = False
     minimum_free_disk_bytes: int = Field(default=0, ge=0)
     timeout_seconds: int = Field(default=120, ge=1)
@@ -201,7 +234,8 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
     target_generated_cache_key: str = ""
     target_generated_cache_run_ids: tuple[int, ...] = ()
     idle_observation_count: int = Field(default=2, ge=2, le=10)
-    idle_observation_interval_seconds: int = Field(default=5, ge=0, le=60)
+    idle_observation_interval_seconds: int = Field(default=5, ge=1, le=60)
+    idle_max_age_seconds: int = Field(default=300, ge=1, le=86_400)
     resolve_action_started: bool = False
     target_buildkit_builder: str = ""
     allowed_buildkit_builders: tuple[str, ...] = ()
@@ -237,6 +271,54 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
             self.audit_record_key,
             self.prune_until,
         )
+        self.current_runner_name = self.current_runner_name.strip()
+        normalized_bindings: list[RunnerHostGitHubBinding] = []
+        seen_binding_keys: set[tuple[str, str, str]] = set()
+        seen_service_units: set[str] = set()
+        for binding in self.github_idle_bindings:
+            repository_scope = binding.repository_scope.strip().lower()
+            execution_lane = binding.execution_lane.strip().lower()
+            runner_name = binding.runner_name.strip()
+            service_unit = binding.service_unit.strip()
+            if not re.fullmatch(r"[a-z0-9_.-]+/[a-z0-9_.-]+", repository_scope):
+                raise ValueError("runner host GitHub binding repository must use owner/name")
+            if not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,127}", execution_lane):
+                raise ValueError("runner host GitHub binding execution lane must be public-safe")
+            if (
+                not runner_name
+                or len(runner_name) > 255
+                or any(ord(character) < 32 for character in runner_name)
+            ):
+                raise ValueError("runner host GitHub binding requires a valid runner name")
+            if (
+                not service_unit.endswith(".service")
+                or len(service_unit) > 255
+                or re.search(r"[^A-Za-z0-9_.@-]", service_unit)
+            ):
+                raise ValueError("runner host GitHub binding requires a valid systemd service unit")
+            binding_key = (repository_scope, execution_lane, runner_name)
+            if binding_key in seen_binding_keys or service_unit in seen_service_units:
+                raise ValueError("runner host GitHub bindings must be unique")
+            seen_binding_keys.add(binding_key)
+            seen_service_units.add(service_unit)
+            normalized_bindings.append(
+                RunnerHostGitHubBinding(
+                    repository_scope=repository_scope,
+                    execution_lane=execution_lane,
+                    runner_name=runner_name,
+                    service_unit=service_unit,
+                )
+            )
+        self.github_idle_bindings = tuple(
+            sorted(
+                normalized_bindings,
+                key=lambda item: (
+                    item.repository_scope,
+                    item.execution_lane,
+                    item.runner_name,
+                ),
+            )
+        )
         self.retained_warm_builders = tuple(
             token.strip().lower() for token in self.retained_warm_builders if token.strip()
         )
@@ -269,6 +351,7 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
             key = generated_root.key.strip().lower()
             path = generated_root.path.strip().rstrip("/")
             source_repository = generated_root.source_repository.strip().lower()
+            idle_scope_key = (generated_root.idle_scope_key or key).strip().lower()
             if not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", key):
                 raise ValueError("generated run cache key must be a public-safe token")
             if (
@@ -281,6 +364,13 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
                 raise ValueError("generated run cache path must be a scoped absolute path")
             if not re.fullmatch(r"[a-z0-9_.-]+/[a-z0-9_.-]+", source_repository):
                 raise ValueError("generated run cache repository must use owner/name")
+            if generated_root.idle_scope != "isolated_user":
+                raise ValueError(
+                    "generated run cache idle scope must be isolated_user until "
+                    "lane-scoped process evidence is implemented"
+                )
+            if not re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,63}", idle_scope_key):
+                raise ValueError("generated run cache idle scope key must be public-safe")
             if (
                 generated_root.high_water_bytes <= 0
                 or generated_root.low_water_bytes >= generated_root.high_water_bytes
@@ -303,6 +393,8 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
                     low_water_bytes=generated_root.low_water_bytes,
                     minimum_age_hours=generated_root.minimum_age_hours,
                     cooldown_hours=generated_root.cooldown_hours,
+                    idle_scope=generated_root.idle_scope,
+                    idle_scope_key=idle_scope_key,
                 )
             )
         self.generated_run_cache_roots = tuple(
@@ -406,6 +498,26 @@ class RunnerHostHygieneExecutorRequest(BaseModel):
             raise ValueError("runner host hygiene executor requires service_user")
         if "/" not in self.repository_scope:
             raise ValueError("runner host hygiene executor requires repository_scope as owner/name")
+        current_bindings = tuple(
+            binding
+            for binding in self.github_idle_bindings
+            if binding.repository_scope == self.repository_scope.lower()
+            and binding.execution_lane == self.execution_lane.lower()
+            and binding.runner_name == self.current_runner_name
+        )
+        if self.github_idle_bindings and self.current_runner_name and len(current_bindings) != 1:
+            raise ValueError(
+                "runner host GitHub bindings must identify the current repository, lane, and runner"
+            )
+        if self.mutate and self.action != "prune_generated_run_cache":
+            if not self.github_idle_bindings:
+                raise ValueError(
+                    "shared Docker mutation requires a complete runner host GitHub binding manifest"
+                )
+            if not self.current_runner_name or len(current_bindings) != 1:
+                raise ValueError(
+                    "shared Docker mutation requires the current runner in the host binding manifest"
+                )
         if not self.audit_record_key:
             raise ValueError("runner host hygiene executor requires audit_record_key")
         if not self.retained_warm_builders:
@@ -442,6 +554,14 @@ def _strip_text_fields(*values: str) -> tuple[str, ...]:
     return tuple(value.strip() for value in values)
 
 
+def _executor_intent_sha256(request: RunnerHostHygieneExecutorRequest) -> str:
+    payload = request.model_dump(mode="json")
+    payload["resolve_action_started"] = False
+    payload["target_generated_cache_run_ids"] = []
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+
+
 def execute_runner_host_hygiene_executor(
     *,
     request: RunnerHostHygieneExecutorRequest,
@@ -450,10 +570,11 @@ def execute_runner_host_hygiene_executor(
     audit_spool: RunnerHostHygieneAuditSpool | None = None,
     audit_delivery_sleeper: AuditDeliverySleeper = time.sleep,
     github_run_state_reader: GitHubRunStateReader | None = None,
+    github_idle_evidence_reader: GitHubIdleEvidenceReader | None = None,
 ) -> RunnerHostHygieneExecutorResult:
-    if request.action == "prune_generated_run_cache" and request.mutate and audit_spool is None:
+    if request.mutate and audit_spool is None:
         raise click.ClickException(
-            "generated run cache mutation requires durable host-local audit delivery state"
+            "runner host hygiene mutation requires durable host-local audit delivery state"
         )
     if audit_spool is not None:
         reconciliation_result = _reconcile_audit_spool(
@@ -463,6 +584,7 @@ def execute_runner_host_hygiene_executor(
             audit_poster=audit_poster,
             audit_delivery_sleeper=audit_delivery_sleeper,
             github_run_state_reader=github_run_state_reader,
+            github_idle_evidence_reader=github_idle_evidence_reader,
         )
         if reconciliation_result is not None:
             return reconciliation_result
@@ -471,6 +593,8 @@ def execute_runner_host_hygiene_executor(
         request=request,
         remote_runner=remote_runner,
         github_run_state_reader=github_run_state_reader,
+        github_idle_evidence_reader=github_idle_evidence_reader,
+        idle_observation_sleeper=audit_delivery_sleeper,
     )
     if request.mutate:
         _assert_required_docker_telemetry_available(request=request, report=pre_report)
@@ -504,25 +628,35 @@ def execute_runner_host_hygiene_executor(
         generated_cache_cooldown_hours=(
             target_generated_cache.cooldown_hours if target_generated_cache else 0
         ),
+        idle_scope=(target_generated_cache.idle_scope if target_generated_cache else "full_host"),
+        idle_scope_key=(
+            target_generated_cache.idle_scope_key if target_generated_cache else "host"
+        ),
+        idle_observation_count=action_request.idle_observation_count,
+        idle_observation_interval_seconds=(action_request.idle_observation_interval_seconds),
+        idle_max_age_seconds=action_request.idle_max_age_seconds,
+        idle_decision_at=utc_now_timestamp(),
         audit_record_key=action_request.audit_record_key,
     )
-    apply_plan = plan_runner_host_hygiene_apply(
-        policy=RunnerHostHygieneApplyPolicy(
-            approved_hosts=(action_request.host_name,),
-            required_retained_warm_builders=action_request.retained_warm_builders,
-            require_healthy_report=False,
-            allow_docker_cache_prune=action_request.action == "prune_docker_cache",
-            allow_dangling_image_prune=action_request.action == "prune_dangling_images",
-            allow_generated_run_cache_prune=(action_request.action == "prune_generated_run_cache"),
-            allowed_generated_cache_keys=tuple(
-                root.key for root in action_request.generated_run_cache_roots
-            ),
-            allowed_buildkit_builders=action_request.allowed_buildkit_builders,
-            allow_buildkit_state_volume_remove=(
-                action_request.action == "remove_buildkit_state_volumes"
-            ),
-            allowed_buildkit_state_volumes=action_request.allowed_buildkit_state_volumes,
+    apply_policy = RunnerHostHygieneApplyPolicy(
+        approved_hosts=(action_request.host_name,),
+        required_retained_warm_builders=action_request.retained_warm_builders,
+        require_healthy_report=False,
+        require_idle_convergence=True,
+        allow_docker_cache_prune=action_request.action == "prune_docker_cache",
+        allow_dangling_image_prune=action_request.action == "prune_dangling_images",
+        allow_generated_run_cache_prune=(action_request.action == "prune_generated_run_cache"),
+        allowed_generated_cache_keys=tuple(
+            root.key for root in action_request.generated_run_cache_roots
         ),
+        allowed_buildkit_builders=action_request.allowed_buildkit_builders,
+        allow_buildkit_state_volume_remove=(
+            action_request.action == "remove_buildkit_state_volumes"
+        ),
+        allowed_buildkit_state_volumes=action_request.allowed_buildkit_state_volumes,
+    )
+    apply_plan = plan_runner_host_hygiene_apply(
+        policy=apply_policy,
         request=apply_request,
         report=pre_report,
     )
@@ -545,6 +679,7 @@ def execute_runner_host_hygiene_executor(
         audit_envelope = audit_spool.create(
             planned_audit=planned_audit,
             planned_idempotency_key=planned_idempotency_key,
+            executor_intent_sha256=_executor_intent_sha256(request),
         )
         audit_envelope, delivery_responses = _deliver_audit_envelope(
             envelope=audit_envelope,
@@ -614,29 +749,64 @@ def execute_runner_host_hygiene_executor(
             ),
         )
 
-    idle_result = None
-    if action_request.action != "prune_generated_run_cache":
-        idle_result = _check_host_idle(
-            request=action_request,
-            remote_runner=remote_runner,
-            sleeper=audit_delivery_sleeper,
-        )
-    if idle_result is not None:
-        post_report = _collect_terminal_report(
-            request=action_request,
-            remote_runner=remote_runner,
-            github_run_state_reader=github_run_state_reader,
-        )
+    pre_action_report = _collect_terminal_report(
+        request=action_request,
+        remote_runner=remote_runner,
+        github_run_state_reader=github_run_state_reader,
+        github_idle_evidence_reader=github_idle_evidence_reader,
+        idle_observation_sleeper=audit_delivery_sleeper,
+    )
+    if pre_action_report is None:
         terminal_message = (
-            f"runner host hygiene apply blocked by active runner or build processes: {idle_result}"
+            "runner host hygiene pre-action evidence collection failed; "
+            "host mutation was not executed"
         )
-        if post_report is None:
-            terminal_message += "; terminal evidence collection failed"
         terminal_audit = _terminal_audit(
             request=apply_request,
             apply_plan=apply_plan,
             pre_report=pre_report,
-            post_report=post_report,
+            post_report=None,
+            status="failed",
+            message=terminal_message,
+        )
+        _assert_generated_cache_audit_redacted(audit=terminal_audit, request=action_request)
+        terminal_response, audit_delivery_pending = _deliver_terminal_audit(
+            terminal_audit=terminal_audit,
+            audit_envelope=audit_envelope,
+            audit_spool=audit_spool,
+            audit_poster=audit_poster,
+            audit_delivery_sleeper=audit_delivery_sleeper,
+        )
+        return RunnerHostHygieneExecutorResult(
+            status="audit_delivery_pending" if audit_delivery_pending else "failed",
+            audit_record_key=request.audit_record_key,
+            planned_response=planned_response,
+            terminal_response=terminal_response,
+            audit_delivery_pending=audit_delivery_pending,
+            message=terminal_message,
+        )
+    final_apply_request = RunnerHostHygieneApplyRequest.model_validate(
+        {
+            **apply_request.model_dump(mode="python"),
+            "idle_decision_at": utc_now_timestamp(),
+        }
+    )
+    final_apply_plan = plan_runner_host_hygiene_apply(
+        policy=apply_policy,
+        request=final_apply_request,
+        report=pre_action_report,
+    )
+    if final_apply_plan.status != "ready":
+        blocker_codes = ",".join(blocker.code for blocker in final_apply_plan.blockers)
+        terminal_message = (
+            "runner host hygiene pre-action evidence no longer authorizes mutation: "
+            f"{blocker_codes}"
+        )
+        terminal_audit = _terminal_audit(
+            request=final_apply_request,
+            apply_plan=final_apply_plan,
+            pre_report=pre_action_report,
+            post_report=None,
             status="failed",
             message=terminal_message,
         )
@@ -657,15 +827,43 @@ def execute_runner_host_hygiene_executor(
             message=terminal_message,
         )
 
+    apply_request = final_apply_request
+    apply_plan = final_apply_plan
+    pre_report = pre_action_report
+
     if audit_envelope is not None and audit_spool is not None:
+        action_authorization = sanitize_runner_host_hygiene_audit_record_for_persistence(
+            RunnerHostHygieneApplyAuditRecord(
+                audit_record_key=request.audit_record_key,
+                status="planned",
+                request=apply_request,
+                plan=apply_plan,
+                pre_apply_report=pre_report,
+                message=(
+                    "fresh runner host hygiene pre-action authorization; "
+                    "no host mutation was executed yet"
+                ),
+            )
+        )
+        _assert_generated_cache_audit_redacted(
+            audit=action_authorization,
+            request=action_request,
+        )
         audit_envelope = audit_spool.write(
-            audit_envelope.model_copy(update={"execution_state": "action_started"})
+            audit_envelope.model_copy(
+                update={
+                    "execution_state": "action_started",
+                    "action_authorization": action_authorization,
+                }
+            )
         )
     action_result = _execute_apply_action(request=action_request, remote_runner=remote_runner)
     post_report = _collect_terminal_report(
         request=action_request,
         remote_runner=remote_runner,
         github_run_state_reader=github_run_state_reader,
+        github_idle_evidence_reader=github_idle_evidence_reader,
+        idle_observation_sleeper=audit_delivery_sleeper,
     )
     if post_report is None:
         terminal_status: RunnerHostHygieneApplyAuditStatus = "failed"
@@ -722,6 +920,7 @@ def _reconcile_audit_spool(
     audit_poster: AuditPoster,
     audit_delivery_sleeper: AuditDeliverySleeper,
     github_run_state_reader: GitHubRunStateReader | None,
+    github_idle_evidence_reader: GitHubIdleEvidenceReader | None,
 ) -> RunnerHostHygieneExecutorResult | None:
     for original_envelope in audit_spool.list_for(
         host_name=request.host_name,
@@ -751,15 +950,61 @@ def _reconcile_audit_spool(
                     else "runner host hygiene terminal audit delivery reconciled; action not repeated"
                 ),
             )
+        if is_current_request and envelope.execution_state == "planned":
+            terminal_message = (
+                "runner host hygiene previous execution stopped before action_started; "
+                "host mutation was not executed"
+            )
+            terminal_audit = _terminal_audit(
+                request=envelope.planned_audit.request,
+                apply_plan=envelope.planned_audit.plan,
+                pre_report=envelope.planned_audit.pre_apply_report,
+                post_report=None,
+                status="failed",
+                message=terminal_message,
+            )
+            _assert_generated_cache_audit_redacted(audit=terminal_audit, request=request)
+            terminal_response, delivery_pending = _deliver_terminal_audit(
+                terminal_audit=terminal_audit,
+                audit_envelope=envelope,
+                audit_spool=audit_spool,
+                audit_poster=audit_poster,
+                audit_delivery_sleeper=audit_delivery_sleeper,
+            )
+            return RunnerHostHygieneExecutorResult(
+                status="audit_delivery_pending" if delivery_pending else "failed",
+                audit_record_key=request.audit_record_key,
+                planned_response=delivery_responses.get("planned", {}),
+                terminal_response=terminal_response,
+                audit_delivery_pending=delivery_pending,
+                reconciled=not delivery_pending,
+                message=terminal_message,
+            )
         if (
             is_current_request
             and envelope.execution_state == "action_started"
             and request.resolve_action_started
         ):
+            if (
+                envelope.schema_version >= 2
+                and envelope.executor_intent_sha256 != _executor_intent_sha256(request)
+            ):
+                return RunnerHostHygieneExecutorResult(
+                    status="blocked",
+                    audit_record_key=request.audit_record_key,
+                    planned_response=delivery_responses.get("planned", {}),
+                    reconciled=False,
+                    message=(
+                        "runner host hygiene action_started recovery inputs do not match "
+                        "the durable executor intent; action was not repeated"
+                    ),
+                )
             post_report = _collect_terminal_report(
                 request=request,
                 remote_runner=remote_runner,
                 github_run_state_reader=github_run_state_reader,
+                github_idle_evidence_reader=github_idle_evidence_reader,
+                idle_observation_sleeper=audit_delivery_sleeper,
             )
             if post_report is None:
                 terminal_message = (
@@ -771,10 +1016,11 @@ def _reconcile_audit_spool(
                     "runner host hygiene previous execution stopped after action_started; "
                     "current post evidence was captured and the action was not repeated"
                 )
+            action_authorization = envelope.action_authorization or envelope.planned_audit
             terminal_audit = _terminal_audit(
-                request=envelope.planned_audit.request,
-                apply_plan=envelope.planned_audit.plan,
-                pre_report=envelope.planned_audit.pre_apply_report,
+                request=action_authorization.request,
+                apply_plan=action_authorization.plan,
+                pre_report=action_authorization.pre_apply_report,
                 post_report=post_report,
                 status="failed",
                 message=terminal_message,
@@ -1061,8 +1307,9 @@ def collect_runner_host_hygiene_report(
     request: RunnerHostHygieneExecutorRequest,
     remote_runner: RemoteCommandRunner,
     github_run_state_reader: GitHubRunStateReader | None = None,
+    github_idle_evidence_reader: GitHubIdleEvidenceReader | None = None,
+    idle_observation_sleeper: AuditDeliverySleeper = time.sleep,
 ) -> RunnerHostHygieneReport:
-    observed_at = utc_now_timestamp()
     df_result = _require_remote_success(
         remote_runner(("df", "-B1", "-P", "/"), request.timeout_seconds),
         evidence_name="df",
@@ -1118,6 +1365,25 @@ def collect_runner_host_hygiene_report(
         remote_runner=remote_runner,
         github_run_state_reader=github_run_state_reader,
     )
+    full_host_idle_convergence = (
+        _collect_full_host_idle_convergence(
+            request=request,
+            remote_runner=remote_runner,
+            github_idle_evidence_reader=github_idle_evidence_reader,
+            sleeper=idle_observation_sleeper,
+        )
+        if request.action != "prune_generated_run_cache"
+        else None
+    )
+    observed_at = utc_now_timestamp()
+    idle_convergences = (
+        *((full_host_idle_convergence,) if full_host_idle_convergence is not None else ()),
+        *(
+            usage.idle_convergence
+            for usage in generated_cache_usage
+            if usage.idle_convergence is not None
+        ),
+    )
     docker_cache_class_measurements = docker_disk_usage.cache_class_measurements
     if not image_inventory_available:
         docker_cache_class_measurements = _mark_docker_cache_class_measurement_partial(
@@ -1143,6 +1409,7 @@ def collect_runner_host_hygiene_report(
         generated_cache_apparent_bytes=sum(item.apparent_bytes for item in generated_cache_usage),
         generated_cache_allocated_bytes=sum(item.allocated_bytes for item in generated_cache_usage),
         generated_cache_usage=generated_cache_usage,
+        idle_convergences=idle_convergences,
         cache_class_telemetry=_docker_cache_class_telemetry(
             docker_cache_class_measurements,
             observed_at=observed_at,
@@ -1181,6 +1448,475 @@ def collect_runner_host_hygiene_report(
         ),
         observation=observation,
     )
+
+
+def _collect_full_host_idle_convergence(
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    remote_runner: RemoteCommandRunner,
+    github_idle_evidence_reader: GitHubIdleEvidenceReader | None,
+    sleeper: AuditDeliverySleeper,
+) -> RunnerHostHygieneIdleConvergence:
+    process_results: list[RemoteCommandResult] = []
+    service_results: list[RemoteCommandResult] = []
+    github_samples: list[tuple[RunnerHostHygieneIdleObservation, ...]] = []
+    for sample_index in range(request.idle_observation_count):
+        process_results.append(
+            remote_runner(("bash", "-lc", _ACTIVE_WORK_COMMAND), request.timeout_seconds)
+        )
+        service_results.append(
+            remote_runner(
+                ("bash", "-lc", _RUNNER_SERVICE_STATE_COMMAND),
+                request.timeout_seconds,
+            )
+        )
+        github_samples.append(
+            _read_github_idle_sample(
+                request=request,
+                github_idle_evidence_reader=github_idle_evidence_reader,
+            )
+        )
+        if sample_index + 1 < request.idle_observation_count:
+            sleeper(float(request.idle_observation_interval_seconds))
+    observed_at = utc_now_timestamp()
+    required_window_seconds = (
+        request.idle_observation_count - 1
+    ) * request.idle_observation_interval_seconds
+    observations: list[RunnerHostHygieneIdleObservation] = [
+        _local_process_idle_observation(
+            results=tuple(process_results),
+            observed_at=observed_at,
+            observation_window_seconds=required_window_seconds,
+        ),
+        _runner_service_idle_observation(
+            results=tuple(service_results),
+            observed_at=observed_at,
+            observation_window_seconds=required_window_seconds,
+            expected_service_units=tuple(
+                binding.service_unit for binding in request.github_idle_bindings
+            ),
+        ),
+    ]
+    observations.extend(
+        _aggregate_github_idle_samples(
+            samples=tuple(github_samples),
+            observed_at=observed_at,
+            observation_window_seconds=required_window_seconds,
+        )
+    )
+    requirements = tuple(
+        RunnerHostHygieneIdleSourceRequirement(
+            source=observation.source,
+            subject_key=observation.subject_key,
+            minimum_observation_count=request.idle_observation_count,
+        )
+        for observation in observations
+    )
+    return build_runner_host_hygiene_idle_convergence(
+        scope="full_host",
+        scope_key="host",
+        evaluated_at=utc_now_timestamp(),
+        minimum_observation_interval_seconds=(request.idle_observation_interval_seconds),
+        maximum_evidence_age_seconds=request.idle_max_age_seconds,
+        requirements=requirements,
+        observations=tuple(observations),
+    )
+
+
+def _read_github_idle_sample(
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    github_idle_evidence_reader: GitHubIdleEvidenceReader | None,
+) -> tuple[RunnerHostHygieneIdleObservation, ...]:
+    observed_at = utc_now_timestamp()
+    if not request.github_idle_bindings:
+        subject_key = _public_identity_key("host-bindings", "missing")
+        return tuple(
+            _unavailable_idle_observation(
+                source=source,
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                reason_code="source_missing",
+            )
+            for source in ("github_jobs", "github_runners")
+        )
+    observations: list[RunnerHostHygieneIdleObservation] = []
+    for binding in request.github_idle_bindings:
+        subject_key = _github_binding_subject_key(binding)
+        is_current_binding = (
+            binding.repository_scope == request.repository_scope.lower()
+            and binding.execution_lane == request.execution_lane.lower()
+            and binding.runner_name == request.current_runner_name
+        )
+        if github_idle_evidence_reader is None:
+            returned: tuple[RunnerHostHygieneIdleObservation, ...] = ()
+            unavailable_reason = "source_unavailable"
+        else:
+            try:
+                returned = github_idle_evidence_reader(
+                    binding.repository_scope,
+                    binding.execution_lane,
+                    binding.runner_name,
+                    is_current_binding,
+                )
+                unavailable_reason = "source_missing"
+            except (OSError, ValueError):
+                returned = ()
+                unavailable_reason = "source_unavailable"
+        for source in ("github_jobs", "github_runners"):
+            matching = tuple(item for item in returned if item.source == source)
+            if len(matching) != 1:
+                observations.append(
+                    _unavailable_idle_observation(
+                        source=source,
+                        scope="full_host",
+                        scope_key="host",
+                        subject_key=subject_key,
+                        observed_at=observed_at,
+                        reason_code=(
+                            unavailable_reason if not matching else "source_contradictory"
+                        ),
+                    )
+                )
+                continue
+            observation = matching[0]
+            if (
+                observation.scope != "full_host"
+                or observation.scope_key != "host"
+                or observation.subject_key != subject_key
+                or observation.sample_count != 1
+                or observation.observation_window_seconds != 0
+            ):
+                observations.append(
+                    _unavailable_idle_observation(
+                        source=source,
+                        scope="full_host",
+                        scope_key="host",
+                        subject_key=subject_key,
+                        observed_at=observed_at,
+                        reason_code="source_contradictory",
+                    )
+                )
+                continue
+            observations.append(observation)
+    return tuple(observations)
+
+
+def _github_binding_subject_key(binding: RunnerHostGitHubBinding) -> str:
+    return _public_identity_key(
+        "runner",
+        "|".join(
+            (
+                binding.repository_scope,
+                binding.execution_lane,
+                binding.runner_name,
+            )
+        ),
+    )
+
+
+def _aggregate_github_idle_samples(
+    *,
+    samples: tuple[tuple[RunnerHostHygieneIdleObservation, ...], ...],
+    observed_at: str,
+    observation_window_seconds: int,
+) -> tuple[RunnerHostHygieneIdleObservation, ...]:
+    observations: list[RunnerHostHygieneIdleObservation] = []
+    observation_keys = tuple(
+        sorted(
+            {
+                (observation.source, observation.subject_key)
+                for sample in samples
+                for observation in sample
+            }
+        )
+    )
+    for source, subject_key in observation_keys:
+        source_samples = tuple(
+            observation
+            for sample in samples
+            for observation in sample
+            if observation.source == source and observation.subject_key == subject_key
+        )
+        source_observed_at = max(
+            (observation.observed_at for observation in source_samples),
+            default=observed_at,
+        )
+        if len(source_samples) != len(samples):
+            observations.append(
+                _unavailable_idle_observation(
+                    source=source,
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=source_observed_at,
+                    reason_code="source_contradictory",
+                    sample_count=max(len(source_samples), 1),
+                    observation_window_seconds=(
+                        observation_window_seconds if len(source_samples) > 1 else 0
+                    ),
+                )
+            )
+            continue
+        if any(observation.availability != "available" for observation in source_samples):
+            reason_codes = {
+                observation.reason_code for observation in source_samples if observation.reason_code
+            }
+            if len(reason_codes) > 1 or any(
+                observation.availability == "available" for observation in source_samples
+            ):
+                reason_code = "source_contradictory"
+            elif "source_unauthorized" in reason_codes:
+                reason_code = "source_unauthorized"
+            elif "source_stale" in reason_codes:
+                reason_code = "source_stale"
+            elif any(observation.truncated for observation in source_samples):
+                reason_code = "source_truncated"
+            else:
+                reason_code = next(iter(reason_codes), "source_unavailable")
+            if reason_code == "source_truncated":
+                observations.append(
+                    _partial_idle_observation(
+                        source=source,
+                        scope="full_host",
+                        scope_key="host",
+                        subject_key=subject_key,
+                        observed_at=source_observed_at,
+                        sample_count=len(source_samples),
+                        observation_window_seconds=observation_window_seconds,
+                        reason_code=reason_code,
+                        truncated=True,
+                    )
+                )
+            else:
+                observations.append(
+                    _unavailable_idle_observation(
+                        source=source,
+                        scope="full_host",
+                        scope_key="host",
+                        subject_key=subject_key,
+                        observed_at=source_observed_at,
+                        reason_code=reason_code,
+                        sample_count=len(source_samples),
+                        observation_window_seconds=observation_window_seconds,
+                    )
+                )
+            continue
+        active_count = max(
+            (observation.active_count or 0 for observation in source_samples),
+            default=0,
+        )
+        total_count = max(
+            (observation.total_count or 0 for observation in source_samples),
+            default=0,
+        )
+        observations.append(
+            RunnerHostHygieneIdleObservation(
+                source=source,
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=source_observed_at,
+                availability="available",
+                state="active" if active_count else "idle",
+                sample_count=len(source_samples),
+                observation_window_seconds=observation_window_seconds,
+                active_count=active_count,
+                total_count=total_count,
+            )
+        )
+    return tuple(observations)
+
+
+def _local_process_idle_observation(
+    *,
+    results: tuple[RemoteCommandResult, ...],
+    observed_at: str,
+    observation_window_seconds: int,
+) -> RunnerHostHygieneIdleObservation:
+    if any(result.returncode != 0 for result in results):
+        return _unavailable_idle_observation(
+            source="local_processes",
+            scope="full_host",
+            scope_key="host",
+            subject_key="host-processes",
+            observed_at=observed_at,
+            reason_code="probe_failed",
+            sample_count=len(results),
+            observation_window_seconds=observation_window_seconds,
+        )
+    active_counts = tuple(len(_active_work_evidence_lines(result.stdout)) for result in results)
+    active_count = max(active_counts, default=0)
+    return RunnerHostHygieneIdleObservation(
+        source="local_processes",
+        scope="full_host",
+        scope_key="host",
+        subject_key="host-processes",
+        observed_at=observed_at,
+        availability="available",
+        state="active" if active_count else "idle",
+        sample_count=len(results),
+        observation_window_seconds=observation_window_seconds,
+        active_count=active_count,
+        total_count=active_count,
+    )
+
+
+def _runner_service_idle_observation(
+    *,
+    results: tuple[RemoteCommandResult, ...],
+    observed_at: str,
+    observation_window_seconds: int,
+    expected_service_units: tuple[str, ...],
+) -> RunnerHostHygieneIdleObservation:
+    if any(result.returncode != 0 for result in results):
+        return _unavailable_idle_observation(
+            source="runner_services",
+            scope="full_host",
+            scope_key="host",
+            subject_key="runner-services",
+            observed_at=observed_at,
+            reason_code="probe_failed",
+            sample_count=len(results),
+            observation_window_seconds=observation_window_seconds,
+        )
+    parsed_samples = tuple(_runner_service_states(result.stdout) for result in results)
+    if not expected_service_units or any(not sample for sample in parsed_samples):
+        return _unavailable_idle_observation(
+            source="runner_services",
+            scope="full_host",
+            scope_key="host",
+            subject_key="runner-services",
+            observed_at=observed_at,
+            reason_code="source_missing",
+            sample_count=len(results),
+            observation_window_seconds=observation_window_seconds,
+        )
+    expected_units = tuple(sorted(expected_service_units))
+    if any(
+        tuple(unit_name for unit_name, _, _ in sample) != expected_units
+        for sample in parsed_samples
+    ):
+        return _partial_idle_observation(
+            source="runner_services",
+            scope="full_host",
+            scope_key="host",
+            subject_key="runner-services",
+            observed_at=observed_at,
+            sample_count=len(results),
+            observation_window_seconds=observation_window_seconds,
+            reason_code="source_contradictory",
+        )
+    if len({tuple(unit_name for unit_name, _, _ in sample) for sample in parsed_samples}) != 1:
+        return _partial_idle_observation(
+            source="runner_services",
+            scope="full_host",
+            scope_key="host",
+            subject_key="runner-services",
+            observed_at=observed_at,
+            sample_count=len(results),
+            observation_window_seconds=observation_window_seconds,
+            reason_code="source_contradictory",
+        )
+    if any(
+        active_state != "active" or sub_state != "running"
+        for sample in parsed_samples
+        for _, active_state, sub_state in sample
+    ):
+        return _partial_idle_observation(
+            source="runner_services",
+            scope="full_host",
+            scope_key="host",
+            subject_key="runner-services",
+            observed_at=observed_at,
+            sample_count=len(results),
+            observation_window_seconds=observation_window_seconds,
+            reason_code="source_contradictory",
+        )
+    return RunnerHostHygieneIdleObservation(
+        source="runner_services",
+        scope="full_host",
+        scope_key="host",
+        subject_key="runner-services",
+        observed_at=observed_at,
+        availability="available",
+        state="idle",
+        sample_count=len(results),
+        observation_window_seconds=observation_window_seconds,
+        active_count=0,
+        total_count=len(expected_units),
+    )
+
+
+def _runner_service_states(output: str) -> tuple[tuple[str, str, str], ...]:
+    states: list[tuple[str, str, str]] = []
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) != 3:
+            return ()
+        states.append((parts[0].lower(), parts[1].lower(), parts[2].lower()))
+    return tuple(states)
+
+
+def _partial_idle_observation(
+    *,
+    source: RunnerHostHygieneIdleSource,
+    scope: RunnerHostHygieneIdleScope,
+    scope_key: str,
+    subject_key: str,
+    observed_at: str,
+    sample_count: int,
+    observation_window_seconds: int,
+    reason_code: str,
+    truncated: bool = False,
+) -> RunnerHostHygieneIdleObservation:
+    return RunnerHostHygieneIdleObservation(
+        source=source,
+        scope=scope,
+        scope_key=scope_key,
+        subject_key=subject_key,
+        observed_at=observed_at,
+        availability="partial",
+        state="unknown",
+        sample_count=sample_count,
+        observation_window_seconds=observation_window_seconds,
+        truncated=truncated,
+        reason_code=reason_code,
+    )
+
+
+def _unavailable_idle_observation(
+    *,
+    source: RunnerHostHygieneIdleSource,
+    scope: RunnerHostHygieneIdleScope,
+    scope_key: str,
+    subject_key: str,
+    observed_at: str,
+    reason_code: str,
+    sample_count: int = 1,
+    observation_window_seconds: int = 0,
+) -> RunnerHostHygieneIdleObservation:
+    return RunnerHostHygieneIdleObservation(
+        source=source,
+        scope=scope,
+        scope_key=scope_key,
+        subject_key=subject_key,
+        observed_at=observed_at,
+        availability="unavailable",
+        state="unknown",
+        sample_count=sample_count,
+        observation_window_seconds=observation_window_seconds,
+        reason_code=reason_code,
+    )
+
+
+def _public_identity_key(prefix: str, value: str) -> str:
+    normalized_prefix = prefix.strip().lower()
+    normalized_value = value.strip().lower()
+    digest = hashlib.sha256(normalized_value.encode("utf-8")).hexdigest()[:12]
+    return f"{normalized_prefix}-{digest}"
 
 
 def build_local_command_runner() -> RemoteCommandRunner:
@@ -1293,7 +2029,10 @@ def build_github_run_state_reader(
             try:
                 with urlopen(request, timeout=30) as response:
                     payload = json.loads(response.read().decode("utf-8"))
-            except (HTTPError, URLError, TimeoutError, socket.timeout, json.JSONDecodeError):
+            except HTTPError as error:
+                states[run_id] = "unauthorized" if error.code in {401, 403} else "unknown"
+                continue
+            except (URLError, TimeoutError, socket.timeout, json.JSONDecodeError):
                 states[run_id] = "unknown"
                 continue
             if not isinstance(payload, dict):
@@ -1303,6 +2042,373 @@ def build_github_run_state_reader(
         return states
 
     return read
+
+
+def build_github_idle_evidence_reader(
+    *,
+    bearer_token: str,
+    api_base_url: str = "https://api.github.com",
+    current_run_id: int | None = None,
+    current_runner_name: str = "",
+) -> GitHubIdleEvidenceReader:
+    normalized_token = bearer_token.strip()
+    normalized_api_base_url = api_base_url.strip().rstrip("/")
+    normalized_runner_name = current_runner_name.strip()
+    if not normalized_api_base_url:
+        raise click.ClickException("runner idle GitHub evidence requires API base URL")
+
+    def read(
+        repository: str,
+        execution_lane: str,
+        runner_name: str = "",
+        exclude_current: bool = False,
+    ) -> tuple[RunnerHostHygieneIdleObservation, ...]:
+        owner, name = repository.split("/", maxsplit=1)
+        observed_at = utc_now_timestamp()
+        effective_runner_name = runner_name.strip() or normalized_runner_name
+        effective_exclude_current = exclude_current or not runner_name.strip()
+        subject_key = _public_identity_key(
+            "runner",
+            "|".join(
+                (
+                    repository.strip().lower(),
+                    execution_lane.strip().lower(),
+                    effective_runner_name,
+                )
+            ),
+        )
+        repository_url = (
+            f"{normalized_api_base_url}/repos/{quote(owner, safe='')}/{quote(name, safe='')}"
+        )
+        jobs_observation = _github_jobs_idle_observation(
+            repository_url=repository_url,
+            execution_lane=execution_lane,
+            bearer_token=normalized_token,
+            current_run_id=current_run_id,
+            exclude_current_run=effective_exclude_current,
+            subject_key=subject_key,
+            observed_at=observed_at,
+        )
+        runners_observation = _github_runners_idle_observation(
+            repository_url=repository_url,
+            execution_lane=execution_lane,
+            bearer_token=normalized_token,
+            runner_name=effective_runner_name,
+            exclude_current_runner=effective_exclude_current,
+            subject_key=subject_key,
+            observed_at=observed_at,
+        )
+        return jobs_observation, runners_observation
+
+    return read
+
+
+def _github_jobs_idle_observation(
+    *,
+    repository_url: str,
+    execution_lane: str,
+    bearer_token: str,
+    current_run_id: int | None,
+    exclude_current_run: bool,
+    subject_key: str,
+    observed_at: str,
+) -> RunnerHostHygieneIdleObservation:
+    if exclude_current_run and current_run_id is None:
+        return _unavailable_idle_observation(
+            source="github_jobs",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            reason_code="source_missing",
+        )
+    active_run_ids: set[int] = set()
+    for status in ("queued", "in_progress"):
+        payload, reason_code = _github_api_object(
+            url=f"{repository_url}/actions/runs?status={status}&per_page=100",
+            bearer_token=bearer_token,
+        )
+        if payload is None:
+            return _unavailable_idle_observation(
+                source="github_jobs",
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                reason_code=reason_code,
+            )
+        workflow_runs = payload.get("workflow_runs")
+        total_count = payload.get("total_count")
+        if not isinstance(workflow_runs, list) or not isinstance(total_count, int):
+            return _unavailable_idle_observation(
+                source="github_jobs",
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                reason_code="source_contradictory",
+            )
+        if total_count > len(workflow_runs):
+            return _partial_idle_observation(
+                source="github_jobs",
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                sample_count=1,
+                observation_window_seconds=0,
+                reason_code="source_truncated",
+                truncated=True,
+            )
+        for workflow_run in workflow_runs:
+            if not isinstance(workflow_run, dict):
+                return _unavailable_idle_observation(
+                    source="github_jobs",
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=observed_at,
+                    reason_code="source_contradictory",
+                )
+            run_id = workflow_run.get("id")
+            if isinstance(run_id, int) and (not exclude_current_run or run_id != current_run_id):
+                active_run_ids.add(run_id)
+    if len(active_run_ids) > MAX_GITHUB_IDLE_ACTIVE_RUNS:
+        return _partial_idle_observation(
+            source="github_jobs",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            sample_count=1,
+            observation_window_seconds=0,
+            reason_code="source_truncated",
+            truncated=True,
+        )
+    normalized_lane = execution_lane.strip().lower()
+    active_jobs = 0
+    observed_jobs = 0
+    for run_id in sorted(active_run_ids):
+        payload, reason_code = _github_api_object(
+            url=f"{repository_url}/actions/runs/{run_id}/jobs?filter=latest&per_page=100",
+            bearer_token=bearer_token,
+        )
+        if payload is None:
+            return _unavailable_idle_observation(
+                source="github_jobs",
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                reason_code=reason_code,
+            )
+        jobs = payload.get("jobs")
+        total_count = payload.get("total_count")
+        if not isinstance(jobs, list) or not isinstance(total_count, int):
+            return _unavailable_idle_observation(
+                source="github_jobs",
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                reason_code="source_contradictory",
+            )
+        if total_count > len(jobs):
+            return _partial_idle_observation(
+                source="github_jobs",
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                sample_count=1,
+                observation_window_seconds=0,
+                reason_code="source_truncated",
+                truncated=True,
+            )
+        for job in jobs:
+            if not isinstance(job, dict):
+                return _unavailable_idle_observation(
+                    source="github_jobs",
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=observed_at,
+                    reason_code="source_contradictory",
+                )
+            labels = job.get("labels")
+            if not isinstance(labels, list) or not all(isinstance(label, str) for label in labels):
+                return _unavailable_idle_observation(
+                    source="github_jobs",
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=observed_at,
+                    reason_code="source_contradictory",
+                )
+            normalized_labels = {label.strip().lower() for label in labels}
+            if "self-hosted" not in normalized_labels or normalized_lane not in normalized_labels:
+                continue
+            observed_jobs += 1
+            if job.get("status") in {"queued", "in_progress", "waiting", "pending"}:
+                active_jobs += 1
+    return RunnerHostHygieneIdleObservation(
+        source="github_jobs",
+        scope="full_host",
+        scope_key="host",
+        subject_key=subject_key,
+        observed_at=observed_at,
+        availability="available",
+        state="active" if active_jobs else "idle",
+        active_count=active_jobs,
+        total_count=observed_jobs,
+    )
+
+
+def _github_runners_idle_observation(
+    *,
+    repository_url: str,
+    execution_lane: str,
+    bearer_token: str,
+    runner_name: str,
+    exclude_current_runner: bool,
+    subject_key: str,
+    observed_at: str,
+) -> RunnerHostHygieneIdleObservation:
+    if not runner_name:
+        return _unavailable_idle_observation(
+            source="github_runners",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            reason_code="source_missing",
+        )
+    payload, reason_code = _github_api_object(
+        url=f"{repository_url}/actions/runners?per_page=100",
+        bearer_token=bearer_token,
+    )
+    if payload is None:
+        return _unavailable_idle_observation(
+            source="github_runners",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            reason_code=reason_code,
+        )
+    runners = payload.get("runners")
+    total_count = payload.get("total_count")
+    if not isinstance(runners, list) or not isinstance(total_count, int):
+        return _unavailable_idle_observation(
+            source="github_runners",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            reason_code="source_contradictory",
+        )
+    if total_count > len(runners):
+        return _partial_idle_observation(
+            source="github_runners",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            sample_count=1,
+            observation_window_seconds=0,
+            reason_code="source_truncated",
+            truncated=True,
+        )
+    normalized_lane = execution_lane.strip().lower()
+    matching_runners: list[dict[str, object]] = []
+    for runner in runners:
+        if not isinstance(runner, dict):
+            return _unavailable_idle_observation(
+                source="github_runners",
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                reason_code="source_contradictory",
+            )
+        labels = runner.get("labels")
+        if not isinstance(labels, list):
+            return _unavailable_idle_observation(
+                source="github_runners",
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at=observed_at,
+                reason_code="source_contradictory",
+            )
+        label_names = {
+            label.get("name", "").strip().lower()
+            for label in labels
+            if isinstance(label, dict) and isinstance(label.get("name"), str)
+        }
+        if normalized_lane in label_names and runner.get("name") == runner_name:
+            matching_runners.append(runner)
+    if len(matching_runners) != 1:
+        return _unavailable_idle_observation(
+            source="github_runners",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            reason_code=("source_missing" if not matching_runners else "source_contradictory"),
+        )
+    if any(runner.get("status") != "online" for runner in matching_runners):
+        return _unavailable_idle_observation(
+            source="github_runners",
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            reason_code="source_contradictory",
+        )
+    busy_runners = sum(
+        1
+        for runner in matching_runners
+        if runner.get("busy") is True and not exclude_current_runner
+    )
+    return RunnerHostHygieneIdleObservation(
+        source="github_runners",
+        scope="full_host",
+        scope_key="host",
+        subject_key=subject_key,
+        observed_at=observed_at,
+        availability="available",
+        state="active" if busy_runners else "idle",
+        active_count=busy_runners,
+        total_count=len(matching_runners),
+    )
+
+
+def _github_api_object(
+    *,
+    url: str,
+    bearer_token: str,
+) -> tuple[dict[str, object] | None, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "launchplane-runner-host-hygiene",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    request = Request(url, headers=headers, method="GET")
+    try:
+        with urlopen(request, timeout=30) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except HTTPError as error:
+        return None, ("source_unauthorized" if error.code in {401, 403} else "source_unavailable")
+    except (URLError, TimeoutError, socket.timeout):
+        return None, "source_unavailable"
+    except json.JSONDecodeError:
+        return None, "source_contradictory"
+    if not isinstance(payload, dict):
+        return None, "source_contradictory"
+    return cast(dict[str, object], payload), ""
 
 
 def build_refreshing_service_audit_poster(
@@ -1840,6 +2946,14 @@ def _collect_generated_run_cache_usage(
                     cache_key=root.key,
                     measurement_status="unavailable",
                     reason_code="probe_failed",
+                    idle_convergence=_unavailable_generated_cache_idle_convergence(
+                        root=root,
+                        observed_at=utc_now_timestamp(),
+                        observation_count=request.idle_observation_count,
+                        observation_interval_seconds=(request.idle_observation_interval_seconds),
+                        maximum_evidence_age_seconds=request.idle_max_age_seconds,
+                        reason_code="probe_failed",
+                    ),
                 )
             )
             continue
@@ -1849,6 +2963,9 @@ def _collect_generated_run_cache_usage(
                     output=result.stdout,
                     root=root,
                     github_run_state_reader=effective_github_run_state_reader,
+                    observation_count=request.idle_observation_count,
+                    observation_interval_seconds=(request.idle_observation_interval_seconds),
+                    maximum_evidence_age_seconds=request.idle_max_age_seconds,
                 )
             )
         except (click.ClickException, ValueError):
@@ -1857,6 +2974,14 @@ def _collect_generated_run_cache_usage(
                     cache_key=root.key,
                     measurement_status="unavailable",
                     reason_code="invalid_evidence",
+                    idle_convergence=_unavailable_generated_cache_idle_convergence(
+                        root=root,
+                        observed_at=utc_now_timestamp(),
+                        observation_count=request.idle_observation_count,
+                        observation_interval_seconds=(request.idle_observation_interval_seconds),
+                        maximum_evidence_age_seconds=request.idle_max_age_seconds,
+                        reason_code="source_contradictory",
+                    ),
                 )
             )
     return tuple(usage)
@@ -1867,6 +2992,9 @@ def _parse_generated_run_cache_usage(
     output: str,
     root: GeneratedRunCacheRoot,
     github_run_state_reader: GitHubRunStateReader | None,
+    observation_count: int,
+    observation_interval_seconds: int,
+    maximum_evidence_age_seconds: int,
 ) -> RunnerHostHygieneGeneratedCacheUsage:
     rows = _parse_json_lines(output, evidence_name=f"generated_cache:{root.key}")
     summary_rows = tuple(row for row in rows if row.get("record_type") == "summary")
@@ -1901,11 +3029,18 @@ def _parse_generated_run_cache_usage(
             }
         )
     )
-    github_states = (
-        github_run_state_reader(root.source_repository, run_ids)
-        if github_run_state_reader is not None and run_ids
-        else {}
-    )
+    github_state_available = not run_ids
+    github_state_reason_code = ""
+    github_states: Mapping[int, str] = {}
+    if github_run_state_reader is not None and run_ids:
+        try:
+            github_states = github_run_state_reader(root.source_repository, run_ids)
+            github_state_available = True
+        except (OSError, ValueError):
+            github_states = {}
+    if "unauthorized" in github_states.values():
+        github_state_available = False
+        github_state_reason_code = "source_unauthorized"
     entries = tuple(
         RunnerHostHygieneGeneratedCacheEntry(
             run_id=_strict_positive_int(row.get("run_id"), evidence_name="generated cache run id"),
@@ -1960,6 +3095,18 @@ def _parse_generated_run_cache_usage(
             (allocated_bytes - last_post_cleanup_allocated_bytes) * 86_400 // elapsed_since_cleanup
         )
     measurement_status = _generated_cache_measurement_status(summary.get("measurement_status"))
+    owner_worker_observations = _strict_non_negative_int_tuple(
+        summary.get("owner_worker_observations"),
+        evidence_name="generated cache owner-worker observations",
+    )
+    observed_at = (
+        datetime.fromtimestamp(
+            observed_epoch_seconds,
+            tz=timezone.utc,
+        )
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
     return RunnerHostHygieneGeneratedCacheUsage(
         cache_key=root.key,
         apparent_bytes=_strict_non_negative_int(
@@ -1975,10 +3122,7 @@ def _parse_generated_run_cache_usage(
         owner_valid=_strict_bool(summary.get("owner_valid"), evidence_name="owner_valid"),
         mode_valid=_strict_bool(summary.get("mode_valid"), evidence_name="mode_valid"),
         symlink_safe=_strict_bool(summary.get("symlink_safe"), evidence_name="symlink_safe"),
-        owner_worker_observations=_strict_non_negative_int_tuple(
-            summary.get("owner_worker_observations"),
-            evidence_name="generated cache owner-worker observations",
-        ),
+        owner_worker_observations=owner_worker_observations,
         age_buckets=_generated_cache_age_buckets(entries),
         entries=entries,
         entries_truncated=_strict_bool(
@@ -1996,6 +3140,210 @@ def _parse_generated_run_cache_usage(
         ),
         estimated_daily_growth_bytes=estimated_daily_growth_bytes,
         cooldown_remaining_seconds=cooldown_remaining_seconds,
+        idle_convergence=_build_generated_cache_idle_convergence(
+            root=root,
+            observed_at=observed_at,
+            owner_worker_observations=owner_worker_observations,
+            entries=entries,
+            entries_truncated=_strict_bool(
+                summary.get("entries_truncated"), evidence_name="entries_truncated"
+            ),
+            github_state_available=github_state_available,
+            github_state_reason_code=github_state_reason_code,
+            observation_count=observation_count,
+            observation_interval_seconds=observation_interval_seconds,
+            maximum_evidence_age_seconds=maximum_evidence_age_seconds,
+        ),
+    )
+
+
+def _build_generated_cache_idle_convergence(
+    *,
+    root: GeneratedRunCacheRoot,
+    observed_at: str,
+    owner_worker_observations: tuple[int, ...],
+    entries: tuple[RunnerHostHygieneGeneratedCacheEntry, ...],
+    entries_truncated: bool,
+    github_state_available: bool,
+    github_state_reason_code: str,
+    observation_count: int,
+    observation_interval_seconds: int,
+    maximum_evidence_age_seconds: int,
+) -> RunnerHostHygieneIdleConvergence:
+    owner_sample_count = max(len(owner_worker_observations), 1)
+    owner_window_seconds = max(owner_sample_count - 1, 0) * observation_interval_seconds
+    if owner_worker_observations:
+        owner_active_count = max(owner_worker_observations)
+        owner_observation = RunnerHostHygieneIdleObservation(
+            source="local_user_processes",
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key="owner-workers",
+            observed_at=observed_at,
+            availability="available",
+            state="active" if owner_active_count else "idle",
+            sample_count=len(owner_worker_observations),
+            observation_window_seconds=owner_window_seconds,
+            active_count=owner_active_count,
+        )
+    else:
+        owner_observation = _unavailable_idle_observation(
+            source="local_user_processes",
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key="owner-workers",
+            observed_at=observed_at,
+            reason_code="source_missing",
+        )
+
+    handle_sample_counts = {len(entry.open_handle_observations) for entry in entries}
+    if entries_truncated:
+        handles_observation = _partial_idle_observation(
+            source="open_handles",
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key="cache-entries",
+            observed_at=observed_at,
+            sample_count=observation_count,
+            observation_window_seconds=((observation_count - 1) * observation_interval_seconds),
+            reason_code="source_truncated",
+            truncated=True,
+        )
+    elif len(handle_sample_counts) > 1 or 0 in handle_sample_counts:
+        handles_observation = _unavailable_idle_observation(
+            source="open_handles",
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key="cache-entries",
+            observed_at=observed_at,
+            reason_code="source_contradictory",
+        )
+    else:
+        handle_sample_count = next(iter(handle_sample_counts), observation_count)
+        active_handles = max(
+            (
+                sum(entry.open_handle_observations[sample_index] for entry in entries)
+                for sample_index in range(handle_sample_count)
+            ),
+            default=0,
+        )
+        handles_observation = RunnerHostHygieneIdleObservation(
+            source="open_handles",
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key="cache-entries",
+            observed_at=observed_at,
+            availability="available",
+            state="active" if active_handles else "idle",
+            sample_count=handle_sample_count,
+            observation_window_seconds=(
+                max(handle_sample_count - 1, 0) * observation_interval_seconds
+            ),
+            active_count=active_handles,
+        )
+
+    github_states = tuple(entry.github_run_state for entry in entries)
+    if entries_truncated:
+        github_observation = _partial_idle_observation(
+            source="github_jobs",
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key="cache-runs",
+            observed_at=observed_at,
+            sample_count=1,
+            observation_window_seconds=0,
+            reason_code="source_truncated",
+            truncated=True,
+        )
+    elif not github_state_available or "unknown" in github_states:
+        github_observation = _unavailable_idle_observation(
+            source="github_jobs",
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key="cache-runs",
+            observed_at=observed_at,
+            reason_code=github_state_reason_code or "source_unavailable",
+        )
+    else:
+        active_runs = sum(state == "active" for state in github_states)
+        github_observation = RunnerHostHygieneIdleObservation(
+            source="github_jobs",
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key="cache-runs",
+            observed_at=observed_at,
+            availability="available",
+            state="active" if active_runs else "idle",
+            active_count=active_runs,
+            total_count=len(github_states),
+        )
+    observations = (owner_observation, handles_observation, github_observation)
+    requirements = tuple(
+        RunnerHostHygieneIdleSourceRequirement(
+            source=observation.source,
+            subject_key=observation.subject_key,
+            minimum_observation_count=(
+                1 if observation.source == "github_jobs" else observation_count
+            ),
+        )
+        for observation in observations
+    )
+    return build_runner_host_hygiene_idle_convergence(
+        scope=root.idle_scope,
+        scope_key=root.idle_scope_key,
+        evaluated_at=observed_at,
+        minimum_observation_interval_seconds=observation_interval_seconds,
+        maximum_evidence_age_seconds=maximum_evidence_age_seconds,
+        requirements=requirements,
+        observations=observations,
+    )
+
+
+def _unavailable_generated_cache_idle_convergence(
+    *,
+    root: GeneratedRunCacheRoot,
+    observed_at: str,
+    observation_count: int,
+    observation_interval_seconds: int,
+    maximum_evidence_age_seconds: int,
+    reason_code: str,
+) -> RunnerHostHygieneIdleConvergence:
+    observations = tuple(
+        _unavailable_idle_observation(
+            source=source,
+            scope=root.idle_scope,
+            scope_key=root.idle_scope_key,
+            subject_key=subject_key,
+            observed_at=observed_at,
+            reason_code=reason_code,
+        )
+        for source, subject_key in cast(
+            tuple[tuple[RunnerHostHygieneIdleSource, str], ...],
+            (
+                ("local_user_processes", "owner-workers"),
+                ("open_handles", "cache-entries"),
+                ("github_jobs", "cache-runs"),
+            ),
+        )
+    )
+    requirements = tuple(
+        RunnerHostHygieneIdleSourceRequirement(
+            source=observation.source,
+            subject_key=observation.subject_key,
+            minimum_observation_count=(
+                1 if observation.source == "github_jobs" else observation_count
+            ),
+        )
+        for observation in observations
+    )
+    return build_runner_host_hygiene_idle_convergence(
+        scope=root.idle_scope,
+        scope_key=root.idle_scope_key,
+        evaluated_at=observed_at,
+        minimum_observation_interval_seconds=observation_interval_seconds,
+        maximum_evidence_age_seconds=maximum_evidence_age_seconds,
+        requirements=requirements,
+        observations=observations,
     )
 
 
@@ -2118,11 +3466,15 @@ def _generated_cache_measurement_status(value: object) -> Literal["complete", "p
     raise click.ClickException("runner host generated cache measurement status was invalid")
 
 
-def _github_run_state(value: object) -> Literal["completed", "active", "unknown"]:
+def _github_run_state(
+    value: object,
+) -> Literal["completed", "active", "unknown", "unauthorized"]:
     if value == "completed":
         return "completed"
     if value == "active":
         return "active"
+    if value == "unauthorized":
+        return "unauthorized"
     return "unknown"
 
 
@@ -2550,44 +3902,20 @@ def _parse_docker_size_bytes(value: str) -> int:
     return int(numeric_value * multiplier)
 
 
-def _compact_evidence(output: str) -> str:
-    compact = " | ".join(line.strip() for line in output.splitlines() if line.strip())
-    return compact[:500]
-
-
-def _check_host_idle(
-    *,
-    request: RunnerHostHygieneExecutorRequest,
-    remote_runner: RemoteCommandRunner,
-    sleeper: AuditDeliverySleeper,
-) -> str | None:
-    for sample_index in range(request.idle_observation_count):
-        active_processes = _require_remote_success(
-            remote_runner(
-                ("bash", "-lc", _ACTIVE_WORK_COMMAND),
-                request.timeout_seconds,
-            ),
-            evidence_name="active_runner_or_build_processes",
-        )
-        raw_lines = tuple(
-            line.strip() for line in active_processes.stdout.splitlines() if line.strip()
-        )
-        ancestor_pids: set[str] = set()
-        lines: list[str] = []
-        for line in raw_lines:
-            if line.startswith("ancestor_pids="):
-                ancestor_pids.update(line.partition("=")[2].split())
-                continue
-            process_id = line.split(maxsplit=1)[0]
-            if "Runner.Worker" in line and process_id in ancestor_pids:
-                continue
-            if "runner-host-hygiene" not in line:
-                lines.append(line)
-        if lines:
-            return _compact_evidence(_redact_sensitive_text("\n".join(lines)))
-        if sample_index + 1 < request.idle_observation_count:
-            sleeper(float(request.idle_observation_interval_seconds))
-    return None
+def _active_work_evidence_lines(output: str) -> tuple[str, ...]:
+    raw_lines = tuple(line.strip() for line in output.splitlines() if line.strip())
+    ancestor_pids: set[str] = set()
+    lines: list[str] = []
+    for line in raw_lines:
+        if line.startswith("ancestor_pids="):
+            ancestor_pids.update(line.partition("=")[2].split())
+            continue
+        process_id = line.split(maxsplit=1)[0]
+        if "Runner.Worker" in line and process_id in ancestor_pids:
+            continue
+        if "runner-host-hygiene" not in line:
+            lines.append(line)
+    return tuple(lines)
 
 
 def _terminal_audit(
@@ -2617,12 +3945,16 @@ def _collect_terminal_report(
     request: RunnerHostHygieneExecutorRequest,
     remote_runner: RemoteCommandRunner,
     github_run_state_reader: GitHubRunStateReader | None,
+    github_idle_evidence_reader: GitHubIdleEvidenceReader | None,
+    idle_observation_sleeper: AuditDeliverySleeper,
 ) -> RunnerHostHygieneReport | None:
     try:
         return collect_runner_host_hygiene_report(
             request=request,
             remote_runner=remote_runner,
             github_run_state_reader=github_run_state_reader,
+            github_idle_evidence_reader=github_idle_evidence_reader,
+            idle_observation_sleeper=idle_observation_sleeper,
         )
     except click.ClickException:
         return None

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -63,6 +63,16 @@ with the exact confirmation phrase and an operator reason. Specific rollout
 lane sets and ordering belong in issue-backed plans and workflow inputs, not in
 checked-in docs.
 
+Runner-host hygiene uses the protected `Runner Host Hygiene` workflow and the
+deployed evidence API. Shared Docker mutation requires a runtime-only binding
+manifest for every repository, lane, runner, and systemd service on the host;
+the executor cross-checks that manifest against local service discovery and
+persists only public hashes and counts. Missing or unauthorized GitHub sources,
+manifest/service disagreement, stale evidence, or changed recovery inputs block
+mutation. Every mutating action also requires the host-local durable audit spool
+described in `docs/runner-host-hygiene.md`; do not invoke the executor from an
+arbitrary checkout or bypass its planned/action-started/terminal evidence flow.
+
 After the provider-target audit is clean, use the manual
 `Product Environment Evidence` workflow to collect read-model evidence through
 the deployed service. The workflow calls `GET

--- a/docs/records.md
+++ b/docs/records.md
@@ -529,9 +529,13 @@ an ORM column/table or remains only in the evidence payload.
   source and measurement-basis metadata, filesystem apparent/allocated bytes,
   Docker logical/reclaimable bytes, bounded inventory counts and truncation,
   age buckets, numeric run ids, GitHub completion state, bounded worker and
-  open-handle observations, cleanup history, and hysteresis/cooldown evidence
-  also stay payload-only. Absolute cache paths and source repository identity
-  are executor-local runtime authority and are not persisted in the audit.
+  open-handle observations, cleanup history, hysteresis/cooldown evidence, and
+  source-attributed idle convergence also stay payload-only. Idle convergence
+  records public-safe scope and subject keys, source availability, state,
+  sample count, nonzero observation window, timestamps, bounded counts,
+  truncation/reason codes, and derived blockers. Absolute cache paths, raw
+  command output, runner names, and source repository identity are
+  executor-local runtime authority and are not persisted in the audit.
   Docker toolchain evidence, host-command output, Docker summaries, and rollout
   notes stay payload-only until they need queryable operational views. Bounded
   list, sanitized detail, and observation-history reads use the existing JSON

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -265,10 +265,11 @@ builds GitHub source requirements from that manifest and requires its service
 units to match the complete local `systemctl` inventory; an omitted or extra
 lane therefore blocks rather than disappearing from `full_host` evidence. Only
 public hashes and counts enter persisted evidence. The executor excludes only
-its own GitHub run and runner registration, using `GITHUB_RUN_ID` and
-`RUNNER_NAME`; missing identity, unauthorized APIs, incomplete pagination,
-manifest disagreement, stale timestamps, or a short or zero observation window
-blocks the apply plan.
+its own GitHub job, identified by `GITHUB_RUN_ID` and `RUNNER_NAME`, across the
+current repository/lane bindings, and excludes only its own runner
+registration. Sibling jobs and runner registrations remain visible. Missing
+identity, unauthorized APIs, incomplete pagination, manifest disagreement,
+stale timestamps, or a short or zero observation window blocks the apply plan.
 Generated run-cache actions do not use full-host evidence. Each policy-owned
 root instead records one `isolated_user` convergence with owner-process,
 per-entry open-handle, and GitHub run-state evidence. `isolated_lane` remains a

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -145,19 +145,21 @@ under `runner_host_hygiene_audit.write`, preserves the `Idempotency-Key`
 replay/conflict contract, and returns the accepted record key plus audit result
 details. The local planner only prints the planned record; the approved executor
 calls the service route after it captures the required pre/post host evidence.
-The executor also keeps a host-persistent delivery envelope outside the Actions
-workspace. It atomically records planned intent before mutation, records
-`action_started` immediately before the privileged command, and records terminal
-evidence before remote delivery. Transient delivery failures retain the exact
+Every mutation requires a host-persistent delivery envelope outside the Actions
+workspace. It atomically records planned intent, then stores the fresh
+pre-action request, ready plan, and sanitized source evidence together with
+`action_started` immediately before the privileged command. Terminal evidence
+is durable before remote delivery. Transient delivery failures retain the exact
 idempotency key and block another mutation for the same host/action until the
-pending envelope is reconciled. The current-run envelope is copied to a redacted
-workflow artifact; bearer tokens and raw authorization headers are never part of
-the envelope. A permanently rejected planned audit (for example, authorization,
-route, or idempotency conflict) blocks mutation; a retryable transport/service
-failure may proceed only because the planned intent is already durable locally.
-Generated run-cache mutation is stricter: it requires both the durable host
-spool and accepted service delivery of the planned audit before the privileged
-helper can run. A pending or rejected planned record leaves that action blocked.
+pending envelope is reconciled. The envelope also stores a SHA-256 integrity
+digest over runtime-only executor inputs so recovery cannot collect post
+evidence under changed roots, repositories, lanes, or targets. The current-run
+envelope is copied to a redacted workflow artifact; bearer tokens, raw runtime
+topology, and authorization headers are never part of persisted evidence. A
+permanently rejected planned audit blocks mutation. Generated run-cache
+mutation is stricter still: accepted service delivery of the planned audit is
+required before the privileged helper can run. A pending or rejected planned
+record leaves that action blocked.
 
 Authorized operators and workflows can read the durable evidence through:
 
@@ -254,6 +256,27 @@ limit, and its cooldown has expired. The helper deletes only selected
 completed-run directories and records the lower post-cleanup size; it never
 touches sibling Cargo, Bazel disk, package, credential, or configuration roots.
 
+Idle safety is persisted as typed, source-attributed convergence rather than
+anonymous process-count tuples. Shared Docker actions use one `full_host`
+convergence containing consecutive GitHub job, GitHub runner, local process,
+and runner-service observations. A runtime-only host binding manifest names
+every expected repository, lane, runner, and systemd service unit. The executor
+builds GitHub source requirements from that manifest and requires its service
+units to match the complete local `systemctl` inventory; an omitted or extra
+lane therefore blocks rather than disappearing from `full_host` evidence. Only
+public hashes and counts enter persisted evidence. The executor excludes only
+its own GitHub run and runner registration, using `GITHUB_RUN_ID` and
+`RUNNER_NAME`; missing identity, unauthorized APIs, incomplete pagination,
+manifest disagreement, stale timestamps, or a short or zero observation window
+blocks the apply plan.
+Generated run-cache actions do not use full-host evidence. Each policy-owned
+root instead records one `isolated_user` convergence with owner-process,
+per-entry open-handle, and GitHub run-state evidence. `isolated_lane` remains a
+reserved contract value and is rejected by this executor until lane-scoped
+process evidence exists. Successful and blocking convergence is preserved in
+planned and terminal audit reports and is exposed through the sanitized
+runner-host hygiene read model.
+
 Launchplane's PostgreSQL integration job mounts `/var/lib/postgresql/data` as a
 bounded tmpfs. The official PostgreSQL image declares that path as a volume;
 overriding it keeps ephemeral test data out of durable anonymous Docker volumes
@@ -285,6 +308,12 @@ The workflow requires these repository variables:
   evidence; the absolute path and repository identity remain executor-local
   runtime authority. High water must be positive, low water must be smaller,
   and minimum age must be at least one hour.
+- `LAUNCHPLANE_RUNNER_HOST_HYGIENE_GITHUB_IDLE_BINDINGS`, as comma-separated
+  `owner/repository|lane|runner-name|systemd-service-unit` entries covering
+  every runner service on the host. This is runtime topology, not a checked-in
+  catalog. Shared Docker mutation is rejected unless the manifest includes the
+  current `GITHUB_REPOSITORY`, execution lane, and `RUNNER_NAME`, and its exact
+  service-unit set matches local discovery.
 - `LAUNCHPLANE_RUNNER_HOST_HYGIENE_ALLOWED_BUILDKIT_STATE_VOLUMES` for any
   approved BuildKit state-volume retirement target. Leave it empty when no
   named volume cleanup has been reviewed.
@@ -299,24 +328,36 @@ The workflow requires these repository variables:
   executor rejects values below 8 GiB. Capacity remains runtime authority;
   production code contains no host-specific cache budget.
 
-Public source repositories need no GitHub credential for generated-cache run
-state. Private source repositories require the optional
-`LAUNCHPLANE_RUNNER_HOST_HYGIENE_GITHUB_READ_TOKEN` secret, scoped only to
-Actions-read access for the exact source repositories. Do not reuse runner
-registration or administration credentials for this evidence path.
+`LAUNCHPLANE_RUNNER_HOST_HYGIENE_GITHUB_READ_TOKEN` is required for shared-host
+idle convergence. Scope it to every repository named by the runtime host
+binding manifest with read-only Actions and Administration permissions: Actions
+reads provide active workflow and job state, while Administration read is
+needed to list self-hosted runner registrations. A repository-level runner API
+that cannot see the named runner fails closed as `source_missing`; organization
+or enterprise registrations require an equivalent reader before they can be
+listed in the manifest. Generated-cache run-state reads use only Actions read.
+The credential grants no runner-registration write or repository-content write
+authority.
 
 The executor fails closed unless the process user matches the requested service
 user, the GitHub repository matches the requested repository scope, retained
-warm builders are present in pre-apply evidence, the apply plan is ready, no
-active Docker build client or another Actions `Runner.Worker` process is observed
-in two consecutive local samples. Manual mutations additionally require
-`mutate=true`. Monday-through-Saturday scheduled runs stop at the
+warm builders are present in pre-apply evidence, the apply plan is ready, and
+the action's required idle scope converges over at least two samples separated
+by a nonzero interval. Every mutation requires a durable host-local audit spool.
+After planned-audit delivery, the executor recollects every required source,
+replans against a new decision timestamp, and atomically stores that sanitized
+authorization with `action_started` before invoking the mutation. Manual
+mutations additionally require `mutate=true`.
+Monday-through-Saturday scheduled runs stop at the
 `mutate_not_requested` blocker, while the Sunday maintenance schedule supplies
 explicit mutation intent for bounded Docker, dangling-image, named-builder, and
 generated completed-run cache actions. Shared Docker actions require full-host
-idle. Generated run-cache actions instead require two idle observations for the
-configured owning user plus two zero-handle observations for every exact target;
-unrelated users and lanes do not block that isolated cache class.
+idle from every required GitHub and local source. Generated run-cache actions
+instead require two idle observations for the configured owning user plus two
+zero-handle observations for every exact target; unrelated users and lanes do
+not block that isolated cache class. The default evidence age limit is five
+minutes and is configurable through `--idle-max-age-seconds` without permitting
+zero-second observation intervals.
 Cache and image maintenance may proceed when the report has unrelated attention
 findings so cleanup can remediate pressure; host identity, warm-image retention,
 audit durability, exact builder allowlists, and the idle gate remain mandatory.

--- a/docs/runner-host-hygiene.md
+++ b/docs/runner-host-hygiene.md
@@ -453,8 +453,8 @@ install -o root -g root -m 0600 <prepared-generated-cache-bindings> \
 ```
 
 ```sudoers
-Cmnd_Alias LAUNCHPLANE_GENERATED_CACHE_OBSERVE = /usr/local/sbin/launchplane-generated-run-cache ^observe [a-z0-9][a-z0-9._-]{0,63}=/[^[:space:]]+ ([2-9]|10) ([0-9]|[1-5][0-9]|60)$
-Cmnd_Alias LAUNCHPLANE_GENERATED_CACHE_PRUNE = /usr/local/sbin/launchplane-generated-run-cache ^prune [a-z0-9][a-z0-9._-]{0,63}=/[^[:space:]]+ ([2-9]|10) ([0-9]|[1-5][0-9]|60) [1-9][0-9]*(,[1-9][0-9]*)*$
+Cmnd_Alias LAUNCHPLANE_GENERATED_CACHE_OBSERVE = /usr/local/sbin/launchplane-generated-run-cache ^observe [a-z0-9][a-z0-9._-]{0,63}=/[^[:space:]]+ ([2-9]|10) ([1-9]|[1-5][0-9]|60)$
+Cmnd_Alias LAUNCHPLANE_GENERATED_CACHE_PRUNE = /usr/local/sbin/launchplane-generated-run-cache ^prune [a-z0-9][a-z0-9._-]{0,63}=/[^[:space:]]+ ([2-9]|10) ([1-9]|[1-5][0-9]|60) [1-9][0-9]*(,[1-9][0-9]*)*$
 <service-user> ALL=(root) NOPASSWD: NOSETENV: LAUNCHPLANE_GENERATED_CACHE_OBSERVE, LAUNCHPLANE_GENERATED_CACHE_PRUNE
 ```
 

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -3024,7 +3024,11 @@ The corresponding read routes require the separate
 
 List responses contain summaries rather than inventory-bearing audit payloads.
 Detail and history responses omit raw image and volume rows and expose bounded
-counts, truncation state, finding codes, and availability-aware cache telemetry.
+counts, truncation state, finding codes, availability-aware cache telemetry,
+and public-safe source-attributed idle convergence. The convergence payload
+distinguishes `idle`, `active`, `incomplete`, and `conflicting` states and keeps
+unavailable, stale, unauthorized, truncated, and contradictory sources
+explicit rather than converting them to zero activity.
 Limits default to 25 and cannot exceed 100. Reports written after this contract
 preserve `observed_at`; older reports remain readable as `legacy_missing`
 without inferring time from an audit key. Read access does not authorize writes,

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -18508,6 +18508,10 @@
               "approved_host_mismatch",
               "audit_record_required",
               "host_needs_attention",
+              "idle_evidence_missing",
+              "idle_evidence_not_converged",
+              "idle_evidence_scope_mismatch",
+              "idle_evidence_stale",
               "mutate_not_requested",
               "report_host_mismatch",
               "target_volume_active",
@@ -18668,6 +18672,47 @@
           },
           "host_name": {
             "title": "Host Name",
+            "type": "string"
+          },
+          "idle_decision_at": {
+            "default": "",
+            "title": "Idle Decision At",
+            "type": "string"
+          },
+          "idle_max_age_seconds": {
+            "default": 300,
+            "maximum": 86400.0,
+            "minimum": 1.0,
+            "title": "Idle Max Age Seconds",
+            "type": "integer"
+          },
+          "idle_observation_count": {
+            "default": 2,
+            "maximum": 10.0,
+            "minimum": 2.0,
+            "title": "Idle Observation Count",
+            "type": "integer"
+          },
+          "idle_observation_interval_seconds": {
+            "default": 5,
+            "maximum": 3600.0,
+            "minimum": 1.0,
+            "title": "Idle Observation Interval Seconds",
+            "type": "integer"
+          },
+          "idle_scope": {
+            "default": "full_host",
+            "enum": [
+              "full_host",
+              "isolated_user",
+              "isolated_lane"
+            ],
+            "title": "Idle Scope",
+            "type": "string"
+          },
+          "idle_scope_key": {
+            "default": "host",
+            "title": "Idle Scope Key",
             "type": "string"
           },
           "max_used_space_bytes": {
@@ -19203,6 +19248,9 @@
               "generated_cache_above_limit",
               "generated_cache_measurement_partial",
               "generated_cache_safety_failed",
+              "idle_evidence_active",
+              "idle_evidence_conflicting",
+              "idle_evidence_incomplete",
               "orphan_buildkit_present",
               "required_warm_builder_missing",
               "runner_workdir_above_limit",
@@ -19288,7 +19336,8 @@
             "enum": [
               "completed",
               "active",
-              "unknown"
+              "unknown",
+              "unauthorized"
             ],
             "title": "Github Run State",
             "type": "string"
@@ -19370,6 +19419,16 @@
             "minimum": 0.0,
             "title": "Estimated Daily Growth Bytes",
             "type": "integer"
+          },
+          "idle_convergence": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RunnerHostHygieneIdleConvergence"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "last_cleanup_epoch_seconds": {
             "default": 0,
@@ -19566,6 +19625,246 @@
         "title": "RunnerHostHygieneHistoryResponse",
         "type": "object"
       },
+      "RunnerHostHygieneIdleConvergence": {
+        "additionalProperties": false,
+        "properties": {
+          "blocker_codes": {
+            "default": [],
+            "items": {
+              "enum": [
+                "observation_count_insufficient",
+                "observation_time_invalid",
+                "observation_window_too_short",
+                "source_active",
+                "source_conflicting",
+                "source_missing",
+                "source_stale",
+                "source_truncated",
+                "source_unauthorized",
+                "source_unavailable"
+              ],
+              "type": "string"
+            },
+            "title": "Blocker Codes",
+            "type": "array"
+          },
+          "evaluated_at": {
+            "title": "Evaluated At",
+            "type": "string"
+          },
+          "maximum_evidence_age_seconds": {
+            "default": 300,
+            "maximum": 86400.0,
+            "minimum": 1.0,
+            "title": "Maximum Evidence Age Seconds",
+            "type": "integer"
+          },
+          "minimum_observation_interval_seconds": {
+            "maximum": 3600.0,
+            "minimum": 1.0,
+            "title": "Minimum Observation Interval Seconds",
+            "type": "integer"
+          },
+          "observations": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneIdleObservation"
+            },
+            "title": "Observations",
+            "type": "array"
+          },
+          "requirements": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneIdleSourceRequirement"
+            },
+            "title": "Requirements",
+            "type": "array"
+          },
+          "scope": {
+            "enum": [
+              "full_host",
+              "isolated_user",
+              "isolated_lane"
+            ],
+            "title": "Scope",
+            "type": "string"
+          },
+          "scope_key": {
+            "title": "Scope Key",
+            "type": "string"
+          },
+          "status": {
+            "default": "incomplete",
+            "enum": [
+              "idle",
+              "active",
+              "incomplete",
+              "conflicting"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "scope",
+          "scope_key",
+          "evaluated_at",
+          "minimum_observation_interval_seconds",
+          "requirements",
+          "observations"
+        ],
+        "title": "RunnerHostHygieneIdleConvergence",
+        "type": "object"
+      },
+      "RunnerHostHygieneIdleObservation": {
+        "additionalProperties": false,
+        "properties": {
+          "active_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Active Count"
+          },
+          "availability": {
+            "enum": [
+              "available",
+              "partial",
+              "unavailable",
+              "stale"
+            ],
+            "title": "Availability",
+            "type": "string"
+          },
+          "observation_window_seconds": {
+            "default": 0,
+            "maximum": 36000.0,
+            "minimum": 0.0,
+            "title": "Observation Window Seconds",
+            "type": "integer"
+          },
+          "observed_at": {
+            "title": "Observed At",
+            "type": "string"
+          },
+          "reason_code": {
+            "default": "",
+            "title": "Reason Code",
+            "type": "string"
+          },
+          "sample_count": {
+            "default": 1,
+            "maximum": 10.0,
+            "minimum": 1.0,
+            "title": "Sample Count",
+            "type": "integer"
+          },
+          "scope": {
+            "enum": [
+              "full_host",
+              "isolated_user",
+              "isolated_lane"
+            ],
+            "title": "Scope",
+            "type": "string"
+          },
+          "scope_key": {
+            "title": "Scope Key",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "github_jobs",
+              "github_runners",
+              "local_processes",
+              "local_user_processes",
+              "runner_services",
+              "open_handles"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "state": {
+            "enum": [
+              "idle",
+              "active",
+              "unknown"
+            ],
+            "title": "State",
+            "type": "string"
+          },
+          "subject_key": {
+            "title": "Subject Key",
+            "type": "string"
+          },
+          "total_count": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Count"
+          },
+          "truncated": {
+            "default": false,
+            "title": "Truncated",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "source",
+          "scope",
+          "scope_key",
+          "subject_key",
+          "observed_at",
+          "availability",
+          "state"
+        ],
+        "title": "RunnerHostHygieneIdleObservation",
+        "type": "object"
+      },
+      "RunnerHostHygieneIdleSourceRequirement": {
+        "additionalProperties": false,
+        "properties": {
+          "minimum_observation_count": {
+            "default": 2,
+            "maximum": 10.0,
+            "minimum": 1.0,
+            "title": "Minimum Observation Count",
+            "type": "integer"
+          },
+          "source": {
+            "enum": [
+              "github_jobs",
+              "github_runners",
+              "local_processes",
+              "local_user_processes",
+              "runner_services",
+              "open_handles"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
+          "subject_key": {
+            "title": "Subject Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source",
+          "subject_key"
+        ],
+        "title": "RunnerHostHygieneIdleSourceRequirement",
+        "type": "object"
+      },
       "RunnerHostHygieneImageInventoryItem": {
         "additionalProperties": false,
         "properties": {
@@ -19689,6 +19988,14 @@
           "host_name": {
             "title": "Host Name",
             "type": "string"
+          },
+          "idle_convergences": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneIdleConvergence"
+            },
+            "title": "Idle Convergences",
+            "type": "array"
           },
           "image_inventory": {
             "default": [],
@@ -19854,6 +20161,13 @@
             "title": "Host Name",
             "type": "string"
           },
+          "idle_convergences": {
+            "items": {
+              "$ref": "#/components/schemas/RunnerHostHygieneIdleConvergence"
+            },
+            "title": "Idle Convergences",
+            "type": "array"
+          },
           "image_inventory_total_count": {
             "title": "Image Inventory Total Count",
             "type": "integer"
@@ -19914,6 +20228,7 @@
           "generated_cache_apparent_bytes",
           "generated_cache_allocated_bytes",
           "cache_class_telemetry",
+          "idle_convergences",
           "image_inventory_total_count",
           "image_inventory_truncated",
           "volume_inventory_total_count",

--- a/scripts/runner-host-hygiene-generated-run-cache.sh
+++ b/scripts/runner-host-hygiene-generated-run-cache.sh
@@ -437,7 +437,7 @@ readonly prune_observation_count="$3"
 readonly prune_observation_interval_seconds="$4"
 readonly requested_run_ids_csv="$5"
 [[ "$prune_observation_count" =~ ^([2-9]|10)$ ]]
-[[ "$prune_observation_interval_seconds" =~ ^([0-9]|[1-5][0-9]|60)$ ]]
+[[ "$prune_observation_interval_seconds" =~ ^([1-9]|[1-5][0-9]|60)$ ]]
 [[ "$requested_run_ids_csv" =~ ^[1-9][0-9]*(,[1-9][0-9]*)*$ ]]
 
 collect_inventory "$prune_observation_count" "$prune_observation_interval_seconds"

--- a/scripts/runner-host-hygiene-generated-run-cache.sh
+++ b/scripts/runner-host-hygiene-generated-run-cache.sh
@@ -43,7 +43,7 @@ else
   readonly observation_interval_seconds="$4"
 fi
 [[ "$observation_count" =~ ^([2-9]|10)$ ]]
-[[ "$observation_interval_seconds" =~ ^([0-9]|[1-5][0-9]|60)$ ]]
+[[ "$observation_interval_seconds" =~ ^([1-9]|[1-5][0-9]|60)$ ]]
 
 readonly cache_key="${binding%%=*}"
 readonly root_path="${binding#*=}"

--- a/tests/http_app_test_support.py
+++ b/tests/http_app_test_support.py
@@ -100,6 +100,13 @@ from control_plane.contracts.runner_host_hygiene import (
     evaluate_runner_host_hygiene,
     plan_runner_host_hygiene_apply,
 )
+from control_plane.contracts.runner_host_hygiene_idle import (
+    RunnerHostHygieneIdleConvergence,
+    RunnerHostHygieneIdleObservation,
+    RunnerHostHygieneIdleSource,
+    RunnerHostHygieneIdleSourceRequirement,
+    build_runner_host_hygiene_idle_convergence,
+)
 from control_plane.contracts.runner_lane_inventory import build_runner_lane_inventory
 from control_plane.contracts.runner_lane_registration import (
     RunnerLaneRegistrationAuditRecord,
@@ -1168,6 +1175,7 @@ def _runner_host_hygiene_audit_payload(
             observed_at="2026-05-23T13:00:00Z",
             free_disk_bytes=500,
             warm_builders=("odoo-docker-chris-testing",),
+            idle_convergences=(_runner_host_idle_convergence(),),
         ),
     )
     request = RunnerHostHygieneApplyRequest(
@@ -1199,6 +1207,46 @@ def _runner_host_hygiene_audit_payload(
         "product": product,
         "audit": audit_record.model_dump(mode="json"),
     }
+
+
+def _runner_host_idle_convergence() -> RunnerHostHygieneIdleConvergence:
+    sources: tuple[tuple[RunnerHostHygieneIdleSource, str], ...] = (
+        ("github_jobs", "lane-key"),
+        ("github_runners", "lane-key"),
+        ("local_processes", "host-processes"),
+        ("runner_services", "runner-services"),
+    )
+    return build_runner_host_hygiene_idle_convergence(
+        scope="full_host",
+        scope_key="host",
+        evaluated_at="2026-05-23T13:00:00Z",
+        minimum_observation_interval_seconds=5,
+        maximum_evidence_age_seconds=300,
+        requirements=tuple(
+            RunnerHostHygieneIdleSourceRequirement(
+                source=source,
+                subject_key=subject_key,
+                minimum_observation_count=2,
+            )
+            for source, subject_key in sources
+        ),
+        observations=tuple(
+            RunnerHostHygieneIdleObservation(
+                source=source,
+                scope="full_host",
+                scope_key="host",
+                subject_key=subject_key,
+                observed_at="2026-05-23T13:00:00Z",
+                availability="available",
+                state="idle",
+                sample_count=2,
+                observation_window_seconds=5,
+                active_count=0,
+                total_count=1,
+            )
+            for source, subject_key in sources
+        ),
+    )
 
 
 def _runner_lane_registration_audit_write_identity() -> GitHubActionsIdentity:

--- a/tests/test_http_app_records.py
+++ b/tests/test_http_app_records.py
@@ -2392,7 +2392,16 @@ class FastApiRunnerHostHygieneAuditReadTests(unittest.IsolatedAsyncioTestCase):
             detail_response.json()["record"]["summary"]["audit_record_key"],
             newer_record.audit_record_key,
         )
-        self.assertNotIn("image_inventory", detail_response.json()["record"]["pre_apply_report"])
+        pre_apply_report = detail_response.json()["record"]["pre_apply_report"]
+        self.assertNotIn("image_inventory", pre_apply_report)
+        self.assertEqual(pre_apply_report["idle_convergences"][0]["status"], "idle")
+        self.assertEqual(
+            {
+                observation["source"]
+                for observation in pre_apply_report["idle_convergences"][0]["observations"]
+            },
+            {"github_jobs", "github_runners", "local_processes", "runner_services"},
+        )
         self.assertEqual(history_response.status_code, 200)
         history_payload = history_response.json()
         self.assertEqual(history_payload["host_name"], "chris-testing")

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -418,6 +418,7 @@ class RunnerHostHygieneTests(unittest.TestCase):
                 ),
             ),
             remote_runner=runner,
+            idle_observation_sleeper=lambda _seconds: None,
         )
 
         self.assertIsNotNone(report.docker_toolchain)
@@ -518,6 +519,7 @@ class RunnerHostHygieneTests(unittest.TestCase):
                 ),
             ),
             remote_runner=runner,
+            idle_observation_sleeper=lambda _seconds: None,
         )
 
         self.assertIsNotNone(report.docker_toolchain)
@@ -638,6 +640,7 @@ class RunnerHostHygieneTests(unittest.TestCase):
                 ),
             ),
             remote_runner=runner,
+            idle_observation_sleeper=lambda _seconds: None,
         )
 
         self.assertIsNone(report.docker_toolchain)

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -735,6 +735,41 @@ class RunnerHostHygieneCliTests(unittest.TestCase):
 
         self.assertEqual(token, "env-token")
 
+    def test_executor_requires_github_token_env_for_idle_bindings(self) -> None:
+        with TemporaryDirectory() as temporary_directory:
+            result = CliRunner().invoke(
+                CLI_MAIN,
+                [
+                    "work-graph",
+                    "runner-host-hygiene-executor",
+                    "--host-name",
+                    "runner-host",
+                    "--execution-lane",
+                    "ops-gate",
+                    "--service-user",
+                    "runner-hygiene",
+                    "--repository-scope",
+                    "example/launchplane",
+                    "--audit-record-key",
+                    "runner-host-hygiene/test",
+                    "--retained-warm-builder",
+                    "warm-builder",
+                    "--runner-workdir-root",
+                    "runner=/srv/runner",
+                    "--github-idle-binding",
+                    "example/launchplane|ops-gate|runner-1|runner@ops-gate.service",
+                    "--service-url",
+                    "https://launchplane.example",
+                    "--github-token-env",
+                    "",
+                    "--audit-spool-root",
+                    temporary_directory,
+                ],
+            )
+
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("GitHub evidence requires --github-token-env", result.output)
+
     def test_executor_bearer_token_mints_actions_oidc_token_on_demand(self) -> None:
         class _Response:
             def __enter__(self) -> "_Response":
@@ -1593,6 +1628,31 @@ class RunnerHostHygieneApplyPlanTests(unittest.TestCase):
                 pre_apply_report=healthy_report,
                 post_apply_report=healthy_report,
             )
+
+    def test_failed_apply_audit_can_record_blocked_pre_action_plan(self) -> None:
+        request = RunnerHostHygieneApplyRequest(
+            action="prune_docker_cache",
+            host_name="chris-testing",
+            mutate=True,
+            audit_record_key="runner-host-hygiene/2026-05-23/chris-testing",
+        )
+        blocked_plan = plan_runner_host_hygiene_apply(
+            policy=RunnerHostHygieneApplyPolicy(approved_hosts=("chris-testing",)),
+            request=request,
+            report=_attention_report(),
+        )
+
+        audit = RunnerHostHygieneApplyAuditRecord(
+            audit_record_key=request.audit_record_key,
+            status="failed",
+            request=request,
+            plan=blocked_plan,
+            pre_apply_report=_attention_report(),
+            message="fresh pre-action evidence blocked mutation",
+        )
+
+        self.assertEqual(audit.plan.status, "blocked")
+        self.assertEqual(audit.status, "failed")
 
 
 class RunnerHostHygieneAdapterBoundaryTests(unittest.TestCase):

--- a/tests/test_runner_host_hygiene.py
+++ b/tests/test_runner_host_hygiene.py
@@ -735,40 +735,46 @@ class RunnerHostHygieneCliTests(unittest.TestCase):
 
         self.assertEqual(token, "env-token")
 
-    def test_executor_requires_github_token_env_for_idle_bindings(self) -> None:
+    def test_executor_requires_github_token_configuration_for_idle_bindings(self) -> None:
         with TemporaryDirectory() as temporary_directory:
-            result = CliRunner().invoke(
+            arguments = [
+                "work-graph",
+                "runner-host-hygiene-executor",
+                "--host-name",
+                "runner-host",
+                "--execution-lane",
+                "ops-gate",
+                "--service-user",
+                "runner-hygiene",
+                "--repository-scope",
+                "example/launchplane",
+                "--audit-record-key",
+                "runner-host-hygiene/test",
+                "--retained-warm-builder",
+                "warm-builder",
+                "--runner-workdir-root",
+                "runner=/srv/runner",
+                "--github-idle-binding",
+                "example/launchplane|ops-gate|runner-1|runner@ops-gate.service",
+                "--service-url",
+                "https://launchplane.example",
+                "--audit-spool-root",
+                temporary_directory,
+            ]
+            missing_name = CliRunner().invoke(
                 CLI_MAIN,
-                [
-                    "work-graph",
-                    "runner-host-hygiene-executor",
-                    "--host-name",
-                    "runner-host",
-                    "--execution-lane",
-                    "ops-gate",
-                    "--service-user",
-                    "runner-hygiene",
-                    "--repository-scope",
-                    "example/launchplane",
-                    "--audit-record-key",
-                    "runner-host-hygiene/test",
-                    "--retained-warm-builder",
-                    "warm-builder",
-                    "--runner-workdir-root",
-                    "runner=/srv/runner",
-                    "--github-idle-binding",
-                    "example/launchplane|ops-gate|runner-1|runner@ops-gate.service",
-                    "--service-url",
-                    "https://launchplane.example",
-                    "--github-token-env",
-                    "",
-                    "--audit-spool-root",
-                    temporary_directory,
-                ],
+                [*arguments, "--github-token-env", ""],
             )
+            with patch.dict(os.environ, {}, clear=True):
+                missing_value = CliRunner().invoke(
+                    CLI_MAIN,
+                    [*arguments, "--github-token-env", "MISSING_GITHUB_TOKEN"],
+                )
 
-        self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("GitHub evidence requires --github-token-env", result.output)
+        self.assertNotEqual(missing_name.exit_code, 0)
+        self.assertIn("GitHub evidence requires --github-token-env", missing_name.output)
+        self.assertNotEqual(missing_value.exit_code, 0)
+        self.assertIn("requires a populated token", missing_value.output)
 
     def test_executor_bearer_token_mints_actions_oidc_token_on_demand(self) -> None:
         class _Response:

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -1409,6 +1409,10 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             '[[ "$observation_interval_seconds" =~ ^([1-9]|[1-5][0-9]|60)$ ]]',
             helper_text,
         )
+        self.assertIn(
+            '[[ "$prune_observation_interval_seconds" =~ ^([1-9]|[1-5][0-9]|60)$ ]]',
+            helper_text,
+        )
         self.assertIn("--one-file-system", helper_text)
         self.assertIn("candidate_low_water < candidate_high_water", helper_text)
         self.assertIn("entry_identity_by_name", helper_text)
@@ -1979,6 +1983,67 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             self.assertEqual(envelope.execution_state, "terminal_recorded")
             self.assertEqual(envelope.terminal_delivery_state, "delivered")
 
+    def test_executor_records_fresh_pre_action_block_without_mutation(self) -> None:
+        class _ActivityAppearsCommandRunner(_CommandRunner):
+            def __init__(self) -> None:
+                super().__init__()
+                self._idle_probe_count = 0
+
+            def __call__(self, command: Sequence[str], timeout_seconds: int) -> RemoteCommandResult:
+                command_tuple = tuple(command)
+                if command_tuple[:2] == ("bash", "-lc") and "pgrep -af" in command_tuple[2]:
+                    self.commands.append(command_tuple)
+                    self._idle_probe_count += 1
+                    return RemoteCommandResult(
+                        returncode=0,
+                        stdout=(
+                            ""
+                            if self._idle_probe_count <= 2
+                            else "789 /opt/actions-runner/bin/Runner.Worker spawnclient 456\n"
+                        ),
+                    )
+                return super().__call__(command_tuple, timeout_seconds)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
+            request = _request(mutate=True)
+            command_runner = _ActivityAppearsCommandRunner()
+
+            result = execute_runner_host_hygiene_executor(
+                request=request,
+                remote_runner=command_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(result.status, "failed")
+            self.assertFalse(
+                any(command[:5] == _ENGINE_PRUNE_PREFIX for command in command_runner.commands)
+            )
+            envelope = spool.read(
+                host_name=request.host_name,
+                action=request.action,
+                audit_record_key=request.audit_record_key,
+            )
+            assert envelope is not None
+            self.assertEqual(envelope.execution_state, "terminal_recorded")
+            terminal_audit = envelope.terminal_audit
+            assert terminal_audit is not None
+            self.assertEqual(terminal_audit.status, "failed")
+            self.assertEqual(terminal_audit.plan.status, "blocked")
+
+            reconciled = execute_runner_host_hygiene_executor(
+                request=request,
+                remote_runner=_CommandRunner(),
+                audit_poster=_AuditPoster(),
+                audit_spool=spool,
+                audit_delivery_sleeper=lambda _seconds: None,
+            )
+
+            self.assertEqual(reconciled.status, "failed")
+            self.assertTrue(reconciled.reconciled)
+
     def test_executor_retries_terminal_audit_delivery(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
@@ -2464,29 +2529,42 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
 
     def test_service_audit_poster_refreshes_token_per_post(self) -> None:
         class _Response:
+            def __init__(self, payload: Mapping[str, object]) -> None:
+                self._payload = payload
+
             def __enter__(self) -> "_Response":
                 return self
 
             def __exit__(self, *_args: object) -> None:
                 return None
 
-            @staticmethod
-            def read() -> bytes:
-                return b'{"status":"accepted"}'
+            def read(self) -> bytes:
+                return json.dumps(self._payload).encode()
 
         observed_authorization_headers: list[str | None] = []
         tokens = iter(("first-token", "second-token"))
+        audit = _planned_audit()
+        response_payload = {
+            "status": "accepted",
+            "records": {
+                "runner_host_hygiene_audit_record_key": audit.audit_record_key,
+            },
+            "result": {
+                "runner_host_hygiene_audit_record_key": audit.audit_record_key,
+                "audit_status": audit.status,
+                "mutate": audit.request.mutate,
+            },
+        }
 
         def fake_urlopen(request: Request, timeout: int) -> _Response:
             self.assertEqual(timeout, 30)
             observed_authorization_headers.append(request.get_header("Authorization"))
-            return _Response()
+            return _Response(response_payload)
 
         poster = build_refreshing_service_audit_poster(
             service_url="https://launchplane.example",
             bearer_token_provider=lambda: next(tokens),
         )
-        audit = _planned_audit()
         with patch(
             "control_plane.workflows.runner_host_hygiene_executor.urlopen",
             side_effect=fake_urlopen,
@@ -2498,6 +2576,31 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             observed_authorization_headers,
             ["Bearer first-token", "Bearer second-token"],
         )
+
+    def test_service_audit_poster_rejects_mismatched_acceptance(self) -> None:
+        class _Response:
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            @staticmethod
+            def read() -> bytes:
+                return b'{"status":"accepted","records":{},"result":{}}'
+
+        poster = build_refreshing_service_audit_poster(
+            service_url="https://launchplane.example",
+            bearer_token_provider=lambda: "token",
+        )
+        with (
+            patch(
+                "control_plane.workflows.runner_host_hygiene_executor.urlopen",
+                return_value=_Response(),
+            ),
+            self.assertRaisesRegex(AuditDeliveryError, "mismatched audit acceptance"),
+        ):
+            poster(_planned_audit(), "idempotency-key")
 
     def test_github_run_state_reader_supports_public_repository_without_token(self) -> None:
         class _Response:
@@ -2556,6 +2659,12 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 "total_count": 2,
                 "workflow_runs": [{"id": 102}, {"id": 999}],
             },
+            "status=waiting": {
+                "total_count": 1,
+                "workflow_runs": [{"id": 103}],
+            },
+            "status=pending": {"total_count": 0, "workflow_runs": []},
+            "status=requested": {"total_count": 0, "workflow_runs": []},
             "/actions/runs/101/jobs": {
                 "total_count": 1,
                 "jobs": [
@@ -2571,6 +2680,15 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                     {
                         "status": "in_progress",
                         "labels": ["self-hosted", "other-lane"],
+                    }
+                ],
+            },
+            "/actions/runs/103/jobs": {
+                "total_count": 1,
+                "jobs": [
+                    {
+                        "status": "waiting",
+                        "labels": ["self-hosted", "ops-gate"],
                     }
                 ],
             },
@@ -2632,7 +2750,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
 
         by_source = {observation.source: observation for observation in observations}
         self.assertEqual(by_source["github_jobs"].state, "active")
-        self.assertEqual(by_source["github_jobs"].active_count, 1)
+        self.assertEqual(by_source["github_jobs"].active_count, 2)
         self.assertEqual(by_source["github_runners"].state, "idle")
         self.assertEqual(by_source["github_runners"].active_count, 0)
         self.assertNotEqual(by_source["github_jobs"].subject_key, "ops-gate")

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -622,6 +622,73 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertEqual(len(github_observations), 4)
         self.assertEqual(len({item.subject_key for item in github_observations}), 2)
 
+    def test_full_host_idle_excludes_current_job_across_same_repository_lane(self) -> None:
+        bindings = (
+            RunnerHostGitHubBinding(
+                repository_scope="cbusillo/launchplane",
+                execution_lane="shared-lane",
+                runner_name="primary-runner",
+                service_unit="launchplane-runner@primary.service",
+            ),
+            RunnerHostGitHubBinding(
+                repository_scope="cbusillo/launchplane",
+                execution_lane="shared-lane",
+                runner_name="secondary-runner",
+                service_unit="launchplane-runner@secondary.service",
+            ),
+        )
+        exclusions: list[tuple[str, bool]] = []
+
+        def github_reader(
+            repository: str,
+            execution_lane: str,
+            runner_name: str,
+            exclude_current_job: bool,
+        ) -> tuple[RunnerHostHygieneIdleObservation, ...]:
+            exclusions.append((runner_name, exclude_current_job))
+            subject_key = _public_identity_key(
+                "runner",
+                "|".join((repository, execution_lane, runner_name)),
+            )
+            return tuple(
+                RunnerHostHygieneIdleObservation(
+                    source=source,
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=utc_now_timestamp(),
+                    availability="available",
+                    state="idle",
+                    active_count=0,
+                    total_count=1,
+                )
+                for source in ("github_jobs", "github_runners")
+            )
+
+        report = _collect_runner_host_hygiene_report(
+            request=_request(
+                mutate=False,
+                repository_scope="cbusillo/launchplane",
+                execution_lane="shared-lane",
+                current_runner_name="primary-runner",
+                github_idle_bindings=bindings,
+            ),
+            remote_runner=_CommandRunner(
+                runner_service_output=(
+                    "launchplane-runner@primary.service active running\n"
+                    "launchplane-runner@secondary.service active running\n"
+                )
+            ),
+            github_idle_evidence_reader=github_reader,
+            idle_observation_sleeper=lambda _seconds: None,
+        )
+
+        self.assertEqual(report.idle_convergences[0].status, "idle")
+        self.assertEqual(
+            set(exclusions),
+            {("primary-runner", True), ("secondary-runner", True)},
+        )
+
     def test_executor_posts_planned_and_completed_audits(self) -> None:
         command_runner = _CommandRunner()
         audit_poster = _AuditPoster()
@@ -1946,6 +2013,10 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             artifact_text = (temporary_path / "artifact.json").read_text(encoding="utf-8")
             self.assertNotIn("Bearer", artifact_text)
             self.assertNotIn("temporary-token", artifact_text)
+            self.assertNotIn(request.execution_lane, artifact_text)
+            self.assertNotIn(request.service_user, artifact_text)
+            self.assertNotIn(request.repository_scope, artifact_text)
+            self.assertNotIn(request.current_runner_name, artifact_text)
 
             reconciliation_runner = _CommandRunner()
             reconciled = execute_runner_host_hygiene_executor(
@@ -2692,6 +2763,16 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                     }
                 ],
             },
+            "/actions/runs/999/jobs": {
+                "total_count": 1,
+                "jobs": [
+                    {
+                        "status": "in_progress",
+                        "labels": ["self-hosted", "ops-gate"],
+                        "runner_name": "current-runner",
+                    }
+                ],
+            },
             "/actions/runners": {
                 "total_count": 2,
                 "runners": [
@@ -2756,17 +2837,107 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertNotEqual(by_source["github_jobs"].subject_key, "ops-gate")
         self.assertTrue(by_source["github_jobs"].subject_key.startswith("runner-"))
 
-    def test_github_idle_reader_preserves_unauthorized_runner_source(self) -> None:
+    def test_github_idle_reader_excludes_only_current_runner_for_sibling_binding(self) -> None:
+        responses = {
+            "status=queued": {"total_count": 0, "workflow_runs": []},
+            "status=in_progress": {
+                "total_count": 1,
+                "workflow_runs": [{"id": 999}],
+            },
+            "status=waiting": {"total_count": 0, "workflow_runs": []},
+            "status=pending": {"total_count": 0, "workflow_runs": []},
+            "status=requested": {"total_count": 0, "workflow_runs": []},
+            "/actions/runs/999/jobs": {
+                "total_count": 1,
+                "jobs": [
+                    {
+                        "status": "in_progress",
+                        "labels": ["self-hosted", "ops-gate"],
+                        "runner_name": "current-runner",
+                    }
+                ],
+            },
+            "/actions/runners": {
+                "total_count": 2,
+                "runners": [
+                    {
+                        "name": "current-runner",
+                        "status": "online",
+                        "busy": True,
+                        "labels": [{"name": "ops-gate"}],
+                    },
+                    {
+                        "name": "sibling-runner",
+                        "status": "online",
+                        "busy": True,
+                        "labels": [{"name": "ops-gate"}],
+                    },
+                ],
+            },
+        }
+
         class _Response:
+            def __init__(self, payload: Mapping[str, object]) -> None:
+                self._payload = payload
+
             def __enter__(self) -> "_Response":
                 return self
 
             def __exit__(self, *_args: object) -> None:
                 return None
 
-            @staticmethod
-            def read() -> bytes:
-                return b'{"total_count":0,"workflow_runs":[]}'
+            def read(self) -> bytes:
+                return json.dumps(self._payload).encode()
+
+        def fake_urlopen(request: Request, timeout: int) -> _Response:
+            self.assertEqual(timeout, 30)
+            for fragment, payload in responses.items():
+                if fragment in request.full_url:
+                    return _Response(payload)
+            raise AssertionError(f"unexpected GitHub request: {request.full_url}")
+
+        reader = build_github_idle_evidence_reader(
+            bearer_token="token",
+            current_run_id=999,
+            current_runner_name="current-runner",
+        )
+        with patch(
+            "control_plane.workflows.runner_host_hygiene_executor.urlopen",
+            side_effect=fake_urlopen,
+        ):
+            current = reader(
+                "cbusillo/launchplane",
+                "ops-gate",
+                "current-runner",
+                True,
+            )
+            sibling = reader(
+                "cbusillo/launchplane",
+                "ops-gate",
+                "sibling-runner",
+                True,
+            )
+
+        current_by_source = {item.source: item for item in current}
+        sibling_by_source = {item.source: item for item in sibling}
+        self.assertEqual(current_by_source["github_jobs"].state, "idle")
+        self.assertEqual(current_by_source["github_runners"].state, "idle")
+        self.assertEqual(sibling_by_source["github_jobs"].state, "idle")
+        self.assertEqual(sibling_by_source["github_runners"].state, "active")
+
+    def test_github_idle_reader_preserves_unauthorized_runner_source(self) -> None:
+        class _Response:
+            def __init__(self, payload: Mapping[str, object]) -> None:
+                self._payload = payload
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(self._payload).encode()
 
         def fake_urlopen(request: Request, timeout: int) -> _Response:
             self.assertEqual(timeout, 30)
@@ -2778,7 +2949,27 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                     hdrs=Message(),
                     fp=BytesIO(b"forbidden"),
                 )
-            return _Response()
+            if "/actions/runs/999/jobs" in request.full_url:
+                return _Response(
+                    {
+                        "total_count": 1,
+                        "jobs": [
+                            {
+                                "status": "in_progress",
+                                "labels": ["self-hosted", "ops-gate"],
+                                "runner_name": "current-runner",
+                            }
+                        ],
+                    }
+                )
+            return _Response(
+                {
+                    "total_count": 1 if "status=in_progress" in request.full_url else 0,
+                    "workflow_runs": (
+                        [{"id": 999}] if "status=in_progress" in request.full_url else []
+                    ),
+                }
+            )
 
         reader = build_github_idle_evidence_reader(
             bearer_token="token",

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from email.message import Message
+from functools import partial
 from io import BytesIO
 import tempfile
 import unittest
@@ -10,7 +11,8 @@ from collections.abc import Sequence
 from collections.abc import Mapping
 import subprocess
 from pathlib import Path
-from typing import Literal
+import time
+from typing import Any, Literal
 from unittest.mock import patch
 from urllib.error import HTTPError
 from urllib.request import Request
@@ -18,17 +20,24 @@ from urllib.request import Request
 import click
 
 from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyAuditRecord
+from control_plane.contracts.runner_host_hygiene_idle import (
+    RunnerHostHygieneIdleObservation,
+)
 from control_plane.workflows.runner_host_hygiene_executor import RemoteCommandResult
 from control_plane.workflows.runner_host_hygiene_executor import RunnerHostHygieneExecutorRequest
 from control_plane.workflows.runner_host_hygiene_executor import GeneratedRunCacheRoot
+from control_plane.workflows.runner_host_hygiene_executor import RunnerHostGitHubBinding
 from control_plane.workflows.runner_host_hygiene_executor import RunnerWorkdirRoot
 from control_plane.workflows.runner_host_hygiene_executor import AuditDeliveryError
 from control_plane.workflows.runner_host_hygiene_executor import (
     build_refreshing_service_audit_poster,
 )
+from control_plane.workflows.runner_host_hygiene_executor import (
+    build_github_idle_evidence_reader,
+)
 from control_plane.workflows.runner_host_hygiene_executor import build_github_run_state_reader
 from control_plane.workflows.runner_host_hygiene_executor import (
-    execute_runner_host_hygiene_executor,
+    execute_runner_host_hygiene_executor as _execute_runner_host_hygiene_executor,
 )
 from control_plane.workflows.runner_host_hygiene_executor import _DOCKER_DISK_USAGE_COMMAND
 from control_plane.workflows.runner_host_hygiene_executor import _GENERATED_RUN_CACHE_HELPER
@@ -40,8 +49,13 @@ from control_plane.workflows.runner_host_hygiene_executor import (
 )
 from control_plane.workflows.runner_host_hygiene_executor import _parse_docker_disk_usage
 from control_plane.workflows.runner_host_hygiene_executor import _RUNNER_WORKDIR_USAGE_HELPER
-from control_plane.workflows.runner_host_hygiene_executor import collect_runner_host_hygiene_report
+from control_plane.workflows.runner_host_hygiene_executor import (
+    collect_runner_host_hygiene_report as _collect_runner_host_hygiene_report,
+)
+from control_plane.workflows.runner_host_hygiene_executor import _public_identity_key
+from control_plane.workflows.runner_host_hygiene_executor import _aggregate_github_idle_samples
 from control_plane.workflows.runner_host_hygiene_executor import validate_local_executor_environment
+from control_plane.workflows.ship import utc_now_timestamp
 from control_plane.workflows.runner_host_hygiene_audit_spool import (
     RunnerHostHygieneAuditSpool,
 )
@@ -93,6 +107,7 @@ class _CommandRunner:
         runner_workdir_status: Literal["complete", "partial"] = "complete",
         generated_cache_before: str = "",
         generated_cache_after: str = "",
+        runner_service_output: str = ("launchplane-runner@ops-gate.service active running\n"),
     ) -> None:
         self.commands: list[tuple[str, ...]] = []
         self._prune_returncode = prune_returncode
@@ -146,6 +161,7 @@ class _CommandRunner:
         self._runner_workdir_status = runner_workdir_status
         self._generated_cache_before = generated_cache_before
         self._generated_cache_after = generated_cache_after
+        self._runner_service_output = runner_service_output
         self._generated_cache_pruned = False
         self._pruned = False
         self.removed_volumes: list[str] = []
@@ -226,6 +242,11 @@ class _CommandRunner:
             return RemoteCommandResult(returncode=1, stderr="image missing")
         if command_tuple[:2] == ("bash", "-lc") and "pgrep -af" in command_tuple[2]:
             return RemoteCommandResult(returncode=0, stdout=self._active_build_processes)
+        if command_tuple[:2] == ("bash", "-lc") and "systemctl list-units" in command_tuple[2]:
+            return RemoteCommandResult(
+                returncode=0,
+                stdout=self._runner_service_output,
+            )
         if command_tuple[:4] == ("docker", "inspect", "--format", "{{.State.Running}}"):
             return RemoteCommandResult(returncode=0, stdout="true\n")
         if command_tuple[:2] == ("docker", "exec") and command_tuple[3:] == (
@@ -294,6 +315,56 @@ class _CommandRunner:
                 stderr="volume rm failed",
             )
         return RemoteCommandResult(returncode=127, stderr="unexpected command")
+
+
+def _github_idle_evidence_reader(
+    repository: str,
+    execution_lane: str,
+    runner_name: str = "test-runner",
+    _exclude_current: bool = True,
+) -> tuple[RunnerHostHygieneIdleObservation, ...]:
+    observed_at = utc_now_timestamp()
+    subject_key = _public_identity_key(
+        "runner",
+        "|".join((repository.lower(), execution_lane.lower(), runner_name)),
+    )
+    return tuple(
+        RunnerHostHygieneIdleObservation(
+            source=source,
+            scope="full_host",
+            scope_key="host",
+            subject_key=subject_key,
+            observed_at=observed_at,
+            availability="available",
+            state="idle",
+            active_count=0,
+            total_count=1,
+        )
+        for source in ("github_jobs", "github_runners")
+    )
+
+
+def execute_runner_host_hygiene_executor(
+    *,
+    request: RunnerHostHygieneExecutorRequest,
+    **kwargs: Any,
+) -> Any:
+    kwargs.setdefault("audit_delivery_sleeper", lambda _seconds: None)
+    kwargs.setdefault("github_idle_evidence_reader", _github_idle_evidence_reader)
+    if request.mutate and kwargs.get("audit_spool") is None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            kwargs["audit_spool"] = RunnerHostHygieneAuditSpool(
+                root=Path(temporary_directory) / "spool"
+            )
+            return _execute_runner_host_hygiene_executor(request=request, **kwargs)
+    return _execute_runner_host_hygiene_executor(request=request, **kwargs)
+
+
+collect_runner_host_hygiene_report = partial(
+    _collect_runner_host_hygiene_report,
+    idle_observation_sleeper=lambda _seconds: None,
+    github_idle_evidence_reader=_github_idle_evidence_reader,
+)
 
 
 def _buildkit_volume_evidence(
@@ -397,6 +468,20 @@ class _CrashingCommandRunner(_CommandRunner):
         return super().__call__(command_tuple, timeout_seconds)
 
 
+class _PreActionCrashingCommandRunner(_CommandRunner):
+    def __init__(self) -> None:
+        super().__init__()
+        self._disk_observations = 0
+
+    def __call__(self, command: Sequence[str], timeout_seconds: int) -> RemoteCommandResult:
+        command_tuple = tuple(command)
+        if command_tuple == ("df", "-B1", "-P", "/"):
+            self._disk_observations += 1
+            if self._disk_observations == 2:
+                raise RuntimeError("simulated pre-action termination")
+        return super().__call__(command_tuple, timeout_seconds)
+
+
 class RunnerHostHygieneWorkflowTests(unittest.TestCase):
     def test_workflow_runs_on_ops_lane_without_xargs_dependency(self) -> None:
         workflow_text = Path(".github/workflows/runner-host-hygiene.yml").read_text(
@@ -446,6 +531,97 @@ class RunnerHostHygieneWorkflowTests(unittest.TestCase):
 
 
 class RunnerHostHygieneExecutorTests(unittest.TestCase):
+    def test_full_host_idle_requires_complete_binding_manifest(self) -> None:
+        report = collect_runner_host_hygiene_report(
+            request=_request(
+                mutate=False,
+                current_runner_name="",
+                github_idle_bindings=(),
+            ),
+            remote_runner=_CommandRunner(),
+        )
+
+        convergence = report.idle_convergences[0]
+        self.assertEqual(convergence.status, "incomplete")
+        self.assertIn("source_missing", convergence.blocker_codes)
+        self.assertEqual(
+            {
+                observation.source
+                for observation in convergence.observations
+                if observation.reason_code == "source_missing"
+            },
+            {"github_jobs", "github_runners", "runner_services"},
+        )
+
+    def test_full_host_idle_covers_every_repository_binding(self) -> None:
+        bindings = (
+            RunnerHostGitHubBinding(
+                repository_scope="cbusillo/launchplane",
+                execution_lane="shared-lane",
+                runner_name="primary-runner",
+                service_unit="launchplane-runner@ops-gate.service",
+            ),
+            RunnerHostGitHubBinding(
+                repository_scope="example/secondary",
+                execution_lane="shared-lane",
+                runner_name="secondary-runner",
+                service_unit="launchplane-runner@secondary.service",
+            ),
+        )
+
+        def github_reader(
+            repository: str,
+            execution_lane: str,
+            runner_name: str,
+            _exclude_current: bool,
+        ) -> tuple[RunnerHostHygieneIdleObservation, ...]:
+            subject_key = _public_identity_key(
+                "runner",
+                "|".join((repository, execution_lane, runner_name)),
+            )
+            active = repository == "example/secondary"
+            return tuple(
+                RunnerHostHygieneIdleObservation(
+                    source=source,
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at=utc_now_timestamp(),
+                    availability="available",
+                    state="active" if active and source == "github_jobs" else "idle",
+                    active_count=1 if active and source == "github_jobs" else 0,
+                    total_count=1,
+                )
+                for source in ("github_jobs", "github_runners")
+            )
+
+        report = _collect_runner_host_hygiene_report(
+            request=_request(
+                mutate=False,
+                execution_lane="shared-lane",
+                current_runner_name="primary-runner",
+                github_idle_bindings=bindings,
+            ),
+            remote_runner=_CommandRunner(
+                runner_service_output=(
+                    "launchplane-runner@ops-gate.service active running\n"
+                    "launchplane-runner@secondary.service active running\n"
+                )
+            ),
+            github_idle_evidence_reader=github_reader,
+            idle_observation_sleeper=lambda _seconds: None,
+        )
+
+        convergence = report.idle_convergences[0]
+        self.assertEqual(convergence.status, "active")
+        github_observations = tuple(
+            observation
+            for observation in convergence.observations
+            if observation.source in {"github_jobs", "github_runners"}
+        )
+        self.assertEqual(len(github_observations), 4)
+        self.assertEqual(len({item.subject_key for item in github_observations}), 2)
+
     def test_executor_posts_planned_and_completed_audits(self) -> None:
         command_runner = _CommandRunner()
         audit_poster = _AuditPoster()
@@ -555,6 +731,10 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
     def test_executor_rejects_prune_age_below_retention_floor(self) -> None:
         with self.assertRaisesRegex(ValueError, "retain at least 168 hours"):
             _request(mutate=True, prune_until="167h")
+
+    def test_executor_rejects_zero_idle_observation_interval(self) -> None:
+        with self.assertRaisesRegex(ValueError, "idle_observation_interval_seconds"):
+            _request(mutate=True, idle_observation_interval_seconds=0)
 
     def test_executor_normalizes_prune_age_hours(self) -> None:
         request = _request(mutate=True, prune_until="168H")
@@ -732,7 +912,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertTrue(volume.dangling)
         self.assertEqual(volume.mountpoint, "")
         self.assertEqual(volume.labels, ())
-        self.assertEqual(command_runner.commands.count(_DOCKER_DISK_USAGE_COMMAND), 2)
+        self.assertEqual(command_runner.commands.count(_DOCKER_DISK_USAGE_COMMAND), 3)
 
     def test_report_bounds_docker_inventories_and_marks_telemetry_partial(self) -> None:
         image_rows: list[dict[str, object]] = [
@@ -869,6 +1049,15 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             audit_poster.audits[0].request.target_generated_cache_run_ids,
             (101, 102),
         )
+        pre_apply_idle = audit_poster.audits[0].pre_apply_report.idle_convergences
+        self.assertEqual(len(pre_apply_idle), 1)
+        self.assertEqual(pre_apply_idle[0].scope, "isolated_user")
+        self.assertEqual(pre_apply_idle[0].scope_key, root.key)
+        self.assertEqual(pre_apply_idle[0].status, "idle")
+        self.assertEqual(
+            {observation.source for observation in pre_apply_idle[0].observations},
+            {"github_jobs", "local_user_processes", "open_handles"},
+        )
         prune_command = next(
             command
             for command in command_runner.commands
@@ -964,6 +1153,67 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             any(command[:7] == _GENERATED_CACHE_PRUNE_PREFIX for command in command_runner.commands)
         )
 
+    def test_generated_run_cache_preserves_unauthorized_github_state(self) -> None:
+        root = GeneratedRunCacheRoot(
+            key="codex-lab-runs",
+            path="/home/gha/.cache/codex-ci",
+            source_repository="cbusillo/codex-lab",
+            high_water_bytes=100,
+            low_water_bytes=10,
+            minimum_age_hours=1,
+            cooldown_hours=1,
+        )
+        command_runner = _CommandRunner(
+            generated_cache_before=_generated_cache_evidence(
+                entries=((101, 120, 120, 7_200, (0, 0)),),
+                worker_observations=(0, 0),
+            )
+        )
+        audit_poster = _AuditPoster()
+
+        result = execute_runner_host_hygiene_executor(
+            request=_request(
+                mutate=True,
+                action="prune_generated_run_cache",
+                generated_run_cache_roots=(root,),
+                target_generated_cache_key=root.key,
+            ),
+            remote_runner=command_runner,
+            audit_poster=audit_poster,
+            github_run_state_reader=lambda _repository, run_ids: {
+                run_id: "unauthorized" for run_id in run_ids
+            },
+        )
+
+        self.assertEqual(result.status, "blocked")
+        cache = audit_poster.audits[0].pre_apply_report.generated_cache_usage[0]
+        self.assertEqual(cache.entries[0].github_run_state, "unauthorized")
+        assert cache.idle_convergence is not None
+        github_observation = next(
+            item for item in cache.idle_convergence.observations if item.source == "github_jobs"
+        )
+        self.assertEqual(github_observation.reason_code, "source_unauthorized")
+
+    def test_generated_run_cache_rejects_unimplemented_isolated_lane_scope(self) -> None:
+        root = GeneratedRunCacheRoot(
+            key="codex-lab-runs",
+            path="/home/gha/.cache/codex-ci",
+            source_repository="cbusillo/codex-lab",
+            high_water_bytes=100,
+            low_water_bytes=10,
+            minimum_age_hours=1,
+            cooldown_hours=1,
+            idle_scope="isolated_lane",
+        )
+
+        with self.assertRaisesRegex(ValueError, "isolated_user"):
+            _request(
+                mutate=False,
+                action="prune_generated_run_cache",
+                generated_run_cache_roots=(root,),
+                target_generated_cache_key=root.key,
+            )
+
     def test_generated_run_cache_mutation_requires_durable_spool(self) -> None:
         root = GeneratedRunCacheRoot(
             key="codex-lab-runs",
@@ -976,7 +1226,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         )
 
         with self.assertRaisesRegex(click.ClickException, "requires durable"):
-            execute_runner_host_hygiene_executor(
+            _execute_runner_host_hygiene_executor(
                 request=_request(
                     mutate=True,
                     action="prune_generated_run_cache",
@@ -985,6 +1235,8 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 ),
                 remote_runner=_CommandRunner(),
                 audit_poster=_AuditPoster(),
+                audit_delivery_sleeper=lambda _seconds: None,
+                github_idle_evidence_reader=_github_idle_evidence_reader,
             )
 
     def test_generated_run_cache_below_high_water_is_not_needed(self) -> None:
@@ -1042,6 +1294,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             generated_cache_before=_generated_cache_evidence(
                 entries=((101, 120, 120, 7_200, (0, 0)),),
                 worker_observations=(0, 0),
+                observed_epoch_seconds=10_000,
                 last_cleanup_epoch_seconds=9_900,
             )
         )
@@ -1152,6 +1405,10 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertIn("/proc/self/fd/4", helper_text)
         self.assertIn("owner_worker_observations", helper_text)
         self.assertIn("open_handle_observations", helper_text)
+        self.assertIn(
+            '[[ "$observation_interval_seconds" =~ ^([1-9]|[1-5][0-9]|60)$ ]]',
+            helper_text,
+        )
         self.assertIn("--one-file-system", helper_text)
         self.assertIn("candidate_low_water < candidate_high_water", helper_text)
         self.assertIn("entry_identity_by_name", helper_text)
@@ -1236,7 +1493,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                     _RUNNER_WORKDIR_USAGE_HELPER,
                 ):
                     helper_calls += 1
-                    if helper_calls == 2:
+                    if helper_calls == 3:
                         return RemoteCommandResult(
                             returncode=1,
                             stderr="sudo denied legacy=/private/runner/root",
@@ -1567,11 +1824,11 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             audit_poster=audit_poster,
         )
 
-        self.assertEqual(result.status, "failed")
-        self.assertIn("active runner or build processes", result.message)
+        self.assertEqual(result.status, "blocked")
+        self.assertEqual([record[0] for record in audit_poster.records], ["planned"])
         self.assertIn(
-            ("failed", "runner-host-hygiene:runner-host-hygiene/2026-05-23/chris-testing:failed"),
-            audit_poster.records,
+            "idle_evidence_active",
+            {finding.code for finding in audit_poster.audits[0].pre_apply_report.findings},
         )
         self.assertFalse(
             any(command[:5] == _ENGINE_PRUNE_PREFIX for command in command_runner.commands)
@@ -1589,8 +1846,11 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             audit_poster=audit_poster,
         )
 
-        self.assertEqual(result.status, "failed")
-        self.assertIn("Runner.Worker", result.message)
+        self.assertEqual(result.status, "blocked")
+        self.assertIn(
+            "idle_evidence_active",
+            {finding.code for finding in audit_poster.audits[0].pre_apply_report.findings},
+        )
         self.assertFalse(
             any(command[:5] == _ENGINE_PRUNE_PREFIX for command in command_runner.commands)
         )
@@ -1628,8 +1888,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             audit_delivery_sleeper=lambda _seconds: None,
         )
 
-        self.assertEqual(result.status, "failed")
-        self.assertIn("789", result.message)
+        self.assertEqual(result.status, "blocked")
 
     def test_executor_requires_two_consecutive_idle_samples(self) -> None:
         command_runner = _CommandRunner()
@@ -1647,7 +1906,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             for command in command_runner.commands
             if command[:2] == ("bash", "-lc") and "pgrep -af" in command[2]
         ]
-        self.assertEqual(len(idle_commands), 2)
+        self.assertEqual(len(idle_commands), 6)
 
     def test_executor_spools_terminal_audit_before_failed_delivery(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -1822,10 +2081,27 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
             request = _request(mutate=True)
+            crashing_runner = _CrashingCommandRunner()
+            disk_observations = iter((900, 800))
+
+            def varying_evidence_runner(
+                command: Sequence[str], timeout_seconds: int
+            ) -> RemoteCommandResult:
+                if tuple(command) == ("df", "-B1", "-P", "/"):
+                    available_bytes = next(disk_observations)
+                    return RemoteCommandResult(
+                        returncode=0,
+                        stdout=(
+                            "Filesystem 1B-blocks Used Available Use% Mounted on\n"
+                            f"/dev/disk 1000 100 {available_bytes} 10% /\n"
+                        ),
+                    )
+                return crashing_runner(command, timeout_seconds)
+
             with self.assertRaisesRegex(RuntimeError, "simulated runner termination"):
                 execute_runner_host_hygiene_executor(
                     request=request,
-                    remote_runner=_CrashingCommandRunner(),
+                    remote_runner=varying_evidence_runner,
                     audit_poster=_AuditPoster(),
                     audit_spool=spool,
                     audit_delivery_sleeper=lambda _seconds: None,
@@ -1837,18 +2113,33 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             )
             assert envelope is not None
             self.assertEqual(envelope.execution_state, "action_started")
+            self.assertIsNotNone(envelope.action_authorization)
+            assert envelope.action_authorization is not None
+            self.assertEqual(
+                envelope.planned_audit.pre_apply_report.free_disk_bytes,
+                900,
+            )
+            self.assertEqual(
+                envelope.action_authorization.pre_apply_report.free_disk_bytes,
+                800,
+            )
             resolution_runner = _CommandRunner()
+            resolution_poster = _AuditPoster()
 
             resolved = execute_runner_host_hygiene_executor(
                 request=_request(mutate=True, resolve_action_started=True),
                 remote_runner=resolution_runner,
-                audit_poster=_AuditPoster(),
+                audit_poster=resolution_poster,
                 audit_spool=spool,
                 audit_delivery_sleeper=lambda _seconds: None,
             )
 
             self.assertEqual(resolved.status, "failed")
             self.assertTrue(resolved.reconciled)
+            self.assertEqual(
+                resolution_poster.audits[-1].pre_apply_report.free_disk_bytes,
+                800,
+            )
             self.assertFalse(
                 any(
                     command[:5]
@@ -1862,6 +2153,65 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                     for command in resolution_runner.commands
                 )
             )
+
+    def test_executor_terminalizes_interrupted_planned_state_without_mutation(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
+            request = _request(mutate=True)
+            with self.assertRaisesRegex(RuntimeError, "pre-action termination"):
+                execute_runner_host_hygiene_executor(
+                    request=request,
+                    remote_runner=_PreActionCrashingCommandRunner(),
+                    audit_poster=_AuditPoster(),
+                    audit_spool=spool,
+                )
+            envelope = spool.read(
+                host_name=request.host_name,
+                action=request.action,
+                audit_record_key=request.audit_record_key,
+            )
+            assert envelope is not None
+            self.assertEqual(envelope.execution_state, "planned")
+            reconciliation_runner = _CommandRunner()
+
+            result = execute_runner_host_hygiene_executor(
+                request=request,
+                remote_runner=reconciliation_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=spool,
+            )
+
+            self.assertEqual(result.status, "failed")
+            self.assertTrue(result.reconciled)
+            self.assertEqual(reconciliation_runner.commands, [])
+
+    def test_action_started_recovery_rejects_changed_executor_intent(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            spool = RunnerHostHygieneAuditSpool(root=Path(temporary_directory) / "spool")
+            request = _request(mutate=True)
+            with self.assertRaisesRegex(RuntimeError, "simulated runner termination"):
+                execute_runner_host_hygiene_executor(
+                    request=request,
+                    remote_runner=_CrashingCommandRunner(),
+                    audit_poster=_AuditPoster(),
+                    audit_spool=spool,
+                )
+            resolution_runner = _CommandRunner()
+
+            result = execute_runner_host_hygiene_executor(
+                request=_request(
+                    mutate=True,
+                    resolve_action_started=True,
+                    idle_observation_interval_seconds=2,
+                ),
+                remote_runner=resolution_runner,
+                audit_poster=_AuditPoster(),
+                audit_spool=spool,
+            )
+
+            self.assertEqual(result.status, "blocked")
+            self.assertIn("do not match", result.message)
+            self.assertEqual(resolution_runner.commands, [])
 
     def test_executor_redacts_action_failure_before_audit_and_artifact(self) -> None:
         secret = "ghp_aaaaaaaaaaaa"
@@ -2179,6 +2529,200 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         self.assertEqual(states, {101: "completed"})
         self.assertEqual(observed_authorization, [None])
 
+    def test_github_run_state_reader_preserves_unauthorized_response(self) -> None:
+        reader = build_github_run_state_reader(bearer_token="token")
+
+        with patch(
+            "control_plane.workflows.runner_host_hygiene_executor.urlopen",
+            side_effect=HTTPError(
+                url="https://api.github.test/run",
+                code=403,
+                msg="forbidden",
+                hdrs=Message(),
+                fp=BytesIO(b"forbidden"),
+            ),
+        ):
+            states = reader("cbusillo/codex-lab", (101,))
+
+        self.assertEqual(states, {101: "unauthorized"})
+
+    def test_github_idle_reader_attributes_job_and_runner_activity(self) -> None:
+        responses = {
+            "status=queued": {
+                "total_count": 1,
+                "workflow_runs": [{"id": 101}],
+            },
+            "status=in_progress": {
+                "total_count": 2,
+                "workflow_runs": [{"id": 102}, {"id": 999}],
+            },
+            "/actions/runs/101/jobs": {
+                "total_count": 1,
+                "jobs": [
+                    {
+                        "status": "queued",
+                        "labels": ["self-hosted", "ops-gate"],
+                    }
+                ],
+            },
+            "/actions/runs/102/jobs": {
+                "total_count": 1,
+                "jobs": [
+                    {
+                        "status": "in_progress",
+                        "labels": ["self-hosted", "other-lane"],
+                    }
+                ],
+            },
+            "/actions/runners": {
+                "total_count": 2,
+                "runners": [
+                    {
+                        "name": "current-runner",
+                        "status": "online",
+                        "busy": True,
+                        "labels": [{"name": "ops-gate"}],
+                    },
+                    {
+                        "name": "peer-runner",
+                        "status": "online",
+                        "busy": False,
+                        "labels": [{"name": "ops-gate"}],
+                    },
+                ],
+            },
+        }
+
+        class _Response:
+            def __init__(self, payload: Mapping[str, object]) -> None:
+                self._payload = payload
+
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            def read(self) -> bytes:
+                return json.dumps(self._payload).encode()
+
+        def fake_urlopen(request: Request, timeout: int) -> _Response:
+            self.assertEqual(timeout, 30)
+            self.assertEqual(request.get_header("Authorization"), "Bearer token")
+            for fragment, payload in responses.items():
+                if fragment in request.full_url:
+                    return _Response(payload)
+            raise AssertionError(f"unexpected GitHub request: {request.full_url}")
+
+        reader = build_github_idle_evidence_reader(
+            bearer_token="token",
+            current_run_id=999,
+            current_runner_name="current-runner",
+        )
+        with patch(
+            "control_plane.workflows.runner_host_hygiene_executor.urlopen",
+            side_effect=fake_urlopen,
+        ):
+            observations = reader(
+                "cbusillo/launchplane",
+                "ops-gate",
+                "current-runner",
+                True,
+            )
+
+        by_source = {observation.source: observation for observation in observations}
+        self.assertEqual(by_source["github_jobs"].state, "active")
+        self.assertEqual(by_source["github_jobs"].active_count, 1)
+        self.assertEqual(by_source["github_runners"].state, "idle")
+        self.assertEqual(by_source["github_runners"].active_count, 0)
+        self.assertNotEqual(by_source["github_jobs"].subject_key, "ops-gate")
+        self.assertTrue(by_source["github_jobs"].subject_key.startswith("runner-"))
+
+    def test_github_idle_reader_preserves_unauthorized_runner_source(self) -> None:
+        class _Response:
+            def __enter__(self) -> "_Response":
+                return self
+
+            def __exit__(self, *_args: object) -> None:
+                return None
+
+            @staticmethod
+            def read() -> bytes:
+                return b'{"total_count":0,"workflow_runs":[]}'
+
+        def fake_urlopen(request: Request, timeout: int) -> _Response:
+            self.assertEqual(timeout, 30)
+            if "/actions/runners" in request.full_url:
+                raise HTTPError(
+                    url=request.full_url,
+                    code=403,
+                    msg="forbidden",
+                    hdrs=Message(),
+                    fp=BytesIO(b"forbidden"),
+                )
+            return _Response()
+
+        reader = build_github_idle_evidence_reader(
+            bearer_token="token",
+            current_run_id=999,
+            current_runner_name="current-runner",
+        )
+        with patch(
+            "control_plane.workflows.runner_host_hygiene_executor.urlopen",
+            side_effect=fake_urlopen,
+        ):
+            observations = reader(
+                "cbusillo/launchplane",
+                "ops-gate",
+                "current-runner",
+                True,
+            )
+
+        by_source = {observation.source: observation for observation in observations}
+        self.assertEqual(by_source["github_jobs"].state, "idle")
+        self.assertEqual(by_source["github_runners"].availability, "unavailable")
+        self.assertEqual(by_source["github_runners"].reason_code, "source_unauthorized")
+
+    def test_github_idle_reader_fails_closed_without_current_job_identity(self) -> None:
+        reader = build_github_idle_evidence_reader(bearer_token="token")
+
+        observations = reader("cbusillo/launchplane", "ops-gate", "", True)
+
+        self.assertEqual(
+            {observation.reason_code for observation in observations},
+            {"source_missing"},
+        )
+
+    def test_github_idle_aggregation_preserves_source_timestamp(self) -> None:
+        samples = tuple(
+            tuple(
+                RunnerHostHygieneIdleObservation(
+                    source=source,
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key="lane-key",
+                    observed_at="2026-07-30T12:00:00Z",
+                    availability="available",
+                    state="idle",
+                    active_count=0,
+                    total_count=1,
+                )
+                for source in ("github_jobs", "github_runners")
+            )
+            for _ in range(2)
+        )
+
+        observations = _aggregate_github_idle_samples(
+            samples=samples,
+            observed_at="2026-07-30T13:00:00Z",
+            observation_window_seconds=5,
+        )
+
+        self.assertEqual(
+            {observation.observed_at for observation in observations},
+            {"2026-07-30T12:00:00Z"},
+        )
+
     def test_service_audit_poster_marks_route_not_found_non_retryable(self) -> None:
         poster = build_refreshing_service_audit_poster(
             service_url="https://launchplane.example",
@@ -2226,14 +2770,28 @@ def _request(
     ),
     generated_run_cache_roots: tuple[GeneratedRunCacheRoot, ...] = (),
     target_generated_cache_key: str = "",
+    idle_observation_interval_seconds: int = 1,
     resolve_action_started: bool = False,
+    execution_lane: str = "chris-testing-ops-gate",
+    repository_scope: str = "cbusillo/launchplane",
+    current_runner_name: str = "test-runner",
+    github_idle_bindings: tuple[RunnerHostGitHubBinding, ...] = (
+        RunnerHostGitHubBinding(
+            repository_scope="cbusillo/launchplane",
+            execution_lane="chris-testing-ops-gate",
+            runner_name="test-runner",
+            service_unit="launchplane-runner@ops-gate.service",
+        ),
+    ),
 ) -> RunnerHostHygieneExecutorRequest:
     return RunnerHostHygieneExecutorRequest(
         action=action,
         host_name="chris-testing",
-        execution_lane="chris-testing-ops-gate",
+        execution_lane=execution_lane,
         service_user="launchplane-runner-hygiene",
-        repository_scope="cbusillo/launchplane",
+        repository_scope=repository_scope,
+        current_runner_name=current_runner_name,
+        github_idle_bindings=github_idle_bindings,
         audit_record_key=audit_record_key,
         retained_warm_builders=("odoo-docker-chris-testing",),
         target_buildkit_builder=target_buildkit_builder,
@@ -2246,7 +2804,7 @@ def _request(
         runner_workdir_roots=runner_workdir_roots,
         generated_run_cache_roots=generated_run_cache_roots,
         target_generated_cache_key=target_generated_cache_key,
-        idle_observation_interval_seconds=0,
+        idle_observation_interval_seconds=idle_observation_interval_seconds,
         resolve_action_started=resolve_action_started,
     )
 
@@ -2270,6 +2828,7 @@ def _generated_cache_evidence(
     *,
     entries: tuple[tuple[int, int, int, int, tuple[int, ...]], ...],
     worker_observations: tuple[int, ...],
+    observed_epoch_seconds: int | None = None,
     last_cleanup_epoch_seconds: int = 0,
     last_reclaimed_bytes: int = 0,
 ) -> str:
@@ -2279,7 +2838,9 @@ def _generated_cache_evidence(
         {
             "record_type": "summary",
             "cache_key": "codex-lab-runs",
-            "observed_epoch_seconds": 10_000,
+            "observed_epoch_seconds": (
+                int(time.time()) if observed_epoch_seconds is None else observed_epoch_seconds
+            ),
             "apparent_bytes": apparent_bytes,
             "allocated_bytes": allocated_bytes,
             "entry_count": len(entries),

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -1986,6 +1986,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 root=temporary_path / "spool",
                 artifact_file=temporary_path / "artifact.json",
             )
+            current_service_unit = "launchplane-runner@ops-gate.service"
             sibling_runner_name = "sibling-runner"
             sibling_service_unit = "launchplane-runner@secondary.service"
             request = _request(
@@ -1995,7 +1996,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                         repository_scope="cbusillo/launchplane",
                         execution_lane="chris-testing-ops-gate",
                         runner_name="test-runner",
-                        service_unit="launchplane-runner@ops-gate.service",
+                        service_unit=current_service_unit,
                     ),
                     RunnerHostGitHubBinding(
                         repository_scope="cbusillo/launchplane",
@@ -2010,7 +2011,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 request=request,
                 remote_runner=_CommandRunner(
                     runner_service_output=(
-                        "launchplane-runner@ops-gate.service active running\n"
+                        f"{current_service_unit} active running\n"
                         f"{sibling_service_unit} active running\n"
                     )
                 ),
@@ -2044,6 +2045,7 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 self.assertNotIn(request.service_user, persisted_text)
                 self.assertNotIn(request.repository_scope, persisted_text)
                 self.assertNotIn(request.current_runner_name, persisted_text)
+                self.assertNotIn(current_service_unit, persisted_text)
                 self.assertNotIn(sibling_runner_name, persisted_text)
                 self.assertNotIn(sibling_service_unit, persisted_text)
 

--- a/tests/test_runner_host_hygiene_executor.py
+++ b/tests/test_runner_host_hygiene_executor.py
@@ -1986,11 +1986,34 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 root=temporary_path / "spool",
                 artifact_file=temporary_path / "artifact.json",
             )
-            request = _request(mutate=True)
+            sibling_runner_name = "sibling-runner"
+            sibling_service_unit = "launchplane-runner@secondary.service"
+            request = _request(
+                mutate=True,
+                github_idle_bindings=(
+                    RunnerHostGitHubBinding(
+                        repository_scope="cbusillo/launchplane",
+                        execution_lane="chris-testing-ops-gate",
+                        runner_name="test-runner",
+                        service_unit="launchplane-runner@ops-gate.service",
+                    ),
+                    RunnerHostGitHubBinding(
+                        repository_scope="cbusillo/launchplane",
+                        execution_lane="chris-testing-ops-gate",
+                        runner_name=sibling_runner_name,
+                        service_unit=sibling_service_unit,
+                    ),
+                ),
+            )
 
             result = execute_runner_host_hygiene_executor(
                 request=request,
-                remote_runner=_CommandRunner(),
+                remote_runner=_CommandRunner(
+                    runner_service_output=(
+                        "launchplane-runner@ops-gate.service active running\n"
+                        f"{sibling_service_unit} active running\n"
+                    )
+                ),
                 audit_poster=_TerminalFailingAuditPoster(),
                 audit_spool=spool,
                 audit_delivery_sleeper=lambda _seconds: None,
@@ -2011,12 +2034,18 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             assert terminal_audit is not None
             self.assertEqual(terminal_audit.status, "completed")
             artifact_text = (temporary_path / "artifact.json").read_text(encoding="utf-8")
-            self.assertNotIn("Bearer", artifact_text)
-            self.assertNotIn("temporary-token", artifact_text)
-            self.assertNotIn(request.execution_lane, artifact_text)
-            self.assertNotIn(request.service_user, artifact_text)
-            self.assertNotIn(request.repository_scope, artifact_text)
-            self.assertNotIn(request.current_runner_name, artifact_text)
+            spool_paths = tuple((temporary_path / "spool").rglob("*.json"))
+            self.assertEqual(len(spool_paths), 1)
+            spool_text = spool_paths[0].read_text(encoding="utf-8")
+            for persisted_text in (artifact_text, spool_text):
+                self.assertNotIn("Bearer", persisted_text)
+                self.assertNotIn("temporary-token", persisted_text)
+                self.assertNotIn(request.execution_lane, persisted_text)
+                self.assertNotIn(request.service_user, persisted_text)
+                self.assertNotIn(request.repository_scope, persisted_text)
+                self.assertNotIn(request.current_runner_name, persisted_text)
+                self.assertNotIn(sibling_runner_name, persisted_text)
+                self.assertNotIn(sibling_service_unit, persisted_text)
 
             reconciliation_runner = _CommandRunner()
             reconciled = execute_runner_host_hygiene_executor(
@@ -2724,15 +2753,18 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
         responses = {
             "status=queued": {
                 "total_count": 1,
-                "workflow_runs": [{"id": 101}],
+                "workflow_runs": [{"id": 101, "status": "queued"}],
             },
             "status=in_progress": {
                 "total_count": 2,
-                "workflow_runs": [{"id": 102}, {"id": 999}],
+                "workflow_runs": [
+                    {"id": 102, "status": "in_progress"},
+                    {"id": 999, "status": "in_progress"},
+                ],
             },
             "status=waiting": {
                 "total_count": 1,
-                "workflow_runs": [{"id": 103}],
+                "workflow_runs": [{"id": 103, "status": "waiting"}],
             },
             "status=pending": {"total_count": 0, "workflow_runs": []},
             "status=requested": {"total_count": 0, "workflow_runs": []},
@@ -2842,19 +2874,24 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             "status=queued": {"total_count": 0, "workflow_runs": []},
             "status=in_progress": {
                 "total_count": 1,
-                "workflow_runs": [{"id": 999}],
+                "workflow_runs": [{"id": 999, "status": "in_progress"}],
             },
             "status=waiting": {"total_count": 0, "workflow_runs": []},
             "status=pending": {"total_count": 0, "workflow_runs": []},
             "status=requested": {"total_count": 0, "workflow_runs": []},
             "/actions/runs/999/jobs": {
-                "total_count": 1,
+                "total_count": 2,
                 "jobs": [
                     {
                         "status": "in_progress",
                         "labels": ["self-hosted", "ops-gate"],
                         "runner_name": "current-runner",
-                    }
+                    },
+                    {
+                        "status": "in_progress",
+                        "labels": ["self-hosted", "ops-gate"],
+                        "runner_name": "sibling-runner",
+                    },
                 ],
             },
             "/actions/runners": {
@@ -2920,9 +2957,11 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
 
         current_by_source = {item.source: item for item in current}
         sibling_by_source = {item.source: item for item in sibling}
-        self.assertEqual(current_by_source["github_jobs"].state, "idle")
+        self.assertEqual(current_by_source["github_jobs"].state, "active")
+        self.assertEqual(current_by_source["github_jobs"].active_count, 1)
         self.assertEqual(current_by_source["github_runners"].state, "idle")
-        self.assertEqual(sibling_by_source["github_jobs"].state, "idle")
+        self.assertEqual(sibling_by_source["github_jobs"].state, "active")
+        self.assertEqual(sibling_by_source["github_jobs"].active_count, 1)
         self.assertEqual(sibling_by_source["github_runners"].state, "active")
 
     def test_github_idle_reader_preserves_unauthorized_runner_source(self) -> None:
@@ -2966,7 +3005,9 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
                 {
                     "total_count": 1 if "status=in_progress" in request.full_url else 0,
                     "workflow_runs": (
-                        [{"id": 999}] if "status=in_progress" in request.full_url else []
+                        [{"id": 999, "status": "in_progress"}]
+                        if "status=in_progress" in request.full_url
+                        else []
                     ),
                 }
             )
@@ -3001,6 +3042,106 @@ class RunnerHostHygieneExecutorTests(unittest.TestCase):
             {observation.reason_code for observation in observations},
             {"source_missing"},
         )
+
+    def test_github_idle_reader_fails_closed_on_missing_or_malformed_current_job(self) -> None:
+        def read_jobs_observation(
+            *,
+            run_status: str,
+            jobs: list[dict[str, object]],
+        ) -> RunnerHostHygieneIdleObservation:
+            responses = {
+                "status=queued": {"total_count": 0, "workflow_runs": []},
+                "status=in_progress": {
+                    "total_count": 1,
+                    "workflow_runs": [{"id": 999, "status": run_status}],
+                },
+                "status=waiting": {"total_count": 0, "workflow_runs": []},
+                "status=pending": {"total_count": 0, "workflow_runs": []},
+                "status=requested": {"total_count": 0, "workflow_runs": []},
+                "/actions/runs/999/jobs": {
+                    "total_count": len(jobs),
+                    "jobs": jobs,
+                },
+                "/actions/runners": {
+                    "total_count": 1,
+                    "runners": [
+                        {
+                            "name": "current-runner",
+                            "status": "online",
+                            "busy": True,
+                            "labels": [{"name": "ops-gate"}],
+                        }
+                    ],
+                },
+            }
+
+            class _Response:
+                def __init__(self, payload: Mapping[str, object]) -> None:
+                    self._payload = payload
+
+                def __enter__(self) -> "_Response":
+                    return self
+
+                def __exit__(self, *_args: object) -> None:
+                    return None
+
+                def read(self) -> bytes:
+                    return json.dumps(self._payload).encode()
+
+            def fake_urlopen(request: Request, timeout: int) -> _Response:
+                self.assertEqual(timeout, 30)
+                for fragment, payload in responses.items():
+                    if fragment in request.full_url:
+                        return _Response(payload)
+                raise AssertionError(f"unexpected GitHub request: {request.full_url}")
+
+            reader = build_github_idle_evidence_reader(
+                bearer_token="token",
+                current_run_id=999,
+                current_runner_name="current-runner",
+            )
+            with patch(
+                "control_plane.workflows.runner_host_hygiene_executor.urlopen",
+                side_effect=fake_urlopen,
+            ):
+                observations = reader(
+                    "cbusillo/launchplane",
+                    "ops-gate",
+                    "current-runner",
+                    True,
+                )
+            return next(item for item in observations if item.source == "github_jobs")
+
+        missing_current_job = read_jobs_observation(
+            run_status="in_progress",
+            jobs=[
+                {
+                    "status": "completed",
+                    "labels": ["self-hosted", "ops-gate"],
+                    "runner_name": "sibling-runner",
+                }
+            ],
+        )
+        malformed_run_status = read_jobs_observation(
+            run_status="mystery",
+            jobs=[],
+        )
+        malformed_job_status = read_jobs_observation(
+            run_status="in_progress",
+            jobs=[
+                {
+                    "status": "mystery",
+                    "labels": ["self-hosted", "ops-gate"],
+                    "runner_name": "current-runner",
+                }
+            ],
+        )
+
+        self.assertEqual(missing_current_job.availability, "unavailable")
+        self.assertEqual(missing_current_job.reason_code, "source_missing")
+        for malformed in (malformed_run_status, malformed_job_status):
+            self.assertEqual(malformed.availability, "unavailable")
+            self.assertEqual(malformed.reason_code, "source_contradictory")
 
     def test_github_idle_aggregation_preserves_source_timestamp(self) -> None:
         samples = tuple(

--- a/tests/test_runner_host_hygiene_idle.py
+++ b/tests/test_runner_host_hygiene_idle.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyPolicy
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneApplyRequest
+from control_plane.contracts.runner_host_hygiene import RunnerHostHygieneReport
+from control_plane.contracts.runner_host_hygiene import plan_runner_host_hygiene_apply
+from control_plane.contracts.runner_host_hygiene_idle import (
+    RunnerHostHygieneIdleConvergence,
+    RunnerHostHygieneIdleObservation,
+)
+from control_plane.contracts.runner_host_hygiene_idle import (
+    RunnerHostHygieneIdleSource,
+)
+from control_plane.contracts.runner_host_hygiene_idle import (
+    RunnerHostHygieneIdleSourceRequirement,
+)
+from control_plane.contracts.runner_host_hygiene_idle import (
+    build_runner_host_hygiene_idle_convergence,
+)
+
+
+class RunnerHostHygieneIdleContractTests(unittest.TestCase):
+    def test_full_host_sources_converge_idle(self) -> None:
+        convergence = _full_host_convergence()
+
+        self.assertEqual(convergence.status, "idle")
+        self.assertEqual(convergence.blocker_codes, ())
+
+    def test_active_source_prevents_idle_convergence(self) -> None:
+        convergence = _full_host_convergence(active_source="local_processes")
+
+        self.assertEqual(convergence.status, "active")
+        self.assertIn("source_active", convergence.blocker_codes)
+
+    def test_unauthorized_source_fails_closed(self) -> None:
+        convergence = _full_host_convergence(
+            incomplete_source="github_runners",
+            reason_code="source_unauthorized",
+        )
+
+        self.assertEqual(convergence.status, "incomplete")
+        self.assertIn("source_unauthorized", convergence.blocker_codes)
+
+    def test_truncated_source_fails_closed(self) -> None:
+        convergence = _full_host_convergence(
+            incomplete_source="github_jobs",
+            reason_code="source_truncated",
+            truncated=True,
+        )
+
+        self.assertEqual(convergence.status, "incomplete")
+        self.assertIn("source_truncated", convergence.blocker_codes)
+
+    def test_insufficient_temporal_window_fails_closed(self) -> None:
+        convergence = _full_host_convergence(
+            short_window_source="local_processes",
+        )
+
+        self.assertEqual(convergence.status, "incomplete")
+        self.assertIn("observation_window_too_short", convergence.blocker_codes)
+
+    def test_contradictory_source_has_distinct_status(self) -> None:
+        convergence = _full_host_convergence(
+            incomplete_source="runner_services",
+            reason_code="source_contradictory",
+        )
+
+        self.assertEqual(convergence.status, "conflicting")
+        self.assertIn("source_conflicting", convergence.blocker_codes)
+        self.assertNotIn("source_unavailable", convergence.blocker_codes)
+
+    def test_observation_scope_must_match_convergence(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "scope must match convergence"):
+            build_runner_host_hygiene_idle_convergence(
+                scope="full_host",
+                scope_key="host",
+                evaluated_at="2026-07-30T12:00:05Z",
+                minimum_observation_interval_seconds=5,
+                maximum_evidence_age_seconds=300,
+                requirements=(
+                    RunnerHostHygieneIdleSourceRequirement(
+                        source="local_processes",
+                        subject_key="host-processes",
+                    ),
+                ),
+                observations=(
+                    RunnerHostHygieneIdleObservation(
+                        source="local_processes",
+                        scope="isolated_user",
+                        scope_key="cache",
+                        subject_key="host-processes",
+                        observed_at="2026-07-30T12:00:05Z",
+                        availability="available",
+                        state="idle",
+                        sample_count=2,
+                        observation_window_seconds=5,
+                        active_count=0,
+                    ),
+                ),
+            )
+
+    def test_apply_plan_accepts_fresh_matching_idle_scope(self) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=_apply_policy(),
+            request=_apply_request(),
+            report=_report(_full_host_convergence()),
+        )
+
+        self.assertEqual(plan.status, "ready")
+
+    def test_apply_plan_blocks_stale_decision(self) -> None:
+        plan = plan_runner_host_hygiene_apply(
+            policy=_apply_policy(),
+            request=_apply_request(idle_decision_at="2026-07-30T12:06:00Z"),
+            report=_report(_full_host_convergence()),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn("idle_evidence_stale", {blocker.code for blocker in plan.blockers})
+
+    def test_apply_plan_rejects_incomplete_required_source_set(self) -> None:
+        convergence = build_runner_host_hygiene_idle_convergence(
+            scope="full_host",
+            scope_key="host",
+            evaluated_at="2026-07-30T12:00:05Z",
+            minimum_observation_interval_seconds=5,
+            maximum_evidence_age_seconds=300,
+            requirements=(
+                RunnerHostHygieneIdleSourceRequirement(
+                    source="local_processes",
+                    subject_key="host-processes",
+                ),
+            ),
+            observations=(_observation(source="local_processes", subject_key="host-processes"),),
+        )
+
+        plan = plan_runner_host_hygiene_apply(
+            policy=_apply_policy(),
+            request=_apply_request(),
+            report=_report(convergence),
+        )
+
+        self.assertEqual(plan.status, "blocked")
+        self.assertIn(
+            "idle_evidence_not_converged",
+            {blocker.code for blocker in plan.blockers},
+        )
+
+
+def _full_host_convergence(
+    *,
+    active_source: RunnerHostHygieneIdleSource | None = None,
+    incomplete_source: RunnerHostHygieneIdleSource | None = None,
+    short_window_source: RunnerHostHygieneIdleSource | None = None,
+    reason_code: str = "source_unavailable",
+    truncated: bool = False,
+) -> RunnerHostHygieneIdleConvergence:
+    sources: tuple[tuple[RunnerHostHygieneIdleSource, str], ...] = (
+        ("github_jobs", "lane-key"),
+        ("github_runners", "lane-key"),
+        ("local_processes", "host-processes"),
+        ("runner_services", "runner-services"),
+    )
+    requirements = tuple(
+        RunnerHostHygieneIdleSourceRequirement(
+            source=source,
+            subject_key=subject_key,
+            minimum_observation_count=2,
+        )
+        for source, subject_key in sources
+    )
+    observations = []
+    for source, subject_key in sources:
+        if source == incomplete_source:
+            observations.append(
+                RunnerHostHygieneIdleObservation(
+                    source=source,
+                    scope="full_host",
+                    scope_key="host",
+                    subject_key=subject_key,
+                    observed_at="2026-07-30T12:00:05Z",
+                    availability="partial" if truncated else "unavailable",
+                    state="unknown",
+                    sample_count=2,
+                    observation_window_seconds=5,
+                    truncated=truncated,
+                    reason_code=reason_code,
+                )
+            )
+            continue
+        observations.append(
+            _observation(
+                source=source,
+                subject_key=subject_key,
+                active=source == active_source,
+                observation_window_seconds=(0 if source == short_window_source else 5),
+            )
+        )
+    return build_runner_host_hygiene_idle_convergence(
+        scope="full_host",
+        scope_key="host",
+        evaluated_at="2026-07-30T12:00:05Z",
+        minimum_observation_interval_seconds=5,
+        maximum_evidence_age_seconds=300,
+        requirements=requirements,
+        observations=tuple(observations),
+    )
+
+
+def _observation(
+    *,
+    source: RunnerHostHygieneIdleSource,
+    subject_key: str,
+    active: bool = False,
+    observation_window_seconds: int = 5,
+) -> RunnerHostHygieneIdleObservation:
+    return RunnerHostHygieneIdleObservation(
+        source=source,
+        scope="full_host",
+        scope_key="host",
+        subject_key=subject_key,
+        observed_at="2026-07-30T12:00:05Z",
+        availability="available",
+        state="active" if active else "idle",
+        sample_count=2,
+        observation_window_seconds=observation_window_seconds,
+        active_count=1 if active else 0,
+        total_count=1,
+    )
+
+
+def _apply_policy() -> RunnerHostHygieneApplyPolicy:
+    return RunnerHostHygieneApplyPolicy(
+        approved_hosts=("runner-host",),
+        require_healthy_report=False,
+        require_audit_record=False,
+        require_idle_convergence=True,
+        allow_docker_cache_prune=True,
+    )
+
+
+def _apply_request(
+    *,
+    idle_decision_at: str = "2026-07-30T12:00:06Z",
+) -> RunnerHostHygieneApplyRequest:
+    return RunnerHostHygieneApplyRequest(
+        action="prune_docker_cache",
+        host_name="runner-host",
+        mutate=True,
+        idle_observation_count=2,
+        idle_observation_interval_seconds=5,
+        idle_max_age_seconds=300,
+        idle_decision_at=idle_decision_at,
+    )
+
+
+def _report(convergence: RunnerHostHygieneIdleConvergence) -> RunnerHostHygieneReport:
+    return RunnerHostHygieneReport(
+        status="healthy",
+        host_name="runner-host",
+        observed_at="2026-07-30T12:00:05Z",
+        idle_convergences=(convergence,),
+        summary="runner host hygiene report is healthy",
+    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add typed, source-attributed idle observations and convergence for runner-host hygiene
- require a complete runtime-only repository/lane/runner/service binding manifest for full-host Docker actions
- add isolated generated-cache evidence, fail-closed GitHub/API handling, and precise current-job attribution
- persist redacted planned, action-started, blocked, and terminal audit evidence with replay-safe intent binding
- document the runtime configuration, helper boundary, and operator behavior

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` — 2,479 targets passed
- `uv run --extra dev mypy control_plane tests` — 587 files passed
- focused runner-host suites — 137 tests passed
- changed-file Ruff check and format check passed
- JetBrains changed-file inspection passed with 0 findings
- frontend validation, OpenAPI drift, PostgreSQL integration, container build, config-authority audit, Actionlint, and shell syntax checks passed during branch validation
- independent multi-agent final reviews completed; all concrete findings resolved

Closes #1901
Parent: #1842