### PR TITLE
feat: add exact manager preview approval contract

### DIFF
--- a/control_plane/contracts/manager_preview_approval.py
+++ b/control_plane/contracts/manager_preview_approval.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import re
+from typing import Literal
+from urllib.parse import urlsplit
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from control_plane.contracts.artifact_dependency_provenance import (
+    normalize_artifact_sha256_digest,
+)
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+
+
+MANAGER_PREVIEW_APPROVAL_READ_ACTION = "manager_preview_approval.read"
+MANAGER_PREVIEW_APPROVAL_WRITE_ACTION = "manager_preview_approval.write"
+
+ManagerPreviewApprovalAction = Literal[
+    "approved",
+    "changes_requested",
+    "revoked",
+    "superseded",
+    "invalidated",
+]
+ManagerPreviewApprovalDecisionStatus = Literal[
+    "pending",
+    "approved",
+    "changes_requested",
+    "revoked",
+    "stale",
+    "unavailable",
+]
+ManagerPreviewApprovalReasonCode = Literal[
+    "approval_missing",
+    "approval_valid",
+    "changes_requested",
+    "approval_revoked",
+    "approval_stale",
+    "preview_inactive",
+    "serving_generation_missing",
+    "serving_generation_mismatch",
+    "generation_not_ready",
+    "generation_verification_failed",
+    "preview_identity_mismatch",
+    "artifact_identity_missing",
+    "runtime_identity_missing",
+    "runtime_identity_mismatch",
+    "policy_unavailable",
+]
+ManagerPreviewApprovalEventWriteStatus = Literal["written", "replayed"]
+
+_GIT_SHA_PATTERN = re.compile(r"^[0-9a-f]{40}(?:[0-9a-f]{24})?$")
+_SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$")
+_MANAGER_ACTIONS = frozenset({"approved", "changes_requested", "revoked"})
+_SYSTEM_ACTIONS = frozenset({"superseded", "invalidated"})
+
+
+class ManagerPreviewApprovalBinding(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    product: str
+    context: str
+    repository: str
+    pr_number: int = Field(ge=1)
+    pr_url: str
+    head_sha: str
+    preview_id: str
+    serving_generation_id: str
+    artifact_id: str
+    artifact_image_digest: str
+    manifest_fingerprint: str
+    preview_url: str
+    runtime_identity: RuntimeIdentity
+    runtime_identity_sha256: str = ""
+    binding_sha256: str = ""
+
+    @model_validator(mode="after")
+    def _validate_binding(self) -> "ManagerPreviewApprovalBinding":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported manager preview approval binding schema version.")
+        self.product = _required_token(self.product, "product").lower()
+        self.context = _required_token(self.context, "context").lower()
+        self.repository = _required_token(self.repository, "repository").lower()
+        self.pr_url = _required_http_url(self.pr_url, "pr_url")
+        self.head_sha = _required_token(self.head_sha, "head_sha").lower()
+        self.preview_id = _required_token(self.preview_id, "preview_id")
+        self.serving_generation_id = _required_token(
+            self.serving_generation_id, "serving_generation_id"
+        )
+        self.artifact_id = _required_token(self.artifact_id, "artifact_id")
+        self.artifact_image_digest = normalize_artifact_sha256_digest(
+            self.artifact_image_digest,
+            label="manager preview approval artifact_image_digest",
+        )
+        self.manifest_fingerprint = _required_token(
+            self.manifest_fingerprint, "manifest_fingerprint"
+        )
+        self.preview_url = _required_http_url(self.preview_url, "preview_url")
+        if _GIT_SHA_PATTERN.fullmatch(self.head_sha) is None:
+            raise ValueError(
+                "manager preview approval binding head_sha must be an exact lowercase Git SHA"
+            )
+
+        runtime_identity = self.runtime_identity
+        expected_runtime_values = {
+            "product": self.product,
+            "context": self.context,
+            "artifact_id": self.artifact_id,
+            "source_git_ref": self.head_sha,
+        }
+        mismatches = [
+            field_name
+            for field_name, expected_value in expected_runtime_values.items()
+            if str(getattr(runtime_identity, field_name)).strip().lower() != expected_value.lower()
+        ]
+        if runtime_identity.environment_kind.strip().lower() != "preview":
+            mismatches.append("environment_kind")
+        if not runtime_identity.preview_id.strip():
+            mismatches.append("preview_id")
+        if (
+            runtime_identity.preview_generation_id.strip()
+            and runtime_identity.preview_generation_id != self.serving_generation_id
+        ):
+            mismatches.append("preview_generation_id")
+        if mismatches:
+            raise ValueError(
+                "manager preview approval runtime identity mismatched fields: "
+                + ", ".join(mismatches)
+            )
+        image_digest = immutable_image_digest(runtime_identity.image_reference)
+        if image_digest != self.artifact_image_digest:
+            raise ValueError(
+                "manager preview approval runtime image does not match artifact_image_digest"
+            )
+
+        computed_runtime_identity_sha256 = runtime_identity_sha256(runtime_identity)
+        if self.runtime_identity_sha256:
+            self.runtime_identity_sha256 = self.runtime_identity_sha256.strip().lower()
+            if self.runtime_identity_sha256 != computed_runtime_identity_sha256:
+                raise ValueError(
+                    "manager preview approval runtime_identity_sha256 does not match payload"
+                )
+        else:
+            self.runtime_identity_sha256 = computed_runtime_identity_sha256
+
+        computed_binding_sha256 = manager_preview_approval_binding_sha256(self)
+        if self.binding_sha256:
+            self.binding_sha256 = self.binding_sha256.strip().lower()
+            if self.binding_sha256 != computed_binding_sha256:
+                raise ValueError("manager preview approval binding_sha256 does not match payload")
+        else:
+            self.binding_sha256 = computed_binding_sha256
+        return self
+
+
+class ManagerPreviewApprovalAuthorization(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    role: Literal["manager"] = "manager"
+    action: Literal["manager_preview_approval.write"] = "manager_preview_approval.write"
+    manager_github_id: int = Field(ge=1)
+    manager_login: str
+    managed_set_id: str
+    managed_rule_id: str
+    policy_record_id: str
+    policy_revision: int = Field(ge=1)
+    policy_schema_version: Literal[2] = 2
+    policy_sha256: str
+    policy_source: str
+    authorized_at: str
+
+    @model_validator(mode="after")
+    def _validate_authorization(self) -> "ManagerPreviewApprovalAuthorization":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported manager preview approval authorization schema version.")
+        for field_name in (
+            "manager_login",
+            "managed_set_id",
+            "managed_rule_id",
+            "policy_record_id",
+            "policy_source",
+        ):
+            setattr(self, field_name, _required_token(str(getattr(self, field_name)), field_name))
+        self.policy_sha256 = self.policy_sha256.strip().lower()
+        if _SHA256_PATTERN.fullmatch(self.policy_sha256) is None:
+            raise ValueError("manager preview approval authorization requires a policy SHA-256")
+        self.authorized_at = _normalize_utc_timestamp(self.authorized_at, "authorized_at")
+        return self
+
+
+class ManagerPreviewApprovalEventRecord(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    event_id: str = ""
+    approval_id: str = ""
+    binding: ManagerPreviewApprovalBinding
+    action: ManagerPreviewApprovalAction
+    occurred_at: str
+    source_event_kind: str
+    source_event_id: str
+    reason: str = ""
+    authorization: ManagerPreviewApprovalAuthorization | None = None
+
+    @model_validator(mode="after")
+    def _validate_event(self) -> "ManagerPreviewApprovalEventRecord":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported manager preview approval event schema version.")
+        self.occurred_at = _normalize_utc_timestamp(self.occurred_at, "occurred_at")
+        self.source_event_kind = _required_token(self.source_event_kind, "source_event_kind")
+        self.source_event_id = _required_token(self.source_event_id, "source_event_id")
+        self.reason = self.reason.strip()
+        if self.action != "approved" and not self.reason:
+            raise ValueError(f"manager preview approval action {self.action!r} requires a reason")
+        if self.action in _MANAGER_ACTIONS:
+            if self.authorization is None:
+                raise ValueError(
+                    f"manager preview approval action {self.action!r} requires authorization"
+                )
+            if self.authorization.authorized_at != self.occurred_at:
+                raise ValueError(
+                    "manager preview approval authorization and event timestamps must match"
+                )
+        elif self.action in _SYSTEM_ACTIONS and self.authorization is not None:
+            raise ValueError(
+                f"manager preview approval action {self.action!r} must be system-authored"
+            )
+
+        computed_approval_id = build_manager_preview_approval_id(
+            binding_sha256=self.binding.binding_sha256
+        )
+        if self.approval_id:
+            self.approval_id = self.approval_id.strip()
+            if self.approval_id != computed_approval_id:
+                raise ValueError("manager preview approval approval_id does not match binding")
+        else:
+            self.approval_id = computed_approval_id
+
+        computed_event_id = build_manager_preview_approval_event_id(
+            binding_sha256=self.binding.binding_sha256,
+            action=self.action,
+            source_event_kind=self.source_event_kind,
+            source_event_id=self.source_event_id,
+        )
+        if self.event_id:
+            self.event_id = self.event_id.strip()
+            if self.event_id != computed_event_id:
+                raise ValueError("manager preview approval event_id does not match event payload")
+        else:
+            self.event_id = computed_event_id
+        return self
+
+    @property
+    def manager_github_id(self) -> int:
+        return self.authorization.manager_github_id if self.authorization is not None else 0
+
+    @property
+    def manager_login(self) -> str:
+        return self.authorization.manager_login if self.authorization is not None else ""
+
+    @property
+    def policy_record_id(self) -> str:
+        return self.authorization.policy_record_id if self.authorization is not None else ""
+
+    @property
+    def policy_sha256(self) -> str:
+        return self.authorization.policy_sha256 if self.authorization is not None else ""
+
+
+class ManagerPreviewApprovalDecision(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=1, ge=1)
+    status: ManagerPreviewApprovalDecisionStatus
+    reason_code: ManagerPreviewApprovalReasonCode
+    reason: str
+    current_binding_sha256: str = ""
+    event_id: str = ""
+    approval_id: str = ""
+    manager_github_id: int = Field(default=0, ge=0)
+    manager_login: str = ""
+    evaluated_at: str
+
+    @model_validator(mode="after")
+    def _validate_decision(self) -> "ManagerPreviewApprovalDecision":
+        if self.schema_version != 1:
+            raise ValueError("Unsupported manager preview approval decision schema version.")
+        self.reason = _required_token(self.reason, "reason")
+        self.evaluated_at = _normalize_utc_timestamp(self.evaluated_at, "evaluated_at")
+        for field_name in ("current_binding_sha256", "event_id", "approval_id", "manager_login"):
+            setattr(self, field_name, str(getattr(self, field_name)).strip())
+        if (
+            self.current_binding_sha256
+            and _SHA256_PATTERN.fullmatch(self.current_binding_sha256) is None
+        ):
+            raise ValueError("manager preview approval decision has invalid binding SHA-256")
+        return self
+
+
+def runtime_identity_sha256(identity: RuntimeIdentity) -> str:
+    return _canonical_sha256(identity.model_dump(mode="json", exclude_none=True))
+
+
+def manager_preview_approval_binding_sha256(binding: ManagerPreviewApprovalBinding) -> str:
+    payload = binding.model_dump(
+        mode="json",
+        exclude={"binding_sha256", "runtime_identity_sha256"},
+        exclude_none=True,
+    )
+    payload["runtime_identity_sha256"] = runtime_identity_sha256(binding.runtime_identity)
+    return _canonical_sha256(payload)
+
+
+def build_manager_preview_approval_id(*, binding_sha256: str) -> str:
+    normalized = _required_sha256(binding_sha256, "binding_sha256")
+    return f"manager-preview-approval-{normalized[:32]}"
+
+
+def build_manager_preview_approval_event_id(
+    *,
+    binding_sha256: str,
+    action: ManagerPreviewApprovalAction,
+    source_event_kind: str,
+    source_event_id: str,
+) -> str:
+    normalized_binding = _required_sha256(binding_sha256, "binding_sha256")
+    payload = {
+        "binding_sha256": normalized_binding,
+        "action": action,
+        "source_event_kind": _required_token(source_event_kind, "source_event_kind"),
+        "source_event_id": _required_token(source_event_id, "source_event_id"),
+    }
+    return f"manager-preview-approval-event-{_canonical_sha256(payload)[:32]}"
+
+
+def immutable_image_digest(image_reference: str) -> str:
+    normalized = image_reference.strip()
+    _, separator, digest = normalized.rpartition("@")
+    if not separator:
+        raise ValueError(
+            "manager preview approval runtime identity requires an immutable image reference"
+        )
+    return normalize_artifact_sha256_digest(
+        digest,
+        label="manager preview approval runtime image digest",
+    )
+
+
+def _required_sha256(value: str, label: str) -> str:
+    normalized = value.strip().lower()
+    if _SHA256_PATTERN.fullmatch(normalized) is None:
+        raise ValueError(f"manager preview approval {label} requires a lowercase SHA-256")
+    return normalized
+
+
+def _required_token(value: str, label: str) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"manager preview approval requires {label}")
+    return normalized
+
+
+def _required_http_url(value: str, label: str) -> str:
+    normalized = _required_token(value, label)
+    parsed = urlsplit(normalized)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError(f"manager preview approval {label} must be an HTTP(S) URL")
+    return normalized
+
+
+def _normalize_utc_timestamp(value: str, label: str) -> str:
+    normalized = _required_token(value, label)
+    try:
+        parsed = datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise ValueError(
+            f"manager preview approval {label} must be an ISO-8601 timestamp"
+        ) from error
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"manager preview approval {label} requires a timezone")
+    return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _canonical_sha256(payload: object) -> str:
+    canonical_json = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical_json.encode("utf-8")).hexdigest()

--- a/control_plane/contracts/preview_mutation_request.py
+++ b/control_plane/contracts/preview_mutation_request.py
@@ -11,6 +11,7 @@ from control_plane.contracts.preview_generation_record import (
 )
 from control_plane.contracts.preview_record import PreviewState
 from control_plane.contracts.promotion_record import ReleaseStatus
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 
 
 class PreviewMutationRequest(BaseModel):
@@ -76,6 +77,7 @@ class PreviewGenerationMutationRequest(BaseModel):
     overall_health_status: ReleaseStatus = "pending"
     failure_stage: str = ""
     failure_summary: str = ""
+    runtime_identity: RuntimeIdentity | None = None
 
     @model_validator(mode="after")
     def _validate_request(self) -> "PreviewGenerationMutationRequest":

--- a/control_plane/drivers/generic_web_preview_dispatch.py
+++ b/control_plane/drivers/generic_web_preview_dispatch.py
@@ -485,6 +485,7 @@ def _generic_web_preview_refresh_mutation_requests(
         overall_health_status=states.overall_health_status,
         failure_stage=states.failure_stage,
         failure_summary="" if refresh_passed else failure_summary,
+        runtime_identity=driver_result.runtime_identity,
     )
     return preview_request, generation_request
 
@@ -581,6 +582,7 @@ def _apply_generic_web_preview_verification_records(
             overall_health_status="pass" if verification_passed else "fail",
             failure_stage="" if verification_passed else "verify",
             failure_summary="" if verification_passed else failure_summary,
+            runtime_identity=generation.runtime_identity,
         ),
     )
     verification_result = GenericWebPreviewVerificationResult(

--- a/control_plane/launchplane_mutations.py
+++ b/control_plane/launchplane_mutations.py
@@ -142,6 +142,9 @@ def build_launchplane_preview_generation_from_request(
             max((record.sequence for record in existing_generations), default=0) + 1
         )
         resolved_generation_id = request.generation_id.strip()
+    resolved_runtime_identity = request.runtime_identity
+    if resolved_runtime_identity is None and existing_generation is not None:
+        resolved_runtime_identity = existing_generation.runtime_identity
 
     return build_preview_generation_record(
         preview_id=preview_record.preview_id,
@@ -170,6 +173,7 @@ def build_launchplane_preview_generation_from_request(
         overall_health_status=request.overall_health_status,
         failure_stage=request.failure_stage,
         failure_summary=request.failure_summary,
+        runtime_identity=resolved_runtime_identity,
     )
 
 

--- a/control_plane/manager_preview_approval.py
+++ b/control_plane/manager_preview_approval.py
@@ -1,0 +1,424 @@
+from __future__ import annotations
+
+from typing import NamedTuple, Protocol, cast
+
+from control_plane.contracts.authz_policy_record import LaunchplaneAuthzPolicyRecord
+from control_plane.contracts.manager_preview_approval import (
+    MANAGER_PREVIEW_APPROVAL_WRITE_ACTION,
+    ManagerPreviewApprovalAction,
+    ManagerPreviewApprovalAuthorization,
+    ManagerPreviewApprovalBinding,
+    ManagerPreviewApprovalDecision,
+    ManagerPreviewApprovalDecisionStatus,
+    ManagerPreviewApprovalEventRecord,
+    ManagerPreviewApprovalEventWriteStatus,
+    ManagerPreviewApprovalReasonCode,
+    immutable_image_digest,
+)
+from control_plane.contracts.preview_generation_record import PreviewGenerationRecord
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.service_auth import AuthorizationTarget, GitHubHumanIdentity
+
+
+class ManagerPreviewApprovalEvidenceError(ValueError):
+    def __init__(self, *, code: ManagerPreviewApprovalReasonCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+class ManagerPreviewApprovalAuthorizationError(PermissionError):
+    pass
+
+
+class ManagerPreviewApprovalEventConflictError(RuntimeError):
+    pass
+
+
+class ManagerPreviewApprovalEventStore(Protocol):
+    def write_manager_preview_approval_event_record(
+        self, record: ManagerPreviewApprovalEventRecord
+    ) -> ManagerPreviewApprovalEventWriteStatus:
+        raise NotImplementedError
+
+    def list_manager_preview_approval_event_records(
+        self,
+        *,
+        product: str = "",
+        context: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        preview_id: str = "",
+        action: str = "",
+        limit: int | None = None,
+    ) -> tuple[ManagerPreviewApprovalEventRecord, ...]:
+        raise NotImplementedError
+
+
+class ManagerPreviewApprovalWriteResult(NamedTuple):
+    status: ManagerPreviewApprovalEventWriteStatus
+    record: ManagerPreviewApprovalEventRecord
+
+
+def build_current_manager_preview_approval_binding(
+    *,
+    product: str,
+    preview: PreviewRecord,
+    generation: PreviewGenerationRecord,
+) -> ManagerPreviewApprovalBinding:
+    if preview.state != "active":
+        raise ManagerPreviewApprovalEvidenceError(
+            code="preview_inactive",
+            message="The preview is not active.",
+        )
+    if not preview.serving_generation_id:
+        raise ManagerPreviewApprovalEvidenceError(
+            code="serving_generation_missing",
+            message="The preview does not have a serving generation.",
+        )
+    if (
+        generation.preview_id != preview.preview_id
+        or generation.generation_id != preview.serving_generation_id
+    ):
+        raise ManagerPreviewApprovalEvidenceError(
+            code="serving_generation_mismatch",
+            message="The supplied generation is not the preview's serving generation.",
+        )
+    if generation.state != "ready":
+        raise ManagerPreviewApprovalEvidenceError(
+            code="generation_not_ready",
+            message="The serving preview generation is not ready.",
+        )
+    if any(
+        status != "pass"
+        for status in (
+            generation.deploy_status,
+            generation.verify_status,
+            generation.overall_health_status,
+        )
+    ):
+        raise ManagerPreviewApprovalEvidenceError(
+            code="generation_verification_failed",
+            message="The serving preview generation has not passed deployment and verification.",
+        )
+    if (
+        generation.anchor_summary.repo.lower() != preview.anchor_repo.lower()
+        or generation.anchor_summary.pr_number != preview.anchor_pr_number
+        or generation.anchor_summary.pr_url != preview.anchor_pr_url
+        or preview.latest_manifest_fingerprint != generation.resolved_manifest_fingerprint
+    ):
+        raise ManagerPreviewApprovalEvidenceError(
+            code="preview_identity_mismatch",
+            message="The preview and serving generation identity do not match.",
+        )
+    if not generation.artifact_id:
+        raise ManagerPreviewApprovalEvidenceError(
+            code="artifact_identity_missing",
+            message="The serving preview generation does not have immutable artifact identity.",
+        )
+    if generation.runtime_identity is None:
+        raise ManagerPreviewApprovalEvidenceError(
+            code="runtime_identity_missing",
+            message="The serving preview generation does not have verified runtime identity.",
+        )
+    try:
+        artifact_image_digest = immutable_image_digest(generation.runtime_identity.image_reference)
+        return ManagerPreviewApprovalBinding(
+            product=product,
+            context=preview.context,
+            repository=preview.anchor_repo,
+            pr_number=preview.anchor_pr_number,
+            pr_url=preview.anchor_pr_url,
+            head_sha=generation.anchor_summary.head_sha,
+            preview_id=preview.preview_id,
+            serving_generation_id=generation.generation_id,
+            artifact_id=generation.artifact_id,
+            artifact_image_digest=artifact_image_digest,
+            manifest_fingerprint=generation.resolved_manifest_fingerprint,
+            preview_url=preview.canonical_url,
+            runtime_identity=generation.runtime_identity,
+        )
+    except ValueError as error:
+        raise ManagerPreviewApprovalEvidenceError(
+            code="runtime_identity_mismatch",
+            message="The serving preview runtime identity is incomplete or inconsistent.",
+        ) from error
+
+
+def capture_manager_preview_approval_authorization(
+    *,
+    identity: GitHubHumanIdentity,
+    product: str,
+    context: str,
+    policy_record: LaunchplaneAuthzPolicyRecord,
+    authorized_at: str,
+) -> ManagerPreviewApprovalAuthorization:
+    if identity.github_id < 1:
+        raise ManagerPreviewApprovalAuthorizationError(
+            "Manager preview approval requires a stable GitHub numeric identity."
+        )
+    if policy_record.status != "active" or policy_record.policy.schema_version != 2:
+        raise ManagerPreviewApprovalAuthorizationError(
+            "Manager preview approval requires one active schema-v2 authorization policy."
+        )
+    target = AuthorizationTarget(scope="context")
+    matching_rules = tuple(
+        rule
+        for rule in policy_record.policy.github_humans
+        if rule.managed_set_id is not None
+        and rule.managed_rule_id is not None
+        and identity.github_id in rule.github_ids
+        and MANAGER_PREVIEW_APPROVAL_WRITE_ACTION in rule.actions
+        and rule.allows(
+            identity=identity,
+            action=MANAGER_PREVIEW_APPROVAL_WRITE_ACTION,
+            product=product,
+            context=context,
+            target=target,
+            schema_version=2,
+        )
+    )
+    if len(matching_rules) != 1:
+        raise ManagerPreviewApprovalAuthorizationError(
+            "Manager preview approval requires exactly one managed policy rule for the actor."
+        )
+    matching_rule = matching_rules[0]
+    return ManagerPreviewApprovalAuthorization(
+        manager_github_id=identity.github_id,
+        manager_login=identity.login,
+        managed_set_id=cast(str, matching_rule.managed_set_id),
+        managed_rule_id=cast(str, matching_rule.managed_rule_id),
+        policy_record_id=policy_record.record_id,
+        policy_revision=policy_record.revision,
+        policy_sha256=policy_record.policy_sha256,
+        policy_source=policy_record.source,
+        authorized_at=authorized_at,
+    )
+
+
+def record_manager_preview_approval_event(
+    *,
+    record_store: ManagerPreviewApprovalEventStore,
+    identity: GitHubHumanIdentity,
+    policy_record: LaunchplaneAuthzPolicyRecord,
+    product: str,
+    preview: PreviewRecord,
+    generation: PreviewGenerationRecord,
+    action: ManagerPreviewApprovalAction,
+    occurred_at: str,
+    source_event_kind: str,
+    source_event_id: str,
+    reason: str = "",
+) -> ManagerPreviewApprovalWriteResult:
+    if action not in {"approved", "changes_requested", "revoked"}:
+        raise ValueError("Manager-authored preview approval events require a manager action.")
+    binding = build_current_manager_preview_approval_binding(
+        product=product,
+        preview=preview,
+        generation=generation,
+    )
+    authorization = capture_manager_preview_approval_authorization(
+        identity=identity,
+        product=binding.product,
+        context=binding.context,
+        policy_record=policy_record,
+        authorized_at=occurred_at,
+    )
+    record = ManagerPreviewApprovalEventRecord(
+        binding=binding,
+        action=action,
+        occurred_at=occurred_at,
+        source_event_kind=source_event_kind,
+        source_event_id=source_event_id,
+        reason=reason,
+        authorization=authorization,
+    )
+    status = record_store.write_manager_preview_approval_event_record(record)
+    return ManagerPreviewApprovalWriteResult(status=status, record=record)
+
+
+def build_manager_preview_approval_system_event(
+    *,
+    binding: ManagerPreviewApprovalBinding,
+    action: ManagerPreviewApprovalAction,
+    occurred_at: str,
+    source_event_kind: str,
+    source_event_id: str,
+    reason: str,
+) -> ManagerPreviewApprovalEventRecord:
+    if action not in {"superseded", "invalidated"}:
+        raise ValueError("System preview approval events require superseded or invalidated action.")
+    return ManagerPreviewApprovalEventRecord(
+        binding=binding,
+        action=action,
+        occurred_at=occurred_at,
+        source_event_kind=source_event_kind,
+        source_event_id=source_event_id,
+        reason=reason,
+    )
+
+
+def evaluate_manager_preview_approval(
+    *,
+    product: str,
+    preview: PreviewRecord,
+    generation: PreviewGenerationRecord,
+    policy_record: LaunchplaneAuthzPolicyRecord | None,
+    events: tuple[ManagerPreviewApprovalEventRecord, ...],
+    evaluated_at: str,
+) -> ManagerPreviewApprovalDecision:
+    """Evaluate current evidence against the complete approval history for the PR."""
+    try:
+        binding = build_current_manager_preview_approval_binding(
+            product=product,
+            preview=preview,
+            generation=generation,
+        )
+    except ManagerPreviewApprovalEvidenceError as error:
+        return _decision(
+            status="unavailable",
+            reason_code=error.code,
+            reason=str(error),
+            evaluated_at=evaluated_at,
+        )
+    if (
+        policy_record is None
+        or policy_record.status != "active"
+        or policy_record.policy.schema_version != 2
+    ):
+        return _decision(
+            status="unavailable",
+            reason_code="policy_unavailable",
+            reason="The active manager authorization policy is unavailable.",
+            binding=binding,
+            evaluated_at=evaluated_at,
+        )
+
+    subject_events = tuple(
+        event
+        for event in events
+        if event.binding.product == binding.product
+        and event.binding.context == binding.context
+        and event.binding.repository == binding.repository
+        and event.binding.pr_number == binding.pr_number
+    )
+    exact_events = tuple(
+        event for event in subject_events if event.binding.binding_sha256 == binding.binding_sha256
+    )
+    if not exact_events:
+        if subject_events:
+            return _decision(
+                status="stale",
+                reason_code="approval_stale",
+                reason="Prior approval evidence does not match the current preview.",
+                binding=binding,
+                evaluated_at=evaluated_at,
+            )
+        return _decision(
+            status="pending",
+            reason_code="approval_missing",
+            reason="The current preview has not been approved by the manager.",
+            binding=binding,
+            evaluated_at=evaluated_at,
+        )
+
+    latest_event = max(exact_events, key=lambda event: (event.occurred_at, event.event_id))
+    if latest_event.action == "approved":
+        if not _approval_authorization_matches_policy(
+            event=latest_event,
+            policy_record=policy_record,
+        ):
+            return _decision(
+                status="stale",
+                reason_code="approval_stale",
+                reason="The approval was recorded under a different authorization policy.",
+                binding=binding,
+                event=latest_event,
+                evaluated_at=evaluated_at,
+            )
+        return _decision(
+            status="approved",
+            reason_code="approval_valid",
+            reason="The manager approved the exact current preview.",
+            binding=binding,
+            event=latest_event,
+            evaluated_at=evaluated_at,
+        )
+    if latest_event.action == "changes_requested":
+        return _decision(
+            status="changes_requested",
+            reason_code="changes_requested",
+            reason="The manager requested changes to the current preview.",
+            binding=binding,
+            event=latest_event,
+            evaluated_at=evaluated_at,
+        )
+    if latest_event.action == "revoked":
+        return _decision(
+            status="revoked",
+            reason_code="approval_revoked",
+            reason="The manager revoked approval for the current preview.",
+            binding=binding,
+            event=latest_event,
+            evaluated_at=evaluated_at,
+        )
+    return _decision(
+        status="stale",
+        reason_code="approval_stale",
+        reason="The current preview approval was superseded or invalidated.",
+        binding=binding,
+        event=latest_event,
+        evaluated_at=evaluated_at,
+    )
+
+
+def _approval_authorization_matches_policy(
+    *,
+    event: ManagerPreviewApprovalEventRecord,
+    policy_record: LaunchplaneAuthzPolicyRecord,
+) -> bool:
+    authorization = event.authorization
+    if authorization is None:
+        return False
+    if (
+        authorization.policy_record_id != policy_record.record_id
+        or authorization.policy_revision != policy_record.revision
+        or authorization.policy_sha256 != policy_record.policy_sha256
+    ):
+        return False
+    matching_rules = tuple(
+        rule
+        for rule in policy_record.policy.github_humans
+        if rule.managed_set_id == authorization.managed_set_id
+        and rule.managed_rule_id == authorization.managed_rule_id
+    )
+    if len(matching_rules) != 1:
+        return False
+    rule = matching_rules[0]
+    return (
+        authorization.manager_github_id in rule.github_ids
+        and MANAGER_PREVIEW_APPROVAL_WRITE_ACTION in rule.actions
+        and (not rule.products or event.binding.product in rule.products)
+        and (not rule.contexts or event.binding.context in rule.contexts)
+    )
+
+
+def _decision(
+    *,
+    status: ManagerPreviewApprovalDecisionStatus,
+    reason_code: ManagerPreviewApprovalReasonCode,
+    reason: str,
+    evaluated_at: str,
+    binding: ManagerPreviewApprovalBinding | None = None,
+    event: ManagerPreviewApprovalEventRecord | None = None,
+) -> ManagerPreviewApprovalDecision:
+    return ManagerPreviewApprovalDecision(
+        status=status,
+        reason_code=reason_code,
+        reason=reason,
+        current_binding_sha256=binding.binding_sha256 if binding is not None else "",
+        event_id=event.event_id if event is not None else "",
+        approval_id=event.approval_id if event is not None else "",
+        manager_github_id=event.manager_github_id if event is not None else 0,
+        manager_login=event.manager_login if event is not None else "",
+        evaluated_at=evaluated_at,
+    )

--- a/control_plane/service_auth.py
+++ b/control_plane/service_auth.py
@@ -419,6 +419,7 @@ class GitHubActionsPolicyRule(ManagedAuthzPolicyRule):
 class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
     model_config = ConfigDict(extra="forbid")
 
+    github_ids: tuple[int, ...] = ()
     logins: tuple[str, ...] = ()
     organizations: tuple[str, ...] = ()
     teams: tuple[str, ...] = ()
@@ -427,6 +428,13 @@ class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
     contexts: tuple[str, ...] = ()
     instances: AuthzInstanceSelectors = ()
     actions: tuple[str, ...] = ()
+
+    @model_validator(mode="after")
+    def _validate_github_ids(self) -> "GitHubHumanPolicyRule":
+        if any(github_id < 1 for github_id in self.github_ids):
+            raise ValueError("GitHub human policy rule github_ids must be positive.")
+        self.github_ids = tuple(dict.fromkeys(self.github_ids))
+        return self
 
     @staticmethod
     def _matches_any(value: str, allowed_values: tuple[str, ...]) -> bool:
@@ -451,6 +459,8 @@ class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
         target: AuthorizationTarget | None = None,
         schema_version: AuthzPolicySchemaVersion = 1,
     ) -> bool:
+        if self.github_ids and identity.github_id not in self.github_ids:
+            return False
         if self.logins and not self._matches_any(identity.login, self.logins):
             return False
         if self.organizations and not self._intersects(identity.organizations, self.organizations):
@@ -476,11 +486,14 @@ class GitHubHumanPolicyRule(ManagedAuthzPolicyRule):
     def matches_principal(
         self,
         *,
+        github_id: int,
         login: str,
         organizations: frozenset[str],
         teams: frozenset[str],
         role: Literal["read_only", "admin"],
     ) -> bool:
+        if self.github_ids and github_id not in self.github_ids:
+            return False
         if self.logins and not self._matches_any(login, self.logins):
             return False
         if self.organizations and not self._intersects(organizations, self.organizations):
@@ -860,6 +873,9 @@ class LaunchplaneAuthzPolicy(BaseModel):
                 rule.pop("repository_id", None)
             if not rule.get("repository_owner_id"):
                 rule.pop("repository_owner_id", None)
+        for rule in payload.get("github_humans", ()):
+            if not rule.get("github_ids"):
+                rule.pop("github_ids", None)
         if self.schema_version == 1:
             for rule_collection_name in (
                 "github_actions",
@@ -957,20 +973,29 @@ class LaunchplaneAuthzPolicy(BaseModel):
     def human_role_for(
         self,
         *,
+        github_id: int = 0,
         login: str,
         organizations: frozenset[str],
         teams: frozenset[str],
     ) -> Literal["read_only", "admin"] | None:
         if any(
             rule.matches_principal(
-                login=login, organizations=organizations, teams=teams, role="admin"
+                github_id=github_id,
+                login=login,
+                organizations=organizations,
+                teams=teams,
+                role="admin",
             )
             for rule in self.github_humans
         ):
             return "admin"
         if any(
             rule.matches_principal(
-                login=login, organizations=organizations, teams=teams, role="read_only"
+                github_id=github_id,
+                login=login,
+                organizations=organizations,
+                teams=teams,
+                role="read_only",
             )
             for rule in self.github_humans
         ):

--- a/control_plane/service_human_auth.py
+++ b/control_plane/service_human_auth.py
@@ -239,6 +239,7 @@ class GitHubOAuthClient:
         login = str(user_payload.get("login", "")).strip()
         if not login:
             raise ValueError("GitHub OAuth user response did not include a login.")
+        github_id = int(user_payload.get("id") or 0)
         public_email = str(user_payload.get("email") or "").strip()
         verified_emails = _verified_email_addresses(email_payload)
         primary_email = _primary_email_address(email_payload)
@@ -259,6 +260,7 @@ class GitHubOAuthClient:
             role: Literal["read_only", "admin"] | None = "admin"
         else:
             role = authz_policy.human_role_for(
+                github_id=github_id,
                 login=login,
                 organizations=organizations,
                 teams=teams,
@@ -267,7 +269,7 @@ class GitHubOAuthClient:
             raise PermissionError("GitHub user is not authorized for Launchplane.")
         return GitHubHumanIdentity(
             login=login,
-            github_id=int(user_payload.get("id") or 0),
+            github_id=github_id,
             name=str(user_payload.get("name") or "").strip(),
             email=(
                 bootstrap_admin_email
@@ -354,6 +356,7 @@ class HumanSessionManager:
         if email and email in self._config.bootstrap_admin_emails:
             return "admin"
         return authz_policy.human_role_for(
+            github_id=identity.github_id,
             login=identity.login,
             organizations=identity.organizations,
             teams=identity.teams,

--- a/control_plane/storage/filesystem.py
+++ b/control_plane/storage/filesystem.py
@@ -41,6 +41,10 @@ from control_plane.contracts.generic_web_rollback import GenericWebRollbackPlanR
 from control_plane.contracts.idempotency_record import LaunchplaneIdempotencyRecord
 from control_plane.contracts.ingress_canary_route_record import IngressCanaryRouteRecord
 from control_plane.contracts.ingress_route_audit_record import IngressRouteAuditRecord
+from control_plane.contracts.manager_preview_approval import (
+    ManagerPreviewApprovalEventRecord,
+    ManagerPreviewApprovalEventWriteStatus,
+)
 from control_plane.contracts.merge_train_batch import MergeTrainBatchCandidateRecord
 from control_plane.contracts.merge_train_batch import MergeTrainBatchLandingPlanRecord
 from control_plane.contracts.merge_train_controller_state import (
@@ -128,6 +132,7 @@ from control_plane.contracts.public_ingress_monitoring import PublicIngressObser
 from control_plane.contracts.promotion_record import PromotionRecord
 from control_plane.contracts.release_tuple_record import ReleaseTupleRecord
 from control_plane.contracts.deploy_target import ProviderTargetRecord
+from control_plane.manager_preview_approval import ManagerPreviewApprovalEventConflictError
 from control_plane.contracts.dokploy_target_id_record import DokployTargetIdRecord
 from control_plane.contracts.dokploy_target_record import DokployTargetRecord
 from control_plane.contracts.runtime_environment_record import (
@@ -1541,6 +1546,55 @@ class FilesystemRecordStore:
         records.sort(key=lambda record: (record.updated_at, record.gate_id), reverse=True)
         if offset > 0:
             records = records[offset:]
+        if limit is not None:
+            records = records[:limit]
+        return tuple(records)
+
+    def write_manager_preview_approval_event_record(
+        self, record: ManagerPreviewApprovalEventRecord
+    ) -> ManagerPreviewApprovalEventWriteStatus:
+        record_type = "launchplane_manager_preview_approval_events"
+        with self._product_authority_bundle_lock():
+            record_path = self._record_path(record_type, record.event_id)
+            if record_path.exists():
+                existing = self._read_model_locked(
+                    ManagerPreviewApprovalEventRecord,
+                    record_type,
+                    record.event_id,
+                )
+                if existing != record:
+                    raise ManagerPreviewApprovalEventConflictError(
+                        "Manager preview approval event replay changed the persisted payload."
+                    )
+                return "replayed"
+            self._write_model_locked(record_type, record.event_id, record)
+            return "written"
+
+    def list_manager_preview_approval_event_records(
+        self,
+        *,
+        product: str = "",
+        context: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        preview_id: str = "",
+        action: str = "",
+        limit: int | None = None,
+    ) -> tuple[ManagerPreviewApprovalEventRecord, ...]:
+        records = [
+            record
+            for record in self._list_models(
+                ManagerPreviewApprovalEventRecord,
+                "launchplane_manager_preview_approval_events",
+            )
+            if (not product or record.binding.product == product.lower())
+            and (not context or record.binding.context == context.lower())
+            and (not repository or record.binding.repository == repository.lower())
+            and (pr_number is None or record.binding.pr_number == pr_number)
+            and (not preview_id or record.binding.preview_id == preview_id)
+            and (not action or record.action == action)
+        ]
+        records.sort(key=lambda record: (record.occurred_at, record.event_id), reverse=True)
         if limit is not None:
             records = records[:limit]
         return tuple(records)

--- a/control_plane/storage/migrations/versions/e8a0c2d4f6b8_add_manager_preview_approval_events.py
+++ b/control_plane/storage/migrations/versions/e8a0c2d4f6b8_add_manager_preview_approval_events.py
@@ -1,0 +1,102 @@
+"""add manager preview approval events
+
+Revision ID: e8a0c2d4f6b8
+Revises: d7f9a1b3c5e7
+Create Date: 2026-07-30 00:00:00.000000+00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "e8a0c2d4f6b8"
+down_revision: str | None = "d7f9a1b3c5e7"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "launchplane_manager_preview_approval_events"
+
+
+def _table_exists() -> bool:
+    return _TABLE in set(sa.inspect(op.get_bind()).get_table_names())
+
+
+def _index_exists(index_name: str) -> bool:
+    if not _table_exists():
+        return False
+    return index_name in {
+        str(index["name"]) for index in sa.inspect(op.get_bind()).get_indexes(_TABLE)
+    }
+
+
+def upgrade() -> None:
+    if not _table_exists():
+        op.create_table(
+            _TABLE,
+            sa.Column("event_id", sa.String(), nullable=False),
+            sa.Column("approval_id", sa.String(), nullable=False),
+            sa.Column("product", sa.String(), nullable=False),
+            sa.Column("context", sa.String(), nullable=False),
+            sa.Column("repository", sa.String(), nullable=False),
+            sa.Column("pr_number", sa.Integer(), nullable=False),
+            sa.Column("head_sha", sa.String(), nullable=False),
+            sa.Column("preview_id", sa.String(), nullable=False),
+            sa.Column("serving_generation_id", sa.String(), nullable=False),
+            sa.Column("artifact_id", sa.String(), nullable=False),
+            sa.Column("artifact_image_digest", sa.String(), nullable=False),
+            sa.Column("manifest_fingerprint", sa.String(), nullable=False),
+            sa.Column("runtime_identity_sha256", sa.String(), nullable=False),
+            sa.Column("action", sa.String(), nullable=False),
+            sa.Column("manager_github_id", sa.BigInteger(), nullable=False, server_default="0"),
+            sa.Column("manager_login", sa.String(), nullable=False, server_default=""),
+            sa.Column("policy_record_id", sa.String(), nullable=False, server_default=""),
+            sa.Column("policy_sha256", sa.String(), nullable=False, server_default=""),
+            sa.Column("occurred_at", sa.String(), nullable=False),
+            sa.Column(
+                "payload",
+                sa.JSON().with_variant(
+                    postgresql.JSONB(astext_type=sa.Text()),
+                    "postgresql",
+                ),
+                nullable=False,
+            ),
+            sa.PrimaryKeyConstraint("event_id"),
+        )
+    subject_index = "launchplane_manager_preview_approval_events_subject_idx"
+    if not _index_exists(subject_index):
+        op.create_index(
+            subject_index,
+            _TABLE,
+            ["product", "context", "repository", "pr_number", sa.text("occurred_at DESC")],
+        )
+    preview_index = "launchplane_manager_preview_approval_events_preview_idx"
+    if not _index_exists(preview_index):
+        op.create_index(
+            preview_index,
+            _TABLE,
+            ["preview_id", "serving_generation_id", sa.text("occurred_at DESC")],
+        )
+    approval_index = "launchplane_manager_preview_approval_events_approval_idx"
+    if not _index_exists(approval_index):
+        op.create_index(
+            approval_index,
+            _TABLE,
+            ["approval_id", sa.text("occurred_at DESC")],
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists():
+        return
+    for index_name in (
+        "launchplane_manager_preview_approval_events_approval_idx",
+        "launchplane_manager_preview_approval_events_preview_idx",
+        "launchplane_manager_preview_approval_events_subject_idx",
+    ):
+        if _index_exists(index_name):
+            op.drop_index(index_name, table_name=_TABLE)
+    op.drop_table(_TABLE)

--- a/control_plane/storage/postgres.py
+++ b/control_plane/storage/postgres.py
@@ -68,6 +68,10 @@ from control_plane.contracts.idempotency_record import (
 from control_plane.contracts.ingress_canary_route_record import IngressCanaryRouteRecord
 from control_plane.contracts.ingress_route_audit_record import IngressRouteAuditRecord
 from control_plane.contracts.lane_summary import LaunchplaneLaneSummary
+from control_plane.contracts.manager_preview_approval import (
+    ManagerPreviewApprovalEventRecord,
+    ManagerPreviewApprovalEventWriteStatus,
+)
 from control_plane.contracts.merge_train_batch import (
     MergeTrainBatchCandidateRecord,
     MergeTrainBatchLandingPlanRecord,
@@ -135,6 +139,7 @@ from control_plane.contracts.private_health_endpoint_record import (
     PrivateHealthEndpointRecord,
     private_health_endpoint_record_sha256,
 )
+from control_plane.manager_preview_approval import ManagerPreviewApprovalEventConflictError
 from control_plane.contracts.route_binding_record import (
     EnvironmentRouteBindingRecord,
     route_binding_record_sha256,
@@ -554,6 +559,52 @@ class LaunchplanePreviewGenerationRow(Base):
     requested_at: Mapped[str] = mapped_column(String, nullable=False)
     finished_at: Mapped[str] = mapped_column(String, nullable=False)
     artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
+
+
+class LaunchplaneManagerPreviewApprovalEventRow(Base):
+    __tablename__ = "launchplane_manager_preview_approval_events"
+    __table_args__ = (
+        Index(
+            "launchplane_manager_preview_approval_events_subject_idx",
+            "product",
+            "context",
+            "repository",
+            "pr_number",
+            desc("occurred_at"),
+        ),
+        Index(
+            "launchplane_manager_preview_approval_events_preview_idx",
+            "preview_id",
+            "serving_generation_id",
+            desc("occurred_at"),
+        ),
+        Index(
+            "launchplane_manager_preview_approval_events_approval_idx",
+            "approval_id",
+            desc("occurred_at"),
+        ),
+    )
+
+    event_id: Mapped[str] = mapped_column(String, primary_key=True)
+    approval_id: Mapped[str] = mapped_column(String, nullable=False)
+    product: Mapped[str] = mapped_column(String, nullable=False)
+    context: Mapped[str] = mapped_column(String, nullable=False)
+    repository: Mapped[str] = mapped_column(String, nullable=False)
+    pr_number: Mapped[int] = mapped_column(Integer, nullable=False)
+    head_sha: Mapped[str] = mapped_column(String, nullable=False)
+    preview_id: Mapped[str] = mapped_column(String, nullable=False)
+    serving_generation_id: Mapped[str] = mapped_column(String, nullable=False)
+    artifact_id: Mapped[str] = mapped_column(String, nullable=False)
+    artifact_image_digest: Mapped[str] = mapped_column(String, nullable=False)
+    manifest_fingerprint: Mapped[str] = mapped_column(String, nullable=False)
+    runtime_identity_sha256: Mapped[str] = mapped_column(String, nullable=False)
+    action: Mapped[str] = mapped_column(String, nullable=False)
+    manager_github_id: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
+    manager_login: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    policy_record_id: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    policy_sha256: Mapped[str] = mapped_column(String, nullable=False, server_default="")
+    occurred_at: Mapped[str] = mapped_column(String, nullable=False)
     payload: Mapped[PayloadDict] = mapped_column(PayloadJsonType, nullable=False)
 
 
@@ -7048,6 +7099,91 @@ class PostgresRecordStore(HumanSessionStore):
             limit=limit,
         )
 
+    def write_manager_preview_approval_event_record(
+        self, record: ManagerPreviewApprovalEventRecord
+    ) -> ManagerPreviewApprovalEventWriteStatus:
+        row = LaunchplaneManagerPreviewApprovalEventRow(
+            event_id=record.event_id,
+            approval_id=record.approval_id,
+            product=record.binding.product,
+            context=record.binding.context,
+            repository=record.binding.repository,
+            pr_number=record.binding.pr_number,
+            head_sha=record.binding.head_sha,
+            preview_id=record.binding.preview_id,
+            serving_generation_id=record.binding.serving_generation_id,
+            artifact_id=record.binding.artifact_id,
+            artifact_image_digest=record.binding.artifact_image_digest,
+            manifest_fingerprint=record.binding.manifest_fingerprint,
+            runtime_identity_sha256=record.binding.runtime_identity_sha256,
+            action=record.action,
+            manager_github_id=record.manager_github_id,
+            manager_login=record.manager_login,
+            policy_record_id=record.policy_record_id,
+            policy_sha256=record.policy_sha256,
+            occurred_at=record.occurred_at,
+            payload=self._payload_dict(record),
+        )
+        with self._session_factory() as session:
+            session.add(row)
+            try:
+                session.commit()
+                return "written"
+            except IntegrityError:
+                session.rollback()
+                existing_row = session.get(
+                    LaunchplaneManagerPreviewApprovalEventRow,
+                    record.event_id,
+                )
+                if existing_row is None:
+                    raise
+                existing = self._read_payload(
+                    model_type=ManagerPreviewApprovalEventRecord,
+                    payload=existing_row.payload,
+                )
+                if existing != record:
+                    raise ManagerPreviewApprovalEventConflictError(
+                        "Manager preview approval event replay changed the persisted payload."
+                    )
+                return "replayed"
+
+    def list_manager_preview_approval_event_records(
+        self,
+        *,
+        product: str = "",
+        context: str = "",
+        repository: str = "",
+        pr_number: int | None = None,
+        preview_id: str = "",
+        action: str = "",
+        limit: int | None = None,
+    ) -> tuple[ManagerPreviewApprovalEventRecord, ...]:
+        filters: list[object] = []
+        if product:
+            filters.append(LaunchplaneManagerPreviewApprovalEventRow.product == product.lower())
+        if context:
+            filters.append(LaunchplaneManagerPreviewApprovalEventRow.context == context.lower())
+        if repository:
+            filters.append(
+                LaunchplaneManagerPreviewApprovalEventRow.repository == repository.lower()
+            )
+        if pr_number is not None:
+            filters.append(LaunchplaneManagerPreviewApprovalEventRow.pr_number == pr_number)
+        if preview_id:
+            filters.append(LaunchplaneManagerPreviewApprovalEventRow.preview_id == preview_id)
+        if action:
+            filters.append(LaunchplaneManagerPreviewApprovalEventRow.action == action)
+        return self._list_models(
+            model_type=ManagerPreviewApprovalEventRecord,
+            orm_model=LaunchplaneManagerPreviewApprovalEventRow,
+            filters=filters,
+            order_by=(
+                LaunchplaneManagerPreviewApprovalEventRow.occurred_at.desc(),
+                LaunchplaneManagerPreviewApprovalEventRow.event_id.desc(),
+            ),
+            limit=limit,
+        )
+
     def write_preview_enablement_record(self, record: PreviewEnablementRecord) -> None:
         self._write_row(
             LaunchplanePreviewEnablementRow(
@@ -10780,6 +10916,7 @@ class PostgresRecordStore(HumanSessionStore):
             "preview_records": 0,
             "preview_enablement": 0,
             "preview_generations": 0,
+            "manager_preview_approval_events": 0,
             "preview_desired_states": 0,
             "preview_inventory_scans": 0,
             "preview_lifecycle_cleanups": 0,
@@ -10837,6 +10974,10 @@ class PostgresRecordStore(HumanSessionStore):
         for generation_record in filesystem_store.list_preview_generation_records():
             self.write_preview_generation_record(generation_record)
             counts["preview_generations"] += 1
+        if hasattr(filesystem_store, "list_manager_preview_approval_event_records"):
+            for event_record in filesystem_store.list_manager_preview_approval_event_records():
+                self.write_manager_preview_approval_event_record(event_record)
+                counts["manager_preview_approval_events"] += 1
         if hasattr(filesystem_store, "list_preview_inventory_scan_records"):
             for scan_record in filesystem_store.list_preview_inventory_scan_records():
                 self.write_preview_inventory_scan_record(scan_record)

--- a/control_plane/storage/schema_invariants.py
+++ b/control_plane/storage/schema_invariants.py
@@ -10,7 +10,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import SQLAlchemyError
 
 AUTHZ_COMPATIBILITY_FLOOR_REVISION = "f3b5d7e9a1c2"
-EXPECTED_ALEMBIC_HEAD_REVISION = "d7f9a1b3c5e7"
+EXPECTED_ALEMBIC_HEAD_REVISION = "e8a0c2d4f6b8"
 RUNTIME_COMPATIBLE_ALEMBIC_REVISIONS = (EXPECTED_ALEMBIC_HEAD_REVISION,)
 _AUTHZ_POLICY_TABLE = "launchplane_authz_policies"
 _AUTHZ_POLICY_WRITE_FENCE_TRIGGER = "launchplane_authz_policy_write_fence"
@@ -159,6 +159,16 @@ CRITICAL_POSTGRES_COLUMN_TYPES: tuple[CriticalColumnType, ...] = (
     ),
     CriticalColumnType(
         "launchplane_public_ingress_incident_events",
+        "payload",
+        ("jsonb",),
+    ),
+    CriticalColumnType(
+        "launchplane_manager_preview_approval_events",
+        "manager_github_id",
+        ("bigint", "int8"),
+    ),
+    CriticalColumnType(
+        "launchplane_manager_preview_approval_events",
         "payload",
         ("jsonb",),
     ),
@@ -372,12 +382,31 @@ CRITICAL_SCHEMA_INDEXES: tuple[CriticalIndex, ...] = (
         "launchplane_merge_train_controller_states_lease_idx",
         ("status", "lease_expires_at", "updated_at"),
     ),
+    CriticalIndex(
+        "launchplane_manager_preview_approval_events",
+        "launchplane_manager_preview_approval_events_subject_idx",
+        ("product", "context", "repository", "pr_number", "occurred_at"),
+    ),
+    CriticalIndex(
+        "launchplane_manager_preview_approval_events",
+        "launchplane_manager_preview_approval_events_preview_idx",
+        ("preview_id", "serving_generation_id", "occurred_at"),
+    ),
+    CriticalIndex(
+        "launchplane_manager_preview_approval_events",
+        "launchplane_manager_preview_approval_events_approval_idx",
+        ("approval_id", "occurred_at"),
+    ),
 )
 
 CRITICAL_PRIMARY_KEYS: tuple[CriticalPrimaryKey, ...] = (
     CriticalPrimaryKey(
         "launchplane_route_bindings",
         ("product", "context", "instance"),
+    ),
+    CriticalPrimaryKey(
+        "launchplane_manager_preview_approval_events",
+        ("event_id",),
     ),
 )
 

--- a/control_plane/workflows/generic_web_preview.py
+++ b/control_plane/workflows/generic_web_preview.py
@@ -225,6 +225,7 @@ class GenericWebPreviewRefreshResult(BaseModel):
     preview_url: str
     readiness: GenericWebPreviewReadinessResult | None = None
     smoke: GenericWebPreviewSmokeResult | None = None
+    runtime_identity: RuntimeIdentity | None = None
     error_message: str = ""
 
 
@@ -1292,6 +1293,7 @@ def execute_generic_web_preview_refresh(
     application_id = ""
     host = ""
     token = ""
+    preview_runtime_identity: RuntimeIdentity | None = None
     try:
         host, token = dokploy_source.read_dokploy_config(control_plane_root=control_plane_root)
         target_definition, template_application, target_error = _read_template_payload(
@@ -1403,6 +1405,7 @@ def execute_generic_web_preview_refresh(
             application_id=application_id,
             preview_url=preview_url,
             readiness=readiness,
+            runtime_identity=preview_runtime_identity,
             error_message=message,
         )
 
@@ -1418,6 +1421,7 @@ def execute_generic_web_preview_refresh(
         application_id=application_id,
         preview_url=preview_url,
         readiness=readiness,
+        runtime_identity=preview_runtime_identity,
     )
 
 

--- a/control_plane/workflows/launchplane.py
+++ b/control_plane/workflows/launchplane.py
@@ -1618,6 +1618,9 @@ def build_preview_generation_record_from_request(
             preview_id=preview.preview_id,
             sequence=resolved_sequence,
         )
+    resolved_runtime_identity = request.runtime_identity
+    if resolved_runtime_identity is None and existing_generation is not None:
+        resolved_runtime_identity = existing_generation.runtime_identity
 
     return build_preview_generation_record(
         preview_id=preview.preview_id,
@@ -1646,6 +1649,7 @@ def build_preview_generation_record_from_request(
         overall_health_status=request.overall_health_status,
         failure_stage=request.failure_stage,
         failure_summary=request.failure_summary,
+        runtime_identity=resolved_runtime_identity,
     )
 
 

--- a/docs/records.md
+++ b/docs/records.md
@@ -1734,6 +1734,9 @@ run` is the foreground loop intended for an external process supervisor, and
 - Record the resolved manifest fingerprint, exact repo-to-SHA source map,
   baseline release tuple, artifact identity, health evidence, and failure
   details when a replacement does not become ready.
+- Ready generation evidence preserves the runtime identity checked by the
+  preview health verifier so downstream approval can bind the exact observed
+  product, context, source ref, preview runtime, deployment, artifact, and image.
 - Generation history should remain ordered and inspectable even when the latest
   generation failed and an older generation is still serving.
 - Launchplane read models should derive status/list/history payloads from these
@@ -1754,6 +1757,37 @@ run` is the foreground loop intended for an external process supervisor, and
 - Those CLI surfaces should be treated as temporary adapters for the target
   Launchplane API payloads, not as the final integration boundary external
   products are expected to couple to forever.
+
+## Manager Preview Approval Event Record
+
+- One append-only event per manager decision or lifecycle invalidation for an
+  exact rendered preview identity. Events use deterministic ids derived from
+  the exact binding, action, and source event so delivery retries replay without
+  overwriting history; a conflicting replay is rejected.
+- The binding captures product, context, repository, pull request, head SHA,
+  preview and serving-generation ids, artifact id and immutable image digest,
+  resolved manifest fingerprint, preview URL, and the full checked runtime
+  identity plus canonical runtime/binding digests.
+- Manager-authored `approved`, `changes_requested`, and `revoked` events require
+  a stable GitHub numeric identity and exactly one schema-v2 managed
+  authorization rule granting `manager_preview_approval.write` for the product
+  and context. The event stores the display login only as audit presentation and
+  records the managed rule ids plus authorization policy record id, revision,
+  source, and digest.
+- Lifecycle-authored `superseded` and `invalidated` events preserve teardown,
+  PR-close, generation-replacement, and related history without impersonating a
+  manager. Preview destroy and cleanup remain available independently of
+  approval and never consult approval as an admission gate.
+- The decision projection is computed from the append-only ledger and current
+  preview/generation/policy evidence. It returns `pending`, `approved`,
+  `changes_requested`, `revoked`, `stale`, or `unavailable` with a public-safe
+  reason. Any head, serving generation, artifact digest, manifest, runtime
+  identity, verification, preview state, or policy mismatch fails closed.
+- People-based manager resolution is private agent routing for communication and
+  planning only. It is not persisted in this record and is never runtime
+  authorization. Launchplane's active managed policy is the authority; GitHub
+  interaction and promotion-check projection are separate downstream adapters,
+  and tenant repositories own only their thin workflow integration.
 
 ## Launchplane Preview Enablement Record
 
@@ -1923,11 +1957,11 @@ preflights.
 - Every Code PR feedback webhooks and `/preview ok` or `/preview changes ...`
   source-issue comments are actor-gated before they become pending work for a
   local session. The repository owner is trusted, the source issue author is
-  trusted for preview validation, and configured managers from the local planning
-  manager map are accepted as a bootstrap policy source until Launchplane owns a
-  mutable repo trust-policy record. Bot-authored and untrusted human comments are
-  accepted-but-skipped so webhook delivery remains idempotent without sending
-  automation chatter to Every Code.
+  trusted for Every Code source-issue validation. Those semantics are distinct
+  from Launchplane manager approval of a rendered product preview: local People
+  or planning maps never authorize runtime approval. Bot-authored and untrusted
+  human comments are accepted-but-skipped so webhook delivery remains idempotent
+  without sending automation chatter to Every Code.
 - Agent callers should prefer `GET /v1/every-code/summary` over raw work-request
   reads when they only need status. The summary projection links back to the
   issue and result PR, reports whether work is active, stuck, complete, or

--- a/docs/service-boundary.md
+++ b/docs/service-boundary.md
@@ -651,6 +651,32 @@ ID/revision/digest, supersedes and inserts only when changed, completes replay
 evidence, and commits the transaction as one unit. No-op applies complete replay
 evidence without creating policy history.
 
+Manager approval of rendered previews is a separate Launchplane domain from
+Every Code preview-gate validation. `control_plane/manager_preview_approval.py`
+builds and evaluates exact preview bindings from the current preview record,
+serving generation, immutable artifact image digest, checked runtime identity,
+and active authorization policy. Manager-authored events require exactly one
+schema-v2 managed GitHub-human rule granting
+`manager_preview_approval.write`; that rule must include the actor's stable
+numeric GitHub id. The login is display evidence and may change without changing
+the authorized identity.
+
+The resulting `launchplane_manager_preview_approval_events` ledger is
+append-only in both filesystem rehearsal storage and PostgreSQL. Approval reads
+use `manager_preview_approval.read`, and the decision projection fails closed to
+pending, stale, or unavailable whenever current head, serving generation,
+artifact, manifest, runtime identity, verification, preview state, or policy
+does not exactly match the recorded event. This contract does not add a browser
+or GitHub mutation route by itself; GitHub comment handling, check projection,
+and promotion admission belong to the downstream interaction layer.
+
+People-based manager lookup remains private Every Code communication and
+planning context. It cannot populate, authorize, or override Launchplane runtime
+approval records. Tenant repositories own site code and thin workflow inputs;
+Launchplane owns authorization, durable approval evidence, and lifecycle
+invalidation. Preview destroy, PR close, label removal, and cleanup never call
+the approval decision as an admission gate.
+
 Schema-v1 migration and unmanaged-rule adoption are never implicit. The caller
 must request `schema_migration = migrate_v1_to_v2` and/or
 `unmanaged_adoption = adopt_matching` during both review and apply. Once a

--- a/frontend/generated/openapi-canonical.json
+++ b/frontend/generated/openapi-canonical.json
@@ -9322,6 +9322,16 @@
             "title": "Resolved Manifest Fingerprint",
             "type": "string"
           },
+          "runtime_identity": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RuntimeIdentity"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "schema_version": {
             "default": 1,
             "minimum": 1.0,
@@ -24271,6 +24281,14 @@
                           "type": "string"
                         },
                         "title": "Contexts",
+                        "type": "array"
+                      },
+                      "github_ids": {
+                        "default": [],
+                        "items": {
+                          "type": "integer"
+                        },
+                        "title": "Github Ids",
                         "type": "array"
                       },
                       "instances": {

--- a/tests/test_generic_web_http.py
+++ b/tests/test_generic_web_http.py
@@ -3351,6 +3351,17 @@ class GenericWebHttpTests(unittest.TestCase):
                 "application_name": "sellyouroutboard-pr-42",
                 "application_id": "app-preview",
                 "preview_url": "https://pr-42.example.test",
+                "runtime_identity": {
+                    "product": "sellyouroutboard",
+                    "context": "sellyouroutboard-testing",
+                    "instance": "pr-42",
+                    "environment_kind": "preview",
+                    "deployment_record_id": "deployment-pr-42",
+                    "artifact_id": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                    "source_git_ref": "abc123",
+                    "image_reference": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                    "preview_id": "pr-42",
+                },
                 "smoke": {
                     "smoke_status": "fail",
                     "checked_at": "2026-05-03T15:04:55Z",
@@ -3374,6 +3385,7 @@ class GenericWebHttpTests(unittest.TestCase):
                         "preview_slug": "pr-42",
                         "preview_url": "https://pr-42.request.example.test",
                         "image_reference": "ghcr.io/cbusillo/sellyouroutboard:sha",
+                        "anchor_head_sha": "abc123",
                     }
                 ),
                 driver_result=driver_result,
@@ -3388,6 +3400,7 @@ class GenericWebHttpTests(unittest.TestCase):
         self.assertEqual(generation_request.verify_status, "fail")
         self.assertEqual(generation_request.failure_stage, "verify")
         self.assertEqual(generation_request.failure_summary, "Smoke failed on /api/health.")
+        self.assertEqual(generation_request.runtime_identity, driver_result.runtime_identity)
 
     def test_generic_web_preview_refresh_route_accepts_omitted_preview_url(self) -> None:
         with TemporaryDirectory() as temporary_directory_name:

--- a/tests/test_generic_web_preview.py
+++ b/tests/test_generic_web_preview.py
@@ -1206,6 +1206,11 @@ class GenericWebPreviewTests(unittest.TestCase):
 
         self.assertEqual(result.refresh_status, "pass")
         self.assertEqual(result.application_id, "app-preview")
+        self.assertIsNotNone(result.runtime_identity)
+        assert result.runtime_identity is not None
+        self.assertEqual(result.runtime_identity.environment_kind, "preview")
+        self.assertEqual(result.runtime_identity.source_git_ref, "abc123")
+        self.assertEqual(result.runtime_identity.preview_id, "preview-42-site")
         self.assertEqual(
             [request["path"] for request in requests],
             [

--- a/tests/test_launchplane_mutations.py
+++ b/tests/test_launchplane_mutations.py
@@ -10,6 +10,7 @@ from control_plane.contracts.preview_mutation_request import (
     PreviewMutationRequest,
 )
 from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity
 from control_plane.launchplane_mutations import (
     apply_launchplane_destroy_preview,
     apply_launchplane_generation_evidence,
@@ -164,6 +165,61 @@ class LaunchplaneMutationTests(unittest.TestCase):
         preview = store.previews["preview-site-testing-cbusillo-site-pr-42"]
         self.assertEqual(preview.state, "active")
         self.assertEqual(preview.serving_generation_id, result["generation_id"])
+
+    def test_generation_evidence_persists_checked_runtime_identity(self) -> None:
+        store = _BundledPreviewMutationStore()
+        runtime_identity = RuntimeIdentity(
+            product="site",
+            context="site-testing",
+            instance="pr-42",
+            environment_kind="preview",
+            deployment_record_id="deployment-pr-42",
+            artifact_id="artifact-preview-42",
+            source_git_ref="abc123",
+            image_reference=f"ghcr.io/cbusillo/site@sha256:{'a' * 64}",
+            preview_id="pr-42",
+        )
+
+        result = apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(runtime_identity=runtime_identity),
+        )
+
+        generation = store.generations[str(result["generation_id"])]
+        self.assertEqual(generation.runtime_identity, runtime_identity)
+        self.assertEqual(store.evidence_write_count, 1)
+
+    def test_generation_evidence_replay_preserves_checked_runtime_identity(self) -> None:
+        store = _BundledPreviewMutationStore()
+        runtime_identity = RuntimeIdentity(
+            product="site",
+            context="site-testing",
+            instance="pr-42",
+            environment_kind="preview",
+            deployment_record_id="deployment-pr-42",
+            artifact_id="artifact-preview-42",
+            source_git_ref="abc123",
+            image_reference=f"ghcr.io/cbusillo/site@sha256:{'a' * 64}",
+            preview_id="pr-42",
+        )
+        first = apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(runtime_identity=runtime_identity),
+        )
+
+        apply_launchplane_generation_evidence(
+            control_plane_root_path=Path("/launchplane"),
+            record_store=store,
+            preview_request=_preview_request(),
+            generation_request=_generation_request(),
+        )
+
+        generation = store.generations[str(first["generation_id"])]
+        self.assertEqual(generation.runtime_identity, runtime_identity)
 
     def test_generation_evidence_uses_bundled_store_write_when_available(self) -> None:
         store = _BundledPreviewMutationStore()

--- a/tests/test_manager_preview_approval.py
+++ b/tests/test_manager_preview_approval.py
@@ -1,0 +1,519 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+import unittest
+
+from control_plane.contracts.authz_policy_record import (
+    LaunchplaneAuthzPolicyRecord,
+    authz_policy_sha256,
+    build_authz_policy_record_id,
+)
+from control_plane.contracts.manager_preview_approval import (
+    MANAGER_PREVIEW_APPROVAL_READ_ACTION,
+    MANAGER_PREVIEW_APPROVAL_WRITE_ACTION,
+    ManagerPreviewApprovalDecision,
+    ManagerPreviewApprovalEventRecord,
+)
+from control_plane.contracts.preview_generation_record import (
+    PreviewGenerationRecord,
+    PreviewPullRequestSummary,
+)
+from control_plane.contracts.preview_record import PreviewRecord
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.manager_preview_approval import (
+    ManagerPreviewApprovalAuthorizationError,
+    ManagerPreviewApprovalEventConflictError,
+    ManagerPreviewApprovalEventStore,
+    build_current_manager_preview_approval_binding,
+    build_manager_preview_approval_system_event,
+    capture_manager_preview_approval_authorization,
+    evaluate_manager_preview_approval,
+    record_manager_preview_approval_event,
+)
+from control_plane.service_auth import (
+    GitHubHumanIdentity,
+    GitHubHumanPolicyRule,
+    LaunchplaneAuthzPolicy,
+)
+from control_plane.storage.filesystem import FilesystemRecordStore
+from control_plane.storage.postgres import PostgresRecordStore
+
+
+PRODUCT = "example-site"
+CONTEXT = "example-site-testing"
+REPOSITORY = "example/example-site"
+PR_NUMBER = 17
+HEAD_SHA = "1" * 40
+IMAGE_DIGEST = f"sha256:{'a' * 64}"
+OCCURRED_AT = "2026-07-30T12:00:00Z"
+
+
+class ManagerPreviewApprovalTests(unittest.TestCase):
+    def test_records_approval_only_after_exact_manager_authorization(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            result = record_manager_preview_approval_event(
+                record_store=store,
+                identity=_manager_identity(login="renamed-manager"),
+                policy_record=_policy_record(),
+                product=PRODUCT,
+                preview=_preview(),
+                generation=_generation(),
+                action="approved",
+                occurred_at=OCCURRED_AT,
+                source_event_kind="github_issue_comment",
+                source_event_id="comment-101",
+            )
+
+            self.assertEqual(result.status, "written")
+            self.assertEqual(result.record.manager_github_id, 101)
+            self.assertEqual(result.record.manager_login, "renamed-manager")
+            self.assertEqual(result.record.binding.head_sha, HEAD_SHA)
+            self.assertEqual(result.record.binding.artifact_image_digest, IMAGE_DIGEST)
+            self.assertEqual(
+                store.list_manager_preview_approval_event_records(
+                    product=PRODUCT,
+                    context=CONTEXT,
+                    repository=REPOSITORY,
+                    pr_number=PR_NUMBER,
+                ),
+                (result.record,),
+            )
+
+    def test_rejects_actor_not_named_by_stable_github_id(self) -> None:
+        with self.assertRaisesRegex(
+            ManagerPreviewApprovalAuthorizationError,
+            "exactly one managed policy rule",
+        ):
+            capture_manager_preview_approval_authorization(
+                identity=_manager_identity(github_id=202),
+                product=PRODUCT,
+                context=CONTEXT,
+                policy_record=_policy_record(),
+                authorized_at=OCCURRED_AT,
+            )
+
+    def test_rejects_actor_without_stable_github_numeric_identity(self) -> None:
+        with self.assertRaisesRegex(
+            ManagerPreviewApprovalAuthorizationError,
+            "stable GitHub numeric identity",
+        ):
+            capture_manager_preview_approval_authorization(
+                identity=_manager_identity(github_id=0),
+                product=PRODUCT,
+                context=CONTEXT,
+                policy_record=_policy_record(),
+                authorized_at=OCCURRED_AT,
+            )
+
+    def test_manager_write_path_rejects_system_actions(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            with self.assertRaisesRegex(ValueError, "manager action"):
+                record_manager_preview_approval_event(
+                    record_store=store,
+                    identity=_manager_identity(),
+                    policy_record=_policy_record(),
+                    product=PRODUCT,
+                    preview=_preview(),
+                    generation=_generation(),
+                    action="superseded",
+                    occurred_at=OCCURRED_AT,
+                    source_event_kind="preview_generation",
+                    source_event_id="generation-18",
+                    reason="A new serving generation replaced this preview.",
+                )
+
+    def test_requires_current_verified_runtime_identity(self) -> None:
+        with self.assertRaisesRegex(ValueError, "runtime identity"):
+            build_current_manager_preview_approval_binding(
+                product=PRODUCT,
+                preview=_preview(),
+                generation=_generation(runtime_identity=None),
+            )
+
+    def test_rejects_runtime_identity_for_wrong_source_or_environment(self) -> None:
+        mismatch_cases = {
+            "source": _runtime_identity(source_git_ref="2" * 40),
+            "environment": _runtime_identity(environment_kind="stable"),
+            "preview_id": _runtime_identity(preview_id=""),
+            "generation": _runtime_identity(preview_generation_id="generation-18"),
+        }
+        for label, runtime_identity in mismatch_cases.items():
+            with self.subTest(label=label):
+                with self.assertRaisesRegex(ValueError, "runtime identity"):
+                    build_current_manager_preview_approval_binding(
+                        product=PRODUCT,
+                        preview=_preview(),
+                        generation=_generation(runtime_identity=runtime_identity),
+                    )
+
+    def test_filesystem_replays_identical_event_and_rejects_conflicting_payload(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            event = _approved_event(store)
+
+            self.assertEqual(store.write_manager_preview_approval_event_record(event), "replayed")
+            conflicting = ManagerPreviewApprovalEventRecord.model_validate(
+                {**event.model_dump(mode="json"), "reason": "Conflicting replay."}
+            )
+            with self.assertRaises(ManagerPreviewApprovalEventConflictError):
+                store.write_manager_preview_approval_event_record(conflicting)
+
+    def test_sql_store_persists_and_replays_append_only_event(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            database_path = Path(temporary_directory_name) / "launchplane.sqlite3"
+            store = PostgresRecordStore(database_url=f"sqlite:///{database_path}")
+            store.ensure_schema()
+            event = _approved_event(store)
+            try:
+                self.assertEqual(
+                    store.write_manager_preview_approval_event_record(event),
+                    "replayed",
+                )
+                self.assertEqual(
+                    store.list_manager_preview_approval_event_records(preview_id="preview-17"),
+                    (event,),
+                )
+                conflicting = ManagerPreviewApprovalEventRecord.model_validate(
+                    {**event.model_dump(mode="json"), "reason": "Conflicting replay."}
+                )
+                with self.assertRaises(ManagerPreviewApprovalEventConflictError):
+                    store.write_manager_preview_approval_event_record(conflicting)
+            finally:
+                store.close()
+
+    def test_decision_tracks_changes_requested_revocation_and_invalidation(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            approved = _approved_event(store)
+            changes_requested = record_manager_preview_approval_event(
+                record_store=store,
+                identity=_manager_identity(),
+                policy_record=_policy_record(),
+                product=PRODUCT,
+                preview=_preview(),
+                generation=_generation(),
+                action="changes_requested",
+                occurred_at="2026-07-30T12:01:00Z",
+                source_event_kind="github_issue_comment",
+                source_event_id="comment-102",
+                reason="Adjust the primary call to action.",
+            ).record
+            decision = _decision(events=(approved, changes_requested))
+            self.assertEqual(decision.status, "changes_requested")
+
+            revoked = record_manager_preview_approval_event(
+                record_store=store,
+                identity=_manager_identity(),
+                policy_record=_policy_record(),
+                product=PRODUCT,
+                preview=_preview(),
+                generation=_generation(),
+                action="revoked",
+                occurred_at="2026-07-30T12:02:00Z",
+                source_event_kind="github_issue_comment",
+                source_event_id="comment-103",
+                reason="Approval was revoked.",
+            ).record
+            decision = _decision(events=(approved, changes_requested, revoked))
+            self.assertEqual(decision.status, "revoked")
+
+            invalidated = build_manager_preview_approval_system_event(
+                binding=approved.binding,
+                action="invalidated",
+                occurred_at="2026-07-30T12:03:00Z",
+                source_event_kind="preview_destroyed",
+                source_event_id="preview-17-destroyed",
+                reason="The preview was destroyed.",
+            )
+            decision = _decision(events=(approved, changes_requested, revoked, invalidated))
+            self.assertEqual(decision.status, "stale")
+
+            superseded = build_manager_preview_approval_system_event(
+                binding=approved.binding,
+                action="superseded",
+                occurred_at="2026-07-30T12:04:00Z",
+                source_event_kind="preview_generation",
+                source_event_id="generation-18",
+                reason="A new serving generation replaced this preview.",
+            )
+            decision = _decision(
+                events=(approved, changes_requested, revoked, invalidated, superseded)
+            )
+            self.assertEqual(decision.status, "stale")
+
+    def test_exact_approval_becomes_stale_when_preview_identity_changes(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            approved = _approved_event(store)
+            stale_cases = {
+                "head": (
+                    _preview(),
+                    _generation(
+                        head_sha="2" * 40,
+                        runtime_identity=_runtime_identity(source_git_ref="2" * 40),
+                    ),
+                ),
+                "generation": (
+                    _preview(
+                        active_generation_id="generation-18",
+                        serving_generation_id="generation-18",
+                        latest_generation_id="generation-18",
+                    ),
+                    _generation(
+                        generation_id="generation-18",
+                        runtime_identity=_runtime_identity(preview_generation_id="generation-18"),
+                    ),
+                ),
+                "artifact": (
+                    _preview(),
+                    _generation(
+                        artifact_id="artifact-18",
+                        runtime_identity=_runtime_identity(
+                            artifact_id="artifact-18",
+                            image_reference=f"ghcr.io/example/site@sha256:{'b' * 64}",
+                        ),
+                    ),
+                ),
+                "manifest": (
+                    _preview(latest_manifest_fingerprint="manifest-18"),
+                    _generation(resolved_manifest_fingerprint="manifest-18"),
+                ),
+                "runtime": (
+                    _preview(),
+                    _generation(
+                        runtime_identity=_runtime_identity(deployment_record_id="deployment-18")
+                    ),
+                ),
+            }
+            for label, (preview, generation) in stale_cases.items():
+                with self.subTest(label=label):
+                    decision = _decision(
+                        preview=preview,
+                        generation=generation,
+                        events=(approved,),
+                    )
+                    self.assertEqual(decision.status, "stale")
+
+    def test_policy_change_makes_prior_approval_stale(self) -> None:
+        with TemporaryDirectory() as temporary_directory_name:
+            store = FilesystemRecordStore(state_dir=Path(temporary_directory_name))
+            approved = _approved_event(store)
+            changed_policy = _policy_record(
+                revision=2,
+                extra_actions=("product_profile.read",),
+            )
+
+            decision = _decision(events=(approved,), policy_record=changed_policy)
+
+            self.assertEqual(decision.status, "stale")
+            self.assertEqual(decision.reason_code, "approval_stale")
+
+    def test_missing_policy_makes_approval_unavailable(self) -> None:
+        decision = evaluate_manager_preview_approval(
+            product=PRODUCT,
+            preview=_preview(),
+            generation=_generation(),
+            policy_record=None,
+            events=(),
+            evaluated_at="2026-07-30T12:10:00Z",
+        )
+
+        self.assertEqual(decision.status, "unavailable")
+        self.assertEqual(decision.reason_code, "policy_unavailable")
+
+    def test_destroyed_or_failed_preview_is_unavailable_without_gating_cleanup(self) -> None:
+        destroyed = _decision(
+            preview=_preview(state="destroyed"),
+            events=(),
+        )
+        failed = _decision(
+            generation=_generation(verify_status="fail"),
+            events=(),
+        )
+
+        self.assertEqual(destroyed.status, "unavailable")
+        self.assertEqual(destroyed.reason_code, "preview_inactive")
+        self.assertEqual(failed.status, "unavailable")
+        self.assertEqual(failed.reason_code, "generation_verification_failed")
+
+    def test_empty_github_ids_do_not_change_existing_policy_serialization(self) -> None:
+        policy = LaunchplaneAuthzPolicy(
+            schema_version=2,
+            github_humans=(
+                GitHubHumanPolicyRule(
+                    logins=("example",),
+                    roles=("read_only",),
+                    actions=(MANAGER_PREVIEW_APPROVAL_READ_ACTION,),
+                ),
+            ),
+        )
+
+        payload = json.loads(policy.model_dump_json())
+
+        self.assertNotIn("github_ids", payload["github_humans"][0])
+
+
+def _approved_event(
+    record_store: ManagerPreviewApprovalEventStore,
+) -> ManagerPreviewApprovalEventRecord:
+    return record_manager_preview_approval_event(
+        record_store=record_store,
+        identity=_manager_identity(),
+        policy_record=_policy_record(),
+        product=PRODUCT,
+        preview=_preview(),
+        generation=_generation(),
+        action="approved",
+        occurred_at=OCCURRED_AT,
+        source_event_kind="github_issue_comment",
+        source_event_id="comment-101",
+    ).record
+
+
+def _decision(
+    *,
+    preview: PreviewRecord | None = None,
+    generation: PreviewGenerationRecord | None = None,
+    policy_record: LaunchplaneAuthzPolicyRecord | None = None,
+    events: tuple[ManagerPreviewApprovalEventRecord, ...],
+) -> ManagerPreviewApprovalDecision:
+    return evaluate_manager_preview_approval(
+        product=PRODUCT,
+        preview=preview or _preview(),
+        generation=generation or _generation(),
+        policy_record=policy_record or _policy_record(),
+        events=events,
+        evaluated_at="2026-07-30T12:10:00Z",
+    )
+
+
+def _manager_identity(*, github_id: int = 101, login: str = "manager") -> GitHubHumanIdentity:
+    return GitHubHumanIdentity(
+        login=login,
+        github_id=github_id,
+        name="Example Manager",
+        email="manager@example.com",
+        organizations=frozenset(),
+        teams=frozenset(),
+        role="read_only",
+    )
+
+
+def _policy_record(
+    *,
+    revision: int = 1,
+    extra_actions: tuple[str, ...] = (),
+) -> LaunchplaneAuthzPolicyRecord:
+    policy = LaunchplaneAuthzPolicy(
+        schema_version=2,
+        github_humans=(
+            GitHubHumanPolicyRule(
+                managed_set_id="manager.example-site",
+                managed_rule_id="preview-approval",
+                github_ids=(101,),
+                roles=("read_only",),
+                products=(PRODUCT,),
+                contexts=(CONTEXT,),
+                actions=(
+                    MANAGER_PREVIEW_APPROVAL_READ_ACTION,
+                    MANAGER_PREVIEW_APPROVAL_WRITE_ACTION,
+                    *extra_actions,
+                ),
+            ),
+        ),
+    )
+    policy_sha256 = authz_policy_sha256(policy)
+    return LaunchplaneAuthzPolicyRecord(
+        record_id=build_authz_policy_record_id(
+            revision=revision,
+            policy_sha256=policy_sha256,
+        ),
+        revision=revision,
+        status="active",
+        source="test:manager-preview-approval",
+        updated_at=OCCURRED_AT,
+        policy_sha256=policy_sha256,
+        policy=policy,
+    )
+
+
+def _preview(**updates: object) -> PreviewRecord:
+    payload = {
+        "preview_id": "preview-17",
+        "context": CONTEXT,
+        "anchor_repo": REPOSITORY,
+        "anchor_pr_number": PR_NUMBER,
+        "anchor_pr_url": f"https://github.com/{REPOSITORY}/pull/{PR_NUMBER}",
+        "preview_label": "launchplane-preview",
+        "canonical_url": "https://preview-17.example.com/",
+        "state": "active",
+        "created_at": "2026-07-30T11:00:00Z",
+        "updated_at": "2026-07-30T11:30:00Z",
+        "eligible_at": "2026-07-30T11:00:00Z",
+        "active_generation_id": "generation-17",
+        "serving_generation_id": "generation-17",
+        "latest_generation_id": "generation-17",
+        "latest_manifest_fingerprint": "manifest-17",
+    }
+    payload.update(updates)
+    return PreviewRecord.model_validate(payload)
+
+
+def _generation(**updates: object) -> PreviewGenerationRecord:
+    payload = {
+        "generation_id": "generation-17",
+        "preview_id": "preview-17",
+        "sequence": 1,
+        "state": "ready",
+        "requested_reason": "Preview requested.",
+        "requested_at": "2026-07-30T11:00:00Z",
+        "started_at": "2026-07-30T11:01:00Z",
+        "ready_at": "2026-07-30T11:30:00Z",
+        "finished_at": "2026-07-30T11:30:00Z",
+        "resolved_manifest_fingerprint": "manifest-17",
+        "artifact_id": "artifact-17",
+        "anchor_summary": PreviewPullRequestSummary(
+            repo=REPOSITORY,
+            pr_number=PR_NUMBER,
+            head_sha=HEAD_SHA,
+            pr_url=f"https://github.com/{REPOSITORY}/pull/{PR_NUMBER}",
+        ),
+        "deploy_status": "pass",
+        "verify_status": "pass",
+        "overall_health_status": "pass",
+        "runtime_identity": _runtime_identity(),
+    }
+    head_sha = updates.pop("head_sha", None)
+    if head_sha is not None:
+        payload["anchor_summary"] = PreviewPullRequestSummary(
+            repo=REPOSITORY,
+            pr_number=PR_NUMBER,
+            head_sha=str(head_sha),
+            pr_url=f"https://github.com/{REPOSITORY}/pull/{PR_NUMBER}",
+        )
+    payload.update(updates)
+    return PreviewGenerationRecord.model_validate(payload)
+
+
+def _runtime_identity(**updates: object) -> RuntimeIdentity:
+    payload: dict[str, object] = {
+        "product": PRODUCT,
+        "context": CONTEXT,
+        "instance": "preview-17",
+        "environment_kind": "preview",
+        "deployment_record_id": "deployment-17",
+        "artifact_id": "artifact-17",
+        "source_git_ref": HEAD_SHA,
+        "image_reference": f"ghcr.io/example/site@{IMAGE_DIGEST}",
+        "preview_id": "preview-17",
+        "preview_generation_id": "generation-17",
+        "deployed_at": "2026-07-30T11:20:00Z",
+    }
+    payload.update(updates)
+    return RuntimeIdentity.model_validate(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -33,6 +33,11 @@ from control_plane.contracts.every_code_work_request import (
     EveryCodeWorkRequestRecord,
     EveryCodeWorkRequestStatusUpdate,
 )
+from control_plane.contracts.manager_preview_approval import (
+    ManagerPreviewApprovalAuthorization,
+    ManagerPreviewApprovalBinding,
+    ManagerPreviewApprovalEventRecord,
+)
 from control_plane.contracts.merge_train_controller_state import (
     MergeTrainControllerLeaseHeldError,
     MergeTrainControllerLeaseLostError,
@@ -66,6 +71,8 @@ from control_plane.contracts.route_binding_record import (
     RouteBindingSource,
     RouteBindingTls,
 )
+from control_plane.contracts.runtime_identity import RuntimeIdentity
+from control_plane.manager_preview_approval import ManagerPreviewApprovalEventConflictError
 from control_plane.provider_operations import (
     DurableProviderOperationResult,
     ProviderMutationOutcome,
@@ -491,7 +498,77 @@ def _outbox_delivery(*, suffix: str = "one") -> OutboxDeliveryRecord:
     )
 
 
+def _manager_preview_approval_event() -> ManagerPreviewApprovalEventRecord:
+    occurred_at = "2026-07-30T12:00:00Z"
+    binding = ManagerPreviewApprovalBinding(
+        product="example-site",
+        context="example-site-testing",
+        repository="example/example-site",
+        pr_number=17,
+        pr_url="https://github.com/example/example-site/pull/17",
+        head_sha="1" * 40,
+        preview_id="preview-17",
+        serving_generation_id="generation-17",
+        artifact_id="artifact-17",
+        artifact_image_digest=f"sha256:{'a' * 64}",
+        manifest_fingerprint="manifest-17",
+        preview_url="https://preview-17.example.com/",
+        runtime_identity=RuntimeIdentity(
+            product="example-site",
+            context="example-site-testing",
+            instance="preview-17",
+            environment_kind="preview",
+            deployment_record_id="deployment-17",
+            artifact_id="artifact-17",
+            source_git_ref="1" * 40,
+            image_reference=f"ghcr.io/example/site@sha256:{'a' * 64}",
+            preview_id="preview-17",
+            preview_generation_id="generation-17",
+        ),
+    )
+    return ManagerPreviewApprovalEventRecord(
+        binding=binding,
+        action="approved",
+        occurred_at=occurred_at,
+        source_event_kind="github_issue_comment",
+        source_event_id="comment-101",
+        authorization=ManagerPreviewApprovalAuthorization(
+            manager_github_id=101,
+            manager_login="manager",
+            managed_set_id="manager.example-site",
+            managed_rule_id="preview-approval",
+            policy_record_id="launchplane-authz-policy-r00000000000000000001-example",
+            policy_revision=1,
+            policy_sha256="b" * 64,
+            policy_source="test:manager-preview-approval",
+            authorized_at=occurred_at,
+        ),
+    )
+
+
 class RealPostgresSchemaIntegrationTests(unittest.TestCase):
+    def test_manager_preview_approval_events_persist_append_only(self) -> None:
+        with _store_for_fresh_head_database() as store:
+            event = _manager_preview_approval_event()
+
+            self.assertEqual(store.write_manager_preview_approval_event_record(event), "written")
+            self.assertEqual(store.write_manager_preview_approval_event_record(event), "replayed")
+            self.assertEqual(
+                store.list_manager_preview_approval_event_records(
+                    product="example-site",
+                    context="example-site-testing",
+                    repository="example/example-site",
+                    pr_number=17,
+                ),
+                (event,),
+            )
+
+            conflicting = ManagerPreviewApprovalEventRecord.model_validate(
+                {**event.model_dump(mode="json"), "reason": "Conflicting replay."}
+            )
+            with self.assertRaises(ManagerPreviewApprovalEventConflictError):
+                store.write_manager_preview_approval_event_record(conflicting)
+
     def test_full_release_upgrades_compatibility_floor_before_store_startup(self) -> None:
         with _isolated_postgres_database() as database_url:
             alembic_command.upgrade(

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -6027,6 +6027,7 @@ env_var = "GH_TOKEN"
                     "preview_records": 1,
                     "preview_enablement": 1,
                     "preview_generations": 1,
+                    "manager_preview_approval_events": 0,
                     "preview_desired_states": 1,
                     "preview_inventory_scans": 1,
                     "preview_lifecycle_cleanups": 1,


### PR DESCRIPTION
## Summary
- add append-only manager preview approval events with exact preview, generation, artifact, runtime, and policy binding
- authorize manager writes through stable GitHub numeric identities in Launchplane-managed schema-v2 policy
- persist checked runtime identity through the production preview generation evidence path
- add filesystem/PostgreSQL storage, Alembic migration, decision projection, docs, and generated OpenAPI updates

## Validation
- `uv run --extra dev launchplane ci unittest-shard local` (2,481 targets)
- `uv run --extra dev mypy control_plane tests`
- `pnpm --dir frontend validate`
- changed-file Ruff check and format check
- JetBrains changed-files inspection: clean
- real PostgreSQL integration test added; local execution skipped because `LAUNCHPLANE_TEST_POSTGRES_URL` is not configured

Closes #1910